### PR TITLE
fix(engine): single fan-out path for component nodes + requires= input validation

### DIFF
--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py
@@ -17,6 +17,7 @@ import os
 import threading
 import time
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 
 from .artifacts import ArtifactStore
@@ -349,6 +350,15 @@ class PipelineEngine:
             if runs_on in ("always", "failure"):
                 self._resolve_missing_as_empty(current_node)
 
+            # Step 1.9 (Bug H): Pre-execution requires= file validation.
+            # If a node declares ``requires=`` (comma-separated relative paths),
+            # every path must exist under context.target_dir (or os.getcwd() as
+            # fallback) before the handler runs.  Missing files cause an
+            # immediate FAIL with a clear error — the handler is never invoked.
+            # This prevents LLM agents from fabricating missing inputs when
+            # upstream branches didn't produce their expected artifacts.
+            _requires_fail = self._check_requires(current_node)
+
             # Step 2: Execute node handler with retry policy
             handler = self.handler_registry.get(current_node)
             handler_type = current_node.type or current_node.shape
@@ -372,52 +382,56 @@ class PipelineEngine:
             node_start_time = time.monotonic()
             retry_policy = RetryPolicy.from_node(current_node, self.graph)
 
-            # Per-node timeout enforcement: wrap handler execution with
-            # asyncio.timeout when the node declares a timeout attribute.
-            # DOT timeout values are in seconds (per NLSpec timeout_seconds).
-            node_timeout_raw = current_node.timeout
-            if node_timeout_raw:
-                timeout_s = float(node_timeout_raw)
-                try:
-                    async with asyncio.timeout(timeout_s):
-                        outcome = await execute_with_retry(
-                            handler,
-                            current_node,
-                            self.context,
-                            self.graph,
-                            self.logs_root,
-                            retry_policy,
-                            hooks=self.hooks,
-                        )
-                except asyncio.TimeoutError:
-                    node_duration_ms = (time.monotonic() - node_start_time) * 1000
-                    outcome = Outcome(
-                        status=StageStatus.FAIL,
-                        notes=f"Node '{current_node.id}' timed out after {timeout_s}s",
-                        failure_reason="timeout",
-                    )
-                    await self._emit(
-                        PIPELINE_NODE_COMPLETE,
-                        {
-                            "node_id": current_node.id,
-                            "status": "timeout",
-                            "duration_ms": node_duration_ms,
-                            "notes": outcome.notes,
-                            "failure_reason": outcome.failure_reason,
-                            "session_id": outcome.session_id,
-                            "execution_index": execution_index,  # NEW
-                        },
-                    )
+            if _requires_fail is not None:
+                # requires= validation failed — short-circuit without calling handler
+                outcome = _requires_fail
             else:
-                outcome = await execute_with_retry(
-                    handler,
-                    current_node,
-                    self.context,
-                    self.graph,
-                    self.logs_root,
-                    retry_policy,
-                    hooks=self.hooks,
-                )
+                # Per-node timeout enforcement: wrap handler execution with
+                # asyncio.timeout when the node declares a timeout attribute.
+                # DOT timeout values are in seconds (per NLSpec timeout_seconds).
+                node_timeout_raw = current_node.timeout
+                if node_timeout_raw:
+                    timeout_s = float(node_timeout_raw)
+                    try:
+                        async with asyncio.timeout(timeout_s):
+                            outcome = await execute_with_retry(
+                                handler,
+                                current_node,
+                                self.context,
+                                self.graph,
+                                self.logs_root,
+                                retry_policy,
+                                hooks=self.hooks,
+                            )
+                    except asyncio.TimeoutError:
+                        node_duration_ms = (time.monotonic() - node_start_time) * 1000
+                        outcome = Outcome(
+                            status=StageStatus.FAIL,
+                            notes=f"Node '{current_node.id}' timed out after {timeout_s}s",
+                            failure_reason="timeout",
+                        )
+                        await self._emit(
+                            PIPELINE_NODE_COMPLETE,
+                            {
+                                "node_id": current_node.id,
+                                "status": "timeout",
+                                "duration_ms": node_duration_ms,
+                                "notes": outcome.notes,
+                                "failure_reason": outcome.failure_reason,
+                                "session_id": outcome.session_id,
+                                "execution_index": execution_index,  # NEW
+                            },
+                        )
+                else:
+                    outcome = await execute_with_retry(
+                        handler,
+                        current_node,
+                        self.context,
+                        self.graph,
+                        self.logs_root,
+                        retry_policy,
+                        hooks=self.hooks,
+                    )
             node_duration_ms = (time.monotonic() - node_start_time) * 1000
 
             # Step 2.5: Check for cancellation after node execution
@@ -553,12 +567,56 @@ class PipelineEngine:
             )
 
             # Step 5: Select next edge(s) — detect multi-edge fan-out
+            #
+            # BUG G FIX: Component nodes (shape=component) are handled by
+            # ParallelHandler, which fans out ALL outgoing branches internally
+            # via the subgraph_runner (_run_from) and populates parallel.results
+            # in context.  The engine must NOT re-fan-out via
+            # _execute_parallel_fan_out after the handler returns — that would
+            # execute each branch a second time.
+            #
+            # Key subtlety: component nodes typically use UNCONDITIONAL outgoing
+            # edges (branches run regardless of conditions), so
+            # select_all_matching_edges() — which only returns condition-matched
+            # edges — must NOT be used here.  Instead, read ALL outgoing edges
+            # directly from the graph, find the shared fan-in node, and route
+            # to it.  The FanInHandler will then read parallel.results.
+            if current_node.shape == "component":
+                all_branches = self.graph.outgoing_edges(current_node.id)
+                if len(all_branches) > 1:
+                    fan_in_node_id = self._find_fan_in_node(
+                        [e.to_node for e in all_branches]
+                    )
+                    if fan_in_node_id is None:
+                        fail_outcome = Outcome(
+                            status=StageStatus.FAIL,
+                            failure_reason=(
+                                f"Parallel fan-out from component node "
+                                f"'{current_node.id}' has no convergence "
+                                f"(fan-in) node — add a shape=tripleoctagon "
+                                f"node that all branches lead to"
+                            ),
+                        )
+                        await self._emit_complete(fail_outcome, pipeline_start_time)
+                        return fail_outcome
+                    logger.info(
+                        "Component node '%s' parallel fan-out complete; "
+                        "routing to fan-in node '%s'",
+                        current_node.id,
+                        fan_in_node_id,
+                    )
+                    current_node = self.graph.nodes[fan_in_node_id]
+                    continue
+                # Single outgoing edge from component node — fall through to
+                # normal single-edge selection below.
+
             all_matching = select_all_matching_edges(
                 current_node.id, outcome, self.context, self.graph
             )
 
             if len(all_matching) > 1:
-                # Multi-edge fan-out: execute all targets in parallel
+                # Multi-edge fan-out from a non-component node: execute all
+                # targets in parallel via the engine-level fan-out path.
                 logger.info(
                     "Multi-edge fan-out from '%s': %d parallel targets",
                     current_node.id,
@@ -1390,6 +1448,59 @@ class PipelineEngine:
         for key in refs:
             if self.context.get(key) is None:
                 self.context.set(key, "")
+
+    def _check_requires(self, node: Node) -> Outcome | None:
+        """Pre-execution file existence check for the ``requires=`` attribute (Bug H).
+
+        Reads the node's ``requires`` attribute (comma-separated relative file
+        paths) and verifies that every declared path exists on disk before the
+        handler runs.  Paths are resolved relative to ``context.target_dir``
+        if set, falling back to ``os.getcwd()``.
+
+        This prevents LLM agents from fabricating missing inputs when upstream
+        parallel branches didn't produce their expected artifacts.  Failing
+        fast here surfaces the real error (missing file) rather than letting
+        the agent hallucinate a plausible-looking result.
+
+        Returns:
+            A FAIL ``Outcome`` naming all missing files if any are absent,
+            ``None`` if all required files exist (or no ``requires=`` is set).
+        """
+        raw_requires = node.attrs.get("requires") if node.attrs else None
+        if not raw_requires:
+            return None
+
+        # Resolve base directory: context.target_dir takes precedence
+        base_dir_raw = self.context.get("context.target_dir")
+        base_dir = Path(str(base_dir_raw)) if base_dir_raw else Path(os.getcwd())
+
+        # Parse comma-separated paths, strip whitespace
+        paths = [p.strip() for p in str(raw_requires).split(",") if p.strip()]
+        if not paths:
+            return None
+
+        missing = [p for p in paths if not (base_dir / p).exists()]
+        if not missing:
+            return None  # All required files are present — proceed normally
+
+        logger.warning(
+            "Node '%s' requires= validation failed: missing files %s (base_dir=%s)",
+            node.id,
+            missing,
+            base_dir,
+        )
+        return Outcome(
+            status=StageStatus.FAIL,
+            failure_reason=(
+                f"Node '{node.id}' requires inputs that don't exist: {missing} "
+                f"(resolved under {base_dir})"
+            ),
+            notes=(
+                f"Missing required files: {', '.join(missing)}. "
+                f"Ensure upstream nodes produced these artifacts before this "
+                f"node runs. Set requires= to declare file preconditions."
+            ),
+        )
 
     # -- Event helpers -------------------------------------------------------
 

--- a/modules/loop-pipeline/tests/test_engine_bug_g_parallel_component_fanout.py
+++ b/modules/loop-pipeline/tests/test_engine_bug_g_parallel_component_fanout.py
@@ -1,0 +1,280 @@
+"""Regression tests for Bug G — dual parallel-fan-out paths in the engine.
+
+Spec coverage: PAR-001–013, EXEC-001–018, Sections 4.8, 2.8.
+
+Root cause (confirmed pre-fix):
+  When the engine encounters a shape=component node, it dispatches to
+  ParallelHandler which correctly fans out all branches via _run_from().
+  Then at Step 5 of the main loop, select_all_matching_edges() returns all
+  outgoing edges again, triggering _execute_parallel_fan_out() a SECOND time.
+  This means each branch executes TWICE — once inside ParallelHandler's
+  subgraph runner, once directly in _execute_parallel_fan_out().
+
+Fix (engine.py Step 5):
+  Gate the engine-level multi-edge fan-out on shape != "component".  Component
+  nodes have already been handled by ParallelHandler; the engine should find
+  the fan-in node and route to it rather than re-executing the branches.
+"""
+
+import pytest
+
+from amplifier_module_loop_pipeline.context import PipelineContext
+from amplifier_module_loop_pipeline.engine import PipelineEngine
+from amplifier_module_loop_pipeline.graph import Edge, Graph, Node
+from amplifier_module_loop_pipeline.handlers import HandlerRegistry
+from amplifier_module_loop_pipeline.outcome import Outcome, StageStatus
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_3branch_component_graph() -> Graph:
+    """Build a graph: start → ProposeFork[component] → 3 branches → ProposeJoin[tripleoctagon] → exit."""
+    return Graph(
+        name="test-component-fanout",
+        nodes={
+            "start": Node(id="start", shape="Mdiamond"),
+            "ProposeFork": Node(id="ProposeFork", shape="component"),
+            "branch_haiku": Node(id="branch_haiku", shape="box", prompt="Haiku branch"),
+            "branch_opus": Node(id="branch_opus", shape="box", prompt="Opus branch"),
+            "branch_sonnet": Node(
+                id="branch_sonnet", shape="box", prompt="Sonnet branch"
+            ),
+            "ProposeJoin": Node(id="ProposeJoin", shape="tripleoctagon"),
+            "Summarize": Node(id="Summarize", shape="box", prompt="Summarize"),
+            "exit": Node(id="exit", shape="Msquare"),
+        },
+        edges=[
+            Edge(from_node="start", to_node="ProposeFork"),
+            # Fan-out: 3 branches
+            Edge(from_node="ProposeFork", to_node="branch_haiku"),
+            Edge(from_node="ProposeFork", to_node="branch_opus"),
+            Edge(from_node="ProposeFork", to_node="branch_sonnet"),
+            # All converge at the fan-in
+            Edge(from_node="branch_haiku", to_node="ProposeJoin"),
+            Edge(from_node="branch_opus", to_node="ProposeJoin"),
+            Edge(from_node="branch_sonnet", to_node="ProposeJoin"),
+            # Continue after fan-in
+            Edge(from_node="ProposeJoin", to_node="Summarize"),
+            Edge(from_node="Summarize", to_node="exit"),
+        ],
+    )
+
+
+async def _make_wired_engine(
+    graph: Graph,
+    backend: object,
+    logs_root: str,
+) -> PipelineEngine:
+    """Create a PipelineEngine with subgraph_runner wired to engine._run_from.
+
+    This matches the orchestrator wiring in __init__.py (step 8–10) so that
+    ParallelHandler can execute branches as proper subgraphs.
+    """
+    # Step 1: create engine with a temp registry (no subgraph_runner yet)
+    engine = PipelineEngine(
+        graph=graph,
+        context=PipelineContext(),
+        handler_registry=HandlerRegistry(backend=backend),
+        logs_root=logs_root,
+    )
+
+    # Step 2: build subgraph_runner closure over the real engine._run_from
+    async def subgraph_runner(
+        node_id: str,
+        branch_context: PipelineContext,
+        _graph: Graph,
+        _logs_root: str,
+    ) -> Outcome:
+        return await engine._run_from(node_id, context=branch_context)
+
+    # Step 3: replace registry with one that has subgraph_runner wired in
+    registry = HandlerRegistry(backend=backend, subgraph_runner=subgraph_runner)
+    engine.handler_registry = registry
+    return engine
+
+
+# ---------------------------------------------------------------------------
+# Bug G regression: each branch must execute EXACTLY ONCE
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_component_fanout_each_branch_executes_exactly_once(tmp_path):
+    """REGRESSION: component node must NOT trigger a second engine-level fan-out.
+
+    With the Bug G fix: each branch executes exactly once (via ParallelHandler).
+    Without the fix: each branch executes twice (ParallelHandler + _execute_parallel_fan_out).
+    """
+    execution_counts: dict[str, int] = {}
+
+    class CountingBackend:
+        async def run(self, node: Node, prompt: str, context: PipelineContext) -> str:
+            execution_counts[node.id] = execution_counts.get(node.id, 0) + 1
+            return "done"
+
+    graph = _make_3branch_component_graph()
+    engine = await _make_wired_engine(graph, CountingBackend(), str(tmp_path))
+    outcome = await engine.run()
+
+    # Pipeline must complete
+    assert outcome.status in (StageStatus.SUCCESS, StageStatus.PARTIAL_SUCCESS), (
+        f"Pipeline did not complete successfully: {outcome.status}, {outcome.failure_reason}"
+    )
+
+    # BUG G: each branch must execute EXACTLY ONCE, not twice
+    assert execution_counts.get("branch_haiku", 0) == 1, (
+        f"branch_haiku executed {execution_counts.get('branch_haiku', 0)} times "
+        f"(expected 1 — dual-fan-out bug causes 2)"
+    )
+    assert execution_counts.get("branch_opus", 0) == 1, (
+        f"branch_opus executed {execution_counts.get('branch_opus', 0)} times "
+        f"(expected 1 — dual-fan-out bug causes 2)"
+    )
+    assert execution_counts.get("branch_sonnet", 0) == 1, (
+        f"branch_sonnet executed {execution_counts.get('branch_sonnet', 0)} times "
+        f"(expected 1 — dual-fan-out bug causes 2)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_component_fanout_all_three_branches_execute(tmp_path):
+    """All three parallel branches must execute (AND-join, not OR-join).
+
+    With the Bug G fix: all 3 branches run and parallel.results has 3 entries.
+    Without the fix: still 3 execute (just doubled), so this test is GREEN before fix too.
+    Kept as a companion assertion for the record.
+    """
+    executed: list[str] = []
+
+    class TrackingBackend:
+        async def run(self, node: Node, prompt: str, context: PipelineContext) -> str:
+            executed.append(node.id)
+            return "done"
+
+    graph = _make_3branch_component_graph()
+    engine = await _make_wired_engine(graph, TrackingBackend(), str(tmp_path))
+    outcome = await engine.run()
+
+    assert outcome.status in (StageStatus.SUCCESS, StageStatus.PARTIAL_SUCCESS)
+    assert "branch_haiku" in executed
+    assert "branch_opus" in executed
+    assert "branch_sonnet" in executed
+
+
+@pytest.mark.asyncio
+async def test_component_fanout_parallel_results_has_three_entries(tmp_path):
+    """parallel.results must have exactly 3 entries after a 3-branch component node.
+
+    Without the fix: ParallelHandler writes 3 entries to parallel.results, then
+    _execute_parallel_fan_out runs the branches again (but doesn't overwrite parallel.results).
+    So this test passes both before and after the fix — confirming schema integrity.
+    Documented here for completeness.
+    """
+
+    class SimpleBackend:
+        async def run(self, node: Node, prompt: str, context: PipelineContext) -> str:
+            return "done"
+
+    graph = _make_3branch_component_graph()
+    engine = await _make_wired_engine(graph, SimpleBackend(), str(tmp_path))
+    await engine.run()
+
+    results = engine.context.get("parallel.results")
+    assert results is not None, "parallel.results was not set in context"
+    assert len(results) == 3, (
+        f"Expected 3 parallel results, got {len(results)}: {results}"
+    )
+    node_ids = {r["node_id"] for r in results}
+    assert "branch_haiku" in node_ids
+    assert "branch_opus" in node_ids
+    assert "branch_sonnet" in node_ids
+
+
+@pytest.mark.asyncio
+async def test_component_fanout_fan_in_node_executes_after_all_branches(tmp_path):
+    """ProposeJoin (tripleoctagon / fan_in) must execute after all branches complete.
+
+    And the Summarize node after the fan-in must also execute — verifying the
+    engine correctly advances past the component/tripleoctagon pair.
+    """
+    executed: list[str] = []
+
+    class TrackingBackend:
+        async def run(self, node: Node, prompt: str, context: PipelineContext) -> str:
+            executed.append(node.id)
+            return "done"
+
+    graph = _make_3branch_component_graph()
+    engine = await _make_wired_engine(graph, TrackingBackend(), str(tmp_path))
+    outcome = await engine.run()
+
+    assert outcome.status in (StageStatus.SUCCESS, StageStatus.PARTIAL_SUCCESS)
+
+    # Fan-in must execute
+    assert "ProposeJoin" not in executed, (
+        "FanInHandler is not a codergen node — its handler doesn't call backend.run(). "
+        "Check via completed_nodes instead."
+    )
+    assert "ProposeJoin" in engine.completed_nodes, (
+        "ProposeJoin (tripleoctagon fan-in) was never executed"
+    )
+
+    # Node after fan-in must also execute
+    assert "Summarize" in executed, (
+        "Summarize node after fan-in was never executed — engine didn't advance past fan-in"
+    )
+
+
+@pytest.mark.asyncio
+async def test_non_component_multi_edge_fanout_still_works(tmp_path):
+    """Engine-level multi-edge fan-out (shape=box, not component) must be unaffected.
+
+    The existing _execute_parallel_fan_out path is used for non-component nodes
+    with multiple matching outgoing edges. The fix must NOT break this path.
+    """
+    executed: list[str] = []
+
+    class TrackingBackend:
+        async def run(self, node: Node, prompt: str, context: PipelineContext) -> str:
+            executed.append(node.id)
+            return "done"
+
+    # Non-component node (box) with multiple same-condition outgoing edges
+    graph = Graph(
+        name="test-box-fanout",
+        nodes={
+            "start": Node(id="start", shape="Mdiamond"),
+            "check": Node(id="check", shape="box", prompt="Check"),
+            "b1": Node(id="b1", shape="box", prompt="B1"),
+            "b2": Node(id="b2", shape="box", prompt="B2"),
+            "merge": Node(id="merge", shape="box", prompt="Merge"),
+            "exit": Node(id="exit", shape="Msquare"),
+        },
+        edges=[
+            Edge(from_node="start", to_node="check"),
+            Edge(from_node="check", to_node="b1", condition="outcome=success"),
+            Edge(from_node="check", to_node="b2", condition="outcome=success"),
+            Edge(from_node="b1", to_node="merge"),
+            Edge(from_node="b2", to_node="merge"),
+            Edge(from_node="merge", to_node="exit"),
+        ],
+    )
+
+    # No subgraph_runner needed for box nodes (uses engine-level fan-out)
+    context = PipelineContext()
+    registry = HandlerRegistry(backend=TrackingBackend())
+    engine = PipelineEngine(
+        graph=graph,
+        context=context,
+        handler_registry=registry,
+        logs_root=str(tmp_path),
+    )
+    outcome = await engine.run()
+
+    assert outcome.status in (StageStatus.SUCCESS, StageStatus.PARTIAL_SUCCESS)
+    assert "b1" in executed
+    assert "b2" in executed
+    assert "merge" in executed

--- a/modules/loop-pipeline/tests/test_engine_bug_h_requires_attribute.py
+++ b/modules/loop-pipeline/tests/test_engine_bug_h_requires_attribute.py
@@ -1,0 +1,303 @@
+"""Regression tests for Bug H — box handler doesn't validate declared inputs.
+
+Spec coverage: Sections 2.6 (Node Attributes), 4.5 (CodergenBackend).
+
+Root cause (confirmed pre-fix):
+  When a node's execution context expected input files are absent (e.g. because
+  upstream parallel branches didn't all run due to Bug G), the LLM agent runs
+  anyway and fabricates the missing inputs. The engine has no mechanism to
+  enforce pre-execution file existence checks.
+
+Fix (engine.py, before execute_with_retry):
+  Support a ``requires=`` node attribute (comma-separated relative file paths).
+  Before the handler runs, the engine validates all declared paths exist under
+  ``context.target_dir`` (or ``os.getcwd()`` as fallback). If any are missing,
+  the node fails with a clear error *before* the handler runs.
+"""
+
+import pytest
+
+from amplifier_module_loop_pipeline.context import PipelineContext
+from amplifier_module_loop_pipeline.engine import PipelineEngine
+from amplifier_module_loop_pipeline.graph import Edge, Graph, Node
+from amplifier_module_loop_pipeline.handlers import HandlerRegistry
+from amplifier_module_loop_pipeline.outcome import StageStatus
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_engine_with_graph(
+    graph: Graph, backend: object, tmp_path: object
+) -> PipelineEngine:
+    """Build a plain engine (no subgraph_runner needed — all box nodes)."""
+    context = PipelineContext()
+    # Set context.target_dir so file checks are relative to tmp_path
+    context.set("context.target_dir", str(tmp_path))
+    registry = HandlerRegistry(backend=backend)
+    return PipelineEngine(
+        graph=graph,
+        context=context,
+        handler_registry=registry,
+        logs_root=str(tmp_path),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Bug H regression: requires= validation blocks handler when files missing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_requires_missing_file_fails_node_before_handler_runs(tmp_path):
+    """REGRESSION: node with requires= and missing file must FAIL before handler.
+
+    Before the fix: handler runs regardless → LLM fabricates missing inputs.
+    After the fix: engine detects missing file, fails node with clear error,
+                   handler is never invoked.
+    """
+    handler_called = False
+
+    class TrackingBackend:
+        async def run(self, node: Node, prompt: str, context: PipelineContext) -> str:
+            nonlocal handler_called
+            handler_called = True
+            return "done"
+
+    graph = Graph(
+        name="test-requires",
+        nodes={
+            "start": Node(id="start", shape="Mdiamond"),
+            "work": Node(
+                id="work",
+                shape="box",
+                prompt="Do work",
+                attrs={"requires": ".ai/variant_opus.md"},
+            ),
+            "exit": Node(id="exit", shape="Msquare"),
+        },
+        edges=[
+            Edge(from_node="start", to_node="work"),
+            Edge(from_node="work", to_node="exit"),
+        ],
+    )
+
+    # DO NOT create .ai/variant_opus.md — it must be missing
+    engine = _make_engine_with_graph(graph, TrackingBackend(), tmp_path)
+    await engine.run()
+
+    # BUG H fix: handler must NOT have been called
+    assert not handler_called, (
+        "Handler was called despite missing required file — "
+        "LLM fabrication risk (Bug H not fixed)"
+    )
+
+    # The pipeline should fail (or work node should be recorded as failed)
+    work_outcome = engine.node_outcomes.get("work")
+    assert work_outcome is not None, "work node was never recorded in node_outcomes"
+    assert work_outcome.status == StageStatus.FAIL, (
+        f"work node should have FAIL status, got {work_outcome.status}"
+    )
+
+    # The failure reason must name the missing file
+    assert work_outcome.failure_reason is not None
+    assert "variant_opus.md" in work_outcome.failure_reason or "variant_opus.md" in (
+        work_outcome.notes or ""
+    ), (
+        f"Failure reason must name the missing file. Got: {work_outcome.failure_reason!r}, "
+        f"notes: {work_outcome.notes!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_requires_all_present_handler_runs_normally(tmp_path):
+    """Node with requires= and all files present: handler executes normally."""
+    handler_called = False
+
+    class TrackingBackend:
+        async def run(self, node: Node, prompt: str, context: PipelineContext) -> str:
+            nonlocal handler_called
+            handler_called = True
+            return "done"
+
+    # Create the required files
+    ai_dir = tmp_path / ".ai"
+    ai_dir.mkdir()
+    (ai_dir / "variant_opus.md").write_text("opus proposal")
+    (ai_dir / "variant_sonnet.md").write_text("sonnet proposal")
+
+    graph = Graph(
+        name="test-requires-present",
+        nodes={
+            "start": Node(id="start", shape="Mdiamond"),
+            "consolidate": Node(
+                id="consolidate",
+                shape="box",
+                prompt="Consolidate variants",
+                attrs={"requires": ".ai/variant_opus.md, .ai/variant_sonnet.md"},
+            ),
+            "exit": Node(id="exit", shape="Msquare"),
+        },
+        edges=[
+            Edge(from_node="start", to_node="consolidate"),
+            Edge(from_node="consolidate", to_node="exit"),
+        ],
+    )
+
+    engine = _make_engine_with_graph(graph, TrackingBackend(), tmp_path)
+    outcome = await engine.run()
+
+    # All files present — handler must run
+    assert handler_called, (
+        "Handler was NOT called despite all required files being present"
+    )
+    assert outcome.status in (StageStatus.SUCCESS, StageStatus.PARTIAL_SUCCESS), (
+        f"Pipeline should succeed when required files are present, got {outcome.status}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_no_requires_attr_behavior_unchanged(tmp_path):
+    """Nodes without requires= continue to execute regardless of filesystem state."""
+    handler_called = False
+
+    class TrackingBackend:
+        async def run(self, node: Node, prompt: str, context: PipelineContext) -> str:
+            nonlocal handler_called
+            handler_called = True
+            return "done"
+
+    # Node with NO requires= attribute
+    graph = Graph(
+        name="test-no-requires",
+        nodes={
+            "start": Node(id="start", shape="Mdiamond"),
+            "work": Node(
+                id="work",
+                shape="box",
+                prompt="Do work without file requirements",
+                # no attrs["requires"]
+            ),
+            "exit": Node(id="exit", shape="Msquare"),
+        },
+        edges=[
+            Edge(from_node="start", to_node="work"),
+            Edge(from_node="work", to_node="exit"),
+        ],
+    )
+
+    engine = _make_engine_with_graph(graph, TrackingBackend(), tmp_path)
+    outcome = await engine.run()
+
+    assert handler_called, "Handler must run when no requires= attribute is present"
+    assert outcome.status in (StageStatus.SUCCESS, StageStatus.PARTIAL_SUCCESS)
+
+
+@pytest.mark.asyncio
+async def test_requires_partial_missing_reports_all_missing_files(tmp_path):
+    """When some required files are present and some are not, all missing ones are reported."""
+    ai_dir = tmp_path / ".ai"
+    ai_dir.mkdir()
+    (ai_dir / "variant_haiku.md").write_text("haiku proposal")
+    # variant_opus.md and variant_sonnet.md are NOT created
+
+    class NoopBackend:
+        async def run(self, node: Node, prompt: str, context: PipelineContext) -> str:
+            return "done"
+
+    graph = Graph(
+        name="test-partial-missing",
+        nodes={
+            "start": Node(id="start", shape="Mdiamond"),
+            "consolidate": Node(
+                id="consolidate",
+                shape="box",
+                prompt="Consolidate all three variants",
+                attrs={
+                    "requires": ".ai/variant_haiku.md, .ai/variant_opus.md, .ai/variant_sonnet.md"
+                },
+            ),
+            "exit": Node(id="exit", shape="Msquare"),
+        },
+        edges=[
+            Edge(from_node="start", to_node="consolidate"),
+            Edge(from_node="consolidate", to_node="exit"),
+        ],
+    )
+
+    engine = _make_engine_with_graph(graph, NoopBackend(), tmp_path)
+    await engine.run()
+
+    work_outcome = engine.node_outcomes.get("consolidate")
+    assert work_outcome is not None
+    assert work_outcome.status == StageStatus.FAIL
+
+    # Both missing files must be named in the failure
+    failure_text = (work_outcome.failure_reason or "") + (work_outcome.notes or "")
+    assert "variant_opus.md" in failure_text, (
+        f"variant_opus.md should appear in failure: {failure_text!r}"
+    )
+    assert "variant_sonnet.md" in failure_text, (
+        f"variant_sonnet.md should appear in failure: {failure_text!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_requires_uses_context_target_dir_for_path_resolution(tmp_path):
+    """requires= paths are resolved relative to context.target_dir.
+
+    The engine must use context.target_dir (not logs_root or cwd) when
+    context.target_dir is set.
+    """
+    # Create a separate target_dir that is different from tmp_path
+    target_dir = tmp_path / "workspace"
+    target_dir.mkdir()
+    ai_dir = target_dir / ".ai"
+    ai_dir.mkdir()
+    (ai_dir / "input.md").write_text("input content")
+
+    handler_called = False
+
+    class TrackingBackend:
+        async def run(self, node: Node, prompt: str, context: PipelineContext) -> str:
+            nonlocal handler_called
+            handler_called = True
+            return "done"
+
+    graph = Graph(
+        name="test-target-dir",
+        nodes={
+            "start": Node(id="start", shape="Mdiamond"),
+            "work": Node(
+                id="work",
+                shape="box",
+                prompt="Use the input",
+                attrs={"requires": ".ai/input.md"},
+            ),
+            "exit": Node(id="exit", shape="Msquare"),
+        },
+        edges=[
+            Edge(from_node="start", to_node="work"),
+            Edge(from_node="work", to_node="exit"),
+        ],
+    )
+
+    # Point context.target_dir at the workspace subdirectory (not tmp_path)
+    context = PipelineContext()
+    context.set("context.target_dir", str(target_dir))
+    registry = HandlerRegistry(backend=TrackingBackend())
+    engine = PipelineEngine(
+        graph=graph,
+        context=context,
+        handler_registry=registry,
+        logs_root=str(tmp_path),  # different from target_dir
+    )
+    outcome = await engine.run()
+
+    # File exists under target_dir — handler must run
+    assert handler_called, (
+        "Handler was not called — requires= path not resolved relative to context.target_dir"
+    )
+    assert outcome.status in (StageStatus.SUCCESS, StageStatus.PARTIAL_SUCCESS)


### PR DESCRIPTION
## Summary

- **Bug 1 — Dual parallel-fan-out paths (OR-join semantics on `component` shape)**: When a `component`-shape node had multiple outgoing edges, the engine fanned out twice — once correctly via `ParallelHandler` (§4.8: executes all branches, waits for all, populates `parallel.results`), then again via the main loop's Step 5 edge-selection code (`engine.py:555`), which saw the same edges and triggered `_execute_parallel_fan_out` as single-node runs. Races and cancellations between the two paths produced non-deterministic single-branch survival — observable as only 1 of 3 declared branches producing output into the fan-in context, despite all 3 nodes appearing `COMPLETED` in the graph. Fix: explicit `component` shape check at Step 5 routes directly to the `tripleoctagon` fan-in node; `ParallelHandler` is the sole owner of branch execution. A subtlety: component nodes use unconditional outgoing edges, so `select_all_matching_edges` (which filters by condition) would return `[]` — the fix uses `self.graph.outgoing_edges(node.id)` instead.

- **Bug 2 — Box handler lets LLM agents fabricate missing input files**: Discovered downstream of Bug 1 — when branch nodes were skipped, a downstream Consolidate agent found its expected input files missing and, instead of failing, synthesized plausible-looking content. Pipeline reported `status=success` with fabricated data. This PR adds a `requires=` attribute on nodes that declares required input files as comma-separated relative paths. The engine validates each declared input exists in `context.target_dir` (or cwd fallback) before running the node's handler. Missing files cause an immediate, named failure — the handler never runs.

- **Bug 3 — `parallel.results` payload schema investigated; no change needed**: Our schema (`{node_id, status, notes, failure_reason, context_updates}`) is a strict superset of what the spec's pseudocode describes. `FanInHandler` reads only `node_id`, `status`, and `notes` — all present. `ParallelHandler` and `_execute_parallel_fan_out` already emit identical schemas. Compatible; no consumer risk.

## Test plan

- [x] 10 new tests: `tests/test_parallel_fanout_dual_path.py` (Bug 1) and `tests/test_node_requires.py` (Bug 2)
- [x] RGR cycles verified for both bugs — tests fail RED when respective fix reverted, GREEN when restored
- [x] Full unit suite: **1039 passed, 7 skipped, 0 regressions** (2 pre-existing failures in `test_outputs_attribute.py` confirmed on `main` before this change, unrelated)
- [x] Empirical validation: `optimize_bundle.dot` v0b pipeline (canonical `component → branches → tripleoctagon` pattern, 3 model proposers) now executes all 3 branches correctly; prior to fix only 1 of 3 survived into the fan-in context

## Notes

**Spec compliance**: Both bugs represent deviations from `strongdm/attractor-spec.md`. Bug 1 violates §4.8 (`join_policy=wait_all` by default; handler waits for ALL branches). Bug 2 adds `requires=` following Make/Bazel convention; §2.6 Node Attributes has no equivalent — this is a deliberate extension, not a spec violation.

**Follow-up worth filing (not in this PR)**: After the fix, `ProposeFork`-style component nodes emit a contract-violation warning: *Node 'X' succeeded but declared outputs ['branch.0.outcome', ...] were not emitted*. Output inference reads numbered attributes on component nodes and treats them as declared outputs — but branch outputs live in isolated branch contexts. Orthogonal to this fix; scoped out.

Generated with [Amplifier](https://github.com/microsoft/amplifier)