### PR TITLE
fix: remove [tool.uv.sources] local path overrides from all modules

### DIFF
--- a/modules/hooks-pipeline-observability/pyproject.toml
+++ b/modules/hooks-pipeline-observability/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.11"
 authors = [
     { name = "Microsoft MADE:Explorations Team" },
 ]
-dependencies = ["amplifier-core"]
+dependencies = ["amplifier-core>=0.1.0"]
 
 [project.entry-points."amplifier.modules"]
 hooks-pipeline-observability = "amplifier_module_hooks_pipeline_observability:mount"
@@ -19,8 +19,7 @@ build-backend = "hatchling.build"
 [tool.uv]
 package = true
 
-[tool.uv.sources]
-amplifier-core = { path = "../../../amplifier-core", editable = true }
+
 
 [tool.hatch.build.targets.wheel]
 packages = ["amplifier_module_hooks_pipeline_observability"]

--- a/modules/hooks-pipeline-progress/pyproject.toml
+++ b/modules/hooks-pipeline-progress/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.11"
 authors = [
     { name = "Microsoft MADE:Explorations Team" },
 ]
-dependencies = ["amplifier-core"]
+dependencies = ["amplifier-core>=0.1.0"]
 
 [project.entry-points."amplifier.modules"]
 hooks-pipeline-progress = "amplifier_module_hooks_pipeline_progress:mount"
@@ -19,8 +19,7 @@ build-backend = "hatchling.build"
 [tool.uv]
 package = true
 
-[tool.uv.sources]
-amplifier-core = { path = "../../../amplifier-core", editable = true }
+
 
 [tool.hatch.build.targets.wheel]
 packages = ["amplifier_module_hooks_pipeline_progress"]

--- a/modules/hooks-tool-truncation/pyproject.toml
+++ b/modules/hooks-tool-truncation/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
     { name = "Microsoft MADE:Explorations Team" },
 ]
 dependencies = [
-    "amplifier-core",
+    "amplifier-core>=0.1.0",
 ]
 
 [project.entry-points."amplifier.modules"]
@@ -23,8 +23,7 @@ build-backend = "hatchling.build"
 [tool.uv]
 package = true
 
-[tool.uv.sources]
-amplifier-core = { path = "../../../amplifier-core", editable = true }
+
 
 [tool.hatch.build.targets.wheel]
 packages = [

--- a/modules/loop-agent/pyproject.toml
+++ b/modules/loop-agent/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.11"
 authors = [
     { name = "Microsoft MADE:Explorations Team" },
 ]
-dependencies = []
+dependencies = ["amplifier-core>=0.1.0"]
 
 [project.entry-points."amplifier.modules"]
 loop-agent = "amplifier_module_loop_agent:mount"
@@ -33,9 +33,7 @@ dev = [
     "pytest-asyncio>=1.0.0",
 ]
 
-[tool.uv.sources]
-amplifier-core = { path = "../../../amplifier-core", editable = true }
-unified-llm-client = { path = "../../../unified-llm-client", editable = true }
+
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/modules/loop-pipeline/pyproject.toml
+++ b/modules/loop-pipeline/pyproject.toml
@@ -8,6 +8,7 @@ authors = [
     { name = "Microsoft MADE:Explorations Team" },
 ]
 dependencies = [
+    "amplifier-core>=0.1.0",
     "unified-llm-client",
 ]
 
@@ -23,8 +24,7 @@ build-backend = "hatchling.build"
 [tool.uv]
 package = true
 
-[tool.uv.sources]
-unified-llm-client = { path = "../../../unified-llm-client" }
+
 
 [tool.hatch.build.targets.wheel]
 packages = [

--- a/modules/tool-apply-patch/pyproject.toml
+++ b/modules/tool-apply-patch/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
     { name = "Microsoft MADE:Explorations Team" },
 ]
 dependencies = [
-    "amplifier-core",
+    "amplifier-core>=0.1.0",
 ]
 
 [project.entry-points."amplifier.modules"]
@@ -21,8 +21,7 @@ build-backend = "hatchling.build"
 [tool.uv]
 package = true
 
-[tool.uv.sources]
-amplifier-core = { path = "../../../amplifier-core", editable = true }
+
 
 [tool.hatch.build.targets.wheel]
 packages = ["amplifier_module_tool_apply_patch"]

--- a/modules/tool-pipeline-run/pyproject.toml
+++ b/modules/tool-pipeline-run/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
     { name = "Microsoft MADE:Explorations Team" },
 ]
 dependencies = [
-    "amplifier-core",
+    "amplifier-core>=0.1.0",
 ]
 
 [project.entry-points."amplifier.modules"]
@@ -21,8 +21,7 @@ build-backend = "hatchling.build"
 [tool.uv]
 package = true
 
-[tool.uv.sources]
-amplifier-core = { path = "../../../amplifier-core", editable = true }
+
 
 [tool.hatch.build.targets.wheel]
 packages = ["amplifier_module_tool_pipeline_run"]

--- a/modules/tool-pipeline-status/pyproject.toml
+++ b/modules/tool-pipeline-status/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
     { name = "Microsoft MADE:Explorations Team" },
 ]
 dependencies = [
-    "amplifier-core",
+    "amplifier-core>=0.1.0",
 ]
 
 [project.entry-points."amplifier.modules"]
@@ -21,8 +21,7 @@ build-backend = "hatchling.build"
 [tool.uv]
 package = true
 
-[tool.uv.sources]
-amplifier-core = { path = "../../../amplifier-core", editable = true }
+
 
 [tool.hatch.build.targets.wheel]
 packages = ["amplifier_module_tool_pipeline_status"]

--- a/modules/tool-report-outcome/pyproject.toml
+++ b/modules/tool-report-outcome/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
     { name = "Microsoft MADE:Explorations Team" },
 ]
 dependencies = [
-    "amplifier-core",
+    "amplifier-core>=0.1.0",
 ]
 
 [project.entry-points."amplifier.modules"]
@@ -21,8 +21,7 @@ build-backend = "hatchling.build"
 [tool.uv]
 package = true
 
-[tool.uv.sources]
-amplifier-core = { path = "../../../amplifier-core", editable = true }
+
 
 [tool.hatch.build.targets.wheel]
 packages = ["amplifier_module_tool_report_outcome"]


### PR DESCRIPTION
## Problem

All attractor bundle modules have a `[tool.uv.sources]` section that overrides `amplifier-core` with a relative path:

```toml
[tool.uv.sources]
amplifier-core = { path = "../../../amplifier-core", editable = true }
```

This works in local development but breaks in container environments (e.g., Amplifier Resolve containers) where `amplifier-core` is installed as a pip package, not a local checkout.

## Fix

Remove `[tool.uv.sources]` sections from all 9 module `pyproject.toml` files and use versioned PyPI dependencies instead (`amplifier-core>=0.1.0`).

This follows the pattern used by other Amplifier ecosystem modules (amplifier-bundle-filesystem, amplifier-bundle-notify, etc.).

## Modules Affected
- hooks-pipeline-observability
- hooks-pipeline-progress
- hooks-tool-truncation
- loop-agent
- loop-pipeline
- tool-apply-patch
- tool-pipeline-run
- tool-pipeline-status
- tool-report-outcome

## Verification

Tested with a script that verifies:
1. No modules have `[tool.uv.sources]` sections
2. All modules have proper `amplifier-core>=0.1.0` dependencies

All tests pass after the fix.