### PR TITLE
fix(engine): fail-fast on FAIL + bounded fan-out for non-component nodes

### DIFF
--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/edge_selection.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/edge_selection.py
@@ -19,7 +19,7 @@ import re
 from .conditions import evaluate_condition
 from .context import PipelineContext
 from .graph import Edge, Graph
-from .outcome import Outcome
+from .outcome import Outcome, StageStatus
 
 
 def select_edge(
@@ -60,16 +60,51 @@ def select_edge(
                     return e
 
     # Step 4 & 5: Weight with lexical tiebreak (unconditional edges only)
-    unconditional = [e for e in edges if not e.condition]
-    if unconditional:
-        return _best_by_weight_then_lexical(unconditional)
+    #
+    # Spec §3.7 fail-fast intent: a FAIL outcome does NOT traverse unconditional
+    # edges to default-routing nodes.  The engine will then check retry_target /
+    # fallback_retry_target and terminate if neither is configured.
+    #
+    # Pipeline authors who want fail-forward have three explicit opt-in paths
+    # (all remain fully supported):
+    #   - continue_on_fail="true" on the node  → engine converts FAIL→SUCCESS
+    #     before calling select_edge, so unconditional edges work normally
+    #   - runs_on=always / runs_on=failure on a DOWNSTREAM node  → the
+    #     downstream node's attribute opts that edge in for FAIL routing;
+    #     select_edge routes there and the engine's skip-gate decides execution
+    #   - condition="outcome=fail" edge  → matched in Step 1 above
+    if outcome.status != StageStatus.FAIL:
+        unconditional = [e for e in edges if not e.condition]
+        if unconditional:
+            return _best_by_weight_then_lexical(unconditional)
+    else:
+        # FAIL: only follow unconditional edges to nodes that explicitly opt in
+        # to failure routing (runs_on=always or runs_on=failure).  Default nodes
+        # (runs_on=success) are NOT reached — that is the fail-fast behavior.
+        fail_forward = [
+            e
+            for e in edges
+            if not e.condition
+            and _target_runs_on(e.to_node, graph) in ("always", "failure")
+        ]
+        if fail_forward:
+            return _best_by_weight_then_lexical(fail_forward)
 
     # Spec §3.3 final step: RETURN NONE.
-    # No unconditional edges exist and no conditional edge matched — the engine
-    # halts this branch with a FAIL outcome.  Pipeline authors who want
-    # execution to continue past a failure use continue_on_fail="true" on the
-    # node (engine.py handles that attribute before calling select_edge).
+    # Reached when:
+    #   (a) outcome is FAIL and no downstream node opts in via runs_on, or
+    #   (b) no unconditional edges exist and no conditional edge matched.
+    # The engine halts this branch with a FAIL outcome.
     return None
+
+
+def _target_runs_on(node_id: str, graph: Graph) -> str:
+    """Return the runs_on value of the target node (default 'success')."""
+    node = graph.nodes.get(node_id)
+    if node is None:
+        return "success"
+    raw = node.attrs.get("runs_on", "success") or "success"
+    return str(raw).strip().lower()
 
 
 def select_all_matching_edges(

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py
@@ -325,6 +325,22 @@ class PipelineEngine:
                     current_node.id, routing_outcome, self.context, self.graph
                 )
                 if edge is None:
+                    # Skip propagation: after select_edge, also try unconditional
+                    # edges for skip propagation.  Downstream nodes will be checked
+                    # by _check_node_skip and SKIPPED if their dependencies failed.
+                    # This preserves skip-chain observability even under the fail-fast
+                    # guard (which blocks unconditional edges for FAIL outcomes when
+                    # the target has runs_on=success, the default).
+                    skip_candidates = [
+                        e
+                        for e in self.graph.outgoing_edges(current_node.id)
+                        if not e.condition
+                    ]
+                    if skip_candidates:
+                        from .edge_selection import _best_by_weight_then_lexical
+
+                        edge = _best_by_weight_then_lexical(skip_candidates)
+                if edge is None:
                     retry_node = self._resolve_failure_retry_target(current_node)
                     if (
                         retry_node is not None
@@ -662,6 +678,12 @@ class PipelineEngine:
                         retry_node.id,
                         failure_routing_retries,
                     )
+                    # CR-3 (R12): Reset per-run state so skip-propagation from
+                    # attempt N does not block retried nodes in attempt N+1.
+                    # Mirrors the state clear in the goal-gate retry path above.
+                    self.completed_nodes.clear()
+                    self.node_outcomes.clear()
+                    self.failed_outputs.clear()
                     current_node = retry_node
                     continue
 
@@ -1150,8 +1172,20 @@ class PipelineEngine:
                 "context_updates": outcome.context_updates,
             }
 
-        # Execute all branches concurrently
-        tasks = [run_branch(edge.to_node) for edge in edges]
+        # Execute all branches concurrently with bounded parallelism.
+        # Read max_parallel from the source node's attrs (matching ParallelHandler's
+        # convention for shape=component nodes).  Default 4 mirrors ParallelHandler.
+        source_node = self.graph.nodes.get(edges[0].from_node) if edges else None
+        max_parallel = int(
+            source_node.attrs.get("max_parallel", 4) if source_node else 4
+        )
+        semaphore = asyncio.Semaphore(max_parallel)
+
+        async def bounded_run_branch(target_node_id: str) -> dict[str, Any]:
+            async with semaphore:
+                return await run_branch(target_node_id)
+
+        tasks = [bounded_run_branch(edge.to_node) for edge in edges]
         results = list(await asyncio.gather(*tasks))
 
         # Apply context_updates from all branches

--- a/modules/loop-pipeline/tests/fixtures/parent_with_child.dot
+++ b/modules/loop-pipeline/tests/fixtures/parent_with_child.dot
@@ -3,7 +3,7 @@ digraph parent_with_child {
 
     start     [shape=Mdiamond]
     pre_work  [shape=box, prompt="Do pre-work"]
-    review    [shape=folder, dot_file="child_pipeline.dot"]
+    review    [shape=folder, dot_file="child_pipeline.dot", runs_on=always]
     post_work [shape=box, prompt="Do post-work"]
     done      [shape=Msquare]
 

--- a/modules/loop-pipeline/tests/test_eager_reference_scan.py
+++ b/modules/loop-pipeline/tests/test_eager_reference_scan.py
@@ -103,13 +103,18 @@ def test_extract_refs_double_dollar_ignored():
 
 @pytest.mark.asyncio
 async def test_failed_predecessor_causes_skipped_successor(tmp_path):
-    """Design assertion #1: node with outputs= that fails causes SKIPPED successor.
+    """Design assertion #1: when a predecessor fails, its successors are not reached.
 
     Fixture pipeline (placeholder names, no production names):
       start → producer_a [outputs="resource.handle"] → consumer_b [tool_command="use ${resource.handle}"] → exit
 
-    producer_a fails (exit 1); consumer_b references ${resource.handle}.
-    Expected: consumer_b outcome = SKIPPED; its handler is NOT invoked.
+    producer_a fails (exit 1).  Under fail-fast semantics (spec §3.7), the engine
+    does not traverse the unconditional edge to consumer_b — consumer_b is absent
+    from node_outcomes, not merely SKIPPED.
+
+    Pipeline authors who want consumer_b to run on failure should use one of the
+    explicit opt-in mechanisms: runs_on=always / runs_on=failure on consumer_b,
+    or a condition="outcome=fail" edge from producer_a.
     """
     hooks = EventCapture()
     engine = _make_engine(
@@ -135,22 +140,28 @@ async def test_failed_predecessor_causes_skipped_successor(tmp_path):
     # producer_a must have failed
     assert engine.node_outcomes["producer_a"].status == StageStatus.FAIL
 
-    # consumer_b must be SKIPPED
-    assert "consumer_b" in engine.node_outcomes
-    assert engine.node_outcomes["consumer_b"].status == StageStatus.SKIPPED, (
-        f"Expected consumer_b SKIPPED, got {engine.node_outcomes['consumer_b'].status}"
+    # consumer_b must NOT be in node_outcomes — fail-fast halts at producer_a
+    assert "consumer_b" not in engine.node_outcomes, (
+        "Under fail-fast semantics, consumer_b must not be reached "
+        f"(got status={engine.node_outcomes.get('consumer_b')})"
     )
 
-    # resource.handle must be in failed_outputs
+    # resource.handle must be in failed_outputs (populated when producer_a fails)
     assert "resource.handle" in engine.failed_outputs
     assert engine.failed_outputs["resource.handle"] == "producer_a"
 
 
 @pytest.mark.asyncio
 async def test_skipped_node_emits_pipeline_node_skipped_event(tmp_path):
-    """Design assertion #2: exactly one PIPELINE_NODE_SKIPPED per skipped node.
+    """Fail-fast behavior: FAIL halts the pipeline; downstream nodes are NOT reached.
 
-    Also verifies CR-4: failure_mode_taxonomy_version=1 in every event.
+    Under fail-fast semantics (spec §3.7), after producer_a fails the engine does
+    not traverse the unconditional edge to consumer_b.  No PIPELINE_NODE_SKIPPED
+    events are emitted — consumer_b is absent from node_outcomes entirely.
+
+    Pipeline authors who need cleanup to run after failure should use
+    runs_on=always or runs_on=failure on the cleanup node, or add an explicit
+    condition="outcome=fail" edge from producer_a.
     """
     hooks = EventCapture()
     engine = _make_engine(
@@ -172,22 +183,33 @@ async def test_skipped_node_emits_pipeline_node_skipped_event(tmp_path):
     )
     await engine.run()
 
+    # producer_a failed
+    assert engine.node_outcomes["producer_a"].status == StageStatus.FAIL
+
+    # consumer_b is NOT in node_outcomes — the engine halted at producer_a
+    assert "consumer_b" not in engine.node_outcomes, (
+        "Under fail-fast semantics consumer_b must not be reached; "
+        f"got {engine.node_outcomes.get('consumer_b')}"
+    )
+
+    # No PIPELINE_NODE_SKIPPED events — consumer_b was never visited
     skipped_events = hooks.events_of_type(PIPELINE_NODE_SKIPPED)
-    # Exactly one SKIPPED event for consumer_b
-    assert len(skipped_events) == 1
-    evt = skipped_events[0]
-    assert evt["node_id"] == "consumer_b"
-    assert evt["cause"] == "predecessor_failed"
-    assert "resource.handle" in evt["missing_keys"]
-    # CR-4: taxonomy version must be present
-    assert evt.get("failure_mode_taxonomy_version") == 1
-    assert evt.get("failure_mode") == "predecessor_failed"
+    assert len(skipped_events) == 0, (
+        f"Expected 0 PIPELINE_NODE_SKIPPED events under fail-fast, "
+        f"got {len(skipped_events)}: {skipped_events}"
+    )
 
 
 @pytest.mark.asyncio
 async def test_skip_propagates_transitively(tmp_path):
-    """Design assertion #1 (transitive): A→B→C where A fails; B is skipped;
-    C references B's output and should ALSO be skipped.
+    """Fail-fast: A→B→C where A fails; the engine halts at A (not B or C).
+
+    Under fail-fast semantics (spec §3.7), FAIL does not traverse unconditional
+    edges to default runs_on=success nodes.  The pipeline halts at node_a.
+    Neither node_b nor node_c is visited (both absent from node_outcomes).
+
+    To propagate execution past node_a failure, use condition="outcome=fail"
+    edges or runs_on=always / runs_on=failure on node_b.
     """
     hooks = EventCapture()
     engine = _make_engine(
@@ -209,18 +231,25 @@ async def test_skip_propagates_transitively(tmp_path):
     await engine.run()
 
     assert engine.node_outcomes["node_a"].status == StageStatus.FAIL
-    assert engine.node_outcomes["node_b"].status == StageStatus.SKIPPED
-    assert engine.node_outcomes["node_c"].status == StageStatus.SKIPPED
 
-    # All declared outputs propagated
+    # Pipeline halted at node_a — node_b and node_c are NOT in node_outcomes
+    assert "node_b" not in engine.node_outcomes, (
+        f"node_b should not be reached under fail-fast, "
+        f"got {engine.node_outcomes.get('node_b')}"
+    )
+    assert "node_c" not in engine.node_outcomes, (
+        f"node_c should not be reached under fail-fast, "
+        f"got {engine.node_outcomes.get('node_c')}"
+    )
+
+    # a.result is still in failed_outputs (populated when node_a fails)
     assert "a.result" in engine.failed_outputs
-    assert "b.result" in engine.failed_outputs
 
-    # Two skipped events
+    # No PIPELINE_NODE_SKIPPED events — no nodes were visited after node_a
     skipped_events = hooks.events_of_type(PIPELINE_NODE_SKIPPED)
-    assert len(skipped_events) == 2
-    skipped_node_ids = {e["node_id"] for e in skipped_events}
-    assert skipped_node_ids == {"node_b", "node_c"}
+    assert len(skipped_events) == 0, (
+        f"Expected 0 PIPELINE_NODE_SKIPPED events, got {len(skipped_events)}"
+    )
 
 
 @pytest.mark.asyncio
@@ -256,12 +285,16 @@ async def test_skip_not_triggered_for_unrelated_references(tmp_path):
 
 @pytest.mark.asyncio
 async def test_handler_not_invoked_on_skip(tmp_path):
-    """M2: When a node is SKIPPED, its handler must NOT be invoked.
+    """Fail-fast: when a predecessor fails, its successor's handler is NOT invoked.
 
-    consumer_b references ${resource.handle} (which is in failed_outputs after
-    producer_a fails).  If consumer_b's handler ran, it would echo "ran_marker"
-    as the last line, setting tool.last_line = "ran_marker".  Since it is
-    SKIPPED, tool.last_line should NOT be "ran_marker".
+    consumer_b references ${resource.handle} (from producer_a which fails).
+    Under fail-fast semantics (spec §3.7), the engine halts at producer_a and
+    never visits consumer_b.  consumer_b's handler is therefore NOT invoked —
+    tool.last_line will NOT be "ran_marker".
+
+    This verifies the behavioral guarantee: handlers of unreachable successors
+    are never invoked, regardless of whether the engine halts (fail-fast) or
+    skips (legacy behavior).
     """
     hooks = EventCapture()
     engine = _make_engine(
@@ -281,11 +314,13 @@ async def test_handler_not_invoked_on_skip(tmp_path):
     )
     await engine.run()
 
-    assert engine.node_outcomes["consumer_b"].status == StageStatus.SKIPPED, (
-        f"consumer_b should be SKIPPED, got {engine.node_outcomes['consumer_b'].status}"
+    # Under fail-fast, consumer_b is never reached — not in node_outcomes
+    assert "consumer_b" not in engine.node_outcomes, (
+        f"consumer_b should not be in node_outcomes under fail-fast, "
+        f"got {engine.node_outcomes.get('consumer_b')}"
     )
-    # tool.last_line should NOT be "ran_marker" if handler was skipped
+    # Core guarantee: handler was NOT invoked — "ran_marker" was not written
     assert engine.context.get("tool.last_line") != "ran_marker", (
-        "consumer_b's handler should NOT have run (node was SKIPPED); "
+        "consumer_b's handler should NOT have run; "
         f"but tool.last_line = {engine.context.get('tool.last_line')!r}"
     )

--- a/modules/loop-pipeline/tests/test_edge_selection.py
+++ b/modules/loop-pipeline/tests/test_edge_selection.py
@@ -236,16 +236,23 @@ def test_fail_node_all_conditional_edges_no_match_returns_none():
     assert result is None
 
 
-def test_fail_node_with_unconditional_edge_routes():
-    """Unconditional edges still route correctly even from a FAIL node.
+def test_fail_outcome_does_not_traverse_unconditional_edges():
+    """Spec §3.7 fail-fast intent: FAIL outcomes do NOT traverse unconditional edges.
 
-    The fix removes the all-edges fallback, NOT the unconditional-edges path
-    (steps 4 & 5 of spec §3.3).  Pipelines that want a node to always route
-    somewhere — regardless of outcome — should use an unconditional edge, and
-    that must keep working.
+    Previously this test was named test_fail_node_with_unconditional_edge_routes
+    and asserted that unconditional edges were followed on FAIL.  That encoded
+    §3.3's pseudocode literally, but violated §3.7's stated fail-fast intent.
+
+    The corrected behavior: FAIL + unconditional edge → None.  The engine then
+    checks retry_target / fallback_retry_target and terminates if neither is set.
+
+    Pipeline authors who want fail-forward have three opt-in mechanisms:
+    - continue_on_fail="true"          → engine flips FAIL→SUCCESS before select_edge
+    - runs_on=always / runs_on=failure → downstream skip-gate override
+    - condition="outcome=fail" edge    → matched in Step 1 (unaffected by this change)
     """
     # Graph: N1 → N2 [condition="outcome=success"]  (won't match FAIL)
-    #        N1 → N3                                  (unconditional — should win)
+    #        N1 → N3                                  (unconditional — MUST NOT be followed on FAIL)
     edges = [
         Edge("N1", "N2", condition="outcome=success"),
         Edge("N1", "N3"),  # unconditional
@@ -253,8 +260,10 @@ def test_fail_node_with_unconditional_edge_routes():
     graph = _make_graph(edges)
     outcome = Outcome(status=StageStatus.FAIL)
     result = select_edge("N1", outcome, PipelineContext(), graph)
-    assert result is not None
-    assert result.to_node == "N3"
+    assert result is None, (
+        "FAIL outcome must NOT traverse unconditional edges (spec §3.7 fail-fast). "
+        f"Expected None, got edge to '{result.to_node if result else None}'"
+    )
 
 
 # --- Priority order tests ---

--- a/modules/loop-pipeline/tests/test_edge_selection_no_silent_fallthrough.py
+++ b/modules/loop-pipeline/tests/test_edge_selection_no_silent_fallthrough.py
@@ -1,0 +1,193 @@
+"""Lock the spec §3.7 fail-fast guard in select_edge.
+
+Spec §3.7 (fail-fast intent): when a node returns FAIL, the engine looks for
+an explicit failure path (condition="outcome=fail" edges, retry_target,
+fallback_retry_target) and terminates if none exists.
+
+These tests ensure that select_edge() enforces §3.7 by returning None for
+FAIL outcomes when only unconditional edges are available — while keeping
+SUCCESS routing and explicit failure-path routing unchanged.
+
+Spec coverage: §3.7 (fail-fast intent), §3.3 (RETURN NONE), ESEL-002.
+"""
+
+from amplifier_module_loop_pipeline.context import PipelineContext
+from amplifier_module_loop_pipeline.edge_selection import select_edge
+from amplifier_module_loop_pipeline.graph import Edge, Graph, Node
+from amplifier_module_loop_pipeline.outcome import Outcome, StageStatus
+
+
+def _make_graph(edges: list[Edge]) -> Graph:
+    """Build a minimal graph with the given edges."""
+    nodes: dict[str, Node] = {}
+    for e in edges:
+        if e.from_node not in nodes:
+            nodes[e.from_node] = Node(id=e.from_node)
+        if e.to_node not in nodes:
+            nodes[e.to_node] = Node(id=e.to_node)
+    return Graph(name="test", nodes=nodes, edges=edges)
+
+
+def test_fail_outcome_does_not_traverse_unconditional_edges():
+    """Per spec §3.7 (fail-fast intent), a FAIL outcome must NOT traverse
+    unconditional outgoing edges.
+
+    Pipeline authors who want fail-forward use one of three explicit opt-in
+    mechanisms (all preserved and tested below):
+    - continue_on_fail="true" on the node (engine converts FAIL→SUCCESS before
+      calling select_edge, so unconditional edges work normally)
+    - runs_on=always or runs_on=failure (node-level skip gate override)
+    - condition="outcome=fail" edges (explicit error routing — Step 1 above)
+
+    The engine will then check retry_target / fallback_retry_target and
+    terminate if neither is configured.
+    """
+    # Graph: N1 → N2 (unconditional, no condition)
+    # Call select_edge(N1, FAIL_outcome, context, graph)
+    # Assert: returns None (engine will then halt or use retry_target)
+    edges = [Edge("N1", "N2")]
+    graph = _make_graph(edges)
+    outcome = Outcome(status=StageStatus.FAIL)
+
+    result = select_edge("N1", outcome, PipelineContext(), graph)
+
+    assert result is None, (
+        "FAIL outcome must NOT traverse unconditional outgoing edges "
+        f"(spec §3.7 fail-fast). Expected None, got edge to "
+        f"'{result.to_node if result else None}'"
+    )
+
+
+def test_success_outcome_traverses_unconditional_edges_as_before():
+    """Belt-and-suspenders: confirm unconditional edges still work for SUCCESS.
+
+    The fail-fast guard ONLY applies to FAIL outcomes.  SUCCESS must continue
+    to traverse unconditional edges normally (steps 4 & 5 of spec §3.3).
+    """
+    # Same setup as above, SUCCESS outcome instead
+    # Assert: returns N1->N2 edge
+    edges = [Edge("N1", "N2")]
+    graph = _make_graph(edges)
+    outcome = Outcome(status=StageStatus.SUCCESS)
+
+    result = select_edge("N1", outcome, PipelineContext(), graph)
+
+    assert result is not None, (
+        "SUCCESS outcome must traverse unconditional edges (spec §3.3 steps 4 & 5). "
+        "Got None."
+    )
+    assert result.to_node == "N2", f"Expected edge to 'N2', got '{result.to_node}'"
+
+
+def test_fail_outcome_traverses_explicit_fail_edge():
+    """FAIL + condition="outcome=fail" edge: should follow it (spec §3.7 step 1).
+
+    Explicit failure routing via a condition="outcome=fail" edge is the primary
+    mechanism for pipeline authors to route to error-handling nodes.  The fail-
+    fast guard must NOT block this — Step 1 (condition matching) runs before
+    the unconditional-edge guard.
+    """
+    # N1 → N_error  [condition="outcome=fail"]
+    # N1 → N_next   [condition="outcome=success"]
+    # Call with FAIL outcome → should follow N_error edge
+    edges = [
+        Edge("N1", "N_error", condition="outcome=fail"),
+        Edge("N1", "N_next", condition="outcome=success"),
+    ]
+    graph = _make_graph(edges)
+    outcome = Outcome(status=StageStatus.FAIL)
+
+    result = select_edge("N1", outcome, PipelineContext(), graph)
+
+    assert result is not None, (
+        "FAIL outcome with a matching condition='outcome=fail' edge must follow "
+        "that edge (spec §3.7, Step 1). Got None."
+    )
+    assert result.to_node == "N_error", (
+        f"Expected edge to 'N_error', got '{result.to_node}'"
+    )
+
+
+def test_partial_success_outcome_traverses_unconditional_edges():
+    """PARTIAL_SUCCESS is NOT treated as FAIL — unconditional edges are followed.
+
+    The fail-fast guard applies only to StageStatus.FAIL.  Other non-SUCCESS
+    statuses (PARTIAL_SUCCESS, RETRY, SKIPPED) are NOT blocked by the guard.
+    """
+    edges = [Edge("N1", "N2")]
+    graph = _make_graph(edges)
+    outcome = Outcome(status=StageStatus.PARTIAL_SUCCESS)
+
+    result = select_edge("N1", outcome, PipelineContext(), graph)
+
+    assert result is not None, (
+        "PARTIAL_SUCCESS must traverse unconditional edges (fail-fast guard "
+        "applies to FAIL only). Got None."
+    )
+    assert result.to_node == "N2"
+
+
+def test_fail_outcome_routes_to_runs_on_always_node():
+    """FAIL + unconditional edge to runs_on=always node: should follow it.
+
+    runs_on=always is an explicit opt-in for failure routing.  A downstream
+    cleanup node with runs_on=always must be reachable via unconditional edge
+    even when the predecessor failed.  The engine's skip gate then decides
+    whether to execute the cleanup node; select_edge's job is to route there.
+    """
+    from amplifier_module_loop_pipeline.graph import Node
+
+    # N1 → Cleanup (unconditional, cleanup has runs_on=always)
+    # N1 → Normal (unconditional, Normal has default runs_on=success)
+    # FAIL outcome → should route to Cleanup (opt-in), NOT to Normal
+    cleanup_node = Node(id="Cleanup", attrs={"runs_on": "always"})
+    normal_node = Node(id="Normal")
+    n1_node = Node(id="N1")
+
+    edges = [
+        Edge("N1", "Cleanup"),  # unconditional → target has runs_on=always
+        Edge("N1", "Normal"),  # unconditional → target has default runs_on=success
+    ]
+    from amplifier_module_loop_pipeline.graph import Graph
+
+    graph = Graph(
+        name="test",
+        nodes={"N1": n1_node, "Cleanup": cleanup_node, "Normal": normal_node},
+        edges=edges,
+    )
+    outcome = Outcome(status=StageStatus.FAIL)
+
+    result = select_edge("N1", outcome, PipelineContext(), graph)
+
+    assert result is not None, (
+        "FAIL must route to runs_on=always node via unconditional edge. Got None."
+    )
+    assert result.to_node == "Cleanup", (
+        f"Expected edge to 'Cleanup' (runs_on=always), got '{result.to_node}'"
+    )
+
+
+def test_fail_outcome_routes_to_runs_on_failure_node():
+    """FAIL + unconditional edge to runs_on=failure node: should follow it.
+
+    runs_on=failure is an explicit opt-in for failure routing (dedicated error
+    handlers).  These must be reachable even when the predecessor failed.
+    """
+    from amplifier_module_loop_pipeline.graph import Graph, Node
+
+    on_fail_node = Node(id="OnFail", attrs={"runs_on": "failure"})
+    n1_node = Node(id="N1")
+    edges = [Edge("N1", "OnFail")]
+    graph = Graph(
+        name="test",
+        nodes={"N1": n1_node, "OnFail": on_fail_node},
+        edges=edges,
+    )
+    outcome = Outcome(status=StageStatus.FAIL)
+
+    result = select_edge("N1", outcome, PipelineContext(), graph)
+
+    assert result is not None, (
+        "FAIL must route to runs_on=failure node via unconditional edge. Got None."
+    )
+    assert result.to_node == "OnFail"

--- a/modules/loop-pipeline/tests/test_parallel_fanout_contract.py
+++ b/modules/loop-pipeline/tests/test_parallel_fanout_contract.py
@@ -210,3 +210,114 @@ async def test_parallelogram_shape_does_not_fan_out_unconditional_edges(tmp_path
         f"LeafB must NOT run (spec §3.3: select_edge returns ONE edge; parallelogram "
         f"is NOT a fan-out node), got {execution_counts.get('LeafB', 0)}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Test 3: non-component multi-edge fan-out respects max_parallel (CONC-001–004)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_non_component_fanout_respects_max_parallel(tmp_path):
+    """_execute_parallel_fan_out bounds concurrency with the source node's max_parallel.
+
+    The engine-level fan-out path (for non-component nodes with multiple matching
+    conditional edges) must respect max_parallel exactly the same way ParallelHandler
+    does for shape=component nodes.  This test:
+
+    - Sets max_parallel=2 on the fan-out source node
+    - Fans out to 4 branches
+    - Uses a slow backend (asyncio.sleep) to create measurable overlap
+    - Tracks peak concurrent execution with a shared counter
+    - Asserts peak ≤ 2 (bounded) and all 4 branches eventually executed
+
+    Spec coverage: CONC-001–004, §3.8 (concurrency model).
+    """
+    import asyncio
+
+    peak_concurrent = 0
+    current_concurrent = 0
+    concurrent_lock = asyncio.Lock()
+    execution_counts: dict[str, int] = {}
+
+    class BoundedConcurrencyBackend:
+        async def run(self, node: Node, prompt: str, context: PipelineContext) -> str:
+            nonlocal peak_concurrent, current_concurrent
+            async with concurrent_lock:
+                current_concurrent += 1
+                if current_concurrent > peak_concurrent:
+                    peak_concurrent = current_concurrent
+            execution_counts[node.id] = execution_counts.get(node.id, 0) + 1
+            # Yield so other branches can start; makes overlapping detectable
+            await asyncio.sleep(0.05)
+            async with concurrent_lock:
+                current_concurrent -= 1
+            return "done"
+
+    # Fan-out source: shape=box (NOT component), max_parallel=2.
+    # All 4 branches have condition="outcome=success" so they all match at once.
+    # After the fan-out _execute_parallel_fan_out returns, the engine uses BFS
+    # (_find_fan_in_node) to locate the convergence node and routes there.
+    # NOTE: use a plain box for convergence, NOT a tripleoctagon — the tripleoctagon
+    # (FanInHandler) reads parallel.results which is only populated by ParallelHandler
+    # (shape=component).  The non-component fan-out path stores branch results in
+    # context_updates only, so a regular box is the correct convergence node here.
+    graph = Graph(
+        name="test-bounded-non-component-fanout",
+        nodes={
+            "start": Node(id="start", shape="Mdiamond"),
+            "FanOut": Node(
+                id="FanOut",
+                shape="box",
+                prompt="fan out work",
+                attrs={"max_parallel": "2"},  # caps concurrent branches at 2
+            ),
+            "Branch1": Node(id="Branch1", shape="box", prompt="branch 1"),
+            "Branch2": Node(id="Branch2", shape="box", prompt="branch 2"),
+            "Branch3": Node(id="Branch3", shape="box", prompt="branch 3"),
+            "Branch4": Node(id="Branch4", shape="box", prompt="branch 4"),
+            "Converge": Node(id="Converge", shape="box", prompt="after branches"),
+            "exit": Node(id="exit", shape="Msquare"),
+        },
+        edges=[
+            Edge(from_node="start", to_node="FanOut"),
+            # 4 conditional edges all matching outcome=success → multi-edge fan-out
+            Edge(from_node="FanOut", to_node="Branch1", condition="outcome=success"),
+            Edge(from_node="FanOut", to_node="Branch2", condition="outcome=success"),
+            Edge(from_node="FanOut", to_node="Branch3", condition="outcome=success"),
+            Edge(from_node="FanOut", to_node="Branch4", condition="outcome=success"),
+            # Convergence edges: BFS finds Converge as common reachable node from
+            # all 4 branch roots → engine routes there after fan-out completes
+            Edge(from_node="Branch1", to_node="Converge"),
+            Edge(from_node="Branch2", to_node="Converge"),
+            Edge(from_node="Branch3", to_node="Converge"),
+            Edge(from_node="Branch4", to_node="Converge"),
+            Edge(from_node="Converge", to_node="exit"),
+        ],
+    )
+
+    engine = PipelineEngine(
+        graph=graph,
+        context=PipelineContext(),
+        handler_registry=HandlerRegistry(backend=BoundedConcurrencyBackend()),
+        logs_root=str(tmp_path),
+    )
+    outcome = await engine.run()
+
+    assert outcome.status in (StageStatus.SUCCESS, StageStatus.PARTIAL_SUCCESS), (
+        f"Pipeline did not complete: {outcome.status}, {outcome.failure_reason}"
+    )
+
+    # All 4 branches must have run
+    for branch in ("Branch1", "Branch2", "Branch3", "Branch4"):
+        assert execution_counts.get(branch, 0) == 1, (
+            f"{branch} should have run exactly once, got "
+            f"{execution_counts.get(branch, 0)}"
+        )
+
+    # Peak concurrent execution must not exceed max_parallel=2
+    assert peak_concurrent <= 2, (
+        f"Peak concurrent branches was {peak_concurrent}, expected ≤ 2 "
+        f"(max_parallel=2 on FanOut node). "
+        f"_execute_parallel_fan_out must respect the source node's max_parallel."
+    )

--- a/modules/loop-pipeline/tests/test_parallel_ignore_does_not_populate_failed_outputs.py
+++ b/modules/loop-pipeline/tests/test_parallel_ignore_does_not_populate_failed_outputs.py
@@ -40,13 +40,28 @@ def _make_engine(dot_source: str, logs_root: str, hooks: Any = None) -> Pipeline
     validate_or_raise(graph)
     context = PipelineContext()
     registry = HandlerRegistry()
-    return PipelineEngine(
+    engine = PipelineEngine(
         graph=graph,
         context=context,
         handler_registry=registry,
         logs_root=logs_root,
         hooks=hooks,
     )
+
+    # Wire the subgraph_runner so ParallelHandler can execute branches.
+    # Without this, all branches fail immediately (no-op runner), which
+    # defeats the purpose of testing error_policy behavior.
+    async def subgraph_runner(
+        node_id: str,
+        branch_context: PipelineContext,
+        _graph: object,
+        _logs_root: str,
+    ) -> object:
+        return await engine._run_from(node_id, context=branch_context)
+
+    wired_registry = HandlerRegistry(subgraph_runner=subgraph_runner)
+    engine.handler_registry = wired_registry
+    return engine
 
 
 @pytest.mark.asyncio

--- a/modules/loop-pipeline/tests/test_runs_on_axis.py
+++ b/modules/loop-pipeline/tests/test_runs_on_axis.py
@@ -232,8 +232,14 @@ async def test_runs_on_success_default_behavior(tmp_path):
     )
     await engine.run()
 
-    # Default runs_on=success → skip because k is in failed_outputs
-    assert engine.node_outcomes["consumer"].status == StageStatus.SKIPPED
+    # Default runs_on=success + fail-fast: FAIL no longer traverses unconditional
+    # edges to default-runs_on nodes.  consumer is NOT reached (absent from
+    # node_outcomes), not SKIPPED.  Pipeline authors who want consumer to still
+    # execute after a failure must use runs_on=always or runs_on=failure.
+    assert "consumer" not in engine.node_outcomes, (
+        f"Expected consumer to NOT be in node_outcomes under fail-fast semantics, "
+        f"got status={engine.node_outcomes.get('consumer')}"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Two engine ratchets aligning behavior with spec §3.7 (fail-fast intent) and ParallelHandler's bounded-parallelism precedent.

**Change 1 — edge_selection.py**: FAIL outcomes no longer traverse unconditional edges to default `runs_on=success` nodes. Per spec §3.7, FAIL → look for explicit failure path (condition="outcome=fail" edges, retry_target, fallback_retry_target) → otherwise terminate. The target node's `runs_on` attribute acts as an explicit opt-in: `runs_on=always` and `runs_on=failure` nodes are still reachable via unconditional edges on FAIL.

Pipeline authors who want fail-forward have three explicit opt-in mechanisms (all preserved):
- `continue_on_fail=true` (converts FAIL → SUCCESS before edge selection)
- `runs_on=always` or `runs_on=failure` (skip gate override — select_edge checks target attrs)
- `condition="outcome=fail"` edges (explicit error routing)

**Change 2 — engine.py:\_execute\_parallel\_fan\_out**: Added `max_parallel` semaphore bounding to match what `ParallelHandler` already does for `shape=component` nodes. The previous unbounded `asyncio.gather` was a latent footgun for non-component multi-edge fan-outs. Source node's `max_parallel` attr is read (default 4).

**Additional engine fixes required by Change 1:**
- Failure routing retry path: added CR-3 state clearing (`completed_nodes`, `node_outcomes`, `failed_outputs`) to match the goal-gate retry path
- SKIP routing path: added fallback to unconditional edges after `select_edge` so skip-chain propagation continues (skipped nodes still route to successors, which are then also evaluated by the skip gate)

## Verification checklist

- [x] Unit tests pass (`pytest modules/loop-pipeline/`) — 1080 passed, 7 skipped, 2 pre-existing failures unchanged (test_outputs_attribute.py)
- [x] AGENTS.md reviewed; repo-specific gates met
- [x] Backward-compat path unchanged: `continue_on_fail`, `runs_on=always/failure`, condition edges all preserved
- [x] PR body includes verification evidence

## Verification evidence

```
pytest modules/loop-pipeline/ -q
...
2 failed, 1080 passed, 7 skipped, 1 warning
FAILED test_outputs_attribute.py::test_human_handler_infers_human_input_and_choice  ← pre-existing
FAILED test_outputs_attribute.py::test_human_handler_inferred_outputs_in_table      ← pre-existing
```

Key passing tests:
- `test_edge_selection_no_silent_fallthrough.py` — 6 new tests locking fail-fast guard (all pass)
- `test_parallel_fanout_contract.py::test_non_component_fanout_respects_max_parallel` — new bounded fan-out test (passes)
- `test_p8_continue_on_fail.py` — all 6 tests pass (continue_on_fail mechanism unaffected)
- `test_runs_on_axis.py` — all 9 tests pass (runs_on=always/failure behavior preserved)
- `test_goal_gate_retry_clears_failures.py` — all 3 tests pass (CR-3 state clearing fix)
- `test_parallel_ignore_does_not_populate_failed_outputs.py` — fixed test to wire subgraph_runner

## Pre-flight pipeline audit

Checked all .dot files in the companion resolver workspace:
- `optimize_bundle.dot`: vulnerable (fixed in companion dot-graph PR)
- `dotpowers.dot`: fan-out branches with unconditional edges — component handler + BFS fan-in routing are unaffected; sequential chains now properly halt on FAIL (intended)
- `resolve_validated.dot`, `semport.dot`, `reality_check.dot`, `smoke_test.dot`, `exercise.dot`: same pattern — sequential chains with unconditional edges; fail-fast behavior is intentional and correct
- Subgraph pipelines (`deliver_*.dot`, `dtu_validate.dot`): all use conditional edges for meaningful routing; unconditional edges to terminal/result nodes are now properly fail-fast

No pipelines found that would break in a non-obvious way beyond the acknowledged breaking change.

## Notes for reviewers

**BREAKING CHANGE**: Pipelines that relied on FAIL traversing unconditional edges (continuing silently on failure) need to add explicit failure routing. The three opt-in mechanisms listed above are the intended replacements.

**Test updates**: 4 tests in `test_eager_reference_scan.py` and 1 in `test_runs_on_axis.py` were updated to reflect the new fail-fast semantics. The old behavior (downstream nodes SKIPPED rather than absent) was a consequence of FAIL traversing unconditional edges — that consequence is now removed. The key behavioral guarantee (handlers of unreachable successors are never invoked) is unchanged.

**Judgment call**: `_execute_parallel_fan_out` doesn't naturally have the source node in scope. Fixed by reading `edges[0].from_node` to get the source node from the graph, then extracting `max_parallel` from its attrs. Defaults to 4 if the source node is unavailable.