### PR TITLE
fix(pipeline): wire subgraph_runner into child HandlerRegistry

### DIFF
--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/pipeline.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/pipeline.py
@@ -162,15 +162,30 @@ class PipelineHandler:
         child_logs = os.path.join(logs_root, f"subgraph_{node.id}")
         os.makedirs(child_logs, exist_ok=True)
 
-        # (8) Create child HandlerRegistry
+        # (8) Create child HandlerRegistry — wire subgraph_runner so that
+        # ManagerLoopHandler and ParallelHandler can supervise child subgraphs.
+        #
+        # The closure below references child_engine, which is assigned in step (9)
+        # below.  Python closures are late-binding: the name is resolved at call time,
+        # not at definition time, so the assignment order is safe.
         if self._handler_registry_factory is not None:
             child_registry = self._handler_registry_factory()
         else:
+            async def child_subgraph_runner(
+                node_id: str,
+                branch_context: Any,
+                _graph: Any,
+                _logs_root: str,
+            ) -> Any:
+                """Execute a child subgraph branch via the child engine."""
+                return await child_engine._run_from(node_id, context=branch_context)
+
             child_registry = HandlerRegistry(
                 backend=self._backend,
                 hooks=self._hooks,
                 cancel_event=self._cancel_event,
                 interviewer=self._interviewer,
+                subgraph_runner=child_subgraph_runner,
             )
 
         # (9) Create child PipelineEngine

--- a/modules/loop-pipeline/tests/test_pipeline_handler.py
+++ b/modules/loop-pipeline/tests/test_pipeline_handler.py
@@ -913,3 +913,203 @@ class TestOutputsMergeBack:
         await handler.execute(graph.nodes["sub"], context, graph, logs_root)
 
         assert context.get("injected") is None
+
+
+# ---------------------------------------------------------------------------
+# Regression tests: issue #249 — child HandlerRegistry subgraph_runner wiring
+# ---------------------------------------------------------------------------
+
+# Child DOT with a manager (shape=house) node.  Uses correct manager.* attribute
+# names (not stack.* aliases) so max_cycles and actions are actually read by
+# ManagerLoopHandler — keeping the test deterministic and fast.
+_CHILD_DOT_WITH_MANAGER = """\
+digraph child_manager {
+    start [shape=Mdiamond]
+    mgr [shape=house, "manager.max_cycles"="1", "manager.actions"="observe"]
+    work [shape=box, prompt="child work"]
+    done [shape=Msquare]
+    start -> mgr
+    mgr -> work
+    work -> done
+}
+"""
+
+
+def _make_parent_graph_with_manager_child(tmp_path):
+    """Write _CHILD_DOT_WITH_MANAGER to tmp_path and return a parent Graph."""
+    child_dot_path = tmp_path / "child_mgr.dot"
+    child_dot_path.write_text(_CHILD_DOT_WITH_MANAGER)
+    return Graph(
+        name="parent",
+        nodes={
+            "start": Node(id="start", shape="Mdiamond"),
+            "sub": Node(
+                id="sub",
+                shape="folder",
+                type="pipeline",
+                attrs={"dot_file": str(child_dot_path)},
+            ),
+            "done": Node(id="done", shape="Msquare"),
+        },
+        edges=[
+            Edge(from_node="start", to_node="sub"),
+            Edge(from_node="sub", to_node="done"),
+        ],
+        source_dir=str(tmp_path),
+    )
+
+
+class TestChildRegistrySubgraphRunnerWiring:
+    """Regression tests for issue #249.
+
+    PipelineHandler.execute() was building the child HandlerRegistry without
+    passing subgraph_runner, leaving ManagerLoopHandler._runner and
+    ParallelHandler._runner as None.  Any child node with shape=house or
+    shape=component inside a shape=folder sub-pipeline therefore failed
+    immediately with "Manager loop requires a subgraph_runner".
+    """
+
+    @pytest.mark.asyncio
+    async def test_child_registry_has_subgraph_runners_wired(self, tmp_path):
+        """Child HandlerRegistry must have subgraph_runner on both ManagerLoopHandler and ParallelHandler.
+
+        Pins the internal contract: after PipelineHandler.execute() builds the
+        child HandlerRegistry (the else-branch, no factory), both
+        ``_handlers["stack.manager_loop"]._runner`` and
+        ``_handlers["parallel"]._runner`` must not be None.
+
+        Without the fix both are None, causing immediate FAIL on any child node
+        with shape=house or shape=component (issue #249).
+        """
+        from amplifier_module_loop_pipeline.engine import PipelineEngine
+        from amplifier_module_loop_pipeline.handlers import HandlerRegistry
+
+        graph = _make_parent_graph_with_manager_child(tmp_path)
+
+        # Spy: capture every HandlerRegistry instance constructed during the run.
+        instances: list = []
+        original_init = HandlerRegistry.__init__
+
+        def _spy_init(self_reg, **kw):
+            original_init(self_reg, **kw)
+            instances.append(self_reg)
+
+        HandlerRegistry.__init__ = _spy_init
+
+        context = PipelineContext()
+        logs_root = str(tmp_path / "logs")
+
+        try:
+            # Build parent engine canonically (mirrors PipelineOrchestrator.execute()).
+            engine = PipelineEngine(
+                graph=graph,
+                context=context,
+                handler_registry=HandlerRegistry(),  # temp [0]
+                logs_root=logs_root,
+            )
+
+            async def _subgraph_runner(node_id, branch_context, _graph, _logs_root):
+                return await engine._run_from(node_id, context=branch_context)
+
+            engine.handler_registry = HandlerRegistry(  # real [1]
+                subgraph_runner=_subgraph_runner,
+                backend=_MockBackend(),
+            )
+
+            # Run: PipelineHandler.execute() will be called for "sub", building
+            # the child registry [2].  We don't care whether the full run
+            # succeeds — registry construction already happened by this point.
+            await engine.run(goal="test wiring")
+        except Exception:
+            pass  # Registry construction already happened; state check below is valid.
+        finally:
+            HandlerRegistry.__init__ = original_init
+
+        # Before fix: [0]=temp parent, [1]=real parent, [2]=child without runner  → runner=None
+        # After fix:  [0]=temp parent, [1]=real parent, [2]=child WITH runner wired → runner=SET
+        # In both cases len==3 and instances[-1]==instances[2] is the child registry.
+        assert len(instances) >= 3, (
+            f"Expected >=3 HandlerRegistry instances (temp+real parent + child), "
+            f"got {len(instances)}.  PipelineHandler.execute() may not have been reached."
+        )
+        child_registry = instances[2]
+
+        mgr_runner = child_registry._handlers["stack.manager_loop"]._runner
+        par_runner = child_registry._handlers["parallel"]._runner
+
+        assert mgr_runner is not None, (
+            "Child HandlerRegistry ManagerLoopHandler._runner is None — "
+            "subgraph_runner not wired (issue #249)"
+        )
+        assert par_runner is not None, (
+            "Child HandlerRegistry ParallelHandler._runner is None — "
+            "subgraph_runner not wired (issue #249)"
+        )
+
+    @pytest.mark.asyncio
+    async def test_child_manager_node_runner_is_invoked(self, tmp_path):
+        """E2E: parent folder -> child house manager must invoke its subgraph_runner.
+
+        Before the fix:
+          child manager:  FAIL "Manager loop requires a subgraph_runner"
+          parent outcome: FAIL (edge selection re-surfaces child failure)
+
+        After the fix: child manager is wired, its subgraph_runner is invoked
+        (mock backend handles the branch work node), and the pipeline completes
+        with SUCCESS end-to-end.
+
+        Spec: issue #249 regression test.
+        """
+        from amplifier_module_loop_pipeline.engine import PipelineEngine
+        from amplifier_module_loop_pipeline.handlers import HandlerRegistry
+
+        graph = _make_parent_graph_with_manager_child(tmp_path)
+        context = PipelineContext()
+        logs_root = str(tmp_path / "logs")
+
+        # Build parent engine canonically (temp -> closure -> real registry).
+        engine = PipelineEngine(
+            graph=graph,
+            context=context,
+            handler_registry=HandlerRegistry(),  # temp
+            logs_root=logs_root,
+        )
+
+        async def _subgraph_runner(node_id, branch_context, _graph, _logs_root):
+            return await engine._run_from(node_id, context=branch_context)
+
+        engine.handler_registry = HandlerRegistry(
+            subgraph_runner=_subgraph_runner,
+            backend=_MockBackend(),
+        )
+
+        outcome = await engine.run(goal="test child manager runner")
+
+        # Retrieve the subgraph run data recorded by PipelineHandler.
+        pipeline_handler = engine.handler_registry._handlers["pipeline"]
+        subgraph_run = pipeline_handler._subgraph_runs.get("sub")
+        assert subgraph_run is not None, (
+            "PipelineHandler did not record a subgraph run for node 'sub' — "
+            "check that the parent engine reached the folder node"
+        )
+
+        mgr_outcome_data = subgraph_run["node_outcomes"].get("mgr")
+        assert mgr_outcome_data is not None, (
+            "Manager node 'mgr' not found in child subgraph node_outcomes — "
+            "the child pipeline may not have reached the manager node"
+        )
+
+        # Key regression assertion: manager must NOT fail with the missing-runner error.
+        assert mgr_outcome_data["failure_reason"] != "Manager loop requires a subgraph_runner", (
+            "Manager node failed with 'Manager loop requires a subgraph_runner' — "
+            "subgraph_runner not wired in child HandlerRegistry (issue #249)"
+        )
+
+        # With the fix the manager's subgraph_runner is invoked.  The mock backend
+        # handles "work" successfully, manager completes in 1 cycle, child pipeline
+        # succeeds, parent pipeline succeeds end-to-end.
+        assert mgr_outcome_data["status"] == "success", (
+            f"Manager node did not succeed — status={mgr_outcome_data['status']!r}, "
+            f"failure_reason={mgr_outcome_data.get('failure_reason')!r}"
+        )
+        assert outcome.status == StageStatus.SUCCESS


### PR DESCRIPTION
Fixes microsoft-amplifier/amplifier-support#249.

`PipelineHandler.execute()` (the handler for `shape=folder` nodes) constructed its child `HandlerRegistry` without passing `subgraph_runner`. As a result, any `shape=house` (manager) or `shape=component` (parallel) node inside a nested child pipeline failed immediately:

- `ManagerLoopHandler`: `Outcome(FAIL, "Manager loop requires a subgraph_runner")`
- `ParallelHandler`: same mechanism — `Outcome(FAIL, "No subgraph_runner configured")`

Both failures were re-surfaced by `edge_selection` at the parent as the misleading `"No matching edge from node <id>"` (a separate observability gap, tracked separately).

**Root cause confirmed before fixing**: instrumented `HandlerRegistry.__init__` to capture every registry instance constructed during a nested-pipeline run. The child registry built by `PipelineHandler.execute()` had `ManagerLoopHandler._runner = None` and `ParallelHandler._runner = None`.

**Fix**: define `child_subgraph_runner` as a late-binding closure over `child_engine._run_from`, pass it to the child `HandlerRegistry`. The closure references `child_engine` by name; the name resolves at call time, so the closure is defined just before `child_engine` is assigned. This is slightly cleaner than the temp-registry / swap dance in `PipelineOrchestrator.execute()` (3 registries per nested run instead of 4) while producing equivalent semantics. The `handler_registry_factory` escape hatch is preserved.

**Tests added** (`tests/test_pipeline_handler.py::TestChildRegistrySubgraphRunnerWiring`):
- `test_child_registry_has_subgraph_runners_wired` — spy on `HandlerRegistry.__init__`, assert the child registry (instance #2) has both `_runner` attributes SET after the fix.
- `test_child_manager_node_runner_is_invoked` — full engine e2e: parent `shape=folder` → child `shape=house`, asserts the manager node succeeds and does NOT return `"Manager loop requires a subgraph_runner"`.

Both tests RED on `main`, GREEN after this fix.

**Scope discipline (intentional)**: This patch does not refactor the `SubgraphRunner` kwarg / closure dance, even though the bug exists because that pattern is duplicated across 4 sites. See follow-up issue microsoft-amplifier/amplifier-support#250. This patch also does not address the misleading `"No matching edge"` message that masks the inner handlers `failure_reason`. See follow-up issue microsoft-amplifier/amplifier-support#251.