### PR TITLE
fix(examples): resolve bundle-ref agents in spawn capability

### DIFF
--- a/docs/APP-INTEGRATION-GUIDE.md
+++ b/docs/APP-INTEGRATION-GUIDE.md
@@ -175,16 +175,30 @@ def register_spawn_capability(session: Any, prepared: PreparedBundle) -> None:
                 f"Agent '{agent_name}' not found. Available: {available}"
             )
 
-        child_bundle = Bundle(
-            name=agent_name,
-            version="1.0.0",
-            session=config.get("session", {}),
-            providers=config.get("providers", []),
-            tools=config.get("tools", []),
-            hooks=config.get("hooks", []),
-            instruction=config.get("instruction")
-            or config.get("system", {}).get("instruction"),
-        )
+        # Agent configs arrive in two shapes -- build the child bundle for each:
+        #
+        #   1. Lazy bundle-ref: a single-key dict {"bundle": "<uri>"}. It has
+        #      no inline fields, so you MUST load_bundle() it. Building a
+        #      Bundle(...) from config.get(...) here would produce a
+        #      structurally empty child that inherits the parent's
+        #      orchestrator and falls to a no-tools backend (an
+        #      ImportError / silent fallback at runtime).
+        #
+        #   2. Inline config: a dict of bundle fields (tools/providers/
+        #      instruction/...). Build the child Bundle(...) from those fields.
+        if "bundle" in config and len(config) == 1:
+            child_bundle = await load_bundle(config["bundle"])
+        else:
+            child_bundle = Bundle(
+                name=agent_name,
+                version="1.0.0",
+                session=config.get("session", {}),
+                providers=config.get("providers", []),
+                tools=config.get("tools", []),
+                hooks=config.get("hooks", []),
+                instruction=config.get("instruction")
+                or config.get("system", {}).get("instruction"),
+            )
 
         return await prepared.spawn(
             child_bundle=child_bundle,
@@ -260,6 +274,26 @@ session.execute()   # Run the pipeline
 **Key principle:** `prepare()` is expensive (module downloads, dependency
 resolution). Call it once. `create_session()` is cheap -- call it for each
 pipeline run.
+
+### Offline / Pinned Execution
+
+If the environment already has every module installed (CI runners, air-gapped
+hosts, reproducible builds), use the supported offline path:
+
+```python
+prepared = await composed.prepare(install_deps=False)
+```
+
+`prepare(install_deps=False)` skips all network access: it discovers the paths
+of already-installed modules and builds the resolver from them, but installs
+nothing. The modules must already be importable in the active environment.
+
+**Trap:** do not try to skip `prepare()` entirely by hand-feeding a raw
+mount-plan to `create_session()`. The resolver (module path map, dependency
+graph) is computed *inside* `prepare()` and cannot be precomputed or supplied
+externally -- a hand-built mount-plan leaves the resolver unset and the session
+fails to wire its modules. Always go through `prepare()`; use
+`install_deps=False` when you need it to stay offline.
 
 ### How Backend Selection Works
 
@@ -451,6 +485,8 @@ When composing bundles for isolated execution, follow these rules:
 | `DirectProviderBackend` nodes have no tools | Cannot read/write files or run commands | Use Path B (AmplifierSession) for coding pipelines |
 | Provider model in global settings overrides bundle | Unexpected model selection | Use project-level `.amplifier/settings.yaml` |
 | `PreparedBundle.spawn()` returns string | Requires JSON-in-string parsing for structured results | The engine handles this internally |
+| Box node whose final assistant message is only tool-calls returns empty | The engine sees an empty result and treats it as a silent failure / fallback | Nudge the node prompt so the final message is non-empty text (e.g. "After running tools, end with a one-line summary -- the final message must not be empty") |
+| LLM node has no model when the agent bundle carries no `default_model` | The node cannot select a provider/model and fails | Set an explicit model -- via the node's `llm_provider`/model attribute, `provider_preferences` on `create_session()`, or a `default_model` in the bundle |
 
 ## Further Reading
 

--- a/examples/programmatic_usage.py
+++ b/examples/programmatic_usage.py
@@ -113,8 +113,25 @@ def register_spawn_capability(session: Any, prepared: Any) -> None:
     This is the minimal implementation. For production use, see
     amplifier-foundation/examples/07_full_workflow.py which handles
     additional kwargs (tool_inheritance, hook_inheritance, etc.).
+
+    Agent configs come in two shapes, and the child bundle must be built
+    differently for each:
+
+    1. Inline config -- a dict of bundle fields
+       (``{"tools": [...], "providers": [...], "instruction": "..."}``).
+       Build the child ``Bundle(...)`` directly from those fields.
+
+    2. Lazy bundle-ref -- a single-key dict ``{"bundle": "<uri>"}`` that
+       points at a bundle to load. You MUST ``load_bundle(...)`` it: a
+       bundle-ref has no inline fields, so ``config.get(...)`` would return
+       empty for everything, producing a structurally empty child that
+       inherits the parent's orchestrator and ends up on a no-tools backend
+       (an ImportError / silent fallback at runtime).
+
+    Note: hooks composed into the PARENT bundle auto-propagate to every
+    spawned child via ``prepared.spawn(compose=True)`` (the default).
     """
-    from amplifier_foundation import Bundle
+    from amplifier_foundation import Bundle, load_bundle
     from amplifier_foundation.bundle import PreparedBundle
 
     assert isinstance(prepared, PreparedBundle)
@@ -140,16 +157,29 @@ def register_spawn_capability(session: Any, prepared: Any) -> None:
             available = list(agent_configs.keys()) + list(prepared.bundle.agents.keys())
             raise ValueError(f"Agent '{agent_name}' not found. Available: {available}")
 
-        child_bundle = Bundle(
-            name=agent_name,
-            version="1.0.0",
-            session=config.get("session", {}),
-            providers=config.get("providers", []),
-            tools=config.get("tools", []),
-            hooks=config.get("hooks", []),
-            instruction=config.get("instruction")
-            or config.get("system", {}).get("instruction"),
-        )
+        # Two agent-config shapes -- build the child bundle accordingly:
+        #
+        #   1. Lazy bundle-ref: a single-key dict {"bundle": "<uri>"}. There
+        #      are NO inline fields, so we must load_bundle() it. Building a
+        #      Bundle(...) from config.get(...) here would yield a structurally
+        #      empty child that inherits the parent's orchestrator and falls to
+        #      a no-tools backend (ImportError / silent fallback at runtime).
+        #
+        #   2. Inline config: a dict of bundle fields (tools/providers/...).
+        #      Build the child Bundle(...) directly from those fields.
+        if "bundle" in config and len(config) == 1:
+            child_bundle = await load_bundle(config["bundle"])
+        else:
+            child_bundle = Bundle(
+                name=agent_name,
+                version="1.0.0",
+                session=config.get("session", {}),
+                providers=config.get("providers", []),
+                tools=config.get("tools", []),
+                hooks=config.get("hooks", []),
+                instruction=config.get("instruction")
+                or config.get("system", {}).get("instruction"),
+            )
 
         return await prepared.spawn(
             child_bundle=child_bundle,


### PR DESCRIPTION
## Problem

When an agent entry references a bundle lazily via a single-key dict:
```json
{"bundle": "<uri>"}
```

The previous code built an **empty child Bundle**, causing the child to inherit the parent's orchestrator and fall to a no-tools backend → `ImportError` crash when the agent tries to dispatch tool calls.

This is a latent crash in the shipped reference implementation (this file + amplifier-foundation/examples/07_full_workflow.py).

## The Fix

Detect the single-key bundle-ref shape and call `load_bundle()` before spawning, building a proper child with agents, tools, and the correct orchestrator context.

## Changes

**examples/programmatic_usage.py:**
- Detects both agent-config shapes (inline bundle vs lazy bundle-ref)
- Loads bundle-refs before spawning
- Documents `compose=True` hook-propagation behavior
- Clarifies register-spawn ordering (after create, before execute)

**docs/APP-INTEGRATION-GUIDE.md:**
- Applies same fix to Path-B code block
- New section: "Offline / Pinned Execution" covering `prepare(install_deps=False)` and why raw mount-plan feeding is a trap
- Two new Known-Limitations rows (tool-only final message; LLM node model requirement)

## Verification

Pattern is verified via a runnable example being contributed to amplifier-foundation (example 23). The bundle-ref agent — the exact case that crashes under the naive code — spawns a real child session successfully.

## Related

Complementary contribution to amplifier-foundation (new example 23 + guide updates) documents the full spawn lifecycle and hook propagation.

---

Generated with [Amplifier](https://github.com/microsoft/amplifier)