### PR TITLE
docs(engine): document M5 substitution contract + absent-key policy

### DIFF
--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py
@@ -831,6 +831,23 @@ class PipelineEngine:
         """Mirror graph attributes into context.
 
         Spec Section 3.1: Initialize phase.
+
+        This seeds context with graph-level attributes only.  Additional keys
+        arrive through external channels:
+
+        - The resolver/dispatcher injects user-provided params and any
+          schema-declared defaults (e.g. ``default:`` fields in
+          resolver.yaml) into context before ``run()`` is called.  That is a
+          resolver-layer responsibility, not an engine responsibility.
+        - Subsequent nodes write outputs into context via the M5
+          substitution mechanism and ``outputs=`` declarations.
+
+        The engine itself has no concept of "param defaults".  Keys that exist
+        in context at execution time are available for ``$variable``
+        substitution in tool_command strings; keys that are absent leave the
+        literal token unchanged (see ``substitution.py`` M5 contract).
+        Pipeline authors should use shell ``${VAR:-default}`` syntax for any
+        context key that may be absent at execution time.
         """
         # Set goal from argument or graph attribute
         effective_goal = goal or self.graph.goal

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/substitution.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/substitution.py
@@ -14,6 +14,44 @@ are raised on missing keys; failures are caught by the engine's eager scan
 
 Key ordering: longest keys replaced first to avoid partial matches when a
 shorter key is a prefix of a longer one (e.g. "tool" vs "tool.output").
+
+Spec note (§4.5):
+    The NLSpec defines ``$goal`` as the only template variable in codergen
+    handler prompts.  M5 generalises this to all context keys in
+    tool_command strings — a conscious extension beyond the written spec.
+
+Implications for pipeline authors:
+    When a tool_command runs under ``set -eu`` bash, any token whose key
+    is absent from context survives as a literal string (e.g. the four
+    characters ``$foo``).  Bash then treats it as an unbound shell variable
+    and exits with "parameter not set" (exit 2).
+
+    The universally-portable defence is shell-default syntax in the bash::
+
+        ${optional_var:-fallback_value}
+
+    This works regardless of invocation path — dot-graph resolver,
+    attractor-as-tool in an AmplifierSession, custom resolver, or
+    ``attractor run`` CLI.  No upstream abstraction layer needs to be
+    relied upon.
+
+Implications for resolver authors:
+    Resolvers MAY pre-seed context with declared defaults from their own
+    schema before the engine runs (e.g. the dot-graph resolver reads
+    ``default:`` fields from resolver.yaml and injects them into context
+    at dispatch time).  This is an enhancement on top of the universal
+    shell-default baseline, not a replacement for it.
+
+Three-layer default pattern:
+    1. Universal floor — shell defaults in bash (works for all consumers).
+    2. Bridge enforcement — resolver seeds context with schema-declared
+       defaults at dispatch (protects direct API callers that bypass UI).
+    3. UI affordance — resolver emits A2UI ``defaultValue`` on schema
+       components so users see pre-filled fields without knowing the
+       underlying attractor mechanics.
+
+    The engine participates only at layer 1, via the absent-key
+    pass-through described above.  Layers 2 and 3 are resolver concerns.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
The engine's M5 substitution (variable expansion for `tool_command` strings) generalizes spec §4.5's `$goal`-only template to all context keys. The behavior for absent keys (literal pass-through, no exception) was implemented but never explicitly documented in the module's contract.

This created real confusion: pipeline authors using `set -eu` bash would assume context defaults were applied by some abstraction layer, when in fact the engine has no concept of param defaults.

This PR adds module-level docstrings to `substitution.py` and `_initialize_context()` in `engine.py` that:

- State the absent-key behavior (literal pass-through)
- Explain the implications for pipeline authors (use shell `${VAR:-default}`)
- Explain the implications for resolver authors (MAY pre-seed defaults)
- Reference the three-layer pattern: universal shell defaults (engine side), bridge enforcement (resolver seeds defaults from schema), A2UI affordance (resolver emits `defaultValue` for UI surfacing)

No behavior change.