### PR TITLE
fix(parser): strip outer quotes from attribute key tokens

### DIFF
--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/dot_parser.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/dot_parser.py
@@ -545,7 +545,7 @@ def _parse_attr_block(tokens: list[str], pos: int) -> dict[str, Any]:
         if i + 2 <= end and tokens[i + 1] == "=":
             if prev_was_value:
                 found_missing_comma = True
-            key = tokens[i]
+            key = _unquote_key(tokens[i])
             raw_val = tokens[i + 2]
             attrs[key] = _parse_value(raw_val)
             prev_was_value = True
@@ -589,6 +589,23 @@ def _find_matching_brace(tokens: list[str], pos: int) -> int:
 
 
 # --- Value parsing ---
+
+
+def _unquote_key(raw: str) -> str:
+    """Strip surrounding double-quotes from an attribute-key token.
+
+    The tokenizer emits a quoted key (e.g. ``"manager.max_cycles"``) verbatim,
+    quotes included.  Downstream attribute lookups use the bare identifier, so
+    the quotes must be removed here.
+
+    Unlike :func:`_parse_value` this does **not** coerce types or process escape
+    sequences — an attribute key is always a plain string identifier.  A quoted
+    numeric key such as ``"3"`` stays the string ``"3"``, not the integer ``3``.
+    Unquoted keys pass through unchanged.
+    """
+    if len(raw) >= 2 and raw[0] == '"' and raw[-1] == '"':
+        return raw[1:-1]
+    return raw
 
 
 def _parse_value(raw: str) -> Any:

--- a/modules/loop-pipeline/tests/test_dot_parser.py
+++ b/modules/loop-pipeline/tests/test_dot_parser.py
@@ -568,7 +568,7 @@ def test_escape_quadruple_backslash_yields_pair():
 def test_escape_multiline_shell_heredoc_tool_command_preserves_structure():
     """Multi-line shell heredoc tool_command must produce valid multi-line shell.
 
-    Before the fix: ``\\\\n`` between script lines became ``\<LF>`` (line
+    Before the fix: ``\\\\n`` between script lines became ``\\<LF>`` (line
     continuation), joining lines into one big logical line and breaking any
     `python3 - << 'PYEOF'` heredoc. Result: dash parsed Python source as shell
     code and crashed on the first ``(``.
@@ -710,3 +710,76 @@ def test_bare_key_truthy_condition_still_supported():
     # Evaluates falsy when context key is absent
     ctx2 = PipelineContext()
     assert evaluate_condition("approved", outcome, ctx2) is False
+
+
+# --- Quoted attribute key stripping (fix/parser-unquote-keys) ---
+
+
+def test_quoted_attribute_key_strips_quotes():
+    """Quoted attribute key must be stored without surrounding double-quotes.
+
+    A DOT attribute block like:
+        A [ "manager.max_cycles"=1 ]
+    produces a tokenized key token that includes the outer quotes verbatim.
+    Downstream lookups use the bare identifier, so attrs.get("manager.max_cycles")
+    must return the value — not None.  Value 1 (unquoted integer) exercises both
+    key-unquoting and normal value type-coercion in the same assertion.
+    """
+    graph = parse_dot(
+        "digraph t { start [shape=Mdiamond]; done [shape=Msquare]; "
+        "start -> done; "
+        'A [ "manager.max_cycles"=1 ] }'
+    )
+    assert graph.nodes["A"].attrs.get("manager.max_cycles") == 1
+
+
+def test_quoted_and_unquoted_keys_coexist():
+    """Quoted and unquoted keys in the same attribute block both resolve correctly.
+
+    Mixing bare unquoted keys (max_iter) with quoted dotted-namespace keys
+    ("stack.child_dotfile") in a single block must not break either lookup.
+    Note: 'shape' is a promoted node field, not stored in attrs — test uses
+    max_iter (a plain unquoted key that does live in attrs) as the control.
+    """
+    graph = parse_dot(
+        "digraph t { start [shape=Mdiamond]; done [shape=Msquare]; start -> done; "
+        'M [ shape=house, "stack.child_dotfile"="child.dot", max_iter=3 ] }'
+    )
+    # Unquoted key — must work both before and after the fix (control).
+    assert graph.nodes["M"].attrs.get("max_iter") == 3
+    # Quoted dotted-namespace key — this is the bug being fixed.
+    assert graph.nodes["M"].attrs.get("stack.child_dotfile") == "child.dot"
+
+
+def test_quoted_key_value_not_type_coerced_as_key():
+    """Quoted numeric key token must stay a plain string, not be type-coerced.
+
+    _unquote_key must strip quotes only; it must NOT route through _parse_value,
+    which would coerce a quoted numeric string like "3" into int 3.
+    A key of "3"=x means the attribute name is the string "3", not the integer 3.
+    """
+    graph = parse_dot(
+        "digraph t { start [shape=Mdiamond]; done [shape=Msquare]; start -> done; "
+        'A [ "3"=x ] }'
+    )
+    # Key must be the string "3" (not the integer 3, not '"3"' with quotes).
+    assert graph.nodes["A"].attrs.get("3") == "x"
+    assert 3 not in graph.nodes["A"].attrs  # int coercion must not have happened
+    assert '"3"' not in graph.nodes["A"].attrs  # raw quoted form must be gone
+
+
+def test_quoted_key_composes_with_backslash_validation():
+    r"""Quoted key + malformed backslash-quote value still raises ValueError.
+
+    A block containing both a valid quoted key ("manager.max_cycles"="1")
+    AND a separate attribute whose value uses a malformed backslash-quote
+    delimiter (condition=\\\"bad\\\") must still raise #44's ValueError.
+    Proves there is no regression in the interaction between the two fixes.
+    """
+    with pytest.raises(ValueError, match="backslash-quote"):
+        parse_dot(
+            "digraph t {"
+            "  s [shape=Mdiamond]; d [shape=Msquare]"
+            '  s -> d [ "manager.max_cycles"="1", condition=\\"bad\\" ]'
+            "}"
+        )


### PR DESCRIPTION
## Problem
The DOT parser strips quotes from attribute *values* but not *keys*, so `"manager.max_cycles"="1"` is stored under key `'"manager.max_cycles"'` (quotes intact). Every `attrs.get("manager.max_cycles")` / `attr_key.startswith("context.")` then misses — a manager node silently skips its `child_dotfile`, and `context.*` keys are dropped. DTU-confirmed: this broke the manager-attribute parsing in a real HITL run.

## Fix
A small strip-only `_unquote_key` helper + a one-line edit at `dot_parser.py:548`. Deliberately does NOT reuse `_parse_value` (which coerces types) — a key `"3"` must stay the string `"3"`, not become `3`. Lives entirely in `_parse_attr_block`, outside the tokenizer, so it composes cleanly with the recently-merged #44 (backslash-quote validation) — the two are complementary (a well-formed quoted key produces no tokenizer gap, so #44 never rejects it).

## Supersedes #33
This is a cleaner reimplementation of #33 (named/scoped helper vs inline; rebased onto current main incl. #44).

## Verification
- 4 unit tests RED→GREEN (quoted key strips; quoted+unquoted coexist; quoted numeric key NOT type-coerced; composes with #44's ValueError). Full parser suite green.
- DTU end-to-end (real worker on this branch): the exact quoted-key form that broke before now resolves — manager reads `max_cycles=2` and invokes `child.dot`; on `main` the same input yields `None`/skip. Direct main-vs-fix contrast confirmed.