### PR TITLE
docs: mark resolved findings (H-11/#36, fidelity/#42/#46) and correct stale _session_pool reference

### DIFF
--- a/docs/plans/track1/track1-1b7-subgraph-runner.md
+++ b/docs/plans/track1/track1-1b7-subgraph-runner.md
@@ -1,3 +1,5 @@
+> **STATUS: Completed — PR #36.**
+
 # Track 1-1B7: Wire subgraph_runner for Parallel/Manager Handlers (H-11)
 
 > **Execution:** Use the subagent-driven-development workflow to implement this plan.

--- a/docs/reports/adversarial-spec-review.md
+++ b/docs/reports/adversarial-spec-review.md
@@ -7,6 +7,10 @@
 
 ---
 
+> **STATUS — Historical (2026-02-10):** Many findings since resolved — H-11 fixed PR #36; fidelity fixed PR #42/#46; C-1 fixed PR #41. Preserved for architectural history.
+
+---
+
 ## Executive Summary
 
 The implementation has strong architectural foundations — 886 unit tests, real API calls proven across 2 providers, DOT parsing and pipeline traversal working. But the adversarial review found **70 total findings** (10 CRITICAL, 14 HIGH, 24 MEDIUM, 22 LOW) across three review dimensions:

--- a/specs/EXTENSIONS.md
+++ b/specs/EXTENSIONS.md
@@ -157,6 +157,8 @@ cross-branch session sharing, because the spec never defines that behavior \u201
 opposite (§3.8 isolation). This change moves observable behavior toward what a conforming
 pipeline already assumes.
 
+> **Implementation note:** `_session_pool` was superseded by `_thread_transcripts` (see §12–13); the per-branch isolation semantics described here remain in effect.
+
 ---
 
 ## 9. Same `thread_id` Across Concurrent Branches Resolves to Isolation


### PR DESCRIPTION
## Summary

Three doc-only edits to eliminate self-contradicting context poison — findings and mechanisms that were fixed/superseded but still read as open/current to any agent reading the files.

**1. `specs/EXTENSIONS.md` §8** — §8 describes `_session_pool` as the current backend mechanism for per-branch session isolation, but §12–13 of the same file (and `backend.py:118`) correctly document that it was superseded by `_thread_transcripts`. Added an implementation note at the end of §8 clarifying the supersession while preserving §8's substantive isolation semantics (which remain in effect).

**2. `docs/reports/adversarial-spec-review.md`** — The adversarial review has no status markers, so H-11 ("subgraph_runner never wired") and the "Recommended Fix Order" still read as open work items. H-11 was fixed in PR #36, fidelity fixed in PR #42/#46, C-1 fixed in PR #41. Added a STATUS banner immediately after the metadata block marking the report historical and listing resolved findings. Individual findings not touched — one header is enough.

**3. `docs/plans/track1/track1-1b7-subgraph-runner.md`** — The H-11 implementation plan has no completion marker, so it reads as pending work. Added a one-line STATUS header at the top marking it completed via PR #36.

No code changes. No AGENTS.md changes (already accurate). No RECURRING-BUG-CLASSES.md changes (already correct).

## Verification checklist

- [x] Unit tests pass (`pytest modules/loop-pipeline/`) — 1167 passed, 7 skipped; 5 pre-existing failures on `origin/main` unrelated to these doc edits (confirmed by stash test against base)
- [x] Live pipeline run exercising changed code path — not applicable; AGENTS.md verification gradient: docs changes require unit tests only
- [x] AGENTS.md reviewed; repo-specific gates met — doc-only change satisfies the "test fixtures, examples, docs → unit tests sufficient" row
- [x] Backward-compat path unchanged — doc-only, no behavior change
- [x] PR body includes verification evidence, not just "tests pass"

## Verification evidence

```
pytest modules/loop-pipeline/ -q
...
5 failed, 1167 passed, 7 skipped, 1 warning in 12.21s
```

Pre-existing failures on `origin/main` before any edits (confirmed via `git stash` test):
- `test_dot_parser.py::test_quoted_and_unquoted_keys_coexist`
- `test_dot_parser.py::test_quoted_key_value_not_type_coerced_as_key`
- `test_outputs_attribute.py::test_human_handler_infers_human_input_and_choice`
- `test_outputs_attribute.py::test_human_handler_inferred_outputs_in_table`

None of these are caused by this PR's changes.

## Notes for reviewers

This is the attractor-bundle half of a broader context-poisoning cleanup sweep across the Amplifier Resolve ecosystem. The resolve-bundle's equivalent PR (#54) has already been opened and covers the much larger M1/Docker→Incus worker poisoning in that repo. This PR is narrower — attractor-specific stale status markers only.

---
See: [Per-Repo Conventions](https://github.com/microsoft/amplifier-foundation/blob/main/docs/PER_REPO_CONVENTIONS.md) and this repo's `AGENTS.md` for the verification discipline this checklist enforces.
