### PR TITLE
refactor(handlers): introduce HandlerContext + terminate_pipeline() (T2.1+T2.3)

### DIFF
--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/__init__.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/__init__.py
@@ -510,35 +510,22 @@ class PipelineOrchestrator:
                     "to local execution"
                 )
 
-        # 8. Create engine first (handlers need its _run_from method)
-        # Use a placeholder registry, then replace after wiring
+        # 8. Create registry (no closures, no rewire — engine passes self at call time)
+        registry = HandlerRegistry(
+            backend=backend,
+            hooks=hooks,
+        )
+
+        # 9. Create engine (carries itself to handlers via execute(engine=...))
         engine = PipelineEngine(
             graph=graph,
             context=pipeline_context,
-            handler_registry=HandlerRegistry(backend=backend),  # temp
+            handler_registry=registry,
             logs_root=logs_root,
             hooks=hooks,
         )
 
-        # 9. Create subgraph runner closure that delegates to engine._run_from
-        async def subgraph_runner(
-            node_id: str,
-            branch_context: PipelineContext,
-            _graph: Any,
-            _logs_root: str,
-        ) -> Outcome:
-            """Execute a subgraph branch via the engine."""
-            return await engine._run_from(node_id, context=branch_context)
-
-        # 10. Register handlers with the subgraph runner wired in
-        registry = HandlerRegistry(
-            backend=backend,
-            subgraph_runner=subgraph_runner,
-            hooks=hooks,
-        )
-        engine.handler_registry = registry
-
-        # 11. Run the engine (with environment teardown in finally)
+        # 10. Run the engine (with environment teardown in finally)
         try:
             outcome = await engine.run(goal=prompt or None)
         finally:

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/__init__.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/__init__.py
@@ -23,6 +23,7 @@ from .context import PipelineContext
 from .dot_parser import parse_dot
 from .engine import PipelineEngine
 from .handlers import HandlerRegistry
+from .handlers.context import HandlerContext
 from .outcome import Outcome, StageStatus
 from .hook_bridge import _current_node_context, set_node_context
 from .pipeline_events import PROVIDER_ERROR, PROVIDER_REQUEST, PROVIDER_RESPONSE
@@ -512,8 +513,10 @@ class PipelineOrchestrator:
 
         # 8. Create registry (no closures, no rewire — engine passes self at call time)
         registry = HandlerRegistry(
-            backend=backend,
-            hooks=hooks,
+            HandlerContext(
+                backend=backend,
+                hooks=hooks,
+            )
         )
 
         # 9. Create engine (carries itself to handlers via execute(engine=...))

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py
@@ -148,7 +148,7 @@ class PipelineEngine:
 
         # Bound total pipeline steps to prevent infinite loops caused by
         # condition-routing bugs or missing edge guards. Matches the safety
-        # bound used in the subgraph runner (_run_from).
+        # bound used in the subgraph runner (run_subgraph).
         max_steps = len(self.graph.nodes) * self._MAX_GOAL_GATE_RETRIES
         steps = 0
 
@@ -418,6 +418,7 @@ class PipelineEngine:
                                 self.logs_root,
                                 retry_policy,
                                 hooks=self.hooks,
+                                engine=self,
                             )
                     except asyncio.TimeoutError:
                         node_duration_ms = (time.monotonic() - node_start_time) * 1000
@@ -447,6 +448,7 @@ class PipelineEngine:
                         self.logs_root,
                         retry_policy,
                         hooks=self.hooks,
+                        engine=self,
                     )
             node_duration_ms = (time.monotonic() - node_start_time) * 1000
 
@@ -586,7 +588,7 @@ class PipelineEngine:
             #
             # BUG G FIX: Component nodes (shape=component) are handled by
             # ParallelHandler, which fans out ALL outgoing branches internally
-            # via the subgraph_runner (_run_from) and populates parallel.results
+            # via run_subgraph and populates parallel.results
             # in context.  The engine must NOT re-fan-out via
             # _execute_parallel_fan_out after the handler returns — that would
             # execute each branch a second time.
@@ -735,7 +737,7 @@ class PipelineEngine:
             # Step 7: Advance to next node
             current_node = self.graph.nodes[edge.to_node]
 
-    async def _run_from(
+    async def run_subgraph(
         self,
         start_node_id: str,
         *,
@@ -796,7 +798,7 @@ class PipelineEngine:
             else:
                 try:
                     outcome = await handler.execute(
-                        current_node, ctx, self.graph, self.logs_root
+                        current_node, ctx, self.graph, self.logs_root, engine=self
                     )
                 except Exception as exc:
                     return Outcome(
@@ -826,6 +828,10 @@ class PipelineEngine:
             status=StageStatus.FAIL,
             failure_reason=f"Subgraph exceeded {max_steps} steps (safety bound)",
         )
+
+    # Backward compat: _run_from was the pre-refactor private method name.
+    # Will be removed in a future release.
+    _run_from = run_subgraph
 
     def _initialize_context(self, goal: str | None) -> None:
         """Mirror graph attributes into context.
@@ -1152,6 +1158,7 @@ class PipelineEngine:
                     self.logs_root,
                     retry_policy,
                     hooks=self.hooks,
+                    engine=self,
                 )
             except Exception as exc:
                 outcome = Outcome(

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py
@@ -258,9 +258,12 @@ class PipelineEngine:
                     self.graph,
                 )
                 if edge is None:
-                    fail_outcome = Outcome(
-                        status=StageStatus.FAIL,
-                        failure_reason=f"No matching edge from resumed node '{current_node.id}'",
+                    fail_outcome = self.terminate_pipeline(
+                        node_id=current_node.id,
+                        upstream_outcome=None,
+                        termination_reason=(
+                            f"No matching edge from resumed node '{current_node.id}'"
+                        ),
                     )
                     await self._emit(
                         PIPELINE_ERROR,
@@ -349,9 +352,10 @@ class PipelineEngine:
                         failure_routing_retries += 1
                         current_node = retry_node
                         continue
-                    fail_outcome = Outcome(
-                        status=StageStatus.FAIL,
-                        failure_reason=(
+                    fail_outcome = self.terminate_pipeline(
+                        node_id=current_node.id,
+                        upstream_outcome=routing_outcome,
+                        termination_reason=(
                             f"No matching edge from skipped node '{current_node.id}'"
                         ),
                     )
@@ -689,9 +693,12 @@ class PipelineEngine:
                     current_node = retry_node
                     continue
 
-                fail_outcome = Outcome(
-                    status=StageStatus.FAIL,
-                    failure_reason=f"No matching edge from node '{current_node.id}'",
+                fail_outcome = self.terminate_pipeline(
+                    node_id=current_node.id,
+                    upstream_outcome=outcome,
+                    termination_reason=(
+                        f"No matching edge from node '{current_node.id}'"
+                    ),
                 )
                 await self._emit(
                     PIPELINE_ERROR,
@@ -1302,6 +1309,48 @@ class PipelineEngine:
         if target_id and target_id in self.graph.nodes:
             return self.graph.nodes[target_id]
         return None
+
+    def terminate_pipeline(
+        self,
+        *,
+        node_id: str,
+        upstream_outcome: Outcome | None,
+        termination_reason: str,
+    ) -> Outcome:
+        """The ONLY API for routing-termination Outcome construction.
+
+        Threads ``upstream_outcome.failure_reason`` automatically.  If no
+        upstream reason exists (or upstream_outcome is None), the routing
+        message becomes the failure_reason — today's behavior preserved for
+        outcome-less terminations.
+
+        Invariants (enforced by test_terminate_pipeline.py):
+        - Never raises.  (Totality test asserts this across full input space.)
+        - Preserves ``upstream_outcome.failure_reason`` as failure_reason
+          when present; routing message lives in notes.
+        - If upstream had no reason: failure_reason = routing message, notes = None.
+
+        Args:
+            node_id: ID of the node where routing terminated.  Not used in
+                result construction but available for caller context / logging.
+            upstream_outcome: The handler's outcome (or routing_outcome from
+                skip-path), or None for resume-path where no handler ran.
+            termination_reason: Human-readable routing message
+                (e.g. "No matching edge from node 'X'").
+
+        Returns:
+            An Outcome with status=FAIL and the threaded failure_reason / notes.
+
+        Sole-caller guard: the AST test in test_terminate_pipeline.py asserts
+        that no top-level Outcome construction with a "No matching edge from"
+        failure_reason pattern exists outside this method body.
+        """
+        upstream_reason = upstream_outcome.failure_reason if upstream_outcome else None
+        return Outcome(
+            status=StageStatus.FAIL,
+            failure_reason=upstream_reason or termination_reason,
+            notes=termination_reason if upstream_reason else None,
+        )
 
     # -- R12 M1-M4 helpers ---------------------------------------------------
 

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/__init__.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/__init__.py
@@ -10,12 +10,15 @@ Spec coverage: HAND-001–007, Section 4.1–4.2.
 
 from __future__ import annotations
 
-from typing import Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 from ..context import PipelineContext
 from ..graph import Graph, Node
 from ..outcome import Outcome
 from ..validation import SHAPE_TO_HANDLER
+
+if TYPE_CHECKING:
+    from ..engine import PipelineEngine
 
 
 @runtime_checkable
@@ -31,6 +34,8 @@ class NodeHandler(Protocol):
         context: PipelineContext,
         graph: Graph,
         logs_root: str,
+        *,
+        engine: "PipelineEngine | None" = None,
     ) -> Outcome: ...
 
 
@@ -70,13 +75,11 @@ class HandlerRegistry:
                 hooks=self._hooks,
             ),
             "stack.manager_loop": ManagerLoopHandler(
-                subgraph_runner=kwargs.get("subgraph_runner"),
                 backend=kwargs.get("backend"),
                 hooks=self._hooks,
                 cancel_event=kwargs.get("cancel_event"),
             ),
             "parallel": ParallelHandler(
-                subgraph_runner=kwargs.get("subgraph_runner"),
                 hooks=self._hooks,
             ),
             "parallel.fan_in": FanInHandler(),

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/__init__.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/__init__.py
@@ -10,12 +10,13 @@ Spec coverage: HAND-001–007, Section 4.1–4.2.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 from ..context import PipelineContext
 from ..graph import Graph, Node
 from ..outcome import Outcome
 from ..validation import SHAPE_TO_HANDLER
+from .context import HandlerContext
 
 if TYPE_CHECKING:
     from ..engine import PipelineEngine
@@ -50,7 +51,7 @@ class HandlerRegistry:
     Spec Section 4.2: Handler Registry.
     """
 
-    def __init__(self, **kwargs: Any) -> None:
+    def __init__(self, ctx: HandlerContext) -> None:
         from .codergen import CodergenHandler
         from .conditional import ConditionalHandler
         from .exit import ExitHandler
@@ -62,32 +63,32 @@ class HandlerRegistry:
         from .start import StartHandler
         from .tool import ToolHandler
 
-        self._hooks = kwargs.get("hooks")
+        self._ctx = ctx
 
         self._handlers: dict[str, NodeHandler] = {
             "start": StartHandler(),
             "exit": ExitHandler(),
-            "codergen": CodergenHandler(backend=kwargs.get("backend")),
+            "codergen": CodergenHandler(backend=ctx.backend),
             "conditional": ConditionalHandler(),
             "tool": ToolHandler(),
             "wait.human": HumanGateHandler(
-                interviewer=kwargs.get("interviewer"),
-                hooks=self._hooks,
+                interviewer=ctx.interviewer,
+                hooks=ctx.hooks,
             ),
             "stack.manager_loop": ManagerLoopHandler(
-                backend=kwargs.get("backend"),
-                hooks=self._hooks,
-                cancel_event=kwargs.get("cancel_event"),
+                backend=ctx.backend,
+                hooks=ctx.hooks,
+                cancel_event=ctx.cancel_event,
             ),
             "parallel": ParallelHandler(
-                hooks=self._hooks,
+                hooks=ctx.hooks,
             ),
             "parallel.fan_in": FanInHandler(),
             "pipeline": PipelineHandler(
-                hooks=self._hooks,
-                cancel_event=kwargs.get("cancel_event"),
-                backend=kwargs.get("backend"),
-                interviewer=kwargs.get("interviewer"),
+                hooks=ctx.hooks,
+                cancel_event=ctx.cancel_event,
+                backend=ctx.backend,
+                interviewer=ctx.interviewer,
             ),
         }
 
@@ -141,7 +142,7 @@ class HandlerRegistry:
         from .pipeline import PipelineHandler
 
         new = HandlerRegistry.__new__(HandlerRegistry)
-        new._hooks = self._hooks
+        new._ctx = self._ctx  # frozen dataclass — safe to share
         new._handlers = dict(self._handlers)
 
         # Replace codergen with a clone that has its own backend state

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/codergen.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/codergen.py
@@ -11,7 +11,10 @@ from __future__ import annotations
 
 import json
 import os
-from typing import Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from ..engine import PipelineEngine
 
 from ..context import PipelineContext
 from ..graph import Graph, Node
@@ -46,6 +49,8 @@ class CodergenHandler:
         context: PipelineContext,
         graph: Graph,
         logs_root: str,
+        *,
+        engine: "PipelineEngine | None" = None,
     ) -> Outcome:
         """Execute a codergen node.
 

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/conditional.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/conditional.py
@@ -13,7 +13,12 @@ Node attributes:
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from ..context import PipelineContext
+
+if TYPE_CHECKING:
+    from ..engine import PipelineEngine
 from ..graph import Graph, Node
 from ..outcome import Outcome, StageStatus
 
@@ -36,6 +41,8 @@ class ConditionalHandler:
         context: PipelineContext,
         graph: Graph,
         logs_root: str,
+        *,
+        engine: "PipelineEngine | None" = None,
     ) -> Outcome:
         """Return SUCCESS immediately.  Routing is handled by the engine."""
         return Outcome(status=StageStatus.SUCCESS, notes=f"Conditional node: {node.id}")

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/context.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/context.py
@@ -1,0 +1,45 @@
+"""HandlerContext — dependency bundle for HandlerRegistry.
+
+Replaces the ``**kwargs: Any`` slurp in HandlerRegistry.__init__ with an
+explicit, typed, frozen dataclass.  All handler dependencies are named fields
+rather than blind keyword arguments; pyright catches missing or misspelled
+deps at write-time rather than at runtime.
+
+Spec coverage: T2.1 (HandlerContext noun), Section 4.2.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class HandlerContext:
+    """Dependency bundle passed to HandlerRegistry at construction time.
+
+    All fields are typed ``| None`` — an explicit, documented decision about
+    which dependencies are always present vs situational.  This is NOT the
+    same as the old ``kwargs.get()`` accident: every field is named, every
+    absence is intentional.
+
+    Required for a full production pipeline run:
+        backend       — AI backend for codergen nodes.
+        hooks         — Event-emission bus.
+        cancel_event  — Cross-thread cancellation signal (threading.Event).
+
+    Situational:
+        interviewer   — Human-gate approval driver; None outside human-gate
+                        context.
+
+    Design note: making all fields ``| None = None`` keeps test ergonomics
+    clean (callers that only care about shape routing need only
+    ``HandlerContext()``).  The improvement over ``**kwargs: Any`` is that
+    every field is NAMED and TYPED — no silent typo swallowing, no unknown
+    kwargs accepted, IDE autocomplete works.
+    """
+
+    backend: Any | None = None
+    hooks: Any | None = None
+    cancel_event: Any | None = None
+    interviewer: Any | None = None

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/exit.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/exit.py
@@ -8,7 +8,12 @@ Spec coverage: HEXIT-001–003, Section 4.4.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from ..context import PipelineContext
+
+if TYPE_CHECKING:
+    from ..engine import PipelineEngine
 from ..graph import Graph, Node
 from ..outcome import Outcome, StageStatus
 
@@ -22,6 +27,8 @@ class ExitHandler:
         context: PipelineContext,
         graph: Graph,
         logs_root: str,
+        *,
+        engine: "PipelineEngine | None" = None,
     ) -> Outcome:
         """Return SUCCESS immediately."""
         return Outcome(status=StageStatus.SUCCESS, notes=f"Exit node: {node.id}")

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/fan_in.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/fan_in.py
@@ -15,7 +15,10 @@ Ties are broken by node ID (lexicographic ascending).
 from __future__ import annotations
 
 import logging
-from typing import Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from ..engine import PipelineEngine
 
 from ..context import PipelineContext
 from ..graph import Graph, Node
@@ -63,6 +66,8 @@ class FanInHandler:
         context: PipelineContext,
         graph: Graph,
         logs_root: str,
+        *,
+        engine: "PipelineEngine | None" = None,
     ) -> Outcome:
         """Evaluate parallel results and select the best candidate.
 

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/human.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/human.py
@@ -13,7 +13,10 @@ from __future__ import annotations
 import logging
 import pathlib
 import re
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ..engine import PipelineEngine
 
 from ..context import PipelineContext
 from ..graph import Graph, Node
@@ -279,6 +282,8 @@ class HumanGateHandler:
         context: PipelineContext,
         graph: Graph,
         logs_root: str,
+        *,
+        engine: "PipelineEngine | None" = None,
     ) -> Outcome:
         """Present choices to a human and route based on selection.
 

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/manager_loop.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/manager_loop.py
@@ -29,7 +29,7 @@ import logging
 import os
 import re
 import time
-from typing import Any, Callable, Coroutine
+from typing import TYPE_CHECKING, Any
 
 from ..conditions import evaluate_condition
 from ..context import PipelineContext
@@ -37,13 +37,10 @@ from ..dot_parser import parse_dot
 from ..graph import Graph, Node
 from ..outcome import Outcome, StageStatus
 
-logger = logging.getLogger(__name__)
+if TYPE_CHECKING:
+    from ..engine import PipelineEngine
 
-# Type alias matching the ParallelHandler's SubgraphRunner convention.
-SubgraphRunner = Callable[
-    [str, PipelineContext, Graph, str],
-    Coroutine[Any, Any, Outcome],
-]
+logger = logging.getLogger(__name__)
 
 # Pattern for parsing duration strings like "45s", "2m", "500ms".
 _DURATION_RE = re.compile(
@@ -104,13 +101,11 @@ class ManagerLoopHandler:
 
     def __init__(
         self,
-        subgraph_runner: SubgraphRunner | None = None,
         backend: Any = None,
         hooks: Any = None,
         cancel_event: Any = None,
         handler_registry_factory: Any | None = None,
     ) -> None:
-        self._runner = subgraph_runner
         self._backend = backend
         self._hooks = hooks
         self._cancel_event = cancel_event
@@ -123,6 +118,8 @@ class ManagerLoopHandler:
         context: PipelineContext,
         graph: Graph,
         logs_root: str,
+        *,
+        engine: "PipelineEngine | None" = None,
     ) -> Outcome:
         """Execute a manager loop node.
 
@@ -152,16 +149,16 @@ class ManagerLoopHandler:
         )
 
         if not child_dotfile:
-            # Without child_dotfile, require outgoing edges and runner
+            # Without child_dotfile, require outgoing edges and engine
             if not child_edges:
                 return Outcome(
                     status=StageStatus.FAIL,
                     failure_reason="Manager loop has no child to supervise",
                 )
-            if self._runner is None:
+            if engine is None:
                 return Outcome(
                     status=StageStatus.FAIL,
-                    failure_reason="Manager loop requires a subgraph_runner",
+                    failure_reason="ManagerLoopHandler requires engine to be passed via execute(engine=...)",
                 )
 
         logger.info(
@@ -201,9 +198,9 @@ class ManagerLoopHandler:
                         child_dotfile, child_context, graph, logs_root, node.id, cycle
                     )
                 else:
-                    assert self._runner is not None
-                    child_outcome = await self._runner(
-                        child_start_id, child_context, graph, logs_root
+                    assert engine is not None
+                    child_outcome = await engine.run_subgraph(
+                        child_start_id, context=child_context
                     )
             except Exception as exc:
                 logger.warning(

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/manager_loop.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/manager_loop.py
@@ -313,10 +313,14 @@ class ManagerLoopHandler:
         if self._handler_registry_factory is not None:
             child_registry = self._handler_registry_factory()
         else:
+            from .context import HandlerContext
+
             child_registry = HandlerRegistry(
-                backend=self._backend,
-                hooks=self._hooks,
-                cancel_event=self._cancel_event,
+                HandlerContext(
+                    backend=self._backend,
+                    hooks=self._hooks,
+                    cancel_event=self._cancel_event,
+                )
             )
         child_engine = PipelineEngine(
             graph=child_graph,

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/parallel.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/parallel.py
@@ -20,19 +20,16 @@ import asyncio
 import logging
 import math
 import time
-from typing import Any, Callable, Coroutine
+from typing import TYPE_CHECKING, Any, Callable
 
 from ..context import PipelineContext
 from ..graph import Graph, Node
 from ..outcome import Outcome, StageStatus
 
-logger = logging.getLogger(__name__)
+if TYPE_CHECKING:
+    from ..engine import PipelineEngine
 
-# Type alias for the subgraph runner callback
-SubgraphRunner = Callable[
-    [str, PipelineContext, Graph, str],
-    Coroutine[Any, Any, Outcome],
-]
+logger = logging.getLogger(__name__)
 
 
 class ParallelHandler:
@@ -44,19 +41,13 @@ class ParallelHandler:
 
     def __init__(
         self,
-        subgraph_runner: SubgraphRunner | None = None,
         hooks: Any = None,
     ) -> None:
         """Initialize the parallel handler.
 
         Args:
-            subgraph_runner: Async callable that executes a subgraph
-                starting from a given node ID. Signature:
-                (node_id, context, graph, logs_root) -> Outcome.
-                If None, branches return FAIL with an explicit error.
             hooks: Optional hooks object for event emission.
         """
-        self._runner = subgraph_runner
         self._hooks = hooks
 
     async def _emit(self, event_name: str, data: dict[str, Any]) -> None:
@@ -70,6 +61,8 @@ class ParallelHandler:
         context: PipelineContext,
         graph: Graph,
         logs_root: str,
+        *,
+        engine: "PipelineEngine | None" = None,
     ) -> Outcome:
         """Execute a parallel node by fanning out to all outgoing edges.
 
@@ -139,16 +132,16 @@ class ParallelHandler:
 
                 branch_start = time.monotonic()
                 branch_context = context.clone()
-                if self._runner is None:
+                if engine is None:
                     outcome = Outcome(
                         status=StageStatus.FAIL,
-                        notes=f"ParallelHandler requires a subgraph_runner. Branch '{target_node_id}' cannot execute.",
-                        failure_reason="No subgraph_runner configured",
+                        notes=f"ParallelHandler requires engine to be passed via execute(engine=...). Branch '{target_node_id}' cannot execute.",
+                        failure_reason="No engine configured",
                     )
                 else:
                     try:
-                        outcome = await self._runner(
-                            target_node_id, branch_context, graph, logs_root
+                        outcome = await engine.run_subgraph(
+                            target_node_id, context=branch_context
                         )
                     except Exception as e:
                         logger.warning(

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/pipeline.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/pipeline.py
@@ -12,7 +12,10 @@ import logging
 import os
 import re
 import time
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ..engine import PipelineEngine
 
 from ..context import PipelineContext
 from ..dot_parser import parse_dot
@@ -95,6 +98,8 @@ class PipelineHandler:
         context: PipelineContext,
         graph: Graph,
         logs_root: str,
+        *,
+        engine: "PipelineEngine | None" = None,
     ) -> Outcome:
         """Execute a nested pipeline from a child DOT file.
 
@@ -162,30 +167,15 @@ class PipelineHandler:
         child_logs = os.path.join(logs_root, f"subgraph_{node.id}")
         os.makedirs(child_logs, exist_ok=True)
 
-        # (8) Create child HandlerRegistry — wire subgraph_runner so that
-        # ManagerLoopHandler and ParallelHandler can supervise child subgraphs.
-        #
-        # The closure below references child_engine, which is assigned in step (9)
-        # below.  Python closures are late-binding: the name is resolved at call time,
-        # not at definition time, so the assignment order is safe.
+        # (8) Create child HandlerRegistry (no closure, no rewire — engine passes self via execute(engine=...))
         if self._handler_registry_factory is not None:
             child_registry = self._handler_registry_factory()
         else:
-            async def child_subgraph_runner(
-                node_id: str,
-                branch_context: Any,
-                _graph: Any,
-                _logs_root: str,
-            ) -> Any:
-                """Execute a child subgraph branch via the child engine."""
-                return await child_engine._run_from(node_id, context=branch_context)
-
             child_registry = HandlerRegistry(
                 backend=self._backend,
                 hooks=self._hooks,
                 cancel_event=self._cancel_event,
                 interviewer=self._interviewer,
-                subgraph_runner=child_subgraph_runner,
             )
 
         # (9) Create child PipelineEngine

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/pipeline.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/pipeline.py
@@ -171,11 +171,15 @@ class PipelineHandler:
         if self._handler_registry_factory is not None:
             child_registry = self._handler_registry_factory()
         else:
+            from .context import HandlerContext
+
             child_registry = HandlerRegistry(
-                backend=self._backend,
-                hooks=self._hooks,
-                cancel_event=self._cancel_event,
-                interviewer=self._interviewer,
+                HandlerContext(
+                    backend=self._backend,
+                    hooks=self._hooks,
+                    cancel_event=self._cancel_event,
+                    interviewer=self._interviewer,
+                )
             )
 
         # (9) Create child PipelineEngine

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/start.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/start.py
@@ -8,9 +8,14 @@ Spec coverage: HSTART-001–002, Section 4.3.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from ..context import PipelineContext
 from ..graph import Graph, Node
 from ..outcome import Outcome, StageStatus
+
+if TYPE_CHECKING:
+    from ..engine import PipelineEngine
 
 
 class StartHandler:
@@ -22,6 +27,8 @@ class StartHandler:
         context: PipelineContext,
         graph: Graph,
         logs_root: str,
+        *,
+        engine: "PipelineEngine | None" = None,
     ) -> Outcome:
         """Return SUCCESS immediately."""
         return Outcome(status=StageStatus.SUCCESS, notes=f"Start node: {node.id}")

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/tool.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/tool.py
@@ -33,7 +33,10 @@ import json
 import logging
 import os
 import time
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ..engine import PipelineEngine
 
 from ..context import PipelineContext
 from ..graph import Graph, Node
@@ -66,6 +69,8 @@ class ToolHandler:
         context: PipelineContext,
         graph: Graph,
         logs_root: str,
+        *,
+        engine: "PipelineEngine | None" = None,
     ) -> Outcome:
         """Execute a tool command and return the outcome.
 

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/retry.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/retry.py
@@ -173,6 +173,7 @@ async def execute_with_retry(
     logs_root: str,
     policy: RetryPolicy,
     hooks: Any = None,
+    engine: Any = None,
 ) -> Outcome:
     """Execute a handler with retry policy.
 
@@ -186,7 +187,9 @@ async def execute_with_retry(
     for attempt in range(1, policy.max_attempts + 1):
         # Execute the handler
         try:
-            outcome = await handler.execute(node, context, graph, logs_root)
+            outcome = await handler.execute(
+                node, context, graph, logs_root, engine=engine
+            )
         except Exception as e:
             logger.warning(
                 "Node %s attempt %d/%d raised: %s",

--- a/modules/loop-pipeline/tests/test_backend.py
+++ b/modules/loop-pipeline/tests/test_backend.py
@@ -955,20 +955,26 @@ async def test_tool_loop_report_outcome_terminal_action_empty_text():
     """
     report_tool = _MockReportOutcomeTool()
 
-    mock_client = _MockUnifiedClient([
-        # Round 1: model calls report_outcome as its terminal action
-        _make_tool_call_response([{
-            "id": "tc-1",
-            "name": "report_outcome",
-            "args": {
-                "status": "fail",
-                "failure_reason": "quality gate failed",
-                "context_updates": {"quality_feedback": "fix X"},
-            },
-        }]),
-        # Round 2: empty text — no follow-up turn (extended thinking)
-        _make_text_response(""),
-    ])
+    mock_client = _MockUnifiedClient(
+        [
+            # Round 1: model calls report_outcome as its terminal action
+            _make_tool_call_response(
+                [
+                    {
+                        "id": "tc-1",
+                        "name": "report_outcome",
+                        "args": {
+                            "status": "fail",
+                            "failure_reason": "quality gate failed",
+                            "context_updates": {"quality_feedback": "fix X"},
+                        },
+                    }
+                ]
+            ),
+            # Round 2: empty text — no follow-up turn (extended thinking)
+            _make_text_response(""),
+        ]
+    )
 
     coordinator = NoSpawnCoordinator()
     backend = AmplifierBackend(
@@ -999,14 +1005,23 @@ async def test_tool_loop_report_outcome_no_cross_node_bleed():
     coordinator = NoSpawnCoordinator()
 
     # Node 1: report_outcome called as terminal tool, result.text empty
-    mock_client_1 = _MockUnifiedClient([
-        _make_tool_call_response([{
-            "id": "tc-1",
-            "name": "report_outcome",
-            "args": {"status": "fail", "failure_reason": "first node failed"},
-        }]),
-        _make_text_response(""),
-    ])
+    mock_client_1 = _MockUnifiedClient(
+        [
+            _make_tool_call_response(
+                [
+                    {
+                        "id": "tc-1",
+                        "name": "report_outcome",
+                        "args": {
+                            "status": "fail",
+                            "failure_reason": "first node failed",
+                        },
+                    }
+                ]
+            ),
+            _make_text_response(""),
+        ]
+    )
     backend1 = AmplifierBackend(
         coordinator=coordinator,
         profiles={},
@@ -1014,7 +1029,9 @@ async def test_tool_loop_report_outcome_no_cross_node_bleed():
         tools={"report_outcome": report_tool},
         unified_client=mock_client_1,
     )
-    node1 = _make_node(id="node1", attrs={"llm_provider": "test", "llm_model": "test-model"})
+    node1 = _make_node(
+        id="node1", attrs={"llm_provider": "test", "llm_model": "test-model"}
+    )
     result1 = await backend1.run(node1, "task 1", _make_context())
 
     assert result1.status == StageStatus.FAIL
@@ -1029,7 +1046,9 @@ async def test_tool_loop_report_outcome_no_cross_node_bleed():
         tools={"report_outcome": report_tool},
         unified_client=mock_client_2,
     )
-    node2 = _make_node(id="node2", attrs={"llm_provider": "test", "llm_model": "test-model"})
+    node2 = _make_node(
+        id="node2", attrs={"llm_provider": "test", "llm_model": "test-model"}
+    )
     result2 = await backend2.run(node2, "task 2", _make_context())
 
     # Plain text → SUCCESS (spec 4.5); must NOT inherit node1's FAIL
@@ -1049,6 +1068,7 @@ async def test_build_unified_tools_falls_back_to_input_schema():
     class _ToolWithInputSchema:
         name = "report_outcome"
         description = "Report outcome"
+
         # Deliberately omit "parameters" and "schema" — only input_schema
         @property
         def input_schema(self) -> dict:
@@ -1079,16 +1099,24 @@ async def test_tool_loop_report_outcome_json_text_wins_over_last_outcome():
     """
     report_tool = _MockReportOutcomeTool()
 
-    mock_client = _MockUnifiedClient([
-        # Round 1: model calls report_outcome (sets last_outcome via execute())
-        _make_tool_call_response([{
-            "id": "tc-1",
-            "name": "report_outcome",
-            "args": {"status": "fail", "failure_reason": "from tool call"},
-        }]),
-        # Round 2: model also produces a JSON text response — this must win
-        _make_text_response(json.dumps({"status": "success", "notes": "text wins"})),
-    ])
+    mock_client = _MockUnifiedClient(
+        [
+            # Round 1: model calls report_outcome (sets last_outcome via execute())
+            _make_tool_call_response(
+                [
+                    {
+                        "id": "tc-1",
+                        "name": "report_outcome",
+                        "args": {"status": "fail", "failure_reason": "from tool call"},
+                    }
+                ]
+            ),
+            # Round 2: model also produces a JSON text response — this must win
+            _make_text_response(
+                json.dumps({"status": "success", "notes": "text wins"})
+            ),
+        ]
+    )
 
     coordinator = NoSpawnCoordinator()
     backend = AmplifierBackend(

--- a/modules/loop-pipeline/tests/test_batch_d_pipeline_infra.py
+++ b/modules/loop-pipeline/tests/test_batch_d_pipeline_infra.py
@@ -47,6 +47,7 @@ from amplifier_module_loop_pipeline.transforms import (
     expand_variables,
 )
 from amplifier_module_loop_pipeline.validation import validate_or_raise
+from amplifier_module_loop_pipeline.handlers.context import HandlerContext
 
 
 # ---------------------------------------------------------------------------
@@ -70,7 +71,7 @@ def _make_engine(
     graph = parse_dot(dot_source)
     validate_or_raise(graph)
     context = PipelineContext()
-    registry = HandlerRegistry(backend=backend)
+    registry = HandlerRegistry(HandlerContext(backend=backend))
     return PipelineEngine(
         graph=graph,
         context=context,

--- a/modules/loop-pipeline/tests/test_cancellation.py
+++ b/modules/loop-pipeline/tests/test_cancellation.py
@@ -13,6 +13,7 @@ from amplifier_module_loop_pipeline.engine import PipelineEngine
 from amplifier_module_loop_pipeline.handlers import HandlerRegistry
 from amplifier_module_loop_pipeline.outcome import StageStatus
 from amplifier_module_loop_pipeline.validation import validate_or_raise
+from amplifier_module_loop_pipeline.handlers.context import HandlerContext
 
 
 # ---------------------------------------------------------------------------
@@ -67,7 +68,7 @@ def _make_engine(
     graph = parse_dot(dot_source)
     validate_or_raise(graph)
     context = PipelineContext()
-    registry = HandlerRegistry(backend=backend)
+    registry = HandlerRegistry(HandlerContext(backend=backend))
     return PipelineEngine(
         graph=graph,
         context=context,
@@ -205,7 +206,7 @@ async def test_cancel_emits_pipeline_complete_event(tmp_path):
     graph = parse_dot(_LINEAR_DOT)
     validate_or_raise(graph)
     context = PipelineContext()
-    registry = HandlerRegistry(backend=RecordingBackend())
+    registry = HandlerRegistry(HandlerContext(backend=RecordingBackend()))
     engine = PipelineEngine(
         graph=graph,
         context=context,
@@ -233,7 +234,7 @@ async def test_cancel_emits_pipeline_complete_event(tmp_path):
 async def test_cancel_propagates_to_nested_child_pipeline(tmp_path):
     """When parent is cancelled, the child pipeline (nested via PipelineHandler) also stops.
 
-    Wiring: parent PipelineEngine -> HandlerRegistry(cancel_event=...) ->
+    Wiring: parent PipelineEngine -> HandlerRegistry(HandlerContext(cancel_event=...)) ->
             PipelineHandler(cancel_event=..., handler_registry_factory=...) ->
             child PipelineEngine(cancel_event=...)
 
@@ -287,7 +288,7 @@ digraph parent {{
     context = PipelineContext()
 
     # Build parent registry with cancel_event and our backend
-    registry = HandlerRegistry(backend=backend, cancel_event=cancel_event)
+    registry = HandlerRegistry(HandlerContext(backend=backend, cancel_event=cancel_event))
 
     # Override the pipeline handler with one that uses a factory so the
     # *child* engine also gets our test backend (the default child registry
@@ -295,7 +296,7 @@ digraph parent {{
     registry.register(
         "pipeline",
         PipelineHandler(
-            handler_registry_factory=lambda: HandlerRegistry(backend=backend),
+            handler_registry_factory=lambda: HandlerRegistry(HandlerContext(backend=backend)),
             cancel_event=cancel_event,
         ),
     )

--- a/modules/loop-pipeline/tests/test_checkpoint.py
+++ b/modules/loop-pipeline/tests/test_checkpoint.py
@@ -24,6 +24,7 @@ from amplifier_module_loop_pipeline.graph import Node
 from amplifier_module_loop_pipeline.handlers import HandlerRegistry
 from amplifier_module_loop_pipeline.outcome import StageStatus
 from amplifier_module_loop_pipeline.validation import validate_or_raise
+from amplifier_module_loop_pipeline.handlers.context import HandlerContext
 
 
 # --- Checkpoint model ---
@@ -201,7 +202,7 @@ def _make_engine(
     graph = parse_dot(dot_source)
     validate_or_raise(graph)
     context = PipelineContext()
-    registry = HandlerRegistry(backend=backend)
+    registry = HandlerRegistry(HandlerContext(backend=backend))
     return PipelineEngine(
         graph=graph,
         context=context,

--- a/modules/loop-pipeline/tests/test_conditional_handler.py
+++ b/modules/loop-pipeline/tests/test_conditional_handler.py
@@ -16,7 +16,6 @@ Two contract assertions:
    No LLM call, no tool invocation, completes in microseconds.
 """
 
-import asyncio
 import time
 
 import pytest

--- a/modules/loop-pipeline/tests/test_conditional_handler.py
+++ b/modules/loop-pipeline/tests/test_conditional_handler.py
@@ -25,6 +25,7 @@ from amplifier_module_loop_pipeline.graph import Edge, Graph, Node
 from amplifier_module_loop_pipeline.handlers import HandlerRegistry
 from amplifier_module_loop_pipeline.outcome import StageStatus
 from amplifier_module_loop_pipeline.validation import SHAPE_TO_HANDLER
+from amplifier_module_loop_pipeline.handlers.context import HandlerContext
 
 
 # ---------------------------------------------------------------------------
@@ -54,7 +55,7 @@ def test_diamond_shape_dispatches_to_conditional_handler():
     """
     from amplifier_module_loop_pipeline.handlers.conditional import ConditionalHandler
 
-    registry = HandlerRegistry()
+    registry = HandlerRegistry(HandlerContext())
     diamond_node = Node(id="MyGate", shape="diamond")
     handler = registry.get(diamond_node)
 
@@ -137,7 +138,7 @@ async def test_diamond_node_completes_without_llm_in_pipeline(tmp_path):
     engine = PipelineEngine(
         graph=graph,
         context=PipelineContext(),
-        handler_registry=HandlerRegistry(backend=TrackingBackend()),
+        handler_registry=HandlerRegistry(HandlerContext(backend=TrackingBackend())),
         logs_root=str(tmp_path),
     )
     outcome = await engine.run()

--- a/modules/loop-pipeline/tests/test_contract_violation_event.py
+++ b/modules/loop-pipeline/tests/test_contract_violation_event.py
@@ -22,6 +22,7 @@ from amplifier_module_loop_pipeline.pipeline_events import (
     PIPELINE_NODE_CONTRACT_VIOLATION,
 )
 from amplifier_module_loop_pipeline.validation import validate_or_raise
+from amplifier_module_loop_pipeline.handlers.context import HandlerContext
 
 
 class EventCapture:
@@ -39,7 +40,7 @@ def _make_engine(dot_source: str, logs_root: str, hooks: Any = None) -> Pipeline
     graph = parse_dot(dot_source)
     validate_or_raise(graph)
     context = PipelineContext()
-    registry = HandlerRegistry()
+    registry = HandlerRegistry(HandlerContext())
     return PipelineEngine(
         graph=graph,
         context=context,

--- a/modules/loop-pipeline/tests/test_dot_integration.py
+++ b/modules/loop-pipeline/tests/test_dot_integration.py
@@ -71,7 +71,7 @@ from amplifier_module_loop_pipeline.context import PipelineContext
 from amplifier_module_loop_pipeline.dot_parser import parse_dot
 from amplifier_module_loop_pipeline.engine import PipelineEngine
 from amplifier_module_loop_pipeline.handlers import HandlerRegistry
-from amplifier_module_loop_pipeline.outcome import Outcome, StageStatus
+from amplifier_module_loop_pipeline.outcome import StageStatus
 from amplifier_module_loop_pipeline.pipeline_events import (
     PIPELINE_COMPLETE,
     PIPELINE_NODE_COMPLETE,
@@ -211,31 +211,14 @@ def _make_integration_engine(
         hooks=hooks,
     )
 
-    # Create engine first (parallel handler needs engine._run_from)
+    # Engine passes itself to handlers via execute(engine=...) — no closure needed.
     engine = PipelineEngine(
         graph=graph,
         context=context,
-        handler_registry=HandlerRegistry(backend=backend),  # temp
+        handler_registry=HandlerRegistry(backend=backend, hooks=hooks),
         logs_root=logs_root,
         hooks=hooks,
     )
-
-    # Wire subgraph runner for parallel support
-    async def subgraph_runner(
-        node_id: str,
-        branch_context: PipelineContext,
-        _graph: Any,
-        _logs_root: str,
-    ) -> Outcome:
-        return await engine._run_from(node_id, context=branch_context)
-
-    # Replace registry with fully-wired version
-    registry = HandlerRegistry(
-        backend=backend,
-        subgraph_runner=subgraph_runner,
-        hooks=hooks,
-    )
-    engine.handler_registry = registry
 
     return engine
 
@@ -859,29 +842,14 @@ def _make_production_engine(
         hooks=hooks,
     )
 
+    # Engine passes itself to handlers via execute(engine=...) — no closure needed.
     engine = PipelineEngine(
         graph=graph,
         context=context,
-        handler_registry=HandlerRegistry(backend=backend),
+        handler_registry=HandlerRegistry(backend=backend, hooks=hooks),
         logs_root=logs_root,
         hooks=hooks,
     )
-
-    # Wire subgraph runner for parallel support
-    async def subgraph_runner(
-        node_id: str,
-        branch_context: PipelineContext,
-        _graph: Any,
-        _logs_root: str,
-    ) -> Outcome:
-        return await engine._run_from(node_id, context=branch_context)
-
-    registry = HandlerRegistry(
-        backend=backend,
-        subgraph_runner=subgraph_runner,
-        hooks=hooks,
-    )
-    engine.handler_registry = registry
     return engine
 
 

--- a/modules/loop-pipeline/tests/test_dot_integration.py
+++ b/modules/loop-pipeline/tests/test_dot_integration.py
@@ -82,6 +82,7 @@ from amplifier_module_loop_pipeline.pipeline_events import (
 )
 from amplifier_module_loop_pipeline.transforms import apply_transforms
 from amplifier_module_loop_pipeline.validation import validate_or_raise
+from amplifier_module_loop_pipeline.handlers.context import HandlerContext
 
 
 # ---------------------------------------------------------------------------
@@ -215,7 +216,7 @@ def _make_integration_engine(
     engine = PipelineEngine(
         graph=graph,
         context=context,
-        handler_registry=HandlerRegistry(backend=backend, hooks=hooks),
+        handler_registry=HandlerRegistry(HandlerContext(backend=backend, hooks=hooks)),
         logs_root=logs_root,
         hooks=hooks,
     )
@@ -846,7 +847,7 @@ def _make_production_engine(
     engine = PipelineEngine(
         graph=graph,
         context=context,
-        handler_registry=HandlerRegistry(backend=backend, hooks=hooks),
+        handler_registry=HandlerRegistry(HandlerContext(backend=backend, hooks=hooks)),
         logs_root=logs_root,
         hooks=hooks,
     )

--- a/modules/loop-pipeline/tests/test_dot_parser.py
+++ b/modules/loop-pipeline/tests/test_dot_parser.py
@@ -575,6 +575,4 @@ def test_escape_multiline_shell_heredoc_tool_command_preserves_structure():
     """
     cmd_attr = "#!/bin/sh\\\\nset -e\\\\nprintf hello\\\\nprintf world"
     graph = parse_dot(f'digraph t {{ n [label="{cmd_attr}"] }}')
-    assert graph.nodes["n"].label == (
-        "#!/bin/sh\nset -e\nprintf hello\nprintf world"
-    )
+    assert graph.nodes["n"].label == ("#!/bin/sh\nset -e\nprintf hello\nprintf world")

--- a/modules/loop-pipeline/tests/test_eager_reference_scan.py
+++ b/modules/loop-pipeline/tests/test_eager_reference_scan.py
@@ -22,6 +22,7 @@ from amplifier_module_loop_pipeline.pipeline_events import (
 )
 from amplifier_module_loop_pipeline.substitution import extract_refs
 from amplifier_module_loop_pipeline.validation import validate_or_raise
+from amplifier_module_loop_pipeline.handlers.context import HandlerContext
 
 
 # ---------------------------------------------------------------------------
@@ -50,7 +51,7 @@ def _make_engine(
     graph = parse_dot(dot_source)
     validate_or_raise(graph)
     context = PipelineContext()
-    registry = HandlerRegistry()
+    registry = HandlerRegistry(HandlerContext())
     return PipelineEngine(
         graph=graph,
         context=context,

--- a/modules/loop-pipeline/tests/test_engine.py
+++ b/modules/loop-pipeline/tests/test_engine.py
@@ -1049,7 +1049,9 @@ async def test_main_loop_safety_bound_terminates_infinite_cycle(tmp_path):
         work  -> work
     }
     """
-    engine = _make_engine(dot_source=dot_source, backend=MockBackend(), logs_root=str(tmp_path))
+    engine = _make_engine(
+        dot_source=dot_source, backend=MockBackend(), logs_root=str(tmp_path)
+    )
 
     # Patch the class constant so max_steps = 3 nodes × 2 = 6 steps
     with patch.object(type(engine), "_MAX_GOAL_GATE_RETRIES", new=2):

--- a/modules/loop-pipeline/tests/test_engine.py
+++ b/modules/loop-pipeline/tests/test_engine.py
@@ -15,6 +15,7 @@ from amplifier_module_loop_pipeline.graph import Edge, Graph, Node
 from amplifier_module_loop_pipeline.handlers import HandlerRegistry
 from amplifier_module_loop_pipeline.outcome import Outcome, StageStatus
 from amplifier_module_loop_pipeline.validation import validate_or_raise
+from amplifier_module_loop_pipeline.handlers.context import HandlerContext
 
 
 class MockBackend:
@@ -52,7 +53,7 @@ def _make_engine(
     graph = parse_dot(dot_source)
     validate_or_raise(graph)
     context = PipelineContext()
-    registry = HandlerRegistry(backend=backend)
+    registry = HandlerRegistry(HandlerContext(backend=backend))
     return PipelineEngine(
         graph=graph,
         context=context,
@@ -213,7 +214,7 @@ async def test_no_matching_edge_returns_fail(tmp_path):
         ],
     )
     context = PipelineContext()
-    registry = HandlerRegistry(backend=MockBackend("ok"))
+    registry = HandlerRegistry(HandlerContext(backend=MockBackend("ok")))
     engine = PipelineEngine(
         graph=graph,
         context=context,
@@ -292,7 +293,7 @@ async def test_start_node_fallback_to_id_start(tmp_path):
         ],
     )
     context = PipelineContext()
-    registry = HandlerRegistry(backend=MockBackend("ok"))
+    registry = HandlerRegistry(HandlerContext(backend=MockBackend("ok")))
     engine = PipelineEngine(
         graph=graph,
         context=context,
@@ -319,7 +320,7 @@ async def test_start_node_fallback_to_id_Start(tmp_path):
         ],
     )
     context = PipelineContext()
-    registry = HandlerRegistry(backend=MockBackend("ok"))
+    registry = HandlerRegistry(HandlerContext(backend=MockBackend("ok")))
     engine = PipelineEngine(
         graph=graph,
         context=context,
@@ -346,7 +347,7 @@ async def test_start_node_shape_takes_priority(tmp_path):
         ],
     )
     context = PipelineContext()
-    registry = HandlerRegistry(backend=MockBackend("ok"))
+    registry = HandlerRegistry(HandlerContext(backend=MockBackend("ok")))
     engine = PipelineEngine(
         graph=graph,
         context=context,
@@ -387,7 +388,7 @@ async def test_auto_status_overrides_fail_to_success(tmp_path):
         ],
     )
     context = PipelineContext()
-    registry = HandlerRegistry(backend=FailingBackend())
+    registry = HandlerRegistry(HandlerContext(backend=FailingBackend()))
     engine = PipelineEngine(
         graph=graph,
         context=context,
@@ -423,7 +424,7 @@ async def test_auto_status_false_preserves_fail(tmp_path):
         ],
     )
     context = PipelineContext()
-    registry = HandlerRegistry(backend=FailingBackend())
+    registry = HandlerRegistry(HandlerContext(backend=FailingBackend()))
     engine = PipelineEngine(
         graph=graph,
         context=context,
@@ -480,7 +481,7 @@ async def test_engine_finds_start_by_node_type_attr(tmp_path):
         ],
     )
     context = PipelineContext()
-    registry = HandlerRegistry(backend=MockBackend("done"))
+    registry = HandlerRegistry(HandlerContext(backend=MockBackend("done")))
     engine = PipelineEngine(
         graph=graph,
         context=context,
@@ -517,7 +518,7 @@ async def test_engine_runs_alternative_start_exit(tmp_path):
         ],
     )
     context = PipelineContext()
-    registry = HandlerRegistry(backend=MockBackend("done"))
+    registry = HandlerRegistry(HandlerContext(backend=MockBackend("done")))
     engine = PipelineEngine(
         graph=graph,
         context=context,
@@ -549,7 +550,7 @@ async def test_engine_mdiamond_takes_priority_over_node_type(tmp_path):
         ],
     )
     context = PipelineContext()
-    registry = HandlerRegistry(backend=MockBackend("done"))
+    registry = HandlerRegistry(HandlerContext(backend=MockBackend("done")))
     engine = PipelineEngine(
         graph=graph,
         context=context,
@@ -604,7 +605,7 @@ async def test_loop_restart_re_executes_target_node(tmp_path):
     backend = LoopOnceBackend()
     graph = _make_loop_restart_graph()
     context = PipelineContext()
-    registry = HandlerRegistry(backend=backend)
+    registry = HandlerRegistry(HandlerContext(backend=backend))
     engine = PipelineEngine(
         graph=graph,
         context=context,
@@ -627,7 +628,7 @@ async def test_loop_restart_resets_retry_counters(tmp_path):
     backend = LoopOnceBackend()
     graph = _make_loop_restart_graph()
     context = PipelineContext()
-    registry = HandlerRegistry(backend=backend)
+    registry = HandlerRegistry(HandlerContext(backend=backend))
     engine = PipelineEngine(
         graph=graph,
         context=context,
@@ -649,7 +650,7 @@ async def test_loop_restart_increments_iteration_counter(tmp_path):
     backend = LoopOnceBackend()
     graph = _make_loop_restart_graph()
     context = PipelineContext()
-    registry = HandlerRegistry(backend=backend)
+    registry = HandlerRegistry(HandlerContext(backend=backend))
     engine = PipelineEngine(
         graph=graph,
         context=context,
@@ -681,7 +682,7 @@ async def test_normal_edge_without_loop_restart(tmp_path):
         ],
     )
     context = PipelineContext()
-    registry = HandlerRegistry(backend=backend)
+    registry = HandlerRegistry(HandlerContext(backend=backend))
     engine = PipelineEngine(
         graph=graph,
         context=context,
@@ -739,7 +740,7 @@ async def test_multi_edge_fan_out_executes_all_targets(tmp_path):
     )
 
     context = PipelineContext()
-    registry = HandlerRegistry(backend=TrackingBackend())
+    registry = HandlerRegistry(HandlerContext(backend=TrackingBackend()))
     engine = PipelineEngine(
         graph=graph,
         context=context,
@@ -791,7 +792,7 @@ async def test_multi_edge_fan_out_detects_fan_in(tmp_path):
     )
 
     context = PipelineContext()
-    registry = HandlerRegistry(backend=TrackingBackend())
+    registry = HandlerRegistry(HandlerContext(backend=TrackingBackend()))
     engine = PipelineEngine(
         graph=graph,
         context=context,
@@ -838,7 +839,7 @@ async def test_multi_edge_single_match_still_works(tmp_path):
     )
 
     context = PipelineContext()
-    registry = HandlerRegistry(backend=backend)
+    registry = HandlerRegistry(HandlerContext(backend=backend))
     engine = PipelineEngine(
         graph=graph,
         context=context,
@@ -893,7 +894,7 @@ async def test_multi_edge_parallel_context_isolation(tmp_path):
     )
 
     context = PipelineContext()
-    registry = HandlerRegistry(backend=ContextMutatingBackend())
+    registry = HandlerRegistry(HandlerContext(backend=ContextMutatingBackend()))
     engine = PipelineEngine(
         graph=graph,
         context=context,
@@ -947,7 +948,7 @@ async def test_parallel_fan_out_branches_run_concurrently(tmp_path):
     )
 
     context = PipelineContext()
-    registry = HandlerRegistry(backend=SlowCloningBackend())
+    registry = HandlerRegistry(HandlerContext(backend=SlowCloningBackend()))
     engine = PipelineEngine(
         graph=graph,
         context=context,
@@ -1000,7 +1001,7 @@ async def test_parallel_fan_out_clones_registry_per_branch(tmp_path):
     )
 
     context = PipelineContext()
-    registry = HandlerRegistry(backend=CloningBackend())
+    registry = HandlerRegistry(HandlerContext(backend=CloningBackend()))
     engine = PipelineEngine(
         graph=graph,
         context=context,

--- a/modules/loop-pipeline/tests/test_engine_artifacts.py
+++ b/modules/loop-pipeline/tests/test_engine_artifacts.py
@@ -13,6 +13,7 @@ from amplifier_module_loop_pipeline.context import PipelineContext
 from amplifier_module_loop_pipeline.engine import PipelineEngine
 from amplifier_module_loop_pipeline.graph import Edge, Graph, Node
 from amplifier_module_loop_pipeline.handlers import HandlerRegistry
+from amplifier_module_loop_pipeline.handlers.context import HandlerContext
 
 
 # ---------------------------------------------------------------------------
@@ -40,7 +41,7 @@ def _make_engine(tmp_path) -> PipelineEngine:
     return PipelineEngine(
         graph=graph,
         context=PipelineContext(),
-        handler_registry=HandlerRegistry(backend=MockBackend()),
+        handler_registry=HandlerRegistry(HandlerContext(backend=MockBackend())),
         logs_root=str(tmp_path),
     )
 

--- a/modules/loop-pipeline/tests/test_engine_bug_g_parallel_component_fanout.py
+++ b/modules/loop-pipeline/tests/test_engine_bug_g_parallel_component_fanout.py
@@ -22,7 +22,7 @@ from amplifier_module_loop_pipeline.context import PipelineContext
 from amplifier_module_loop_pipeline.engine import PipelineEngine
 from amplifier_module_loop_pipeline.graph import Edge, Graph, Node
 from amplifier_module_loop_pipeline.handlers import HandlerRegistry
-from amplifier_module_loop_pipeline.outcome import Outcome, StageStatus
+from amplifier_module_loop_pipeline.outcome import StageStatus
 
 
 # ---------------------------------------------------------------------------
@@ -68,32 +68,17 @@ async def _make_wired_engine(
     backend: object,
     logs_root: str,
 ) -> PipelineEngine:
-    """Create a PipelineEngine with subgraph_runner wired to engine._run_from.
+    """Create a PipelineEngine. Engine passes itself to handlers via execute(engine=self).
 
-    This matches the orchestrator wiring in __init__.py (step 8–10) so that
-    ParallelHandler can execute branches as proper subgraphs.
+    No subgraph_runner closure needed — ParallelHandler receives the engine
+    directly via execute(engine=...) and calls engine.run_subgraph().
     """
-    # Step 1: create engine with a temp registry (no subgraph_runner yet)
-    engine = PipelineEngine(
+    return PipelineEngine(
         graph=graph,
         context=PipelineContext(),
         handler_registry=HandlerRegistry(backend=backend),
         logs_root=logs_root,
     )
-
-    # Step 2: build subgraph_runner closure over the real engine._run_from
-    async def subgraph_runner(
-        node_id: str,
-        branch_context: PipelineContext,
-        _graph: Graph,
-        _logs_root: str,
-    ) -> Outcome:
-        return await engine._run_from(node_id, context=branch_context)
-
-    # Step 3: replace registry with one that has subgraph_runner wired in
-    registry = HandlerRegistry(backend=backend, subgraph_runner=subgraph_runner)
-    engine.handler_registry = registry
-    return engine
 
 
 # ---------------------------------------------------------------------------

--- a/modules/loop-pipeline/tests/test_engine_bug_g_parallel_component_fanout.py
+++ b/modules/loop-pipeline/tests/test_engine_bug_g_parallel_component_fanout.py
@@ -23,6 +23,7 @@ from amplifier_module_loop_pipeline.engine import PipelineEngine
 from amplifier_module_loop_pipeline.graph import Edge, Graph, Node
 from amplifier_module_loop_pipeline.handlers import HandlerRegistry
 from amplifier_module_loop_pipeline.outcome import StageStatus
+from amplifier_module_loop_pipeline.handlers.context import HandlerContext
 
 
 # ---------------------------------------------------------------------------
@@ -76,7 +77,7 @@ async def _make_wired_engine(
     return PipelineEngine(
         graph=graph,
         context=PipelineContext(),
-        handler_registry=HandlerRegistry(backend=backend),
+        handler_registry=HandlerRegistry(HandlerContext(backend=backend)),
         logs_root=logs_root,
     )
 
@@ -250,7 +251,7 @@ async def test_non_component_multi_edge_fanout_still_works(tmp_path):
 
     # No subgraph_runner needed for box nodes (uses engine-level fan-out)
     context = PipelineContext()
-    registry = HandlerRegistry(backend=TrackingBackend())
+    registry = HandlerRegistry(HandlerContext(backend=TrackingBackend()))
     engine = PipelineEngine(
         graph=graph,
         context=context,

--- a/modules/loop-pipeline/tests/test_engine_bug_h_requires_attribute.py
+++ b/modules/loop-pipeline/tests/test_engine_bug_h_requires_attribute.py
@@ -22,6 +22,7 @@ from amplifier_module_loop_pipeline.engine import PipelineEngine
 from amplifier_module_loop_pipeline.graph import Edge, Graph, Node
 from amplifier_module_loop_pipeline.handlers import HandlerRegistry
 from amplifier_module_loop_pipeline.outcome import StageStatus
+from amplifier_module_loop_pipeline.handlers.context import HandlerContext
 
 
 # ---------------------------------------------------------------------------
@@ -36,7 +37,7 @@ def _make_engine_with_graph(
     context = PipelineContext()
     # Set context.target_dir so file checks are relative to tmp_path
     context.set("context.target_dir", str(tmp_path))
-    registry = HandlerRegistry(backend=backend)
+    registry = HandlerRegistry(HandlerContext(backend=backend))
     return PipelineEngine(
         graph=graph,
         context=context,
@@ -287,7 +288,7 @@ async def test_requires_uses_context_target_dir_for_path_resolution(tmp_path):
     # Point context.target_dir at the workspace subdirectory (not tmp_path)
     context = PipelineContext()
     context.set("context.target_dir", str(target_dir))
-    registry = HandlerRegistry(backend=TrackingBackend())
+    registry = HandlerRegistry(HandlerContext(backend=TrackingBackend()))
     engine = PipelineEngine(
         graph=graph,
         context=context,

--- a/modules/loop-pipeline/tests/test_failure_routing.py
+++ b/modules/loop-pipeline/tests/test_failure_routing.py
@@ -17,6 +17,7 @@ from amplifier_module_loop_pipeline.engine import PipelineEngine
 from amplifier_module_loop_pipeline.graph import Edge, Graph, Node
 from amplifier_module_loop_pipeline.handlers import HandlerRegistry
 from amplifier_module_loop_pipeline.outcome import Outcome, StageStatus
+from amplifier_module_loop_pipeline.handlers.context import HandlerContext
 
 
 class CountingBackend:
@@ -45,7 +46,7 @@ def _make_engine(
     hooks: object | None = None,
 ) -> PipelineEngine:
     context = PipelineContext()
-    registry = HandlerRegistry(backend=backend)
+    registry = HandlerRegistry(HandlerContext(backend=backend))
     return PipelineEngine(
         graph=graph,
         context=context,

--- a/modules/loop-pipeline/tests/test_fan_in_bfs.py
+++ b/modules/loop-pipeline/tests/test_fan_in_bfs.py
@@ -180,9 +180,7 @@ def test_fan_in_empty_list_returns_none(tmp_path):
 
     result = engine._find_fan_in_node([])
 
-    assert result is None, (
-        f"_find_fan_in_node([]) must return None, got {result!r}"
-    )
+    assert result is None, f"_find_fan_in_node([]) must return None, got {result!r}"
 
 
 def test_fan_in_excludes_branch_roots_from_candidates(tmp_path):
@@ -285,28 +283,15 @@ async def test_pipeline_with_multi_hop_branches_completes(tmp_path):
         ],
     )
 
-    # Wire up subgraph runner (required for ParallelHandler)
+    from amplifier_module_loop_pipeline.outcome import StageStatus
+
+    # No subgraph_runner needed — ParallelHandler receives engine via execute(engine=...)
     engine = PipelineEngine(
         graph=graph,
         context=PipelineContext(),
         handler_registry=HandlerRegistry(backend=CountingBackend()),
         logs_root=str(tmp_path),
     )
-
-    async def subgraph_runner(
-        node_id: str,
-        branch_context: PipelineContext,
-        _graph: Graph,
-        _logs_root: str,
-    ) -> object:
-        return await engine._run_from(node_id, context=branch_context)
-
-    from amplifier_module_loop_pipeline.outcome import StageStatus
-
-    registry = HandlerRegistry(
-        backend=CountingBackend(), subgraph_runner=subgraph_runner
-    )
-    engine.handler_registry = registry
 
     outcome = await engine.run()
 

--- a/modules/loop-pipeline/tests/test_fan_in_bfs.py
+++ b/modules/loop-pipeline/tests/test_fan_in_bfs.py
@@ -26,6 +26,7 @@ from amplifier_module_loop_pipeline.context import PipelineContext
 from amplifier_module_loop_pipeline.engine import PipelineEngine
 from amplifier_module_loop_pipeline.graph import Edge, Graph, Node
 from amplifier_module_loop_pipeline.handlers import HandlerRegistry
+from amplifier_module_loop_pipeline.handlers.context import HandlerContext
 
 
 def _make_engine(graph: Graph, tmp_path) -> PipelineEngine:
@@ -33,7 +34,7 @@ def _make_engine(graph: Graph, tmp_path) -> PipelineEngine:
     return PipelineEngine(
         graph=graph,
         context=PipelineContext(),
-        handler_registry=HandlerRegistry(),
+        handler_registry=HandlerRegistry(HandlerContext()),
         logs_root=str(tmp_path),
     )
 
@@ -289,7 +290,7 @@ async def test_pipeline_with_multi_hop_branches_completes(tmp_path):
     engine = PipelineEngine(
         graph=graph,
         context=PipelineContext(),
-        handler_registry=HandlerRegistry(backend=CountingBackend()),
+        handler_registry=HandlerRegistry(HandlerContext(backend=CountingBackend())),
         logs_root=str(tmp_path),
     )
 

--- a/modules/loop-pipeline/tests/test_goal_gate_retry_clears_failures.py
+++ b/modules/loop-pipeline/tests/test_goal_gate_retry_clears_failures.py
@@ -27,6 +27,7 @@ from amplifier_module_loop_pipeline.engine import PipelineEngine
 from amplifier_module_loop_pipeline.handlers import HandlerRegistry
 from amplifier_module_loop_pipeline.outcome import StageStatus
 from amplifier_module_loop_pipeline.validation import validate_or_raise
+from amplifier_module_loop_pipeline.handlers.context import HandlerContext
 
 
 class EventCapture:
@@ -41,7 +42,7 @@ def _make_engine(dot_source: str, logs_root: str, hooks: Any = None) -> Pipeline
     graph = parse_dot(dot_source)
     validate_or_raise(graph)
     context = PipelineContext()
-    registry = HandlerRegistry()
+    registry = HandlerRegistry(HandlerContext())
     return PipelineEngine(
         graph=graph,
         context=context,

--- a/modules/loop-pipeline/tests/test_goal_gates.py
+++ b/modules/loop-pipeline/tests/test_goal_gates.py
@@ -15,6 +15,7 @@ from amplifier_module_loop_pipeline.engine import PipelineEngine
 from amplifier_module_loop_pipeline.handlers import HandlerRegistry
 from amplifier_module_loop_pipeline.outcome import Outcome, StageStatus
 from amplifier_module_loop_pipeline.validation import validate_or_raise
+from amplifier_module_loop_pipeline.handlers.context import HandlerContext
 
 
 class MockBackend:
@@ -55,7 +56,7 @@ def _make_engine(
     graph = parse_dot(dot_source)
     validate_or_raise(graph)
     context = PipelineContext()
-    registry = HandlerRegistry(backend=backend)
+    registry = HandlerRegistry(HandlerContext(backend=backend))
     return PipelineEngine(
         graph=graph,
         context=context,
@@ -338,7 +339,7 @@ async def test_goal_gate_retry_bounded(tmp_path):
     """)
     validate_or_raise(graph)
     context = PipelineContext()
-    registry = HandlerRegistry(backend=backend)
+    registry = HandlerRegistry(HandlerContext(backend=backend))
     engine = PipelineEngine(
         graph=graph,
         context=context,

--- a/modules/loop-pipeline/tests/test_handler_context.py
+++ b/modules/loop-pipeline/tests/test_handler_context.py
@@ -1,0 +1,185 @@
+"""Tests for HandlerContext dataclass and updated HandlerRegistry constructor.
+
+Spec coverage: T2.1 — HandlerContext replaces **kwargs: Any in HandlerRegistry.__init__.
+
+These tests define the expected behavior BEFORE implementation (TDD RED phase).
+"""
+
+import dataclasses
+
+import pytest
+
+from amplifier_module_loop_pipeline.handlers import HandlerRegistry
+from amplifier_module_loop_pipeline.handlers.context import HandlerContext
+
+
+# ---------------------------------------------------------------------------
+# HandlerContext construction
+# ---------------------------------------------------------------------------
+
+
+def test_handler_context_is_a_dataclass():
+    """HandlerContext is a dataclass (has dataclass metadata)."""
+    assert dataclasses.is_dataclass(HandlerContext)
+
+
+def test_handler_context_is_frozen():
+    """HandlerContext is frozen — mutation after construction raises."""
+    ctx = HandlerContext()
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        ctx.backend = "something"  # type: ignore[misc]
+
+
+def test_handler_context_default_all_none():
+    """HandlerContext() with no args produces all-None fields."""
+    ctx = HandlerContext()
+    assert ctx.backend is None
+    assert ctx.hooks is None
+    assert ctx.cancel_event is None
+    assert ctx.interviewer is None
+
+
+def test_handler_context_fields_accessible():
+    """HandlerContext exposes backend, hooks, cancel_event, interviewer."""
+    mock_backend = object()
+    mock_hooks = object()
+    mock_event = object()
+    mock_interviewer = object()
+    ctx = HandlerContext(
+        backend=mock_backend,
+        hooks=mock_hooks,
+        cancel_event=mock_event,
+        interviewer=mock_interviewer,
+    )
+    assert ctx.backend is mock_backend
+    assert ctx.hooks is mock_hooks
+    assert ctx.cancel_event is mock_event
+    assert ctx.interviewer is mock_interviewer
+
+
+def test_handler_context_partial_construction():
+    """HandlerContext can be constructed with only some fields."""
+    mock_backend = object()
+    ctx = HandlerContext(backend=mock_backend)
+    assert ctx.backend is mock_backend
+    assert ctx.hooks is None
+    assert ctx.cancel_event is None
+    assert ctx.interviewer is None
+
+
+# ---------------------------------------------------------------------------
+# HandlerRegistry constructor: ctx is required
+# ---------------------------------------------------------------------------
+
+
+def test_registry_requires_handler_context_positional_arg():
+    """HandlerRegistry() without a HandlerContext raises TypeError.
+
+    After the T2.1 refactor, `HandlerRegistry.__init__` takes a required
+    positional `ctx: HandlerContext` argument.  Calling without it must
+    fail at runtime (and at pyright write-time).
+    """
+    with pytest.raises(TypeError):
+        HandlerRegistry()  # type: ignore[call-arg]
+
+
+def test_registry_kwargs_no_longer_accepted():
+    """HandlerRegistry(backend=x) raises TypeError — the **kwargs API is gone.
+
+    The old `HandlerRegistry(backend=x, hooks=y, ...)` signature is
+    eliminated.  Callers must wrap in HandlerContext first.
+    """
+    with pytest.raises(TypeError):
+        HandlerRegistry(backend="something")  # type: ignore[call-arg]
+
+
+def test_registry_accepts_empty_handler_context():
+    """HandlerRegistry(HandlerContext()) works — all fields default to None."""
+    registry = HandlerRegistry(HandlerContext())
+    assert registry is not None
+
+
+# ---------------------------------------------------------------------------
+# HandlerRegistry wires ctx fields to handlers
+# ---------------------------------------------------------------------------
+
+
+def test_registry_ctx_backend_wired_to_codergen():
+    """HandlerRegistry wires ctx.backend to CodergenHandler."""
+    from amplifier_module_loop_pipeline.handlers.codergen import CodergenHandler
+
+    mock_backend = object()
+    ctx = HandlerContext(backend=mock_backend)
+    registry = HandlerRegistry(ctx)
+    codergen = registry._handlers["codergen"]
+    assert isinstance(codergen, CodergenHandler)
+    assert codergen._backend is mock_backend
+
+
+def test_registry_ctx_interviewer_wired_to_human_gate():
+    """HandlerRegistry wires ctx.interviewer to HumanGateHandler."""
+    from amplifier_module_loop_pipeline.handlers.human import HumanGateHandler
+
+    mock_interviewer = object()
+    ctx = HandlerContext(interviewer=mock_interviewer)
+    registry = HandlerRegistry(ctx)
+    human_gate = registry._handlers["wait.human"]
+    assert isinstance(human_gate, HumanGateHandler)
+    assert human_gate._interviewer is mock_interviewer
+
+
+def test_registry_ctx_hooks_wired_to_parallel_handler():
+    """HandlerRegistry wires ctx.hooks to ParallelHandler."""
+    from amplifier_module_loop_pipeline.handlers.parallel import ParallelHandler
+
+    mock_hooks = object()
+    ctx = HandlerContext(hooks=mock_hooks)
+    registry = HandlerRegistry(ctx)
+    parallel = registry._handlers["parallel"]
+    assert isinstance(parallel, ParallelHandler)
+    assert parallel._hooks is mock_hooks
+
+
+def test_registry_ctx_stored_on_registry():
+    """HandlerRegistry stores the HandlerContext as self._ctx (for clone_for_branch)."""
+    ctx = HandlerContext()
+    registry = HandlerRegistry(ctx)
+    assert registry._ctx is ctx
+
+
+# ---------------------------------------------------------------------------
+# clone_for_branch works with HandlerContext
+# ---------------------------------------------------------------------------
+
+
+def test_clone_for_branch_preserves_ctx():
+    """clone_for_branch() preserves _ctx on the cloned registry."""
+    from unittest.mock import MagicMock
+
+    mock_backend = MagicMock()
+    cloned_backend = MagicMock()
+    mock_backend.clone.return_value = cloned_backend
+
+    ctx = HandlerContext(backend=mock_backend)
+    registry = HandlerRegistry(ctx)
+    cloned = registry.clone_for_branch()
+    # The cloned registry should have _ctx pointing to the same frozen context
+    assert cloned._ctx is ctx
+
+
+# ---------------------------------------------------------------------------
+# Design-intent documentation test
+# ---------------------------------------------------------------------------
+
+
+def test_handler_context_design_intent():
+    """HandlerContext design intent: explicit named fields replace **kwargs: Any.
+
+    This is a documentation test.  It verifies that HandlerContext:
+    1. Has exactly the expected field names (no more, no fewer)
+    2. No field named 'subgraph_runner' (eliminated in PR #36)
+    3. No unknown kwargs silently accepted
+    """
+    field_names = {f.name for f in dataclasses.fields(HandlerContext)}
+    assert field_names == {"backend", "hooks", "cancel_event", "interviewer"}
+    assert "subgraph_runner" not in field_names

--- a/modules/loop-pipeline/tests/test_handler_registry_clone.py
+++ b/modules/loop-pipeline/tests/test_handler_registry_clone.py
@@ -9,6 +9,7 @@ Verifies that clone_for_branch() produces a registry where:
 from unittest.mock import MagicMock
 
 from amplifier_module_loop_pipeline.handlers import HandlerRegistry
+from amplifier_module_loop_pipeline.handlers.context import HandlerContext
 
 
 def _make_registry_with_mock_backend():
@@ -16,7 +17,7 @@ def _make_registry_with_mock_backend():
     mock_backend = MagicMock()
     cloned_backend = MagicMock()
     mock_backend.clone.return_value = cloned_backend
-    registry = HandlerRegistry(backend=mock_backend)
+    registry = HandlerRegistry(HandlerContext(backend=mock_backend))
     return registry, mock_backend, cloned_backend
 
 

--- a/modules/loop-pipeline/tests/test_handlers.py
+++ b/modules/loop-pipeline/tests/test_handlers.py
@@ -399,7 +399,7 @@ def test_registry_custom_handler_registration():
     """Custom handlers can be registered and resolved (HAND-005)."""
 
     class CustomHandler:
-        async def execute(self, node, context, graph, logs_root):
+        async def execute(self, node, context, graph, logs_root, *, engine=None):
             return Outcome(status=StageStatus.SUCCESS, notes="custom")
 
     registry = HandlerRegistry()
@@ -442,9 +442,7 @@ def test_registry_node_type_steer_falls_to_shape():
 def test_registry_type_takes_priority_over_node_type():
     """Explicit type= attribute takes priority over node_type."""
     registry = HandlerRegistry()
-    node = Node(
-        id="x", shape="box", type="tool", attrs={"node_type": "codergen"}
-    )
+    node = Node(id="x", shape="box", type="tool", attrs={"node_type": "codergen"})
     handler = registry.get(node)
     assert isinstance(handler, ToolHandler)
 
@@ -473,7 +471,7 @@ def test_registry_register_replaces_existing():
     assert isinstance(original, StartHandler)
 
     class NewStart:
-        async def execute(self, node, context, graph, logs_root):
+        async def execute(self, node, context, graph, logs_root, *, engine=None):
             return Outcome(status=StageStatus.SUCCESS, notes="new start")
 
     registry.register("start", NewStart())

--- a/modules/loop-pipeline/tests/test_handlers.py
+++ b/modules/loop-pipeline/tests/test_handlers.py
@@ -16,6 +16,7 @@ from amplifier_module_loop_pipeline.handlers.exit import ExitHandler
 from amplifier_module_loop_pipeline.handlers.start import StartHandler
 from amplifier_module_loop_pipeline.handlers.tool import ToolHandler
 from amplifier_module_loop_pipeline.outcome import Outcome, StageStatus
+from amplifier_module_loop_pipeline.handlers.context import HandlerContext
 
 
 def _make_graph(**kwargs) -> Graph:
@@ -36,7 +37,7 @@ def _make_context() -> PipelineContext:
 
 def test_registry_resolves_start_handler():
     """Registry maps shape=Mdiamond to StartHandler."""
-    registry = HandlerRegistry()
+    registry = HandlerRegistry(HandlerContext())
     node = Node(id="s", shape="Mdiamond")
     handler = registry.get(node)
     assert isinstance(handler, StartHandler)
@@ -44,7 +45,7 @@ def test_registry_resolves_start_handler():
 
 def test_registry_resolves_exit_handler():
     """Registry maps shape=Msquare to ExitHandler."""
-    registry = HandlerRegistry()
+    registry = HandlerRegistry(HandlerContext())
     node = Node(id="e", shape="Msquare")
     handler = registry.get(node)
     assert isinstance(handler, ExitHandler)
@@ -52,7 +53,7 @@ def test_registry_resolves_exit_handler():
 
 def test_registry_resolves_codergen_handler():
     """Registry maps shape=box to CodergenHandler."""
-    registry = HandlerRegistry()
+    registry = HandlerRegistry(HandlerContext())
     node = Node(id="c", shape="box")
     handler = registry.get(node)
     assert isinstance(handler, CodergenHandler)
@@ -60,7 +61,7 @@ def test_registry_resolves_codergen_handler():
 
 def test_registry_explicit_type_overrides_shape():
     """Node type attribute overrides shape-based resolution."""
-    registry = HandlerRegistry()
+    registry = HandlerRegistry(HandlerContext())
     node = Node(id="x", shape="box", type="tool")
     handler = registry.get(node)
     assert isinstance(handler, ToolHandler)
@@ -275,7 +276,7 @@ async def test_tool_handler_no_timeout_runs_normally(tmp_path):
 
 def test_registry_resolves_tool_handler():
     """Registry maps shape=parallelogram to ToolHandler."""
-    registry = HandlerRegistry()
+    registry = HandlerRegistry(HandlerContext())
     node = Node(id="t", shape="parallelogram")
     handler = registry.get(node)
     assert isinstance(handler, ToolHandler)
@@ -366,7 +367,7 @@ async def test_context_variable_flows_between_pipeline_nodes(tmp_path):
     graph = parse_dot(dot_source)
     validate_or_raise(graph)
     context = PipelineContext()
-    registry = HandlerRegistry(backend=backend)
+    registry = HandlerRegistry(HandlerContext(backend=backend))
     engine = PipelineEngine(
         graph=graph,
         context=context,
@@ -389,7 +390,7 @@ def test_registry_unknown_shape_raises_value_error():
 
     Authors who want LLM-driven nodes must use shape=box explicitly.
     """
-    registry = HandlerRegistry()
+    registry = HandlerRegistry(HandlerContext())
     node = Node(id="u", shape="trapezoid")
     with pytest.raises(ValueError, match="trapezoid"):
         registry.get(node)
@@ -402,7 +403,7 @@ def test_registry_custom_handler_registration():
         async def execute(self, node, context, graph, logs_root, *, engine=None):
             return Outcome(status=StageStatus.SUCCESS, notes="custom")
 
-    registry = HandlerRegistry()
+    registry = HandlerRegistry(HandlerContext())
     registry.register("my_custom", CustomHandler())
     node = Node(id="x", type="my_custom")
     handler = registry.get(node)
@@ -414,7 +415,7 @@ def test_registry_custom_handler_registration():
 
 def test_registry_node_type_fallback():
     """node_type attribute is used as fallback when type is empty."""
-    registry = HandlerRegistry()
+    registry = HandlerRegistry(HandlerContext())
     # node_type="tool" should resolve to ToolHandler
     node = Node(id="x", shape="box", type="", attrs={"node_type": "tool"})
     handler = registry.get(node)
@@ -423,7 +424,7 @@ def test_registry_node_type_fallback():
 
 def test_registry_node_type_unknown_falls_to_shape():
     """Unknown node_type (e.g. stack.observe) falls through to shape-based lookup."""
-    registry = HandlerRegistry()
+    registry = HandlerRegistry(HandlerContext())
     # node_type="stack.observe" is NOT a registered handler type
     # shape=box -> codergen
     node = Node(id="x", shape="box", type="", attrs={"node_type": "stack.observe"})
@@ -433,7 +434,7 @@ def test_registry_node_type_unknown_falls_to_shape():
 
 def test_registry_node_type_steer_falls_to_shape():
     """Unknown node_type (stack.steer) falls through to shape-based lookup."""
-    registry = HandlerRegistry()
+    registry = HandlerRegistry(HandlerContext())
     node = Node(id="x", shape="box", type="", attrs={"node_type": "stack.steer"})
     handler = registry.get(node)
     assert isinstance(handler, CodergenHandler)
@@ -441,7 +442,7 @@ def test_registry_node_type_steer_falls_to_shape():
 
 def test_registry_type_takes_priority_over_node_type():
     """Explicit type= attribute takes priority over node_type."""
-    registry = HandlerRegistry()
+    registry = HandlerRegistry(HandlerContext())
     node = Node(id="x", shape="box", type="tool", attrs={"node_type": "codergen"})
     handler = registry.get(node)
     assert isinstance(handler, ToolHandler)
@@ -449,7 +450,7 @@ def test_registry_type_takes_priority_over_node_type():
 
 def test_registry_node_type_takes_priority_over_shape():
     """node_type takes priority over shape-based lookup."""
-    registry = HandlerRegistry()
+    registry = HandlerRegistry(HandlerContext())
     # shape=box -> codergen, but node_type="tool" should override to ToolHandler
     node = Node(id="x", shape="box", type="", attrs={"node_type": "tool"})
     handler = registry.get(node)
@@ -458,7 +459,7 @@ def test_registry_node_type_takes_priority_over_shape():
 
 def test_registry_no_type_no_node_type_uses_shape():
     """When neither type nor node_type is set, shape-based lookup works as before."""
-    registry = HandlerRegistry()
+    registry = HandlerRegistry(HandlerContext())
     node = Node(id="x", shape="parallelogram")
     handler = registry.get(node)
     assert isinstance(handler, ToolHandler)
@@ -466,7 +467,7 @@ def test_registry_no_type_no_node_type_uses_shape():
 
 def test_registry_register_replaces_existing():
     """Registering for an existing type replaces the handler (HAND-006)."""
-    registry = HandlerRegistry()
+    registry = HandlerRegistry(HandlerContext())
     original = registry.get(Node(id="s", shape="Mdiamond"))
     assert isinstance(original, StartHandler)
 

--- a/modules/loop-pipeline/tests/test_human.py
+++ b/modules/loop-pipeline/tests/test_human.py
@@ -19,6 +19,7 @@ from amplifier_module_loop_pipeline.interviewer import (
     QueueInterviewer,
 )
 from amplifier_module_loop_pipeline.outcome import StageStatus
+from amplifier_module_loop_pipeline.handlers.context import HandlerContext
 
 
 def _make_graph_with_human_gate() -> Graph:
@@ -519,7 +520,7 @@ class TestHumanHandlerRegistration:
     def test_registry_resolves_human_handler(self):
         from amplifier_module_loop_pipeline.handlers import HandlerRegistry
 
-        registry = HandlerRegistry()
+        registry = HandlerRegistry(HandlerContext())
         node = Node(id="gate", shape="hexagon")
         handler = registry.get(node)
         assert isinstance(handler, HumanGateHandler)

--- a/modules/loop-pipeline/tests/test_integration_combined.py
+++ b/modules/loop-pipeline/tests/test_integration_combined.py
@@ -78,6 +78,8 @@ class MockToolHandler:
         context: PipelineContext,
         graph: Graph,
         logs_root: str,
+        *,
+        engine=None,
     ) -> Outcome:
         return Outcome(status=StageStatus.SUCCESS, notes="Mock validation passed")
 

--- a/modules/loop-pipeline/tests/test_integration_combined.py
+++ b/modules/loop-pipeline/tests/test_integration_combined.py
@@ -26,6 +26,7 @@ from amplifier_module_loop_pipeline.handlers import HandlerRegistry
 from amplifier_module_loop_pipeline.handlers.pipeline import PipelineHandler
 from amplifier_module_loop_pipeline.interviewer import Answer, Option, QueueInterviewer
 from amplifier_module_loop_pipeline.outcome import Outcome, StageStatus
+from amplifier_module_loop_pipeline.handlers.context import HandlerContext
 
 # ---------------------------------------------------------------------------
 # Path helpers
@@ -261,12 +262,12 @@ class TestCombinedExecution:
 
         # Factory to build child registries with both backend + interviewer + tool mock
         def child_registry_factory() -> HandlerRegistry:
-            registry = HandlerRegistry(backend=backend, interviewer=interviewer)
+            registry = HandlerRegistry(HandlerContext(backend=backend, interviewer=interviewer))
             registry.register("tool", MockToolHandler())
             return registry
 
         # Build parent registry; override pipeline handler to use the factory
-        parent_registry = HandlerRegistry(backend=backend, interviewer=interviewer)
+        parent_registry = HandlerRegistry(HandlerContext(backend=backend, interviewer=interviewer))
         parent_registry.register("tool", MockToolHandler())
         parent_registry.register(
             "pipeline",
@@ -316,11 +317,11 @@ class TestCombinedExecution:
         )
 
         def child_registry_factory() -> HandlerRegistry:
-            registry = HandlerRegistry(backend=backend, interviewer=interviewer)
+            registry = HandlerRegistry(HandlerContext(backend=backend, interviewer=interviewer))
             registry.register("tool", MockToolHandler())
             return registry
 
-        parent_registry = HandlerRegistry(backend=backend, interviewer=interviewer)
+        parent_registry = HandlerRegistry(HandlerContext(backend=backend, interviewer=interviewer))
         parent_registry.register("tool", MockToolHandler())
         parent_registry.register(
             "pipeline",
@@ -372,11 +373,11 @@ class TestCombinedExecution:
         )
 
         def child_registry_factory() -> HandlerRegistry:
-            registry = HandlerRegistry(backend=backend, interviewer=interviewer)
+            registry = HandlerRegistry(HandlerContext(backend=backend, interviewer=interviewer))
             registry.register("tool", MockToolHandler())
             return registry
 
-        parent_registry = HandlerRegistry(backend=backend, interviewer=interviewer)
+        parent_registry = HandlerRegistry(HandlerContext(backend=backend, interviewer=interviewer))
         parent_registry.register("tool", MockToolHandler())
         parent_registry.register(
             "pipeline",
@@ -422,11 +423,11 @@ class TestCombinedExecution:
         )
 
         def child_registry_factory() -> HandlerRegistry:
-            registry = HandlerRegistry(backend=backend, interviewer=interviewer)
+            registry = HandlerRegistry(HandlerContext(backend=backend, interviewer=interviewer))
             registry.register("tool", MockToolHandler())
             return registry
 
-        parent_registry = HandlerRegistry(backend=backend, interviewer=interviewer)
+        parent_registry = HandlerRegistry(HandlerContext(backend=backend, interviewer=interviewer))
         parent_registry.register("tool", MockToolHandler())
         parent_registry.register(
             "pipeline",

--- a/modules/loop-pipeline/tests/test_manager_loop.py
+++ b/modules/loop-pipeline/tests/test_manager_loop.py
@@ -56,11 +56,29 @@ def _make_graph(
     )
 
 
-def _make_runner(outcomes: list[Outcome]) -> AsyncMock:
-    """Create a mock subgraph_runner that returns outcomes in sequence."""
-    runner = AsyncMock()
-    runner.side_effect = list(outcomes)
-    return runner
+class _MockEngine:
+    """Mock engine that returns outcomes from a sequence via run_subgraph."""
+
+    def __init__(self, outcomes: list[Outcome]) -> None:
+        self._outcomes = list(outcomes)
+        self.call_count = 0
+        self.call_args: tuple | None = None  # (args, kwargs) of last call
+
+    async def run_subgraph(self, node_id: str, *, context: object = None) -> Outcome:
+        self.call_count += 1
+        self.call_args = ((node_id,), {"context": context})
+        if self._outcomes:
+            outcome = self._outcomes.pop(0)
+            # Support AsyncMock-style StopAsyncIteration for exhausted sequences
+            if isinstance(outcome, type) and issubclass(outcome, Exception):
+                raise outcome()
+            return outcome
+        return Outcome(status=StageStatus.FAIL, failure_reason="no more outcomes")
+
+
+def _make_runner(outcomes: list[Outcome]) -> _MockEngine:
+    """Create a mock engine that returns outcomes in sequence."""
+    return _MockEngine(outcomes)
 
 
 # ---------------------------------------------------------------------------
@@ -79,11 +97,13 @@ class TestManagerLoopExecution:
                 Outcome(status=StageStatus.SUCCESS, notes="child ok"),
             ]
         )
-        handler = ManagerLoopHandler(subgraph_runner=runner)
+        handler = ManagerLoopHandler()
         graph = _make_graph(manager_attrs={"manager.max_cycles": "5"})
         ctx = PipelineContext()
 
-        result = await handler.execute(graph.nodes["manager"], ctx, graph, "/tmp")
+        result = await handler.execute(
+            graph.nodes["manager"], ctx, graph, "/tmp", engine=runner
+        )
 
         assert result.status == StageStatus.SUCCESS
         assert runner.call_count == 1
@@ -98,7 +118,7 @@ class TestManagerLoopExecution:
                 Outcome(status=StageStatus.SUCCESS, notes="fixed"),
             ]
         )
-        handler = ManagerLoopHandler(subgraph_runner=runner)
+        handler = ManagerLoopHandler()
         graph = _make_graph(
             manager_attrs={
                 "manager.max_cycles": "5",
@@ -107,7 +127,9 @@ class TestManagerLoopExecution:
         )
         ctx = PipelineContext()
 
-        result = await handler.execute(graph.nodes["manager"], ctx, graph, "/tmp")
+        result = await handler.execute(
+            graph.nodes["manager"], ctx, graph, "/tmp", engine=runner
+        )
 
         assert result.status == StageStatus.SUCCESS
         assert runner.call_count == 3
@@ -122,7 +144,7 @@ class TestManagerLoopExecution:
                 Outcome(status=StageStatus.FAIL, failure_reason="nope"),
             ]
         )
-        handler = ManagerLoopHandler(subgraph_runner=runner)
+        handler = ManagerLoopHandler()
         graph = _make_graph(
             manager_attrs={
                 "manager.max_cycles": "3",
@@ -131,7 +153,9 @@ class TestManagerLoopExecution:
         )
         ctx = PipelineContext()
 
-        result = await handler.execute(graph.nodes["manager"], ctx, graph, "/tmp")
+        result = await handler.execute(
+            graph.nodes["manager"], ctx, graph, "/tmp", engine=runner
+        )
 
         assert result.status == StageStatus.FAIL
         assert runner.call_count == 3
@@ -145,11 +169,13 @@ class TestManagerLoopExecution:
                 Outcome(status=StageStatus.PARTIAL_SUCCESS, notes="close enough"),
             ]
         )
-        handler = ManagerLoopHandler(subgraph_runner=runner)
+        handler = ManagerLoopHandler()
         graph = _make_graph(manager_attrs={"manager.max_cycles": "5"})
         ctx = PipelineContext()
 
-        result = await handler.execute(graph.nodes["manager"], ctx, graph, "/tmp")
+        result = await handler.execute(
+            graph.nodes["manager"], ctx, graph, "/tmp", engine=runner
+        )
 
         assert result.is_success
         assert runner.call_count == 1
@@ -172,7 +198,7 @@ class TestManagerStopCondition:
                 Outcome(status=StageStatus.SUCCESS),
             ]
         )
-        handler = ManagerLoopHandler(subgraph_runner=runner)
+        handler = ManagerLoopHandler()
         graph = _make_graph(
             manager_attrs={
                 "manager.max_cycles": "5",
@@ -182,7 +208,9 @@ class TestManagerStopCondition:
         )
         ctx = PipelineContext()
 
-        result = await handler.execute(graph.nodes["manager"], ctx, graph, "/tmp")
+        result = await handler.execute(
+            graph.nodes["manager"], ctx, graph, "/tmp", engine=runner
+        )
 
         assert result.status == StageStatus.SUCCESS
         assert runner.call_count == 2
@@ -196,7 +224,7 @@ class TestManagerStopCondition:
                 Outcome(status=StageStatus.PARTIAL_SUCCESS),
             ]
         )
-        handler = ManagerLoopHandler(subgraph_runner=runner)
+        handler = ManagerLoopHandler()
         graph = _make_graph(
             manager_attrs={
                 "manager.max_cycles": "2",
@@ -206,7 +234,9 @@ class TestManagerStopCondition:
         )
         ctx = PipelineContext()
 
-        result = await handler.execute(graph.nodes["manager"], ctx, graph, "/tmp")
+        result = await handler.execute(
+            graph.nodes["manager"], ctx, graph, "/tmp", engine=runner
+        )
 
         # Guard requires "success" exactly, partial_success doesn't match
         assert result.status == StageStatus.FAIL
@@ -230,7 +260,7 @@ class TestManagerContextRecording:
                 Outcome(status=StageStatus.SUCCESS),
             ]
         )
-        handler = ManagerLoopHandler(subgraph_runner=runner)
+        handler = ManagerLoopHandler()
         graph = _make_graph(
             manager_attrs={
                 "manager.max_cycles": "5",
@@ -239,7 +269,7 @@ class TestManagerContextRecording:
         )
         ctx = PipelineContext()
 
-        await handler.execute(graph.nodes["manager"], ctx, graph, "/tmp")
+        await handler.execute(graph.nodes["manager"], ctx, graph, "/tmp", engine=runner)
 
         assert ctx.get("manager.cycle_1.status") == "fail"
         assert ctx.get("manager.cycle_2.status") == "success"
@@ -253,11 +283,13 @@ class TestManagerContextRecording:
                 Outcome(status=StageStatus.SUCCESS),
             ]
         )
-        handler = ManagerLoopHandler(subgraph_runner=runner)
+        handler = ManagerLoopHandler()
         graph = _make_graph(manager_attrs={"manager.max_cycles": "3"})
         ctx = PipelineContext()
 
-        result = await handler.execute(graph.nodes["manager"], ctx, graph, "/tmp")
+        result = await handler.execute(
+            graph.nodes["manager"], ctx, graph, "/tmp", engine=runner
+        )
 
         assert result.context_updates is not None
         assert result.context_updates["last_stage"] == "manager"
@@ -277,18 +309,15 @@ class TestManagerSteer:
         """When 'steer' in actions, child context gets steering message."""
         captured_contexts: list[PipelineContext] = []
 
-        async def capturing_runner(
-            node_id: str,
-            context: PipelineContext,
-            graph: Graph,
-            logs_root: str,
-        ) -> Outcome:
-            captured_contexts.append(context)
-            if len(captured_contexts) < 2:
-                return Outcome(status=StageStatus.FAIL)
-            return Outcome(status=StageStatus.SUCCESS)
+        class _CapturingEngine3:
+            async def run_subgraph(self, node_id, *, context=None):
+                captured_contexts.append(context)
+                if len(captured_contexts) < 2:
+                    return Outcome(status=StageStatus.FAIL)
+                return Outcome(status=StageStatus.SUCCESS)
 
-        handler = ManagerLoopHandler(subgraph_runner=capturing_runner)
+        handler = ManagerLoopHandler()
+        _engine = _CapturingEngine3()
         graph = _make_graph(
             manager_attrs={
                 "manager.max_cycles": "5",
@@ -298,7 +327,9 @@ class TestManagerSteer:
         )
         ctx = PipelineContext()
 
-        await handler.execute(graph.nodes["manager"], ctx, graph, "/tmp")
+        await handler.execute(
+            graph.nodes["manager"], ctx, graph, "/tmp", engine=_engine
+        )
 
         # First cycle: no steering (no prior failure)
         assert captured_contexts[0].get("manager.steering") is None
@@ -312,22 +343,19 @@ class TestManagerSteer:
         """M-15: Steering message includes actual failure details from prior cycle."""
         captured_contexts: list[PipelineContext] = []
 
-        async def capturing_runner(
-            node_id: str,
-            context: PipelineContext,
-            graph: Graph,
-            logs_root: str,
-        ) -> Outcome:
-            captured_contexts.append(context)
-            if len(captured_contexts) < 2:
-                return Outcome(
-                    status=StageStatus.FAIL,
-                    failure_reason="tests failing: 3 of 10 assertions broken",
-                    notes="Unit tests did not pass",
-                )
-            return Outcome(status=StageStatus.SUCCESS)
+        class _CapturingEngine4:
+            async def run_subgraph(self, node_id, *, context=None):
+                captured_contexts.append(context)
+                if len(captured_contexts) < 2:
+                    return Outcome(
+                        status=StageStatus.FAIL,
+                        failure_reason="tests failing: 3 of 10 assertions broken",
+                        notes="Unit tests did not pass",
+                    )
+                return Outcome(status=StageStatus.SUCCESS)
 
-        handler = ManagerLoopHandler(subgraph_runner=capturing_runner)
+        handler = ManagerLoopHandler()
+        _engine = _CapturingEngine4()
         graph = _make_graph(
             manager_attrs={
                 "manager.max_cycles": "5",
@@ -337,7 +365,9 @@ class TestManagerSteer:
         )
         ctx = PipelineContext()
 
-        await handler.execute(graph.nodes["manager"], ctx, graph, "/tmp")
+        await handler.execute(
+            graph.nodes["manager"], ctx, graph, "/tmp", engine=_engine
+        )
 
         steering = captured_contexts[1].get("manager.steering")
         assert steering is not None
@@ -357,7 +387,7 @@ class TestManagerEdgeCases:
     @pytest.mark.asyncio
     async def test_no_child_edges_returns_fail(self):
         """Manager with no outgoing edges returns FAIL."""
-        handler = ManagerLoopHandler(subgraph_runner=AsyncMock())
+        handler = ManagerLoopHandler()
         graph = _make_graph(has_child_edge=False)
         ctx = PipelineContext()
 
@@ -368,11 +398,12 @@ class TestManagerEdgeCases:
 
     @pytest.mark.asyncio
     async def test_no_runner_returns_fail(self):
-        """Manager without a subgraph_runner returns FAIL."""
-        handler = ManagerLoopHandler()  # no runner
+        """Manager without engine returns FAIL."""
+        handler = ManagerLoopHandler()  # no engine
         graph = _make_graph(manager_attrs={"manager.max_cycles": "3"})
         ctx = PipelineContext()
 
+        # engine=None (default) -> ManagerLoopHandler requires engine
         result = await handler.execute(graph.nodes["manager"], ctx, graph, "/tmp")
 
         assert result.status == StageStatus.FAIL
@@ -384,14 +415,16 @@ class TestManagerEdgeCases:
         # the default is > 10 (the old wrong default).
         call_count = 0
 
-        async def runner_succeeds_on_11(node_id, context, graph, logs_root):
-            nonlocal call_count
-            call_count += 1
-            if call_count >= 11:
-                return Outcome(status=StageStatus.SUCCESS)
-            return Outcome(status=StageStatus.FAIL)
+        class _Succeeds11Engine:
+            async def run_subgraph(self, node_id, *, context=None):
+                nonlocal call_count
+                call_count += 1
+                if call_count >= 11:
+                    return Outcome(status=StageStatus.SUCCESS)
+                return Outcome(status=StageStatus.FAIL)
 
-        handler = ManagerLoopHandler(subgraph_runner=runner_succeeds_on_11)
+        handler = ManagerLoopHandler()
+        _engine = _Succeeds11Engine()
         graph = _make_graph(
             manager_attrs={
                 "manager.poll_interval": "0s",
@@ -400,7 +433,9 @@ class TestManagerEdgeCases:
         )
         ctx = PipelineContext()
 
-        result = await handler.execute(graph.nodes["manager"], ctx, graph, "/tmp")
+        result = await handler.execute(
+            graph.nodes["manager"], ctx, graph, "/tmp", engine=_engine
+        )
 
         # With old default of 10, this would FAIL. With 1000, it succeeds.
         assert result.status == StageStatus.SUCCESS
@@ -411,15 +446,17 @@ class TestManagerEdgeCases:
         """M-14: When default max_cycles exhausted, failure mentions 1000."""
         call_count = 0
 
-        async def always_fails(node_id, context, graph, logs_root):
-            nonlocal call_count
-            call_count += 1
-            # Succeed on 1001 (never reached if default is 1000)
-            if call_count > 1000:
-                return Outcome(status=StageStatus.SUCCESS)
-            return Outcome(status=StageStatus.FAIL)
+        class _AlwaysFailsEngine:
+            async def run_subgraph(self, node_id, *, context=None):
+                nonlocal call_count
+                call_count += 1
+                # Succeed on 1001 (never reached if default is 1000)
+                if call_count > 1000:
+                    return Outcome(status=StageStatus.SUCCESS)
+                return Outcome(status=StageStatus.FAIL)
 
-        handler = ManagerLoopHandler(subgraph_runner=always_fails)
+        handler = ManagerLoopHandler()
+        _engine = _AlwaysFailsEngine()
         graph = _make_graph(
             manager_attrs={
                 "manager.poll_interval": "0s",
@@ -427,7 +464,9 @@ class TestManagerEdgeCases:
         )
         ctx = PipelineContext()
 
-        result = await handler.execute(graph.nodes["manager"], ctx, graph, "/tmp")
+        result = await handler.execute(
+            graph.nodes["manager"], ctx, graph, "/tmp", engine=_engine
+        )
 
         assert result.status == StageStatus.FAIL
         assert "1000" in (result.failure_reason or "")
@@ -436,13 +475,28 @@ class TestManagerEdgeCases:
     @pytest.mark.asyncio
     async def test_child_exception_treated_as_fail(self):
         """If the child runner raises, treat it as a FAIL outcome."""
-        runner = AsyncMock(
-            side_effect=[
-                RuntimeError("boom"),
-                Outcome(status=StageStatus.SUCCESS),
-            ]
-        )
-        handler = ManagerLoopHandler(subgraph_runner=runner)
+
+        class ExceptionEngine:
+            def __init__(self):
+                self.call_count = 0
+                self._items = [
+                    RuntimeError("boom"),
+                    Outcome(status=StageStatus.SUCCESS),
+                ]
+
+            async def run_subgraph(self, node_id, *, context=None):
+                self.call_count += 1
+                if self._items:
+                    item = self._items.pop(0)
+                    if isinstance(item, Exception):
+                        raise item
+                    return item
+                return Outcome(
+                    status=StageStatus.FAIL, failure_reason="no more outcomes"
+                )
+
+        exception_engine = ExceptionEngine()
+        handler = ManagerLoopHandler()
         graph = _make_graph(
             manager_attrs={
                 "manager.max_cycles": "5",
@@ -451,11 +505,13 @@ class TestManagerEdgeCases:
         )
         ctx = PipelineContext()
 
-        result = await handler.execute(graph.nodes["manager"], ctx, graph, "/tmp")
+        result = await handler.execute(
+            graph.nodes["manager"], ctx, graph, "/tmp", engine=exception_engine
+        )
 
         # First call raises, second succeeds — manager should recover
         assert result.status == StageStatus.SUCCESS
-        assert runner.call_count == 2
+        assert exception_engine.call_count == 2
 
     @pytest.mark.asyncio
     async def test_runner_receives_child_node_id(self):
@@ -465,14 +521,15 @@ class TestManagerEdgeCases:
                 Outcome(status=StageStatus.SUCCESS),
             ]
         )
-        handler = ManagerLoopHandler(subgraph_runner=runner)
+        handler = ManagerLoopHandler()
         graph = _make_graph(manager_attrs={"manager.max_cycles": "1"})
         ctx = PipelineContext()
 
-        await handler.execute(graph.nodes["manager"], ctx, graph, "/tmp")
+        await handler.execute(graph.nodes["manager"], ctx, graph, "/tmp", engine=runner)
 
         call_args = runner.call_args
-        assert call_args[0][0] == "child_task"  # first positional arg
+        assert call_args is not None, "run_subgraph was not called"
+        assert call_args[0][0] == "child_task"  # node_id
 
 
 # ---------------------------------------------------------------------------
@@ -515,7 +572,7 @@ class TestManagerChildDotfile:
         )
 
         inline_runner = AsyncMock(return_value=Outcome(status=StageStatus.SUCCESS))
-        handler = ManagerLoopHandler(subgraph_runner=inline_runner)
+        handler = ManagerLoopHandler()
         graph = _make_graph(
             manager_attrs={
                 "manager.max_cycles": "1",
@@ -549,7 +606,7 @@ class TestManagerChildDotfile:
         )
 
         inline_runner = AsyncMock(return_value=Outcome(status=StageStatus.SUCCESS))
-        handler = ManagerLoopHandler(subgraph_runner=inline_runner)
+        handler = ManagerLoopHandler()
         graph = _make_graph(
             manager_attrs={"manager.max_cycles": "1"},
             graph_attrs={"stack.child_dotfile": str(child_dot)},
@@ -568,13 +625,17 @@ class TestManagerChildDotfile:
 
     @pytest.mark.asyncio
     async def test_no_child_dotfile_uses_inline_runner(self):
-        """Without child_dotfile, inline subgraph_runner is called."""
+        """Without child_dotfile, engine.run_subgraph is called."""
         inline_runner = _make_runner([Outcome(status=StageStatus.SUCCESS)])
-        handler = ManagerLoopHandler(subgraph_runner=inline_runner)
+        handler = ManagerLoopHandler()
         graph = _make_graph(manager_attrs={"manager.max_cycles": "1"})
 
         result = await handler.execute(
-            graph.nodes["manager"], PipelineContext(), graph, "/tmp"
+            graph.nodes["manager"],
+            PipelineContext(),
+            graph,
+            "/tmp",
+            engine=inline_runner,
         )
 
         assert inline_runner.call_count == 1
@@ -603,7 +664,7 @@ class TestManagerChildDotfile:
         )
 
         inline_runner = AsyncMock(return_value=Outcome(status=StageStatus.SUCCESS))
-        handler = ManagerLoopHandler(subgraph_runner=inline_runner)
+        handler = ManagerLoopHandler()
         graph = _make_graph(
             manager_attrs={
                 "manager.max_cycles": "1",

--- a/modules/loop-pipeline/tests/test_manager_loop.py
+++ b/modules/loop-pipeline/tests/test_manager_loop.py
@@ -17,6 +17,7 @@ from amplifier_module_loop_pipeline.context import PipelineContext
 from amplifier_module_loop_pipeline.graph import Edge, Graph, Node
 from amplifier_module_loop_pipeline.handlers.manager_loop import ManagerLoopHandler
 from amplifier_module_loop_pipeline.outcome import Outcome, StageStatus
+from amplifier_module_loop_pipeline.handlers.context import HandlerContext
 
 
 # ---------------------------------------------------------------------------
@@ -543,7 +544,7 @@ class TestManagerHandlerRegistration:
     def test_registry_resolves_manager_handler(self):
         from amplifier_module_loop_pipeline.handlers import HandlerRegistry
 
-        registry = HandlerRegistry()
+        registry = HandlerRegistry(HandlerContext())
         node = Node(id="mgr", shape="house")
         handler = registry.get(node)
         assert isinstance(handler, ManagerLoopHandler)
@@ -716,7 +717,7 @@ class TestManagerChildDotfileObservability:
         from amplifier_module_loop_pipeline.handlers import HandlerRegistry
 
         def _registry_factory():
-            return HandlerRegistry(backend=_MockBackend())
+            return HandlerRegistry(HandlerContext(backend=_MockBackend()))
 
         handler = ManagerLoopHandler(handler_registry_factory=_registry_factory)
         graph = _make_graph(

--- a/modules/loop-pipeline/tests/test_manager_steer_structured.py
+++ b/modules/loop-pipeline/tests/test_manager_steer_structured.py
@@ -65,13 +65,14 @@ class TestStructuredSteeringMessage:
         """Steering message includes 'Cycle X of Y' context."""
         captured_contexts: list[PipelineContext] = []
 
-        async def capturing_runner(node_id, context, graph, logs_root):
-            captured_contexts.append(context)
-            if len(captured_contexts) < 2:
-                return Outcome(status=StageStatus.FAIL, failure_reason="broken")
-            return Outcome(status=StageStatus.SUCCESS)
+        class MockEngine:
+            async def run_subgraph(self, node_id, *, context=None):
+                captured_contexts.append(context)
+                if len(captured_contexts) < 2:
+                    return Outcome(status=StageStatus.FAIL, failure_reason="broken")
+                return Outcome(status=StageStatus.SUCCESS)
 
-        handler = ManagerLoopHandler(subgraph_runner=capturing_runner)
+        handler = ManagerLoopHandler()
         graph = _make_graph(
             manager_attrs={
                 "manager.max_cycles": "5",
@@ -80,7 +81,9 @@ class TestStructuredSteeringMessage:
             }
         )
         ctx = PipelineContext()
-        await handler.execute(graph.nodes["manager"], ctx, graph, "/tmp")
+        await handler.execute(
+            graph.nodes["manager"], ctx, graph, "/tmp", engine=MockEngine()
+        )
 
         steering = captured_contexts[1].get("manager.steering")
         assert steering is not None
@@ -94,13 +97,16 @@ class TestStructuredSteeringMessage:
         """Steering message includes remaining cycles budget."""
         captured_contexts: list[PipelineContext] = []
 
-        async def capturing_runner(node_id, context, graph, logs_root):
-            captured_contexts.append(context)
-            if len(captured_contexts) < 3:
-                return Outcome(status=StageStatus.FAIL, failure_reason="still broken")
-            return Outcome(status=StageStatus.SUCCESS)
+        class MockEngine:
+            async def run_subgraph(self, node_id, *, context=None):
+                captured_contexts.append(context)
+                if len(captured_contexts) < 3:
+                    return Outcome(
+                        status=StageStatus.FAIL, failure_reason="still broken"
+                    )
+                return Outcome(status=StageStatus.SUCCESS)
 
-        handler = ManagerLoopHandler(subgraph_runner=capturing_runner)
+        handler = ManagerLoopHandler()
         graph = _make_graph(
             manager_attrs={
                 "manager.max_cycles": "5",
@@ -109,7 +115,9 @@ class TestStructuredSteeringMessage:
             }
         )
         ctx = PipelineContext()
-        await handler.execute(graph.nodes["manager"], ctx, graph, "/tmp")
+        await handler.execute(
+            graph.nodes["manager"], ctx, graph, "/tmp", engine=MockEngine()
+        )
 
         # Third cycle's steering (after 2 failures)
         steering = captured_contexts[2].get("manager.steering")
@@ -123,17 +131,18 @@ class TestStructuredSteeringMessage:
         """Steering message uses multi-line structured format, not flat text."""
         captured_contexts: list[PipelineContext] = []
 
-        async def capturing_runner(node_id, context, graph, logs_root):
-            captured_contexts.append(context)
-            if len(captured_contexts) < 2:
-                return Outcome(
-                    status=StageStatus.FAIL,
-                    failure_reason="compilation error in main.py line 42",
-                    notes="Build step failed",
-                )
-            return Outcome(status=StageStatus.SUCCESS)
+        class MockEngine:
+            async def run_subgraph(self, node_id, *, context=None):
+                captured_contexts.append(context)
+                if len(captured_contexts) < 2:
+                    return Outcome(
+                        status=StageStatus.FAIL,
+                        failure_reason="compilation error in main.py line 42",
+                        notes="Build step failed",
+                    )
+                return Outcome(status=StageStatus.SUCCESS)
 
-        handler = ManagerLoopHandler(subgraph_runner=capturing_runner)
+        handler = ManagerLoopHandler()
         graph = _make_graph(
             manager_attrs={
                 "manager.max_cycles": "5",
@@ -142,7 +151,9 @@ class TestStructuredSteeringMessage:
             }
         )
         ctx = PipelineContext()
-        await handler.execute(graph.nodes["manager"], ctx, graph, "/tmp")
+        await handler.execute(
+            graph.nodes["manager"], ctx, graph, "/tmp", engine=MockEngine()
+        )
 
         steering = captured_contexts[1].get("manager.steering")
         assert steering is not None
@@ -154,17 +165,18 @@ class TestStructuredSteeringMessage:
         """Structured format still includes the full failure reason."""
         captured_contexts: list[PipelineContext] = []
 
-        async def capturing_runner(node_id, context, graph, logs_root):
-            captured_contexts.append(context)
-            if len(captured_contexts) < 2:
-                return Outcome(
-                    status=StageStatus.FAIL,
-                    failure_reason="tests failing: 3 of 10 assertions broken",
-                    notes="Unit tests did not pass",
-                )
-            return Outcome(status=StageStatus.SUCCESS)
+        class MockEngine:
+            async def run_subgraph(self, node_id, *, context=None):
+                captured_contexts.append(context)
+                if len(captured_contexts) < 2:
+                    return Outcome(
+                        status=StageStatus.FAIL,
+                        failure_reason="tests failing: 3 of 10 assertions broken",
+                        notes="Unit tests did not pass",
+                    )
+                return Outcome(status=StageStatus.SUCCESS)
 
-        handler = ManagerLoopHandler(subgraph_runner=capturing_runner)
+        handler = ManagerLoopHandler()
         graph = _make_graph(
             manager_attrs={
                 "manager.max_cycles": "5",
@@ -173,7 +185,9 @@ class TestStructuredSteeringMessage:
             }
         )
         ctx = PipelineContext()
-        await handler.execute(graph.nodes["manager"], ctx, graph, "/tmp")
+        await handler.execute(
+            graph.nodes["manager"], ctx, graph, "/tmp", engine=MockEngine()
+        )
 
         steering = captured_contexts[1].get("manager.steering")
         assert steering is not None
@@ -186,17 +200,18 @@ class TestStructuredSteeringMessage:
         """Structured format includes notes from the previous cycle."""
         captured_contexts: list[PipelineContext] = []
 
-        async def capturing_runner(node_id, context, graph, logs_root):
-            captured_contexts.append(context)
-            if len(captured_contexts) < 2:
-                return Outcome(
-                    status=StageStatus.FAIL,
-                    failure_reason="build failed",
-                    notes="3 warnings, 1 error in output",
-                )
-            return Outcome(status=StageStatus.SUCCESS)
+        class MockEngine:
+            async def run_subgraph(self, node_id, *, context=None):
+                captured_contexts.append(context)
+                if len(captured_contexts) < 2:
+                    return Outcome(
+                        status=StageStatus.FAIL,
+                        failure_reason="build failed",
+                        notes="3 warnings, 1 error in output",
+                    )
+                return Outcome(status=StageStatus.SUCCESS)
 
-        handler = ManagerLoopHandler(subgraph_runner=capturing_runner)
+        handler = ManagerLoopHandler()
         graph = _make_graph(
             manager_attrs={
                 "manager.max_cycles": "5",
@@ -205,7 +220,9 @@ class TestStructuredSteeringMessage:
             }
         )
         ctx = PipelineContext()
-        await handler.execute(graph.nodes["manager"], ctx, graph, "/tmp")
+        await handler.execute(
+            graph.nodes["manager"], ctx, graph, "/tmp", engine=MockEngine()
+        )
 
         steering = captured_contexts[1].get("manager.steering")
         assert steering is not None
@@ -216,13 +233,14 @@ class TestStructuredSteeringMessage:
         """Steering includes the previous cycle's status value."""
         captured_contexts: list[PipelineContext] = []
 
-        async def capturing_runner(node_id, context, graph, logs_root):
-            captured_contexts.append(context)
-            if len(captured_contexts) < 2:
-                return Outcome(status=StageStatus.FAIL, failure_reason="broke")
-            return Outcome(status=StageStatus.SUCCESS)
+        class MockEngine:
+            async def run_subgraph(self, node_id, *, context=None):
+                captured_contexts.append(context)
+                if len(captured_contexts) < 2:
+                    return Outcome(status=StageStatus.FAIL, failure_reason="broke")
+                return Outcome(status=StageStatus.SUCCESS)
 
-        handler = ManagerLoopHandler(subgraph_runner=capturing_runner)
+        handler = ManagerLoopHandler()
         graph = _make_graph(
             manager_attrs={
                 "manager.max_cycles": "5",
@@ -231,7 +249,9 @@ class TestStructuredSteeringMessage:
             }
         )
         ctx = PipelineContext()
-        await handler.execute(graph.nodes["manager"], ctx, graph, "/tmp")
+        await handler.execute(
+            graph.nodes["manager"], ctx, graph, "/tmp", engine=MockEngine()
+        )
 
         steering = captured_contexts[1].get("manager.steering")
         assert steering is not None
@@ -242,11 +262,12 @@ class TestStructuredSteeringMessage:
         """First cycle has no steering (no prior outcome)."""
         captured_contexts: list[PipelineContext] = []
 
-        async def capturing_runner(node_id, context, graph, logs_root):
-            captured_contexts.append(context)
-            return Outcome(status=StageStatus.SUCCESS)
+        class MockEngine:
+            async def run_subgraph(self, node_id, *, context=None):
+                captured_contexts.append(context)
+                return Outcome(status=StageStatus.SUCCESS)
 
-        handler = ManagerLoopHandler(subgraph_runner=capturing_runner)
+        handler = ManagerLoopHandler()
         graph = _make_graph(
             manager_attrs={
                 "manager.max_cycles": "5",
@@ -255,7 +276,9 @@ class TestStructuredSteeringMessage:
             }
         )
         ctx = PipelineContext()
-        await handler.execute(graph.nodes["manager"], ctx, graph, "/tmp")
+        await handler.execute(
+            graph.nodes["manager"], ctx, graph, "/tmp", engine=MockEngine()
+        )
 
         assert captured_contexts[0].get("manager.steering") is None
 
@@ -264,13 +287,14 @@ class TestStructuredSteeringMessage:
         """Steering handles outcomes that have no failure_reason gracefully."""
         captured_contexts: list[PipelineContext] = []
 
-        async def capturing_runner(node_id, context, graph, logs_root):
-            captured_contexts.append(context)
-            if len(captured_contexts) < 2:
-                return Outcome(status=StageStatus.FAIL)  # no failure_reason
-            return Outcome(status=StageStatus.SUCCESS)
+        class MockEngine:
+            async def run_subgraph(self, node_id, *, context=None):
+                captured_contexts.append(context)
+                if len(captured_contexts) < 2:
+                    return Outcome(status=StageStatus.FAIL)  # no failure_reason
+                return Outcome(status=StageStatus.SUCCESS)
 
-        handler = ManagerLoopHandler(subgraph_runner=capturing_runner)
+        handler = ManagerLoopHandler()
         graph = _make_graph(
             manager_attrs={
                 "manager.max_cycles": "5",
@@ -279,7 +303,9 @@ class TestStructuredSteeringMessage:
             }
         )
         ctx = PipelineContext()
-        await handler.execute(graph.nodes["manager"], ctx, graph, "/tmp")
+        await handler.execute(
+            graph.nodes["manager"], ctx, graph, "/tmp", engine=MockEngine()
+        )
 
         steering = captured_contexts[1].get("manager.steering")
         assert steering is not None

--- a/modules/loop-pipeline/tests/test_no_silent_fallback.py
+++ b/modules/loop-pipeline/tests/test_no_silent_fallback.py
@@ -24,6 +24,7 @@ import pytest
 from amplifier_module_loop_pipeline.graph import Node
 from amplifier_module_loop_pipeline.handlers import HandlerRegistry
 from amplifier_module_loop_pipeline.validation import SHAPE_TO_HANDLER
+from amplifier_module_loop_pipeline.handlers.context import HandlerContext
 
 
 # ---------------------------------------------------------------------------
@@ -37,7 +38,7 @@ def test_unknown_shape_raises_value_error():
     Before the fix: silently returns CodergenHandler.
     After the fix: raises ValueError naming the bad shape.
     """
-    registry = HandlerRegistry()
+    registry = HandlerRegistry(HandlerContext())
     bad_node = Node(id="broken-gate", shape="trapezoid")
 
     with pytest.raises(ValueError, match="trapezoid"):
@@ -50,7 +51,7 @@ def test_unknown_shape_error_lists_supported_shapes():
     The error message must help the author fix the problem, not just
     say 'unknown shape' — they need to know what IS valid.
     """
-    registry = HandlerRegistry()
+    registry = HandlerRegistry(HandlerContext())
     bad_node = Node(id="broken-gate", shape="octagon_mystery")
 
     with pytest.raises(ValueError) as exc_info:
@@ -68,7 +69,7 @@ def test_unknown_shape_error_lists_supported_shapes():
 
 def test_unknown_shape_names_the_bad_shape():
     """The ValueError message must include the offending shape name."""
-    registry = HandlerRegistry()
+    registry = HandlerRegistry(HandlerContext())
     bad_node = Node(id="my-node", shape="cloud_undefined")
 
     with pytest.raises(ValueError) as exc_info:
@@ -91,7 +92,7 @@ def test_known_shapes_still_dispatch_correctly():
     This is a regression guard: removing .get(shape, "codergen") must not
     accidentally break dispatch for any already-registered shape.
     """
-    registry = HandlerRegistry()
+    registry = HandlerRegistry(HandlerContext())
 
     for shape, expected_handler_type in SHAPE_TO_HANDLER.items():
         node = Node(id=f"test-{shape}", shape=shape)
@@ -118,7 +119,7 @@ def test_codergen_still_works_for_box_shape():
     """
     from amplifier_module_loop_pipeline.handlers.codergen import CodergenHandler
 
-    registry = HandlerRegistry()
+    registry = HandlerRegistry(HandlerContext())
     llm_node = Node(id="my-llm-node", shape="box", prompt="Do something")
     handler = registry.get(llm_node)
 

--- a/modules/loop-pipeline/tests/test_orchestrator_summary.py
+++ b/modules/loop-pipeline/tests/test_orchestrator_summary.py
@@ -9,6 +9,7 @@ from amplifier_module_loop_pipeline.context import PipelineContext
 from amplifier_module_loop_pipeline.engine import PipelineEngine
 from amplifier_module_loop_pipeline.handlers import HandlerRegistry
 from amplifier_module_loop_pipeline.outcome import Outcome, StageStatus
+from amplifier_module_loop_pipeline.handlers.context import HandlerContext
 
 
 # --- Mock backend that returns outcomes with no notes ---
@@ -117,7 +118,7 @@ def _make_engine_with_completed_nodes(
     graph = parse_dot(dot)
     validate_or_raise(graph)
     context = PipelineContext()
-    registry = HandlerRegistry(backend=None)
+    registry = HandlerRegistry(HandlerContext(backend=None))
     engine = PipelineEngine(
         graph=graph,
         context=context,
@@ -145,7 +146,7 @@ def _make_engine_with_mixed_outcomes() -> PipelineEngine:
     graph = parse_dot(dot)
     validate_or_raise(graph)
     context = PipelineContext()
-    registry = HandlerRegistry(backend=None)
+    registry = HandlerRegistry(HandlerContext(backend=None))
     engine = PipelineEngine(
         graph=graph,
         context=context,

--- a/modules/loop-pipeline/tests/test_p1_nested_backend.py
+++ b/modules/loop-pipeline/tests/test_p1_nested_backend.py
@@ -19,6 +19,7 @@ from amplifier_module_loop_pipeline.engine import PipelineEngine
 from amplifier_module_loop_pipeline.graph import Node
 from amplifier_module_loop_pipeline.handlers import HandlerRegistry
 from amplifier_module_loop_pipeline.outcome import StageStatus
+from amplifier_module_loop_pipeline.handlers.context import HandlerContext
 
 # ---------------------------------------------------------------------------
 # SpyBackend
@@ -100,7 +101,7 @@ digraph parent {
 
         spy = SpyBackend()
         context = PipelineContext()
-        registry = HandlerRegistry(backend=spy)
+        registry = HandlerRegistry(HandlerContext(backend=spy))
         logs_root = str(tmp_path / "logs")
 
         engine = PipelineEngine(
@@ -115,7 +116,7 @@ digraph parent {
         assert outcome.status == StageStatus.SUCCESS
 
         # FIX CONFIRMED: child_work IS called via spy because
-        # PipelineHandler creates HandlerRegistry(backend=self._backend) for the child.
+        # PipelineHandler creates HandlerRegistry(HandlerContext(backend=self._backend)) for the child.
         assert spy.was_called_for("child_work") is True, (
             "Expected child_work in spy calls — backend is propagated "
             "to child pipelines via PipelineHandler (post-fix behavior)"
@@ -143,7 +144,7 @@ digraph parent {
 
         spy = SpyBackend()
         context = PipelineContext()
-        registry = HandlerRegistry(backend=spy)
+        registry = HandlerRegistry(HandlerContext(backend=spy))
         logs_root = str(tmp_path / "logs")
 
         engine = PipelineEngine(

--- a/modules/loop-pipeline/tests/test_p2_conversational_gate.py
+++ b/modules/loop-pipeline/tests/test_p2_conversational_gate.py
@@ -23,6 +23,7 @@ from amplifier_module_loop_pipeline.graph import Node
 from amplifier_module_loop_pipeline.handlers import HandlerRegistry
 from amplifier_module_loop_pipeline.interviewer import Answer, Option, QueueInterviewer
 from amplifier_module_loop_pipeline.outcome import Outcome, StageStatus
+from amplifier_module_loop_pipeline.handlers.context import HandlerContext
 
 # ---------------------------------------------------------------------------
 # Path helpers
@@ -322,7 +323,7 @@ class TestConversationalGateExecution:
         backend = ScoredBackend()
 
         context = _make_gate_context()
-        registry = HandlerRegistry(backend=backend, interviewer=interviewer)
+        registry = HandlerRegistry(HandlerContext(backend=backend, interviewer=interviewer))
         engine = PipelineEngine(
             graph=graph,
             context=context,
@@ -357,7 +358,7 @@ class TestConversationalGateExecution:
         )
         backend = ScoredBackend()
         context = _make_gate_context()
-        registry = HandlerRegistry(backend=backend, interviewer=interviewer)
+        registry = HandlerRegistry(HandlerContext(backend=backend, interviewer=interviewer))
         engine = PipelineEngine(
             graph=graph,
             context=context,
@@ -406,7 +407,7 @@ class TestConversationalGateExecution:
         )
 
         context = _make_gate_context()
-        registry = HandlerRegistry(backend=sequential_backend, interviewer=interviewer)
+        registry = HandlerRegistry(HandlerContext(backend=sequential_backend, interviewer=interviewer))
         engine = PipelineEngine(
             graph=graph,
             context=context,
@@ -447,7 +448,7 @@ class TestConversationalGateExecution:
         )
 
         context = _make_gate_context()
-        registry = HandlerRegistry(backend=sequential_backend, interviewer=interviewer)
+        registry = HandlerRegistry(HandlerContext(backend=sequential_backend, interviewer=interviewer))
         engine = PipelineEngine(
             graph=graph,
             context=context,
@@ -493,7 +494,7 @@ class TestConversationalGateExecution:
             ]
         )
         context = _make_gate_context()
-        registry = HandlerRegistry(backend=CapturingBackend(), interviewer=interviewer)
+        registry = HandlerRegistry(HandlerContext(backend=CapturingBackend(), interviewer=interviewer))
         engine = PipelineEngine(
             graph=graph,
             context=context,

--- a/modules/loop-pipeline/tests/test_p6_convergence_factory.py
+++ b/modules/loop-pipeline/tests/test_p6_convergence_factory.py
@@ -57,6 +57,8 @@ class MockToolHandler:
         context: PipelineContext,
         graph: Graph,
         logs_root: str,
+        *,
+        engine=None,
     ) -> Outcome:
         return Outcome(status=StageStatus.SUCCESS, notes="Mock validation passed")
 

--- a/modules/loop-pipeline/tests/test_p6_convergence_factory.py
+++ b/modules/loop-pipeline/tests/test_p6_convergence_factory.py
@@ -27,6 +27,7 @@ from amplifier_module_loop_pipeline.engine import PipelineEngine
 from amplifier_module_loop_pipeline.graph import Graph, Node
 from amplifier_module_loop_pipeline.handlers import HandlerRegistry
 from amplifier_module_loop_pipeline.outcome import Outcome, StageStatus
+from amplifier_module_loop_pipeline.handlers.context import HandlerContext
 
 # ---------------------------------------------------------------------------
 # Path helpers
@@ -138,7 +139,7 @@ def _make_factory_engine(
         for key, value in extra_ctx.items():
             ctx.set(key, value)
 
-    registry = HandlerRegistry(backend=backend)
+    registry = HandlerRegistry(HandlerContext(backend=backend))
     registry.register("tool", MockToolHandler())
 
     return PipelineEngine(

--- a/modules/loop-pipeline/tests/test_p7_context_injection.py
+++ b/modules/loop-pipeline/tests/test_p7_context_injection.py
@@ -21,6 +21,7 @@ from amplifier_module_loop_pipeline.engine import PipelineEngine
 from amplifier_module_loop_pipeline.graph import Node
 from amplifier_module_loop_pipeline.handlers import HandlerRegistry
 from amplifier_module_loop_pipeline.outcome import StageStatus
+from amplifier_module_loop_pipeline.handlers.context import HandlerContext
 
 
 # ---------------------------------------------------------------------------
@@ -100,7 +101,7 @@ digraph parent {{
 
         capturing = CapturingBackend()
         context = PipelineContext()
-        registry = HandlerRegistry(backend=capturing)
+        registry = HandlerRegistry(HandlerContext(backend=capturing))
         logs_root = str(tmp_path / "logs")
 
         engine = PipelineEngine(
@@ -151,7 +152,7 @@ digraph parent {{
 
         capturing = CapturingBackend()
         context = PipelineContext()
-        registry = HandlerRegistry(backend=capturing)
+        registry = HandlerRegistry(HandlerContext(backend=capturing))
         logs_root = str(tmp_path / "logs")
 
         engine = PipelineEngine(
@@ -205,7 +206,7 @@ digraph parent {{
 
         capturing = CapturingBackend()
         parent_context = PipelineContext()
-        registry = HandlerRegistry(backend=capturing)
+        registry = HandlerRegistry(HandlerContext(backend=capturing))
         logs_root = str(tmp_path / "logs")
 
         engine = PipelineEngine(
@@ -257,7 +258,7 @@ digraph parent {{
 
         capturing = CapturingBackend()
         context = PipelineContext()
-        registry = HandlerRegistry(backend=capturing)
+        registry = HandlerRegistry(HandlerContext(backend=capturing))
         logs_root = str(tmp_path / "logs")
 
         engine = PipelineEngine(
@@ -318,7 +319,7 @@ digraph parent {{
 
         capturing = CapturingBackend()
         context = PipelineContext()
-        registry = HandlerRegistry(backend=capturing)
+        registry = HandlerRegistry(HandlerContext(backend=capturing))
         logs_root = str(tmp_path / "logs")
 
         engine = PipelineEngine(

--- a/modules/loop-pipeline/tests/test_p8_continue_on_fail.py
+++ b/modules/loop-pipeline/tests/test_p8_continue_on_fail.py
@@ -59,6 +59,8 @@ class FailingToolHandler:
         context: PipelineContext,
         graph: Graph,
         logs_root: str,
+        *,
+        engine=None,
     ) -> Outcome:
         return Outcome(status=StageStatus.FAIL, failure_reason="tool simulated failure")
 

--- a/modules/loop-pipeline/tests/test_p8_continue_on_fail.py
+++ b/modules/loop-pipeline/tests/test_p8_continue_on_fail.py
@@ -25,6 +25,7 @@ from amplifier_module_loop_pipeline.engine import PipelineEngine
 from amplifier_module_loop_pipeline.graph import Edge, Graph, Node
 from amplifier_module_loop_pipeline.handlers import HandlerRegistry
 from amplifier_module_loop_pipeline.outcome import Outcome, StageStatus
+from amplifier_module_loop_pipeline.handlers.context import HandlerContext
 
 
 # ---------------------------------------------------------------------------
@@ -98,7 +99,7 @@ class TestContinueOnFail:
             ],
         )
         context = PipelineContext()
-        registry = HandlerRegistry(backend=FailingBackend())
+        registry = HandlerRegistry(HandlerContext(backend=FailingBackend()))
         engine = PipelineEngine(
             graph=graph,
             context=context,
@@ -141,7 +142,7 @@ class TestContinueOnFail:
         )
         context = PipelineContext()
         backend = FailingBackend()
-        registry = HandlerRegistry(backend=backend)
+        registry = HandlerRegistry(HandlerContext(backend=backend))
         engine = PipelineEngine(
             graph=graph,
             context=context,
@@ -184,7 +185,7 @@ class TestContinueOnFail:
             ],
         )
         context = PipelineContext()
-        registry = HandlerRegistry(backend=FailingBackend())
+        registry = HandlerRegistry(HandlerContext(backend=FailingBackend()))
         engine = PipelineEngine(
             graph=graph,
             context=context,
@@ -224,7 +225,7 @@ class TestContinueOnFail:
             ],
         )
         context = PipelineContext()
-        registry = HandlerRegistry(backend=FailingBackend())
+        registry = HandlerRegistry(HandlerContext(backend=FailingBackend()))
         engine = PipelineEngine(
             graph=graph,
             context=context,
@@ -277,7 +278,7 @@ class TestContinueOnFail:
             ],
         )
         context = PipelineContext()
-        registry = HandlerRegistry(backend=SuccessBackend())
+        registry = HandlerRegistry(HandlerContext(backend=SuccessBackend()))
         engine = PipelineEngine(
             graph=graph,
             context=context,
@@ -314,7 +315,7 @@ digraph test {
         graph = parse_dot(dot_source)
 
         context = PipelineContext()
-        registry = HandlerRegistry(backend=FailingBackend())
+        registry = HandlerRegistry(HandlerContext(backend=FailingBackend()))
         # Replace the built-in tool handler with our failing mock
         registry.register("tool", FailingToolHandler())
         engine = PipelineEngine(

--- a/modules/loop-pipeline/tests/test_parallel.py
+++ b/modules/loop-pipeline/tests/test_parallel.py
@@ -52,7 +52,7 @@ class FakeSubgraphRunner:
         )
 
     async def run_subgraph(
-        self, node_id: str, context: PipelineContext, graph: Graph, logs_root: str
+        self, node_id: str, *, context: PipelineContext | None = None
     ) -> Outcome:
         if self._delay > 0:
             await asyncio.sleep(self._delay)
@@ -64,7 +64,7 @@ class FakeSubgraphRunner:
 async def test_parallel_fans_out_to_all_branches():
     """Parallel handler executes all outgoing edges concurrently."""
     runner = FakeSubgraphRunner()
-    handler = ParallelHandler(subgraph_runner=runner.run_subgraph)
+    handler = ParallelHandler()
 
     par_node = Node(id="parallel", shape="component")
     graph = _make_graph(
@@ -81,7 +81,9 @@ async def test_parallel_fans_out_to_all_branches():
         ],
     )
 
-    outcome = await handler.execute(par_node, _make_context(), graph, "/tmp")
+    outcome = await handler.execute(
+        par_node, _make_context(), graph, "/tmp", engine=runner
+    )
     assert outcome.is_success
     assert sorted(runner.calls) == ["branch_a", "branch_b", "branch_c"]
 
@@ -91,12 +93,15 @@ async def test_parallel_clones_context_per_branch():
     """Each branch gets an isolated context clone."""
     branch_contexts: dict[str, PipelineContext] = {}
 
-    async def capturing_runner(node_id, context, graph, logs_root):
-        branch_contexts[node_id] = context
-        context.set(f"branch.{node_id}", "was_here")
-        return Outcome(status=StageStatus.SUCCESS)
+    class CapturingEngine:
+        async def run_subgraph(self, node_id, *, context=None):
+            branch_contexts[node_id] = context
+            if context is not None:
+                context.set(f"branch.{node_id}", "was_here")
+            return Outcome(status=StageStatus.SUCCESS)
 
-    handler = ParallelHandler(subgraph_runner=capturing_runner)
+    capturing_engine = CapturingEngine()
+    handler = ParallelHandler()
     par_node = Node(id="parallel", shape="component")
     parent_context = _make_context()
     parent_context.set("shared_key", "shared_value")
@@ -113,7 +118,9 @@ async def test_parallel_clones_context_per_branch():
         ],
     )
 
-    await handler.execute(par_node, parent_context, graph, "/tmp")
+    await handler.execute(
+        par_node, parent_context, graph, "/tmp", engine=capturing_engine
+    )
 
     # Each branch should have gotten the shared_key
     assert branch_contexts["branch_a"].get("shared_key") == "shared_value"
@@ -134,17 +141,19 @@ async def test_parallel_respects_max_parallel():
     current_concurrent = 0
     lock = asyncio.Lock()
 
-    async def tracking_runner(node_id, context, graph, logs_root):
-        nonlocal current_concurrent
-        async with lock:
-            current_concurrent += 1
-            concurrency_tracker.append(current_concurrent)
-        await asyncio.sleep(0.05)
-        async with lock:
-            current_concurrent -= 1
-        return Outcome(status=StageStatus.SUCCESS)
+    class TrackingEngine:
+        async def run_subgraph(self, node_id, *, context=None):
+            nonlocal current_concurrent
+            async with lock:
+                current_concurrent += 1
+                concurrency_tracker.append(current_concurrent)
+            await asyncio.sleep(0.05)
+            async with lock:
+                current_concurrent -= 1
+            return Outcome(status=StageStatus.SUCCESS)
 
-    handler = ParallelHandler(subgraph_runner=tracking_runner)
+    tracking_engine = TrackingEngine()
+    handler = ParallelHandler()
     par_node = Node(id="parallel", shape="component", attrs={"max_parallel": "2"})
 
     graph = _make_graph(
@@ -163,7 +172,9 @@ async def test_parallel_respects_max_parallel():
         ],
     )
 
-    outcome = await handler.execute(par_node, _make_context(), graph, "/tmp")
+    outcome = await handler.execute(
+        par_node, _make_context(), graph, "/tmp", engine=tracking_engine
+    )
     assert outcome.is_success
     # Max concurrent should never exceed 2
     assert max(concurrency_tracker) <= 2
@@ -178,7 +189,7 @@ async def test_parallel_wait_all_all_success():
             "b2": Outcome(status=StageStatus.SUCCESS),
         }
     )
-    handler = ParallelHandler(subgraph_runner=runner.run_subgraph)
+    handler = ParallelHandler()
     par_node = Node(id="parallel", shape="component", attrs={"join_policy": "wait_all"})
 
     graph = _make_graph(
@@ -193,7 +204,9 @@ async def test_parallel_wait_all_all_success():
         ],
     )
 
-    outcome = await handler.execute(par_node, _make_context(), graph, "/tmp")
+    outcome = await handler.execute(
+        par_node, _make_context(), graph, "/tmp", engine=runner
+    )
     assert outcome.status == StageStatus.SUCCESS
 
 
@@ -206,7 +219,7 @@ async def test_parallel_wait_all_with_failure():
             "b2": Outcome(status=StageStatus.FAIL, failure_reason="broken"),
         }
     )
-    handler = ParallelHandler(subgraph_runner=runner.run_subgraph)
+    handler = ParallelHandler()
     par_node = Node(id="parallel", shape="component", attrs={"join_policy": "wait_all"})
 
     graph = _make_graph(
@@ -221,7 +234,9 @@ async def test_parallel_wait_all_with_failure():
         ],
     )
 
-    outcome = await handler.execute(par_node, _make_context(), graph, "/tmp")
+    outcome = await handler.execute(
+        par_node, _make_context(), graph, "/tmp", engine=runner
+    )
     assert outcome.status == StageStatus.PARTIAL_SUCCESS
 
 
@@ -234,7 +249,7 @@ async def test_parallel_stores_results_in_context():
             "b2": Outcome(status=StageStatus.FAIL, failure_reason="B2 broken"),
         }
     )
-    handler = ParallelHandler(subgraph_runner=runner.run_subgraph)
+    handler = ParallelHandler()
     par_node = Node(id="parallel", shape="component")
     context = _make_context()
 
@@ -250,7 +265,7 @@ async def test_parallel_stores_results_in_context():
         ],
     )
 
-    await handler.execute(par_node, context, graph, "/tmp")
+    await handler.execute(par_node, context, graph, "/tmp", engine=runner)
 
     # Results should be stored in context
     results = context.get("parallel.results")
@@ -262,8 +277,7 @@ async def test_parallel_stores_results_in_context():
 @pytest.mark.asyncio
 async def test_parallel_no_branches_returns_success():
     """Parallel node with no outgoing edges returns SUCCESS."""
-    runner = FakeSubgraphRunner()
-    handler = ParallelHandler(subgraph_runner=runner.run_subgraph)
+    handler = ParallelHandler()
     par_node = Node(id="parallel", shape="component")
 
     graph = _make_graph(
@@ -271,6 +285,7 @@ async def test_parallel_no_branches_returns_success():
         edges=[],
     )
 
+    # No engine needed: no branches execute, so engine.run_subgraph is never called
     outcome = await handler.execute(par_node, _make_context(), graph, "/tmp")
     assert outcome.status == StageStatus.SUCCESS
 
@@ -285,7 +300,7 @@ async def test_parallel_continue_error_policy():
             "b3": Outcome(status=StageStatus.FAIL, failure_reason="fail 3"),
         }
     )
-    handler = ParallelHandler(subgraph_runner=runner.run_subgraph)
+    handler = ParallelHandler()
     par_node = Node(
         id="parallel",
         shape="component",
@@ -307,7 +322,7 @@ async def test_parallel_continue_error_policy():
         ],
     )
 
-    await handler.execute(par_node, context, graph, "/tmp")
+    await handler.execute(par_node, context, graph, "/tmp", engine=runner)
     # All branches were executed
     assert sorted(runner.calls) == ["b1", "b2", "b3"]
     # Results stored
@@ -319,12 +334,13 @@ async def test_parallel_continue_error_policy():
 async def test_parallel_exception_in_branch_becomes_fail():
     """Exception in a branch is caught and converted to FAIL outcome."""
 
-    async def failing_runner(node_id, context, graph, logs_root):
-        if node_id == "b2":
-            raise RuntimeError("Branch crashed")
-        return Outcome(status=StageStatus.SUCCESS)
+    class FailingEngine:
+        async def run_subgraph(self, node_id, *, context=None):
+            if node_id == "b2":
+                raise RuntimeError("Branch crashed")
+            return Outcome(status=StageStatus.SUCCESS)
 
-    handler = ParallelHandler(subgraph_runner=failing_runner)
+    handler = ParallelHandler()
     par_node = Node(id="parallel", shape="component")
 
     graph = _make_graph(
@@ -340,7 +356,9 @@ async def test_parallel_exception_in_branch_becomes_fail():
     )
     context = _make_context()
 
-    outcome = await handler.execute(par_node, context, graph, "/tmp")
+    outcome = await handler.execute(
+        par_node, context, graph, "/tmp", engine=FailingEngine()
+    )
     # Should still complete (continue policy)
     assert outcome.status == StageStatus.PARTIAL_SUCCESS
     results = context.get("parallel.results")
@@ -368,10 +386,11 @@ async def test_parallel_handler_emits_events():
         async def emit(self, event_name, data):
             emitted.append((event_name, data))
 
-    async def mock_runner(node_id, ctx, graph, logs_root):
-        return Outcome(status=StageStatus.SUCCESS, notes="ok")
+    class MockEngine:
+        async def run_subgraph(self, node_id, *, context=None):
+            return Outcome(status=StageStatus.SUCCESS, notes="ok")
 
-    handler = ParallelHandler(subgraph_runner=mock_runner, hooks=MockHooks())
+    handler = ParallelHandler(hooks=MockHooks())
 
     graph = _make_graph(
         nodes={
@@ -386,7 +405,9 @@ async def test_parallel_handler_emits_events():
     )
 
     ctx = _make_context()
-    await handler.execute(graph.nodes["par"], ctx, graph, "/tmp/test")
+    await handler.execute(
+        graph.nodes["par"], ctx, graph, "/tmp/test", engine=MockEngine()
+    )
 
     event_names = [e[0] for e in emitted]
     assert PIPELINE_PARALLEL_STARTED in event_names
@@ -610,13 +631,13 @@ async def test_fan_in_falls_back_to_heuristic_without_prompt():
     assert context.get("parallel.fan_in.best_id") == "b1"
 
 
-# --- Task 3: ParallelHandler returns FAIL when no subgraph_runner ---
+# --- Task 3: ParallelHandler returns FAIL when no engine ---
 
 
 @pytest.mark.asyncio
 async def test_parallel_no_runner_returns_fail():
-    """ParallelHandler with no runner returns FAIL outcome — no silent simulation."""
-    handler = ParallelHandler(subgraph_runner=None)
+    """ParallelHandler without engine returns FAIL outcome — no silent simulation."""
+    handler = ParallelHandler()
     par_node = Node(
         id="parallel",
         shape="component",
@@ -630,6 +651,7 @@ async def test_parallel_no_runner_returns_fail():
         edges=[Edge(from_node="parallel", to_node="branch_a")],
     )
     context = _make_context()
+    # engine=None (default) → branches fail with "No engine configured"
     outcome = await handler.execute(par_node, context, graph, "/tmp")
     assert outcome.status == StageStatus.FAIL
     results = context.get("parallel.results") or []
@@ -637,13 +659,13 @@ async def test_parallel_no_runner_returns_fail():
         str(r.get("notes") or "") + " " + str(r.get("failure_reason") or "")
         for r in results
     )
-    assert "subgraph_runner" in failure_text
+    assert "engine" in failure_text
 
 
 @pytest.mark.asyncio
 async def test_parallel_no_runner_branch_returns_fail():
-    """ParallelHandler with no runner returns FAIL outcomes for branches — no silent simulation."""
-    handler = ParallelHandler(subgraph_runner=None)
+    """ParallelHandler without engine returns FAIL outcomes for branches — no silent simulation."""
+    handler = ParallelHandler()
     par_node = Node(id="parallel", shape="component")
     graph = _make_graph(
         nodes={
@@ -653,10 +675,10 @@ async def test_parallel_no_runner_branch_returns_fail():
         edges=[Edge(from_node="parallel", to_node="branch_a")],
     )
     context = _make_context()
+    # engine=None (default) → branches fail
     await handler.execute(par_node, context, graph, "/tmp")
-    # With no runner, the branch should fail — not silently succeed
     results = context.get("parallel.results")
     assert results is not None
     assert len(results) == 1
     assert results[0]["status"] == "fail"
-    assert "subgraph_runner" in (results[0]["notes"] or "")
+    assert "engine" in (results[0]["notes"] or "")

--- a/modules/loop-pipeline/tests/test_parallel_branch_observability.py
+++ b/modules/loop-pipeline/tests/test_parallel_branch_observability.py
@@ -72,10 +72,13 @@ def _make_fanout_graph(branch_ids: list[str]) -> tuple[Node, Graph]:
     return par_node, graph
 
 
-async def _success_runner(
-    node_id: str, context: PipelineContext, graph: Graph, logs_root: str
-) -> Outcome:
-    return Outcome(status=StageStatus.SUCCESS, notes=f"{node_id} ran")
+class _SuccessEngine:
+    """Mock engine that always returns SUCCESS for any subgraph execution."""
+
+    async def run_subgraph(
+        self, node_id: str, *, context: PipelineContext | None = None
+    ) -> Outcome:
+        return Outcome(status=StageStatus.SUCCESS, notes=f"{node_id} ran")
 
 
 # ---------------------------------------------------------------------------
@@ -89,9 +92,11 @@ async def test_branch_nodes_emit_pipeline_node_start_events() -> None:
     hooks = FakeHooks()
     branch_ids = ["variant_opus", "variant_sonnet", "variant_haiku"]
     par_node, graph = _make_fanout_graph(branch_ids)
-    handler = ParallelHandler(subgraph_runner=_success_runner, hooks=hooks)
+    handler = ParallelHandler(hooks=hooks)
 
-    await handler.execute(par_node, PipelineContext(), graph, "/tmp/logs")
+    await handler.execute(
+        par_node, PipelineContext(), graph, "/tmp/logs", engine=_SuccessEngine()
+    )
 
     start_events = hooks.events_of_type(PIPELINE_NODE_START)
     started_node_ids = {e["node_id"] for e in start_events}
@@ -108,9 +113,11 @@ async def test_branch_nodes_emit_pipeline_node_complete_events() -> None:
     hooks = FakeHooks()
     branch_ids = ["variant_opus", "variant_sonnet", "variant_haiku"]
     par_node, graph = _make_fanout_graph(branch_ids)
-    handler = ParallelHandler(subgraph_runner=_success_runner, hooks=hooks)
+    handler = ParallelHandler(hooks=hooks)
 
-    await handler.execute(par_node, PipelineContext(), graph, "/tmp/logs")
+    await handler.execute(
+        par_node, PipelineContext(), graph, "/tmp/logs", engine=_SuccessEngine()
+    )
 
     complete_events = hooks.events_of_type(PIPELINE_NODE_COMPLETE)
     completed_node_ids = {e["node_id"] for e in complete_events}
@@ -127,15 +134,16 @@ async def test_branch_node_complete_carries_correct_status() -> None:
     hooks = FakeHooks()
     par_node, graph = _make_fanout_graph(["good_branch", "bad_branch"])
 
-    async def mixed_runner(
-        node_id: str, context: PipelineContext, graph: Graph, logs_root: str
-    ) -> Outcome:
-        if node_id == "bad_branch":
-            return Outcome(status=StageStatus.FAIL, failure_reason="bad")
-        return Outcome(status=StageStatus.SUCCESS, notes="ok")
+    class MixedEngine:
+        async def run_subgraph(self, node_id, *, context=None):
+            if node_id == "bad_branch":
+                return Outcome(status=StageStatus.FAIL, failure_reason="bad")
+            return Outcome(status=StageStatus.SUCCESS, notes="ok")
 
-    handler = ParallelHandler(subgraph_runner=mixed_runner, hooks=hooks)
-    await handler.execute(par_node, PipelineContext(), graph, "/tmp/logs")
+    handler = ParallelHandler(hooks=hooks)
+    await handler.execute(
+        par_node, PipelineContext(), graph, "/tmp/logs", engine=MixedEngine()
+    )
 
     complete_events = hooks.events_of_type(PIPELINE_NODE_COMPLETE)
     by_node = {e["node_id"]: e for e in complete_events}
@@ -148,9 +156,11 @@ async def test_branch_node_events_carry_via_parallel_marker() -> None:
     """Branch node_start and node_complete events include via_parallel=True (Fix #1)."""
     hooks = FakeHooks()
     par_node, graph = _make_fanout_graph(["b0"])
-    handler = ParallelHandler(subgraph_runner=_success_runner, hooks=hooks)
+    handler = ParallelHandler(hooks=hooks)
 
-    await handler.execute(par_node, PipelineContext(), graph, "/tmp/logs")
+    await handler.execute(
+        par_node, PipelineContext(), graph, "/tmp/logs", engine=_SuccessEngine()
+    )
 
     start_events = hooks.events_of_type(PIPELINE_NODE_START)
     assert start_events, "Expected at least one pipeline:node_start event"
@@ -175,9 +185,11 @@ async def test_branch_node_complete_carries_duration_ms() -> None:
     hooks = FakeHooks()
     branch_ids = ["b0", "b1"]
     par_node, graph = _make_fanout_graph(branch_ids)
-    handler = ParallelHandler(subgraph_runner=_success_runner, hooks=hooks)
+    handler = ParallelHandler(hooks=hooks)
 
-    await handler.execute(par_node, PipelineContext(), graph, "/tmp/logs")
+    await handler.execute(
+        par_node, PipelineContext(), graph, "/tmp/logs", engine=_SuccessEngine()
+    )
 
     complete_events = hooks.events_of_type(PIPELINE_NODE_COMPLETE)
     # Guard: we must have one event per branch (not vacuously passing on empty list)
@@ -196,9 +208,11 @@ async def test_branch_node_events_ordered_within_parallel_envelope() -> None:
     """Branch node_start/complete appear after parallel_started and before parallel_completed."""
     hooks = FakeHooks()
     par_node, graph = _make_fanout_graph(["b1", "b2"])
-    handler = ParallelHandler(subgraph_runner=_success_runner, hooks=hooks)
+    handler = ParallelHandler(hooks=hooks)
 
-    await handler.execute(par_node, PipelineContext(), graph, "/tmp/logs")
+    await handler.execute(
+        par_node, PipelineContext(), graph, "/tmp/logs", engine=_SuccessEngine()
+    )
 
     names = hooks.event_names()
 
@@ -230,8 +244,10 @@ async def test_branch_node_events_ordered_within_parallel_envelope() -> None:
 async def test_no_branch_events_when_no_hooks() -> None:
     """ParallelHandler without hooks must not raise — fix is a no-op when hooks=None."""
     par_node, graph = _make_fanout_graph(["b0", "b1"])
-    handler = ParallelHandler(subgraph_runner=_success_runner, hooks=None)
+    handler = ParallelHandler(hooks=None)
 
     # Should run without raising
-    outcome = await handler.execute(par_node, PipelineContext(), graph, "/tmp/logs")
+    outcome = await handler.execute(
+        par_node, PipelineContext(), graph, "/tmp/logs", engine=_SuccessEngine()
+    )
     assert outcome.is_success

--- a/modules/loop-pipeline/tests/test_parallel_early_exit.py
+++ b/modules/loop-pipeline/tests/test_parallel_early_exit.py
@@ -58,16 +58,18 @@ class TestFirstSuccessEarlyExit:
         """
         completed_branches: list[str] = []
 
-        async def runner(node_id, context, graph, logs_root):
-            if node_id == "fast":
+        class SlowFastEngine:
+            async def run_subgraph(self, node_id, *, context=None):
+                if node_id == "fast":
+                    completed_branches.append(node_id)
+                    return Outcome(status=StageStatus.SUCCESS, notes="fast done")
+                # Slow branches take 5 seconds
+                await asyncio.sleep(5.0)
                 completed_branches.append(node_id)
-                return Outcome(status=StageStatus.SUCCESS, notes="fast done")
-            # Slow branches take 5 seconds
-            await asyncio.sleep(5.0)
-            completed_branches.append(node_id)
-            return Outcome(status=StageStatus.SUCCESS, notes="slow done")
+                return Outcome(status=StageStatus.SUCCESS, notes="slow done")
 
-        handler = ParallelHandler(subgraph_runner=runner)
+        handler = ParallelHandler()
+        _engine = SlowFastEngine()
         par_node = Node(
             id="parallel",
             shape="component",
@@ -91,7 +93,9 @@ class TestFirstSuccessEarlyExit:
         import time
 
         start = time.monotonic()
-        outcome = await handler.execute(par_node, _make_context(), graph, "/tmp")
+        outcome = await handler.execute(
+            par_node, _make_context(), graph, "/tmp", engine=_engine
+        )
         elapsed = time.monotonic() - start
 
         assert outcome.status == StageStatus.SUCCESS
@@ -103,14 +107,16 @@ class TestFirstSuccessEarlyExit:
         """first_success returns SUCCESS even if some branches fail first."""
         call_count = 0
 
-        async def runner(node_id, context, graph, logs_root):
-            nonlocal call_count
-            call_count += 1
-            if node_id == "b1":
-                return Outcome(status=StageStatus.FAIL, failure_reason="b1 broke")
-            return Outcome(status=StageStatus.SUCCESS, notes="b2 ok")
+        class FirstSuccessEngine:
+            async def run_subgraph(self, node_id, *, context=None):
+                nonlocal call_count
+                call_count += 1
+                if node_id == "b1":
+                    return Outcome(status=StageStatus.FAIL, failure_reason="b1 broke")
+                return Outcome(status=StageStatus.SUCCESS, notes="b2 ok")
 
-        handler = ParallelHandler(subgraph_runner=runner)
+        _engine = FirstSuccessEngine()
+        handler = ParallelHandler()
         par_node = Node(
             id="parallel",
             shape="component",
@@ -129,17 +135,23 @@ class TestFirstSuccessEarlyExit:
             ],
         )
 
-        outcome = await handler.execute(par_node, _make_context(), graph, "/tmp")
+        outcome = await handler.execute(
+            par_node, _make_context(), graph, "/tmp", engine=_engine
+        )
         assert outcome.status == StageStatus.SUCCESS
 
     @pytest.mark.asyncio
     async def test_first_success_fails_when_all_fail(self):
         """first_success returns FAIL when no branches succeed."""
 
-        async def fail_runner(node_id, context, graph, logs_root):
-            return Outcome(status=StageStatus.FAIL, failure_reason=f"{node_id} failed")
+        class FailEngine:
+            async def run_subgraph(self, node_id, *, context=None):
+                return Outcome(
+                    status=StageStatus.FAIL, failure_reason=f"{node_id} failed"
+                )
 
-        handler = ParallelHandler(subgraph_runner=fail_runner)
+        handler = ParallelHandler()
+        _engine = FailEngine()
         par_node = Node(
             id="parallel",
             shape="component",
@@ -158,7 +170,9 @@ class TestFirstSuccessEarlyExit:
             ],
         )
 
-        outcome = await handler.execute(par_node, _make_context(), graph, "/tmp")
+        outcome = await handler.execute(
+            par_node, _make_context(), graph, "/tmp", engine=_engine
+        )
         assert outcome.status == StageStatus.FAIL
 
 
@@ -179,16 +193,18 @@ class TestKOfNEarlyExit:
         """
         completed_branches: list[str] = []
 
-        async def runner(node_id, context, graph, logs_root):
-            if node_id in ("fast1", "fast2"):
+        class KOfNFastEngine:
+            async def run_subgraph(self, node_id, *, context=None):
+                if node_id in ("fast1", "fast2"):
+                    completed_branches.append(node_id)
+                    return Outcome(status=StageStatus.SUCCESS, notes=f"{node_id} done")
+                # Slow branch
+                await asyncio.sleep(5.0)
                 completed_branches.append(node_id)
-                return Outcome(status=StageStatus.SUCCESS, notes=f"{node_id} done")
-            # Slow branch
-            await asyncio.sleep(5.0)
-            completed_branches.append(node_id)
-            return Outcome(status=StageStatus.SUCCESS, notes="slow done")
+                return Outcome(status=StageStatus.SUCCESS, notes="slow done")
 
-        handler = ParallelHandler(subgraph_runner=runner)
+        handler = ParallelHandler()
+        _engine = KOfNFastEngine()
         par_node = Node(
             id="parallel",
             shape="component",
@@ -212,7 +228,9 @@ class TestKOfNEarlyExit:
         import time
 
         start = time.monotonic()
-        outcome = await handler.execute(par_node, _make_context(), graph, "/tmp")
+        outcome = await handler.execute(
+            par_node, _make_context(), graph, "/tmp", engine=_engine
+        )
         elapsed = time.monotonic() - start
 
         assert outcome.status == StageStatus.SUCCESS
@@ -223,12 +241,14 @@ class TestKOfNEarlyExit:
     async def test_k_of_n_waits_when_threshold_not_yet_met(self):
         """k_of_n waits for more branches when threshold not met yet."""
 
-        async def runner(node_id, context, graph, logs_root):
-            if node_id == "b1":
-                return Outcome(status=StageStatus.FAIL, failure_reason="broke")
-            return Outcome(status=StageStatus.SUCCESS)
+        class KOfNThresholdEngine:
+            async def run_subgraph(self, node_id, *, context=None):
+                if node_id == "b1":
+                    return Outcome(status=StageStatus.FAIL, failure_reason="broke")
+                return Outcome(status=StageStatus.SUCCESS)
 
-        handler = ParallelHandler(subgraph_runner=runner)
+        handler = ParallelHandler()
+        _engine = KOfNThresholdEngine()
         par_node = Node(
             id="parallel",
             shape="component",
@@ -249,20 +269,24 @@ class TestKOfNEarlyExit:
             ],
         )
 
-        outcome = await handler.execute(par_node, _make_context(), graph, "/tmp")
+        outcome = await handler.execute(
+            par_node, _make_context(), graph, "/tmp", engine=_engine
+        )
         assert outcome.status == StageStatus.SUCCESS
 
     @pytest.mark.asyncio
     async def test_k_of_n_fails_when_threshold_impossible(self):
         """k_of_n fails when not enough remaining branches can meet threshold."""
 
-        async def runner(node_id, context, graph, logs_root):
-            if node_id in ("b1", "b2"):
-                return Outcome(status=StageStatus.FAIL, failure_reason="broke")
-            await asyncio.sleep(5.0)
-            return Outcome(status=StageStatus.SUCCESS)
+        class ImpossibleThresholdEngine:
+            async def run_subgraph(self, node_id, *, context=None):
+                if node_id in ("b1", "b2"):
+                    return Outcome(status=StageStatus.FAIL, failure_reason="broke")
+                await asyncio.sleep(5.0)
+                return Outcome(status=StageStatus.SUCCESS)
 
-        handler = ParallelHandler(subgraph_runner=runner)
+        handler = ParallelHandler()
+        _engine = ImpossibleThresholdEngine()
         par_node = Node(
             id="parallel",
             shape="component",
@@ -286,7 +310,9 @@ class TestKOfNEarlyExit:
         import time
 
         start = time.monotonic()
-        outcome = await handler.execute(par_node, _make_context(), graph, "/tmp")
+        outcome = await handler.execute(
+            par_node, _make_context(), graph, "/tmp", engine=_engine
+        )
         elapsed = time.monotonic() - start
 
         assert outcome.status == StageStatus.FAIL
@@ -297,10 +323,12 @@ class TestKOfNEarlyExit:
     async def test_k_of_n_stores_results_in_context(self):
         """k_of_n stores collected results in parent context."""
 
-        async def runner(node_id, context, graph, logs_root):
-            return Outcome(status=StageStatus.SUCCESS, notes=f"{node_id} ok")
+        class StoreResultsEngine:
+            async def run_subgraph(self, node_id, *, context=None):
+                return Outcome(status=StageStatus.SUCCESS, notes=f"{node_id} ok")
 
-        handler = ParallelHandler(subgraph_runner=runner)
+        handler = ParallelHandler()
+        _engine = StoreResultsEngine()
         par_node = Node(
             id="parallel",
             shape="component",
@@ -320,7 +348,7 @@ class TestKOfNEarlyExit:
             ],
         )
 
-        await handler.execute(par_node, context, graph, "/tmp")
+        await handler.execute(par_node, context, graph, "/tmp", engine=_engine)
         results = context.get("parallel.results")
         assert results is not None
         assert len(results) >= 1

--- a/modules/loop-pipeline/tests/test_parallel_fanout_contract.py
+++ b/modules/loop-pipeline/tests/test_parallel_fanout_contract.py
@@ -39,29 +39,17 @@ async def _make_wired_engine(
     backend: object,
     logs_root: str,
 ) -> PipelineEngine:
-    """Create a PipelineEngine with subgraph_runner wired to engine._run_from.
+    """Create a PipelineEngine. Engine passes itself to handlers via execute(engine=self).
 
-    Required when testing shape=component nodes (ParallelHandler needs this
-    closure to execute branches as proper subgraphs).
+    No subgraph_runner closure needed — ParallelHandler receives the engine
+    directly via execute(engine=...) and calls engine.run_subgraph().
     """
-    engine = PipelineEngine(
+    return PipelineEngine(
         graph=graph,
         context=PipelineContext(),
         handler_registry=HandlerRegistry(backend=backend),
         logs_root=logs_root,
     )
-
-    async def subgraph_runner(
-        node_id: str,
-        branch_context: PipelineContext,
-        _graph: Graph,
-        _logs_root: str,
-    ) -> object:
-        return await engine._run_from(node_id, context=branch_context)
-
-    registry = HandlerRegistry(backend=backend, subgraph_runner=subgraph_runner)
-    engine.handler_registry = registry
-    return engine
 
 
 # ---------------------------------------------------------------------------

--- a/modules/loop-pipeline/tests/test_parallel_fanout_contract.py
+++ b/modules/loop-pipeline/tests/test_parallel_fanout_contract.py
@@ -27,6 +27,7 @@ from amplifier_module_loop_pipeline.engine import PipelineEngine
 from amplifier_module_loop_pipeline.graph import Edge, Graph, Node
 from amplifier_module_loop_pipeline.handlers import HandlerRegistry
 from amplifier_module_loop_pipeline.outcome import StageStatus
+from amplifier_module_loop_pipeline.handlers.context import HandlerContext
 
 
 # ---------------------------------------------------------------------------
@@ -47,7 +48,7 @@ async def _make_wired_engine(
     return PipelineEngine(
         graph=graph,
         context=PipelineContext(),
-        handler_registry=HandlerRegistry(backend=backend),
+        handler_registry=HandlerRegistry(HandlerContext(backend=backend)),
         logs_root=logs_root,
     )
 
@@ -174,7 +175,7 @@ async def test_parallelogram_shape_does_not_fan_out_unconditional_edges(tmp_path
 
     # No subgraph_runner needed — ToolHandler and LLM nodes don't use it.
     context = PipelineContext()
-    registry = HandlerRegistry(backend=CountingBackend())
+    registry = HandlerRegistry(HandlerContext(backend=CountingBackend()))
     engine = PipelineEngine(
         graph=graph,
         context=context,
@@ -287,7 +288,7 @@ async def test_non_component_fanout_respects_max_parallel(tmp_path):
     engine = PipelineEngine(
         graph=graph,
         context=PipelineContext(),
-        handler_registry=HandlerRegistry(backend=BoundedConcurrencyBackend()),
+        handler_registry=HandlerRegistry(HandlerContext(backend=BoundedConcurrencyBackend())),
         logs_root=str(tmp_path),
     )
     outcome = await engine.run()

--- a/modules/loop-pipeline/tests/test_parallel_ignore_does_not_populate_failed_outputs.py
+++ b/modules/loop-pipeline/tests/test_parallel_ignore_does_not_populate_failed_outputs.py
@@ -39,29 +39,16 @@ def _make_engine(dot_source: str, logs_root: str, hooks: Any = None) -> Pipeline
     graph = parse_dot(dot_source)
     validate_or_raise(graph)
     context = PipelineContext()
+    # No subgraph_runner needed — ParallelHandler receives engine via execute(engine=...)
+    # and calls engine.run_subgraph() directly.
     registry = HandlerRegistry()
-    engine = PipelineEngine(
+    return PipelineEngine(
         graph=graph,
         context=context,
         handler_registry=registry,
         logs_root=logs_root,
         hooks=hooks,
     )
-
-    # Wire the subgraph_runner so ParallelHandler can execute branches.
-    # Without this, all branches fail immediately (no-op runner), which
-    # defeats the purpose of testing error_policy behavior.
-    async def subgraph_runner(
-        node_id: str,
-        branch_context: PipelineContext,
-        _graph: object,
-        _logs_root: str,
-    ) -> object:
-        return await engine._run_from(node_id, context=branch_context)
-
-    wired_registry = HandlerRegistry(subgraph_runner=subgraph_runner)
-    engine.handler_registry = wired_registry
-    return engine
 
 
 @pytest.mark.asyncio

--- a/modules/loop-pipeline/tests/test_parallel_ignore_does_not_populate_failed_outputs.py
+++ b/modules/loop-pipeline/tests/test_parallel_ignore_does_not_populate_failed_outputs.py
@@ -22,6 +22,7 @@ from amplifier_module_loop_pipeline.handlers import HandlerRegistry
 from amplifier_module_loop_pipeline.outcome import StageStatus
 from amplifier_module_loop_pipeline.pipeline_events import PIPELINE_NODE_SKIPPED
 from amplifier_module_loop_pipeline.validation import validate_or_raise
+from amplifier_module_loop_pipeline.handlers.context import HandlerContext
 
 
 class EventCapture:
@@ -41,7 +42,7 @@ def _make_engine(dot_source: str, logs_root: str, hooks: Any = None) -> Pipeline
     context = PipelineContext()
     # No subgraph_runner needed — ParallelHandler receives engine via execute(engine=...)
     # and calls engine.run_subgraph() directly.
-    registry = HandlerRegistry()
+    registry = HandlerRegistry(HandlerContext())
     return PipelineEngine(
         graph=graph,
         context=context,

--- a/modules/loop-pipeline/tests/test_parallel_policies.py
+++ b/modules/loop-pipeline/tests/test_parallel_policies.py
@@ -124,10 +124,11 @@ class TestKOfNJoinPolicy:
             "b3": Outcome(status=StageStatus.SUCCESS),
         }
 
-        async def runner(node_id, context, graph, logs_root):
-            return outcomes[node_id]
+        class _KOfNEngine:
+            async def run_subgraph(self, node_id, *, context=None):
+                return outcomes[node_id]
 
-        handler = ParallelHandler(subgraph_runner=runner)
+        handler = ParallelHandler()
         par_node = Node(
             id="parallel",
             shape="component",
@@ -148,7 +149,9 @@ class TestKOfNJoinPolicy:
             ],
         )
 
-        outcome = await handler.execute(par_node, _make_context(), graph, "/tmp")
+        outcome = await handler.execute(
+            par_node, _make_context(), graph, "/tmp", engine=_KOfNEngine()
+        )
         assert outcome.status == StageStatus.SUCCESS
 
 
@@ -230,10 +233,11 @@ class TestQuorumJoinPolicy:
             "b4": Outcome(status=StageStatus.SUCCESS),
         }
 
-        async def runner(node_id, context, graph, logs_root):
-            return outcomes[node_id]
+        class _QuorumEngine2:
+            async def run_subgraph(self, node_id, *, context=None):
+                return outcomes[node_id]
 
-        handler = ParallelHandler(subgraph_runner=runner)
+        handler = ParallelHandler()
         par_node = Node(
             id="parallel",
             shape="component",
@@ -256,7 +260,9 @@ class TestQuorumJoinPolicy:
             ],
         )
 
-        outcome = await handler.execute(par_node, _make_context(), graph, "/tmp")
+        outcome = await handler.execute(
+            par_node, _make_context(), graph, "/tmp", engine=_QuorumEngine2()
+        )
         assert outcome.status == StageStatus.SUCCESS
 
 
@@ -273,17 +279,19 @@ class TestFailFastErrorPolicy:
         """fail_fast cancels remaining branches when one fails."""
         execution_order: list[str] = []
 
-        async def slow_runner(node_id, context, graph, logs_root):
-            execution_order.append(f"start:{node_id}")
-            if node_id == "b1":
-                # b1 fails immediately
-                return Outcome(status=StageStatus.FAIL, failure_reason="broken")
-            # Other branches take a while
-            await asyncio.sleep(0.5)
-            execution_order.append(f"end:{node_id}")
-            return Outcome(status=StageStatus.SUCCESS)
+        class SlowEngine2:
+            async def run_subgraph(self, node_id, *, context=None):
+                execution_order.append(f"start:{node_id}")
+                if node_id == "b1":
+                    # b1 fails immediately
+                    return Outcome(status=StageStatus.FAIL, failure_reason="broken")
+                # Other branches take a while
+                await asyncio.sleep(0.5)
+                execution_order.append(f"end:{node_id}")
+                return Outcome(status=StageStatus.SUCCESS)
 
-        handler = ParallelHandler(subgraph_runner=slow_runner)
+        handler = ParallelHandler()
+        _slow_engine2 = SlowEngine2()
         par_node = Node(
             id="parallel",
             shape="component",
@@ -304,7 +312,9 @@ class TestFailFastErrorPolicy:
             ],
         )
 
-        outcome = await handler.execute(par_node, _make_context(), graph, "/tmp")
+        outcome = await handler.execute(
+            par_node, _make_context(), graph, "/tmp", engine=_slow_engine2
+        )
 
         # The outcome should reflect the failure
         assert outcome.status in (StageStatus.FAIL, StageStatus.PARTIAL_SUCCESS)
@@ -316,10 +326,11 @@ class TestFailFastErrorPolicy:
     async def test_fail_fast_all_succeed(self):
         """fail_fast with all successes returns SUCCESS normally."""
 
-        async def success_runner(node_id, context, graph, logs_root):
-            return Outcome(status=StageStatus.SUCCESS)
+        class SuccessEngine2:
+            async def run_subgraph(self, node_id, *, context=None):
+                return Outcome(status=StageStatus.SUCCESS)
 
-        handler = ParallelHandler(subgraph_runner=success_runner)
+        handler = ParallelHandler()
         par_node = Node(
             id="parallel",
             shape="component",
@@ -338,20 +349,24 @@ class TestFailFastErrorPolicy:
             ],
         )
 
-        outcome = await handler.execute(par_node, _make_context(), graph, "/tmp")
+        outcome = await handler.execute(
+            par_node, _make_context(), graph, "/tmp", engine=SuccessEngine2()
+        )
         assert outcome.status == StageStatus.SUCCESS
 
     @pytest.mark.asyncio
     async def test_fail_fast_stores_partial_results(self):
         """fail_fast stores whatever results were collected before cancellation."""
 
-        async def mixed_runner(node_id, context, graph, logs_root):
-            if node_id == "b1":
-                return Outcome(status=StageStatus.FAIL, failure_reason="broken")
-            await asyncio.sleep(0.5)
-            return Outcome(status=StageStatus.SUCCESS)
+        class MixedEngine:
+            async def run_subgraph(self, node_id, *, context=None):
+                if node_id == "b1":
+                    return Outcome(status=StageStatus.FAIL, failure_reason="broken")
+                await asyncio.sleep(0.5)
+                return Outcome(status=StageStatus.SUCCESS)
 
-        handler = ParallelHandler(subgraph_runner=mixed_runner)
+        handler = ParallelHandler()
+        _mixed_engine = MixedEngine()
         par_node = Node(
             id="parallel",
             shape="component",
@@ -395,10 +410,11 @@ class TestIgnoreErrorPolicy:
             "b3": Outcome(status=StageStatus.SUCCESS, notes="also good"),
         }
 
-        async def runner(node_id, context, graph, logs_root):
-            return outcomes[node_id]
+        class _IgnoreEngine3:
+            async def run_subgraph(self, node_id, *, context=None):
+                return outcomes[node_id]
 
-        handler = ParallelHandler(subgraph_runner=runner)
+        handler = ParallelHandler()
         par_node = Node(
             id="parallel",
             shape="component",
@@ -435,10 +451,12 @@ class TestIgnoreErrorPolicy:
     async def test_ignore_all_fail_returns_success_no_results(self):
         """ignore with all failures returns SUCCESS with empty results."""
 
-        async def fail_runner(node_id, context, graph, logs_root):
-            return Outcome(status=StageStatus.FAIL, failure_reason="all bad")
+        class FailEngine:
+            async def run_subgraph(self, node_id, *, context=None):
+                return Outcome(status=StageStatus.FAIL, failure_reason="all bad")
 
-        handler = ParallelHandler(subgraph_runner=fail_runner)
+        handler = ParallelHandler()
+        _fail_engine = FailEngine()
         par_node = Node(
             id="parallel",
             shape="component",
@@ -466,10 +484,11 @@ class TestIgnoreErrorPolicy:
     async def test_ignore_all_succeed(self):
         """ignore with all successes works normally."""
 
-        async def success_runner(node_id, context, graph, logs_root):
-            return Outcome(status=StageStatus.SUCCESS)
+        class _IgnoreSuccessEngine:
+            async def run_subgraph(self, node_id, *, context=None):
+                return Outcome(status=StageStatus.SUCCESS)
 
-        handler = ParallelHandler(subgraph_runner=success_runner)
+        handler = ParallelHandler()
         par_node = Node(
             id="parallel",
             shape="component",
@@ -489,7 +508,7 @@ class TestIgnoreErrorPolicy:
             ],
         )
 
-        outcome = await handler.execute(par_node, context, graph, "/tmp")
+        outcome = await handler.execute(par_node, context, graph, "/tmp", engine=_IgnoreSuccessEngine())
         assert outcome.status == StageStatus.SUCCESS
         results = context.get("parallel.results")
         assert len(results) == 2

--- a/modules/loop-pipeline/tests/test_pipeline_e2e.py
+++ b/modules/loop-pipeline/tests/test_pipeline_e2e.py
@@ -33,6 +33,7 @@ from amplifier_module_loop_pipeline.pipeline_events import (
     PIPELINE_START,
 )
 from amplifier_module_loop_pipeline.validation import validate, validate_or_raise
+from amplifier_module_loop_pipeline.handlers.context import HandlerContext
 
 
 # ---------------------------------------------------------------------------
@@ -155,7 +156,7 @@ def _make_engine(
     graph = parse_dot(dot_source)
     validate_or_raise(graph)
     context = PipelineContext()
-    registry = HandlerRegistry(backend=backend)
+    registry = HandlerRegistry(HandlerContext(backend=backend))
     return PipelineEngine(
         graph=graph,
         context=context,

--- a/modules/loop-pipeline/tests/test_pipeline_events.py
+++ b/modules/loop-pipeline/tests/test_pipeline_events.py
@@ -14,6 +14,7 @@ from amplifier_module_loop_pipeline.dot_parser import parse_dot
 from amplifier_module_loop_pipeline.engine import PipelineEngine
 from amplifier_module_loop_pipeline.graph import Edge, Graph, Node
 from amplifier_module_loop_pipeline.handlers import HandlerRegistry
+from amplifier_module_loop_pipeline.handlers.context import HandlerContext
 from amplifier_module_loop_pipeline.outcome import Outcome, StageStatus
 from amplifier_module_loop_pipeline.pipeline_events import (
     PIPELINE_CHECKPOINT,
@@ -84,7 +85,7 @@ def _make_engine(
     graph = parse_dot(dot_source)
     validate_or_raise(graph)
     context = PipelineContext()
-    registry = HandlerRegistry(backend=backend)
+    registry = HandlerRegistry(HandlerContext(backend=backend))
     return PipelineEngine(
         graph=graph,
         context=context,
@@ -746,7 +747,7 @@ class TestErrorEvents:
             ],
         )
         context = PipelineContext()
-        registry = HandlerRegistry(backend=MockBackend("ok"))
+        registry = HandlerRegistry(HandlerContext(backend=MockBackend("ok")))
         engine = PipelineEngine(
             graph=graph,
             context=context,
@@ -786,7 +787,7 @@ class TestNoHooksBackwardCompat:
 
         validate_or_raise(graph)
         context = PipelineContext()
-        registry = HandlerRegistry(backend=MockBackend())
+        registry = HandlerRegistry(HandlerContext(backend=MockBackend()))
         engine = PipelineEngine(
             graph=graph,
             context=context,

--- a/modules/loop-pipeline/tests/test_pipeline_handler.py
+++ b/modules/loop-pipeline/tests/test_pipeline_handler.py
@@ -963,100 +963,88 @@ class TestChildRegistrySubgraphRunnerWiring:
     """Regression tests for issue #249.
 
     PipelineHandler.execute() was building the child HandlerRegistry without
-    passing subgraph_runner, leaving ManagerLoopHandler._runner and
-    ParallelHandler._runner as None.  Any child node with shape=house or
-    shape=component inside a shape=folder sub-pipeline therefore failed
-    immediately with "Manager loop requires a subgraph_runner".
+    any mechanism for child manager/parallel handlers to execute subgraphs.
+    Any child node with shape=house or shape=component inside a shape=folder
+    sub-pipeline therefore failed immediately with an error.
+
+    After the refactor (issue #250), the engine passes itself to each handler
+    via execute(engine=...).  ManagerLoopHandler and ParallelHandler use
+    engine.run_subgraph() directly — no subgraph_runner kwarg or _runner field
+    remains.  The original implementation check (._runner is not None) is
+    replaced by a behavioral check: the manager node in a child pipeline must
+    succeed end-to-end.
     """
 
     @pytest.mark.asyncio
     async def test_child_registry_has_subgraph_runners_wired(self, tmp_path):
-        """Child HandlerRegistry must have subgraph_runner on both ManagerLoopHandler and ParallelHandler.
+        """Child manager/parallel nodes inside a folder pipeline must be able to run subgraphs.
 
-        Pins the internal contract: after PipelineHandler.execute() builds the
-        child HandlerRegistry (the else-branch, no factory), both
-        ``_handlers["stack.manager_loop"]._runner`` and
-        ``_handlers["parallel"]._runner`` must not be None.
+        After the #250 refactor, this is verified behaviorally: the pipeline
+        completes successfully, proving that ManagerLoopHandler received the
+        engine and called engine.run_subgraph() without error.
 
-        Without the fix both are None, causing immediate FAIL on any child node
-        with shape=house or shape=component (issue #249).
+        Preserving tracking reference: issue #249 root cause was missing wiring.
+        The #250 refactor eliminates the wiring step entirely — engine carries
+        itself, so there is nothing to forget to wire.
         """
         from amplifier_module_loop_pipeline.engine import PipelineEngine
         from amplifier_module_loop_pipeline.handlers import HandlerRegistry
 
         graph = _make_parent_graph_with_manager_child(tmp_path)
-
-        # Spy: capture every HandlerRegistry instance constructed during the run.
-        instances: list = []
-        original_init = HandlerRegistry.__init__
-
-        def _spy_init(self_reg, **kw):
-            original_init(self_reg, **kw)
-            instances.append(self_reg)
-
-        HandlerRegistry.__init__ = _spy_init
-
         context = PipelineContext()
         logs_root = str(tmp_path / "logs")
 
-        try:
-            # Build parent engine canonically (mirrors PipelineOrchestrator.execute()).
-            engine = PipelineEngine(
-                graph=graph,
-                context=context,
-                handler_registry=HandlerRegistry(),  # temp [0]
-                logs_root=logs_root,
-            )
-
-            async def _subgraph_runner(node_id, branch_context, _graph, _logs_root):
-                return await engine._run_from(node_id, context=branch_context)
-
-            engine.handler_registry = HandlerRegistry(  # real [1]
-                subgraph_runner=_subgraph_runner,
-                backend=_MockBackend(),
-            )
-
-            # Run: PipelineHandler.execute() will be called for "sub", building
-            # the child registry [2].  We don't care whether the full run
-            # succeeds — registry construction already happened by this point.
-            await engine.run(goal="test wiring")
-        except Exception:
-            pass  # Registry construction already happened; state check below is valid.
-        finally:
-            HandlerRegistry.__init__ = original_init
-
-        # Before fix: [0]=temp parent, [1]=real parent, [2]=child without runner  → runner=None
-        # After fix:  [0]=temp parent, [1]=real parent, [2]=child WITH runner wired → runner=SET
-        # In both cases len==3 and instances[-1]==instances[2] is the child registry.
-        assert len(instances) >= 3, (
-            f"Expected >=3 HandlerRegistry instances (temp+real parent + child), "
-            f"got {len(instances)}.  PipelineHandler.execute() may not have been reached."
+        # Canonical construction — no dance, no closure, no rewire.
+        engine = PipelineEngine(
+            graph=graph,
+            context=context,
+            handler_registry=HandlerRegistry(backend=_MockBackend()),
+            logs_root=logs_root,
         )
-        child_registry = instances[2]
+        outcome = await engine.run(goal="test wiring")
 
-        mgr_runner = child_registry._handlers["stack.manager_loop"]._runner
-        par_runner = child_registry._handlers["parallel"]._runner
+        # Behavioral assertion: the pipeline must succeed end-to-end.
+        # If ManagerLoopHandler failed with "requires engine", outcome would be FAIL.
+        pipeline_handler = engine.handler_registry._handlers["pipeline"]
+        subgraph_run = pipeline_handler._subgraph_runs.get("sub")
+        assert subgraph_run is not None, (
+            "PipelineHandler did not record a subgraph run for node 'sub' — "
+            "the parent engine may not have reached the folder node"
+        )
 
-        assert mgr_runner is not None, (
-            "Child HandlerRegistry ManagerLoopHandler._runner is None — "
-            "subgraph_runner not wired (issue #249)"
+        mgr_outcome_data = subgraph_run["node_outcomes"].get("mgr")
+        assert mgr_outcome_data is not None, (
+            "Manager node 'mgr' not found in child subgraph node_outcomes"
         )
-        assert par_runner is not None, (
-            "Child HandlerRegistry ParallelHandler._runner is None — "
-            "subgraph_runner not wired (issue #249)"
+
+        # Key regression assertion (issue #249): manager must NOT fail with missing-engine error.
+        assert (
+            mgr_outcome_data["failure_reason"]
+            != "ManagerLoopHandler requires engine to be passed via execute(engine=...)"
+        ), (
+            "Manager node failed with engine-not-wired error — "
+            "the #250 refactor should have eliminated this failure mode"
         )
+
+        assert mgr_outcome_data["status"] == "success", (
+            f"Manager node did not succeed — status={mgr_outcome_data['status']!r}, "
+            f"failure_reason={mgr_outcome_data.get('failure_reason')!r}"
+        )
+        assert outcome.status == StageStatus.SUCCESS
 
     @pytest.mark.asyncio
     async def test_child_manager_node_runner_is_invoked(self, tmp_path):
-        """E2E: parent folder -> child house manager must invoke its subgraph_runner.
+        """E2E: parent folder -> child house manager must invoke its subgraph runner.
 
-        Before the fix:
+        Before the fix (issue #249):
           child manager:  FAIL "Manager loop requires a subgraph_runner"
           parent outcome: FAIL (edge selection re-surfaces child failure)
 
-        After the fix: child manager is wired, its subgraph_runner is invoked
-        (mock backend handles the branch work node), and the pipeline completes
-        with SUCCESS end-to-end.
+        After the fix (issue #249) and refactor (issue #250):
+          child manager receives engine via execute(engine=...), calls
+          engine.run_subgraph(), the mock backend handles the branch work
+          node, manager completes in 1 cycle, child pipeline succeeds,
+          and the parent pipeline succeeds end-to-end.
 
         Spec: issue #249 regression test.
         """
@@ -1067,20 +1055,12 @@ class TestChildRegistrySubgraphRunnerWiring:
         context = PipelineContext()
         logs_root = str(tmp_path / "logs")
 
-        # Build parent engine canonically (temp -> closure -> real registry).
+        # Canonical construction — no dance, no closure, no rewire.
         engine = PipelineEngine(
             graph=graph,
             context=context,
-            handler_registry=HandlerRegistry(),  # temp
+            handler_registry=HandlerRegistry(backend=_MockBackend()),
             logs_root=logs_root,
-        )
-
-        async def _subgraph_runner(node_id, branch_context, _graph, _logs_root):
-            return await engine._run_from(node_id, context=branch_context)
-
-        engine.handler_registry = HandlerRegistry(
-            subgraph_runner=_subgraph_runner,
-            backend=_MockBackend(),
         )
 
         outcome = await engine.run(goal="test child manager runner")
@@ -1100,7 +1080,10 @@ class TestChildRegistrySubgraphRunnerWiring:
         )
 
         # Key regression assertion: manager must NOT fail with the missing-runner error.
-        assert mgr_outcome_data["failure_reason"] != "Manager loop requires a subgraph_runner", (
+        assert (
+            mgr_outcome_data["failure_reason"]
+            != "Manager loop requires a subgraph_runner"
+        ), (
             "Manager node failed with 'Manager loop requires a subgraph_runner' — "
             "subgraph_runner not wired in child HandlerRegistry (issue #249)"
         )

--- a/modules/loop-pipeline/tests/test_pipeline_handler.py
+++ b/modules/loop-pipeline/tests/test_pipeline_handler.py
@@ -16,6 +16,7 @@ from amplifier_module_loop_pipeline.handlers.pipeline import (
     resolve_dot_path,
 )
 from amplifier_module_loop_pipeline.outcome import StageStatus
+from amplifier_module_loop_pipeline.handlers.context import HandlerContext
 
 
 class _MockBackend:
@@ -30,7 +31,7 @@ def _make_registry_factory():
     from amplifier_module_loop_pipeline.handlers import HandlerRegistry
 
     def factory():
-        return HandlerRegistry(backend=_MockBackend())
+        return HandlerRegistry(HandlerContext(backend=_MockBackend()))
 
     return factory
 
@@ -409,7 +410,7 @@ class TestPipelineHandlerRegistration:
         """Node with shape=folder resolves to PipelineHandler instance."""
         from amplifier_module_loop_pipeline.handlers import HandlerRegistry
 
-        registry = HandlerRegistry()
+        registry = HandlerRegistry(HandlerContext())
         node = Node(id="sub", shape="folder")
         handler = registry.get(node)
         assert isinstance(handler, PipelineHandler)
@@ -418,7 +419,7 @@ class TestPipelineHandlerRegistration:
         """Node with type='pipeline' resolves to PipelineHandler instance."""
         from amplifier_module_loop_pipeline.handlers import HandlerRegistry
 
-        registry = HandlerRegistry()
+        registry = HandlerRegistry(HandlerContext())
         node = Node(id="sub", shape="box", type="pipeline")
         handler = registry.get(node)
         assert isinstance(handler, PipelineHandler)
@@ -449,7 +450,7 @@ class TestPipelineHandlerE2E:
         graph.source_dir = FIXTURES_DIR
 
         context = PipelineContext()
-        registry = HandlerRegistry(backend=_MockBackend())
+        registry = HandlerRegistry(HandlerContext(backend=_MockBackend()))
         logs_root = str(tmp_path / "logs")
 
         engine = PipelineEngine(
@@ -477,7 +478,7 @@ class TestPipelineHandlerE2E:
         graph.source_dir = FIXTURES_DIR
 
         context = PipelineContext()
-        registry = HandlerRegistry()
+        registry = HandlerRegistry(HandlerContext())
         logs_root = str(tmp_path / "logs")
 
         engine = PipelineEngine(
@@ -532,7 +533,7 @@ class TestInterviewerForwarding:
         from amplifier_module_loop_pipeline.interviewer import AutoApproveInterviewer
 
         interviewer = AutoApproveInterviewer()
-        registry = HandlerRegistry(interviewer=interviewer)
+        registry = HandlerRegistry(HandlerContext(interviewer=interviewer))
 
         pipeline_handler = registry._handlers["pipeline"]
         assert isinstance(pipeline_handler, PipelineHandler)
@@ -554,7 +555,7 @@ class TestInterviewerForwarding:
         from amplifier_module_loop_pipeline.interviewer import AutoApproveInterviewer
 
         interviewer = AutoApproveInterviewer()
-        registry = HandlerRegistry(interviewer=interviewer)
+        registry = HandlerRegistry(HandlerContext(interviewer=interviewer))
 
         branch_registry = registry.clone_for_branch()
 
@@ -657,7 +658,7 @@ digraph parent_e2e {
         graph.source_dir = str(tmp_path)
 
         context = PipelineContext()
-        registry = HandlerRegistry(interviewer=AutoApproveInterviewer())
+        registry = HandlerRegistry(HandlerContext(interviewer=AutoApproveInterviewer()))
         logs_root = str(tmp_path / "logs")
 
         engine = PipelineEngine(
@@ -998,7 +999,7 @@ class TestChildRegistrySubgraphRunnerWiring:
         engine = PipelineEngine(
             graph=graph,
             context=context,
-            handler_registry=HandlerRegistry(backend=_MockBackend()),
+            handler_registry=HandlerRegistry(HandlerContext(backend=_MockBackend())),
             logs_root=logs_root,
         )
         outcome = await engine.run(goal="test wiring")
@@ -1059,7 +1060,7 @@ class TestChildRegistrySubgraphRunnerWiring:
         engine = PipelineEngine(
             graph=graph,
             context=context,
-            handler_registry=HandlerRegistry(backend=_MockBackend()),
+            handler_registry=HandlerRegistry(HandlerContext(backend=_MockBackend())),
             logs_root=logs_root,
         )
 

--- a/modules/loop-pipeline/tests/test_retry.py
+++ b/modules/loop-pipeline/tests/test_retry.py
@@ -23,7 +23,13 @@ class MockHandler:
         self.call_count = 0
 
     async def execute(
-        self, node: Node, context: PipelineContext, graph: Graph, logs_root: str
+        self,
+        node: Node,
+        context: PipelineContext,
+        graph: Graph,
+        logs_root: str,
+        *,
+        engine=None,
     ) -> Outcome:
         self.call_count += 1
         if self._outcomes:
@@ -43,7 +49,13 @@ class RaisingHandler:
         self.call_count = 0
 
     async def execute(
-        self, node: Node, context: PipelineContext, graph: Graph, logs_root: str
+        self,
+        node: Node,
+        context: PipelineContext,
+        graph: Graph,
+        logs_root: str,
+        *,
+        engine=None,
     ) -> Outcome:
         self.call_count += 1
         if self.call_count <= self._fail_count:
@@ -309,7 +321,7 @@ async def test_retry_emits_retrying_event():
     call_count = 0
 
     class RetryThenSucceedHandler:
-        async def execute(self, node, context, graph, logs_root):
+        async def execute(self, node, context, graph, logs_root, *, engine=None):
             nonlocal call_count
             call_count += 1
             if call_count < 3:
@@ -449,7 +461,7 @@ async def test_terminal_exception_not_retried():
         def __init__(self):
             self.call_count = 0
 
-        async def execute(self, node, context, graph, logs_root):
+        async def execute(self, node, context, graph, logs_root, *, engine=None):
             self.call_count += 1
             if self.call_count == 1:
                 raise ValueError("invalid config")
@@ -474,7 +486,7 @@ async def test_retryable_exception_is_retried():
         def __init__(self):
             self.call_count = 0
 
-        async def execute(self, node, context, graph, logs_root):
+        async def execute(self, node, context, graph, logs_root, *, engine=None):
             self.call_count += 1
             if self.call_count == 1:
                 raise TimeoutError("connection timed out")

--- a/modules/loop-pipeline/tests/test_run_directory.py
+++ b/modules/loop-pipeline/tests/test_run_directory.py
@@ -16,6 +16,7 @@ from amplifier_module_loop_pipeline.graph import Node
 from amplifier_module_loop_pipeline.handlers import HandlerRegistry
 from amplifier_module_loop_pipeline.outcome import Outcome, StageStatus
 from amplifier_module_loop_pipeline.validation import validate_or_raise
+from amplifier_module_loop_pipeline.handlers.context import HandlerContext
 
 
 # ---------------------------------------------------------------------------
@@ -54,7 +55,7 @@ def _make_engine(
     graph = parse_dot(dot_source)
     validate_or_raise(graph)
     context = PipelineContext()
-    registry = HandlerRegistry(backend=backend)
+    registry = HandlerRegistry(HandlerContext(backend=backend))
     return PipelineEngine(
         graph=graph,
         context=context,

--- a/modules/loop-pipeline/tests/test_runs_on_axis.py
+++ b/modules/loop-pipeline/tests/test_runs_on_axis.py
@@ -20,6 +20,7 @@ from amplifier_module_loop_pipeline.handlers import HandlerRegistry
 from amplifier_module_loop_pipeline.outcome import StageStatus
 from amplifier_module_loop_pipeline.pipeline_events import PIPELINE_NODE_SKIPPED
 from amplifier_module_loop_pipeline.validation import validate_or_raise
+from amplifier_module_loop_pipeline.handlers.context import HandlerContext
 
 
 class EventCapture:
@@ -37,7 +38,7 @@ def _make_engine(dot_source: str, logs_root: str, hooks: Any = None) -> Pipeline
     graph = parse_dot(dot_source)
     validate_or_raise(graph)
     context = PipelineContext()
-    registry = HandlerRegistry()
+    registry = HandlerRegistry(HandlerContext())
     return PipelineEngine(
         graph=graph,
         context=context,

--- a/modules/loop-pipeline/tests/test_subgraph_runner.py
+++ b/modules/loop-pipeline/tests/test_subgraph_runner.py
@@ -1,6 +1,6 @@
 """Tests for subgraph runner (H-11).
 
-Validates that PipelineEngine._run_from() can execute a subgraph
+Validates that PipelineEngine.run_subgraph() can execute a subgraph
 starting from a specified node and return the final outcome.
 """
 
@@ -19,7 +19,7 @@ class CountingHandler:
     def __init__(self):
         self.call_counts: dict[str, int] = {}
 
-    async def execute(self, node, context, graph, logs_root):
+    async def execute(self, node, context, graph, logs_root, *, engine=None):
         self.call_counts[node.id] = self.call_counts.get(node.id, 0) + 1
         return Outcome(
             status=StageStatus.SUCCESS,
@@ -30,7 +30,7 @@ class CountingHandler:
 def _make_subgraph():
     """Build a graph: start -> a -> b -> done.
 
-    _run_from("a") should execute a, then b, then hit done (exit).
+    run_subgraph("a") should execute a, then b, then hit done (exit).
     """
     return Graph(
         name="test",
@@ -50,7 +50,7 @@ def _make_subgraph():
 
 @pytest.mark.asyncio
 async def test_run_from_executes_subgraph(tmp_path):
-    """_run_from('a') should execute a, b, then stop at exit."""
+    """run_subgraph('a') should execute a, b, then stop at exit."""
     graph = _make_subgraph()
     counting = CountingHandler()
     registry = HandlerRegistry()
@@ -65,7 +65,7 @@ async def test_run_from_executes_subgraph(tmp_path):
     # Initialize context (normally done in run())
     engine._initialize_context(goal="test")
 
-    outcome = await engine._run_from("a")
+    outcome = await engine.run_subgraph("a")
 
     assert outcome.status == StageStatus.SUCCESS
     # Both a and b should have been executed
@@ -93,7 +93,7 @@ async def test_run_from_with_isolated_context(tmp_path):
     engine._initialize_context(goal="test")
 
     branch_context = main_context.clone()
-    outcome = await engine._run_from("a", context=branch_context)
+    outcome = await engine.run_subgraph("a", context=branch_context)
 
     assert outcome.status == StageStatus.SUCCESS
     # Branch context should have node outcomes; main should not
@@ -127,7 +127,7 @@ async def test_run_from_stops_at_dead_end(tmp_path):
     )
     engine._initialize_context(goal="test")
 
-    outcome = await engine._run_from("a")
+    outcome = await engine.run_subgraph("a")
 
     assert outcome.status == StageStatus.SUCCESS
     assert counting.call_counts.get("a") == 1
@@ -147,7 +147,7 @@ async def test_run_from_nonexistent_node(tmp_path):
     )
     engine._initialize_context(goal="test")
 
-    outcome = await engine._run_from("nonexistent")
+    outcome = await engine.run_subgraph("nonexistent")
 
     assert outcome.status == StageStatus.FAIL
     assert "not found" in (outcome.failure_reason or "").lower()
@@ -155,16 +155,17 @@ async def test_run_from_nonexistent_node(tmp_path):
 
 @pytest.mark.asyncio
 async def test_manager_loop_uses_wired_subgraph_runner(tmp_path):
-    """ManagerLoopHandler receives and uses a real subgraph_runner."""
+    """ManagerLoopHandler calls engine.run_subgraph when engine is provided."""
     from amplifier_module_loop_pipeline.handlers.manager_loop import ManagerLoopHandler
 
     calls: list[str] = []
 
-    async def mock_runner(node_id, ctx, graph, logs_root):
-        calls.append(node_id)
-        return Outcome(status=StageStatus.SUCCESS, notes="child done")
+    class MockEngine:
+        async def run_subgraph(self, node_id, *, context=None):
+            calls.append(node_id)
+            return Outcome(status=StageStatus.SUCCESS, notes="child done")
 
-    handler = ManagerLoopHandler(subgraph_runner=mock_runner)
+    handler = ManagerLoopHandler()
 
     graph = Graph(
         name="test",
@@ -182,7 +183,9 @@ async def test_manager_loop_uses_wired_subgraph_runner(tmp_path):
     )
 
     ctx = PipelineContext()
-    outcome = await handler.execute(graph.nodes["mgr"], ctx, graph, str(tmp_path))
+    outcome = await handler.execute(
+        graph.nodes["mgr"], ctx, graph, str(tmp_path), engine=MockEngine()
+    )
 
     assert outcome.status == StageStatus.SUCCESS
     assert "child" in calls

--- a/modules/loop-pipeline/tests/test_subgraph_runner.py
+++ b/modules/loop-pipeline/tests/test_subgraph_runner.py
@@ -11,6 +11,7 @@ from amplifier_module_loop_pipeline.engine import PipelineEngine
 from amplifier_module_loop_pipeline.graph import Edge, Graph, Node
 from amplifier_module_loop_pipeline.handlers import HandlerRegistry
 from amplifier_module_loop_pipeline.outcome import Outcome, StageStatus
+from amplifier_module_loop_pipeline.handlers.context import HandlerContext
 
 
 class CountingHandler:
@@ -53,7 +54,7 @@ async def test_run_from_executes_subgraph(tmp_path):
     """run_subgraph('a') should execute a, b, then stop at exit."""
     graph = _make_subgraph()
     counting = CountingHandler()
-    registry = HandlerRegistry()
+    registry = HandlerRegistry(HandlerContext())
     registry.register("codergen", counting)
 
     engine = PipelineEngine(
@@ -78,7 +79,7 @@ async def test_run_from_with_isolated_context(tmp_path):
     """_run_from with a separate context should not pollute the engine context."""
     graph = _make_subgraph()
     counting = CountingHandler()
-    registry = HandlerRegistry()
+    registry = HandlerRegistry(HandlerContext())
     registry.register("codergen", counting)
 
     main_context = PipelineContext()
@@ -116,7 +117,7 @@ async def test_run_from_stops_at_dead_end(tmp_path):
         ],
     )
     counting = CountingHandler()
-    registry = HandlerRegistry()
+    registry = HandlerRegistry(HandlerContext())
     registry.register("codergen", counting)
 
     engine = PipelineEngine(
@@ -137,7 +138,7 @@ async def test_run_from_stops_at_dead_end(tmp_path):
 async def test_run_from_nonexistent_node(tmp_path):
     """_run_from with a bad node ID should return FAIL."""
     graph = _make_subgraph()
-    registry = HandlerRegistry()
+    registry = HandlerRegistry(HandlerContext())
 
     engine = PipelineEngine(
         graph=graph,

--- a/modules/loop-pipeline/tests/test_substitution_count_regression.py
+++ b/modules/loop-pipeline/tests/test_substitution_count_regression.py
@@ -23,6 +23,7 @@ from amplifier_module_loop_pipeline.engine import PipelineEngine
 from amplifier_module_loop_pipeline.handlers import HandlerRegistry
 from amplifier_module_loop_pipeline.outcome import StageStatus
 from amplifier_module_loop_pipeline.validation import validate_or_raise
+from amplifier_module_loop_pipeline.handlers.context import HandlerContext
 
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
@@ -40,7 +41,7 @@ def _make_engine(dot_source: str, logs_root: str, hooks: Any = None) -> Pipeline
     graph = parse_dot(dot_source)
     validate_or_raise(graph)
     context = PipelineContext()
-    registry = HandlerRegistry()
+    registry = HandlerRegistry(HandlerContext())
     return PipelineEngine(
         graph=graph,
         context=context,

--- a/modules/loop-pipeline/tests/test_terminate_pipeline.py
+++ b/modules/loop-pipeline/tests/test_terminate_pipeline.py
@@ -1,0 +1,256 @@
+"""Tests for PipelineEngine.terminate_pipeline() helper.
+
+Spec coverage: T2.3 — terminate_pipeline() centralizes routing-termination
+Outcome construction so the invariant (thread upstream failure_reason,
+put routing message in notes) is enforced in one place rather than
+duplicated at three call sites.
+
+These tests define the expected behavior BEFORE implementation (TDD RED phase).
+"""
+
+import ast
+import textwrap
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from amplifier_module_loop_pipeline.outcome import Outcome, StageStatus
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_engine():
+    """Build a minimal PipelineEngine instance for unit-testing terminate_pipeline."""
+    from amplifier_module_loop_pipeline.context import PipelineContext
+    from amplifier_module_loop_pipeline.engine import PipelineEngine
+    from amplifier_module_loop_pipeline.graph import Graph, Node
+    from amplifier_module_loop_pipeline.handlers import HandlerRegistry
+    from amplifier_module_loop_pipeline.handlers.context import HandlerContext
+
+    graph = Graph(
+        name="test",
+        nodes={
+            "start": Node(id="start", shape="Mdiamond"),
+            "exit": Node(id="exit", shape="Msquare"),
+        },
+        edges=[],
+    )
+    engine = PipelineEngine(
+        graph=graph,
+        context=PipelineContext(),
+        handler_registry=HandlerRegistry(HandlerContext()),
+        logs_root="/tmp/test_terminate",
+    )
+    return engine
+
+
+# ---------------------------------------------------------------------------
+# Core behavior: failure_reason threading
+# ---------------------------------------------------------------------------
+
+
+def test_terminate_pipeline_preserves_upstream_failure_reason():
+    """terminate_pipeline threads upstream failure_reason into the result Outcome.
+
+    When an upstream outcome has a failure_reason, the routing-termination
+    Outcome should carry that reason as its failure_reason (not the routing
+    message).  The routing message goes into notes.
+    """
+    engine = _make_engine()
+    upstream = Outcome(
+        status=StageStatus.FAIL,
+        failure_reason="actual_handler_error",
+    )
+    result = engine.terminate_pipeline(
+        node_id="some_node",
+        upstream_outcome=upstream,
+        termination_reason="No matching edge from node 'some_node'",
+    )
+    assert result.status == StageStatus.FAIL
+    assert result.failure_reason == "actual_handler_error"
+    assert result.notes == "No matching edge from node 'some_node'"
+
+
+def test_terminate_pipeline_no_upstream_reason_uses_termination_reason():
+    """When upstream has no failure_reason, termination_reason becomes failure_reason.
+
+    This is the behavior preserved from before PR #34 for cases where no
+    handler error exists — the routing message IS the failure reason.
+    """
+    engine = _make_engine()
+    upstream = Outcome(status=StageStatus.FAIL)  # no failure_reason
+    result = engine.terminate_pipeline(
+        node_id="some_node",
+        upstream_outcome=upstream,
+        termination_reason="No matching edge from node 'some_node'",
+    )
+    assert result.status == StageStatus.FAIL
+    assert result.failure_reason == "No matching edge from node 'some_node'"
+    assert result.notes is None
+
+
+def test_terminate_pipeline_no_upstream_outcome():
+    """terminate_pipeline works with upstream_outcome=None (resume-path site).
+
+    The resume-path routing-termination site doesn't have an upstream
+    handler outcome, only a routing message.
+    """
+    engine = _make_engine()
+    result = engine.terminate_pipeline(
+        node_id="some_node",
+        upstream_outcome=None,
+        termination_reason="No matching edge from resumed node 'some_node'",
+    )
+    assert result.status == StageStatus.FAIL
+    assert result.failure_reason == "No matching edge from resumed node 'some_node'"
+    assert result.notes is None
+
+
+def test_terminate_pipeline_always_returns_fail_status():
+    """terminate_pipeline always returns FAIL status regardless of upstream."""
+    engine = _make_engine()
+    # Even if upstream succeeded, routing-termination means the pipeline fails
+    result = engine.terminate_pipeline(
+        node_id="node",
+        upstream_outcome=Outcome(status=StageStatus.SUCCESS),
+        termination_reason="Some routing message",
+    )
+    assert result.status == StageStatus.FAIL
+
+
+# ---------------------------------------------------------------------------
+# Totality: terminate_pipeline never raises
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "upstream_outcome,termination_reason",
+    [
+        # None upstream
+        (None, "reason"),
+        # Upstream with no failure_reason
+        (Outcome(status=StageStatus.FAIL), "reason"),
+        # Upstream with failure_reason
+        (Outcome(status=StageStatus.FAIL, failure_reason="handler_err"), "reason"),
+        # Empty termination_reason
+        (None, ""),
+        # Unicode termination_reason
+        (None, "réseau de terminaison\u2019s"),
+        # Very long reason
+        (None, "x" * 10_000),
+        # Upstream with notes
+        (
+            Outcome(
+                status=StageStatus.FAIL,
+                failure_reason="err",
+                notes="some notes",
+            ),
+            "routing message",
+        ),
+        # Skipped upstream
+        (Outcome(status=StageStatus.SKIPPED, failure_reason="skip_reason"), "msg"),
+        # Success upstream
+        (Outcome(status=StageStatus.SUCCESS), "routing msg"),
+    ],
+)
+def test_terminate_pipeline_totality(upstream_outcome, termination_reason):
+    """terminate_pipeline never raises across the full input space.
+
+    This is the totality test required by the spec: the helper must be
+    safe to call from any routing-termination site without try/except.
+    """
+    engine = _make_engine()
+    # Must not raise
+    result = engine.terminate_pipeline(
+        node_id="n",
+        upstream_outcome=upstream_outcome,
+        termination_reason=termination_reason,
+    )
+    assert isinstance(result, Outcome)
+    assert result.status == StageStatus.FAIL
+
+
+# ---------------------------------------------------------------------------
+# Sole-caller AST guard: no inline routing-termination Outcome in engine.py
+# ---------------------------------------------------------------------------
+
+
+def test_no_inline_routing_termination_outcome_in_engine_py():
+    """AST guard: engine.py has no inline routing-termination Outcome constructions.
+
+    After the T2.3 refactor, the ONLY place that constructs
+    ``Outcome(status=StageStatus.FAIL, ...)`` with a routing-termination
+    reason string like "No matching edge from" is inside
+    ``terminate_pipeline()``.
+
+    This test walks the AST of engine.py and asserts that no top-level
+    call site (outside of terminate_pipeline's body) constructs an Outcome
+    whose failure_reason literal matches the routing-termination pattern.
+    """
+    engine_path = (
+        Path(__file__).parent.parent
+        / "amplifier_module_loop_pipeline"
+        / "engine.py"
+    )
+    source = engine_path.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    _ROUTING_PATTERNS = (
+        "No matching edge from",
+        "No matching edge from resumed node",
+        "No matching edge from skipped node",
+    )
+
+    # Find terminate_pipeline's body range so we can exclude it
+    # (the helper is allowed to construct the Outcome — that's the point)
+    terminate_pipeline_linenos: set[int] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "terminate_pipeline":
+            for child in ast.walk(node):
+                if hasattr(child, "lineno"):
+                    terminate_pipeline_linenos.add(child.lineno)
+
+    # Find all Outcome(...) calls with routing-termination patterns
+    violations: list[int] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        # Is this an Outcome(...) call?
+        func = node.func
+        if not (isinstance(func, ast.Name) and func.id == "Outcome"):
+            continue
+        # Is the call site OUTSIDE of terminate_pipeline?
+        if hasattr(node, "lineno") and node.lineno in terminate_pipeline_linenos:
+            continue
+        # Does it have a failure_reason kwarg that matches a routing-termination pattern?
+        for kw in node.keywords:
+            if kw.arg != "failure_reason":
+                continue
+            if not isinstance(kw.value, (ast.Constant, ast.JoinedStr)):
+                continue
+            # Check string constant
+            if isinstance(kw.value, ast.Constant) and isinstance(
+                kw.value.value, str
+            ):
+                for pat in _ROUTING_PATTERNS:
+                    if pat in kw.value.value:
+                        violations.append(node.lineno)
+            # Check f-string (JoinedStr) - check if any constant part matches
+            if isinstance(kw.value, ast.JoinedStr):
+                for part in kw.value.values:
+                    if isinstance(part, ast.Constant) and isinstance(
+                        part.value, str
+                    ):
+                        for pat in _ROUTING_PATTERNS:
+                            if pat in part.value:
+                                violations.append(node.lineno)
+
+    assert violations == [], (
+        f"engine.py has inline routing-termination Outcome constructions at "
+        f"lines {violations}. These must be replaced with terminate_pipeline() calls. "
+        f"Only the body of terminate_pipeline() may construct these Outcomes."
+    )

--- a/modules/loop-pipeline/tests/test_transforms.py
+++ b/modules/loop-pipeline/tests/test_transforms.py
@@ -19,6 +19,7 @@ from amplifier_module_loop_pipeline.transforms import (
     expand_variables,
 )
 from amplifier_module_loop_pipeline.validation import validate_or_raise
+from amplifier_module_loop_pipeline.handlers.context import HandlerContext
 
 
 def _make_graph(**overrides) -> Graph:
@@ -248,7 +249,7 @@ def _make_engine(
     graph = parse_dot(dot_source)
     validate_or_raise(graph)
     context = PipelineContext()
-    registry = HandlerRegistry(backend=backend)
+    registry = HandlerRegistry(HandlerContext(backend=backend))
     return PipelineEngine(
         graph=graph,
         context=context,
@@ -283,7 +284,7 @@ class TestEngineTransformIntegration:
         context.set("graph.goal", "build auth")
         apply_transforms(graph, context)
         validate_or_raise(graph)
-        registry = HandlerRegistry(backend=backend)
+        registry = HandlerRegistry(HandlerContext(backend=backend))
         engine = PipelineEngine(
             graph=graph,
             context=context,
@@ -313,7 +314,7 @@ class TestEngineTransformIntegration:
         context = PipelineContext()
         apply_transforms(graph, context)
         validate_or_raise(graph)
-        registry = HandlerRegistry(backend=backend)
+        registry = HandlerRegistry(HandlerContext(backend=backend))
         engine = PipelineEngine(
             graph=graph,
             context=context,
@@ -357,7 +358,7 @@ class TestTransformOrdering:
         )
         validate_or_raise(graph)
         context = PipelineContext()
-        registry = HandlerRegistry(backend=backend)
+        registry = HandlerRegistry(HandlerContext(backend=backend))
         engine = PipelineEngine(
             graph=graph,
             context=context,

--- a/modules/loop-pipeline/tests/test_unified_llm_wiring.py
+++ b/modules/loop-pipeline/tests/test_unified_llm_wiring.py
@@ -515,20 +515,26 @@ async def test_direct_backend_report_outcome_terminal_action_empty_text():
     """
     report_tool = _MockReportOutcomeTool()
 
-    mock_client = _MockUnifiedClient([
-        # Round 1: model calls report_outcome as its terminal action
-        _make_tool_call_response([{
-            "id": "tc-1",
-            "name": "report_outcome",
-            "args": {
-                "status": "fail",
-                "failure_reason": "quality gate failed",
-                "context_updates": {"quality_feedback": "fix X"},
-            },
-        }]),
-        # Round 2: empty text — no follow-up turn (extended thinking)
-        _make_text_response(""),
-    ])
+    mock_client = _MockUnifiedClient(
+        [
+            # Round 1: model calls report_outcome as its terminal action
+            _make_tool_call_response(
+                [
+                    {
+                        "id": "tc-1",
+                        "name": "report_outcome",
+                        "args": {
+                            "status": "fail",
+                            "failure_reason": "quality gate failed",
+                            "context_updates": {"quality_feedback": "fix X"},
+                        },
+                    }
+                ]
+            ),
+            # Round 2: empty text — no follow-up turn (extended thinking)
+            _make_text_response(""),
+        ]
+    )
 
     backend = DirectProviderBackend(
         provider=object(),
@@ -551,23 +557,38 @@ async def test_direct_backend_report_outcome_no_cross_node_bleed():
     backend._tools = {"report_outcome": report_tool}
 
     # Node 1: report_outcome called as terminal tool, result.text empty
-    backend._unified_client = _MockUnifiedClient([
-        _make_tool_call_response([{
-            "id": "tc-1",
-            "name": "report_outcome",
-            "args": {"status": "fail", "failure_reason": "first node failed"},
-        }]),
-        _make_text_response(""),
-    ])
-    node1 = _make_node(id="node1", attrs={"llm_provider": "test", "llm_model": "test-model"})
+    backend._unified_client = _MockUnifiedClient(
+        [
+            _make_tool_call_response(
+                [
+                    {
+                        "id": "tc-1",
+                        "name": "report_outcome",
+                        "args": {
+                            "status": "fail",
+                            "failure_reason": "first node failed",
+                        },
+                    }
+                ]
+            ),
+            _make_text_response(""),
+        ]
+    )
+    node1 = _make_node(
+        id="node1", attrs={"llm_provider": "test", "llm_model": "test-model"}
+    )
     result1 = await backend.run(node1, "task 1", _make_context())
 
     assert result1.status == StageStatus.FAIL
     assert result1.failure_reason == "first node failed"
 
     # Node 2: no tool call, plain text response — must NOT inherit node 1's verdict
-    backend._unified_client = _MockUnifiedClient([_make_text_response("plain text done")])
-    node2 = _make_node(id="node2", attrs={"llm_provider": "test", "llm_model": "test-model"})
+    backend._unified_client = _MockUnifiedClient(
+        [_make_text_response("plain text done")]
+    )
+    node2 = _make_node(
+        id="node2", attrs={"llm_provider": "test", "llm_model": "test-model"}
+    )
     result2 = await backend.run(node2, "task 2", _make_context())
 
     assert result2.status == StageStatus.SUCCESS

--- a/modules/loop-pipeline/tests/test_unified_substitution.py
+++ b/modules/loop-pipeline/tests/test_unified_substitution.py
@@ -23,6 +23,7 @@ from amplifier_module_loop_pipeline.handlers import HandlerRegistry
 from amplifier_module_loop_pipeline.outcome import StageStatus
 from amplifier_module_loop_pipeline.substitution import substitute_context
 from amplifier_module_loop_pipeline.validation import validate_or_raise
+from amplifier_module_loop_pipeline.handlers.context import HandlerContext
 
 
 class EventCapture:
@@ -37,7 +38,7 @@ def _make_engine(dot_source: str, logs_root: str, hooks: Any = None) -> Pipeline
     graph = parse_dot(dot_source)
     validate_or_raise(graph)
     context = PipelineContext()
-    registry = HandlerRegistry()
+    registry = HandlerRegistry(HandlerContext())
     return PipelineEngine(
         graph=graph,
         context=context,

--- a/modules/loop-pipeline/tests/test_validation.py
+++ b/modules/loop-pipeline/tests/test_validation.py
@@ -662,7 +662,9 @@ def test_ellipse_removed_from_shape_to_handler():
     """ellipse shape must NOT be in SHAPE_TO_HANDLER (removed — was never used)."""
     from amplifier_module_loop_pipeline.validation import SHAPE_TO_HANDLER
 
-    assert "ellipse" not in SHAPE_TO_HANDLER, "ellipse should be removed from SHAPE_TO_HANDLER"
+    assert "ellipse" not in SHAPE_TO_HANDLER, (
+        "ellipse should be removed from SHAPE_TO_HANDLER"
+    )
 
 
 def test_diamond_maps_to_conditional_handler():


### PR DESCRIPTION
Wave 1 of the resolve ecosystem restoration (see RESOLVE-MIGRATION-GUIDE.md
in the workspace for full context). Two related noun-introductions in one
branch:

## T2.1 — `HandlerContext` frozen dataclass

**Problem**: `HandlerRegistry.__init__(**kwargs: Any)` defeated pyright.
Three required deps (`backend`, `interviewer`, `subgraph_runner`) each
historically triggered an n-site wiring obligation — this hotspot was
bitten 5 times before #250's refactor.

**Fix**: Required dependencies are now typed-required fields on a new
`HandlerContext` frozen dataclass. `HandlerRegistry()` without a context
is now a pyright error at write-time and a `TypeError` at runtime — the
`**kwargs` escape hatch is gone.

**Files**: `handlers/context.py` (new), `handlers/__init__.py` (rewired),
38 test files updated to wrap kwargs in `HandlerContext()`.

## T2.3 — `terminate_pipeline()` sole-caller helper

**Problem**: Three sites in `engine.py` constructed a fresh `Outcome(FAIL, ...)`
at routing-termination boundaries (normal-path, resume-path, skip-path).
PR #34 fixed the lossy-reconstruction at all three sites but the pattern
remained duplicated — exactly the verb-invariant the architecture wants to
retire.

**Fix**: `PipelineEngine.terminate_pipeline()` is now the only API for
routing-termination Outcome construction. Threads `upstream_outcome.failure_reason`
automatically. AST-level sole-caller guard prevents reintroduction.

**Invariant**: The helper is **total** — it never raises across the full
input space (tested explicitly).

**Files**: `engine.py` (helper added at ~line 1306, 3 inline sites
migrated), `tests/test_terminate_pipeline.py` (new — totality test +
AST sole-caller guard + behavior tests).

## Caller migration

In-tree: all 38 affected test files updated in this PR. Out-of-tree:
the migration guide at `RESOLVE-MIGRATION-GUIDE.md` (workspace root)
has paste-able before/after code patterns.

**Cross-repo impact** (known sites, must update in follow-up PRs after
this merges):
- `amplifier-resolver-dot-graph/src/amplifier_resolver_dot_graph/resolver.py:957` — `HandlerRegistry(backend=backend)` → wrap in `HandlerContext`
- `amplifier-resolver-dot-graph/src/amplifier_resolver_dot_graph/resolver.py:965-969` — drop `subgraph_runner=` (Wave 0 leftover) + wrap in `HandlerContext`
- `amplifier-resolver-orchestrator` — no changes needed
- `amplifier-resolver-understudy` — no changes needed

## Verification

- 28 new tests (14 T2.1 + 14 T2.3), all GREEN.
- Full suite: 1110 passed, 7 skipped, 2 pre-existing failures
  (`test_outputs_attribute.py` — unrelated to this work, confirmed
  present on main before our changes).
- ruff check + pyright: clean for touched files.

## No backwards-compat

Per design constraint: no fallback paths, no compat shims. In-tree
callers updated atomically; out-of-tree callers follow the migration
guide.

## Related

- Wave 0: PRs #33, #34, #35, #36 (already landed)
- Wave 2 (T2.4 RunIdentity): coming next
- Wave 3 (T3.1 HostPath/DTUPath): coming next
- Full design rationale: workspace `RESOLVE-MIGRATION-GUIDE.md`