### PR TITLE
fix(engine): restore fidelity=full intra-run session continuity

### DIFF
--- a/docs/designs/fidelity-full-session-continuity.md
+++ b/docs/designs/fidelity-full-session-continuity.md
@@ -1,0 +1,214 @@
+# Design: fidelity=full Session Continuity
+
+Status: validated through a full /systems-design pass (Phases 1-7, user-approved at each gate). Intra-run scope recommended for implementation; cross-run resume defined and deferred to a separate design.
+
+Spec authority: strongdm/attractor nlspec @ `fb57a55`.
+
+---
+
+## 1. Problem Framing
+
+`fidelity=full` cross-node session continuity is broken in the loop-pipeline backend
+(`modules/loop-pipeline/amplifier_module_loop_pipeline/backend.py`).
+
+Root cause: `_session_pool` stores a `session_id` and re-passes it to `session.spawn`
+(fresh-spawn by design in every implementation) expecting the prior conversation to
+resume — but `session_id` is an identity/trace token, not a history pointer, so history
+is never restored. A `full` node that should "remember" an earlier same-thread node
+starts fresh ("first message in this session").
+
+**It is a type confusion: an *id* stored where a *conversation* belongs.**
+
+Goal: restore intra-run, same-thread, in-process `full` continuity (spec-mandated by
+§5.4). Discovered via a real DTU run plus multi-agent investigation; not a regression —
+it never worked through the loop-pipeline backend.
+
+---
+
+## 2. Explicit Assumptions
+
+- **Granularity:** `full` continuity = node-exchange `(instruction, final_output)` pairs.
+  The spawn result exposes only `output` + `session_id`, NOT the child's inner tool-loop
+  turns — so the carrier captures the conversation *between* nodes, not the child agent's
+  internal reasoning. (User-accepted as the meaning of `full` at the backend layer.)
+- **Sequentiality:** same-thread-key `full` nodes do not run concurrently *within one
+  branch* (§3.8 sequential same-thread traversal). **MUST-VERIFY-DURING-IMPLEMENTATION** —
+  if intra-branch same-key concurrency is real, add a per-thread lock around the
+  truncate-append.
+- **Context contract:** the child context implements `set_messages` — verified a validated
+  `amplifier_core` contract method (`interfaces.py:202`, `validation/context.py:333`), so
+  foundation's `parent_messages` injection reliably fires for our path.
+
+---
+
+## 3. System Boundaries
+
+- **In scope (this design):** the loop-pipeline backend's continuity carrier. Reuses
+  foundation's existing `parent_messages` injection (`_prepared.py:861`), which fires only
+  when `session_id` is absent.
+- **Out of scope (Phase 2):** cross-run resume after container restart (see the Phase 2
+  section).
+- **Layering:** the fix sits BELOW the spec's §4.5 backend contract
+  (`run(node, prompt, context) → String|Outcome` — no session primitive); per §4.5
+  silence, the realization mechanism is app-layer policy (mechanism-not-policy).
+
+Spec authority: strongdm/attractor nlspec — §5.4 (`full` = reuse same thread, full history
+preserved), §5.3 (sessions in-memory, non-serializable), unified-llm §2.6 (stateless
+client; continuity = caller-passed message list).
+
+---
+
+## 4. Components and Responsibilities
+
+- **`_thread_transcripts: dict[str, list[Message]]`** — renamed from `_session_pool`
+  (which will no longer hold sessions). thread_key → accumulated conversation. Born
+  branch-local: `clone_for_branch` already resets it to `{}` (`backend.py:150`), so the
+  per-branch isolation fix (already shipped) composes for free — transcripts never cross
+  branches.
+- **Append (single writer):** after each `full` node completes, append `user`
+  (= instruction) + `assistant` (= final `output`) — user/assistant roles only (strip
+  system/developer, matching app-cli). Idempotent under intra-run replay (see §5).
+- **Carry:** on the next same-thread `full` node, pass the list as `parent_messages` to a
+  FRESH spawn — never a `session_id`. The backend guarantees this mutual exclusion by
+  construction (closes the CR-1 silent-drop) and asserts it.
+- **Outcome `session_id`** is still captured for `status.json` observability — it just no
+  longer drives continuity.
+
+---
+
+## 5. Data and Control Flows
+
+- Node N (`full`, thread T) runs → backend appends `(instr_N, out_N)` to
+  `_thread_transcripts[T]`.
+- Node N+1 (`full`, thread T) → backend passes `parent_messages=_thread_transcripts[T]`
+  (no `session_id`) → foundation `set_messages` → child sees prior history. Realizes the
+  spec's "reuse the same session" as the message list the stateless client already
+  requires.
+- **Idempotency (intra-run):** goal-gate retries clear `completed_nodes` and RE-RUN nodes
+  (`engine.py:245-248` region) — a blind append would double a turn within one run.
+  Resolved by **truncate-to-node-then-append**: a re-run node truncates its prior turn
+  before re-appending, so replay rebuilds rather than duplicates.
+
+---
+
+## 6. Risks and Failure Modes
+
+- **CR-1 silent injection no-op (RESOLVED, was must-fix):** foundation injects only under
+  `if parent_messages and not session_id` + `if hasattr(context, "set_messages")` with no
+  else. Closed backend-side: `set_messages` is a verified contract method (always present
+  for our path), and the backend never passes `session_id` with `parent_messages` (mutual
+  exclusion by construction + assert). Foundation warn-else = optional defense-in-depth,
+  not required.
+- **Intra-run double-append (RESOLVED):** truncate-to-node-then-append (above).
+- **SC-3 thread_id is branch-local:** a shared `thread_id` across parallel branches
+  silently forks into N independent transcripts (the isolation reset). Mitigation:
+  documented note (+ optional parse-time warning).
+- **SC-4 naming/type confusion:** keep the field renamed (`_thread_transcripts`), exactly
+  one writer, and no stale id-into-pool path — leaving the old name/path is how the
+  original bug happened.
+- **Open assumption:** intra-branch same-key concurrency → per-thread lock if real
+  (must-verify; see §2).
+
+---
+
+## 7. Tradeoffs
+
+8-dimension frame, Candidate A (chosen) vs B vs C.
+
+| Dimension | A — transcript in the pool (chosen) | B — `session.resume` + store (app-cli pattern) | C — keep the live session alive |
+|---|---|---|---|
+| Latency | good — in-memory pass, no per-node disk I/O intra-run | poor — `store.save`/`load` disk I/O every node on the hot path | good intra-run, but holds resources for the run duration |
+| Complexity | good — one dict value-type change, 0 new author concepts | poor — new capability + store + routing, 2 repos | poor — session pinning + teardown override |
+| Reliability | good — in-memory, no external store; contained blast radius | adequate — adds store availability/staleness/collision modes | poor — held sessions accumulate; breaks spawn contract |
+| Cost | good — no new storage | adequate — store storage + ops | poor — N live sessions held for run duration |
+| Security | good — stays in-process + existing checkpoint (same trust boundary as #39) | adequate — new transcripts-at-rest surface | neutral |
+| Scalability | adequate — transcript grows per same-thread `full` node (inherent to `full`) | similar growth + store scaling | poor — N held sessions |
+| Reversibility | good — value-type change + additive field, no new API/contract | poor — a registered capability + store is a hard-to-walk-back, 2-repo contract | poor — cross-cutting lifecycle change, least reversible |
+| Org fit | good — single repo (attractor owns it) | poor — 2 repos, imports cross-process machinery | poor — cross-cutting |
+| **Optimizes for** | minimal concepts + reversibility | cross-process persistence | object-identity reuse |
+| **Sacrifices** | inner-agent-turn fidelity (node-exchange granularity only) | simplicity; adds new failure modes | the spawn-and-cleanup lifecycle; serializability |
+
+- **Candidate B** imports a CROSS-PROCESS disk machine for an INTRA-RUN need, then must
+  disable its own cross-run-restore half to stay §5.3-conformant, and re-impose
+  branch-keying on a global store (re-deriving the isolation we already have). It solves
+  the wrong scope and then fights itself.
+- **Candidate C** fights the spawn-and-cleanup lifecycle and the stateless client (there
+  is no durable live session; the conversation is already a message list), so it
+  "collapses into A wearing a costume," can't serialize for cross-run (§5.3 impossible),
+  and changes a cross-cutting lifecycle contract. Highest blast radius.
+- **Dominant tradeoff:** Complexity × Reversibility — A wins decisively. Catalytic
+  question: A is wrong only if inner-agent-turn fidelity across nodes is required (it
+  isn't, per §5.4 + user).
+
+---
+
+## 8. Recommended Design
+
+Candidate A, intra-run scope. The fix is *smaller than the bug* — it removes a type
+confusion (id-where-a-conversation-belongs) rather than adding machinery.
+
+Change the value type of one dict from `dict[str, session_id]` to
+`dict[str, list[Message]]`; append the node exchange after each `full` node; carry the
+list as `parent_messages` to a fresh spawn on the next same-thread `full` node. Reuses
+foundation's `parent_messages` injection, the already-shipped per-branch isolation reset,
+and the existing summary-fidelity machinery — no new components, no new author concepts.
+
+---
+
+## 9. Simplest Credible Alternative
+
+Candidate A IS the simplest credible design (change the value type in one dict; reuse
+three existing mechanisms). B and C are strictly more complex and solve the wrong scope.
+No simpler adequate alternative exists.
+
+---
+
+## 10. Migration and Rollout Plan
+
+Correct-by-default, NO feature flag (a flag would only preserve the broken path; this
+restores spec-mandated behavior that is currently silently broken). Single-repo
+(amplifier-bundle-attractor). Composes with the already-shipped per-branch isolation fix.
+Implementation follows TDD; validate with the seed→recall codeword scenario.
+
+---
+
+## 11. Success Metrics
+
+- Seed→recall continuity test passes intra-run (a `full` node sees the prior same-thread
+  node's exchange).
+- No double-append after a goal-gate retry re-runs a node.
+- Per-branch isolation preserved (no cross-branch transcript leak).
+- Injection is confirmed (no silent continuity drop) — backend assert holds.
+
+---
+
+## Phase 2 — Cross-run resume (DEFINED, deferred — separate design)
+
+Bounded by §5.3: cross-run = degrade the first resumed `full` node to `summary:high`, NOT
+full-session restore (live sessions can't be serialized). Five open items, each a decision
+to be made in a later design:
+
+- **CR-2 load-path:** the engine→backend restore wiring does not exist (resume restores
+  `self.context`/`completed_nodes` only; nothing repopulates `_thread_transcripts`).
+  Saving without a load path = dead weight.
+- **CR-3 summary seam:** M-23's `summary:high` reads `completed_nodes` Outcomes
+  (`fidelity.py:_build_summary_preamble`), NOT a message list — so the degrade story must
+  be rewritten honestly, including the "first-resumed-node missing from the next node's
+  history" seam.
+- **CR-4 cross-run idempotency** (atop the intra-run idempotency this design already
+  solves).
+- **SC-1 boundedness:** `full` transcript growth is unbounded (no compaction exists despite
+  §5.4 naming it); the sharp edge is O(N²) checkpoint write amplification
+  (`save_checkpoint` rewrites the whole indented JSON every node). Decision: compaction vs
+  length cap vs sidecar transcript file.
+- **SC-2 redaction:** verbatim prompts/outputs at rest in `checkpoint.json`.
+
+---
+
+## Proposed EXTENSIONS.md entries (for implementation — note them, do not write here)
+
+1. `full` continuity is realized as a backend-held message-list carrier injected via
+   `parent_messages` (the mechanism §4.5 leaves open), at **node-exchange granularity**
+   `(instruction, final_output)` — not the child agent's inner tool-loop turns.
+2. `thread_id` is **branch-local**: it does not join conversations across parallel branches
+   (the per-branch isolation reset).

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/backend.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/backend.py
@@ -11,6 +11,21 @@ model returns a text-only response.
 
 Spec coverage: Section 4.5 (CodergenBackend Interface), Section 1.4,
                FID-001–010, Section 5.4.
+
+fidelity=full continuity (see docs/designs/fidelity-full-session-continuity.md):
+  ``_thread_transcripts`` maps a branch-local thread_key to a list of
+  (node_id, instruction, output) triples — the accumulated node-exchange
+  history for that thread.  After each ``full`` node, the exchange is
+  appended (truncating any stale tail first, for goal-gate-retry
+  idempotency).  On the next same-thread ``full`` node the history is
+  converted to a ``parent_messages`` list (user/assistant roles) and
+  passed to a FRESH spawn — never a session_id re-pass.  This removes
+  the type confusion (id-where-a-conversation-belongs) that caused the
+  continuity bug.
+
+  Thread_id is branch-local: ``clone()`` resets ``_thread_transcripts``
+  so parallel branches each start with a fresh transcript even when they
+  share an explicit ``thread_id``.  See EXTENSIONS.md §12–13.
 """
 
 from __future__ import annotations
@@ -99,7 +114,14 @@ class AmplifierBackend:
         self._hooks = hooks
         self._spawn_fn: Any | None = None
         self._spawn_checked = False
-        self._session_pool: dict[str, str] = {}
+        # _thread_transcripts: thread_key → list of (node_id, instruction, output) triples.
+        # Replaces the former _session_pool (which stored a session_id — a type confusion:
+        # an id where a conversation belongs).  Each triple represents one node-exchange
+        # at user/assistant granularity.  Idempotent under goal-gate retries via
+        # truncate-to-node-then-append (see _append_to_transcript).
+        # Born branch-local: clone() resets to {} so parallel branches never share history.
+        # See docs/designs/fidelity-full-session-continuity.md and EXTENSIONS.md §12–13.
+        self._thread_transcripts: dict[str, list[tuple[str, str, str]]] = {}
         self._completed_nodes: dict[str, Outcome] = {}
         self._last_node_id: str | None = None
 
@@ -146,8 +168,10 @@ class AmplifierBackend:
         # some branches to receive None and fall to the tool-loop fallback).
         new._spawn_fn = self._spawn_fn
         new._spawn_checked = self._spawn_checked
-        # Fresh mutable state
-        new._session_pool = {}
+        # Fresh mutable state — transcripts are born branch-local so that two
+        # branches sharing the same thread_id maintain independent histories
+        # (§3.8 isolation, EXTENSIONS.md §9 / §13).
+        new._thread_transcripts = {}
         new._completed_nodes = {}
         new._last_node_id = None
         return new
@@ -349,14 +373,40 @@ class AmplifierBackend:
                     }
                 ]
 
-        # Session pool for full fidelity (spec FID-001: thread reuse)
+        # fidelity=full: resolve thread_key once for both pre-spawn history injection
+        # and post-spawn transcript append.
+        #
+        # The former _session_pool stored a session_id and re-passed it as
+        # sub_session_id — a type confusion (an id where a conversation belongs).
+        # The fix: carry the actual node-exchange history in _thread_transcripts and
+        # pass it as parent_messages to a FRESH spawn.  Foundation injects it via
+        # set_messages before the child session runs.
+        #
+        # Mutual-exclusion invariant: for a full-fidelity carry, parent_messages and
+        # sub_session_id are NEVER both present — parent_messages drives continuity;
+        # sub_session_id is never set here.  The assert below enforces this so that
+        # any future code path that accidentally re-introduces the old mechanism will
+        # fail loudly rather than silently dropping history (the original symptom).
+        thread_key: str | None = None
         if fidelity == "full" and graph is not None:
             thread_key = resolve_thread_key(
                 node, incoming_edge, graph, self._last_node_id
             )
-            existing_session = self._session_pool.get(thread_key)
-            if existing_session is not None:
-                spawn_kwargs["sub_session_id"] = existing_session
+            prior_messages = self._get_parent_messages_for_thread(thread_key)
+            if prior_messages:
+                spawn_kwargs["parent_messages"] = prior_messages
+
+        # CR-1 guard: parent_messages and sub_session_id must never coexist.
+        # (sub_session_id is not set by this method for full-fidelity, so this
+        # fires only if a caller or future patch accidentally introduces it.)
+        assert not (
+            spawn_kwargs.get("parent_messages") and spawn_kwargs.get("sub_session_id")
+        ), (
+            "BUG: parent_messages and sub_session_id cannot both be set for a "
+            "full-fidelity spawn.  parent_messages drives continuity; "
+            "sub_session_id re-passes a session identity and would cause "
+            "foundation to silently drop the injected history."
+        )
 
         # Spawn the child session
         try:
@@ -401,17 +451,19 @@ class AmplifierBackend:
 
         outcome = _parse_outcome(output)
 
-        # Capture session_id from spawn result — always, for all fidelity modes
+        # Capture session_id from spawn result for status.json observability.
+        # session_id is kept on the Outcome for telemetry/debugging — it no longer
+        # drives continuity (that role belongs to _thread_transcripts).
         session_id = result.get("session_id") if isinstance(result, dict) else None
         if session_id:
             outcome.session_id = session_id
 
-        # Record session_id in pool for full fidelity reuse
-        if fidelity == "full" and graph is not None and session_id:
-            thread_key = resolve_thread_key(
-                node, incoming_edge, graph, self._last_node_id
-            )
-            self._session_pool[thread_key] = session_id
+        # Append this node's exchange to the thread transcript (full fidelity only).
+        # Uses truncate-to-node-then-append for idempotency: if this node is being
+        # re-run (e.g., after a goal-gate retry), its prior turn is replaced rather
+        # than duplicated.  See _append_to_transcript for the algorithm.
+        if fidelity == "full" and graph is not None and thread_key is not None:
+            self._append_to_transcript(thread_key, node.id, instruction, output)
 
         return outcome
 
@@ -559,6 +611,73 @@ class AmplifierBackend:
             status=StageStatus.SUCCESS,
             notes=f"Stage completed: {node.id}",
         )
+
+    # ------------------------------------------------------------------
+    # _thread_transcripts helpers — fidelity=full continuity carrier
+    # ------------------------------------------------------------------
+
+    def _append_to_transcript(
+        self,
+        thread_key: str,
+        node_id: str,
+        instruction: str,
+        output: str,
+    ) -> None:
+        """Append a node's (instruction, output) exchange to the thread transcript.
+
+        Implements **truncate-to-node-then-append** for goal-gate-retry
+        idempotency: if this node already has a turn in the transcript (from a
+        prior attempt in the same run), all turns from that node onwards are
+        removed before the new turn is appended.  This means a re-run node
+        *replaces* its prior exchange rather than duplicating it.
+
+        Algorithm:
+            1. Scan the current transcript for the first tuple whose node_id
+               matches the incoming node_id.
+            2. If found at position i: truncate the list to the first i entries
+               (discarding that node and all subsequent nodes' entries).
+            3. Append the new triple (node_id, instruction, output).
+
+        Called with role=user/assistant only (system/developer roles are
+        stripped at this layer, matching app-cli behavior).
+
+        Thread_id is branch-local (EXTENSIONS.md §13): ``clone()`` resets
+        ``_thread_transcripts`` so sibling parallel branches each maintain
+        independent transcripts even when they share an explicit thread_id.
+
+        Note on sequentiality (§3.8 / design §2):
+            Same-thread-key full nodes within a single branch always run
+            sequentially (the engine while-loop is sequential; parallel
+            branches each receive an isolated backend clone).  No asyncio
+            lock is required.
+        """
+        turns = self._thread_transcripts.get(thread_key, [])
+        # Truncate from the first occurrence of this node_id, replacing any
+        # stale tail left by a prior attempt of the same node or later nodes.
+        for i, (nid, _, _) in enumerate(turns):
+            if nid == node_id:
+                turns = turns[:i]
+                break
+        turns.append((node_id, instruction, output))
+        self._thread_transcripts[thread_key] = turns
+
+    def _get_parent_messages_for_thread(self, thread_key: str) -> list[dict[str, Any]]:
+        """Return the accumulated conversation history for a thread as a flat
+        ``parent_messages`` list (user/assistant dicts).
+
+        Each stored triple ``(node_id, instruction, output)`` expands to two
+        messages:
+            {"role": "user",      "content": instruction}
+            {"role": "assistant", "content": output}
+
+        Returns an empty list if the thread has no prior exchanges (first node
+        on the thread — no parent_messages will be set in that case).
+        """
+        messages: list[dict[str, Any]] = []
+        for _, instr, out in self._thread_transcripts.get(thread_key, []):
+            messages.append({"role": "user", "content": instr})
+            messages.append({"role": "assistant", "content": out})
+        return messages
 
     def _get_or_create_unified_client(self) -> Any:
         """Return the injected client or lazily create one from environment."""

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/backend.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/backend.py
@@ -243,6 +243,25 @@ class AmplifierBackend:
             # Fallback when graph not provided (backward compat)
             fidelity = node.attrs.get("fidelity", "compact")
 
+        # CR-1 loud guard (silent-continuity-loss class): a fidelity=full node
+        # needs `graph` to resolve its thread key and drive the transcript
+        # store/read.  If `full` continuity is requested but `graph` is missing,
+        # the store/read gates below would silently skip — exactly the dead-code
+        # bug a live DTU run exposed (seeds wrote codewords, recall came back
+        # empty because CodergenHandler.execute dropped `graph`).  Warn loudly so
+        # a future caller that drops `graph` fails visibly instead of silently
+        # losing continuity.  Scoped to the `full` path only: non-full nodes and
+        # legitimately thread-less nodes never need a graph and must not warn.
+        if fidelity == "full" and graph is None:
+            logger.warning(
+                "Node %s requested fidelity=full continuity but no graph was "
+                "passed to backend.run() — the thread key cannot be resolved, so "
+                "conversation continuity will NOT be honored for this node. The "
+                "caller (handler/engine) must forward `graph`. See "
+                "docs/designs/fidelity-full-session-continuity.md.",
+                node.id,
+            )
+
         # 4. Build the instruction with preamble for non-full modes
         if fidelity == "full":
             instruction = prompt

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py
@@ -111,7 +111,7 @@ class PipelineEngine:
 
         Each concurrent parallel branch must have its own engine so that
         ``run_subgraph`` uses an isolated ``handler_registry`` (and therefore
-        an isolated backend ``_session_pool`` / ``_completed_nodes``).
+        an isolated backend ``_thread_transcripts`` / ``_completed_nodes``).
 
         Split table (critic-corrected, implement exactly):
           ISOLATED per branch (cloned):

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/__init__.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/__init__.py
@@ -154,8 +154,8 @@ class HandlerRegistry:
         dependency is severed by Move 2).
 
         Called by ``PipelineEngine.clone_for_branch`` so each concurrent
-        parallel branch gets its own backend mutable state (``_session_pool``,
-        ``_completed_nodes``).
+        parallel branch gets its own backend mutable state
+        (``_thread_transcripts``, ``_completed_nodes``).
         """
         from .codergen import CodergenHandler
         from .pipeline import PipelineHandler
@@ -165,8 +165,8 @@ class HandlerRegistry:
         new._handlers = dict(self._handlers)
 
         # Replace codergen with a clone that has its own backend state.
-        # The cloned backend carries fresh _session_pool and _completed_nodes
-        # so concurrent branches cannot cross-pollute session state.
+        # The cloned backend carries fresh _thread_transcripts and _completed_nodes
+        # so concurrent branches cannot cross-pollute thread transcript or session state.
         original_codergen = self._handlers.get("codergen")
         if isinstance(original_codergen, CodergenHandler):
             backend = original_codergen._backend

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/codergen.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/codergen.py
@@ -9,7 +9,6 @@ Spec coverage: CODER-001-011, Section 4.5
 
 from __future__ import annotations
 
-import inspect
 import json
 import os
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
@@ -54,36 +53,6 @@ class CodergenHandler:
 
     def __init__(self, backend: Any | None = None) -> None:
         self._backend = backend
-        # Cached decision: does this backend's run() accept the `graph` kwarg?
-        # Resolved once on first use (see _backend_accepts_graph).
-        self._backend_accepts_graph: bool | None = None
-
-    def _resolve_backend_accepts_graph(self) -> bool:
-        """Return True if the backend's ``run`` accepts ``graph`` (cached).
-
-        The production ``AmplifierBackend.run`` accepts ``incoming_edge`` and
-        ``graph`` (widened ``CodergenBackend`` Protocol).  Many lightweight test
-        doubles were written against the historical 3-arg ``run(node, prompt,
-        context)`` signature.  We forward ``graph`` only when the backend can
-        receive it, so the production path gets full-fidelity continuity while
-        minimal backends keep working unchanged.  A backend that declares
-        ``**kwargs`` is also treated as accepting it.
-        """
-        if self._backend_accepts_graph is None:
-            run = getattr(self._backend, "run", None)
-            if run is None:
-                self._backend_accepts_graph = False
-            else:
-                try:
-                    params = inspect.signature(run).parameters
-                    self._backend_accepts_graph = "graph" in params or any(
-                        p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()
-                    )
-                except (ValueError, TypeError):
-                    # Builtins / C-callables without an introspectable
-                    # signature: do not forward the optional kwargs.
-                    self._backend_accepts_graph = False
-        return self._backend_accepts_graph
 
     async def execute(
         self,
@@ -141,16 +110,12 @@ class CodergenHandler:
             # needed.
             #
             # `graph`/`incoming_edge` are OPTIONAL CodergenBackend params (declared
-            # with defaults). The production AmplifierBackend accepts them; some
-            # minimal backends are written against the historical 3-arg signature.
-            # Forward only when the backend can receive them (feature-detect once,
-            # cached) so we never pass an unexpected kwarg to a legacy backend.
-            if self._resolve_backend_accepts_graph():
-                result = await self._backend.run(
-                    node, prompt, context, incoming_edge=None, graph=graph
-                )
-            else:
-                result = await self._backend.run(node, prompt, context)
+            # with defaults), so this unconditional call is the whole contract:
+            # the production AmplifierBackend accepts them and all conforming test
+            # doubles match this signature.
+            result = await self._backend.run(
+                node, prompt, context, incoming_edge=None, graph=graph
+            )
             if isinstance(result, Outcome):
                 _write_status(stage_dir, result)
                 return result

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/codergen.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/codergen.py
@@ -9,6 +9,7 @@ Spec coverage: CODER-001-011, Section 4.5
 
 from __future__ import annotations
 
+import inspect
 import json
 import os
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
@@ -27,10 +28,21 @@ class CodergenBackend(Protocol):
     """Interface for LLM execution backends.
 
     Spec Section 4.5: CodergenBackend Interface.
+
+    ``graph`` (and ``incoming_edge`` where available) MUST be forwarded by the
+    handler: the backend's fidelity resolution and fidelity=full transcript
+    store/read gates require ``graph`` to resolve the thread key.  Omitting it
+    silently disables full-fidelity continuity (see
+    docs/designs/fidelity-full-session-continuity.md).
     """
 
     async def run(
-        self, node: Node, prompt: str, context: PipelineContext
+        self,
+        node: Node,
+        prompt: str,
+        context: PipelineContext,
+        incoming_edge: Any | None = None,
+        graph: Graph | None = None,
     ) -> str | Outcome: ...
 
 
@@ -42,6 +54,36 @@ class CodergenHandler:
 
     def __init__(self, backend: Any | None = None) -> None:
         self._backend = backend
+        # Cached decision: does this backend's run() accept the `graph` kwarg?
+        # Resolved once on first use (see _backend_accepts_graph).
+        self._backend_accepts_graph: bool | None = None
+
+    def _resolve_backend_accepts_graph(self) -> bool:
+        """Return True if the backend's ``run`` accepts ``graph`` (cached).
+
+        The production ``AmplifierBackend.run`` accepts ``incoming_edge`` and
+        ``graph`` (widened ``CodergenBackend`` Protocol).  Many lightweight test
+        doubles were written against the historical 3-arg ``run(node, prompt,
+        context)`` signature.  We forward ``graph`` only when the backend can
+        receive it, so the production path gets full-fidelity continuity while
+        minimal backends keep working unchanged.  A backend that declares
+        ``**kwargs`` is also treated as accepting it.
+        """
+        if self._backend_accepts_graph is None:
+            run = getattr(self._backend, "run", None)
+            if run is None:
+                self._backend_accepts_graph = False
+            else:
+                try:
+                    params = inspect.signature(run).parameters
+                    self._backend_accepts_graph = "graph" in params or any(
+                        p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()
+                    )
+                except (ValueError, TypeError):
+                    # Builtins / C-callables without an introspectable
+                    # signature: do not forward the optional kwargs.
+                    self._backend_accepts_graph = False
+        return self._backend_accepts_graph
 
     async def execute(
         self,
@@ -80,7 +122,35 @@ class CodergenHandler:
                 "Pass backend=MockBackend() explicitly if you want simulated responses for testing."
             )
         try:
-            result = await self._backend.run(node, prompt, context)
+            # Forward `graph` into the backend so fidelity resolution and the
+            # fidelity=full transcript store/read gates (which require
+            # `graph is not None`) actually fire on the production path.
+            #
+            # Without this, full-fidelity continuity is silently dead: the
+            # backend's gates skip and seed→recall loses history (proven by a
+            # live DTU run — seeds wrote codewords, recall came back empty).
+            #
+            # `incoming_edge` is NOT available here: execute_with_retry (the sole
+            # invoker, retry.py) threads `graph` but not the edge, and the engine
+            # call sites (engine.py) don't pass it either. The edge only affects
+            # EDGE-level `thread_id`/`fidelity` overrides; node-level and
+            # graph-level thread/fidelity resolution — which the DTU and the vast
+            # majority of pipelines use — work from `graph` alone. We pass
+            # `incoming_edge=None` explicitly; threading the edge end-to-end is a
+            # separate, larger change tracked for when edge-level overrides are
+            # needed.
+            #
+            # `graph`/`incoming_edge` are OPTIONAL CodergenBackend params (declared
+            # with defaults). The production AmplifierBackend accepts them; some
+            # minimal backends are written against the historical 3-arg signature.
+            # Forward only when the backend can receive them (feature-detect once,
+            # cached) so we never pass an unexpected kwarg to a legacy backend.
+            if self._resolve_backend_accepts_graph():
+                result = await self._backend.run(
+                    node, prompt, context, incoming_edge=None, graph=graph
+                )
+            else:
+                result = await self._backend.run(node, prompt, context)
             if isinstance(result, Outcome):
                 _write_status(stage_dir, result)
                 return result

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/parallel.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/parallel.py
@@ -142,7 +142,7 @@ class ParallelHandler:
                     try:
                         # Move 1: give each branch its own engine so run_subgraph
                         # uses an isolated handler_registry (and therefore isolated
-                        # backend _session_pool / _completed_nodes per branch).
+                        # backend _thread_transcripts / _completed_nodes per branch).
                         # Fall back to the parent engine for mock/stub engines used
                         # in unit tests that predate clone_for_branch.
                         clone_fn = getattr(engine, "clone_for_branch", None)

--- a/modules/loop-pipeline/tests/test_backend_clone.py
+++ b/modules/loop-pipeline/tests/test_backend_clone.py
@@ -1,7 +1,7 @@
 """Tests for AmplifierBackend.clone() — parallel branch isolation.
 
 Verifies that clone() produces a new backend with:
-- Fresh mutable state (session_pool, completed_nodes, etc.)
+- Fresh mutable state (_thread_transcripts, completed_nodes, etc.)
 - Shared immutable refs (coordinator, profiles, provider, etc.)
 - Independent tool dict (shallow copy)
 """
@@ -32,21 +32,25 @@ class TestAmplifierBackendClone:
     def test_clone_has_empty_mutable_state(self):
         """Cloned backend starts with fresh mutable state.
 
-        _session_pool, _completed_nodes, and _last_node_id are always fresh.
+        _thread_transcripts, _completed_nodes, and _last_node_id are always fresh.
         _spawn_fn and _spawn_checked are INHERITED from the parent (not reset)
         so branch clones never perform a concurrent first-resolution of
         session.spawn under asyncio.gather.
+
+        _thread_transcripts being fresh is the mechanism that makes thread_id
+        branch-local: sibling parallel branches each start with an empty
+        transcript even if they share an explicit thread_id (EXTENSIONS.md §13).
         """
         original = _make_backend()
         # Dirty the original's mutable state
-        original._session_pool["thread-1"] = "session-abc"
+        original._thread_transcripts["thread-1"] = [("node-1", "instr", "output")]
         original._completed_nodes["node-1"] = Outcome(status=StageStatus.SUCCESS)
         original._last_node_id = "node-1"
         original._spawn_checked = True
 
         clone = original.clone()
 
-        assert clone._session_pool == {}
+        assert clone._thread_transcripts == {}
         assert clone._completed_nodes == {}
         assert clone._last_node_id is None
         # _spawn_checked is inherited (not reset) to prevent concurrent
@@ -82,13 +86,13 @@ class TestAmplifierBackendClone:
         original = _make_backend()
 
         clone = original.clone()
-        clone._session_pool["thread-x"] = "session-999"
+        clone._thread_transcripts["thread-x"] = [("node-x", "instr", "output")]
         clone._completed_nodes["node-x"] = Outcome(status=StageStatus.FAIL)
         clone._last_node_id = "node-x"
         clone._spawn_checked = True
         clone._tools["tool_new"] = MagicMock()
 
-        assert original._session_pool == {}
+        assert original._thread_transcripts == {}
         assert original._completed_nodes == {}
         assert original._last_node_id is None
         assert original._spawn_checked is False

--- a/modules/loop-pipeline/tests/test_backend_fidelity.py
+++ b/modules/loop-pipeline/tests/test_backend_fidelity.py
@@ -196,17 +196,23 @@ async def test_backend_default_fidelity_is_compact():
 
 
 @pytest.mark.asyncio
-async def test_backend_reuses_session_for_full_fidelity():
-    """Full fidelity with same thread_id reuses the session_id from pool."""
+async def test_backend_carries_history_via_parent_messages_for_full_fidelity():
+    """Full fidelity with same thread_id carries history via parent_messages.
+
+    The second node on the same thread must receive the first node's
+    (instruction, output) exchange as parent_messages — NOT sub_session_id.
+    sub_session_id was the type confusion (id-where-a-conversation-belongs)
+    that caused the continuity bug.
+    """
     coordinator = MockCoordinator(
-        spawn_result={"output": "done", "session_id": "sess-abc"}
+        spawn_result={"output": "first task output", "session_id": "sess-abc"}
     )
     backend = AmplifierBackend(
         coordinator=coordinator,
         profiles={"anthropic": "attractor-anthropic"},
     )
 
-    # First call: creates new session
+    # First call: no prior history, spawns fresh
     node1 = _make_node(
         id="step1",
         attrs={
@@ -219,8 +225,17 @@ async def test_backend_reuses_session_for_full_fidelity():
     context = _make_context()
 
     await backend.run(node1, "First task", context, incoming_edge=edge, graph=graph)
+    first_call_kwargs = coordinator.last_spawn_kwargs
 
-    # Second call: same thread_id should reuse session
+    # First call: no prior history → no parent_messages, no sub_session_id
+    assert "sub_session_id" not in first_call_kwargs, (
+        "sub_session_id must never appear on a full-fidelity spawn"
+    )
+    assert not first_call_kwargs.get("parent_messages"), (
+        "First node on a thread has no prior history — no parent_messages"
+    )
+
+    # Second call: same thread_id should carry prior history as parent_messages
     node2 = _make_node(
         id="step2",
         attrs={
@@ -229,12 +244,26 @@ async def test_backend_reuses_session_for_full_fidelity():
             "thread_id": "main-thread",
         },
     )
-    await backend.run(node2, "Second task", context, incoming_edge=edge, graph=graph)
+    edge2 = Edge(from_node="step1", to_node="step2")
+    await backend.run(node2, "Second task", context, incoming_edge=edge2, graph=graph)
     second_call_kwargs = coordinator.last_spawn_kwargs
 
-    # The second call should include sub_session_id for resumption
-    assert "sub_session_id" in second_call_kwargs
-    assert second_call_kwargs["sub_session_id"] == "sess-abc"
+    # Second call: parent_messages carries the first node's exchange
+    assert "parent_messages" in second_call_kwargs, (
+        "Second full-fidelity node on same thread must receive parent_messages"
+    )
+    pm = second_call_kwargs["parent_messages"]
+    assert len(pm) == 2, f"Expected 2 messages (user + assistant), got {len(pm)}: {pm}"
+    assert pm[0]["role"] == "user"
+    assert pm[0]["content"] == "First task"
+    assert pm[1]["role"] == "assistant"
+    assert pm[1]["content"] == "first task output"
+
+    # Second call: never uses sub_session_id
+    assert "sub_session_id" not in second_call_kwargs, (
+        "sub_session_id must never appear on a full-fidelity spawn; "
+        "continuity is via parent_messages"
+    )
 
 
 @pytest.mark.asyncio

--- a/modules/loop-pipeline/tests/test_backend_full_continuity.py
+++ b/modules/loop-pipeline/tests/test_backend_full_continuity.py
@@ -1,0 +1,495 @@
+"""Tests for fidelity=full intra-run session continuity.
+
+Verifies the Candidate A design: _thread_transcripts carries conversation
+across same-thread full-fidelity nodes via parent_messages (not session_id
+reuse).
+
+Design spec: docs/designs/fidelity-full-session-continuity.md
+Spec coverage: §5.4 (full fidelity), §3.8 (sequential same-thread traversal),
+               EXTENSIONS.md §12-13.
+"""
+
+import pytest
+
+from amplifier_module_loop_pipeline.backend import AmplifierBackend
+from amplifier_module_loop_pipeline.context import PipelineContext
+from amplifier_module_loop_pipeline.graph import Edge, Graph, Node
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+class _MockSession:
+    config: dict = {}
+
+
+class _SpawnCapture:
+    """Coordinator mock that captures every spawn call's kwargs."""
+
+    def __init__(self, output: str = "done", session_id: str = "child-1"):
+        self._output = output
+        self._session_id = session_id
+        self.calls: list[dict] = []  # all spawn kwarg dicts in call order
+        self.session = _MockSession()
+        self.config: dict = {"agents": {}}
+
+    def get_capability(self, name: str):
+        if name == "session.spawn":
+            return self._spawn_fn
+        return None
+
+    async def _spawn_fn(self, **kwargs):
+        self.calls.append(dict(kwargs))
+        return {"output": self._output, "session_id": self._session_id}
+
+
+def _make_full_node(node_id: str, thread_id: str = "main") -> Node:
+    return Node(
+        id=node_id,
+        prompt="Do work",
+        attrs={"llm_provider": "anthropic", "fidelity": "full", "thread_id": thread_id},
+    )
+
+
+def _make_graph_with_full_nodes(
+    *node_ids: str, thread_id: str = "main"
+) -> tuple[Graph, Edge]:
+    """Build a minimal linear graph with all nodes set to fidelity=full."""
+    nodes: dict[str, Node] = {"start": Node(id="start", shape="Mdiamond")}
+    for nid in node_ids:
+        nodes[nid] = _make_full_node(nid, thread_id=thread_id)
+    nodes["exit"] = Node(id="exit", shape="Msquare")
+
+    edges: list[Edge] = [Edge(from_node="start", to_node=node_ids[0])]
+    for i in range(len(node_ids) - 1):
+        edges.append(Edge(from_node=node_ids[i], to_node=node_ids[i + 1]))
+    edges.append(Edge(from_node=node_ids[-1], to_node="exit"))
+
+    incoming_edge = Edge(from_node="start", to_node=node_ids[0])
+    graph = Graph(name="test", nodes=nodes, edges=edges, graph_attrs={})
+    return graph, incoming_edge
+
+
+def _make_context() -> PipelineContext:
+    ctx = PipelineContext()
+    ctx.set("graph.goal", "Test continuity")
+    return ctx
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Intra-run continuity — the core proof (RED on main, GREEN after fix)
+#
+# Node A runs on thread T → Node B runs on thread T →
+# B's spawn must receive parent_messages=[{user: A.instr}, {asst: A.output}]
+# B's spawn must NOT receive sub_session_id or session_id.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_full_fidelity_second_node_gets_parent_messages():
+    """Node B on the same thread sees Node A's exchange via parent_messages.
+
+    The FIRST node on a thread gets no parent_messages (no prior history).
+    The SECOND node sees the first node's (instruction, output) pair as
+    parent_messages in user/assistant roles.
+
+    Verifies the core of the Candidate A design:
+      - No sub_session_id for full-fidelity continuity (type confusion removed)
+      - parent_messages carries the prior exchange
+    """
+    coordinator = _SpawnCapture(output="First node output", session_id="sess-A")
+    backend = AmplifierBackend(
+        coordinator=coordinator,
+        profiles={"anthropic": "attractor-anthropic"},
+    )
+
+    graph, _ = _make_graph_with_full_nodes("node_a", "node_b", thread_id="main-thread")
+    context = _make_context()
+
+    # Edges with the correct fidelity context
+    edge_to_a = Edge(from_node="start", to_node="node_a")
+    edge_to_b = Edge(from_node="node_a", to_node="node_b")
+
+    # Run Node A
+    node_a = graph.nodes["node_a"]
+    await backend.run(
+        node_a, "First instruction", context, incoming_edge=edge_to_a, graph=graph
+    )
+
+    # Run Node B (same thread)
+    coordinator._output = "Second node output"
+    coordinator._session_id = "sess-B"
+    node_b = graph.nodes["node_b"]
+    await backend.run(
+        node_b, "Second instruction", context, incoming_edge=edge_to_b, graph=graph
+    )
+
+    # --- Assertions ---
+    assert len(coordinator.calls) == 2, "Expected exactly 2 spawn calls"
+
+    first_call = coordinator.calls[0]
+    second_call = coordinator.calls[1]
+
+    # First node: no prior history → no parent_messages
+    assert "parent_messages" not in first_call or not first_call.get(
+        "parent_messages"
+    ), (
+        "First full-fidelity node on a thread must NOT receive parent_messages "
+        "(no prior history exists)"
+    )
+    # First node: never uses sub_session_id for continuity
+    assert "sub_session_id" not in first_call, (
+        "sub_session_id must never appear on a full-fidelity spawn "
+        "(it was the type confusion that caused the continuity bug)"
+    )
+
+    # Second node: gets parent_messages from Node A's exchange
+    assert "parent_messages" in second_call, (
+        "Second full-fidelity node on same thread must receive parent_messages"
+    )
+    pm = second_call["parent_messages"]
+    assert isinstance(pm, list), "parent_messages must be a list"
+    assert len(pm) == 2, (
+        f"One prior exchange = 2 messages (user + assistant). Got {len(pm)}: {pm}"
+    )
+    assert pm[0]["role"] == "user", "First message in exchange must be role=user"
+    assert pm[0]["content"] == "First instruction", (
+        "user message content must be the node's instruction"
+    )
+    assert pm[1]["role"] == "assistant", (
+        "Second message in exchange must be role=assistant"
+    )
+    assert pm[1]["content"] == "First node output", (
+        "assistant message content must be the node's final output"
+    )
+
+    # Second node: no sub_session_id (continuity is via parent_messages now)
+    assert "sub_session_id" not in second_call, (
+        "sub_session_id must never appear on a full-fidelity spawn; "
+        "continuity is via parent_messages"
+    )
+
+
+@pytest.mark.asyncio
+async def test_full_fidelity_transcript_grows_across_nodes():
+    """Three nodes on the same thread: each subsequent node gets growing history.
+
+    Node A: no parent_messages (first)
+    Node B: 2 messages (A's exchange)
+    Node C: 4 messages (A + B exchanges)
+    """
+    coordinator = _SpawnCapture(output="output-A", session_id="sess-1")
+    backend = AmplifierBackend(
+        coordinator=coordinator,
+        profiles={"anthropic": "attractor-anthropic"},
+    )
+
+    graph, _ = _make_graph_with_full_nodes("a", "b", "c", thread_id="T")
+    context = _make_context()
+
+    edge_ab = Edge(from_node="start", to_node="a")
+    edge_bc = Edge(from_node="a", to_node="b")
+    edge_cd = Edge(from_node="b", to_node="c")
+
+    coordinator._output = "out-A"
+    await backend.run(
+        graph.nodes["a"], "instr-A", context, incoming_edge=edge_ab, graph=graph
+    )
+
+    coordinator._output = "out-B"
+    await backend.run(
+        graph.nodes["b"], "instr-B", context, incoming_edge=edge_bc, graph=graph
+    )
+
+    coordinator._output = "out-C"
+    await backend.run(
+        graph.nodes["c"], "instr-C", context, incoming_edge=edge_cd, graph=graph
+    )
+
+    assert len(coordinator.calls) == 3
+    # Node A: no prior messages
+    assert not coordinator.calls[0].get("parent_messages")
+    # Node B: 2 messages (A's exchange)
+    pm_b = coordinator.calls[1].get("parent_messages", [])
+    assert len(pm_b) == 2
+    # Node C: 4 messages (A + B exchanges)
+    pm_c = coordinator.calls[2].get("parent_messages", [])
+    assert len(pm_c) == 4
+    assert pm_c[0] == {"role": "user", "content": "instr-A"}
+    assert pm_c[1] == {"role": "assistant", "content": "out-A"}
+    assert pm_c[2] == {"role": "user", "content": "instr-B"}
+    assert pm_c[3] == {"role": "assistant", "content": "out-B"}
+
+
+# ---------------------------------------------------------------------------
+# Test 2: Idempotency — goal-gate retry doesn't double-append
+#
+# A node that is re-run (simulating a goal-gate retry that re-executes the node)
+# should replace its prior turn, not duplicate it.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_full_fidelity_idempotent_on_node_rerun():
+    """Re-running a full-fidelity node replaces its transcript turn (not duplicates).
+
+    Simulates a goal-gate retry that re-executes node_a. The next node (node_b)
+    should see exactly ONE exchange from node_a in its parent_messages, not two.
+    """
+    coordinator = _SpawnCapture(output="initial-output", session_id="s1")
+    backend = AmplifierBackend(
+        coordinator=coordinator,
+        profiles={"anthropic": "attractor-anthropic"},
+    )
+
+    graph, _ = _make_graph_with_full_nodes("node_a", "node_b", thread_id="T")
+    context = _make_context()
+    edge_to_a = Edge(from_node="start", to_node="node_a")
+    edge_to_b = Edge(from_node="node_a", to_node="node_b")
+
+    # First run of node_a
+    coordinator._output = "output-attempt-1"
+    await backend.run(
+        graph.nodes["node_a"],
+        "instr-attempt-1",
+        context,
+        incoming_edge=edge_to_a,
+        graph=graph,
+    )
+
+    # Simulate goal-gate retry: node_a is re-run (same node_id, same thread)
+    coordinator._output = "output-attempt-2"
+    await backend.run(
+        graph.nodes["node_a"],
+        "instr-attempt-2",
+        context,
+        incoming_edge=edge_to_a,
+        graph=graph,
+    )
+
+    # Now node_b runs — it should see ONLY the second attempt's exchange
+    coordinator._output = "out-B"
+    await backend.run(
+        graph.nodes["node_b"], "instr-B", context, incoming_edge=edge_to_b, graph=graph
+    )
+
+    b_call = coordinator.calls[-1]
+    pm = b_call.get("parent_messages", [])
+    assert len(pm) == 2, (
+        f"Node B must see exactly ONE exchange from the re-run node_a. "
+        f"Got {len(pm)} messages: {pm}"
+    )
+    assert pm[0]["content"] == "instr-attempt-2", (
+        "The SECOND attempt's instruction must replace the first"
+    )
+    assert pm[1]["content"] == "output-attempt-2", (
+        "The SECOND attempt's output must replace the first"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 3: Isolation — clone resets transcript; same thread_id in sibling
+# branches does NOT join conversations
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_full_fidelity_clone_has_independent_transcript():
+    """clone() resets _thread_transcripts; branch clones are transcript-isolated.
+
+    If two branch clones share the same thread_id, they each get their own
+    independent transcript — they do NOT share history (§3.8 isolation).
+    """
+    coordinator = _SpawnCapture(output="parent-output", session_id="parent-sess")
+    parent_backend = AmplifierBackend(
+        coordinator=coordinator,
+        profiles={"anthropic": "attractor-anthropic"},
+    )
+
+    graph, _ = _make_graph_with_full_nodes(
+        "node_a", "node_b", thread_id="shared-thread"
+    )
+    context = _make_context()
+    edge_to_a = Edge(from_node="start", to_node="node_a")
+    edge_to_b = Edge(from_node="node_a", to_node="node_b")
+
+    # Parent backend runs node_a — builds a transcript entry
+    coordinator._output = "parent-node-a-output"
+    await parent_backend.run(
+        graph.nodes["node_a"],
+        "parent-instr-A",
+        context,
+        incoming_edge=edge_to_a,
+        graph=graph,
+    )
+
+    # Clone the backend (simulates branch isolation)
+    branch_backend = parent_backend.clone()
+
+    # Branch backend runs node_b — its transcript is FRESH (clone resets it)
+    # So node_b in the branch must NOT see parent backend's node_a exchange
+    coord_b = _SpawnCapture(output="branch-output", session_id="branch-sess")
+    branch_backend._coordinator = coord_b
+    branch_backend._spawn_fn = None
+    branch_backend._spawn_checked = False
+
+    await branch_backend.run(
+        graph.nodes["node_b"],
+        "branch-instr-B",
+        context,
+        incoming_edge=edge_to_b,
+        graph=graph,
+    )
+
+    # The branch's node_b spawn must NOT have parent_messages from the parent backend
+    assert len(coord_b.calls) == 1
+    branch_call = coord_b.calls[0]
+    pm = branch_call.get("parent_messages") or []
+    assert len(pm) == 0, (
+        f"Branch backend must have a fresh transcript (clone resets it). "
+        f"Got unexpected parent_messages: {pm}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 4: Loud-not-silent (CR-1) — sub_session_id never appears in full spawns
+#
+# The backend guarantees mutual exclusion of parent_messages and sub_session_id
+# by construction. Verify this for all full-fidelity calls.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_full_fidelity_never_uses_sub_session_id():
+    """Full-fidelity spawns must NEVER include sub_session_id in any call.
+
+    The old broken implementation stored a session_id and re-passed it as
+    sub_session_id. The fix removes this path entirely. Continuity is always
+    via parent_messages, never via session resumption.
+    """
+    coordinator = _SpawnCapture(output="done", session_id="sess-xyz")
+    backend = AmplifierBackend(
+        coordinator=coordinator,
+        profiles={"anthropic": "attractor-anthropic"},
+    )
+
+    graph, _ = _make_graph_with_full_nodes("a", "b", "c", thread_id="T")
+    context = _make_context()
+
+    edges = [
+        Edge(from_node="start", to_node="a"),
+        Edge(from_node="a", to_node="b"),
+        Edge(from_node="b", to_node="c"),
+    ]
+    nodes = ["a", "b", "c"]
+    instructions = ["instr-A", "instr-B", "instr-C"]
+
+    for node_id, edge, instr in zip(nodes, edges, instructions):
+        await backend.run(
+            graph.nodes[node_id], instr, context, incoming_edge=edge, graph=graph
+        )
+
+    for i, call in enumerate(coordinator.calls):
+        assert "sub_session_id" not in call, (
+            f"Call {i} for full-fidelity spawn must not include sub_session_id. "
+            f"sub_session_id is the broken mechanism that caused the continuity bug. "
+            f"Full kwargs: {call}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 5: Different threads remain independent (non-regression)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_full_fidelity_different_threads_dont_share_transcript():
+    """Nodes on different thread_ids keep independent transcripts.
+
+    node_a (thread=T1) and node_c (thread=T2) must not share history.
+    node_b follows node_a on T1; it sees node_a's exchange.
+    node_d follows node_c on T2; it must NOT see T1 history.
+    """
+    coordinator = _SpawnCapture(output="done", session_id="s1")
+    backend = AmplifierBackend(
+        coordinator=coordinator,
+        profiles={"anthropic": "attractor-anthropic"},
+    )
+
+    # Build a graph with 4 nodes across two threads
+    nodes_map = {
+        "start": Node(id="start", shape="Mdiamond"),
+        "node_a": _make_full_node("node_a", thread_id="T1"),
+        "node_b": _make_full_node("node_b", thread_id="T1"),
+        "node_c": _make_full_node("node_c", thread_id="T2"),
+        "node_d": _make_full_node("node_d", thread_id="T2"),
+        "exit": Node(id="exit", shape="Msquare"),
+    }
+    edges = [
+        Edge(from_node="start", to_node="node_a"),
+        Edge(from_node="node_a", to_node="node_b"),
+        Edge(from_node="node_b", to_node="node_c"),
+        Edge(from_node="node_c", to_node="node_d"),
+        Edge(from_node="node_d", to_node="exit"),
+    ]
+    graph = Graph(name="test", nodes=nodes_map, edges=edges, graph_attrs={})
+    context = _make_context()
+
+    # Thread T1
+    coordinator._output = "out-A"
+    await backend.run(
+        graph.nodes["node_a"],
+        "instr-A",
+        context,
+        incoming_edge=edges[0],
+        graph=graph,
+    )
+    coordinator._output = "out-B"
+    await backend.run(
+        graph.nodes["node_b"],
+        "instr-B",
+        context,
+        incoming_edge=edges[1],
+        graph=graph,
+    )
+
+    # Thread T2 — separate thread, should start fresh
+    coordinator._output = "out-C"
+    await backend.run(
+        graph.nodes["node_c"],
+        "instr-C",
+        context,
+        incoming_edge=edges[2],
+        graph=graph,
+    )
+    coordinator._output = "out-D"
+    await backend.run(
+        graph.nodes["node_d"],
+        "instr-D",
+        context,
+        incoming_edge=edges[3],
+        graph=graph,
+    )
+
+    assert len(coordinator.calls) == 4
+
+    # node_a (first on T1): no parent_messages
+    assert not coordinator.calls[0].get("parent_messages")
+    # node_b: sees T1's history only (A's exchange)
+    pm_b = coordinator.calls[1].get("parent_messages", [])
+    assert len(pm_b) == 2
+    assert pm_b[0]["content"] == "instr-A"
+
+    # node_c (first on T2): no parent_messages (fresh thread)
+    assert not coordinator.calls[2].get("parent_messages"), (
+        "node_c is the first node on T2 — must start with no parent_messages"
+    )
+    # node_d (second on T2): sees only T2 history
+    pm_d = coordinator.calls[3].get("parent_messages", [])
+    assert len(pm_d) == 2, (
+        f"node_d on T2 must see only T2 history (node_c's exchange). "
+        f"Got {len(pm_d)} messages: {pm_d}"
+    )
+    assert pm_d[0]["content"] == "instr-C", "node_d must see T2 history, not T1"

--- a/modules/loop-pipeline/tests/test_batch_d_pipeline_infra.py
+++ b/modules/loop-pipeline/tests/test_batch_d_pipeline_infra.py
@@ -60,7 +60,7 @@ class MockBackend:
     def __init__(self, return_value: str = "done") -> None:
         self._return_value = return_value
 
-    async def run(self, node: Node, prompt: str, context: PipelineContext) -> str:
+    async def run(self, node: Node, prompt: str, context: PipelineContext, incoming_edge=None, graph=None) -> str:
         return self._return_value
 
 
@@ -255,7 +255,7 @@ class TestM19StatusJsonFields:
 
         class _SessionOutcomeBackend:
             async def run(
-                self, node: Node, prompt: str, context: PipelineContext
+                self, node: Node, prompt: str, context: PipelineContext, incoming_edge=None, graph=None
             ) -> Outcome:
                 if node.id == "work":
                     return Outcome(
@@ -589,7 +589,7 @@ class TestM23CheckpointFidelityDegradation:
         fidelities_seen: list[str] = []
 
         class FidelityCapturingBackend:
-            async def run(self, node, prompt, context):
+            async def run(self, node, prompt, context, incoming_edge=None, graph=None):
                 fidelity = context.get("graph.default_fidelity")
                 fidelities_seen.append(fidelity)
                 return "done"

--- a/modules/loop-pipeline/tests/test_cancellation.py
+++ b/modules/loop-pipeline/tests/test_cancellation.py
@@ -38,7 +38,7 @@ class RecordingBackend:
         self._return_value = return_value
         self.calls: list[str] = []
 
-    async def run(self, node, prompt, context):
+    async def run(self, node, prompt, context, incoming_edge=None, graph=None):
         self.calls.append(node.id)
         return self._return_value
 
@@ -51,7 +51,7 @@ class BlockingBackend:
         self._signal_event = signal_event
         self.calls: list[str] = []
 
-    async def run(self, node, prompt, context):
+    async def run(self, node, prompt, context, incoming_edge=None, graph=None):
         self.calls.append(node.id)
         if node.id == self._signal_after:
             self._signal_event.set()
@@ -130,7 +130,7 @@ async def test_engine_stops_on_cancel_between_nodes(tmp_path):
         def __init__(self):
             self.calls: list[str] = []
 
-        async def run(self, node, prompt, context):
+        async def run(self, node, prompt, context, incoming_edge=None, graph=None):
             self.calls.append(node.id)
             if node.id == "step1":
                 cancel_event.set()
@@ -275,7 +275,7 @@ digraph parent {{
         def __init__(self):
             self.calls: list[str] = []
 
-        async def run(self, node, prompt, context):
+        async def run(self, node, prompt, context, incoming_edge=None, graph=None):
             self.calls.append(node.id)
             if node.id == "child_step1":
                 cancel_event.set()

--- a/modules/loop-pipeline/tests/test_checkpoint.py
+++ b/modules/loop-pipeline/tests/test_checkpoint.py
@@ -191,7 +191,7 @@ class MockBackend:
         self._return_value = return_value
         self.calls: list[str] = []
 
-    async def run(self, node: Node, prompt: str, context: PipelineContext) -> str:
+    async def run(self, node: Node, prompt: str, context: PipelineContext, incoming_edge=None, graph=None) -> str:
         self.calls.append(node.id)
         return self._return_value
 

--- a/modules/loop-pipeline/tests/test_conditional_handler.py
+++ b/modules/loop-pipeline/tests/test_conditional_handler.py
@@ -113,7 +113,7 @@ async def test_diamond_node_completes_without_llm_in_pipeline(tmp_path):
     execution_counts: dict[str, int] = {}
 
     class TrackingBackend:
-        async def run(self, node: Node, prompt: str, context: PipelineContext) -> str:
+        async def run(self, node: Node, prompt: str, context: PipelineContext, incoming_edge=None, graph=None) -> str:
             execution_counts[node.id] = execution_counts.get(node.id, 0) + 1
             return "done"
 

--- a/modules/loop-pipeline/tests/test_engine.py
+++ b/modules/loop-pipeline/tests/test_engine.py
@@ -25,7 +25,7 @@ class MockBackend:
         self._return_value = return_value
         self.calls: list[str] = []
 
-    async def run(self, node: Node, prompt: str, context: PipelineContext) -> str:
+    async def run(self, node: Node, prompt: str, context: PipelineContext, incoming_edge=None, graph=None) -> str:
         self.calls.append(node.id)
         return self._return_value
 
@@ -38,7 +38,7 @@ class SequenceBackend:
         self.calls: list[str] = []
 
     async def run(
-        self, node: Node, prompt: str, context: PipelineContext
+        self, node: Node, prompt: str, context: PipelineContext, incoming_edge=None, graph=None
     ) -> str | Outcome:
         self.calls.append(node.id)
         return self._outcomes.get(node.id, "ok")
@@ -145,7 +145,7 @@ async def test_context_updates_propagate(tmp_path):
         def __init__(self):
             self.seen_values: dict[str, str | None] = {}
 
-        async def run(self, node, prompt, context):
+        async def run(self, node, prompt, context, incoming_edge=None, graph=None):
             if node.id == "step1":
                 return Outcome(
                     status=StageStatus.SUCCESS,
@@ -231,7 +231,7 @@ async def test_goal_gate_unsatisfied_returns_fail(tmp_path):
     """Goal gate with non-success outcome fails the pipeline at exit."""
 
     class FailingBackend:
-        async def run(self, node, prompt, context):
+        async def run(self, node, prompt, context, incoming_edge=None, graph=None):
             if node.id == "critical":
                 return Outcome(status=StageStatus.FAIL, failure_reason="broken")
             return "ok"
@@ -365,7 +365,7 @@ async def test_auto_status_overrides_fail_to_success(tmp_path):
     """auto_status=true overrides non-success outcome to SUCCESS (L-9)."""
 
     class FailingBackend:
-        async def run(self, node, prompt, context):
+        async def run(self, node, prompt, context, incoming_edge=None, graph=None):
             if node.id == "auto_node":
                 return Outcome(status=StageStatus.FAIL, failure_reason="oops")
             return "ok"
@@ -406,7 +406,7 @@ async def test_auto_status_false_preserves_fail(tmp_path):
     """Without auto_status, FAIL outcome is preserved (L-9)."""
 
     class FailingBackend:
-        async def run(self, node, prompt, context):
+        async def run(self, node, prompt, context, incoming_edge=None, graph=None):
             if node.id == "fail_node":
                 return Outcome(status=StageStatus.FAIL, failure_reason="oops")
             return "ok"
@@ -570,7 +570,7 @@ class LoopOnceBackend:
     def __init__(self):
         self.calls: list[str] = []
 
-    async def run(self, node, prompt, context):
+    async def run(self, node, prompt, context, incoming_edge=None, graph=None):
         self.calls.append(node.id)
         if node.id == "work" and self.calls.count("work") == 1:
             return Outcome(status=StageStatus.SUCCESS, preferred_label="loop")
@@ -710,7 +710,7 @@ async def test_multi_edge_fan_out_executes_all_targets(tmp_path):
     executed_nodes: list[str] = []
 
     class TrackingBackend:
-        async def run(self, node, prompt, context):
+        async def run(self, node, prompt, context, incoming_edge=None, graph=None):
             executed_nodes.append(node.id)
             return Outcome(status=StageStatus.SUCCESS)
 
@@ -762,7 +762,7 @@ async def test_multi_edge_fan_out_detects_fan_in(tmp_path):
     executed_nodes: list[str] = []
 
     class TrackingBackend:
-        async def run(self, node, prompt, context):
+        async def run(self, node, prompt, context, incoming_edge=None, graph=None):
             executed_nodes.append(node.id)
             return Outcome(status=StageStatus.SUCCESS)
 
@@ -860,7 +860,7 @@ async def test_multi_edge_parallel_context_isolation(tmp_path):
     seen_values: dict[str, str | None] = {}
 
     class ContextMutatingBackend:
-        async def run(self, node, prompt, context):
+        async def run(self, node, prompt, context, incoming_edge=None, graph=None):
             if node.id == "branch_a":
                 context.set("branch_key", "from_a")
                 return Outcome(status=StageStatus.SUCCESS)
@@ -919,7 +919,7 @@ async def test_parallel_fan_out_branches_run_concurrently(tmp_path):
         def clone(self):
             return SlowCloningBackend()
 
-        async def run(self, node, prompt, context):
+        async def run(self, node, prompt, context, incoming_edge=None, graph=None):
             if node.id.startswith("b"):
                 await asyncio.sleep(0.2)
             return Outcome(status=StageStatus.SUCCESS)
@@ -974,7 +974,7 @@ async def test_parallel_fan_out_clones_registry_per_branch(tmp_path):
         def clone(self):
             return CloningBackend()
 
-        async def run(self, node, prompt, context):
+        async def run(self, node, prompt, context, incoming_edge=None, graph=None):
             return Outcome(status=StageStatus.SUCCESS)
 
     graph = Graph(

--- a/modules/loop-pipeline/tests/test_engine_artifacts.py
+++ b/modules/loop-pipeline/tests/test_engine_artifacts.py
@@ -24,7 +24,7 @@ from amplifier_module_loop_pipeline.handlers.context import HandlerContext
 class MockBackend:
     """Backend that returns a fixed string for every call."""
 
-    async def run(self, node, prompt, context):
+    async def run(self, node, prompt, context, incoming_edge=None, graph=None):
         return "done"
 
 

--- a/modules/loop-pipeline/tests/test_engine_bug_g_parallel_component_fanout.py
+++ b/modules/loop-pipeline/tests/test_engine_bug_g_parallel_component_fanout.py
@@ -97,7 +97,7 @@ async def test_component_fanout_each_branch_executes_exactly_once(tmp_path):
     execution_counts: dict[str, int] = {}
 
     class CountingBackend:
-        async def run(self, node: Node, prompt: str, context: PipelineContext) -> str:
+        async def run(self, node: Node, prompt: str, context: PipelineContext, incoming_edge=None, graph=None) -> str:
             execution_counts[node.id] = execution_counts.get(node.id, 0) + 1
             return "done"
 
@@ -136,7 +136,7 @@ async def test_component_fanout_all_three_branches_execute(tmp_path):
     executed: list[str] = []
 
     class TrackingBackend:
-        async def run(self, node: Node, prompt: str, context: PipelineContext) -> str:
+        async def run(self, node: Node, prompt: str, context: PipelineContext, incoming_edge=None, graph=None) -> str:
             executed.append(node.id)
             return "done"
 
@@ -161,7 +161,7 @@ async def test_component_fanout_parallel_results_has_three_entries(tmp_path):
     """
 
     class SimpleBackend:
-        async def run(self, node: Node, prompt: str, context: PipelineContext) -> str:
+        async def run(self, node: Node, prompt: str, context: PipelineContext, incoming_edge=None, graph=None) -> str:
             return "done"
 
     graph = _make_3branch_component_graph()
@@ -189,7 +189,7 @@ async def test_component_fanout_fan_in_node_executes_after_all_branches(tmp_path
     executed: list[str] = []
 
     class TrackingBackend:
-        async def run(self, node: Node, prompt: str, context: PipelineContext) -> str:
+        async def run(self, node: Node, prompt: str, context: PipelineContext, incoming_edge=None, graph=None) -> str:
             executed.append(node.id)
             return "done"
 
@@ -224,7 +224,7 @@ async def test_non_component_multi_edge_fanout_still_works(tmp_path):
     executed: list[str] = []
 
     class TrackingBackend:
-        async def run(self, node: Node, prompt: str, context: PipelineContext) -> str:
+        async def run(self, node: Node, prompt: str, context: PipelineContext, incoming_edge=None, graph=None) -> str:
             executed.append(node.id)
             return "done"
 

--- a/modules/loop-pipeline/tests/test_engine_bug_h_requires_attribute.py
+++ b/modules/loop-pipeline/tests/test_engine_bug_h_requires_attribute.py
@@ -62,7 +62,7 @@ async def test_requires_missing_file_fails_node_before_handler_runs(tmp_path):
     handler_called = False
 
     class TrackingBackend:
-        async def run(self, node: Node, prompt: str, context: PipelineContext) -> str:
+        async def run(self, node: Node, prompt: str, context: PipelineContext, incoming_edge=None, graph=None) -> str:
             nonlocal handler_called
             handler_called = True
             return "done"
@@ -118,7 +118,7 @@ async def test_requires_all_present_handler_runs_normally(tmp_path):
     handler_called = False
 
     class TrackingBackend:
-        async def run(self, node: Node, prompt: str, context: PipelineContext) -> str:
+        async def run(self, node: Node, prompt: str, context: PipelineContext, incoming_edge=None, graph=None) -> str:
             nonlocal handler_called
             handler_called = True
             return "done"
@@ -165,7 +165,7 @@ async def test_no_requires_attr_behavior_unchanged(tmp_path):
     handler_called = False
 
     class TrackingBackend:
-        async def run(self, node: Node, prompt: str, context: PipelineContext) -> str:
+        async def run(self, node: Node, prompt: str, context: PipelineContext, incoming_edge=None, graph=None) -> str:
             nonlocal handler_called
             handler_called = True
             return "done"
@@ -205,7 +205,7 @@ async def test_requires_partial_missing_reports_all_missing_files(tmp_path):
     # variant_opus.md and variant_sonnet.md are NOT created
 
     class NoopBackend:
-        async def run(self, node: Node, prompt: str, context: PipelineContext) -> str:
+        async def run(self, node: Node, prompt: str, context: PipelineContext, incoming_edge=None, graph=None) -> str:
             return "done"
 
     graph = Graph(
@@ -262,7 +262,7 @@ async def test_requires_uses_context_target_dir_for_path_resolution(tmp_path):
     handler_called = False
 
     class TrackingBackend:
-        async def run(self, node: Node, prompt: str, context: PipelineContext) -> str:
+        async def run(self, node: Node, prompt: str, context: PipelineContext, incoming_edge=None, graph=None) -> str:
             nonlocal handler_called
             handler_called = True
             return "done"

--- a/modules/loop-pipeline/tests/test_failure_routing.py
+++ b/modules/loop-pipeline/tests/test_failure_routing.py
@@ -27,7 +27,7 @@ class CountingBackend:
         self._outcomes = outcomes or {}
         self._call_counts: dict[str, int] = {}
 
-    async def run(self, node, prompt, context) -> str | Outcome:
+    async def run(self, node, prompt, context, incoming_edge=None, graph=None) -> str | Outcome:
         count = self._call_counts.get(node.id, 0)
         self._call_counts[node.id] = count + 1
         seq = self._outcomes.get(node.id, ["done"])

--- a/modules/loop-pipeline/tests/test_fan_in_bfs.py
+++ b/modules/loop-pipeline/tests/test_fan_in_bfs.py
@@ -245,7 +245,7 @@ async def test_pipeline_with_multi_hop_branches_completes(tmp_path):
     execution_counts: dict[str, int] = {}
 
     class CountingBackend:
-        async def run(self, node: Node, prompt: str, context: PipelineContext) -> str:
+        async def run(self, node: Node, prompt: str, context: PipelineContext, incoming_edge=None, graph=None) -> str:
             execution_counts[node.id] = execution_counts.get(node.id, 0) + 1
             return "done"
 

--- a/modules/loop-pipeline/tests/test_goal_gates.py
+++ b/modules/loop-pipeline/tests/test_goal_gates.py
@@ -25,7 +25,7 @@ class MockBackend:
         self._outcomes = outcomes or {}
         self.calls: list[str] = []
 
-    async def run(self, node, prompt, context) -> str | Outcome:
+    async def run(self, node, prompt, context, incoming_edge=None, graph=None) -> str | Outcome:
         self.calls.append(node.id)
         return self._outcomes.get(node.id, "ok")
 
@@ -39,7 +39,7 @@ class CountingBackend:
         self._counts: dict[str, int] = {}
         self.calls: list[str] = []
 
-    async def run(self, node, prompt, context) -> str | Outcome:
+    async def run(self, node, prompt, context, incoming_edge=None, graph=None) -> str | Outcome:
         self.calls.append(node.id)
         count = self._counts.get(node.id, 0)
         self._counts[node.id] = count + 1

--- a/modules/loop-pipeline/tests/test_handler_backend_continuity_wiring.py
+++ b/modules/loop-pipeline/tests/test_handler_backend_continuity_wiring.py
@@ -1,0 +1,266 @@
+"""Integration tests for the CodergenHandler → AmplifierBackend continuity wiring.
+
+These tests exercise the REAL path that production uses: the engine /
+run_subgraph invoke ``CodergenHandler.execute(node, context, graph, logs_root)``,
+and the handler must forward ``graph`` into ``backend.run(...)`` so that the
+fidelity=full transcript store/read gates (which require ``graph is not None``)
+actually fire.
+
+The earlier unit tests in test_backend_full_continuity.py passed ``graph``
+straight into ``backend.run`` — they proved the mechanism but never the
+handler→backend wiring.  A live DTU run revealed the gap: seeds wrote their
+codewords but recall came back empty, because ``CodergenHandler.execute``
+called ``backend.run(node, prompt, context)`` with only 3 args, leaving
+``graph=None`` and silently skipping the transcript path.
+
+Design: docs/designs/fidelity-full-session-continuity.md
+Spec coverage: §5.4 (full fidelity), §4.5 (backend interface).
+"""
+
+import logging
+
+import pytest
+
+from amplifier_module_loop_pipeline.backend import AmplifierBackend
+from amplifier_module_loop_pipeline.context import PipelineContext
+from amplifier_module_loop_pipeline.graph import Edge, Graph, Node
+from amplifier_module_loop_pipeline.handlers.codergen import CodergenHandler
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+class _MockSession:
+    config: dict = {}
+
+
+class _SpawnCapture:
+    """Coordinator mock that captures every spawn call's kwargs."""
+
+    def __init__(self, output: str = "done", session_id: str = "child-1"):
+        self._output = output
+        self._session_id = session_id
+        self.calls: list[dict] = []
+        self.session = _MockSession()
+        self.config: dict = {"agents": {}}
+
+    def get_capability(self, name: str):
+        if name == "session.spawn":
+            return self._spawn_fn
+        return None
+
+    async def _spawn_fn(self, **kwargs):
+        self.calls.append(dict(kwargs))
+        return {"output": self._output, "session_id": self._session_id}
+
+
+def _make_full_node(node_id: str, prompt: str, thread_id: str = "main") -> Node:
+    return Node(
+        id=node_id,
+        prompt=prompt,
+        attrs={"llm_provider": "anthropic", "fidelity": "full", "thread_id": thread_id},
+    )
+
+
+def _make_full_graph(*node_ids: str, thread_id: str = "main") -> Graph:
+    """Build a minimal linear graph where each listed node is fidelity=full."""
+    nodes: dict[str, Node] = {"start": Node(id="start", shape="Mdiamond")}
+    for nid in node_ids:
+        nodes[nid] = _make_full_node(
+            nid, prompt=f"prompt for {nid}", thread_id=thread_id
+        )
+    nodes["exit"] = Node(id="exit", shape="Msquare")
+
+    edges: list[Edge] = [Edge(from_node="start", to_node=node_ids[0])]
+    for i in range(len(node_ids) - 1):
+        edges.append(Edge(from_node=node_ids[i], to_node=node_ids[i + 1]))
+    edges.append(Edge(from_node=node_ids[-1], to_node="exit"))
+
+    return Graph(name="test", nodes=nodes, edges=edges, graph_attrs={})
+
+
+def _make_context() -> PipelineContext:
+    ctx = PipelineContext()
+    ctx.set("graph.goal", "Test handler continuity wiring")
+    return ctx
+
+
+# ---------------------------------------------------------------------------
+# Test: REAL path — seed node then recall node via CodergenHandler.execute
+#
+# This is the test that would have caught the dead wiring. RED on the branch
+# HEAD before the forwarding fix; GREEN after.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_handler_execute_carries_full_continuity_across_nodes(tmp_path):
+    """Seed → recall through CodergenHandler.execute carries history.
+
+    Drives the handler (not backend.run directly).  The recall node's spawn
+    must receive the seed node's (instruction, output) exchange via
+    parent_messages — proving graph flows handler → backend so the transcript
+    store/read gates fire on the production path.
+    """
+    coordinator = _SpawnCapture(output="The codeword is BANANA", session_id="seed-sess")
+    backend = AmplifierBackend(
+        coordinator=coordinator,
+        profiles={"anthropic": "attractor-anthropic"},
+    )
+    handler = CodergenHandler(backend=backend)
+
+    graph = _make_full_graph("seed", "recall", thread_id="codeword-thread")
+    context = _make_context()
+    logs_root = str(tmp_path / "logs")
+
+    # Seed node — establishes context (the codeword)
+    await handler.execute(graph.nodes["seed"], context, graph, logs_root)
+
+    # Recall node — must see the seed's exchange
+    coordinator._output = "Recalling: BANANA"
+    coordinator._session_id = "recall-sess"
+    await handler.execute(graph.nodes["recall"], context, graph, logs_root)
+
+    assert len(coordinator.calls) == 2, "Expected exactly 2 spawn calls"
+
+    seed_call = coordinator.calls[0]
+    recall_call = coordinator.calls[1]
+
+    # Seed: first node on the thread → no prior history
+    assert not seed_call.get("parent_messages"), (
+        "Seed node is first on its thread — must have no parent_messages"
+    )
+    assert "sub_session_id" not in seed_call
+
+    # Recall: MUST carry the seed's exchange via parent_messages.
+    # Before the wiring fix, graph=None silently skipped the store, so this
+    # list would be empty/absent — the exact DTU failure (recall came back empty).
+    pm = recall_call.get("parent_messages")
+    assert pm, (
+        "WIRING BUG: recall node received no parent_messages. "
+        "CodergenHandler.execute must forward graph to backend.run so the "
+        "fidelity=full transcript store/read gates fire. This is the dead-code "
+        "bug a live DTU run exposed (seeds wrote codewords, recall came back empty)."
+    )
+    assert len(pm) == 2, (
+        f"Expected one prior exchange (2 messages), got {len(pm)}: {pm}"
+    )
+    assert pm[0]["role"] == "user"
+    assert pm[0]["content"] == "prompt for seed"
+    assert pm[1]["role"] == "assistant"
+    assert pm[1]["content"] == "The codeword is BANANA"
+
+    # Recall: continuity via parent_messages, never sub_session_id
+    assert "sub_session_id" not in recall_call
+
+
+# ---------------------------------------------------------------------------
+# Test: handler forwards graph (focused unit test on the wiring contract)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_handler_execute_forwards_graph_to_backend(tmp_path):
+    """CodergenHandler.execute passes the graph object through to backend.run.
+
+    A focused contract test: the backend records the graph it received, and we
+    assert it is the SAME graph object the handler was given (not None).
+    """
+    received: dict = {}
+
+    class _RecordingBackend:
+        async def run(
+            self,
+            node,
+            prompt,
+            context,
+            incoming_edge=None,
+            graph=None,
+        ):
+            received["graph"] = graph
+            received["incoming_edge"] = incoming_edge
+            return "ok"
+
+    handler = CodergenHandler(backend=_RecordingBackend())
+    graph = _make_full_graph("only", thread_id="t")
+    context = _make_context()
+    logs_root = str(tmp_path / "logs")
+
+    await handler.execute(graph.nodes["only"], context, graph, logs_root)
+
+    assert received.get("graph") is graph, (
+        "CodergenHandler.execute must forward the graph object it received "
+        "into backend.run(...). Got: " + repr(received.get("graph"))
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test: loud guard — full node reaching backend.run without a graph WARNs
+# (it does NOT silently skip continuity)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_full_fidelity_without_graph_warns_not_silent(caplog):
+    """A fidelity=full node with no graph emits a loud WARNING.
+
+    This closes the silent-continuity-loss class (CR-1) at the exact spot the
+    existing assert did not cover: a caller that drops ``graph`` for a full
+    node can no longer silently lose continuity — it logs a visible warning.
+    """
+    coordinator = _SpawnCapture(output="done", session_id="s1")
+    backend = AmplifierBackend(
+        coordinator=coordinator,
+        profiles={"anthropic": "attractor-anthropic"},
+    )
+    # fidelity=full node attr, but call backend.run with NO graph (graph=None)
+    node = _make_full_node("orphan", prompt="do work", thread_id="t")
+    context = _make_context()
+
+    with caplog.at_level(logging.WARNING):
+        await backend.run(node, "do work", context)  # no graph, no incoming_edge
+
+    warned = any(
+        "full" in rec.message.lower() and "graph" in rec.message.lower()
+        for rec in caplog.records
+        if rec.levelno >= logging.WARNING
+    )
+    assert warned, (
+        "A fidelity=full node reaching backend.run without a graph must emit a "
+        "loud WARNING (continuity requested but cannot be honored), not silently "
+        "skip the transcript path. Warnings seen: "
+        + repr([r.message for r in caplog.records])
+    )
+
+
+@pytest.mark.asyncio
+async def test_non_full_without_graph_does_not_warn(caplog):
+    """A non-full node with no graph must NOT trigger the continuity warning.
+
+    The guard must be targeted: only fire when full continuity is requested
+    but cannot be honored — never on compact/truncate/summary or thread-less
+    nodes that legitimately run without a graph.
+    """
+    coordinator = _SpawnCapture(output="done", session_id="s1")
+    backend = AmplifierBackend(
+        coordinator=coordinator,
+        profiles={"anthropic": "attractor-anthropic"},
+    )
+    # No fidelity attr → defaults to compact when graph is absent
+    node = Node(id="plain", prompt="do work", attrs={"llm_provider": "anthropic"})
+    context = _make_context()
+
+    with caplog.at_level(logging.WARNING):
+        await backend.run(node, "do work", context)
+
+    spurious = any(
+        "continuity" in rec.message.lower() or "thread" in rec.message.lower()
+        for rec in caplog.records
+        if rec.levelno >= logging.WARNING
+    )
+    assert not spurious, (
+        "Non-full nodes must not trigger the full-continuity warning. "
+        "Warnings seen: " + repr([r.message for r in caplog.records])
+    )

--- a/modules/loop-pipeline/tests/test_handlers.py
+++ b/modules/loop-pipeline/tests/test_handlers.py
@@ -103,7 +103,7 @@ class MockBackend:
         self.call_count = 0
 
     async def run(
-        self, node: Node, prompt: str, context: PipelineContext
+        self, node: Node, prompt: str, context: PipelineContext, incoming_edge=None, graph=None
     ) -> str | Outcome:
         self.last_prompt = prompt
         self.call_count += 1
@@ -153,7 +153,7 @@ async def test_codergen_backend_returns_outcome(tmp_path):
     """If backend returns an Outcome directly, use it."""
 
     class OutcomeBackend:
-        async def run(self, node, prompt, context):
+        async def run(self, node, prompt, context, incoming_edge=None, graph=None):
             return Outcome(status=StageStatus.FAIL, failure_reason="tests failing")
 
     handler = CodergenHandler(backend=OutcomeBackend())
@@ -347,7 +347,7 @@ async def test_context_variable_flows_between_pipeline_nodes(tmp_path):
         def __init__(self):
             self.prompts: dict[str, str] = {}
 
-        async def run(self, node, prompt, context):
+        async def run(self, node, prompt, context, incoming_edge=None, graph=None):
             self.prompts[node.id] = prompt
             if node.id == "draft":
                 return "Here is the draft content about fibonacci"

--- a/modules/loop-pipeline/tests/test_integration_combined.py
+++ b/modules/loop-pipeline/tests/test_integration_combined.py
@@ -57,7 +57,7 @@ class CombinedPatternBackend:
     def __init__(self) -> None:
         self.calls: list[str] = []
 
-    async def run(self, node: Node, prompt: str, context: PipelineContext) -> Outcome:
+    async def run(self, node: Node, prompt: str, context: PipelineContext, incoming_edge=None, graph=None) -> Outcome:
         self.calls.append(node.id)
         if node.id == "eval":
             return Outcome(status=StageStatus.SUCCESS, preferred_label="scored")

--- a/modules/loop-pipeline/tests/test_manager_loop.py
+++ b/modules/loop-pipeline/tests/test_manager_loop.py
@@ -711,7 +711,7 @@ class TestManagerChildDotfileObservability:
         )
 
         class _MockBackend:
-            async def run(self, node, prompt, context):
+            async def run(self, node, prompt, context, incoming_edge=None, graph=None):
                 return _json.dumps({"status": "success", "notes": f"mock: {node.id}"})
 
         from amplifier_module_loop_pipeline.handlers import HandlerRegistry

--- a/modules/loop-pipeline/tests/test_p1_nested_backend.py
+++ b/modules/loop-pipeline/tests/test_p1_nested_backend.py
@@ -32,7 +32,7 @@ class SpyBackend:
     def __init__(self) -> None:
         self.calls: list[tuple[str, str]] = []
 
-    async def run(self, node: Node, prompt: str, context: PipelineContext) -> str:
+    async def run(self, node: Node, prompt: str, context: PipelineContext, incoming_edge=None, graph=None) -> str:
         self.calls.append((node.id, prompt))
         return "done"
 

--- a/modules/loop-pipeline/tests/test_p2_conversational_gate.py
+++ b/modules/loop-pipeline/tests/test_p2_conversational_gate.py
@@ -44,7 +44,7 @@ _DEMO_DOT = _PATTERNS_DIR / "demo-conversational-gates.dot"
 class ScoredBackend:
     """Always returns preferred_label='scored' — simulates a passing evaluation."""
 
-    async def run(self, node: Node, prompt: str, context: PipelineContext) -> Outcome:
+    async def run(self, node: Node, prompt: str, context: PipelineContext, incoming_edge=None, graph=None) -> Outcome:
         return Outcome(status=StageStatus.SUCCESS, preferred_label="scored")
 
 
@@ -56,7 +56,7 @@ class SequentialOutcomeBackend:
         self._idx = 0
         self.call_count = 0
 
-    async def run(self, node: Node, prompt: str, context: PipelineContext) -> Outcome:
+    async def run(self, node: Node, prompt: str, context: PipelineContext, incoming_edge=None, graph=None) -> Outcome:
         result = self._outcomes[min(self._idx, len(self._outcomes) - 1)]
         self._idx += 1
         self.call_count += 1
@@ -480,7 +480,7 @@ class TestConversationalGateExecution:
 
         class CapturingBackend:
             async def run(
-                self, node: Node, prompt: str, context: PipelineContext
+                self, node: Node, prompt: str, context: PipelineContext, incoming_edge=None, graph=None
             ) -> Outcome:
                 captured_prompts[node.id] = prompt
                 return Outcome(status=StageStatus.SUCCESS, preferred_label="scored")

--- a/modules/loop-pipeline/tests/test_p6_convergence_factory.py
+++ b/modules/loop-pipeline/tests/test_p6_convergence_factory.py
@@ -70,7 +70,7 @@ class ConvergedBackend:
     def __init__(self) -> None:
         self.calls: list[str] = []
 
-    async def run(self, node: Node, prompt: str, context: PipelineContext) -> Outcome:
+    async def run(self, node: Node, prompt: str, context: PipelineContext, incoming_edge=None, graph=None) -> Outcome:
         self.calls.append(node.id)
         if node.id == "assess":
             return Outcome(status=StageStatus.SUCCESS, preferred_label="converged")
@@ -88,7 +88,7 @@ class RefineThenConvergeBackend:
         self.calls: list[str] = []
         self._assess_count = 0
 
-    async def run(self, node: Node, prompt: str, context: PipelineContext) -> Outcome:
+    async def run(self, node: Node, prompt: str, context: PipelineContext, incoming_edge=None, graph=None) -> Outcome:
         self.calls.append(node.id)
         if node.id == "assess":
             self._assess_count += 1
@@ -104,7 +104,7 @@ class CapturingBackend:
     def __init__(self) -> None:
         self.prompts: dict[str, str] = {}
 
-    async def run(self, node: Node, prompt: str, context: PipelineContext) -> Outcome:
+    async def run(self, node: Node, prompt: str, context: PipelineContext, incoming_edge=None, graph=None) -> Outcome:
         self.prompts[node.id] = prompt
         if node.id == "assess":
             return Outcome(status=StageStatus.SUCCESS, preferred_label="converged")

--- a/modules/loop-pipeline/tests/test_p7_context_injection.py
+++ b/modules/loop-pipeline/tests/test_p7_context_injection.py
@@ -36,7 +36,7 @@ class CapturingBackend:
         self.prompts: dict[str, str] = {}
         self.context_snapshots: dict[str, dict] = {}
 
-    async def run(self, node: Node, prompt: str, context: PipelineContext) -> str:
+    async def run(self, node: Node, prompt: str, context: PipelineContext, incoming_edge=None, graph=None) -> str:
         self.prompts[node.id] = prompt
         self.context_snapshots[node.id] = context.snapshot()
         return "done"

--- a/modules/loop-pipeline/tests/test_p8_continue_on_fail.py
+++ b/modules/loop-pipeline/tests/test_p8_continue_on_fail.py
@@ -39,7 +39,7 @@ class FailingBackend:
     def __init__(self) -> None:
         self.calls: list[str] = []
 
-    async def run(self, node: Node, prompt: str, context: PipelineContext) -> Outcome:
+    async def run(self, node: Node, prompt: str, context: PipelineContext, incoming_edge=None, graph=None) -> Outcome:
         self.calls.append(node.id)
         if node.id.startswith("fail_"):
             return Outcome(status=StageStatus.FAIL, failure_reason="simulated failure")
@@ -256,7 +256,7 @@ class TestContinueOnFail:
 
         class SuccessBackend:
             async def run(
-                self, node: Node, prompt: str, context: PipelineContext
+                self, node: Node, prompt: str, context: PipelineContext, incoming_edge=None, graph=None
             ) -> Outcome:
                 return Outcome(status=StageStatus.SUCCESS, notes="all good")
 

--- a/modules/loop-pipeline/tests/test_parallel_fanout_contract.py
+++ b/modules/loop-pipeline/tests/test_parallel_fanout_contract.py
@@ -74,7 +74,7 @@ async def test_component_shape_fans_out_unconditional_edges(tmp_path):
     execution_counts: dict[str, int] = {}
 
     class CountingBackend:
-        async def run(self, node: Node, prompt: str, context: PipelineContext) -> str:
+        async def run(self, node: Node, prompt: str, context: PipelineContext, incoming_edge=None, graph=None) -> str:
             execution_counts[node.id] = execution_counts.get(node.id, 0) + 1
             return "done"
 
@@ -146,7 +146,7 @@ async def test_parallelogram_shape_does_not_fan_out_unconditional_edges(tmp_path
     execution_counts: dict[str, int] = {}
 
     class CountingBackend:
-        async def run(self, node: Node, prompt: str, context: PipelineContext) -> str:
+        async def run(self, node: Node, prompt: str, context: PipelineContext, incoming_edge=None, graph=None) -> str:
             execution_counts[node.id] = execution_counts.get(node.id, 0) + 1
             return "done"
 
@@ -230,7 +230,7 @@ async def test_non_component_fanout_respects_max_parallel(tmp_path):
     execution_counts: dict[str, int] = {}
 
     class BoundedConcurrencyBackend:
-        async def run(self, node: Node, prompt: str, context: PipelineContext) -> str:
+        async def run(self, node: Node, prompt: str, context: PipelineContext, incoming_edge=None, graph=None) -> str:
             nonlocal peak_concurrent, current_concurrent
             async with concurrent_lock:
                 current_concurrent += 1

--- a/modules/loop-pipeline/tests/test_pipeline_e2e.py
+++ b/modules/loop-pipeline/tests/test_pipeline_e2e.py
@@ -62,7 +62,7 @@ class SuccessBackend:
         self.calls: list[str] = []
         self.prompts: dict[str, str] = {}
 
-    async def run(self, node: Node, prompt: str, context: PipelineContext) -> str:
+    async def run(self, node: Node, prompt: str, context: PipelineContext, incoming_edge=None, graph=None) -> str:
         self.calls.append(node.id)
         self.prompts[node.id] = prompt
         return f"Completed: {node.id}"
@@ -81,7 +81,7 @@ class OutcomeBackend:
         self.call_counts: dict[str, int] = {}
 
     async def run(
-        self, node: Node, prompt: str, context: PipelineContext
+        self, node: Node, prompt: str, context: PipelineContext, incoming_edge=None, graph=None
     ) -> str | Outcome:
         self.calls.append(node.id)
         self.call_counts[node.id] = self.call_counts.get(node.id, 0) + 1
@@ -102,7 +102,7 @@ class RetryThenSucceedBackend:
         self._node_attempts: dict[str, int] = {}
 
     async def run(
-        self, node: Node, prompt: str, context: PipelineContext
+        self, node: Node, prompt: str, context: PipelineContext, incoming_edge=None, graph=None
     ) -> str | Outcome:
         self.calls.append(node.id)
         self._node_attempts[node.id] = self._node_attempts.get(node.id, 0) + 1
@@ -386,7 +386,7 @@ class TestConditionalBranch:
             def __init__(self):
                 self.calls: list[str] = []
 
-            async def run(self, node, prompt, context):
+            async def run(self, node, prompt, context, incoming_edge=None, graph=None):
                 self.calls.append(node.id)
                 if node.id == "test":
                     call_count["test"] += 1

--- a/modules/loop-pipeline/tests/test_pipeline_events.py
+++ b/modules/loop-pipeline/tests/test_pipeline_events.py
@@ -55,7 +55,7 @@ class MockBackend:
     def __init__(self, return_value: str = "done") -> None:
         self._return_value = return_value
 
-    async def run(self, node: Node, prompt: str, context: PipelineContext) -> str:
+    async def run(self, node: Node, prompt: str, context: PipelineContext, incoming_edge=None, graph=None) -> str:
         return self._return_value
 
 
@@ -66,7 +66,7 @@ class FailingBackend:
         self._fail_node = fail_node
 
     async def run(
-        self, node: Node, prompt: str, context: PipelineContext
+        self, node: Node, prompt: str, context: PipelineContext, incoming_edge=None, graph=None
     ) -> str | Outcome:
         if node.id == self._fail_node:
             return Outcome(status=StageStatus.FAIL, failure_reason="intentional")
@@ -506,7 +506,7 @@ class SessionBackend:
         self._session_id = session_id
 
     async def run(
-        self, node: Node, prompt: str, context: PipelineContext
+        self, node: Node, prompt: str, context: PipelineContext, incoming_edge=None, graph=None
     ) -> str | Outcome:
         if node.id == self._session_node:
             return Outcome(status=StageStatus.SUCCESS, session_id=self._session_id)
@@ -595,7 +595,7 @@ class TestNodeCompleteSessionId:
 
         class SlowBackend:
             async def run(
-                self, node: Node, prompt: str, context: PipelineContext
+                self, node: Node, prompt: str, context: PipelineContext, incoming_edge=None, graph=None
             ) -> str:
                 await asyncio.sleep(10)  # will be timed out
                 return "done"

--- a/modules/loop-pipeline/tests/test_pipeline_handler.py
+++ b/modules/loop-pipeline/tests/test_pipeline_handler.py
@@ -22,7 +22,7 @@ from amplifier_module_loop_pipeline.handlers.context import HandlerContext
 class _MockBackend:
     """Minimal mock backend — returns JSON success outcome for any node."""
 
-    async def run(self, node, prompt, context):
+    async def run(self, node, prompt, context, incoming_edge=None, graph=None):
         return json.dumps({"status": "success", "notes": f"mock: {node.id}"})
 
 

--- a/modules/loop-pipeline/tests/test_run_directory.py
+++ b/modules/loop-pipeline/tests/test_run_directory.py
@@ -30,7 +30,7 @@ class MockBackend:
     def __init__(self, return_value: str = "done") -> None:
         self._return_value = return_value
 
-    async def run(self, node: Node, prompt: str, context: PipelineContext) -> str:
+    async def run(self, node: Node, prompt: str, context: PipelineContext, incoming_edge=None, graph=None) -> str:
         return self._return_value
 
 
@@ -41,7 +41,7 @@ class SequenceBackend:
         self._outcomes = outcomes
 
     async def run(
-        self, node: Node, prompt: str, context: PipelineContext
+        self, node: Node, prompt: str, context: PipelineContext, incoming_edge=None, graph=None
     ) -> str | Outcome:
         return self._outcomes.get(node.id, "ok")
 

--- a/modules/loop-pipeline/tests/test_subgraph_runner.py
+++ b/modules/loop-pipeline/tests/test_subgraph_runner.py
@@ -220,7 +220,7 @@ async def test_parallel_handler_uses_wired_subgraph_runner(tmp_path):
     orchestrator = PipelineOrchestrator({"dot_source": dot, "logs_root": str(tmp_path)})
 
     class _MockBackend:
-        async def run(self, node, prompt, context):
+        async def run(self, node, prompt, context, incoming_edge=None, graph=None):
             return json.dumps({"status": "success", "notes": f"mock: {node.id}"})
 
     result_json = await orchestrator.execute(

--- a/modules/loop-pipeline/tests/test_transforms.py
+++ b/modules/loop-pipeline/tests/test_transforms.py
@@ -236,7 +236,7 @@ class MockBackend:
     def __init__(self) -> None:
         self.seen_prompts: dict[str, str] = {}
 
-    async def run(self, node: Node, prompt: str, context: PipelineContext) -> str:
+    async def run(self, node: Node, prompt: str, context: PipelineContext, incoming_edge=None, graph=None) -> str:
         self.seen_prompts[node.id] = node.prompt
         return "done"
 

--- a/specs/EXTENSIONS.md
+++ b/specs/EXTENSIONS.md
@@ -226,3 +226,53 @@ cross-sub-pipeline session continuity, because the spec never promises it and th
 normative clauses (§5.3, §5.4, §9.4) indicate the opposite. Authors who need a node to continue
 a shared-`thread_id` session must keep it inline in the same graph (or in a flattened cluster),
 not behind a sub-pipeline / folder / manager-child boundary.
+
+---
+
+## 12. `fidelity=full` Continuity Is Realized via `parent_messages` at Node-Exchange Granularity
+
+**What:** The spec's §5.4 `full`-fidelity "reuse the same session / full history preserved"
+requirement is realized in our implementation by a backend-held message-list carrier injected
+into each subsequent same-thread spawn via the `parent_messages` mechanism (foundation
+`_prepared.py` §4.5 leave-open). The carrier holds **node-exchange granularity**: one
+`(role=user, content=instruction)` + `(role=assistant, content=final_output)` pair per `full`
+node. The child agent's inner tool-loop turns are **not** included — only the conversation
+*between* nodes is preserved, not the child's internal reasoning.
+
+**Why:** The spec's §5.4 language ("reuse the same LLM session", "full history preserved") is
+written as a *behavior specification*, not a mechanism mandate. The spec separately notes
+(§5.3) that sessions are in-memory and non-serializable, and unified-llm §2.6 models the LLM
+client as stateless (continuity = caller-passed message list). Our realization of §5.4 using
+`parent_messages` is mechanism-not-policy: the spec's §4.5 CodergenBackend interface is
+silent on how continuity is achieved, leaving this to the app layer. Node-exchange granularity
+(instruction + final output) was accepted as the meaning of `full` at the backend layer — the
+spawn result exposes only `output` + `session_id`, not inner tool-loop turns, so inner-turn
+fidelity across nodes is architecturally inaccessible at this layer.
+
+**Compatibility:** Additive and non-breaking. Prior behavior (sub_session_id re-pass) was
+silently broken — it never preserved history because session_id is an identity/trace token,
+not a history pointer. This change restores the spec-mandated behavior. No spec-conformant
+`.dot` file can depend on the broken non-continuity.
+
+---
+
+## 13. `thread_id` Is Branch-Local — Same `thread_id` in Sibling Branches Does Not Join Conversations
+
+**What:** `fidelity=full` session continuity (§5.4 thread resolution) is *branch-local*: the
+backend's `_thread_transcripts` carrier is reset to `{}` when a backend is cloned for a
+parallel branch (`clone()`). Two sibling branches that both carry an explicit `thread_id`
+**do not share conversation history** — each branch accumulates its own independent
+transcript. Thread-id-based history continuity operates only within a single linear path
+(i.e., a single branch's sequential execution).
+
+**Why:** This resolves the same §5.4 vs §3.8 spec conflict addressed in §9 (per-branch
+session-pool isolation): §3.8 isolation (each parallel branch receives an independent clone)
+takes precedence over §5.4 thread-id-based reuse when the two rules conflict. Isolation is
+the deterministic, safe resolution — a shared conversation across concurrent branches is
+precisely the cross-contamination the per-branch isolation design eliminates. The transcript
+isolation is a natural consequence of the backend clone resetting mutable state.
+
+**Compatibility:** Backward-compatible. The prior implementation was broken for cross-node
+continuity regardless of branching, so no existing pipeline could have been relying on
+cross-branch conversation sharing. Authors who intend a shared thread to carry history across
+nodes must place those nodes in the same sequential path (not in sibling parallel branches).


### PR DESCRIPTION
Problem (B1)

`fidelity=full` cross-node session continuity was silently broken in the loop-pipeline
backend. Root cause: a **type confusion** — `_session_pool` stored a `session_id` (an
identity/trace token, not a history pointer) and re-passed it to `session.spawn`
(fresh-spawn by design), expecting the prior conversation to resume. It never did, so a
`full` node that should "remember" an earlier same-thread node started fresh. Surfaced by a
real DTU run + multi-agent investigation; not a regression (never worked through this path).

## Fix (Candidate A — full /systems-design pass; design doc included)

Replace the carrier, do not add machinery:
- `_session_pool: dict[str, session_id]` → **`_thread_transcripts: dict[str, list[Message]]`**
  (thread_key → accumulated conversation).
- After each `full` node, append `(user=instruction, assistant=final_output)` — user/assistant
  roles only. **Idempotent** under goal-gate re-run via truncate-to-node-then-append.
- Carry forward by passing the transcript as **`parent_messages`** to a fresh spawn (never a
  `session_id`) — rides foundation's existing injection. Realizes the spec's "reuse the same
  session" as the message list the stateless client already requires.
- **Wiring:** `CodergenHandler.execute` now forwards `graph` to `backend.run()` (the
  store/read path requires it) — without this the whole mechanism is dead code in production.
- **Loud-not-silent:** a `full` node reaching the backend without a graph now WARNs instead
  of silently skipping continuity (the failure class this whole effort exists to kill).

Composes with the shipped per-branch isolation (#41) for free: `clone_for_branch` resets the
pool, so transcripts are born branch-local. Single repo, correct-by-default (no flag).

## Spec conformance

Sits below the §4.5 backend contract (realization is app-layer, mechanism-not-policy).
EXTENSIONS.md §12-13 document: `full` continuity = backend-held message-list carrier at
node-exchange granularity; `thread_id` is branch-local. Cross-run resume is intentionally
scoped OUT (Phase 2) — §5.3 caps it at `summary:high` degradation, not full restore.

## Verification

- **Unit:** continuity (node B sees node A's exchange via `parent_messages`), idempotency
  (goal-gate re-run does not double a turn), isolation preserved, handler→backend wiring
  integration test, loud-guard test. Suite green except 2 unrelated pre-existing failures.
- **DTU end-to-end (real dot-graph resolve worker):** the seed→recall codeword scenario that
  exposed B1 now **PASSES** — `recall_a = ALPHA-7` (not BETA-3), `recall_b = BETA-3` (not
  ALPHA-7). Continuity works AND cross-branch isolation holds. Recall files written for the
  first time (every prior run: empty).

Closes the third of three compounding bugs found via DTU validation (clone-spawn race #41;
session-resume-no-history → this; handler graph-wiring → this).

## Follow-up (separate)

Phase-2 cross-run resume (defined in the design doc; bounded by §5.3): engine→backend restore
wiring, transcript-aware summary seam, cross-run idempotency, transcript boundedness
(compaction/cap/sidecar to avoid O(N²) checkpoint rewrite), redaction at rest.

Commits: design doc · `_thread_transcripts` carrier · tests · EXTENSIONS §12-13 · graph wiring + loud guard · wiring integration test · drop-shim/conform-doubles cleanup.