### PR TITLE
fix(engine): use truthy check for edge.loop_restart, not strict `is True`

### DIFF
--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py
@@ -712,7 +712,7 @@ class PipelineEngine:
             )
 
             # Step 6: Handle loop_restart edge attribute (NLSpec Section 174)
-            if edge.loop_restart is True:
+            if edge.loop_restart:
                 self.iteration_count += 1
                 iteration_dir = os.path.join(
                     self.logs_root, f"iteration_{self.iteration_count}"


### PR DESCRIPTION
## Summary

DOT-parsed attribute values come through as Python strings, not bools. Strict identity check `if edge.loop_restart is True:` returns False for the string `"true"`, skipping the loop-iteration state cleanup block entirely.

## Details

The DOT parser (`dot_parser.py`'s `_parse_value()` function) converts quoted attribute values like `loop_restart="true"` into Python strings. The engine's strict identity check at line 715:

```python
if edge.loop_restart is True:  # ❌ False when edge.loop_restart == "true" (string)
```

This means the entire state-cleanup block (lines 716-733) never executes for DOT-parsed pipelines:
- `self.completed_nodes.clear()`
- `self.node_outcomes.clear()`  
- `self.failed_outputs.clear()`
- `iteration_count` increment
- Log directory rotation

This prevents loop_restart back-edges from functioning correctly, as the engine's understanding of prior iterations never clears.

## Evidence

The defensive test in `test_p6_convergence_factory.py:276` already acknowledges both forms must be accepted:

```python
loop_val = edge.loop_restart
assert loop_val is True or loop_val == "true", (
    f"Expected feedback->generate loop_restart=true, got {loop_val!r}"
)
```

This confirms the parser produces strings for quoted attributes, and the team was aware of this ambiguity.

## Fix

Change line 715 from identity check to truthiness:

```python
- if edge.loop_restart is True:
+ if edge.loop_restart:
```

- `True` is truthy — existing behavior preserved ✅
- `"true"` (string) is truthy — parser output now handled ✅  
- `None` is falsy — edge without attribute still skipped ✅
- `False` is falsy — explicitly False edges still skipped ✅

## Testing

Existing tests like `test_loop_restart_increments_iteration_counter` that construct `Edge(loop_restart=True)` directly continue to pass. DOT-parsed pipelines now correctly execute the cleanup block.
