### PR TITLE
fix(engine): preserve handler failure_reason on routing termination

### DIFF
--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py
@@ -258,16 +258,25 @@ class PipelineEngine:
                     self.graph,
                 )
                 if edge is None:
+                    node_outcome = self.node_outcomes.get(current_node.id)
+                    original_reason = (
+                        node_outcome.failure_reason if node_outcome else None
+                    )
                     fail_outcome = Outcome(
                         status=StageStatus.FAIL,
-                        failure_reason=f"No matching edge from resumed node '{current_node.id}'",
+                        failure_reason=original_reason
+                        or f"No matching edge from resumed node '{current_node.id}'",
+                        notes=f"No matching edge from resumed node '{current_node.id}'"
+                        if original_reason
+                        else None,
                     )
                     await self._emit(
                         PIPELINE_ERROR,
                         {
                             "node_id": current_node.id,
                             "error_type": "no_matching_edge",
-                            "message": fail_outcome.failure_reason or "",
+                            "message": f"No matching edge from resumed node '{current_node.id}'",
+                            "handler_failure_reason": original_reason,
                         },
                     )
                     await self._emit_complete(fail_outcome, pipeline_start_time)
@@ -349,11 +358,14 @@ class PipelineEngine:
                         failure_routing_retries += 1
                         current_node = retry_node
                         continue
+                    original_reason = skip_outcome.failure_reason
                     fail_outcome = Outcome(
                         status=StageStatus.FAIL,
-                        failure_reason=(
-                            f"No matching edge from skipped node '{current_node.id}'"
-                        ),
+                        failure_reason=original_reason
+                        or f"No matching edge from skipped node '{current_node.id}'",
+                        notes=f"No matching edge from skipped node '{current_node.id}'"
+                        if original_reason
+                        else None,
                     )
                     await self._emit_complete(fail_outcome, pipeline_start_time)
                     return fail_outcome
@@ -689,14 +701,19 @@ class PipelineEngine:
 
                 fail_outcome = Outcome(
                     status=StageStatus.FAIL,
-                    failure_reason=f"No matching edge from node '{current_node.id}'",
+                    failure_reason=outcome.failure_reason
+                    or f"No matching edge from node '{current_node.id}'",
+                    notes=f"No matching edge from node '{current_node.id}'"
+                    if outcome.failure_reason
+                    else None,
                 )
                 await self._emit(
                     PIPELINE_ERROR,
                     {
                         "node_id": current_node.id,
                         "error_type": "no_matching_edge",
-                        "message": fail_outcome.failure_reason or "",
+                        "message": f"No matching edge from node '{current_node.id}'",
+                        "handler_failure_reason": outcome.failure_reason,
                     },
                 )
                 await self._emit_complete(fail_outcome, pipeline_start_time)

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/pipeline_events.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/pipeline_events.py
@@ -60,6 +60,20 @@ PIPELINE_GOAL_GATE_CHECK: str = "pipeline:goal_gate_check"
 # ---------------------------------------------------------------------------
 # Errors
 # ---------------------------------------------------------------------------
+
+#: Emitted when pipeline execution terminates with an error (e.g. no matching
+#: edge after all retry targets are exhausted).
+#:
+#: Payload fields (always present):
+#:   node_id                  — ID of the node that triggered the error
+#:   error_type               — error classification string (e.g.
+#:                              "no_matching_edge")
+#:   message                  — routing-level description of the failure
+#:                              (e.g. "No matching edge from node 'X'")
+#:   handler_failure_reason   — the failure_reason returned by the node handler,
+#:                              or None when the handler did not provide one.
+#:                              Distinguishes the handler's root cause from the
+#:                              routing-level message. Added in issue #251.
 PIPELINE_ERROR: str = "pipeline:error"
 
 # ---------------------------------------------------------------------------

--- a/modules/loop-pipeline/tests/test_failure_routing.py
+++ b/modules/loop-pipeline/tests/test_failure_routing.py
@@ -10,6 +10,10 @@ Fallback chain: node.retry_target → node.fallback_retry_target →
 Spec coverage: EXEC-015–018, Section 3.3.
 """
 
+from __future__ import annotations
+
+from typing import Any
+
 import pytest
 
 from amplifier_module_loop_pipeline.context import PipelineContext
@@ -17,6 +21,7 @@ from amplifier_module_loop_pipeline.engine import PipelineEngine
 from amplifier_module_loop_pipeline.graph import Edge, Graph, Node
 from amplifier_module_loop_pipeline.handlers import HandlerRegistry
 from amplifier_module_loop_pipeline.outcome import Outcome, StageStatus
+from amplifier_module_loop_pipeline.pipeline_events import PIPELINE_ERROR
 
 
 class CountingBackend:
@@ -219,3 +224,122 @@ class TestFailureRoutingBounded:
         # Total calls should be bounded by _MAX_GOAL_GATE_RETRIES (shared limit)
         total_calls = backend.call_count("a") + backend.call_count("b")
         assert total_calls <= PipelineEngine._MAX_GOAL_GATE_RETRIES + 5
+
+
+# ---------------------------------------------------------------------------
+# Issue #251: Handler failure_reason preservation on routing termination
+# ---------------------------------------------------------------------------
+
+
+class _FailOutcomeBackend:
+    """Backend that returns a specific FAIL Outcome for one node, SUCCESS for others."""
+
+    def __init__(self, fail_node: str, failure_reason: str | None = None) -> None:
+        self._fail_node = fail_node
+        self._failure_reason = failure_reason
+
+    async def run(self, node: Node, prompt: str, context: Any) -> Outcome:
+        if node.id == self._fail_node:
+            return Outcome(status=StageStatus.FAIL, failure_reason=self._failure_reason)
+        return Outcome(status=StageStatus.SUCCESS)
+
+
+class _CapturingHooks:
+    """Minimal hooks implementation that records all emitted events."""
+
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict[str, Any]]] = []
+
+    async def emit(self, name: str, data: dict[str, Any]) -> None:
+        self.events.append((name, data))
+
+    def get(self, name: str) -> list[dict[str, Any]]:
+        return [d for n, d in self.events if n == name]
+
+
+def _graph_with_dead_end_worker() -> Graph:
+    """Graph: start → worker (no outgoing edges from worker).
+
+    A handler that returns FAIL with no matching FAIL-condition edge will
+    trigger routing termination at worker.
+    """
+    return Graph(
+        name="test",
+        nodes={
+            "start": Node(id="start", shape="Mdiamond"),
+            "worker": Node(id="worker", prompt="work"),
+            "exit": Node(id="exit", shape="Msquare"),
+        },
+        edges=[
+            Edge(from_node="start", to_node="worker"),
+            # No edge from worker — routing terminates there
+        ],
+    )
+
+
+class TestHandlerFailureReasonPreservation:
+    """Handler failure_reason must survive routing termination (issue #251).
+
+    When a handler returns Outcome(FAIL, failure_reason="X") and no outgoing
+    edge matches, the pipeline-level failure_reason must carry X, not the
+    routing message.  The routing context ("No matching edge …") moves to
+    the notes field when the handler provided its own reason.
+    """
+
+    @pytest.mark.asyncio
+    async def test_handler_failure_reason_preserved_when_no_matching_edge(
+        self, tmp_path
+    ):
+        """Handler failure_reason is preserved; routing message goes to notes."""
+        graph = _graph_with_dead_end_worker()
+        backend = _FailOutcomeBackend("worker", "specific handler failure reason")
+        engine = _make_engine(graph, backend=backend, logs_root=str(tmp_path))
+        outcome = await engine.run()
+
+        assert outcome.status == StageStatus.FAIL
+        # Handler's own reason must be the failure_reason
+        assert outcome.failure_reason == "specific handler failure reason"
+        # Routing context must be demoted to notes
+        assert outcome.notes is not None
+        assert "No matching edge" in outcome.notes
+        # Routing message must NOT bleed into failure_reason
+        assert "No matching edge" not in (outcome.failure_reason or "")
+
+    @pytest.mark.asyncio
+    async def test_routing_message_used_when_handler_has_no_failure_reason(
+        self, tmp_path
+    ):
+        """Today's behaviour preserved: routing message used when handler silent.
+
+        When a handler returns Outcome(FAIL) with no failure_reason, the routing
+        message becomes the failure_reason and notes stays None.
+        """
+        graph = _graph_with_dead_end_worker()
+        backend = _FailOutcomeBackend("worker", failure_reason=None)
+        engine = _make_engine(graph, backend=backend, logs_root=str(tmp_path))
+        outcome = await engine.run()
+
+        assert outcome.status == StageStatus.FAIL
+        assert "No matching edge" in (outcome.failure_reason or "")
+        assert outcome.notes is None
+
+    @pytest.mark.asyncio
+    async def test_pipeline_error_event_carries_handler_failure_reason(self, tmp_path):
+        """PIPELINE_ERROR event payload includes the handler's failure_reason.
+
+        The event carries both routing context (message) and handler reason
+        (handler_failure_reason) so consumers can distinguish the two.
+        """
+        graph = _graph_with_dead_end_worker()
+        backend = _FailOutcomeBackend("worker", "handler says: something broke")
+        hooks = _CapturingHooks()
+        engine = _make_engine(
+            graph, backend=backend, logs_root=str(tmp_path), hooks=hooks
+        )
+        await engine.run()
+
+        error_events = hooks.get(PIPELINE_ERROR)
+        assert len(error_events) == 1
+        ev = error_events[0]
+        assert ev.get("handler_failure_reason") == "handler says: something broke"
+        assert "No matching edge" in ev.get("message", "")


### PR DESCRIPTION
Fixes microsoft-amplifier/amplifier-support#251.

## Root cause

When a handler returned `Outcome(FAIL, failure_reason="<X>")` and the
node's outgoing edges had no FAIL-condition match, `engine.py:690`
constructed a fresh `Outcome(FAIL, ...)` with `failure_reason="No
matching edge from node '<id>'"``. The handler's actual reason was
silently dropped. Same pattern at 2 secondary sites (resume path
`engine.py:261`, skip path `engine.py:352`).

This masking made bugs like #249 hard to diagnose: a
`ManagerLoopHandler` returning `Outcome(FAIL, "Manager loop requires
a subgraph_runner")` surfaced upstream as `"No matching edge from
node 'manager'"` — pointing at the wrong subsystem.

## What changed

At each of the 3 sites, the routing-termination `Outcome` is now
constructed as:

- `failure_reason`: prefer the handler's `failure_reason`; fall back
  to the routing message if the handler provided none.
- `notes`: the routing message, present only when a handler reason
  was also present (so existing behavior is preserved when the
  handler had no reason).

The `PIPELINE_ERROR` event payload also gains a new
`handler_failure_reason` field (additive, non-breaking) so consumers
can distinguish handler reason from routing message
programmatically.

Documented in `pipeline_events.py`.

Tests added in `test_failure_routing.py`:
- `test_handler_failure_reason_preserved_when_no_matching_edge`
- `test_routing_message_used_when_handler_has_no_failure_reason`
- `test_pipeline_error_event_carries_handler_failure_reason`

The existing `test_no_retry_target_anywhere_returns_fail` continues
to pass unchanged (it uses a SUCCESS-outcome handler whose
`failure_reason` is None, so the fallback path applies and the
"No matching edge" message remains as `failure_reason` — identical
to today's behavior).

## Verification

- New tests RED on `main` baseline, GREEN after fix.
- Full suite: zero new failures vs. baseline.
- `ruff check` + `pyright`: clean.

## Migration

None for in-tree callers. Out-of-tree consumers of `PIPELINE_ERROR`
events can now read `handler_failure_reason` for the underlying
handler reason; existing `message` continues to carry the routing
string. Any caller that previously asserted
`failure_reason == "No matching edge..."` for handler-FAIL cases
needs to check for the handler's reason instead — but that
assertion was masking the actual bug.