### PR TITLE
fix(engine): per-branch backend/session isolation for nested execution in parallel branches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,17 @@ Unit tests alone are insufficient for engine and handler changes. Past bugs have
 - **`tripleoctagon` (fan-in) special-case**: `engine.py` (around line 704) special-cases `tripleoctagon` such that the subgraph runner stops there. If you change subgraph termination semantics, this is the place that breaks first.
 - **Per-branch event contract**: per-branch events emitted from `ParallelHandler` bubble to the main events stream as `pipeline:node_start` / `pipeline:node_complete` with a `via_parallel=True` marker. Downstream observability (and at least one bundle outside this repo) relies on this marker. Don't break that contract silently.
 - **False-positive `ContractViolation`**: there is a known historical class of false-positive ContractViolation events triggered by the main loop re-firing after a handler-internal dispatch. Tests in `tests/test_contract_violation_event.py` and `tests/test_parallel_branch_observability.py` exist to lock this down — read them before changing the affected paths.
+- **`HandlerRegistry` construction requires a `HandlerContext`** (#37): a new handler dependency is a new FIELD on `HandlerContext`, never a `**kwargs` entry. This exact wiring was bitten 5 times before it was made type-required.
+- **Routing-termination outcomes go through `engine.terminate_pipeline()`** (#37): never construct a fresh `Outcome(FAIL, ...)` inline at a no-matching-edge boundary — it drops the handler's `failure_reason`.
+- **Checkpoint resume is identity-gated via `RunIdentity`** (#39): never read run state keyed only by `logs_root`. Mismatched identity must hard-fail, never silently restart — side-effecting nodes would double-apply.
+- **DOT parser normalizes IDs once at the tokenizer entry**, not per-consumer.
+
+## Recurring bug classes — read before designing or reviewing
+
+This ecosystem has five documented recurring bug species: incomplete assembly, lossy reconstruction, unscoped shared state, partial-coverage symmetry, and aspirational contract. The pitfalls above are scar-tissue instances of them.
+
+- **Designing a change**: read [`docs/designs/RECURRING-BUG-CLASSES.md`](docs/designs/RECURRING-BUG-CLASSES.md).
+- **Reviewing a PR**: read [`docs/designs/CODE-REVIEW-CHECKLIST.md`](docs/designs/CODE-REVIEW-CHECKLIST.md).
 
 ## Spec authority
 

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/backend.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/backend.py
@@ -137,13 +137,38 @@ class AmplifierBackend:
             return tool
 
         new._tools = {k: _clone_tool(v) for k, v in self._tools.items()}
+        # Inherit resolved spawn capability — the capability is a stateless
+        # function from the shared _coordinator, so sharing the reference is as
+        # safe as the clone already sharing _coordinator.  Inheriting prevents
+        # concurrent first-resolution when N branch clones run under
+        # asyncio.gather (each clone would otherwise race to call
+        # _coordinator.get_capability("session.spawn") simultaneously, causing
+        # some branches to receive None and fall to the tool-loop fallback).
+        new._spawn_fn = self._spawn_fn
+        new._spawn_checked = self._spawn_checked
         # Fresh mutable state
-        new._spawn_fn = None
-        new._spawn_checked = False
         new._session_pool = {}
         new._completed_nodes = {}
         new._last_node_id = None
         return new
+
+    def ensure_spawn_resolved(self) -> None:
+        """Resolve the session.spawn capability in place, once.
+
+        Call this on the parent backend before creating branch clones via
+        ``clone()``.  This guarantees that all clones inherit an already-
+        resolved ``_spawn_fn`` (and ``_spawn_checked = True``) instead of
+        performing a concurrent first-resolution when N branch engines each
+        hit the lazy-check block in ``run()`` simultaneously under
+        ``asyncio.gather``.
+
+        Idempotent: safe to call multiple times; subsequent calls are no-ops.
+        """
+        if not self._spawn_checked:
+            cap = self._coordinator.get_capability("session.spawn")
+            if cap is not None:
+                self._spawn_fn = cap
+            self._spawn_checked = True
 
     async def run(
         self,

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py
@@ -146,6 +146,21 @@ class PipelineEngine:
             RuntimeError: If called on an engine that is itself a branch clone
                 (nested cloning is not permitted; only the top-level engine clones).
         """
+        # Resolve spawn capability on the parent backend BEFORE cloning so that
+        # branch clones inherit an already-resolved _spawn_fn instead of
+        # performing a concurrent first-resolution under asyncio.gather.
+        # Without this, N parallel branches each receive a fresh clone with
+        # _spawn_fn=None and all race to call get_capability simultaneously,
+        # causing some branches to fall back to the tool loop (session_id: None)
+        # and silently break fidelity=full.
+        # Use getattr so that backends without the method (e.g. test stubs) are
+        # skipped safely — the hasattr + call pattern isn't type-safe on
+        # get_backend()'s "object | None" return type.
+        parent_backend = self.handler_registry.get_backend()
+        ensure_fn = getattr(parent_backend, "ensure_spawn_resolved", None)
+        if ensure_fn is not None:
+            ensure_fn()
+
         clone = PipelineEngine(
             graph=self.graph,
             context=context,

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py
@@ -88,7 +88,7 @@ class PipelineEngine:
             str, int
         ] = {}  # per-node execution count (graph-level visits)
         self._fidelity_degraded_hop: bool = False
-        self._checkpoint_path = os.path.join(logs_root, "checkpoint.json")
+        self._checkpoint_path: str | None = os.path.join(logs_root, "checkpoint.json")
         self.artifact_store = ArtifactStore(base_dir=logs_root)
 
         # M1/M2 (R12): Output table + failed-outputs propagation table.
@@ -98,6 +98,72 @@ class PipelineEngine:
         # came from a failed or skipped predecessor.  Cleared on retry (CR-3).
         self._output_table: dict[str, frozenset[str]] = build_output_table(graph)
         self.failed_outputs: dict[str, str] = {}
+
+        # S5: Branch-clone marker and discriminator.
+        # Set by clone_for_branch() to prevent run() from being called on a
+        # branch engine.  _branch_id is threaded into events emitted from this
+        # engine so concurrent-branch logs are sortable (S4).
+        self._is_branch_clone: bool = False
+        self._branch_id: str | None = None
+
+    def clone_for_branch(self, *, context: PipelineContext) -> "PipelineEngine":
+        """Create a branch-isolated clone of this engine for parallel execution.
+
+        Each concurrent parallel branch must have its own engine so that
+        ``run_subgraph`` uses an isolated ``handler_registry`` (and therefore
+        an isolated backend ``_session_pool`` / ``_completed_nodes``).
+
+        Split table (critic-corrected, implement exactly):
+          ISOLATED per branch (cloned):
+            context          — caller must pass ``context.clone()``
+            handler_registry — ``clone_for_branch()`` gives fresh backend state
+            node_outcomes    — auto-fresh by __init__
+            completed_nodes  — auto-fresh by __init__
+            iteration_count  — auto-fresh by __init__
+            _node_execution_counts — auto-fresh by __init__
+            _fidelity_degraded_hop — auto-fresh by __init__
+            failed_outputs   — auto-fresh by __init__
+
+          SHARED by reference (immutable or shared semantics):
+            graph            — immutable post-load
+            logs_root        — shared str, no mutable state
+            hooks            — events surface on one stream
+            _cancel_event    — cancel propagates across all branches
+            artifact_store   — CRITICAL (C1): share the L-12 lock and
+                               cross-branch artifact visibility
+            _output_table    — pure function of graph, avoid re-derivation
+
+          DISABLED on clones:
+            _checkpoint_path — None; S5 guard prevents run() on branch clones
+
+        Args:
+            context: Branch-isolated context (caller must pass ``context.clone()``).
+
+        Returns:
+            A new ``PipelineEngine`` marked as a branch clone.
+
+        Raises:
+            RuntimeError: If called on an engine that is itself a branch clone
+                (nested cloning is not permitted; only the top-level engine clones).
+        """
+        clone = PipelineEngine(
+            graph=self.graph,
+            context=context,
+            handler_registry=self.handler_registry.clone_for_branch(),
+            logs_root=self.logs_root,
+            hooks=self.hooks,
+            cancel_event=self._cancel_event,
+        )
+        # C1: share the parent's ArtifactStore (preserves L-12 lock and visibility)
+        clone.artifact_store = self.artifact_store
+        # Avoid wasteful re-derivation (output table is a pure function of graph)
+        clone._output_table = self._output_table
+        # S5: disable checkpointing on branch clones
+        clone._checkpoint_path = None
+        # S4 + S5: mark as branch clone and assign a discriminator for log sorting
+        clone._is_branch_clone = True
+        clone._branch_id = f"branch@{id(clone):#x}"
+        return clone
 
     def _check_cancelled(self) -> bool:
         """Check if cancellation has been requested via the cancel event."""
@@ -116,7 +182,25 @@ class PipelineEngine:
 
         Returns:
             The final Outcome of the pipeline run.
+
+        Raises:
+            RuntimeError: If called on a branch-clone engine (S5 guard).
+                Branch engines are driven by ``run_subgraph`` only; calling
+                ``run()`` on them would silently attempt checkpoint
+                resume/save against the shared ``logs_root``, corrupting
+                the parent engine's checkpoint state.
         """
+        # S5: Branch-clone guard — run() must never be called on a branch engine.
+        # Branch engines are driven exclusively via run_subgraph().
+        # Silent checkpoint resume/save on a branch would corrupt the parent's
+        # checkpoint, producing wrong output non-deterministically.
+        if self._is_branch_clone:
+            raise RuntimeError(
+                "run() must not be called on a branch-clone engine; "
+                "branch engines are driven by run_subgraph() only. "
+                "Create a top-level PipelineEngine for full pipeline execution."
+            )
+
         pipeline_start_time = time.monotonic()
 
         # Initialize context with graph attributes
@@ -1012,7 +1096,7 @@ class PipelineEngine:
 
         Spec Section 5.3: Resume behavior, T2.4 (RunIdentity hard-fail).
         """
-        if not os.path.exists(self._checkpoint_path):
+        if self._checkpoint_path is None or not os.path.exists(self._checkpoint_path):
             return False
 
         try:
@@ -1120,6 +1204,8 @@ class PipelineEngine:
             logs=self.context.get_logs(),  # L-7: include logs in checkpoint
             identity=RunIdentity.from_graph(self.graph),  # T2.4: scope to this graph
         )
+        if self._checkpoint_path is None:
+            return  # S5: branch clones never checkpoint (run() guard prevents this)
         save_checkpoint(cp, self._checkpoint_path)
 
     # -- Run directory helpers -----------------------------------------------
@@ -1193,9 +1279,11 @@ class PipelineEngine:
 
         async def run_branch(target_node_id: str) -> dict[str, Any]:
             branch_context = self.context.clone()
-            branch_registry = self.handler_registry.clone_for_branch()
+            # Move 1: give each branch its own engine so run_subgraph uses an
+            # isolated handler_registry (and therefore isolated backend state).
+            branch_engine = self.clone_for_branch(context=branch_context)
             node = self.graph.nodes[target_node_id]
-            handler = branch_registry.get(node)
+            handler = branch_engine.handler_registry.get(node)
             handler_type = node.type or node.shape
 
             # Increment per-node execution count for branch nodes
@@ -1226,7 +1314,7 @@ class PipelineEngine:
                     self.logs_root,
                     retry_policy,
                     hooks=self.hooks,
-                    engine=self,
+                    engine=branch_engine,  # S3: branch engine; outcome recorded below
                 )
             except Exception as exc:
                 outcome = Outcome(
@@ -1236,7 +1324,8 @@ class PipelineEngine:
 
             node_duration = (time.monotonic() - node_start) * 1000
 
-            # Record completion in the main engine state
+            # S3: Record completion in the PARENT engine's state so downstream
+            # edge-selection (select_edge) and fan-in can read branch outcomes.
             self.completed_nodes.append(target_node_id)
             self.node_outcomes[target_node_id] = outcome
 
@@ -1714,8 +1803,15 @@ class PipelineEngine:
     # -- Event helpers -------------------------------------------------------
 
     async def _emit(self, event_name: str, data: dict[str, Any]) -> None:
-        """Emit an event via hooks, if provided."""
+        """Emit an event via hooks, if provided.
+
+        S4: If this engine is a branch clone, injects ``branch_id`` into the
+        event payload so concurrent-branch logs can be disambiguated.  The
+        discriminator is ``None`` for the top-level engine (no overhead).
+        """
         if self.hooks is not None:
+            if self._branch_id is not None:
+                data = {**data, "branch_id": self._branch_id}
             await self.hooks.emit(event_name, data)
 
     async def _emit_complete(self, outcome: Outcome, start_time: float) -> None:

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/__init__.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/__init__.py
@@ -128,15 +128,34 @@ class HandlerRegistry:
             )
         return self._handlers[handler_type]
 
-    def clone_for_branch(self) -> HandlerRegistry:
+    def get_backend(self) -> "object | None":
+        """Return the backend from the codergen handler, if present.
+
+        Used by child-engine builders (PipelineHandler, ManagerLoopHandler)
+        to seed child registries from the currently executing engine's backend
+        rather than a captured ``self._backend`` reference.  This ensures that
+        folder nodes inside a parallel branch inherit the branch-isolated
+        backend rather than the original parent backend (Move 2).
+        """
+        from .codergen import CodergenHandler
+
+        codergen = self._handlers.get("codergen")
+        if isinstance(codergen, CodergenHandler):
+            return codergen._backend
+        return None
+
+    def clone_for_branch(self) -> "HandlerRegistry":
         """Create a branch-isolated copy of this registry.
 
         Shallow-copies the handlers dict and replaces the codergen handler
-        with a new instance backed by a cloned backend.  All other handlers
-        are shared (they are stateless).
+        with a new instance backed by a cloned backend.  The pipeline handler
+        is also replaced with a fresh instance (mutable ``_subgraph_runs``).
+        All other handlers are shared (they are stateless or their backend
+        dependency is severed by Move 2).
 
-        Used by ``_execute_parallel_fan_out`` so each concurrent branch
-        gets its own backend mutable state.
+        Called by ``PipelineEngine.clone_for_branch`` so each concurrent
+        parallel branch gets its own backend mutable state (``_session_pool``,
+        ``_completed_nodes``).
         """
         from .codergen import CodergenHandler
         from .pipeline import PipelineHandler
@@ -145,7 +164,9 @@ class HandlerRegistry:
         new._ctx = self._ctx  # frozen dataclass — safe to share
         new._handlers = dict(self._handlers)
 
-        # Replace codergen with a clone that has its own backend state
+        # Replace codergen with a clone that has its own backend state.
+        # The cloned backend carries fresh _session_pool and _completed_nodes
+        # so concurrent branches cannot cross-pollute session state.
         original_codergen = self._handlers.get("codergen")
         if isinstance(original_codergen, CodergenHandler):
             backend = original_codergen._backend
@@ -153,7 +174,11 @@ class HandlerRegistry:
                 cloned_backend = backend.clone()
                 new._handlers["codergen"] = CodergenHandler(backend=cloned_backend)
 
-        # Replace pipeline handler with a fresh instance (has mutable _subgraph_runs)
+        # Replace pipeline handler with a fresh instance (has mutable _subgraph_runs).
+        # Note: after Move 2, PipelineHandler.execute seeds its child registry
+        # from the executing engine's handler_registry.get_backend() instead of
+        # self._backend, so the backend field here is only a fallback for the
+        # no-engine path.
         original_pipeline = self._handlers.get("pipeline")
         if isinstance(original_pipeline, PipelineHandler):
             new._handlers["pipeline"] = PipelineHandler(

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/manager_loop.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/manager_loop.py
@@ -195,7 +195,13 @@ class ManagerLoopHandler:
             try:
                 if child_dotfile:
                     child_outcome = await self._run_child_dotfile(
-                        child_dotfile, child_context, graph, logs_root, node.id, cycle
+                        child_dotfile,
+                        child_context,
+                        graph,
+                        logs_root,
+                        node.id,
+                        cycle,
+                        engine=engine,  # Move 2: pass engine so child seeds from branch backend
                     )
                 else:
                     assert engine is not None
@@ -267,11 +273,18 @@ class ManagerLoopHandler:
         logs_root: str,
         manager_node_id: str,
         cycle: int,
+        engine: "PipelineEngine | None" = None,
     ) -> Outcome:
         """Run a child pipeline from an external DOT file.
 
         Mirrors PipelineHandler-style child engine execution:
         resolve path, read DOT, parse, create child engine, run.
+
+        Args:
+            engine: The currently executing engine (passed from execute()).
+                Move 2: used to seed the child registry from the engine's
+                backend (which may be a branch-isolated clone) rather than
+                the captured self._backend.
         """
         # Lazy imports to avoid circular dependencies
         from ..engine import PipelineEngine
@@ -309,15 +322,26 @@ class ManagerLoopHandler:
         )
         os.makedirs(child_logs, exist_ok=True)
 
-        # Create child HandlerRegistry and PipelineEngine
+        # Create child HandlerRegistry and PipelineEngine.
+        # Move 2: seed from the executing engine's backend (which may be a
+        # branch-isolated clone) rather than the captured self._backend.
+        # This ensures manager child pipelines inside a parallel branch
+        # inherit the branch's isolated backend state.
+        # Verified safe: a manager handler always receives the same backend
+        # as its parent; _handler_registry_factory is None on production paths.
         if self._handler_registry_factory is not None:
             child_registry = self._handler_registry_factory()
         else:
             from .context import HandlerContext
 
+            effective_backend = (
+                engine.handler_registry.get_backend()
+                if engine is not None
+                else self._backend
+            )
             child_registry = HandlerRegistry(
                 HandlerContext(
-                    backend=self._backend,
+                    backend=effective_backend,
                     hooks=self._hooks,
                     cancel_event=self._cancel_event,
                 )

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/parallel.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/parallel.py
@@ -140,9 +140,21 @@ class ParallelHandler:
                     )
                 else:
                     try:
-                        outcome = await engine.run_subgraph(
-                            target_node_id, context=branch_context
-                        )
+                        # Move 1: give each branch its own engine so run_subgraph
+                        # uses an isolated handler_registry (and therefore isolated
+                        # backend _session_pool / _completed_nodes per branch).
+                        # Fall back to the parent engine for mock/stub engines used
+                        # in unit tests that predate clone_for_branch.
+                        clone_fn = getattr(engine, "clone_for_branch", None)
+                        if clone_fn is not None:
+                            branch_engine = clone_fn(context=branch_context)
+                            outcome = await branch_engine.run_subgraph(
+                                target_node_id, context=branch_context
+                            )
+                        else:
+                            outcome = await engine.run_subgraph(
+                                target_node_id, context=branch_context
+                            )
                     except Exception as e:
                         logger.warning(
                             "Branch %s raised exception: %s", target_node_id, e

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/pipeline.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/pipeline.py
@@ -167,15 +167,31 @@ class PipelineHandler:
         child_logs = os.path.join(logs_root, f"subgraph_{node.id}")
         os.makedirs(child_logs, exist_ok=True)
 
-        # (8) Create child HandlerRegistry (no closure, no rewire — engine passes self via execute(engine=...))
+        # (8) Create child HandlerRegistry.
+        # Move 2: seed the child backend from the EXECUTING ENGINE's registry
+        # rather than the captured self._backend.  This ensures that a folder
+        # node inside a parallel branch inherits the branch's isolated backend
+        # (from clone_for_branch) instead of the original parent backend.
+        # Verified safe: a folder handler always receives the same backend as
+        # its parent (per-node model selection uses _ProviderPreference on
+        # that one backend, not distinct instances); _handler_registry_factory
+        # is None on every production path.
         if self._handler_registry_factory is not None:
             child_registry = self._handler_registry_factory()
         else:
             from .context import HandlerContext
 
+            # Prefer the executing engine's backend so branch isolation propagates
+            # into child pipelines.  Fall back to self._backend when engine is None
+            # (should not happen in production; kept for test-harness compatibility).
+            effective_backend = (
+                engine.handler_registry.get_backend()
+                if engine is not None
+                else self._backend
+            )
             child_registry = HandlerRegistry(
                 HandlerContext(
-                    backend=self._backend,
+                    backend=effective_backend,
                     hooks=self._hooks,
                     cancel_event=self._cancel_event,
                     interviewer=self._interviewer,

--- a/modules/loop-pipeline/tests/test_backend_clone.py
+++ b/modules/loop-pipeline/tests/test_backend_clone.py
@@ -30,7 +30,13 @@ class TestAmplifierBackendClone:
     """Tests for AmplifierBackend.clone()."""
 
     def test_clone_has_empty_mutable_state(self):
-        """Cloned backend starts with fresh mutable state."""
+        """Cloned backend starts with fresh mutable state.
+
+        _session_pool, _completed_nodes, and _last_node_id are always fresh.
+        _spawn_fn and _spawn_checked are INHERITED from the parent (not reset)
+        so branch clones never perform a concurrent first-resolution of
+        session.spawn under asyncio.gather.
+        """
         original = _make_backend()
         # Dirty the original's mutable state
         original._session_pool["thread-1"] = "session-abc"
@@ -43,7 +49,9 @@ class TestAmplifierBackendClone:
         assert clone._session_pool == {}
         assert clone._completed_nodes == {}
         assert clone._last_node_id is None
-        assert clone._spawn_checked is False
+        # _spawn_checked is inherited (not reset) to prevent concurrent
+        # first-resolution; see test_backend_clone_spawn_inheritance.py
+        assert clone._spawn_checked is True
 
     def test_clone_shares_immutable_refs(self):
         """Cloned backend shares the same immutable reference objects."""

--- a/modules/loop-pipeline/tests/test_backend_clone_spawn_inheritance.py
+++ b/modules/loop-pipeline/tests/test_backend_clone_spawn_inheritance.py
@@ -1,0 +1,268 @@
+"""Tests for clone-spawn concurrency regression fix.
+
+Background
+----------
+After the parallel-branch isolation fix (Move 1+2), each branch gets a fresh
+``AmplifierBackend`` clone via ``backend.clone()``.  The previous implementation
+reset ``_spawn_fn = None`` and ``_spawn_checked = False`` on each clone, so N
+concurrent branches all attempted to resolve ``session.spawn`` independently
+under ``asyncio.gather``.
+
+When those concurrent first-resolution calls collide on the shared coordinator,
+some branches receive ``None`` back (or raise) and fall to the tool-loop
+fallback path, setting ``session_id = None`` and never writing to
+``_session_pool``.  The result: ``fidelity=full`` is silently broken for every
+parallel branch — the DTU e2e run showed both seed nodes with ``session_id:
+None`` when branches ran concurrently but a valid ``session_id`` on sequential
+execution.
+
+Fix: "resolve once, then share"
+--------------------------------
+1. ``backend.clone()`` inherits ``_spawn_fn`` and ``_spawn_checked`` from the
+   parent instead of resetting them.  The capability is a stateless function
+   from the shared ``_coordinator`` — sharing the resolved reference is as safe
+   as the clone already sharing ``_coordinator`` itself.
+
+2. A new ``ensure_spawn_resolved()`` method resolves spawn in-place on the
+   parent (idempotent, synchronous — mirrors the lazy check in ``run()``).
+
+3. ``PipelineEngine.clone_for_branch()`` calls ``ensure_spawn_resolved()`` on
+   the parent backend before ``handler_registry.clone_for_branch()`` creates
+   any clones, so all clones inherit an already-resolved ``_spawn_fn`` and
+   ``_spawn_checked = True``.
+
+TDD status
+----------
+RED on the isolation branch before this commit:
+  - ``test_clone_inherits_resolved_spawn_fn``:  clone() resets to None/False
+  - ``test_clone_inherits_unresolved_spawn_state``:  passes trivially (no change needed)
+  - ``test_ensure_spawn_resolved_exists_and_resolves``:  AttributeError (method absent)
+  - ``test_ensure_spawn_resolved_is_idempotent``:  AttributeError (method absent)
+  - ``test_get_capability_called_exactly_once_across_n_clones``:  N+1 calls, not 1
+
+GREEN after this commit (all five).
+
+Spec coverage: FID-001 (fidelity=full session reuse), PAR-001 (parallel isolation).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from amplifier_module_loop_pipeline.backend import AmplifierBackend
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_backend(
+    *, resolved: bool = False
+) -> tuple[AmplifierBackend, MagicMock, MagicMock]:
+    """Return (backend, coordinator, spawn_fn).
+
+    If *resolved* is True, the backend's spawn capability is pre-resolved so
+    ``_spawn_fn`` is set and ``_spawn_checked`` is True.
+    """
+    coordinator = MagicMock()
+    spawn_fn = MagicMock()
+    coordinator.get_capability.return_value = spawn_fn
+    backend = AmplifierBackend(coordinator=coordinator, profiles={"anthropic": "p"})
+    if resolved:
+        # Simulate resolution that would happen during the first run() call.
+        backend._spawn_fn = spawn_fn
+        backend._spawn_checked = True
+    return backend, coordinator, spawn_fn
+
+
+# ---------------------------------------------------------------------------
+# S1 — clone() inherits parent's resolved spawn state
+# ---------------------------------------------------------------------------
+
+
+class TestCloneInheritsSpawnResolution:
+    """After fix: clone() inherits _spawn_fn and _spawn_checked from parent."""
+
+    def test_clone_inherits_resolved_spawn_fn(self):
+        """Clone must inherit _spawn_fn when parent has already resolved.
+
+        RED on current branch: clone() resets _spawn_fn=None/_spawn_checked=False.
+        GREEN after fix: clone inherits the parent's non-None _spawn_fn and True flag.
+        """
+        parent, _, spawn_fn = _make_backend(resolved=True)
+
+        clone = parent.clone()
+
+        assert clone._spawn_checked is True, (
+            "Clone must inherit _spawn_checked=True from a resolved parent — "
+            "otherwise the clone performs a redundant (and concurrent) first-resolution"
+        )
+        assert clone._spawn_fn is spawn_fn, (
+            "Clone must inherit parent's _spawn_fn (same stateless capability reference)"
+        )
+
+    def test_clone_mirrors_unresolved_state_when_parent_unchecked(self):
+        """Clone gets _spawn_checked=False when parent has not resolved yet.
+
+        This test is GREEN on the current branch (both reset to False) and must
+        STAY GREEN after the fix (both are False, mirrored from unchecked parent).
+        """
+        parent, _, _ = _make_backend(resolved=False)
+        assert parent._spawn_checked is False  # sanity
+
+        clone = parent.clone()
+
+        assert clone._spawn_checked is False
+        assert clone._spawn_fn is None
+
+    def test_clone_inherits_none_spawn_fn_when_coordinator_returns_none(self):
+        """If coordinator returned None (no spawn capability), clone inherits that too.
+
+        Parent resolves but finds no spawn capability → _spawn_fn stays None,
+        _spawn_checked is True.  Clone must inherit that exact state so it knows
+        NOT to retry the coordinator.
+        """
+        coordinator = MagicMock()
+        coordinator.get_capability.return_value = None  # no spawn available
+        parent = AmplifierBackend(coordinator=coordinator, profiles={"a": "b"})
+        parent._spawn_checked = True  # resolved, but found nothing
+        parent._spawn_fn = None
+
+        clone = parent.clone()
+
+        assert clone._spawn_checked is True, (
+            "Clone must inherit _spawn_checked=True even when parent found no spawn fn"
+        )
+        assert clone._spawn_fn is None, "Clone must inherit None _spawn_fn"
+
+
+# ---------------------------------------------------------------------------
+# S2 — ensure_spawn_resolved() method
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureSpawnResolved:
+    """ensure_spawn_resolved() must exist, resolve once, and be idempotent."""
+
+    def test_ensure_spawn_resolved_exists_and_resolves(self):
+        """ensure_spawn_resolved() must exist and resolve _spawn_fn on the backend.
+
+        RED on current branch: method does not exist → AttributeError.
+        GREEN after fix: method exists, resolves spawn, sets _spawn_checked=True.
+        """
+        parent, coordinator, spawn_fn = _make_backend(resolved=False)
+        assert not parent._spawn_checked  # pre-condition
+
+        parent.ensure_spawn_resolved()
+
+        coordinator.get_capability.assert_called_once_with("session.spawn")
+        assert parent._spawn_fn is spawn_fn
+        assert parent._spawn_checked is True
+
+    def test_ensure_spawn_resolved_is_idempotent(self):
+        """Calling ensure_spawn_resolved() twice must call get_capability only once.
+
+        RED on current branch: method does not exist → AttributeError.
+        GREEN after fix: second call is a no-op (already checked).
+        """
+        parent, coordinator, _ = _make_backend(resolved=False)
+
+        parent.ensure_spawn_resolved()
+        parent.ensure_spawn_resolved()  # second call — must be no-op
+
+        assert coordinator.get_capability.call_count == 1, (
+            "ensure_spawn_resolved() must be idempotent: "
+            "second call must not hit get_capability again"
+        )
+
+    def test_ensure_spawn_resolved_handles_no_spawn_capability(self):
+        """ensure_spawn_resolved() with no spawn capability sets _spawn_checked=True/_spawn_fn=None.
+
+        Even when coordinator returns None, the method must mark the backend as
+        checked so future calls (and inherited clones) skip the coordinator.
+        """
+        coordinator = MagicMock()
+        coordinator.get_capability.return_value = None
+        parent = AmplifierBackend(coordinator=coordinator, profiles={"a": "b"})
+
+        parent.ensure_spawn_resolved()
+
+        assert parent._spawn_checked is True
+        assert parent._spawn_fn is None
+
+
+# ---------------------------------------------------------------------------
+# S3 — get_capability called exactly once across parent + N clones (fan-out)
+# ---------------------------------------------------------------------------
+
+
+class TestGetCapabilityCalledOnceAcrossFanOut:
+    """Simulated parallel fan-out: resolve once on parent, zero re-resolves on clones."""
+
+    def test_get_capability_called_exactly_once_across_n_clones(self):
+        """Simulated fan-out: get_capability must be called EXACTLY ONCE total.
+
+        This is the core correctness property of the fix:
+          - parent.ensure_spawn_resolved() resolves once
+          - N clones inherit _spawn_fn/_spawn_checked=True from the parent
+          - no clone executes the lazy-check block (``if not _spawn_checked``)
+          - total get_capability calls: 1 (parent only)
+
+        RED on current branch:
+          - ensure_spawn_resolved() doesn't exist → AttributeError, OR
+          - clone() resets _spawn_checked=False → each of 4 clones re-resolves
+            → 5 calls instead of 1.
+
+        GREEN after fix: exactly 1 call.
+        """
+        coordinator = MagicMock()
+        spawn_fn = MagicMock()
+        coordinator.get_capability.return_value = spawn_fn
+
+        parent = AmplifierBackend(coordinator=coordinator, profiles={"a": "b"})
+
+        # Step 1: resolve on parent (simulating clone_for_branch pre-resolve)
+        parent.ensure_spawn_resolved()
+        assert coordinator.get_capability.call_count == 1
+
+        # Step 2: create N clones (simulating N parallel branches)
+        n = 4
+        clones = [parent.clone() for _ in range(n)]
+
+        # Step 3: simulate each clone's lazy-check on first run() entry
+        # (the ``if not self._spawn_checked`` guard in AmplifierBackend.run)
+        for c in clones:
+            if not c._spawn_checked:
+                # This branch must NEVER execute after the fix
+                c._coordinator.get_capability("session.spawn")
+                c._spawn_checked = True
+
+        # Verify: total calls across parent + all clones must be exactly 1
+        total_calls = coordinator.get_capability.call_count
+        assert total_calls == 1, (
+            f"get_capability must be called exactly once (on parent only). "
+            f"Got {total_calls} calls. "
+            f"Branch clones must NOT perform a concurrent first-resolution — "
+            f"they must inherit the parent's already-resolved _spawn_fn."
+        )
+
+    def test_all_clones_share_same_spawn_fn_reference(self):
+        """Every clone in the fan-out must point to the same spawn_fn object.
+
+        The spawn fn is stateless (sourced from shared coordinator); sharing
+        the reference is safe.  This also verifies that clones don't each
+        acquire a different instance via separate get_capability calls.
+
+        RED on current branch: clones reset _spawn_fn=None (not the parent fn).
+        GREEN after fix: all clones inherit the parent's resolved _spawn_fn.
+        """
+        parent, _, spawn_fn = _make_backend(resolved=True)
+
+        clones = [parent.clone() for _ in range(5)]
+
+        for i, c in enumerate(clones):
+            assert c._spawn_fn is spawn_fn, (
+                f"Clone {i}: _spawn_fn must be the same object as parent's spawn_fn. "
+                f"Got {c._spawn_fn!r} (expected {spawn_fn!r})"
+            )

--- a/modules/loop-pipeline/tests/test_parallel_branch_nested_isolation.py
+++ b/modules/loop-pipeline/tests/test_parallel_branch_nested_isolation.py
@@ -1,0 +1,666 @@
+"""Tests for parallel-branch nested backend/session isolation.
+
+TDD: These tests are written BEFORE the implementation.
+
+Test group descriptions:
+  G1  Core regression — component parallel (ParallelHandler) backend isolation
+  G2  Three nested topologies inside a component branch
+  G3  Multi-edge fan-out (_execute_parallel_fan_out) branch-engine isolation
+  G4  Artifact store shared across branches (critic C1)
+  G5  S5 guard — clone_for_branch engine raises on run()
+  G6  Fan-in correctness on both fan-out paths (critic S3)
+
+RED on current main (pre-fix): G1, G2a, G2b, G2c, G3, G5.
+GREEN on baseline AND after fix: G4, G6a, G6b, regression tests.
+
+Spec coverage: PAR-001–013, ISOL-001–005, NEST-001–003.
+
+Implementation note on select_all_matching_edges:
+  Multi-edge fan-out requires conditional edges (condition="outcome=success").
+  Unconditional edges are not returned by select_all_matching_edges and do NOT
+  trigger _execute_parallel_fan_out.  Tests that probe the multi-edge path
+  must use edges with explicit conditions.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from amplifier_module_loop_pipeline.context import PipelineContext
+from amplifier_module_loop_pipeline.dot_parser import parse_dot
+from amplifier_module_loop_pipeline.engine import PipelineEngine
+from amplifier_module_loop_pipeline.graph import Edge, Graph, Node
+from amplifier_module_loop_pipeline.handlers import HandlerRegistry
+from amplifier_module_loop_pipeline.handlers.context import HandlerContext
+from amplifier_module_loop_pipeline.outcome import Outcome, StageStatus
+from amplifier_module_loop_pipeline.validation import validate_or_raise
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers / backends
+# ---------------------------------------------------------------------------
+
+
+class _TrackingBackend:
+    """Records which instance handled each node call.
+
+    Each branch gets its own clone after the fix, so id(self) differs per branch.
+    On baseline (shared parent), id(self) is the same for all branches.
+    """
+
+    def __init__(self, label: str = "root") -> None:
+        self.label = label
+        self._session_pool: dict[str, str] = {}
+        self._completed_nodes: dict[str, Any] = {}
+        self.calls: list[tuple[str, int]] = []  # (node_id, id(self))
+
+    async def run(
+        self,
+        node: Node,
+        prompt: str,
+        context: PipelineContext,
+        **_kwargs: Any,
+    ) -> str:
+        self.calls.append((node.id, id(self)))
+        return "done"
+
+    def clone(self) -> "_TrackingBackend":
+        return _TrackingBackend(label=f"{self.label}@clone{id(self)}")
+
+
+class _RecordingBackend:
+    """Writes (node_id → id(self)) into a shared dict on every call."""
+
+    def __init__(self, record: dict[str, int], label: str = "root") -> None:
+        self._record = record
+        self.label = label
+        self._session_pool: dict[str, str] = {}
+        self._completed_nodes: dict[str, Any] = {}
+
+    async def run(
+        self,
+        node: Node,
+        prompt: str,
+        context: PipelineContext,
+        **_kwargs: Any,
+    ) -> str:
+        self._record[node.id] = id(self)
+        return "done"
+
+    def clone(self) -> "_RecordingBackend":
+        return _RecordingBackend(
+            self._record, label=f"{self.label}@clone{id(self)}"
+        )
+
+
+def _build_engine(dot_source: str, backend: Any, tmp_path: Any) -> PipelineEngine:
+    """Parse DOT, validate, and build a PipelineEngine."""
+    graph = parse_dot(dot_source)
+    validate_or_raise(graph)
+    registry = HandlerRegistry(HandlerContext(backend=backend))
+    return PipelineEngine(
+        graph=graph,
+        context=PipelineContext(),
+        handler_registry=registry,
+        logs_root=str(tmp_path),
+    )
+
+
+# ---------------------------------------------------------------------------
+# G1 — Core regression: component parallel (ParallelHandler) backend isolation
+# ---------------------------------------------------------------------------
+
+_DOT_COMPONENT_PARALLEL = """\
+digraph {
+    start [shape=Mdiamond]
+    par   [shape=component]
+    work_a [prompt="Branch A codergen"]
+    work_b [prompt="Branch B codergen"]
+    fanin [shape=tripleoctagon]
+    done  [shape=Msquare]
+
+    start -> par
+    par -> work_a
+    par -> work_b
+    work_a -> fanin
+    work_b -> fanin
+    fanin -> done
+}
+"""
+
+
+@pytest.mark.asyncio
+async def test_g1_component_parallel_codergen_backends_are_isolated(tmp_path):
+    """G1 core: each component-parallel branch gets its own backend clone.
+
+    RED on baseline: ParallelHandler calls engine.run_subgraph() on the parent
+    → parent handler_registry → same CodergenHandler → same backend instance.
+
+    GREEN after fix: each branch runs on clone_for_branch() engine → cloned
+    registry → distinct backend instance.
+    """
+    record: dict[str, int] = {}
+    backend = _RecordingBackend(record, label="root")
+
+    engine = _build_engine(_DOT_COMPONENT_PARALLEL, backend, tmp_path)
+    outcome = await engine.run()
+
+    assert outcome.status in (StageStatus.SUCCESS, StageStatus.PARTIAL_SUCCESS)
+    assert "work_a" in record, "work_a codergen must have run"
+    assert "work_b" in record, "work_b codergen must have run"
+
+    assert record["work_a"] != record["work_b"], (
+        "Parallel branches must use DIFFERENT backend instances "
+        "(current code shares the parent backend — that is the bug)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# G2 — Three nested topologies inside a component parallel branch
+# ---------------------------------------------------------------------------
+
+# --- G2a: Manager loop inside a component branch ---
+
+_DOT_PARALLEL_WITH_MANAGER = """\
+digraph {
+    start [shape=Mdiamond]
+    par   [shape=component]
+
+    mgr_a [shape=house, "manager.max_cycles"="1", "manager.actions"="observe"]
+    coder_a [prompt="Branch A nested work"]
+
+    mgr_b [shape=house, "manager.max_cycles"="1", "manager.actions"="observe"]
+    coder_b [prompt="Branch B nested work"]
+
+    fanin [shape=tripleoctagon]
+    done  [shape=Msquare]
+
+    start -> par
+    par -> mgr_a
+    par -> mgr_b
+    mgr_a -> coder_a -> fanin
+    mgr_b -> coder_b -> fanin
+    fanin -> done
+}
+"""
+
+
+@pytest.mark.asyncio
+async def test_g2a_manager_loop_inside_parallel_is_isolated(tmp_path):
+    """G2a: manager-loop children run on isolated backends per branch.
+
+    Manager loop calls engine.run_subgraph(child, engine=<passed engine>).
+    Before fix: engine is the parent → shared backend.
+    After fix: engine is the branch engine → isolated backend.
+    """
+    record: dict[str, int] = {}
+    backend = _RecordingBackend(record, label="root")
+
+    engine = _build_engine(_DOT_PARALLEL_WITH_MANAGER, backend, tmp_path)
+    outcome = await engine.run()
+
+    assert outcome.status in (StageStatus.SUCCESS, StageStatus.PARTIAL_SUCCESS)
+    assert "coder_a" in record, "coder_a (nested inside manager) must have run"
+    assert "coder_b" in record, "coder_b (nested inside manager) must have run"
+
+    assert record["coder_a"] != record["coder_b"], (
+        "Nested codergen inside manager loop must use isolated backends per branch"
+    )
+
+
+# --- G2b: Folder (pipeline) node inside a component branch ---
+
+_CHILD_DOT_A = """\
+digraph child_a {
+    start        [shape=Mdiamond]
+    child_work_a [prompt="Child pipeline work A"]
+    done         [shape=Msquare]
+    start -> child_work_a -> done
+}
+"""
+
+_CHILD_DOT_B = """\
+digraph child_b {
+    start        [shape=Mdiamond]
+    child_work_b [prompt="Child pipeline work B"]
+    done         [shape=Msquare]
+    start -> child_work_b -> done
+}
+"""
+
+
+@pytest.mark.asyncio
+async def test_g2b_folder_inside_parallel_is_isolated(tmp_path):
+    """G2b: folder-node (nested pipeline) runs on isolated backend per branch.
+
+    PipelineHandler builds a child registry from self._backend (the captured
+    original).  Before fix: SAME backend for both branches.
+    After fix (Move 2): child registry is seeded from engine.handler_registry
+    → branch-isolated backend.
+    """
+    child_a = str(tmp_path / "child_a.dot")
+    child_b = str(tmp_path / "child_b.dot")
+    with open(child_a, "w", encoding="utf-8") as f:
+        f.write(_CHILD_DOT_A)
+    with open(child_b, "w", encoding="utf-8") as f:
+        f.write(_CHILD_DOT_B)
+
+    dot_source = f"""\
+digraph {{
+    start    [shape=Mdiamond]
+    par      [shape=component]
+    folder_a [shape=folder, dot_file="{child_a}"]
+    folder_b [shape=folder, dot_file="{child_b}"]
+    fanin    [shape=tripleoctagon]
+    done     [shape=Msquare]
+
+    start -> par
+    par -> folder_a
+    par -> folder_b
+    folder_a -> fanin
+    folder_b -> fanin
+    fanin -> done
+}}
+"""
+
+    record: dict[str, int] = {}
+    backend = _RecordingBackend(record, label="root")
+
+    graph = parse_dot(dot_source)
+    validate_or_raise(graph)
+    graph.source_dir = str(tmp_path)
+
+    registry = HandlerRegistry(HandlerContext(backend=backend))
+    engine = PipelineEngine(
+        graph=graph,
+        context=PipelineContext(),
+        handler_registry=registry,
+        logs_root=str(tmp_path),
+    )
+    outcome = await engine.run()
+
+    assert outcome.status in (StageStatus.SUCCESS, StageStatus.PARTIAL_SUCCESS)
+    a_id = record.get("child_work_a")
+    b_id = record.get("child_work_b")
+    assert a_id is not None, "child_work_a (inside folder_a) must have run"
+    assert b_id is not None, "child_work_b (inside folder_b) must have run"
+
+    assert a_id != b_id, (
+        "Folder nodes in parallel branches must run child pipelines "
+        "with isolated (branch-clone) backends"
+    )
+
+
+# --- G2c: Nested fan-out inside a component branch ---
+
+_DOT_NESTED_FANOUT = """\
+digraph {
+    start   [shape=Mdiamond]
+    outer_par [shape=component]
+
+    inner_par_a [shape=component]
+    inner_a1 [prompt="Inner A branch 1"]
+    inner_a2 [prompt="Inner A branch 2"]
+    fanin_a  [shape=tripleoctagon]
+
+    inner_par_b [shape=component]
+    inner_b1 [prompt="Inner B branch 1"]
+    inner_b2 [prompt="Inner B branch 2"]
+    fanin_b  [shape=tripleoctagon]
+
+    outer_fanin [shape=tripleoctagon]
+    done [shape=Msquare]
+
+    start -> outer_par
+    outer_par -> inner_par_a
+    outer_par -> inner_par_b
+
+    inner_par_a -> inner_a1
+    inner_par_a -> inner_a2
+    inner_a1 -> fanin_a
+    inner_a2 -> fanin_a
+
+    inner_par_b -> inner_b1
+    inner_par_b -> inner_b2
+    inner_b1 -> fanin_b
+    inner_b2 -> fanin_b
+
+    fanin_a -> outer_fanin
+    fanin_b -> outer_fanin
+    outer_fanin -> done
+}
+"""
+
+
+@pytest.mark.asyncio
+async def test_g2c_nested_fanout_inside_parallel_is_isolated(tmp_path):
+    """G2c: nested parallel fan-out inside a branch uses isolated backends.
+
+    Before fix: inner branches share the outer-parent engine's handler_registry.
+    After fix: each outer branch gets a branch engine; inner branches from that
+    branch engine also get further branch engines (composition by construction).
+    """
+    record: dict[str, int] = {}
+    backend = _RecordingBackend(record, label="root")
+
+    engine = _build_engine(_DOT_NESTED_FANOUT, backend, tmp_path)
+    outcome = await engine.run()
+
+    assert outcome.status in (StageStatus.SUCCESS, StageStatus.PARTIAL_SUCCESS)
+
+    # Inner A branches must be isolated from inner B branches
+    for inner_a in ("inner_a1", "inner_a2"):
+        for inner_b in ("inner_b1", "inner_b2"):
+            if inner_a in record and inner_b in record:
+                assert record[inner_a] != record[inner_b], (
+                    f"Nested branch '{inner_a}' and '{inner_b}' must use "
+                    "different backend instances (outer branches must isolate)"
+                )
+
+
+# ---------------------------------------------------------------------------
+# G3 — Multi-edge fan-out (_execute_parallel_fan_out) branch-engine isolation
+#
+# Key notes:
+#   - select_all_matching_edges returns edges ONLY when e.condition is truthy
+#     AND matches.  Unconditional edges do NOT trigger _execute_parallel_fan_out.
+#     Edges must have condition="outcome=success" (or similar) to be selected.
+#   - The bug: _execute_parallel_fan_out passes engine=self (parent) to
+#     execute_with_retry.  A CapturingHandler records the received engine.
+#     Before fix: both branches receive the SAME parent engine.
+#     After fix: each branch receives a distinct clone_for_branch() engine.
+# ---------------------------------------------------------------------------
+
+
+class _CapturingHandler:
+    """Records the engine object passed to each execute() call."""
+
+    def __init__(self, captured: list[Any]) -> None:
+        self._captured = captured
+
+    async def execute(
+        self,
+        node: Node,
+        context: PipelineContext,
+        graph: Graph,
+        logs_root: str,
+        *,
+        engine: Any = None,
+    ) -> Outcome:
+        self._captured.append(engine)
+        return Outcome(status=StageStatus.SUCCESS, notes=f"captured {node.id}")
+
+
+def _make_multiedge_graph() -> Graph:
+    """Graph with a codergen gate that fans out (condition=outcome=success)
+    to two custom-type branch nodes, both converging on a codergen node.
+
+    Structure:
+        start -> gate (box/codergen)
+        gate -> branch_c (condition="outcome=success")
+        gate -> branch_d (condition="outcome=success")
+        branch_c -> converge (box/codergen)
+        branch_d -> converge
+        converge -> done (exit)
+    """
+    return Graph(
+        name="multiedge-isolation-test",
+        nodes={
+            "start": Node(id="start", shape="Mdiamond"),
+            "gate": Node(id="gate", shape="box", prompt="Gate triggers fan-out"),
+            "branch_c": Node(id="branch_c", shape="box", type="capturing"),
+            "branch_d": Node(id="branch_d", shape="box", type="capturing"),
+            "converge": Node(id="converge", shape="box", prompt="Converge"),
+            "done": Node(id="done", shape="Msquare"),
+        },
+        edges=[
+            Edge(from_node="start", to_node="gate"),
+            Edge(from_node="gate", to_node="branch_c", condition="outcome=success"),
+            Edge(from_node="gate", to_node="branch_d", condition="outcome=success"),
+            Edge(from_node="branch_c", to_node="converge"),
+            Edge(from_node="branch_d", to_node="converge"),
+            Edge(from_node="converge", to_node="done"),
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_g3_multiedge_fanout_passes_branch_engine_to_handlers(tmp_path):
+    """G3: _execute_parallel_fan_out must pass a branch engine to each handler.
+
+    Before fix: execute_with_retry is called with engine=self (parent) for all
+    branches → both capturing handlers see the SAME engine object.
+
+    After fix: each branch gets clone_for_branch() → distinct branch engine →
+    handlers see DIFFERENT engine objects per branch.
+    """
+    captured_engines: list[Any] = []
+
+    backend = _TrackingBackend()  # needed for gate + converge codergen nodes
+    graph = _make_multiedge_graph()
+
+    registry = HandlerRegistry(HandlerContext(backend=backend))
+    registry.register("capturing", _CapturingHandler(captured_engines))
+
+    engine = PipelineEngine(
+        graph=graph,
+        context=PipelineContext(),
+        handler_registry=registry,
+        logs_root=str(tmp_path),
+    )
+
+    outcome = await engine.run()
+    assert outcome.status in (StageStatus.SUCCESS, StageStatus.PARTIAL_SUCCESS), (
+        f"Multi-edge fan-out must complete: {outcome.failure_reason}"
+    )
+
+    assert len(captured_engines) == 2, (
+        f"Both branch handlers must have executed; got {len(captured_engines)}"
+    )
+
+    # Before fix: both branches receive the parent engine → same object → FAILS here
+    assert captured_engines[0] is not captured_engines[1], (
+        "_execute_parallel_fan_out must pass a distinct branch engine to each "
+        "handler, not the parent engine (pre-fix: same object for all branches)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# G4 — Artifact store shared across branches (critic C1)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_g4_artifact_store_shared_across_branches(tmp_path):
+    """G4 (C1): clone_for_branch() must share the parent's ArtifactStore.
+
+    After the fix, Engine.clone_for_branch() must explicitly set:
+        clone.artifact_store = self.artifact_store
+
+    This preserves:
+    1. The L-12 asyncio.Lock (concurrent-write safety).
+    2. Cross-branch artifact visibility (fan-in can read any branch's artifacts).
+
+    GREEN on baseline (trivially — no branch engines exist pre-fix).
+    Must STAY GREEN after fix.
+    Regression: omitting the store-sharing line gives each branch its own
+    store → fan-in reads miss other branches' artifacts.
+    """
+
+    class SimpleBranchBackend:
+        def __init__(self) -> None:
+            self._session_pool: dict[str, str] = {}
+            self._completed_nodes: dict[str, Any] = {}
+
+        async def run(
+            self,
+            node: Node,
+            prompt: str,
+            context: PipelineContext,
+            **_kwargs: Any,
+        ) -> str:
+            return "done"
+
+        def clone(self) -> "SimpleBranchBackend":
+            return SimpleBranchBackend()
+
+    backend = SimpleBranchBackend()
+    graph = parse_dot(_DOT_COMPONENT_PARALLEL)
+    validate_or_raise(graph)
+    registry = HandlerRegistry(HandlerContext(backend=backend))
+    parent_engine = PipelineEngine(
+        graph=graph,
+        context=PipelineContext(),
+        handler_registry=registry,
+        logs_root=str(tmp_path),
+    )
+    parent_store_id = id(parent_engine.artifact_store)
+
+    # If clone_for_branch exists (post-fix), verify the clone shares the parent store.
+    clone_fn = getattr(parent_engine, "clone_for_branch", None)
+    if clone_fn is not None:
+        branch = clone_fn(context=PipelineContext())
+        assert id(branch.artifact_store) == parent_store_id, (
+            "clone_for_branch() must share the parent's ArtifactStore "
+            "(C1: preserves L-12 lock and cross-branch visibility)"
+        )
+
+    outcome = await parent_engine.run()
+    assert outcome.status in (StageStatus.SUCCESS, StageStatus.PARTIAL_SUCCESS)
+
+
+# ---------------------------------------------------------------------------
+# G5 — S5 guard: clone_for_branch engine raises on run()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_g5_branch_clone_engine_raises_on_run(tmp_path):
+    """G5 (S5): calling run() on a branch-clone engine must raise RuntimeError.
+
+    RED on baseline: Engine.clone_for_branch() does not exist → AttributeError.
+    GREEN after fix: clone_for_branch() exists, run() guards on _is_branch_clone.
+    """
+    backend = _TrackingBackend()
+    graph = parse_dot(_DOT_COMPONENT_PARALLEL)
+    validate_or_raise(graph)
+    registry = HandlerRegistry(HandlerContext(backend=backend))
+    engine = PipelineEngine(
+        graph=graph,
+        context=PipelineContext(),
+        handler_registry=registry,
+        logs_root=str(tmp_path),
+    )
+
+    # AttributeError on baseline (clone_for_branch doesn't exist yet) → test RED.
+    branch_engine = engine.clone_for_branch(context=PipelineContext())  # type: ignore[attr-defined]
+
+    with pytest.raises(RuntimeError, match=r"run\(\).*branch"):
+        await branch_engine.run()
+
+
+# ---------------------------------------------------------------------------
+# G6 — Fan-in correctness on both fan-out paths (critic S3)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_g6a_component_parallel_fan_in_aggregates_results(tmp_path):
+    """G6a (S3-component): branch results reach the fan-in node correctly.
+
+    After the fix, parallel.results must be populated and the fan-in must
+    succeed.  Regression: if branch results stop flowing to the parent context
+    the fan-in gets no data and returns FAIL.
+    """
+    backend = _TrackingBackend()
+    engine = _build_engine(_DOT_COMPONENT_PARALLEL, backend, tmp_path)
+    outcome = await engine.run()
+
+    assert outcome.status in (StageStatus.SUCCESS, StageStatus.PARTIAL_SUCCESS), (
+        f"Component parallel fan-in must aggregate results; got {outcome.status}"
+    )
+    results = engine.context.get("parallel.results")
+    assert results is not None, "parallel.results must be set after component fan-out"
+    assert len(results) == 2, f"Expected 2 branch results, got {len(results)}"
+
+
+@pytest.mark.asyncio
+async def test_g6b_multiedge_fanout_branch_outcomes_reach_parent(tmp_path):
+    """G6b (S3-multiedge): branch top-node outcomes reach parent node_outcomes.
+
+    _execute_parallel_fan_out records each branch outcome in
+    self.node_outcomes[target_node_id].  After the fix (branch engine), this
+    recording must still happen on the PARENT engine, not the branch engine.
+    """
+    captured_engines: list[Any] = []
+
+    backend = _TrackingBackend()
+    graph = _make_multiedge_graph()
+    registry = HandlerRegistry(HandlerContext(backend=backend))
+    registry.register("capturing", _CapturingHandler(captured_engines))
+
+    engine = PipelineEngine(
+        graph=graph,
+        context=PipelineContext(),
+        handler_registry=registry,
+        logs_root=str(tmp_path),
+    )
+    outcome = await engine.run()
+
+    assert outcome.status in (StageStatus.SUCCESS, StageStatus.PARTIAL_SUCCESS), (
+        f"Multi-edge fan-out must complete: {outcome.failure_reason}"
+    )
+
+    # branch_c and branch_d are the top-level branch nodes
+    assert "branch_c" in engine.node_outcomes, (
+        "branch_c outcome must be in parent engine.node_outcomes (S3)"
+    )
+    assert "branch_d" in engine.node_outcomes, (
+        "branch_d outcome must be in parent engine.node_outcomes (S3)"
+    )
+    assert engine.node_outcomes["branch_c"].status in (
+        StageStatus.SUCCESS, StageStatus.PARTIAL_SUCCESS
+    )
+    assert engine.node_outcomes["branch_d"].status in (
+        StageStatus.SUCCESS, StageStatus.PARTIAL_SUCCESS
+    )
+
+
+# ---------------------------------------------------------------------------
+# Regression guard — existing behaviour must be unaffected
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_regression_basic_linear_pipeline_unaffected(tmp_path):
+    """Non-parallel pipelines must be unaffected by the fix."""
+    backend = _TrackingBackend()
+    engine = _build_engine(
+        """\
+digraph {
+    start [shape=Mdiamond]
+    work  [prompt="Sequential work"]
+    done  [shape=Msquare]
+    start -> work -> done
+}
+""",
+        backend,
+        tmp_path,
+    )
+    outcome = await engine.run()
+    assert outcome.status == StageStatus.SUCCESS
+    assert any(nid == "work" for nid, _ in backend.calls), "work must have run"
+
+
+@pytest.mark.asyncio
+async def test_regression_component_parallel_still_runs_all_branches(tmp_path):
+    """Component parallel must still execute all branches after the fix."""
+    backend = _TrackingBackend()
+    engine = _build_engine(_DOT_COMPONENT_PARALLEL, backend, tmp_path)
+    await engine.run()
+
+    called_nodes = {nid for nid, _ in backend.calls}
+    assert "work_a" in called_nodes, "work_a must run"
+    assert "work_b" in called_nodes, "work_b must run"

--- a/modules/loop-pipeline/tests/test_parallel_branch_nested_isolation.py
+++ b/modules/loop-pipeline/tests/test_parallel_branch_nested_isolation.py
@@ -67,17 +67,40 @@ class _TrackingBackend:
         return "done"
 
     def clone(self) -> "_TrackingBackend":
-        return _TrackingBackend(label=f"{self.label}@clone{id(self)}")
+        # Share the calls list so the root backend can observe all branch calls.
+        # id(self) in each call still distinguishes which clone ran the node.
+        cloned = _TrackingBackend(label=f"{self.label}@clone{id(self)}")
+        cloned.calls = self.calls
+        return cloned
+
+
+_RECORDING_BACKEND_COUNTER: int = 0  # module-level monotone counter
 
 
 class _RecordingBackend:
-    """Writes (node_id → id(self)) into a shared dict on every call."""
+    """Writes (node_id → stable_uid) into a shared dict on every call.
 
-    def __init__(self, record: dict[str, int], label: str = "root") -> None:
+    Uses a module-level monotone counter for each instance so that UIDs
+    are guaranteed unique even when objects are garbage-collected and their
+    memory addresses reused between sequential asyncio tasks.
+    """
+
+    def __init__(
+        self,
+        record: dict[str, int],
+        label: str = "root",
+        _uid: int | None = None,
+    ) -> None:
+        global _RECORDING_BACKEND_COUNTER
         self._record = record
         self.label = label
         self._session_pool: dict[str, str] = {}
         self._completed_nodes: dict[str, Any] = {}
+        if _uid is None:
+            _RECORDING_BACKEND_COUNTER += 1
+            self._uid = _RECORDING_BACKEND_COUNTER
+        else:
+            self._uid = _uid
 
     async def run(
         self,
@@ -86,13 +109,14 @@ class _RecordingBackend:
         context: PipelineContext,
         **_kwargs: Any,
     ) -> str:
-        self._record[node.id] = id(self)
+        self._record[node.id] = self._uid
         return "done"
 
     def clone(self) -> "_RecordingBackend":
-        return _RecordingBackend(
-            self._record, label=f"{self.label}@clone{id(self)}"
-        )
+        global _RECORDING_BACKEND_COUNTER
+        _RECORDING_BACKEND_COUNTER += 1
+        uid = _RECORDING_BACKEND_COUNTER
+        return _RecordingBackend(self._record, label=f"{self.label}@c{uid}", _uid=uid)
 
 
 def _build_engine(dot_source: str, backend: Any, tmp_path: Any) -> PipelineEngine:
@@ -621,10 +645,12 @@ async def test_g6b_multiedge_fanout_branch_outcomes_reach_parent(tmp_path):
         "branch_d outcome must be in parent engine.node_outcomes (S3)"
     )
     assert engine.node_outcomes["branch_c"].status in (
-        StageStatus.SUCCESS, StageStatus.PARTIAL_SUCCESS
+        StageStatus.SUCCESS,
+        StageStatus.PARTIAL_SUCCESS,
     )
     assert engine.node_outcomes["branch_d"].status in (
-        StageStatus.SUCCESS, StageStatus.PARTIAL_SUCCESS
+        StageStatus.SUCCESS,
+        StageStatus.PARTIAL_SUCCESS,
     )
 
 

--- a/specs/EXTENSIONS.md
+++ b/specs/EXTENSIONS.md
@@ -197,3 +197,32 @@ spec's §9.4 sub-pipeline pattern with a dedicated, declarative shape.
 §2.8 shape\u2192handler table, and `dot_file` does not collide with any spec-defined attribute
 name, so the mechanism cannot change the behavior of any spec-conformant `.dot` file.
 (Documenting a pre-existing extension that was previously undocumented.)
+
+---
+
+## 11. Sub-Pipeline and Manager-Child Execution Is a Fresh Session Boundary
+
+**What:** Same-`thread_id` LLM session continuity (§5.4 thread resolution) applies WITHIN a
+single graph traversal. It does NOT cross a sub-pipeline boundary: a node inside a
+`shape=folder` / `dot_file=` sub-pipeline (§9.4) or a manager-loop child dotfile (§4.11) runs
+as a separate child graph/engine and starts a fresh LLM session, even if it carries the same
+`thread_id` as a node in the parent graph. Session continuity for a shared `thread_id` holds
+for inline nodes and flattened DOT `subgraph cluster_*` blocks (which §11.1 flattens into the
+same graph), but not across a child-graph execution boundary.
+
+**Why:** The spec frames sessions as run-local and non-serializable (§5.3: "in-memory LLM
+sessions cannot be serialized"; §3.1 finalize closes sessions), the thread-resolution ladder
+is graph-scoped (§5.4, tier 3 is "graph-level default thread"), and §9.4 defines a
+sub-pipeline as "a node whose handler runs an entire sub-graph as its execution" — a separate
+execution unit. This matches the subagent model (coding-agent-loop §7.1: a child session "runs
+its own agentic loop with its own conversation history but shares the parent's execution
+environment"). Our implementation makes this concrete: a sub-pipeline / manager child runs on
+a child engine with its own session pool. The spec does not explicitly state cross-sub-pipeline
+continuity either way; we adopt "fresh boundary" as the deterministic, spec-intent-aligned
+choice, consistent with the per-branch isolation decisions in sections 8 and 9.
+
+**Compatibility:** Backward-compatible. No spec-conformant `.dot` can depend on
+cross-sub-pipeline session continuity, because the spec never promises it and the surrounding
+normative clauses (§5.3, §5.4, §9.4) indicate the opposite. Authors who need a node to continue
+a shared-`thread_id` session must keep it inline in the same graph (or in a flattened cluster),
+not behind a sub-pipeline / folder / manager-child boundary.

--- a/specs/EXTENSIONS.md
+++ b/specs/EXTENSIONS.md
@@ -132,3 +132,68 @@ access. Using `node_type` internally avoids shadowing the built-in. The DOT attr
 
 **Compatibility:** Pipeline authors use `type=llm`, `type=parallel`, etc. in DOT source.
 The internal renaming is invisible at the DOT level.
+
+---
+
+## 8. Per-Branch Session Isolation for Full-Fidelity Threading
+
+**What:** Our implementation realizes the spec's §5.4 `full`-fidelity "reused session / same
+thread" behavior via an internal `_session_pool` on the backend \u2014 an implementation construct
+below the spec's `CodergenBackend` `run(node, prompt, context)` interface (the spec models no
+session object). As of this change, when a node executes inside a **parallel branch**, its
+session pool and completion-tracking state are **isolated per branch**: each branch runs on a
+branch-scoped engine with a cloned backend. Concurrent branches no longer share session state.
+
+**Why:** §3.8 mandates that "each parallel branch receives an isolated clone of the context."
+Our `_session_pool` sits below the spec's abstraction, so the spec does not explicitly govern
+it \u2014 but sharing it across concurrent branches violated the spec's isolation *intent* and our
+own §4.12 handler-statelessness rule, producing silent non-deterministic cross-branch
+contamination under `fidelity=full`. Per-branch isolation extends the spec's isolation intent
+down to our session-pool layer.
+
+**Compatibility:** Fully backward-compatible. Sequential pipelines and parallel pipelines
+without nested stateful codegen see no change. No spec-conformant `.dot` file can depend on
+cross-branch session sharing, because the spec never defines that behavior \u2014 it defines the
+opposite (§3.8 isolation). This change moves observable behavior toward what a conforming
+pipeline already assumes.
+
+---
+
+## 9. Same `thread_id` Across Concurrent Branches Resolves to Isolation
+
+**What:** The spec contains an unresolved interaction: §5.4 thread-resolution says nodes
+sharing a `thread_id` "reuse the same LLM session," while §3.8 says parallel branches must be
+isolated. When the **same explicit `thread_id` appears on nodes in two different concurrent
+parallel branches**, these two rules conflict. Our implementation resolves this by giving
+**§3.8 (branch isolation) precedence**: each branch's nodes get an isolated session even if
+they carry an identical `thread_id` to a sibling branch's nodes. Thread-id-based session reuse
+continues to work normally for the **sequential** case (nodes in the same linear path).
+
+**Why:** §3.8's isolation mandate is the stronger, more consistent guarantee; a shared LLM
+session across concurrent branches is precisely the contamination this change eliminates.
+"Isolate by default" is the safe, deterministic resolution of a spec self-contradiction.
+
+**Compatibility:** Backward-compatible for all spec-conformant pipelines except the narrow,
+spec-self-contradictory case of an author deliberately placing the same `thread_id` on nodes
+in different concurrent branches expecting them to share one session \u2014 a behavior the spec
+never coherently defines. Such a pipeline relies on undefined/contradictory behavior; we make
+the resolution explicit and deterministic here.
+
+---
+
+## 10. `shape=folder` / `dot_file=` Sub-Pipeline Nodes
+
+**What:** We support a sub-pipeline node declared via `shape=folder` with a `dot_file=`
+attribute, which runs an entire child `.dot` graph as a single node's execution. The spec
+describes sub-pipeline composition as a *pattern* (§9.4 \u2014 "a node whose handler runs an entire
+sub-graph as its execution," with the manager loop named as the example) but does not define a
+dedicated `shape=folder` shape or `dot_file=` attribute for it.
+
+**Why:** A first-class folder/sub-pipeline node is ergonomic for composing pipelines from
+reusable `.dot` fragments without the manager-loop supervisor machinery. It implements the
+spec's §9.4 sub-pipeline pattern with a dedicated, declarative shape.
+
+**Compatibility:** Additive and non-shadowing. `folder` is not a spec-assigned shape in the
+§2.8 shape\u2192handler table, and `dot_file` does not collide with any spec-defined attribute
+name, so the mechanism cannot change the behavior of any spec-conformant `.dot` file.
+(Documenting a pre-existing extension that was previously undocumented.)


### PR DESCRIPTION
## Problem

Nested subgraphs (manager loops, nested fan-outs, sub-pipelines) executing inside
concurrent parallel branches shared the parent's mutable backend session state
(`_session_pool`, `_completed_nodes`) instead of branch-isolated copies. Under
`fidelity=full` with concurrent branches this caused silent cross-branch
session-pool collisions and completion-record pollution -> non-deterministic wrong
output. A team begins authoring nested-in-parallel pipelines imminently, so this
moves from latent to load-bearing.

## Fix (Candidate B)

Two coordinated moves:
1. **Per-branch engine spine** - each parallel branch runs on a branch-scoped engine
   (`Engine.clone_for_branch`) whose `handler_registry` carries a cloned backend with
   fresh session state. Both fan-out paths (`ParallelHandler` for `shape=component`
   and `_execute_parallel_fan_out` for multi-edge) converge on this.
2. **Delete the captured-backend bypass** - folder/manager child engines now seed their
   backend from the executing engine (`get_backend()`) instead of a captured
   `self._backend`, so nested execution inherits the branch's isolation by construction.

Plus a regression fix surfaced during end-to-end validation: **resolve `session.spawn`
once serially before fan-out** so branch clones inherit the resolved capability rather
than racing on concurrent first-resolution (which silently dropped parallel-branch
nodes to the tool-loop fallback).

**Decision: isolate-by-default** - the same explicit `thread_id` across concurrent
branches resolves to per-branch isolation (§3.8 precedence over §5.4), documented in
EXTENSIONS.md.

## Spec conformance

Spec-safe: the leak sits below the spec's `CodergenBackend` abstraction; the spec
mandates isolation only at the Context level (preserved). The fix resolves a §4.12
handler-statelessness violation. EXTENSIONS.md sections 8-11 document the conformance
deltas (per-branch session isolation, thread_id precedence, folder-node extension,
sub-pipeline fresh-session boundary).

## Verification

- **Unit:** 11 isolation tests (direct cross-branch `_session_pool` isolation assertions)
  + 7 clone-spawn regression tests ("get_capability called exactly once across N clones").
  Full suite green (only pre-existing unrelated failures).
- **Static trace (LSP):** intra-branch continuity preserved (folder child shares the
  branch's pool via `get_backend()`), cross-branch isolated.
- **Spec ruling:** behavior honors §3.8/§5.4/§9.4.
- **DTU (real resolve worker):** patched code runs; the nested-parallel topology executes
  without error; the clone-spawn regression was caught and is confirmed fixed (parallel
  seeds take the spawn path, three independent proofs); zero cross-branch contamination
  observed.

## Known follow-ups (separate, not this PR)

- A pre-existing session-layer bug (resume doesn't replay conversation history in resolve
  workers) blocks the *positive* codeword-recall e2e signal. Independent of this fix
  (reproduces sequentially without it). To be filed/handled separately.
- Minor: spawn result's `session_id` not surfacing into `status.json` in the full pipeline
  path (cosmetic propagation gap; spawn is taken). Separate follow-up.

Commits: isolation fix + EXTENSIONS 8-10 + clone-spawn fix + EXTENSIONS 11.