### PR TITLE
fix(engine): discard checkpoints from a different graph (issue #252)

### DIFF
--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/checkpoint.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/checkpoint.py
@@ -31,6 +31,7 @@ class Checkpoint:
     timestamp: str
     node_retries: dict[str, int] = field(default_factory=dict)
     logs: list[str] = field(default_factory=list)  # L-7: execution log entries
+    graph_fingerprint: str = field(default="")  # issue #252: cross-graph pollution guard
 
     @property
     def completed_node_list(self) -> list[str]:
@@ -58,6 +59,7 @@ def save_checkpoint(checkpoint: Checkpoint, path: str) -> None:
         "timestamp": checkpoint.timestamp,
         "node_retries": checkpoint.node_retries,
         "logs": checkpoint.logs,  # L-7
+        "graph_fingerprint": checkpoint.graph_fingerprint,  # issue #252
     }
     with open(path, "w") as f:
         json.dump(data, f, indent=2, default=str)
@@ -80,4 +82,5 @@ def load_checkpoint(path: str) -> Checkpoint:
         timestamp=data.get("timestamp", ""),
         node_retries=data.get("node_retries", {}),
         logs=data.get("logs", []),  # L-7
+        graph_fingerprint=data.get("graph_fingerprint", ""),  # issue #252; "" keeps old checkpoints loadable
     )

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py
@@ -963,6 +963,28 @@ class PipelineEngine:
             failure_reason=failure_reason,
         )
 
+    def _compute_graph_fingerprint(self) -> str:
+        """Compute a fingerprint for the current graph to detect checkpoint mismatch.
+
+        Uses the DOT source string when available; falls back to a stable sort of
+        node-id+shape pairs when dot_source is empty.
+
+        Issue #252: prevents cross-graph checkpoint pollution when two engines
+        share the same logs_root.
+        """
+        import hashlib
+
+        source = self.graph.dot_source
+        if not source:
+            # Fallback: stable sort of (node_id, shape) pairs
+            source = ",".join(
+                sorted(
+                    f"{nid}:{node.shape}"
+                    for nid, node in self.graph.nodes.items()
+                )
+            )
+        return hashlib.md5(source.encode()).hexdigest()  # noqa: S324 (non-crypto use)
+
     def _try_resume_from_checkpoint(self) -> bool:
         """Try to load and restore state from an existing checkpoint.
 
@@ -977,6 +999,19 @@ class PipelineEngine:
             cp = load_checkpoint(self._checkpoint_path)
         except (FileNotFoundError, KeyError, ValueError):
             logger.warning("Failed to load checkpoint, starting fresh")
+            return False
+
+        # Guard: discard checkpoints written for a different graph (issue #252).
+        # The empty-string default keeps pre-fix checkpoints loadable (backward compat).
+        current_fp = self._compute_graph_fingerprint()
+        if cp.graph_fingerprint and cp.graph_fingerprint != current_fp:
+            logger.warning(
+                "Checkpoint graph fingerprint mismatch "
+                "(checkpoint=%s…, current=%s…); "
+                "discarding stale checkpoint to prevent cross-graph pollution",
+                cp.graph_fingerprint[:8],
+                current_fp[:8],
+            )
             return False
 
         # Restore context from checkpoint
@@ -1045,6 +1080,7 @@ class PipelineEngine:
             node_outcomes=serialized_outcomes,
             timestamp=datetime.now(timezone.utc).isoformat(),
             logs=self.context.get_logs(),  # L-7: include logs in checkpoint
+            graph_fingerprint=self._compute_graph_fingerprint(),  # issue #252
         )
         save_checkpoint(cp, self._checkpoint_path)
 

--- a/modules/loop-pipeline/tests/test_checkpoint.py
+++ b/modules/loop-pipeline/tests/test_checkpoint.py
@@ -359,3 +359,157 @@ class TestResumeFromCheckpoint:
         assert outcome.status in (StageStatus.SUCCESS, StageStatus.PARTIAL_SUCCESS)
         # Backend called for step (start is handled by StartHandler)
         assert "step" in backend.calls
+
+
+class TestGraphFingerprintIsolation:
+    """Issue #252: checkpoint pollution across graphs sharing the same logs_root."""
+
+    @pytest.mark.asyncio
+    async def test_stale_checkpoint_discarded_on_graph_mismatch(
+        self, tmp_path, caplog
+    ):
+        """Engine B (Graph G') must not consume Engine A's (Graph G) checkpoint
+        when both share the same logs_root.
+
+        RED on main (no guard), GREEN after fix (fingerprint mismatch discards
+        the stale checkpoint).
+        """
+        import logging
+
+        shared_logs = str(tmp_path / "shared-logs")
+
+        # Engine A: Graph G - runs fully, writes checkpoint with WorkerA + WorkerB
+        graph_g = """
+digraph {
+    start [shape=Mdiamond]
+    WorkerA [prompt="Work A"]
+    WorkerB [prompt="Work B"]
+    exit [shape=Msquare]
+    start -> WorkerA -> WorkerB -> exit
+}
+"""
+        engine_a = _make_engine(graph_g, backend=MockBackend("done"), logs_root=shared_logs)
+        outcome_a = await engine_a.run()
+        assert outcome_a.status in (StageStatus.SUCCESS, StageStatus.PARTIAL_SUCCESS)
+
+        # Confirm checkpoint was written and contains Engine A's nodes
+        checkpoint_path = os.path.join(shared_logs, "checkpoint.json")
+        assert os.path.exists(checkpoint_path)
+        with open(checkpoint_path) as f:
+            raw = json.load(f)
+        assert "WorkerA" in raw["completed_nodes"]
+
+        # Engine B: Graph G' - different structure, same logs_root
+        graph_g_prime = """
+digraph {
+    start [shape=Mdiamond]
+    NestedRegression [prompt="Nested work"]
+    exit [shape=Msquare]
+    start -> NestedRegression -> exit
+}
+"""
+        with caplog.at_level(
+            logging.WARNING, logger="amplifier_module_loop_pipeline.engine"
+        ):
+            engine_b = _make_engine(
+                graph_g_prime, backend=MockBackend("done"), logs_root=shared_logs
+            )
+            outcome_b = await engine_b.run()
+
+        # Engine B must NOT have stale entries from Engine A's graph
+        assert "WorkerA" not in engine_b.node_outcomes, (
+            "stale WorkerA from Engine A must not appear in Engine B's node_outcomes"
+        )
+        assert "WorkerB" not in engine_b.node_outcomes, (
+            "stale WorkerB from Engine A must not appear in Engine B's node_outcomes"
+        )
+        # Engine B must complete its own graph successfully
+        assert outcome_b.status in (StageStatus.SUCCESS, StageStatus.PARTIAL_SUCCESS)
+
+    @pytest.mark.asyncio
+    async def test_checkpoint_accepted_on_matching_graph(self, tmp_path):
+        """Resume still works when Engine B runs the same graph as Engine A.
+
+        Should be GREEN on both main and after fix — same graph means same
+        fingerprint, so the guard does not discard the checkpoint.
+        """
+        shared_logs = str(tmp_path / "logs")
+        dot = """
+digraph {
+    start [shape=Mdiamond]
+    plan [prompt="Plan"]
+    implement [prompt="Implement"]
+    exit [shape=Msquare]
+    start -> plan -> implement -> exit
+}
+"""
+        # Engine A: runs the full graph, writes checkpoint
+        backend_a = MockBackend("done")
+        engine_a = _make_engine(dot, backend=backend_a, logs_root=shared_logs)
+        await engine_a.run()
+
+        # Engine B: fresh engine, SAME graph, same logs_root -> must resume
+        backend_b = MockBackend("done")
+        engine_b = _make_engine(dot, backend=backend_b, logs_root=shared_logs)
+        outcome_b = await engine_b.run()
+
+        assert outcome_b.status in (StageStatus.SUCCESS, StageStatus.PARTIAL_SUCCESS)
+        # Backend B must NOT be called — all nodes already completed by Engine A
+        assert backend_b.calls == [], (
+            f"Backend should not be called when all nodes are resumed; "
+            f"got {backend_b.calls}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_backward_compat_checkpoint_without_fingerprint_still_resumes(
+        self, tmp_path
+    ):
+        """Old-style checkpoints without graph_fingerprint must still enable resume.
+
+        The backward-compat guard ``if cp.graph_fingerprint and ...`` is falsy for
+        the empty-string default, so pre-fix checkpoints are always accepted.
+
+        Should be GREEN on both main and after fix.
+        """
+        logs = str(tmp_path / "logs")
+        os.makedirs(logs, exist_ok=True)
+
+        # Handcrafted old-style checkpoint JSON: NO graph_fingerprint field
+        old_checkpoint = {
+            "current_node": "plan",
+            "completed_nodes": {"start": "success", "plan": "success"},
+            "context": {"graph.goal": ""},
+            "node_outcomes": {
+                "start": {"status": "success"},
+                "plan": {"status": "success"},
+            },
+            "timestamp": "2025-01-01T00:00:00Z",
+            "node_retries": {},
+            "logs": [],
+            # Intentionally NO "graph_fingerprint" key — simulates pre-fix checkpoint
+        }
+        with open(os.path.join(logs, "checkpoint.json"), "w") as f:
+            json.dump(old_checkpoint, f)
+
+        dot = """
+digraph {
+    start [shape=Mdiamond]
+    plan [prompt="Plan"]
+    implement [prompt="Implement"]
+    exit [shape=Msquare]
+    start -> plan -> implement -> exit
+}
+"""
+        backend = MockBackend("done")
+        engine = _make_engine(dot, backend=backend, logs_root=logs)
+        outcome = await engine.run()
+
+        assert outcome.status in (StageStatus.SUCCESS, StageStatus.PARTIAL_SUCCESS)
+        # implement must have been executed (was NOT in old checkpoint)
+        assert "implement" in backend.calls, (
+            "implement should have been executed (not in old checkpoint)"
+        )
+        # plan must NOT have been executed (was in old checkpoint)
+        assert "plan" not in backend.calls, (
+            "plan should have been skipped (was already in old checkpoint)"
+        )

--- a/modules/loop-pipeline/tests/test_execution_environment.py
+++ b/modules/loop-pipeline/tests/test_execution_environment.py
@@ -551,7 +551,8 @@ async def test_full_lifecycle_orchestrator_and_backend(tmp_path):
                 context_updates={"last_stage": node.id},
             )
 
-    # Use tmp_path for logs_root to avoid stale checkpoint contamination
+    # Use tmp_path for logs_root for isolation hygiene (issue #252 graph-fingerprint guard
+    # now prevents stale checkpoint contamination across engines)
     orchestrator = PipelineOrchestrator(
         {
             "dot_source": TWO_NODE_DOT,


### PR DESCRIPTION
Fixes microsoft-amplifier/amplifier-support#252.

## Root cause

`Engine._try_resume_from_checkpoint()` unconditionally read
`checkpoint.json` from `logs_root` on startup, populating
`self.node_outcomes` and `self.completed_nodes` from disk. The only
guard was `os.path.exists(checkpoint_path)` — no check that the
checkpoint belonged to the current graph.

Concrete failure: Engine A runs Graph G in `logs_root=L`, writes
checkpoint. Engine B (fresh process, Graph G') runs in same `L`,
picks up stale entries from G in `node_outcomes`. If G and G' share
node IDs, B silently skips executing those nodes because the resumed
checkpoint marks them as already completed.

Maintainers had been working around this in tests with a `tmp_path`
comment in `test_execution_environment.py:554` — workaround
obsoleted by this fix.

## What changed

`Checkpoint` dataclass gains a `graph_fingerprint: str = field(default="")`
field (`checkpoint.py`). On load, mismatch → discard checkpoint with
a warning. Empty fingerprint keeps old checkpoints loadable
(backward compat for any persisted state authored before this
change).

Engine adds `_compute_graph_fingerprint()` (MD5 of `graph.dot_source`
with a stable fallback) and uses it both for saves and for the
mismatch guard on resume.

Tests added in `test_checkpoint.py::TestGraphFingerprintIsolation`:
- `test_stale_checkpoint_discarded_on_graph_mismatch`
- `test_checkpoint_accepted_on_matching_graph`
- `test_backward_compat_checkpoint_without_fingerprint_still_resumes`

The existing `TestResumeFromCheckpoint` suite continues to pass
(handcrafted checkpoints without the field still resume, via the
backward-compat `if cp.graph_fingerprint and ...` guard).

The obsolete workaround comment at
`test_execution_environment.py:554` is updated to note the fix.

## Verification

- New tests RED on `main` baseline, GREEN after fix.
- Resume tests still pass (backward compat guard works).
- Full suite: zero new failures vs. baseline.
- `ruff check` + `pyright`: clean.

## Migration

None for in-tree callers. Resume semantics preserved: same graph =
same fingerprint = resume works exactly as before. Different graph =
clean slate (which is the correct behavior; resuming into a
structurally-changed graph was never sound).