### PR TITLE
fix(dot-parser): fail loud on malformed backslash-quote delimiters

### DIFF
--- a/docs/DOT-AUTHORING-GUIDE.md
+++ b/docs/DOT-AUTHORING-GUIDE.md
@@ -102,6 +102,18 @@ a review node with edges `condition="outcome=pass"` and `condition="outcome=retr
 should call `report_outcome(status="success", preferred_label="pass")` or
 `report_outcome(status="fail", preferred_label="retry")`.
 
+> **Common mistake: escaped-quote delimiters** — Condition (and all attribute)
+> values must use **plain double-quotes** as delimiters.  Writing
+> `condition=\"key=value\"` (backslash-quote) instead of
+> `condition="key=value"` is a syntax error.  Before the fail-loud fix was
+> added, the tokenizer silently mis-parsed the backslash-delimited form as a
+> bare key (`key=value`), which resolves truthy — causing ALL conditional edges
+> to "match" and the engine to fan-out instead of routing.  The parser now
+> raises a `ValueError` immediately with the position and the correct form.
+> See [DOT-SYNTAX.md](DOT-SYNTAX.md#quoting-and-escaping) for the full rule
+> and the one legitimate place `\"` is valid (inside a quoted string value,
+> e.g. a shell command containing literal double-quotes).
+
 > **Recommended pattern:** Use `condition="outcome!=retry"` instead of
 > `condition="outcome=pass"` for forward edges. This is resilient to agents
 > that return `status="success"` without setting `preferred_label`.
@@ -552,6 +564,7 @@ Set these on the `graph` element:
 | Missing `weight` on conditional edges | Nondeterministic edge selection | Add `weight` to break ties between equally-matched edges |
 | Using `full` fidelity everywhere | High cost, slow execution | Use `full` only where conversation continuity matters |
 | Circular dependencies without exit | Infinite loop | Ensure every cycle has a conditional exit path |
+| `condition=\"key=value\"` (backslash delimiters) | Parser error (or, before the fail-loud fix, silent wrong routing) | Use plain quotes: `condition="key=value"` — see callout above |
 
 ## Complete Example: Feature Build Pipeline
 

--- a/docs/DOT-SYNTAX.md
+++ b/docs/DOT-SYNTAX.md
@@ -168,6 +168,37 @@ digraph {
 }
 ```
 
+## Quoting and Escaping
+
+Attribute values are delimited by **plain double-quotes only**.  Backslash-escapes
+are valid **inside** a quoted value, never as the outer delimiter.
+
+```dot
+# CORRECT — plain double-quotes as delimiters
+verify -> execute [condition="context.tool.last_line=continue"]
+node [tool_command="echo \"hello world\""]   # \" inside the value = literal "
+
+# WRONG — backslash-quote as delimiter (parse error)
+verify -> execute [condition=\"context.tool.last_line=continue\"]
+```
+
+**Rule of thumb**: if you're writing `attr=\"...\"`, stop — the outer `\"` is
+wrong.  Only the inner content of a string may use `\"` as an escape.
+
+The tricky case is `tool_command` or `prompt` attributes that contain shell
+quoting.  The outer delimiters are still plain `"`:
+
+```dot
+node [tool_command="if [ ! -d \"$dir\" ]; then echo missing; fi"]
+#                   ^^ interior escape for literal "    ^^ still plain outer
+```
+
+**What happens if you get it wrong (pre-fix):** the tokenizer silently
+mis-parses `\"key=value\"` as the bare key `key=value`, which resolves
+truthy — so a conditional edge appears to match even when its condition
+is false.  **After the fix**, a loud `ValueError` points at the position
+and names the required form.
+
 ## Common Mistakes
 
 | Mistake | Fix |
@@ -180,3 +211,4 @@ digraph {
 | `$goal` not expanding | Ensure graph has `goal="..."` attribute or pass `goal` to the tool |
 | Fan-in without fan-out | `tripleoctagon` expects `parallel.results` in context |
 | `$param` not expanding | Pass `params` dict to `run_pipeline` tool call |
+| Using `\"...\"` as attribute delimiter | Use plain `"..."` — see **Quoting and Escaping** above |

--- a/docs/designs/RECURRING-BUG-CLASSES.md
+++ b/docs/designs/RECURRING-BUG-CLASSES.md
@@ -181,6 +181,58 @@ ecosystem over the past year, and 100% of fix commits in
   refactor**. Filed as future work. The S5 question in the review
   checklist is the immediate guard against new instances landing.
 
+### S6 — Parser fails open on malformed input
+
+- **Invariant violated**: the parser accepts input the spec explicitly
+  rejects, silently producing plausible-but-wrong output.  The
+  malformed input is never surfaced as an error; debugging happens
+  far from the cause, in runtime behaviour.
+- **Recognition signature** (what to look for):
+  - tokenizer / parser uses "best-effort" or "skip-and-continue"
+    semantics on unrecognized tokens
+  - malformed input produces structurally valid (but semantically
+    wrong) intermediate values — conditions, attribute names, etc.
+  - the runtime produces wrong-but-plausible output with no visible
+    error; the only diagnostic is incorrect behavior
+  - "the spec says reject this" but the code path reaches evaluation
+    anyway
+- **Canonical incident**: edge conditions written as
+  `condition=\"key=value\"` (backslash-quote delimiters) instead of
+  the required `condition="key=value"` (plain-quote delimiters).  The
+  tokenizer skipped the stray backslash and tried to match the
+  `"key=value..."` fragment as a string, but the trailing `\"` was
+  treated as an interior escape and the string match failed.  The
+  tokenizer then backed up to the `"` at position +1 and the
+  unquoted `key=value` fragment matched as a bare identifier.  The
+  attribute parser saw `condition = key=value` (a bare ident, not a
+  quoted string), and the condition evaluator reached the bare-key
+  truthy branch: `_resolve_key("key=value", ...)` returned
+  `"continue"` (non-empty) → `True`.  ALL four conditional edges
+  matched; the engine took the parallel fan-out path; `loop_restart`
+  was never processed; hours were spent debugging routing.  Fixed
+  by gap-detection in `_tokenize` (S6-fix, PR to be filed).
+- **Noun-fix**: detect unmatched characters in the tokenizer.  After
+  each regex match, inspect the gap between the last consumed
+  position and the new match start.  A backslash immediately before a
+  double-quote in a gap is unambiguously malformed (valid `\"`
+  interior escapes are consumed inside a `string` token and never
+  appear in a gap).  Raise `ValueError` immediately with position and
+  the correct form.  The "fail-open" surface shrinks to zero for this
+  pattern.
+- **Anti-fix**: extend the tokenizer to ACCEPT `\"...\"` by normalising
+  it to `"..."`.  This makes the parser more permissive than the
+  spec's strict-subset mandate (§2.1) and converts a detection
+  opportunity into a silent acceptance.  The NEXT author with a
+  slightly different malformed form inherits a parser that is even
+  less likely to signal.
+- **What this design CLOSES**: **tokenize-time loud, not runtime
+  guessing**.  Authors see `ValueError: DOT parse error near position
+  N: backslash-quote ('\"') cannot be used as an attribute delimiter`
+  at parse time — before the engine runs a single node.  The error
+  message names the offending construct, points at the position, and
+  states the correct form.  The fix is a 30-line addition that does
+  not change any tokenizer architecture.
+
 ## The "true nouns vs located nouns" distinction (this matters)
 
 Of the five designs shipping or staged in Wave 1–3, **only two make
@@ -193,6 +245,7 @@ violation unconstructable**:
 | **LOCATED NOUN** | terminate_pipeline (T2.3) | Sole-caller AST guard + totality test. Verb relocated earlier in the lifecycle. |
 | **ASSISTED PATTERN** | HostPath / DTUPath (T3.1) | Pyright at write time + `to_host()` runtime validation. Advisory; constructor bypassable. |
 | **SPOT FIX** | DOT parser key-stripping (#33) | Centralized at one site for now. A future tokenizer change could reintroduce S4. |
+| **FAIL-LOUD NOUN** | DOT tokenizer gap-detection (S6-fix) | Parse-time `ValueError` on stray `\"` delimiter. Gap detection runs over every character; a new malformed form must also produce a gap to bypass the check. Closes S6. |
 
 **Lesson**: earlier detection is cheaper than later detection, so the
 located nouns and assisted patterns are still net-positive — but they

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/dot_parser.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/dot_parser.py
@@ -466,9 +466,46 @@ _TOKEN_RE = re.compile(
 
 
 def _tokenize(body: str) -> list[str]:
-    """Tokenize the body of a digraph into a flat list of tokens."""
+    """Tokenize the body of a digraph into a flat list of tokens.
+
+    Raises:
+        ValueError: If a stray backslash-quote sequence (``\\"``) is found
+            outside a quoted string.  This pattern means the caller used
+            ``\\\"value\\\"`` as an attribute delimiter instead of the
+            required plain ``"value"`` form.  The error is raised
+            immediately with an actionable message so the author can fix
+            the source rather than silently receiving a mis-parsed
+            condition (see RECURRING-BUG-CLASSES.md S6).
+    """
     tokens: list[str] = []
+    pos = 0  # tracks the end of the last consumed match
     for m in _TOKEN_RE.finditer(body):
+        # --- Gap check: inspect unmatched characters before this match ---
+        # Any character in the gap between pos and m.start() was NOT consumed
+        # by any token pattern.  The specific error we guard against:
+        # a backslash immediately followed by a double-quote (the ``\"...\"``
+        # delimiter attempt).  Valid ``\"`` interior escapes ARE consumed by
+        # the ``string`` token, so they never appear in a gap.
+        gap_start = pos
+        gap_end = m.start()
+        if gap_end > gap_start:
+            gap = body[gap_start:gap_end]
+            bs_idx = gap.find("\\")
+            if bs_idx != -1:
+                abs_bs = gap_start + bs_idx
+                if abs_bs + 1 < len(body) and body[abs_bs + 1] == '"':
+                    raise ValueError(
+                        f"DOT parse error near position {abs_bs}: "
+                        f"backslash-quote ('\\\"') cannot be used as an "
+                        f"attribute delimiter. Attribute values must use plain "
+                        f"double-quotes. "
+                        f'Write  condition="key=value"  not  '
+                        f'condition=\\"key=value\\". '
+                        f"Backslash-escapes are only valid INSIDE a quoted "
+                        f'string (e.g. tool_command="echo \\"hello\\"").'
+                    )
+        pos = m.end()
+
         if m.group("ws"):
             continue
         if m.group("string"):

--- a/modules/loop-pipeline/tests/test_dot_parser.py
+++ b/modules/loop-pipeline/tests/test_dot_parser.py
@@ -576,3 +576,137 @@ def test_escape_multiline_shell_heredoc_tool_command_preserves_structure():
     cmd_attr = "#!/bin/sh\\\\nset -e\\\\nprintf hello\\\\nprintf world"
     graph = parse_dot(f'digraph t {{ n [label="{cmd_attr}"] }}')
     assert graph.nodes["n"].label == ("#!/bin/sh\nset -e\nprintf hello\nprintf world")
+
+
+# --- Fail-loud: malformed backslash-quote delimiters (Layer A) ---
+
+
+def test_malformed_backslash_delimiter_rejected():
+    r"""Backslash-quote (\"...\") as attribute delimiter must raise ValueError.
+
+    This is the specific failure mode from ralph-loop pipelines: edge conditions
+    used \"value\" instead of "value", causing the tokenizer to silently
+    mis-parse the condition as a bare key (context.tool.last_line) and evaluate
+    it truthy for all 4 outgoing edges, producing a fan-out instead of
+    single-edge routing.  The fix (Layer A) raises an error immediately so the
+    author sees the problem at parse time instead of debugging wrong runtime
+    behaviour.
+
+    See RECURRING-BUG-CLASSES.md S6.
+    """
+    # Python repr: 'condition=\\"context.tool.last_line=continue\\"'
+    # On-disk DOT: condition=\"context.tool.last_line=continue\"
+    with pytest.raises(ValueError, match="backslash-quote"):
+        parse_dot(
+            "digraph test {"
+            "  start [shape=Mdiamond]; done [shape=Msquare]"
+            '  start -> done [condition=\\"context.tool.last_line=continue\\"]'
+            "}"
+        )
+
+
+def test_malformed_backslash_delimiter_error_is_actionable():
+    r"""Error message must name the offending construct and the correct form."""
+    with pytest.raises(ValueError) as exc_info:
+        parse_dot(
+            "digraph t {"
+            "  s [shape=Mdiamond]; d [shape=Msquare]"
+            '  s -> d [condition=\\"outcome=success\\"]'
+            "}"
+        )
+    msg = str(exc_info.value)
+    # Points at the problem
+    assert "backslash-quote" in msg or '\\"' in msg
+    # Names the correct form
+    assert "plain" in msg or 'condition="' in msg
+
+
+def test_plain_quote_condition_parses_and_routes_correctly():
+    r"""Plain-quoted condition must parse and select exactly one matching edge.
+
+    Regression guard: with the old silent-mis-parse behaviour, all 4 conditional
+    edges from Verify matched because the malformed \"context.tool.last_line\"
+    was a truthy bare key.  This test confirms that with plain quotes exactly
+    one edge matches when context.tool.last_line=continue.
+    """
+    from amplifier_module_loop_pipeline.context import PipelineContext
+    from amplifier_module_loop_pipeline.edge_selection import select_all_matching_edges
+    from amplifier_module_loop_pipeline.outcome import Outcome, StageStatus
+
+    graph = parse_dot("""
+    digraph test {
+        start  [shape=Mdiamond]
+        verify [prompt="Verify"]
+        execute     [prompt="Execute again"]
+        report_done [shape=Msquare]
+        report_stalled [shape=Msquare]
+        report_max    [shape=Msquare]
+
+        start -> verify
+        verify -> execute       [condition="context.tool.last_line=continue", loop_restart=true]
+        verify -> report_done   [condition="context.tool.last_line=done"]
+        verify -> report_stalled[condition="context.tool.last_line=stalled"]
+        verify -> report_max    [condition="context.tool.last_line=max_iter"]
+    }
+    """)
+
+    ctx = PipelineContext()
+    ctx.set("tool.last_line", "continue")
+    outcome = Outcome(status=StageStatus.SUCCESS)
+
+    matched = select_all_matching_edges("verify", outcome, ctx, graph)
+    assert len(matched) == 1, (
+        f"Expected exactly 1 matching edge, got {len(matched)}: "
+        f"{[e.to_node for e in matched]}"
+    )
+    assert matched[0].to_node == "execute"
+    assert matched[0].attrs.get("loop_restart") is True
+
+
+def test_backslash_quote_inside_string_value_still_valid():
+    r"""Backslash-quote INSIDE a quoted string (interior escape) must still work.
+
+    The fix must not break the legitimate use: tool_command="echo \"hello\""
+    where \"  is an interior escape for a literal double-quote character,
+    not a delimiter.  The outer delimiters remain plain double-quotes.
+    """
+    graph = parse_dot(
+        "digraph t {"
+        "  s [shape=Mdiamond]; d [shape=Msquare]"
+        '  s [tool_command="echo \\"hello world\\""]'
+        "  s -> d"
+        "}"
+    )
+    assert graph.nodes["s"].attrs.get("tool_command") == 'echo "hello world"'
+
+
+def test_bare_key_truthy_condition_still_supported():
+    """Bare-key truthy conditions (L-20) remain valid after the Layer A fix.
+
+    The Layer A fix only rejects stray backslashes before a double-quote.
+    A bare-key condition like condition="approved" (no operator) is
+    intentional (CEXPR-011, Spec Section 10.5) and must continue to work.
+    """
+    from amplifier_module_loop_pipeline.conditions import evaluate_condition
+    from amplifier_module_loop_pipeline.context import PipelineContext
+    from amplifier_module_loop_pipeline.outcome import Outcome, StageStatus
+
+    # Bare-key condition parses without error
+    graph = parse_dot("""
+    digraph test {
+        start [shape=Mdiamond]; done [shape=Msquare]
+        start -> done [condition="approved"]
+    }
+    """)
+    edge = graph.edges[0]
+    assert edge.condition == "approved"
+
+    # Evaluates truthy when context key has a non-empty value
+    ctx = PipelineContext()
+    ctx.set("approved", "yes")
+    outcome = Outcome(status=StageStatus.SUCCESS)
+    assert evaluate_condition("approved", outcome, ctx) is True
+
+    # Evaluates falsy when context key is absent
+    ctx2 = PipelineContext()
+    assert evaluate_condition("approved", outcome, ctx2) is False


### PR DESCRIPTION
## Summary

The DOT tokenizer silently swallowed stray backslashes, turning a malformed attribute value like `condition=\"context.x=y\"` (backslash as the delimiter, not an interior escape) into a bare-key condition `context.x` that evaluates truthy. As a result, every conditional edge matched and the engine fanned out instead of routing — a silent failure that turned a one-character syntax mistake into hours of mystery debugging.

The strongdm/attractor nlspec mandates the opposite behavior: `\"` is ONLY valid as an escape inside a quoted value (e.g., embedded shell quotes in `tool_command`), never as a delimiter. §7.1–§7.2 require error-severity diagnostics be rejected at parse time.

## The Fix (Layer A — Tokenizer)

Added gap-detection in `_tokenize()`: when an unmatched character gap contains `\"`, raise a `ValueError` with position and an actionable message pointing to the correct plain-quote form. Fail loud, not open.

**Design decision (preserved):** Bare-key truthy conditions (e.g., `condition="context.flag"`) remain valid — they are intentional, tested behavior (L-20 tests in conditions.py). The stray backslash is the unambiguous malformation signal.

## Documentation Added

- **DOT-SYNTAX.md** — new "Quoting and Escaping" section explaining plain `"..."` delimiters and `\"` interior escapes
- **DOT-AUTHORING-GUIDE.md** — callout + anti-pattern table row for the common mistake
- **RECURRING-BUG-CLASSES.md** — new species S6 (parser fails open on malformed input) capturing the meta-lesson that a strict-subset parser must reject what the spec rejects

## Testing

- **6 new tests** covering malformed rejection, plain-quote routing, interior `\"` validity, and bare-key truthy preservation
- **Full suite**: 1272 passed; the 27 pre-existing failures on f0577e8 remain (stash-verified, not introduced here)

## Coordination

This complements **PR #30** (loop_restart truthy-check fix) — same module, same "make the engine behave correctly on real-world DOT" theme. Both land incrementally; this one closes the tokenizer loophole.

Related: workspace pipeline fixes (ralph-loop .dot files) will be committed separately with a submodule bump once this merges.
