### PR TITLE
fix(loop-agent): coerce Decimal cost_usd to JSON-safe type before hook emit

### DIFF
--- a/modules/loop-agent/amplifier_module_loop_agent/agent_session.py
+++ b/modules/loop-agent/amplifier_module_loop_agent/agent_session.py
@@ -173,7 +173,7 @@ class AgentSession:
         reasoning = self._extract_reasoning(response)
         reasoning_sig = self._extract_reasoning_signature(response)
         usage = response.usage
-        usage_data = usage.model_dump() if usage else {}
+        usage_data = usage.model_dump(mode="json") if usage else {}
         response_id = self._extract_response_id(response)
 
         tool_calls: list[dict[str, Any]] = []
@@ -240,7 +240,15 @@ class AgentSession:
             # Capture usage data
             chunk_usage = chunk.get("usage")
             if chunk_usage:
-                usage_data = chunk_usage
+                # Coerce to JSON-safe dict; handles Decimal cost_usd from streaming providers
+                if hasattr(chunk_usage, "model_dump"):
+                    usage_data = chunk_usage.model_dump(mode="json")
+                else:
+                    from decimal import Decimal as _Decimal
+                    usage_data = {
+                        k: float(v) if isinstance(v, _Decimal) else v
+                        for k, v in chunk_usage.items()
+                    }
 
         # Emit text end with full assembled text and reasoning
         text_end_data: dict[str, Any] = {"text": full_text}


### PR DESCRIPTION
## Summary

- Fixes `TypeError: Object of type Decimal is not JSON serializable` that crashed the orchestrator resolver worker immediately after the first LLM response
- Two surgical patches in `agent_session.py`: non-streaming path + streaming path

## Root cause

`usage.model_dump()` (default Python mode) returns `cost_usd` as a raw Python `Decimal`. That dict is immediately passed to `PyHookRegistry::emit()` on the Rust side, which calls `json.dumps()` with no custom encoder → crash.

The event that triggers it: `PROVIDER_RESPONSE` hook, emitted synchronously after every LLM call.

## Fix

**Non-streaming path (`agent_session.py:176`):**
```python
# before
usage_data = usage.model_dump() if usage else {}
# after
usage_data = usage.model_dump(mode="json") if usage else {}
```
`mode="json"` forces Pydantic to emit JSON-native float/int regardless of `amplifier-core` version.

**Streaming path (`agent_session.py:~243`):**
```python
# before
usage_data = chunk_usage  # raw assignment, no coercion
# after — dispatches on type:
if hasattr(chunk_usage, "model_dump"):
    usage_data = chunk_usage.model_dump(mode="json")
else:
    usage_data = {k: float(v) if isinstance(v, Decimal) else v for k, v in chunk_usage.items()}
```
Handles both Pydantic model payloads and plain dict payloads from streaming providers that skip the model layer.

## Test plan

- [ ] Run orchestrator resolver against a real task — confirm no `Decimal is not JSON serializable` crash on first LLM turn
- [ ] Verify `PROVIDER_RESPONSE` hook event emits successfully with `cost_usd` as float
- [ ] Confirm streaming path works end-to-end for providers that return usage as a plain dict

Generated with [Amplifier](https://github.com/microsoft/amplifier)