### PR TITLE
fix(manager): thread interviewer into child-dotfile registry so HITL gates work inside manager child_dotfile

### DIFF
--- a/examples/pipelines/11-manager-child-dotfile-hitl/child-with-gate.dot
+++ b/examples/pipelines/11-manager-child-dotfile-hitl/child-with-gate.dot
@@ -1,0 +1,60 @@
+// 11-manager-child-dotfile-hitl/child-with-gate.dot -- Child pipeline containing a HITL gate.
+//
+// This file is referenced by parent.dot via:
+//   manager [shape=house, "stack.child_dotfile"="child-with-gate.dot"]
+//
+// The human gate (shape=hexagon, type="wait.human") is the critical node for
+// verifying the bug fix: the HumanGateHandler must receive a real interviewer
+// (not None) that was forwarded from the top-level HandlerRegistry through
+// ManagerLoopHandler._run_child_dotfile() -> child HandlerContext.
+//
+// How to drive the gate manually:
+//   When prompted "Approve the sprint deliverable?", type "A" to approve.
+//   DTU / CI uses AutoApproveInterviewer, which selects the first option automatically.
+//
+// Expected flow:
+//   start -> hitl_gate (presents approval question) -> approved -> done
+//   (or: start -> hitl_gate -> rejected -> done, if the human rejects)
+
+digraph ChildWithHITLGate {
+    graph [
+        goal="Approve the sprint deliverable to proceed"
+    ]
+    rankdir=TB
+
+    // Structural nodes
+    start    [shape=Mdiamond, label="Start"]
+    done     [shape=Msquare,  label="Done"]
+
+    // Human-in-the-loop approval gate.
+    // shape=hexagon maps to wait.human handler (HumanGateHandler).
+    // Outgoing edge labels become the options presented to the human.
+    // Accelerator key [A] / [R] are parsed from the label prefix.
+    hitl_gate [
+        shape=hexagon,
+        label="Approve the sprint deliverable?",
+        type="wait.human"
+    ]
+
+    // Outcome nodes — what happens after the human decides
+    approved [
+        label="Mark Approved",
+        prompt="The sprint deliverable has been approved. Record the approval decision."
+    ]
+
+    rejected [
+        label="Request Rework",
+        prompt="The sprint deliverable was rejected. Summarize the rework needed."
+    ]
+
+    // Flow
+    start -> hitl_gate
+
+    // Edge labels become the choices the human sees
+    hitl_gate -> approved [label="[A] Approve"]
+    hitl_gate -> rejected [label="[R] Reject"]
+
+    // Both paths terminate at done
+    approved -> done
+    rejected -> done
+}

--- a/examples/pipelines/11-manager-child-dotfile-hitl/parent.dot
+++ b/examples/pipelines/11-manager-child-dotfile-hitl/parent.dot
@@ -1,0 +1,54 @@
+// 11-manager-child-dotfile-hitl/parent.dot -- Manager node supervising a child pipeline
+// that contains a human-in-the-loop (HITL) approval gate.
+//
+// Reproduces the latent bug fixed in PR #45:
+//   ManagerLoopHandler._run_child_dotfile() was building its child HandlerRegistry
+//   with HandlerContext(...) missing interviewer=, so the HumanGateHandler inside
+//   the child pipeline always received interviewer=None and raised ValueError at
+//   runtime: "HumanGateHandler requires an Interviewer but none was provided."
+//
+// Structure:
+//   parent.dot  (this file)
+//     start -> manager (shape=house, child_dotfile=child-with-gate.dot) -> done
+//   child-with-gate.dot  (sibling file)
+//     start -> hitl_gate (shape=hexagon) -> approved -> done
+//
+// To drive this pipeline, the interviewer must be wired end-to-end:
+//   HandlerRegistry -> ManagerLoopHandler -> child HandlerContext -> HumanGateHandler
+//
+// The human gate presents "Approve the sprint deliverable?" with two outgoing edges:
+//   [A] Approve  -> approved
+//   [R] Reject   -> rejected
+// When driven interactively, approve with "A".
+// When driven by AutoApproveInterviewer (DTU / CI), the gate is auto-approved.
+
+digraph ManagerChildDotfileHITL {
+    graph [
+        goal="Demonstrate manager child_dotfile pipeline with HITL gate",
+        label="Manager Child-Dotfile HITL Example",
+        default_fidelity="full"
+    ]
+    rankdir=TB
+
+    // Structural nodes
+    start [shape=Mdiamond, label="Start"]
+    done  [shape=Msquare,  label="Done"]
+
+    // Manager node (shape=house) — supervises the child pipeline from child-with-gate.dot.
+    // manager.max_cycles=1 keeps the example deterministic (one pass is sufficient to
+    // prove the interviewer is wired through).
+    // manager.actions=observe — no steering or wait needed for this reproduction case.
+    // stack.child_dotfile resolves relative to this file's directory (source_dir).
+    manager [
+        shape=house,
+        label="Supervise Approval Sprint",
+        prompt="Oversee the approval-gate child pipeline.",
+        "manager.max_cycles"="1",
+        "manager.actions"="observe",
+        "stack.child_dotfile"="child-with-gate.dot"
+    ]
+
+    // Flow: start -> manager -> done
+    // The manager's child pipeline is fully contained in child-with-gate.dot.
+    start -> manager -> done
+}

--- a/examples/pipelines/11-manager-child-dotfile-hitl/parent.dot
+++ b/examples/pipelines/11-manager-child-dotfile-hitl/parent.dot
@@ -21,6 +21,12 @@
 //   [R] Reject   -> rejected
 // When driven interactively, approve with "A".
 // When driven by AutoApproveInterviewer (DTU / CI), the gate is auto-approved.
+//
+// DOT parser note: attribute keys with dots (e.g. manager.max_cycles) must be written
+// WITHOUT surrounding double-quotes. The attractor DOT parser stores quoted keys with
+// their embedded quote characters, which breaks lookups using bare key strings.
+// Correct:  manager.max_cycles=1
+// Wrong:    "manager.max_cycles"="1"
 
 digraph ManagerChildDotfileHITL {
     graph [
@@ -39,13 +45,16 @@ digraph ManagerChildDotfileHITL {
     // prove the interviewer is wired through).
     // manager.actions=observe — no steering or wait needed for this reproduction case.
     // stack.child_dotfile resolves relative to this file's directory (source_dir).
+    //
+    // NOTE: attribute keys with dots are written WITHOUT surrounding double-quotes so
+    // the attractor DOT parser stores them as bare strings (matching the lookup code).
     manager [
         shape=house,
         label="Supervise Approval Sprint",
         prompt="Oversee the approval-gate child pipeline.",
-        "manager.max_cycles"="1",
-        "manager.actions"="observe",
-        "stack.child_dotfile"="child-with-gate.dot"
+        manager.max_cycles=1,
+        manager.actions=observe,
+        stack.child_dotfile="child-with-gate.dot"
     ]
 
     // Flow: start -> manager -> done

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/__init__.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/__init__.py
@@ -79,6 +79,7 @@ class HandlerRegistry:
                 backend=ctx.backend,
                 hooks=ctx.hooks,
                 cancel_event=ctx.cancel_event,
+                interviewer=ctx.interviewer,
             ),
             "parallel": ParallelHandler(
                 hooks=ctx.hooks,

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/manager_loop.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/manager_loop.py
@@ -105,11 +105,13 @@ class ManagerLoopHandler:
         hooks: Any = None,
         cancel_event: Any = None,
         handler_registry_factory: Any | None = None,
+        interviewer: Any = None,
     ) -> None:
         self._backend = backend
         self._hooks = hooks
         self._cancel_event = cancel_event
         self._handler_registry_factory = handler_registry_factory
+        self._interviewer = interviewer
         self._subgraph_runs: dict[str, dict[str, Any]] = {}
 
     async def execute(
@@ -344,6 +346,7 @@ class ManagerLoopHandler:
                     backend=effective_backend,
                     hooks=self._hooks,
                     cancel_event=self._cancel_event,
+                    interviewer=self._interviewer,
                 )
             )
         child_engine = PipelineEngine(

--- a/modules/loop-pipeline/tests/test_manager_loop.py
+++ b/modules/loop-pipeline/tests/test_manager_loop.py
@@ -743,3 +743,166 @@ class TestManagerChildDotfileObservability:
         assert "nodes_completed" in run_data
         assert run_data["dot_file"] == str(child_dot)
         assert run_data["total_elapsed_ms"] >= 0
+
+
+# ---------------------------------------------------------------------------
+# Interviewer forwarding tests for the child_dotfile path
+# ---------------------------------------------------------------------------
+
+
+CHILD_DOT_WITH_HITL_GATE = """\
+digraph child_hitl {
+    start [shape=Mdiamond]
+    gate  [shape=hexagon, label="Approve to proceed?", type="wait.human"]
+    done  [shape=Msquare]
+    start -> gate
+    gate  -> done [label="Approve"]
+}
+"""
+
+
+class TestManagerChildDotfileInterviewerForwarding:
+    """Regression tests: ManagerLoopHandler must forward its interviewer to child_dotfile registry.
+
+    Root cause (latent bug): _run_child_dotfile() built its child HandlerContext
+    without interviewer=, so HumanGateHandler inside any manager child_dotfile
+    always received interviewer=None and raised ValueError at runtime.
+
+    Fix: add interviewer param to ManagerLoopHandler.__init__, wire it through
+    HandlerRegistry, and pass interviewer=self._interviewer to the child HandlerContext.
+    """
+
+    def test_registry_passes_interviewer_to_manager_handler(self) -> None:
+        """HandlerRegistry.__init__ must pass ctx.interviewer to ManagerLoopHandler.
+
+        RED on current main: ManagerLoopHandler.__init__ has no interviewer param;
+        registry doesn't pass it; manager_handler._interviewer does not exist.
+        GREEN after fix: param added, registry wired, attribute present and correct.
+        """
+        from amplifier_module_loop_pipeline.handlers import HandlerRegistry
+        from amplifier_module_loop_pipeline.interviewer import AutoApproveInterviewer
+
+        interviewer = AutoApproveInterviewer()
+        registry = HandlerRegistry(HandlerContext(interviewer=interviewer))
+
+        manager_handler = registry._handlers["stack.manager_loop"]
+        assert isinstance(manager_handler, ManagerLoopHandler)
+        assert manager_handler._interviewer is interviewer, (
+            "HandlerRegistry must pass ctx.interviewer to ManagerLoopHandler. "
+            "Without this, HITL gates inside a manager child_dotfile pipeline "
+            "silently receive interviewer=None and raise ValueError at runtime."
+        )
+
+    @pytest.mark.asyncio
+    async def test_hitl_gate_in_manager_child_dotfile_succeeds_with_interviewer(
+        self, tmp_path
+    ) -> None:
+        """HITL gate inside a manager child_dotfile receives the interviewer and auto-approves.
+
+        RED on current main: ManagerLoopHandler.__init__ raises TypeError (no
+        interviewer param), so even constructing the handler fails; and even if
+        constructed another way the child HandlerContext is built without
+        interviewer= so HumanGateHandler raises ValueError.
+        GREEN after fix: interviewer threaded through, AutoApproveInterviewer
+        approves the gate, child pipeline succeeds, manager returns SUCCESS.
+        """
+        from amplifier_module_loop_pipeline.interviewer import AutoApproveInterviewer
+
+        child_dot = tmp_path / "child_hitl.dot"
+        child_dot.write_text(CHILD_DOT_WITH_HITL_GATE)
+
+        # Parent graph: manager node points to the child_dotfile.
+        # has_child_edge=False because the child pipeline lives in the dotfile.
+        graph = _make_graph(
+            manager_attrs={
+                "manager.max_cycles": "1",
+                "manager.actions": "observe",
+                "stack.child_dotfile": str(child_dot),
+            },
+            has_child_edge=False,
+        )
+        graph.source_dir = str(tmp_path)
+
+        # Requires the interviewer param to exist on ManagerLoopHandler.__init__
+        handler = ManagerLoopHandler(interviewer=AutoApproveInterviewer())
+
+        ctx = PipelineContext()
+        outcome = await handler.execute(
+            graph.nodes["manager"], ctx, graph, str(tmp_path), engine=None
+        )
+
+        assert outcome.status == StageStatus.SUCCESS, (
+            f"Expected SUCCESS but got {outcome.status!r} — "
+            f"failure_reason: {outcome.failure_reason!r}. "
+            "Likely cause: HumanGateHandler received interviewer=None because "
+            "ManagerLoopHandler._run_child_dotfile() did not thread the interviewer "
+            "into the child HandlerContext."
+        )
+
+    @pytest.mark.asyncio
+    async def test_e2e_manager_child_dotfile_hitl_via_full_engine(
+        self, tmp_path
+    ) -> None:
+        """Full E2E: PipelineEngine with manager child_dotfile containing HITL gate.
+
+        Interviewer must propagate through the full chain:
+          HandlerRegistry -> ManagerLoopHandler -> child HandlerContext -> HumanGateHandler
+
+        RED on current main: interviewer dropped at the child HandlerContext step.
+        GREEN after fix.
+        """
+        import json as _json
+
+        from amplifier_module_loop_pipeline.dot_parser import parse_dot
+        from amplifier_module_loop_pipeline.engine import PipelineEngine
+        from amplifier_module_loop_pipeline.handlers import HandlerRegistry
+        from amplifier_module_loop_pipeline.interviewer import AutoApproveInterviewer
+
+        class _MockBackend:
+            async def run(self, node, prompt, context, incoming_edge=None, graph=None):
+                return _json.dumps({"status": "success", "notes": f"mock: {node.id}"})
+
+        # Write the child DOT with a HITL gate
+        child_dot = tmp_path / "hitl_child.dot"
+        child_dot.write_text(CHILD_DOT_WITH_HITL_GATE)
+
+        # Parent DOT: manager node (shape=house) with child_dotfile pointing at
+        # the child pipeline that contains a hexagon gate.
+        # Dotted attribute names must be quoted in DOT syntax.
+        parent_dot_source = """\
+digraph parent_manager_hitl {
+    graph [goal="Test manager child_dotfile HITL forwarding"]
+    start   [shape=Mdiamond]
+    manager [shape=house, "manager.max_cycles"="1", "manager.actions"="observe",
+             "stack.child_dotfile"="hitl_child.dot"]
+    done    [shape=Msquare]
+    start -> manager -> done
+}
+"""
+        parent_graph = parse_dot(parent_dot_source)
+        # source_dir so that "hitl_child.dot" resolves relative to tmp_path
+        parent_graph.source_dir = str(tmp_path)
+
+        ctx = PipelineContext()
+        registry = HandlerRegistry(
+            HandlerContext(
+                backend=_MockBackend(),
+                interviewer=AutoApproveInterviewer(),
+            )
+        )
+        logs_root = str(tmp_path / "logs")
+
+        engine = PipelineEngine(
+            graph=parent_graph,
+            context=ctx,
+            handler_registry=registry,
+            logs_root=logs_root,
+        )
+        outcome = await engine.run()
+
+        assert outcome.status == StageStatus.SUCCESS, (
+            f"Expected SUCCESS but got {outcome.status!r} — "
+            f"failure_reason: {outcome.failure_reason!r}. "
+            "Interviewer may not have reached the child HITL gate through the "
+            "manager child_dotfile pipeline."
+        )


### PR DESCRIPTION
## Problem
A human-in-the-loop node (`type=wait.human`) nested inside a manager (`shape=house`) node's `child_dotfile` got `interviewer=None` and failed with "HumanGateHandler requires an Interviewer". `ManagerLoopHandler._run_child_dotfile()` built the child registry's `HandlerContext` without an interviewer, unlike `PipelineHandler` (`pipeline.py:197`).

## Fix
Thread the interviewer through: `ManagerLoopHandler.__init__` accepts `interviewer`, `HandlerRegistry` forwards `ctx.interviewer`, and the child `HandlerContext(...)` is built with `interviewer=self._interviewer` — mirroring `PipelineHandler` exactly.

## Context
This is the one surviving live concern from PR #32; the rest of #32/#36 (the `subgraph_runner` kwarg / closure dance) is already resolved in main via the #41 isolation refactor.

## Verification
- Unit: 3 tests RED→GREEN (registry forwards interviewer; HITL gate in manager child_dotfile succeeds; e2e via full engine). Suite green, no regressions.
- **DTU end-to-end (real resolve worker, genuine InputRequestInterviewer):** ran `examples/pipelines/11-manager-child-dotfile-hitl/parent.dot` — the nested `hitl_gate` surfaced (`pipeline:interview_started` → `resolve.input.requested` → `interview_completed` on approval) and the manager completed SUCCESS. On main the same pipeline dies with "requires an Interviewer".

Repro pipeline added at `examples/pipelines/11-manager-child-dotfile-hitl/`.