### PR TITLE
docs(patterns): honest framing for goal_gate in §6 AP-2

### DIFF
--- a/docs/PIPELINE_PATTERNS.md
+++ b/docs/PIPELINE_PATTERNS.md
@@ -240,6 +240,38 @@ CheckVerdict -> Retry    [condition="context.tool.last_line=rejected"];
 `printf` is deterministic. The routing signal comes from `grep`'s judgment of the agent's
 natural output — not from the agent typing an exact keyword.
 
+**Note on `goal_gate` / `outcome=success/fail/retry`:** The attractor engine provides
+`goal_gate=true` as the spec-designed mechanism for outcome-based routing. When set, the
+engine interprets the LLM's response to compute the node's `outcome` status, which
+conditional edges route on (`condition="outcome=success"`, `condition="outcome=fail"`, etc.).
+Pipeline authors using `goal_gate` are not violating spec — this is the designed-in path for
+verdict routing.
+
+However, `goal_gate` shares the underlying fragility of LLM-emitted routing: the engine's
+interpretation depends on the LLM producing the expected outcome signal. Local models,
+smaller frontier models, and models with verbose tendencies can fail this silently.
+
+**Default lean:** if the LLM is already writing evidence to a file as part of its work
+product, route on that file (LLM writes → parallelogram greps → routes via `printf`). This
+produces the same outcome with less variance and no reliance on exact LLM token output.
+
+**When `goal_gate` is the right choice:**
+
+- The routing decision depends purely on LLM judgment with no file artifact
+- The pipeline targets only frontier models in practice
+- Adding a file-grep parallelogram would be ceremony with no real value
+
+**When to prefer file-based routing over `goal_gate`:**
+
+- The LLM is already writing evidence to a file (audit log, review verdict, validation result)
+- Local model portability is a goal
+- The pipeline runs across model families where exact-token output varies
+
+Community canonical pipelines use `goal_gate` extensively for verdict nodes and that works in
+practice for their target environments. Newer pipeline patterns favor file-based routing when
+the evidence file already exists for other reasons. This is a design trade-off — not a
+hierarchy of right and wrong.
+
 ---
 
 ### AP-3: Prompt/Validator Drift


### PR DESCRIPTION
The current §6 AP-2 section flags LLM-emitted routing sentinels as anti-pattern. The attractor engine's `goal_gate` / `outcome=success/fail` mechanism shares the same mechanical fragility (engine interprets LLM exact-token output) but is the spec-designed mechanism for verdict routing.

The previous text read as a blanket alarm. The cleaner framing:

- `goal_gate` IS the spec-designed path; pipeline authors using it are not violating spec
- It shares LLM-emitted routing fragility limits in practice
- Default lean: if LLM is already writing evidence to file, route on the file
- When `goal_gate` is the right choice: pure LLM judgment with no file artifact, frontier-only model target
- When to prefer file-based: file already exists, local model portability, multi-model-family targets

This prevents readers from flagging all community canonical pipeline verdict-node patterns as anti-pattern when the intent is that file-based routing is preferred where natural, not mandatory in all cases.

No specific community pipeline paths named (dependency awareness).