### PR TITLE
docs(patterns): cite in-the-wild Strategy SF adoption

### DIFF
--- a/docs/PIPELINE_PATTERNS.md
+++ b/docs/PIPELINE_PATTERNS.md
@@ -111,6 +111,18 @@ The validator's exit code is the routing signal, not any LLM output.
 regex, XML change descriptions — any intermediate format that only exists to feed the next
 code step.
 
+**In-the-wild adoption.** Pipeline authors in the broader DOT ecosystem have independently
+converged on Strategy SF for use cases like language-to-language code porting. A
+representative third-party pattern: the implementation node uses file tools to write changes
+directly across target files; a downstream build gate (compiler or test runner) validates via
+deterministic exit code — no intermediate format to specify, no format variance to absorb.
+
+The within-ecosystem contrast is instructive: earlier iterations of the same work used the
+LLM-as-format-translator pattern (model produces structured code blocks → code parses →
+writes files), producing silent file drops when block formatting varied across model runs.
+Later iterations by the same author group adopted Strategy SF — from reliability pressure,
+not from this document. That independent convergence is corroborating evidence.
+
 ---
 
 ## 4. Strategy V+R — Validation + Retry


### PR DESCRIPTION
## What

Adds a brief **In-the-wild adoption** subsection to §3 Strategy SF (Skip the Format) in `docs/PIPELINE_PATTERNS.md`.

## Why

The doc argued for Strategy SF on first-principles grounds. This addition adds external corroboration: experienced pipeline authors in the broader DOT ecosystem have independently converged on the same pattern for language-to-language code porting work — not from reading this document, but from reliability pressure. The within-ecosystem before/after (LLM-as-format-translator → file-tools-direct) is instructive evidence.

## Dependency-awareness rule (from PR #26)

This addition uses generic descriptive language only:
- No specific file paths named
- No specific repo names named
- `grep -E 'semport|dotpowers|dotfiles|strongdm' docs/PIPELINE_PATTERNS.md` added zero new hits (two pre-existing `strongdm` references in intro and cross-reference table are unchanged spec citations, not community file path violations)

## Verification

- Section count: 8 (unchanged — subsection uses bold prose marker, not a new `##` heading, consistent with existing §3 style)
- `git diff docs/PIPELINE_PATTERNS.md | grep '^+' | grep -E 'semport|dotpowers|dotfiles|strongdm'` → no hits (clean)
- Unit tests: `pytest modules/loop-pipeline/tests/test_pipeline_handler.py` — 33 passed
- Change type: docs-only → unit tests sufficient per AGENTS.md verification gradient