### PR TITLE
docs+test-name(awareness): apply REPOSITORY_RULES.md layering — bundle references only declared dependencies

### DIFF
--- a/.amplifier/settings.yaml
+++ b/.amplifier/settings.yaml
@@ -11,5 +11,4 @@ bundle:
     - git+https://github.com/microsoft/amplifier-bundle-webllm@main#subdirectory=behaviors/webllm.yaml
     - git+https://github.com/microsoft/amplifier-bundle-containers@main#subdirectory=behaviors/containers.yaml
     - git+https://github.com/microsoft/amplifier-bundle-rust-dev@main#subdirectory=behaviors/rust-dev.yaml
-    - git+https://github.com/microsoft/amplifier-bundle-browser-tester@main#subdirectory=behaviors/browser.yaml
     - git+https://github.com/microsoft/amplifier-bundle-execution-environments@main#subdirectory=behaviors/env-all.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build/
 uv.lock
 .ruff_cache/
 .pytest_cache/
+/.amplifier/settings.local.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ Run these before opening a PR. The reviewer expects evidence in the PR body, not
 
 - **Unit tests**: `pytest modules/loop-pipeline/` (full suite).
 - **Targeted unit tests**: `pytest modules/loop-pipeline/tests/test_<specific>.py -v` while iterating.
-- **Live pipeline run** (required when touching `engine.py` or any handler): construct or pick a graph that exercises the changed code path and run it through the dot-graph resolver. A representative pipeline from `examples/pipelines/` is acceptable when it covers the path; otherwise build a minimal graph that does. Capture the resulting `events.jsonl` and include the relevant slice in the PR.
+- **Live pipeline run** (required when touching `engine.py` or any handler): construct or pick a graph that exercises the changed code path and run it through any attractor-compatible resolver. A representative pipeline from `examples/pipelines/` is acceptable when it covers the path; otherwise build a minimal graph that does. Capture the resulting `events.jsonl` and include the relevant slice in the PR.
 
 ## Verification gradient
 
@@ -41,6 +41,21 @@ Unit tests alone are insufficient for engine and handler changes. Past bugs have
 ## Spec authority
 
 When behavior is ambiguous, the canonical spec at `github.com/strongdm/attractor` is authoritative. Our implementation extends but does not contradict the spec. If you find yourself "fixing" something that is spec-conformant, stop and check `specs/` first.
+
+## Dependency awareness rule
+
+Attractor depends on `amplifier-core`, its own internal modules, and the strongdm/attractor nlspec (spec-only, no code import). Per
+[REPOSITORY_RULES.md](https://github.com/microsoft/amplifier-foundation/blob/main/docs/REPOSITORY_RULES.md):
+do not introduce references to other repositories in code, comments, docs, or test names. This
+includes resolvers, orchestration platforms, application bundles, or any downstream consumer.
+
+Exception: `amplifier-bundle-recipes` may be cited as historical inspiration — attractor is a
+follow-up to that recipe-bundle work, and specific recipe patterns are a legitimate prior-art
+reference.
+
+If you need to describe *where* to run a pipeline, say "any attractor-compatible resolver" or
+"any Amplifier session with the loop-pipeline module loaded" — not the name of a specific
+downstream resolver.
 
 ## PR checklist
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,25 @@
 Multi-stage AI pipelines for code. Plan, implement, test, review — orchestrated as
 directed graphs.
 
+## Upstream Attribution and Layering
+
+This bundle implements the **attractor nlspec** defined at
+[github.com/strongdm/attractor](https://github.com/strongdm/attractor). Community
+`.dot` files written against the canonical spec should work without modification.
+
+We extend the spec selectively where high-value additions warrant it. Every extension is
+backward-compatible and documented in [`specs/EXTENSIONS.md`](specs/EXTENSIONS.md).
+If you find behavior that diverges from the canonical spec without an entry in that file,
+treat it as a bug.
+
+**Dependency awareness.** Per the Amplifier ecosystem
+[REPOSITORY_RULES.md](https://github.com/microsoft/amplifier-foundation/blob/main/docs/REPOSITORY_RULES.md):
+this bundle's declared code dependencies are `amplifier-core` and its own internal modules.
+It does not reference downstream consumers (resolvers, orchestration platforms, or
+application bundles). The one documented lineage exception is `amplifier-bundle-recipes`:
+attractor is a follow-up to that recipe-bundle work, and specific recipe patterns may be
+cited as prior-art inspiration where useful.
+
 ## Documentation
 
 | Guide | Description |

--- a/docs/designs/r12-node-failure-propagation.md
+++ b/docs/designs/r12-node-failure-propagation.md
@@ -204,8 +204,8 @@ These are implementation choices, not contract changes. The seven acceptance ass
 
 ## Awareness Compliance Check
 
-- ✅ No mention of DTU, LaunchDTU, TeardownDTU, resolve_validated, dotpowers, exercise, reality_check, orchestrator, semport, smoke_test, or any other specific pipeline.
-- ✅ No imports from `amplifier-resolve`, `amplifier-resolver-*`, `amplifier-bundle-resolve`, or any non-foundation bundle.
+- ✅ No mention of specific downstream pipelines or DTU concepts; the engine is consumer-agnostic per the REPOSITORY_RULES.md layering principle.
+- ✅ No imports from downstream consumers. The engine depends only on amplifier-core, internal modules, and (spec-only, no code import) strongdm/attractor.
 - ✅ The vocabulary used — *outputs*, *references*, *skip*, *runs_on* — is generic to any pipeline graph. Examples are placeholder names (`work`, `cleanup`, `launch`, `verify`).
 - ✅ Mechanisms are taught to *all* pipeline authors equally; no pipeline gets privileged status.
 - ✅ The engine remains pure mechanism; pipelines remain pure policy.

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/dot_parser.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/dot_parser.py
@@ -565,8 +565,8 @@ def _parse_value(raw: str) -> Any:
         # Process escape sequences.
         #
         # ORDER MATTERS. ``\\`` -> ``\`` MUST run first; otherwise an input of
-        # ``\\n`` (two literal backslashes followed by n, used by reality_check
-        # and semport pipelines as a logical line separator) is mis-processed:
+        # ``\\n`` (two literal backslashes followed by n — a common escape
+        # pattern in multi-line shell heredoc command attributes) is mis-processed:
         # ``\n`` -> LF runs first, leaving ``\<LF>`` (backslash + real newline,
         # which dash interprets as a line continuation) and the trailing
         # ``\\`` -> ``\`` step finds nothing to replace.

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py
@@ -1317,7 +1317,7 @@ class PipelineEngine:
                         # is the *absence* of a failure (the happy path ran
                         # clean). Emitting "predecessor_failed" when no
                         # predecessor failed produces false-positive hits for
-                        # dashboard filters and reality-check queries on
+                        # downstream observability filters and queries on
                         # failure_mode=predecessor_failed.
                         "failure_mode": None,
                         "failure_mode_taxonomy_version": 1,

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/tool.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/tool.py
@@ -113,7 +113,7 @@ class ToolHandler:
         # back to graph.source_dir (the DOT file's directory), then None.
         # Without this, tool_command scripts that grep/read files created in
         # the project directory fail when graph.source_dir is None (built-in
-        # pipelines loaded via the resolver) because the subprocess defaults
+        # pipelines loaded by the consuming resolver) because the subprocess defaults
         # to /workspace/ instead of /workspace/project/.
         cwd: str | None = context.get("context.target_dir") or graph.source_dir or None
 

--- a/modules/loop-pipeline/tests/test_dot_parser.py
+++ b/modules/loop-pipeline/tests/test_dot_parser.py
@@ -513,14 +513,14 @@ def test_single_attr_no_warning():
     assert len(comma_warnings) == 0
 
 
-# --- Escape sequence regression tests (added for reality_check shell crash) ---
+# --- Escape sequence regression tests (added for multi-line shell heredoc crash) ---
 # Background: chained str.replace() in _parse_value was order-dependent. The bug
 # was that ``\n`` -> LF ran before ``\\`` -> ``\``, so an input of ``\\n`` (two
-# literal backslashes followed by n, used by reality_check and semport
-# pipelines as a logical line separator) was mis-processed into ``\<LF>`` —
-# dash interprets that as line-continuation, joining script lines. The
-# resulting joined line broke heredoc structure in the reality_check
-# RenderVerdict node, causing 100% pipeline failure with
+# literal backslashes followed by n — a common escape pattern in multi-line shell
+# heredoc command attributes — used as a logical line separator) was mis-processed
+# into ``\<LF>`` — dash interprets that as line-continuation, joining script lines.
+# The resulting joined line broke heredoc structure in any tool_command node that
+# used Python heredoc syntax, causing pipeline failure with
 # ``/bin/sh: Syntax error: "(" unexpected``.
 #
 # Fix: reorder the chain so ``\\`` -> ``\`` runs FIRST, before any
@@ -531,8 +531,8 @@ def test_single_attr_no_warning():
 def test_escape_double_backslash_n_yields_newline():
     """REGRESSION: ``\\\\n`` in DOT source must yield a real newline (LF).
 
-    This is the existing semantics expected by reality_check, semport, and
-    smoke_test pipelines that use ``\\\\n`` as a logical line separator.
+    Pipelines that use ``\\\\n`` as a logical line separator in multi-line
+    shell heredoc tool_command attributes depend on this behavior.
     """
     graph = parse_dot('digraph t { n [label="line1\\\\nline2"] }')
     assert graph.nodes["n"].label == "line1\nline2"
@@ -565,11 +565,11 @@ def test_escape_quadruple_backslash_yields_pair():
     assert graph.nodes["n"].label == "\\\\"
 
 
-def test_escape_multiline_shell_script_preserves_structure():
-    """Full reality_check-style tool_command must produce valid multi-line shell.
+def test_escape_multiline_shell_heredoc_tool_command_preserves_structure():
+    """Multi-line shell heredoc tool_command must produce valid multi-line shell.
 
     Before the fix: ``\\\\n`` between script lines became ``\<LF>`` (line
-    continuation), joining lines into one big logical line and breaking the
+    continuation), joining lines into one big logical line and breaking any
     `python3 - << 'PYEOF'` heredoc. Result: dash parsed Python source as shell
     code and crashed on the first ``(``.
     """

--- a/modules/loop-pipeline/tests/test_runs_on_axis.py
+++ b/modules/loop-pipeline/tests/test_runs_on_axis.py
@@ -276,7 +276,7 @@ async def test_runs_on_failure_skipped_event_has_no_failure_mode(tmp_path):
 
     When no predecessor failed the skip is the *absence* of failure.
     Emitting failure_mode='predecessor_failed' produces false-positive hits in
-    dashboard filters and reality-check queries on that field.
+    downstream observability filters and queries on that field.
     """
     hooks = EventCapture()
     engine = _make_engine(

--- a/specs/EXTENSIONS.md
+++ b/specs/EXTENSIONS.md
@@ -1,0 +1,134 @@
+# Attractor Extensions
+
+Documented divergences and additions relative to the canonical attractor nlspec at
+[github.com/strongdm/attractor](https://github.com/strongdm/attractor). The current
+canonical snapshot lives at `specs/canonical/attractor-spec-canonical.md`.
+
+**All extensions are backward-compatible with the canonical spec — community `.dot` files
+written against the canonical spec should continue to work without modification.**
+
+When in doubt about whether a behavior is spec-conformant, consult the canonical snapshot
+before assuming it is a bug.
+
+---
+
+## 1. BareValue Grammar Production
+
+**What:** The value grammar accepts unquoted bare identifiers in addition to quoted strings.
+Examples: `shape=box`, `rankdir=LR`, `node_type=llm`. The grammar production is:
+
+```
+BareValue ::= [A-Za-z_][A-Za-z0-9_.:-]*
+```
+
+**Why:** Graphviz DOT source uses bare identifiers pervasively for built-in shape and
+direction attributes. Requiring quotes everywhere would break existing community `.dot`
+files. This is an additive clarification of what Graphviz already accepts; it is not a
+departure from spec intent.
+
+**Compatibility:** Fully backward-compatible. Quoted values continue to work unchanged.
+
+---
+
+## 2. `default_max_retries` (with Legacy Alias `default_max_retry`)
+
+**What:** The graph-level retry ceiling attribute is `default_max_retries` (plural). The
+singular `default_max_retry` is accepted as a legacy alias and maps to the same behavior.
+Default value is `0` (no retries unless explicitly configured).
+
+**Why:** The plural form is grammatically clearer ("the number of retries" rather than "the
+maximum retry"). The legacy alias ensures any existing `.dot` files using the original
+singular name continue to work without modification.
+
+**Compatibility:** Both names are valid. Prefer `default_max_retries` in new pipelines.
+
+---
+
+## 3. `max_retries` Node Attribute Inherits Graph-Level Default
+
+**What:** When a node omits the `max_retries` attribute, it inherits the graph's
+`default_max_retries` value rather than defaulting to `0` independently. This allows a
+single graph-level setting to establish a retry policy for all nodes simultaneously.
+
+**Why:** Without inheritance, authors must repeat `max_retries=N` on every node that
+should participate in a retry policy. The inheritance behavior is the natural complement to
+`default_max_retries` existing at all: a graph-level default that nothing inherits would
+serve no purpose.
+
+**Compatibility:** Only observable in pipelines that set `default_max_retries` at the
+graph level. Pipelines that do not set it see no change (effective retries remain 0).
+
+---
+
+## 4. `goal_gate` Accepts `PARTIAL_SUCCESS`
+
+**What:** A node marked `goal_gate=true` is considered satisfied by either `SUCCESS` or
+`PARTIAL_SUCCESS` outcome status. It is NOT satisfied by `FAIL`, `SKIP`, or other
+statuses, and the pipeline exits with an unsatisfied-goal error if the node does not
+reach at least `PARTIAL_SUCCESS`.
+
+**Why:** Rigid `SUCCESS`-only gate semantics are too coarse for pipelines that implement
+best-effort or iterative workflows — for example, a test-generation node that passes most
+cases but flags a few as needing human review. Accepting `PARTIAL_SUCCESS` preserves the
+gate intent (the node ran and made meaningful progress) while not blocking pipelines that
+legitimately reach a partial outcome.
+
+**Compatibility:** Existing `goal_gate=true` nodes that return `SUCCESS` are unaffected.
+Nodes that return `PARTIAL_SUCCESS` now satisfy the gate where they previously would have
+caused a pipeline failure.
+
+---
+
+## 5. Explicit TRANSFORM Phase in Execution Lifecycle
+
+**What:** The execution lifecycle includes six phases rather than five:
+
+```
+PARSE -> TRANSFORM -> VALIDATE -> INITIALIZE -> EXECUTE -> FINALIZE
+```
+
+The TRANSFORM phase applies parse-time transforms (stylesheet resolution, variable
+expansion, and custom AST transforms) before validation runs.
+
+**Why:** Placing transforms before validation ensures that validation sees the final,
+expanded graph — not the template form with unexpanded variables or unresolved stylesheets.
+This prevents spurious validation failures on legal pipeline patterns that are valid only
+after expansion.
+
+**Compatibility:** Pipeline authors who consume the execution lifecycle events or hook into
+the lifecycle will see a new `TRANSFORM` phase event before `VALIDATE`. Pipelines that do
+not hook into lifecycle events are unaffected.
+
+---
+
+## 6. Error Semantics: `RETURN Outcome(status=FAIL)` vs `RAISE`
+
+**What:** Handler error paths use `RETURN Outcome(status=FAIL, ...)` rather than raising
+exceptions. Unhandled exceptions in handler code are caught and wrapped into a `FAIL`
+outcome with the exception message in `notes`.
+
+**Why:** Exception propagation from a handler would terminate the entire pipeline rather
+than routing through the graph's conditional edges. Returning a `FAIL` outcome preserves
+the pipeline's ability to dispatch to a failure branch (e.g., a `condition="outcome=fail"`
+edge to a recovery node or human gate). This is the behavior authors expect: a failed node
+should trigger failure-path routing, not crash the pipeline.
+
+**Compatibility:** This is an implementation detail of the engine. Pipeline authors observe
+`FAIL` outcomes on handler errors regardless of whether the internal mechanism uses
+exceptions or return values. Existing pipelines are unaffected.
+
+---
+
+## 7. `type` vs `node_type` Internal Naming
+
+**What:** The externally visible DOT attribute name for the node handler type is `type`.
+The engine may use an internal field named `node_type` to avoid reserved-word conflicts in
+Python (where `type` is a built-in). Both names refer to the same concept; the external
+behavior is identical.
+
+**Why:** Python's `type` built-in creates naming conflicts in dataclasses and attribute
+access. Using `node_type` internally avoids shadowing the built-in. The DOT attribute name
+`type` remains canonical and externally visible.
+
+**Compatibility:** Pipeline authors use `type=llm`, `type=parallel`, etc. in DOT source.
+The internal renaming is invisible at the DOT level.

--- a/specs/canonical/attractor-spec-canonical.md
+++ b/specs/canonical/attractor-spec-canonical.md
@@ -96,13 +96,14 @@ Attr            ::= Key '=' Value
 Key             ::= Identifier | QualifiedId
 QualifiedId     ::= Identifier ( '.' Identifier )+
 
-Value           ::= String | Integer | Float | Boolean | Duration
+Value           ::= String | Integer | Float | Boolean | Duration | BareValue
 Identifier      ::= [A-Za-z_][A-Za-z0-9_]*
 String          ::= '"' ( '\\"' | '\\n' | '\\t' | '\\\\' | [^"\\] )* '"'
 Integer         ::= '-'? [0-9]+
 Float           ::= '-'? [0-9]* '.' [0-9]+
 Boolean         ::= 'true' | 'false'
 Duration        ::= Integer ( 'ms' | 's' | 'm' | 'h' | 'd' )
+BareValue       ::= [A-Za-z_][A-Za-z0-9_.:-]*
 
 Direction       ::= 'TB' | 'LR' | 'BT' | 'RL'
 ```
@@ -135,10 +136,10 @@ Graph attributes are declared in a `graph [ ... ]` block or as top-level `key = 
 | `goal`                    | String   | `""`      | Human-readable goal for the pipeline. Exposed as `$goal` in prompt templates and mirrored into the run context as `graph.goal`. |
 | `label`                   | String   | `""`      | Display name for the graph (used in visualization). |
 | `model_stylesheet`        | String   | `""`      | CSS-like stylesheet for per-node LLM model/provider defaults. See Section 8. |
-| `default_max_retry`       | Integer  | `50`      | Global retry ceiling for nodes that omit `max_retries`. |
+| `default_max_retries`     | Integer  | `0`       | Default additional retries for nodes that omit `max_retries`. Legacy alias: `default_max_retry`. |
 | `retry_target`            | String   | `""`      | Node ID to jump to if exit is reached with unsatisfied goal gates. |
 | `fallback_retry_target`   | String   | `""`      | Secondary jump target if `retry_target` is missing or invalid. |
-| `default_fidelity`        | String   | `""`      | Default context fidelity mode (see Section 5.4). |
+| `default_fidelity`        | String   | `""`      | Default context fidelity mode when explicitly set. Empty string means "unset"; the runtime fallback is `compact` (see Section 5.4). |
 
 ### 2.6 Node Attributes
 
@@ -148,8 +149,8 @@ Graph attributes are declared in a `graph [ ... ]` block or as top-level `key = 
 | `shape`             | String   | `"box"`         | Graphviz shape. Determines the default handler type (see mapping table below). |
 | `type`              | String   | `""`            | Explicit handler type override. Takes precedence over shape-based resolution. |
 | `prompt`            | String   | `""`            | Primary instruction for the stage. Supports `$goal` variable expansion. Falls back to `label` if empty for LLM stages. |
-| `max_retries`       | Integer  | `0`             | Number of additional attempts beyond the initial execution. `max_retries=3` means up to 4 total executions. |
-| `goal_gate`         | Boolean  | `false`         | If `true`, this node must reach SUCCESS before the pipeline can exit. |
+| `max_retries`       | Integer  | inherited       | Number of additional attempts beyond the initial execution. If omitted, inherits graph `default_max_retries`. `max_retries=3` means up to 4 total executions. |
+| `goal_gate`         | Boolean  | `false`         | If `true`, this node must reach `SUCCESS` or `PARTIAL_SUCCESS` before the pipeline can exit. |
 | `retry_target`      | String   | `""`            | Node ID to jump to if this node fails and retries are exhausted. |
 | `fallback_retry_target` | String | `""`          | Secondary retry target. |
 | `fidelity`          | String   | inherited       | Context fidelity mode for this node's LLM session. See Section 5.4. |
@@ -161,6 +162,8 @@ Graph attributes are declared in a `graph [ ... ]` block or as top-level `key = 
 | `reasoning_effort`  | String   | `"high"`        | LLM reasoning effort: `low`, `medium`, `high`. |
 | `auto_status`       | Boolean  | `false`         | If `true` and the handler writes no status, the engine auto-generates a SUCCESS outcome. |
 | `allow_partial`     | Boolean  | `false`         | Accept PARTIAL_SUCCESS when retries are exhausted instead of failing. |
+
+The external DOT attribute name is `type`. Implementations may use an internal field name such as `node_type` to avoid reserved-word conflicts, but the externally visible behavior must remain identical.
 
 ### 2.7 Edge Attributes
 
@@ -180,7 +183,7 @@ The `shape` attribute on a node determines which handler executes it, unless ove
 | Shape             | Handler Type          | Description |
 |-------------------|-----------------------|-------------|
 | `Mdiamond`        | `start`               | Pipeline entry point. No-op handler. Every graph must have exactly one. |
-| `Msquare`         | `exit`                | Pipeline exit point. No-op handler. Every graph must have exactly one. |
+| `Msquare`         | `exit`                | Pipeline exit point. No-op handler. Goal gate enforcement is handled by the execution engine (Section 3.4). Every graph must have exactly one. |
 | `box`             | `codergen`            | LLM task (code generation, analysis, planning). The default for all nodes without an explicit shape. |
 | `hexagon`         | `wait.human`          | Human-in-the-loop gate. Blocks until a human selects an option. |
 | `diamond`         | `conditional`         | Conditional routing point. Routes based on edge conditions against current context. |
@@ -316,17 +319,18 @@ digraph Review {
 
 ### 3.1 Run Lifecycle
 
-The execution lifecycle proceeds through five phases:
+The execution lifecycle proceeds through six phases:
 
 ```
-PARSE -> VALIDATE -> INITIALIZE -> EXECUTE -> FINALIZE
+PARSE -> TRANSFORM -> VALIDATE -> INITIALIZE -> EXECUTE -> FINALIZE
 ```
 
 1. **Parse:** Read the `.dot` source and produce an in-memory Graph model (nodes, edges, attributes).
-2. **Validate:** Run lint rules (Section 7). Reject invalid graphs. Warn on suspicious patterns.
-3. **Initialize:** Create the run directory, initial context, and checkpoint. Mirror graph attributes into the context. Apply transforms (stylesheet, variable expansion).
-4. **Execute:** Traverse the graph from the start node, executing handlers and selecting edges.
-5. **Finalize:** Write the final checkpoint, emit completion events, and clean up resources (close sessions, release files).
+2. **Transform:** Apply parse-time transforms (stylesheet, variable expansion, and custom AST transforms).
+3. **Validate:** Run lint rules (Section 7). Reject invalid graphs. Warn on suspicious patterns.
+4. **Initialize:** Create the run directory, initial context, and checkpoint. Mirror graph attributes into the context.
+5. **Execute:** Traverse the graph from the start node, executing handlers and selecting edges.
+6. **Finalize:** Write the final checkpoint, emit completion events, and clean up resources (close sessions, release files).
 
 ### 3.2 Core Execution Loop
 
@@ -356,8 +360,11 @@ FUNCTION run(graph, config):
                     current_node = graph.nodes[retry_target]
                     CONTINUE
                 ELSE:
-                    RAISE "Goal gate unsatisfied and no retry target"
-            BREAK  -- Exit the loop; pipeline complete
+                    RETURN Outcome(
+                        status=FAIL,
+                        failure_reason="Goal gate unsatisfied and no retry target"
+                    )
+            RETURN Outcome(status=SUCCESS, notes="Pipeline completed")
 
         -- Step 2: Execute node handler with retry policy
         retry_policy = build_retry_policy(node, graph)
@@ -382,8 +389,8 @@ FUNCTION run(graph, config):
         next_edge = select_edge(node, outcome, context, graph)
         IF next_edge is NONE:
             IF outcome.status == FAIL:
-                RAISE "Stage failed with no outgoing fail edge"
-            BREAK
+                RETURN outcome
+            RETURN Outcome(status=SUCCESS, notes="Pipeline completed")
 
         -- Step 7: Handle loop_restart
         IF next_edge has loop_restart=true:
@@ -393,7 +400,7 @@ FUNCTION run(graph, config):
         -- Step 8: Advance to next node
         current_node = graph.nodes[next_edge.to_node]
 
-    RETURN last_outcome
+    RETURN Outcome(status=SUCCESS, notes="Pipeline completed")
 ```
 
 ### 3.3 Edge Selection Algorithm
@@ -402,9 +409,9 @@ After a node completes, the engine selects the next edge from the node's outgoin
 
 **Step 1: Condition-matching edges.** Evaluate each edge's `condition` expression (see Section 10) against the current context and outcome. Edges whose condition evaluates to `true` are eligible. Edges with no condition are not considered in this step; they proceed to later steps.
 
-**Step 2: Preferred label match.** If the node's outcome includes a `preferred_label`, find the first eligible edge (condition-passing or unconditional) whose `label` matches after normalization. Label normalization: lowercase, trim whitespace, strip accelerator prefixes (patterns like `[Y] `, `Y) `, `Y - `).
+**Step 2: Preferred label match.** If no condition-matching edges were found and the node's outcome includes a `preferred_label`, find the first unconditional edge whose `label` matches after normalization. Label normalization: lowercase, trim whitespace, strip accelerator prefixes (patterns like `[Y] `, `Y) `, `Y - `).
 
-**Step 3: Suggested next IDs.** If no label match and the outcome includes `suggested_next_ids`, find the first eligible edge whose target node ID appears in the list.
+**Step 3: Suggested next IDs.** If no label match and the outcome includes `suggested_next_ids`, find the first unconditional edge whose target node ID appears in the list.
 
 **Step 4: Highest weight.** Among remaining eligible unconditional edges, choose the one with the highest `weight` attribute (default 0).
 
@@ -428,14 +435,14 @@ FUNCTION select_edge(node, outcome, context, graph):
     -- Step 2: Preferred label
     IF outcome.preferred_label is not empty:
         FOR EACH edge IN edges:
-            IF normalize_label(edge.label) == normalize_label(outcome.preferred_label):
+            IF edge.condition is empty AND normalize_label(edge.label) == normalize_label(outcome.preferred_label):
                 RETURN edge
 
     -- Step 3: Suggested next IDs
     IF outcome.suggested_next_ids is not empty:
         FOR EACH suggested_id IN outcome.suggested_next_ids:
             FOR EACH edge IN edges:
-                IF edge.to_node == suggested_id:
+                IF edge.condition is empty AND edge.to_node == suggested_id:
                     RETURN edge
 
     -- Step 4 & 5: Weight with lexical tiebreak (unconditional edges only)
@@ -443,8 +450,7 @@ FUNCTION select_edge(node, outcome, context, graph):
     IF unconditional is not empty:
         RETURN best_by_weight_then_lexical(unconditional)
 
-    -- Fallback: any edge
-    RETURN best_by_weight_then_lexical(edges)
+    RETURN NONE
 
 
 FUNCTION best_by_weight_then_lexical(edges):
@@ -459,7 +465,7 @@ Nodes with `goal_gate=true` represent critical stages that must succeed before t
 1. Check all visited nodes that have `goal_gate=true`.
 2. If any goal gate node has a non-success outcome (not SUCCESS or PARTIAL_SUCCESS), the pipeline cannot exit.
 3. Instead, jump to the `retry_target` of the unsatisfied goal gate node. If that is not set, try `fallback_retry_target`. If that is also not set, try the graph-level `retry_target` and `fallback_retry_target`.
-4. If no retry target exists at any level, the pipeline fails with an error.
+4. If no retry target exists at any level, the pipeline ends with a FAIL outcome.
 
 ```
 FUNCTION check_goal_gates(graph, node_outcomes):
@@ -475,9 +481,10 @@ FUNCTION check_goal_gates(graph, node_outcomes):
 
 Each node has a retry policy determined by:
 
-1. Node attribute `max_retries` (if set) -- number of additional attempts beyond the initial execution
-2. Graph attribute `default_max_retry` (fallback)
-3. Built-in default: 0 (no retries)
+1. Node attribute `max_retries` (if explicitly set) -- number of additional attempts beyond the initial execution
+2. Graph attribute `default_max_retries` (fallback; legacy alias `default_max_retry` is accepted)
+
+If neither is set, the built-in default is 0 (no retries).
 
 The `max_retries` attribute specifies additional attempts. So `max_retries=3` means a total of 4 executions (1 initial + 3 retries). Internally this maps to `max_attempts = max_retries + 1`.
 
@@ -632,7 +639,7 @@ StartHandler:
         RETURN Outcome(status=SUCCESS)
 ```
 
-Every graph must have exactly one start node (shape=Mdiamond). The lint rules enforce this.
+Every graph must have exactly one start node (shape=Mdiamond or id matching `start`/`Start`). The lint rules enforce this.
 
 ### 4.4 Exit Handler
 
@@ -644,7 +651,7 @@ ExitHandler:
         RETURN Outcome(status=SUCCESS)
 ```
 
-Every graph must have exactly one exit node (shape=Msquare).
+Every graph must have exactly one exit node (shape=Msquare or id matching `exit`/`end`).
 
 ### 4.5 Codergen Handler (LLM Task)
 
@@ -805,7 +812,6 @@ ParallelHandler:
 
         -- 2. Determine join policy from node attributes
         join_policy = node.attrs.get("join_policy", "wait_all")
-        error_policy = node.attrs.get("error_policy", "continue")
         max_parallel = integer(node.attrs.get("max_parallel", "4"))
 
         -- 3. Execute branches concurrently with bounded parallelism
@@ -815,7 +821,10 @@ ParallelHandler:
             branch_outcome = execute_subgraph(branch.to_node, branch_context, graph, logs_root)
             results.append(branch_outcome)
 
-        -- 4. Evaluate join policy
+        -- 4. Store results in context for downstream fan-in
+        context.set("parallel.results", serialize_results(results))
+
+        -- 5. Evaluate join policy
         success_count = count(r FOR r IN results WHERE r.status == SUCCESS)
         fail_count = count(r FOR r IN results WHERE r.status == FAIL)
 
@@ -831,8 +840,6 @@ ParallelHandler:
             ELSE:
                 RETURN Outcome(status=FAIL)
 
-        -- 5. Store results in context for downstream fan-in
-        context.set("parallel.results", serialize_results(results))
         RETURN Outcome(status=SUCCESS)
 ```
 
@@ -841,17 +848,7 @@ ParallelHandler:
 | Policy           | Behavior |
 |------------------|----------|
 | `wait_all`       | All branches must complete. Join satisfied when all are done. |
-| `k_of_n`         | At least K branches must succeed. |
 | `first_success`  | Join satisfied as soon as one branch succeeds. Others may be cancelled. |
-| `quorum`         | At least a configurable fraction of branches must succeed. |
-
-**Error policies:**
-
-| Policy              | Behavior |
-|---------------------|----------|
-| `fail_fast`         | Cancel all remaining branches on first failure. |
-| `continue`          | Continue remaining branches. Collect all results. |
-| `ignore`            | Ignore failures entirely. Return only successful results. |
 
 ### 4.9 Fan-In Handler
 
@@ -1025,9 +1022,9 @@ Context:
         RELEASE write lock
 
     FUNCTION snapshot() -> Map<String, Any>:
-        -- Returns a serializable copy of all values
+        -- Returns a serializable deep copy of all values
         ACQUIRE read lock
-        result = shallow_copy(values)
+        result = deep_copy(values)
         RELEASE read lock
         RETURN result
 
@@ -1035,7 +1032,7 @@ Context:
         -- Deep copy for parallel branch isolation
         ACQUIRE read lock
         new_context = new Context()
-        new_context.values = shallow_copy(values)
+        new_context.values = deep_copy(values)
         new_context.logs = copy(logs)
         RELEASE read lock
         RETURN new_context
@@ -1084,7 +1081,6 @@ Outcome:
     context_updates    : Map<String, Any> -- key-value pairs to merge into context
     notes              : String          -- human-readable execution summary
     failure_reason     : String          -- reason for failure (when status is FAIL or RETRY)
-    session_id         : String          -- Amplifier session ID that executed this node (optional, backend-dependent)
 ```
 
 **StageStatus values:**
@@ -1164,7 +1160,7 @@ FidelityMode ::= 'full'
 1. Edge `fidelity` attribute (on the incoming edge)
 2. Target node `fidelity` attribute
 3. Graph `default_fidelity` attribute
-4. Default: `compact`
+4. Default when unset: `compact`
 
 **Thread resolution (for `full` fidelity):**
 
@@ -1398,7 +1394,7 @@ Severity:
 | Rule ID                  | Severity | Description |
 |--------------------------|----------|-------------|
 | `start_node`             | ERROR    | Pipeline must have exactly one start node (shape=Mdiamond or id matching `start`/`Start`). |
-| `terminal_node`          | ERROR    | Pipeline must have at least one terminal node (shape=Msquare or id matching `exit`/`end`). |
+| `terminal_node`          | ERROR    | Pipeline must have exactly one terminal node (shape=Msquare or id matching `exit`/`end`). |
 | `reachability`           | ERROR    | All nodes must be reachable from the start node via BFS/DFS traversal. |
 | `edge_target_exists`     | ERROR    | Every edge target must reference an existing node ID. |
 | `start_no_incoming`      | ERROR    | The start node must have no incoming edges. |
@@ -1457,11 +1453,12 @@ The `model_stylesheet` graph attribute provides CSS-like rules for setting defau
 ```
 Stylesheet    ::= Rule+
 Rule          ::= Selector '{' Declaration ( ';' Declaration )* ';'? '}'
-Selector      ::= '*' | '#' Identifier | '.' ClassName
+Selector      ::= '*' | ShapeName | '#' Identifier | '.' ClassName
 ClassName     ::= [a-z0-9-]+
+ShapeName     ::= Identifier
 Declaration   ::= Property ':' PropertyValue
 Property      ::= 'llm_model' | 'llm_provider' | 'reasoning_effort'
-PropertyValue ::= String | 'low' | 'medium' | 'high'
+PropertyValue ::= String | BareValue
 ```
 
 ### 8.3 Selectors and Specificity
@@ -1469,8 +1466,9 @@ PropertyValue ::= String | 'low' | 'medium' | 'high'
 | Selector      | Matches                      | Specificity |
 |---------------|------------------------------|-------------|
 | `*`           | All nodes                    | 0 (lowest)  |
-| `.class_name` | Nodes with that class        | 1 (medium)  |
-| `#node_id`    | Specific node by ID          | 2 (highest) |
+| `box`         | Nodes with that shape        | 1           |
+| `.class_name` | Nodes with that class        | 2           |
+| `#node_id`    | Specific node by ID          | 3 (highest) |
 
 Later rules of equal specificity override earlier ones. Explicit node attributes always override stylesheet values (highest precedence).
 
@@ -1487,7 +1485,7 @@ Later rules of equal specificity override earlier ones. Explicit node attributes
 The resolution order for any model-related property on a node is:
 
 1. Explicit node attribute (e.g., `llm_model="gpt-5.2"` on the node) -- highest precedence
-2. Stylesheet rule matching by specificity (ID > class > universal)
+2. Stylesheet rule matching by specificity (ID > class > shape > universal)
 3. Graph-level default attribute
 4. Handler/system default
 
@@ -1619,11 +1617,9 @@ The engine emits typed events during execution for UI, logging, and metrics inte
 
 **Stage lifecycle events:**
 - `StageStarted(name, index)` -- stage begins
-- `StageCompleted(name, index, duration, session_id)` -- stage succeeded; `session_id` is the child Amplifier session that executed the node (optional, backend-dependent)
+- `StageCompleted(name, index, duration)` -- stage succeeded
 - `StageFailed(name, index, error, will_retry)` -- stage failed
 - `StageRetrying(name, index, attempt, delay)` -- stage retrying
-
-> **Implementation note:** The reference implementation emits these events using `pipeline:*` names (e.g., `pipeline:node_start`, `pipeline:node_complete`). The `pipeline:node_complete` payload includes: `node_id`, `status`, `duration_ms`, `notes`, `failure_reason`, and `session_id`.
 
 **Parallel execution events:**
 - `ParallelStarted(branch_count)` -- parallel block started
@@ -1658,7 +1654,7 @@ Graph-level or node-level attributes `tool_hooks.pre` and `tool_hooks.post` spec
 - **Pre-hook:** Executed before every LLM tool call. Receives tool metadata via environment variables and stdin JSON. Exit code 0 means proceed; non-zero means skip the tool call.
 - **Post-hook:** Executed after every LLM tool call. Receives tool metadata and result. Primarily for logging and auditing.
 
-Hook failures (non-zero exit) do not block the tool call but are recorded in the stage log.
+Pre-hook failures (non-zero exit) skip the tool call and are recorded in the stage log. Post-hook failures do not block the tool call but are recorded.
 
 ---
 
@@ -1678,7 +1674,8 @@ Key            ::= 'outcome'
                  | 'context.' Path
 Path           ::= Identifier ( '.' Identifier )*
 Operator       ::= '=' | '!='
-Literal        ::= String | Integer | Boolean
+Literal        ::= String | Integer | Boolean | BareLiteral
+BareLiteral    ::= [A-Za-z_][A-Za-z0-9_.:-]*
 ```
 
 ### 10.3 Semantics
@@ -1734,13 +1731,20 @@ FUNCTION evaluate_condition(condition, outcome, context) -> Boolean:
 FUNCTION evaluate_clause(clause, outcome, context) -> Boolean:
     IF clause contains "!=":
         (key, value) = split(clause, "!=", max=1)
-        RETURN resolve_key(trim(key), outcome, context) != trim(value)
+        RETURN resolve_key(trim(key), outcome, context) != parse_literal(value)
     ELSE IF clause contains "=":
         (key, value) = split(clause, "=", max=1)
-        RETURN resolve_key(trim(key), outcome, context) == trim(value)
+        RETURN resolve_key(trim(key), outcome, context) == parse_literal(value)
     ELSE:
         -- Bare key: check if truthy
         RETURN bool(resolve_key(trim(clause), outcome, context))
+
+
+FUNCTION parse_literal(value) -> String:
+    value = trim(value)
+    IF value starts with '"' AND value ends with '"':
+        RETURN unescape_string(value[1..-2])
+    RETURN value
 ```
 
 ### 10.6 Examples
@@ -1795,8 +1799,8 @@ This section defines how to validate that an implementation of this spec is comp
 
 ### 11.2 Validation and Linting
 
-- [ ] Exactly one start node (shape=Mdiamond) is required
-- [ ] Exactly one exit node (shape=Msquare) is required
+- [ ] Exactly one start node (shape=Mdiamond or id matching `start`/`Start`) is required
+- [ ] Exactly one exit node (shape=Msquare or id matching `exit`/`end`) is required
 - [ ] Start node has no incoming edges
 - [ ] Exit node has no outgoing edges
 - [ ] All nodes are reachable from start (no orphans)
@@ -1815,12 +1819,12 @@ This section defines how to validate that an implementation of this spec is comp
 - [ ] Edge selection follows the 5-step priority: condition match -> preferred label -> suggested IDs -> weight -> lexical
 - [ ] Engine loops: execute node -> select edge -> advance to next node -> repeat
 - [ ] Terminal node (shape=Msquare) stops execution
-- [ ] Pipeline outcome is "success" if all goal_gate nodes succeeded, "fail" otherwise
+- [ ] Pipeline outcome is "success" if all goal_gate nodes reached `SUCCESS` or `PARTIAL_SUCCESS`, "fail" otherwise
 
 ### 11.4 Goal Gate Enforcement
 
 - [ ] Nodes with `goal_gate=true` are tracked throughout execution
-- [ ] Before allowing exit via a terminal node, the engine checks all goal gate nodes have status SUCCESS
+- [ ] Before allowing exit via a terminal node, the engine checks all goal gate nodes have status `SUCCESS` or `PARTIAL_SUCCESS`
 - [ ] If any goal gate node has not succeeded, the engine routes to `retry_target` (if configured) instead of exiting
 - [ ] If no retry_target and goal gates unsatisfied, pipeline outcome is "fail"
 
@@ -1856,7 +1860,7 @@ This section defines how to validate that an implementation of this spec is comp
 ### 11.8 Human-in-the-Loop
 
 - [ ] Interviewer interface works: `ask(question) -> Answer`
-- [ ] Question supports types: SINGLE_SELECT, MULTI_SELECT, FREE_TEXT, CONFIRM
+- [ ] Question supports types: YES_NO, MULTIPLE_CHOICE, FREEFORM, CONFIRMATION
 - [ ] AutoApproveInterviewer always selects the first option (for automation/testing)
 - [ ] ConsoleInterviewer prompts in terminal and reads user input
 - [ ] CallbackInterviewer delegates to a provided function
@@ -1875,9 +1879,9 @@ This section defines how to validate that an implementation of this spec is comp
 ### 11.10 Model Stylesheet
 
 - [ ] Stylesheet is parsed from the graph's `model_stylesheet` attribute
-- [ ] Selectors by shape name work (e.g., `box { model = "claude-opus-4-6" }`)
-- [ ] Selectors by class name work (e.g., `.fast { model = "gemini-3-flash-preview" }`)
-- [ ] Selectors by node ID work (e.g., `#review { reasoning_effort = "high" }`)
+- [ ] Selectors by shape name work (e.g., `box { llm_model: "claude-opus-4-6" }`)
+- [ ] Selectors by class name work (e.g., `.fast { llm_model: "gemini-3-flash-preview" }`)
+- [ ] Selectors by node ID work (e.g., `#review { reasoning_effort: "high" }`)
 - [ ] Specificity order: universal < shape < class < ID
 - [ ] Stylesheet properties are overridden by explicit node attributes
 
@@ -1986,8 +1990,8 @@ ASSERT "review" IN checkpoint.completed_nodes
 | `goal`                  | String   | `""`    | Pipeline-level goal description |
 | `label`                 | String   | `""`    | Display name for the graph |
 | `model_stylesheet`      | String   | `""`    | CSS-like LLM model/provider stylesheet |
-| `default_max_retry`     | Integer  | `50`    | Global retry ceiling |
-| `default_fidelity`      | String   | `""`    | Default context fidelity mode |
+| `default_max_retries`   | Integer  | `0`     | Default additional retries for nodes that omit `max_retries`. Legacy alias: `default_max_retry`. |
+| `default_fidelity`      | String   | `""`    | Default context fidelity mode when explicitly set. Empty string means unset; runtime fallback is `compact`. |
 | `retry_target`          | String   | `""`    | Node to jump to on unsatisfied exit |
 | `fallback_retry_target` | String   | `""`    | Secondary jump target |
 | `stack.child_dotfile`   | String   | `""`    | Path to child DOT file for supervision |
@@ -2003,8 +2007,8 @@ ASSERT "review" IN checkpoint.completed_nodes
 | `shape`                 | String   | `"box"`       | Graphviz shape (determines handler type) |
 | `type`                  | String   | `""`          | Explicit handler type override |
 | `prompt`                | String   | `""`          | LLM prompt (supports `$goal` expansion) |
-| `max_retries`           | Integer  | `0`           | Additional retry attempts |
-| `goal_gate`             | Boolean  | `false`       | Must succeed before pipeline exit |
+| `max_retries`           | Integer  | inherited     | Additional retry attempts. If omitted, inherits graph `default_max_retries`. |
+| `goal_gate`             | Boolean  | `false`       | Must reach `SUCCESS` or `PARTIAL_SUCCESS` before pipeline exit |
 | `retry_target`          | String   | `""`          | Jump target on failure |
 | `fallback_retry_target` | String   | `""`          | Secondary jump target |
 | `fidelity`              | String   | inherited     | Context fidelity mode |
@@ -2053,25 +2057,23 @@ Each non-terminal node writes a `status.json` file in its stage directory. This 
 ```
 {
     "outcome": "success | retry | fail | partial_success",
-    "preferred_next_label": "<edge label or empty>",
+    "preferred_label": "<edge label or empty>",
     "suggested_next_ids": ["<node_id>", ...],
     "context_updates": {
         "key": "value",
         "nested.key": "value"
     },
-    "notes": "Human-readable execution summary",
-    "session_id": "uuid-of-child-session | null"
+    "notes": "Human-readable execution summary"
 }
 ```
 
 | Field                  | Type            | Required | Description |
 |------------------------|-----------------|----------|-------------|
 | `outcome`              | String (enum)   | Yes      | Outcome status. Drives routing and goal checks. |
-| `preferred_next_label` | String          | No       | Edge label to prioritize for next transition. |
+| `preferred_label`      | String          | No       | Edge label to prioritize for next transition. |
 | `suggested_next_ids`   | List of Strings | No       | Fallback target node IDs if no label match. |
 | `context_updates`      | Map             | No       | Key-value pairs merged into the run context. |
 | `notes`                | String          | No       | Human-readable log entries. |
-| `session_id`           | String          | No       | Amplifier session ID that executed this node. Enables linking to full session transcripts (e.g., context-intelligence events). `null` when the backend does not provide a session. |
 
 When `auto_status=true` on a node and no `status.json` was written by the handler, the engine synthesizes: `{"outcome": "success", "notes": "auto-status: handler completed without writing status"}`.
 


### PR DESCRIPTION
## Summary

Cleans up awareness/layering violations in `amplifier-bundle-attractor` per REPOSITORY_RULES.md, plus adds upstream attribution and extensions documentation.

## Changes

### A. Positive additions
- **README.md**: upstream attribution + layering statement (cites strongdm/attractor, describes dependency boundary per REPOSITORY_RULES.md, notes the recipes lineage exception)
- **specs/EXTENSIONS.md**: new file documenting all divergences from the canonical spec — BareValue grammar, `default_max_retries` rename + legacy alias, `max_retries` inheritance, `PARTIAL_SUCCESS` for `goal_gate`, TRANSFORM phase, error semantics, and `type` vs `node_type` naming. Each extension has a 2-3 sentence rationale.
- **AGENTS.md**: added dependency awareness rule section (what this bundle may and may not reference in code, comments, docs, or test names)

### B. Hard-violation cleanups
- **AGENTS.md:22**: 'run it through the dot-graph resolver' → 'run it through any attractor-compatible resolver'
- **handlers/tool.py:116**: 'pipelines loaded via the resolver' → 'loaded by the consuming resolver'
- **docs/designs/r12-node-failure-propagation.md:201-208**: removed meta-violation (the list was itself naming downstream components in order to forbid them); replaced with principle-level statements
- **engine.py:1320**: 'dashboard filters and reality-check queries' → 'downstream observability filters and queries'
- **dot_parser.py:568**: removed 'used by reality_check and semport pipelines'; described as generic escape pattern
- **tests/test_dot_parser.py**: rewrote escape-sequence regression section comment; rewrote docstrings; renamed `test_escape_multiline_shell_script_preserves_structure` → `test_escape_multiline_shell_heredoc_tool_command_preserves_structure`
- **tests/test_runs_on_axis.py:279**: 'dashboard filters and reality-check queries' → 'downstream observability filters and queries'

### C. Settings
- **.amplifier/settings.yaml**: removed browser-tester include (downstream awareness violation in a tracked file)
- **.amplifier/settings.local.yaml**: new untracked file for local dev browser-tester include
- **.gitignore**: added `/.amplifier/settings.local.yaml`

### D. Spec snapshot
- **specs/canonical/attractor-spec-canonical.md**: re-synced from upstream strongdm/attractor. Key changes in sync: `default_max_retry 50→0`, `default_max_retries` rename with legacy alias, BareValue grammar production added, TRANSFORM lifecycle phase, `PARTIAL_SUCCESS` for `goal_gate`, `type` vs `node_type` note.

## Verification

### Grep checks (all clean)
- No 'dot-graph resolver' or 'the dot-graph' in markdown/py outside specs/
- No 'reality_check' or 'reality-check' in modules py files
- No 'semport' in modules py files (test_dot_integration.py keeps its semport.dot fixture tests — fixture lives in-repo, not a downstream reference)
- No 'amplifier-resolve/amplifier-resolver' in docs/designs
- No 'browser-tester' in .amplifier/settings.yaml

### Unit tests
```
1047 passed, 2 pre-existing failures (test_outputs_attribute.py HumanHandler inference), 7 skipped
```
Pre-existing failures unrelated to this PR. Pre-existing SyntaxWarning in test_dot_parser.py docstring unchanged.

### Checklist
- [x] Grep verifications all pass
- [x] Unit tests identical to pre-PR (same pass count, same pre-existing failures)
- [x] Renamed test still runs and passes
- [x] EXTENSIONS.md documents all known divergences with rationale
- [x] amplifier-bundle-recipes references preserved (one documented exception)
- [x] No executable code changed