### PR TITLE
fix(loop-pipeline): honor allow_partial on node timeout + fix string-vs-bool allow_partial check

### DIFF
--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py
@@ -531,8 +531,14 @@ class PipelineEngine:
                             )
                     except asyncio.TimeoutError:
                         node_duration_ms = (time.monotonic() - node_start_time) * 1000
+                        _ap = current_node.attrs.get("allow_partial")
+                        _timeout_status = (
+                            StageStatus.PARTIAL_SUCCESS
+                            if _ap is True or str(_ap).lower() == "true"
+                            else StageStatus.FAIL
+                        )
                         outcome = Outcome(
-                            status=StageStatus.FAIL,
+                            status=_timeout_status,
                             notes=f"Node '{current_node.id}' timed out after {timeout_s}s",
                             failure_reason="timeout",
                         )

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/retry.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/retry.py
@@ -264,7 +264,8 @@ async def execute_with_retry(
             },
         )
 
-    if node.attrs.get("allow_partial") is True:
+    _ap = node.attrs.get("allow_partial")
+    if _ap is True or str(_ap).lower() == "true":
         return Outcome(
             status=StageStatus.PARTIAL_SUCCESS,
             notes="Retries exhausted, partial accepted",

--- a/modules/loop-pipeline/tests/test_pipeline_events.py
+++ b/modules/loop-pipeline/tests/test_pipeline_events.py
@@ -55,7 +55,14 @@ class MockBackend:
     def __init__(self, return_value: str = "done") -> None:
         self._return_value = return_value
 
-    async def run(self, node: Node, prompt: str, context: PipelineContext, incoming_edge=None, graph=None) -> str:
+    async def run(
+        self,
+        node: Node,
+        prompt: str,
+        context: PipelineContext,
+        incoming_edge=None,
+        graph=None,
+    ) -> str:
         return self._return_value
 
 
@@ -66,7 +73,12 @@ class FailingBackend:
         self._fail_node = fail_node
 
     async def run(
-        self, node: Node, prompt: str, context: PipelineContext, incoming_edge=None, graph=None
+        self,
+        node: Node,
+        prompt: str,
+        context: PipelineContext,
+        incoming_edge=None,
+        graph=None,
     ) -> str | Outcome:
         if node.id == self._fail_node:
             return Outcome(status=StageStatus.FAIL, failure_reason="intentional")
@@ -506,7 +518,12 @@ class SessionBackend:
         self._session_id = session_id
 
     async def run(
-        self, node: Node, prompt: str, context: PipelineContext, incoming_edge=None, graph=None
+        self,
+        node: Node,
+        prompt: str,
+        context: PipelineContext,
+        incoming_edge=None,
+        graph=None,
     ) -> str | Outcome:
         if node.id == self._session_node:
             return Outcome(status=StageStatus.SUCCESS, session_id=self._session_id)
@@ -595,7 +612,12 @@ class TestNodeCompleteSessionId:
 
         class SlowBackend:
             async def run(
-                self, node: Node, prompt: str, context: PipelineContext, incoming_edge=None, graph=None
+                self,
+                node: Node,
+                prompt: str,
+                context: PipelineContext,
+                incoming_edge=None,
+                graph=None,
             ) -> str:
                 await asyncio.sleep(10)  # will be timed out
                 return "done"
@@ -621,6 +643,86 @@ class TestNodeCompleteSessionId:
         for event in timeout_events:
             assert "session_id" in event
             assert event["session_id"] is None
+
+
+# ---------------------------------------------------------------------------
+# Timeout + allow_partial continuation
+# ---------------------------------------------------------------------------
+
+
+class TestTimeoutAllowPartialContinuation:
+    """A node that times out with allow_partial set yields PARTIAL_SUCCESS so the
+    graph continues, instead of terminating the whole run on one node timeout.
+
+    Regression guard for two coupled defects (branch fix/allow-partial-on-timeout):
+      1. The timeout handler ignored allow_partial and always returned FAIL, so a
+         single node timeout tore down the entire graph even when the node opted
+         into partial completion.
+      2. allow_partial parsed from a *quoted* DOT attribute (allow_partial="true")
+         is the string "true"; an `is True` identity check never matched, so the
+         feature was inert for the common quoted spelling.
+
+    Spec: PARTIAL_SUCCESS is success-class for routing (Section 5.2); allow_partial
+    is a Boolean node attribute (Section 2.6). Applying allow_partial on the timeout
+    path (not just retry exhaustion) is a documented extension (specs/EXTENSIONS.md).
+
+    The test parametrizes both DOT spellings so the quoted form (defect #2) is
+    exercised at the integration level alongside the timeout path (defect #1).
+    """
+
+    @pytest.mark.parametrize(
+        "allow_partial_attr", ['allow_partial="true"', "allow_partial=true"]
+    )
+    @pytest.mark.asyncio
+    async def test_timeout_with_allow_partial_continues(
+        self, tmp_path, allow_partial_attr
+    ):
+        import asyncio
+
+        hooks = MockHooks()
+
+        class SlowOnWorkBackend:
+            """Times out on `work`; runs normally everywhere else."""
+
+            async def run(
+                self,
+                node: Node,
+                prompt: str,
+                context: PipelineContext,
+                incoming_edge=None,
+                graph=None,
+            ) -> str:
+                if node.id == "work":
+                    await asyncio.sleep(10)  # exceeds the 0.01s node timeout
+                return "done"
+
+        engine = _make_engine(
+            dot_source=f"""
+            digraph {{
+                start [shape=Mdiamond]
+                work [prompt="Do work" timeout=0.01 {allow_partial_attr}]
+                after [prompt="Keep going"]
+                exit [shape=Msquare]
+                start -> work [label="*"]
+                work -> after [label="*"]
+                after -> exit [label="*"]
+            }}
+            """,
+            backend=SlowOnWorkBackend(),
+            logs_root=str(tmp_path),
+            hooks=hooks,
+        )
+        await engine.run()
+
+        completed = {e["node_id"] for e in hooks.get(PIPELINE_NODE_COMPLETE)}
+        # `after` runs only if the timed-out `work` node yielded a success-class
+        # outcome (PARTIAL_SUCCESS) and the graph continued past it. On the
+        # pre-fix code, `work` timed out -> FAIL -> the unconditional edge to
+        # `after` (runs_on=success) is blocked, so `after` never runs.
+        assert "after" in completed, (
+            "graph terminated at the timed-out node; allow_partial did not take "
+            f"effect (DOT spelling: {allow_partial_attr})"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/specs/EXTENSIONS.md
+++ b/specs/EXTENSIONS.md
@@ -278,3 +278,39 @@ isolation is a natural consequence of the backend clone resetting mutable state.
 continuity regardless of branching, so no existing pipeline could have been relying on
 cross-branch conversation sharing. Authors who intend a shared thread to carry history across
 nodes must place those nodes in the same sequential path (not in sibling parallel branches).
+
+---
+
+## 14. `allow_partial` Applies on Node Timeout, Not Only Retry Exhaustion
+
+**What:** The canonical spec scopes `allow_partial` (§2.6) to a single trigger: "Accept
+PARTIAL_SUCCESS when retries are exhausted instead of failing" (§5.2 retry pseudocode). We
+extend it to a second trigger: when a node with `allow_partial` set exceeds its `timeout`
+(§2.6), the engine yields `PARTIAL_SUCCESS` instead of `FAIL`. Because `PARTIAL_SUCCESS` is
+success-class for routing (§5.2), the graph continues along the timed-out node's unconditional
+edge rather than terminating the run. Without `allow_partial`, a timeout still produces `FAIL`
+and flows through normal failure routing (§3.7) — unchanged.
+
+**Why:** For iterative loops (a node meant to make incremental progress across many
+executions, with progress recorded in context/files), a single slow iteration hitting its
+timeout would otherwise tear down the entire run via §3.7 termination. `allow_partial` is the
+author's explicit opt-in that an incomplete-but-progressing node is "good enough to proceed" —
+the same intent the spec already honors for retry exhaustion and that §4 honors for goal gates.
+Applying it on the timeout path extends that intent to the one other place a node can fail to
+fully complete. The behavior is gated entirely behind the opt-in attribute; nodes without it
+see no change.
+
+**Note on attribute spelling:** This extension also corrects a string-vs-bool defect at the
+`allow_partial` call sites. The DOT parser coerces *unquoted* `allow_partial=true` to bool
+`True` but leaves *quoted* `allow_partial="true"` as the string `"true"`; the call sites
+previously tested `attrs.get("allow_partial") is True`, which never matched the quoted form —
+so `allow_partial` was inert for the common quoted spelling on both the retry-exhaustion and
+timeout paths. Both call sites now accept bool `True` or the string `"true"`, so both DOT
+spellings behave identically (consistent with extension §1, BareValue, where quoted and
+unquoted values are equivalent).
+
+**Compatibility:** Fully backward-compatible. Nodes without `allow_partial` are unaffected
+(timeout still routes via §3.7). Nodes that set it now continue past a timeout where they
+previously terminated the run — moving observable behavior toward the author's stated intent.
+No spec-conformant `.dot` file can depend on the prior "single timeout kills the graph despite
+`allow_partial`" behavior, since that was the defect this corrects.


### PR DESCRIPTION
## Summary
Fixes two coupled defects in `modules/loop-pipeline` where `allow_partial` failed to take effect, so a single node timeout tore down an entire iterative loop instead of letting it continue.

Original fix authored by @robotdad (branch `fix/allow-partial-on-timeout` on his fork). This PR carries his commit as-is and adds a regression test + an EXTENSIONS.md note on top.

## The bugs
1. **Timeout ignored `allow_partial`** — the `engine.py` timeout handler hardcoded `StageStatus.FAIL`, terminating the whole graph even when the node opted into partial completion.
2. **`allow_partial="true"` (quoted) never matched** — the DOT parser leaves a quoted `"true"` as a string, but the call sites tested `is True` (identity), which never matches. The feature was inert for the common quoted spelling, on both the timeout path and the pre-existing retry-exhaustion path.

## The fix
- `engine.py`: on timeout, return `PARTIAL_SUCCESS` when `allow_partial` is set (string-safe check). `PARTIAL_SUCCESS` is success-class for routing (spec §5.2), so the graph continues along the node's unconditional edge — no routing changes needed.
- `retry.py`: same string-safe correction on the retry-exhaustion path.
- Test (`TestTimeoutAllowPartialContinuation`): forces a real node timeout and asserts the loop continues; parametrized over both DOT spellings (`allow_partial="true"` and `allow_partial=true`). Verified to FAIL on pre-fix code and PASS with the fix.
- `specs/EXTENSIONS.md` §14: documents timeout→partial as a backward-compatible extension (the canonical strongdm/attractor nlspec scopes `allow_partial` to retry exhaustion only).

## Verification
Full `loop-pipeline` suite run locally: **1172 passed, 7 skipped**. Two pre-existing failures in `test_outputs_attribute.py` (human-handler inference) are unrelated — they fail identically on base `main` (38db3ef) before this change. NOTE: this repo has no CI workflows configured, so there are no automated checks on this PR; the verification above is local.

## Follow-up (parked)
Root-cause option: coerce spec-declared Boolean attributes to real bools at parse time (allowlist) — eliminates the whole `is True`-vs-quoted-string class. Recommended as a fast-follow; this PR is the targeted, low-risk fix.

Co-authored-by: robotdad <robotdad@example.com>