### PR TITLE
fix(engine): spawn-outcome capture and AsyncClient lifecycle

### DIFF
--- a/modules/loop-agent/amplifier_module_loop_agent/unified_provider_adapter.py
+++ b/modules/loop-agent/amplifier_module_loop_agent/unified_provider_adapter.py
@@ -268,6 +268,22 @@ class UnifiedProviderAdapter:
     # Public API: complete()
     # ------------------------------------------------------------------
 
+    async def close(self) -> None:
+        """Release the wrapped unified LLM client (spec finalize contract).
+
+        The wrapped ``unified_llm.Client`` owns an ``AsyncAnthropic``/httpx
+        client bound to the running event loop.  When the owning (child)
+        session is torn down it must close this WITHIN the loop; otherwise GC
+        later runs ``aclose()`` on a closed loop, raising
+        ``RuntimeError: Event loop is closed``.
+
+        Safe and idempotent: a no-op when the wrapped client does not expose
+        ``close()``.
+        """
+        close_fn = getattr(self._client, "close", None)
+        if close_fn is not None:
+            await close_fn()
+
     async def complete(self, request: ChatRequest) -> ChatResponse:
         """Satisfy loop-agent's provider.complete() contract.
 

--- a/modules/loop-agent/tests/test_unified_provider_adapter.py
+++ b/modules/loop-agent/tests/test_unified_provider_adapter.py
@@ -29,6 +29,47 @@ def test_constructor_stores_config():
 
 
 # ---------------------------------------------------------------------------
+# Bug 1: UnifiedProviderAdapter.close() releases the wrapped client
+#
+# The adapter wraps a unified_llm.Client that owns an AsyncAnthropic/httpx
+# client. Per the spec (unified-llm-spec.md:183), the client implements an
+# async close(); the adapter must expose close() so its owner (the child
+# session / spawn finalize) can release the connection within the event loop,
+# preventing the "Event loop is closed" RuntimeError at corpus scale.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_adapter_close_closes_client():
+    """UnifiedProviderAdapter.close() must await the wrapped client's close()."""
+    mock_client = MagicMock()
+    mock_client.close = AsyncMock()
+    adapter = UnifiedProviderAdapter(
+        provider_name="anthropic",
+        model="claude-sonnet-4-20250514",
+        client=mock_client,
+    )
+    await adapter.close()
+    mock_client.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_adapter_close_is_safe_when_client_has_no_close():
+    """close() must not raise if the wrapped client lacks a close() method."""
+
+    class _NoCloseClient:
+        pass
+
+    adapter = UnifiedProviderAdapter(
+        provider_name="anthropic",
+        model="claude-sonnet-4-20250514",
+        client=_NoCloseClient(),
+    )
+    # Must be a no-op, not an AttributeError.
+    await adapter.close()
+
+
+# ---------------------------------------------------------------------------
 # Task 3: Simple text message translation
 # ---------------------------------------------------------------------------
 from amplifier_core.message_models import ChatRequest, Message as CoreMessage
@@ -238,7 +279,6 @@ def test_translate_thinking_response_with_signature():
 # ---------------------------------------------------------------------------
 # Task 8: Tool call translation
 # ---------------------------------------------------------------------------
-from amplifier_core.message_models import ToolCall as CoreToolCall
 from unified_llm.types import ToolCallData as ULMToolCallData
 
 

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/__init__.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/__init__.py
@@ -532,6 +532,20 @@ class PipelineOrchestrator:
         try:
             outcome = await engine.run(goal=prompt or None)
         finally:
+            # Backend teardown: release any cached LLM client (e.g. the
+            # AsyncAnthropic/httpx client the fallback path lazily creates)
+            # WITHIN this event loop. Skipping it lets GC run aclose() on a
+            # closed loop later, raising "RuntimeError: Event loop is closed"
+            # (spec finalize contract: attractor-spec.md Section 3.1 step 6).
+            backend_close = getattr(backend, "close", None)
+            if backend_close is not None:
+                try:
+                    await backend_close()
+                except Exception:
+                    logger.exception(
+                        "Failed to close backend during finalize - LLM client may leak"
+                    )
+
             # Environment teardown
             if container_id and "env_destroy" in tools:
                 try:

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/backend.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/backend.py
@@ -448,10 +448,25 @@ class AmplifierBackend:
         # Parse outcome from result.
         # If the child produced output, _parse_outcome determines the outcome —
         # including intentional {"status":"fail"} verdicts from goal_gate nodes.
-        # If the child produced NO output (silent failure — crash, bad profile,
-        # etc.), fall back to the direct tool loop the same way an exception would.
         output = result.get("output", "") if isinstance(result, dict) else str(result)
         if not output.strip():
+            # The child's FINAL assistant message was empty — but that does NOT
+            # mean the child failed.  A child that did its work via tool calls
+            # (writing pages, then a terminal report_outcome) and ended on a tool
+            # call legitimately has no closing prose.  Before falling back, honor
+            # the SAME outcome sources the direct tool loop already uses: the
+            # child's report_outcome args and the orchestrator's completion
+            # status (captured in the spawn result, see _prepared.py spawn()).
+            spawn_outcome = _outcome_from_spawn_result(result)
+            if spawn_outcome is not None:
+                session_id = (
+                    result.get("session_id") if isinstance(result, dict) else None
+                )
+                if session_id:
+                    spawn_outcome.session_id = session_id
+                return spawn_outcome
+
+            # Genuinely empty: no text, no report_outcome, no success status.
             if self._provider is not None:
                 logger.warning(
                     "Node %s: spawn returned empty output; "
@@ -707,6 +722,27 @@ class AmplifierBackend:
         self._unified_client = unified_llm.Client.from_env()
         return self._unified_client
 
+    async def close(self) -> None:
+        """Release the cached unified LLM client (spec finalize contract).
+
+        The fallback path lazily creates a ``unified_llm.Client`` wrapping an
+        ``AsyncAnthropic``/httpx client bound to the running event loop.  Under
+        the per-article ``asyncio.run()`` lifecycle, that client must be closed
+        WITHIN its loop; otherwise GC later runs ``aclose()`` on a dead loop,
+        raising ``RuntimeError: Event loop is closed``.  This method is called
+        by the orchestrator's finalize path.
+
+        Idempotent and safe: a no-op when no client was created, and tolerant of
+        clients that do not expose ``close()``.
+        """
+        client = self._unified_client
+        if client is None:
+            return
+        close_fn = getattr(client, "close", None)
+        if close_fn is not None:
+            await close_fn()
+        self._unified_client = None
+
     async def _emit(self, event_name: str, data: dict[str, Any]) -> Any:
         """Emit an event via hooks, if provided.
 
@@ -812,6 +848,65 @@ def _find_report_outcome_call(result: Any) -> dict[str, Any] | None:
         for tc in getattr(step, "tool_calls", []) or []:
             if getattr(tc, "name", None) == "report_outcome":
                 return getattr(tc, "arguments", {}) or {}
+    return None
+
+
+# Spawn-result status strings that count as a real, non-failing completion.
+# These map 1:1 to non-FAIL StageStatus members; any other string (e.g.
+# "error", "", or a missing status) is treated as "no success signal".
+_SPAWN_SUCCESS_STATUSES = frozenset(
+    {
+        StageStatus.SUCCESS.value,
+        StageStatus.PARTIAL_SUCCESS.value,
+    }
+)
+
+
+def _outcome_from_spawn_result(result: Any) -> Outcome | None:
+    """Recover an Outcome from a spawn result whose final text was empty.
+
+    A child that completed its work via tool calls (and ended on a terminal
+    report_outcome) legitimately returns empty final text.  The spawn result
+    still carries the authoritative outcome in the SAME sources the direct
+    tool loop honors:
+
+      1. ``metadata["report_outcome"]`` — the child's report_outcome arguments,
+         captured from its orchestrator:complete metadata.  Mirrors how
+         ``_run_with_tool_loop`` consults ``_find_report_outcome_call``.
+      2. ``status`` — the orchestrator's completion status.  A recognized
+         success status means the child finished cleanly; empty closing prose
+         is acceptable (spec Section 4.5 treats prose/empty success as SUCCESS).
+
+    Returns the recovered Outcome, or ``None`` when there is genuinely no
+    outcome signal (no report_outcome AND no success status), in which case the
+    caller falls back / fails loud as before.
+    """
+    if not isinstance(result, dict):
+        return None
+
+    metadata = result.get("metadata")
+    report_outcome = (
+        metadata.get("report_outcome") if isinstance(metadata, dict) else None
+    )
+    if isinstance(report_outcome, dict):
+        status = _STATUS_MAP.get(report_outcome.get("status", ""))
+        if status is not None:
+            return Outcome(
+                status=status,
+                failure_reason=report_outcome.get("failure_reason"),
+                notes=report_outcome.get("notes"),
+                preferred_label=report_outcome.get("preferred_label"),
+                suggested_next_ids=report_outcome.get("suggested_next_ids"),
+                context_updates=report_outcome.get("context_updates"),
+            )
+
+    if result.get("status") in _SPAWN_SUCCESS_STATUSES:
+        status = _STATUS_MAP[result["status"]]
+        return Outcome(
+            status=status,
+            notes="Child session completed with empty final message",
+        )
+
     return None
 
 

--- a/modules/loop-pipeline/tests/test_backend.py
+++ b/modules/loop-pipeline/tests/test_backend.py
@@ -505,6 +505,163 @@ async def test_backend_handles_no_spawn_no_provider():
     assert "available" in (result.failure_reason or "").lower()
 
 
+# ---------------------------------------------------------------------------
+# Bug 2: spawn path must honor the child's outcome, not gate on final text
+#
+# A child that completes its work via tool calls + report_outcome (or whose
+# orchestrator:complete status is success) but emits NO closing prose returns
+# empty `output`. The spawn path must NOT silently fall back in that case --
+# it must honor the same outcome sources the direct tool loop already uses
+# (report_outcome args + completion status). It should fall back / fail loud
+# ONLY when there is genuinely no text AND no report_outcome AND no success
+# status.
+# ---------------------------------------------------------------------------
+
+
+def _install_fallback_spy(backend: AmplifierBackend) -> dict[str, Any]:
+    """Replace _run_with_tool_loop with a spy that records if it was called.
+
+    Returns a mutable dict whose ``called`` flag flips True if the spawn path
+    falls back to the direct tool loop.
+    """
+    state: dict[str, Any] = {"called": False}
+
+    async def _spy(*_args: Any, **_kwargs: Any) -> Outcome:
+        state["called"] = True
+        return Outcome(status=StageStatus.SUCCESS, notes="fallback ran")
+
+    backend._run_with_tool_loop = _spy  # type: ignore[method-assign]
+    return state
+
+
+@pytest.mark.asyncio
+async def test_spawn_empty_output_with_report_outcome_does_not_fall_back():
+    """Empty final text + a report_outcome in the spawn result => honor it.
+
+    The child did its work and reported an outcome via the report_outcome
+    tool; its final assistant message was just empty. The spawn path must
+    use that outcome and MUST NOT fall back to the direct tool loop.
+    """
+    coordinator = MockCoordinator(
+        spawn_result={
+            "output": "",  # no closing prose
+            "session_id": "c-1",
+            "status": "success",
+            "metadata": {
+                "report_outcome": {
+                    "status": "success",
+                    "notes": "Integrated source 2 into Foo and Bar pages.",
+                }
+            },
+        }
+    )
+    backend = AmplifierBackend(
+        coordinator=coordinator,
+        profiles={"anthropic": "attractor-anthropic"},
+        provider=object(),  # truthy => fallback is POSSIBLE if code chooses it
+    )
+    spy = _install_fallback_spy(backend)
+
+    node = _make_node(attrs={"llm_provider": "anthropic"})
+    result = await backend.run(node, "task", _make_context())
+
+    assert spy["called"] is False, (
+        "spawn path fell back to the direct tool loop even though the child "
+        "reported a valid outcome -- the report_outcome was discarded."
+    )
+    assert isinstance(result, Outcome)
+    assert result.status == StageStatus.SUCCESS
+    assert "Integrated source 2" in (result.notes or "")
+
+
+@pytest.mark.asyncio
+async def test_spawn_empty_output_with_success_status_does_not_fall_back():
+    """Empty final text but status=success => treat as a successful completion.
+
+    A child that finished cleanly (orchestrator:complete status=success) but
+    ended on a tool call with no closing prose must be treated as SUCCESS,
+    not silently re-routed through the fallback path.
+    """
+    coordinator = MockCoordinator(
+        spawn_result={
+            "output": "",
+            "session_id": "c-1",
+            "status": "success",
+            "metadata": {},
+        }
+    )
+    backend = AmplifierBackend(
+        coordinator=coordinator,
+        profiles={"anthropic": "attractor-anthropic"},
+        provider=object(),
+    )
+    spy = _install_fallback_spy(backend)
+
+    node = _make_node(attrs={"llm_provider": "anthropic"})
+    result = await backend.run(node, "task", _make_context())
+
+    assert spy["called"] is False, (
+        "spawn path fell back despite a success completion status."
+    )
+    assert isinstance(result, Outcome)
+    assert result.status == StageStatus.SUCCESS
+
+
+@pytest.mark.asyncio
+async def test_spawn_truly_empty_still_falls_back():
+    """No text, no report_outcome, no success status => still fall back.
+
+    This is the genuinely-empty case the fallback was designed for. The fix
+    must NOT swallow it: with a provider available, the spawn path still
+    delegates to the direct tool loop.
+    """
+    coordinator = MockCoordinator(
+        spawn_result={
+            "output": "",
+            "session_id": "c-1",
+            "status": "error",  # not a success status
+            "metadata": {},
+        }
+    )
+    backend = AmplifierBackend(
+        coordinator=coordinator,
+        profiles={"anthropic": "attractor-anthropic"},
+        provider=object(),
+    )
+    spy = _install_fallback_spy(backend)
+
+    node = _make_node(attrs={"llm_provider": "anthropic"})
+    result = await backend.run(node, "task", _make_context())
+
+    assert spy["called"] is True, (
+        "genuinely-empty spawn output must still fall back to the tool loop."
+    )
+    assert isinstance(result, Outcome)
+
+
+@pytest.mark.asyncio
+async def test_spawn_truly_empty_no_provider_still_fails():
+    """No text, no outcome, no success status, no provider => FAIL (loud)."""
+    coordinator = MockCoordinator(
+        spawn_result={
+            "output": "",
+            "session_id": "c-1",
+            "status": "error",
+            "metadata": {},
+        }
+    )
+    backend = AmplifierBackend(
+        coordinator=coordinator,
+        profiles={"anthropic": "attractor-anthropic"},
+        # no provider => no fallback available
+    )
+    node = _make_node(attrs={"llm_provider": "anthropic"})
+    result = await backend.run(node, "task", _make_context())
+
+    assert isinstance(result, Outcome)
+    assert result.status == StageStatus.FAIL
+
+
 # --- Config forwarding tests ---
 
 
@@ -1168,3 +1325,97 @@ def test_clone_isolates_stateful_tool_instances():
         "status": "fail",
         "failure_reason": "prior run",
     }
+
+
+# ---------------------------------------------------------------------------
+# Bug 1: AmplifierBackend.close() releases the cached unified client
+#
+# The per-article asyncio.run() lifecycle (engine_runner) means the cached
+# AsyncAnthropic/httpx client created in _get_or_create_unified_client must be
+# closed WITHIN its loop before the loop ends; otherwise GC later runs aclose()
+# on a closed loop -> "RuntimeError: Event loop is closed". The spec mandates
+# resource close on finalize (attractor-spec.md:333; unified-llm-spec.md:183).
+# ---------------------------------------------------------------------------
+
+
+class _ClosableClient:
+    """Mock unified client exposing the spec-mandated async close()."""
+
+    def __init__(self) -> None:
+        self.close_calls = 0
+
+    async def close(self) -> None:
+        self.close_calls += 1
+
+
+@pytest.mark.asyncio
+async def test_backend_close_closes_unified_client():
+    """AmplifierBackend.close() must call Client.close() on the cached client."""
+    client = _ClosableClient()
+    backend = AmplifierBackend(
+        coordinator=MockCoordinator(),
+        profiles={},
+        unified_client=client,
+    )
+    await backend.close()
+    assert client.close_calls == 1, (
+        "AmplifierBackend.close() must close the cached unified client "
+        "(spec finalize contract) -- the leaked AsyncAnthropic is the source "
+        "of the 'Event loop is closed' RuntimeError at corpus scale."
+    )
+
+
+@pytest.mark.asyncio
+async def test_backend_close_is_noop_without_client():
+    """close() must be safe when no unified client was ever created."""
+    backend = AmplifierBackend(coordinator=MockCoordinator(), profiles={})
+    # Must not raise even though _unified_client is None.
+    await backend.close()
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_execute_closes_backend(tmp_path):
+    """The orchestrator's finalize path must close the backend it ran with.
+
+    This is the wiring assertion: after PipelineOrchestrator.execute() runs a
+    pipeline, the backend's close() must have been awaited (within the same
+    event loop), satisfying the spec's finalize contract and preventing the
+    client leak.
+    """
+    from amplifier_module_loop_pipeline import PipelineOrchestrator
+
+    class _SpyBackend:
+        def __init__(self) -> None:
+            self.closed = 0
+
+        async def run(self, node, prompt, context, incoming_edge=None, graph=None):
+            return f"Completed: {node.id}"
+
+        async def close(self) -> None:
+            self.closed += 1
+
+    spy = _SpyBackend()
+    orch = PipelineOrchestrator(
+        {
+            "dot_source": (
+                "digraph { "
+                "start [shape=Mdiamond]; "
+                'impl [label="Impl", prompt="do it"]; '
+                "exit [shape=Msquare]; "
+                "start -> impl -> exit }"
+            ),
+            "logs_root": str(tmp_path),
+        }
+    )
+    await orch.execute(
+        prompt="goal",
+        context=None,
+        providers={},
+        tools={},
+        hooks=None,
+        backend=spy,
+    )
+    assert spy.closed == 1, (
+        "PipelineOrchestrator.execute() must close the backend in its finalize "
+        "path so the unified client is released within the event loop."
+    )


### PR DESCRIPTION
## Summary

Two independent fixes in the loop-pipeline engine, found while running the wiki-weaver pipeline over a real corpus and root-caused with file:line evidence:

- **Bug A — spawn path discarded the child's outcome.** `_run_with_spawn` gated "empty" purely on the child's final assistant *text*, so an `ingest` child that completed its work via tool calls + `report_outcome` with no closing prose was wrongly treated as empty and silently fell back to the direct tool loop. Fix: new `_outcome_from_spawn_result()` / `_SPAWN_SUCCESS_STATUSES` — `_run_with_spawn` now honors the child's `report_outcome`/`status` (the same signals the fallback already mined) before declaring empty; only genuinely empty results fall back. Aligns with the strongdm attractor-spec.

- **Bug B — AsyncAnthropic/httpx client never closed.** Per-execution event loop closed while the unified-llm client persisted, so GC ran `AsyncClient.aclose()` on a dead loop → `RuntimeError: Event loop is closed` across a long run. Fix: `AmplifierBackend.close()` + `UnifiedProviderAdapter.close()`, called from the orchestrator's `finally` (within the loop) — satisfying the spec's finalize/close() contract.

## Verification

**Unit tests** (TDD, red-green verified):
- 5 new tests: all PASS with fix, all FAIL without it (correct reasons)
- Full suite regression: 0 new failures (27 pre-existing, identical at baseline)

**Live pipeline run** (DTU, wiki-weaver on 6 real articles):
- `spawn returned empty output`: 0 (was ~half the articles)
- `Event loop is closed`: 0 (was many, from article 4+)
- 6/6 converged, `cli lint` PASS (26 pages, 0 broken/orphans)
- Loaded code proven to be this fix (git snapshot in DTU)

**Backward compatibility**: 0 regressions introduced. Non-empty / non-leak paths identical; full suite shows identical pre-existing failures at baseline.

## Notes for reviewers

- A separate, PRE-EXISTING blocker surfaced in the clean DTU (NOT addressed here, flagging for follow-up): the foundation activator installs modules with `--no-sources`, so the vendored `amplifier-unified-llm-client` (unpublished, from the name-collision rename) is unsatisfiable on a clean install → modules can't load until pre-installed. Worth a follow-up (declare it a first-class installed module, or have the activator honor its source).

- The 27 pre-existing full-suite failures (integration tests needing live env/LLM) are unrelated to this change.

Fixes #(none — discovered via corpus testing, not reported).