### PR TITLE
fix(engine): remove spawn→direct-tool-loop fallback, restore spec fail-loud contract

### DIFF
--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/backend.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/backend.py
@@ -304,10 +304,10 @@ class AmplifierBackend:
                 graph,
                 context,
             )
-            # Fallback logic (infrastructure failure, empty output) is handled
-            # inside _run_with_spawn — see that method for the full rationale.
-            # When _run_with_spawn returns here, the child ran and produced output;
-            # _parse_outcome has already determined the outcome.
+            # When _run_with_spawn returns here, it either extracted an outcome
+            # from the child's output / report_outcome / status, or it returned
+            # Outcome(FAIL) so the engine can route via FAIL-edge → retry_target /
+            # goal_gate.  No silent in-process fallback occurs inside that method.
         elif self._provider is not None:
             outcome = await self._run_with_tool_loop(
                 node,
@@ -432,17 +432,10 @@ class AmplifierBackend:
             result = await self._spawn_fn(**spawn_kwargs)
         except Exception as e:
             # Infrastructure failure: the spawn mechanism itself broke (e.g.
-            # agent profile not found, session init error).  The child never
-            # ran, so falling back to the direct tool loop is reasonable.
+            # agent profile not found, session init error).  Return FAIL so the
+            # engine can route via the spec's FAIL-edge (retry_target / goal_gate)
+            # rather than silently re-running the node in a different harness.
             logger.warning("Spawn failed for node %s: %s", node.id, e)
-            if self._provider is not None:
-                logger.warning(
-                    "Node %s: retrying via direct tool loop after spawn exception",
-                    node.id,
-                )
-                return await self._run_with_tool_loop(
-                    node, instruction, reasoning_effort, max_agent_turns
-                )
             return Outcome(status=StageStatus.FAIL, failure_reason=str(e))
 
         # Parse outcome from result.
@@ -467,16 +460,13 @@ class AmplifierBackend:
                 return spawn_outcome
 
             # Genuinely empty: no text, no report_outcome, no success status.
-            if self._provider is not None:
-                logger.warning(
-                    "Node %s: spawn returned empty output; "
-                    "falling back to direct tool loop. "
-                    "Ensure the child agent profile is correctly configured.",
-                    node.id,
-                )
-                return await self._run_with_tool_loop(
-                    node, instruction, reasoning_effort, max_agent_turns
-                )
+            # Return FAIL so the engine can route via the spec's FAIL-edge
+            # (retry_target / goal_gate) rather than silently re-running the
+            # node in a materially different in-process harness.
+            logger.warning(
+                "Node %s: spawn returned empty output with no recoverable outcome.",
+                node.id,
+            )
             return Outcome(
                 status=StageStatus.FAIL,
                 notes="No output from child session",
@@ -502,7 +492,7 @@ class AmplifierBackend:
         return outcome
 
     # ------------------------------------------------------------------
-    # Path B: Direct provider mini tool loop (fallback)
+    # Path B: Direct provider mini tool loop (spawn-unavailable path)
     # ------------------------------------------------------------------
 
     async def _run_with_tool_loop(

--- a/modules/loop-pipeline/tests/test_backend.py
+++ b/modules/loop-pipeline/tests/test_backend.py
@@ -608,12 +608,13 @@ async def test_spawn_empty_output_with_success_status_does_not_fall_back():
 
 
 @pytest.mark.asyncio
-async def test_spawn_truly_empty_still_falls_back():
-    """No text, no report_outcome, no success status => still fall back.
+async def test_spawn_truly_empty_fails_loud():
+    """No text, no report_outcome, no success status => FAIL (fail-loud).
 
-    This is the genuinely-empty case the fallback was designed for. The fix
-    must NOT swallow it: with a provider available, the spawn path still
-    delegates to the direct tool loop.
+    The fallback has been removed: a genuinely-empty spawn result must now
+    return Outcome(FAIL) regardless of whether a direct provider is available,
+    so the engine can route via FAIL-edge → retry_target / goal_gate rather
+    than silently re-running the node in a different in-process harness.
     """
     coordinator = MockCoordinator(
         spawn_result={
@@ -626,17 +627,19 @@ async def test_spawn_truly_empty_still_falls_back():
     backend = AmplifierBackend(
         coordinator=coordinator,
         profiles={"anthropic": "attractor-anthropic"},
-        provider=object(),
+        provider=object(),  # provider present — must NOT trigger fallback any more
     )
     spy = _install_fallback_spy(backend)
 
     node = _make_node(attrs={"llm_provider": "anthropic"})
     result = await backend.run(node, "task", _make_context())
 
-    assert spy["called"] is True, (
-        "genuinely-empty spawn output must still fall back to the tool loop."
+    assert spy["called"] is False, (
+        "genuinely-empty spawn output must now fail loud (FAIL outcome), "
+        "not silently fall back to the direct tool loop."
     )
     assert isinstance(result, Outcome)
+    assert result.status == StageStatus.FAIL
 
 
 @pytest.mark.asyncio
@@ -660,6 +663,81 @@ async def test_spawn_truly_empty_no_provider_still_fails():
 
     assert isinstance(result, Outcome)
     assert result.status == StageStatus.FAIL
+
+
+# ---------------------------------------------------------------------------
+# Fallback removal: spawn failures / empty output must FAIL loud (fail-loud
+# spec compliance). The direct tool loop must NOT be silently substituted for
+# a failed spawn — the engine needs to see the FAIL so it can route via
+# FAIL-edge → retry_target / goal_gate.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_spawn_raises_with_provider_returns_fail_not_fallback():
+    """Spawn raises + provider set => Outcome(FAIL), NOT a silent fallback.
+
+    Previously the code re-ran the task via _run_with_tool_loop when the
+    spawn raised and self._provider was truthy.  That hid the infrastructure
+    failure from the engine's retry/goal machinery.  Now it must always fail
+    loud, regardless of whether a direct provider is available.
+    """
+    coordinator = FailingCoordinator()
+    backend = AmplifierBackend(
+        coordinator=coordinator,
+        profiles={"anthropic": "attractor-anthropic"},
+        provider=object(),  # truthy — previously triggered the in-process retry
+    )
+    spy = _install_fallback_spy(backend)
+
+    node = _make_node(attrs={"llm_provider": "anthropic"})
+    result = await backend.run(node, "task", _make_context())
+
+    assert spy["called"] is False, (
+        "spawn raised an exception but the code fell back to the direct tool loop "
+        "instead of returning FAIL — the engine never saw the infrastructure failure."
+    )
+    assert isinstance(result, Outcome)
+    assert result.status == StageStatus.FAIL
+
+
+@pytest.mark.asyncio
+async def test_spawn_truly_empty_with_provider_returns_fail_not_fallback():
+    """Empty spawn + no recoverable outcome + provider set => FAIL, NOT fallback.
+
+    Previously the code re-ran the task via _run_with_tool_loop when spawn
+    returned empty output with no report_outcome / success status and
+    self._provider was truthy.  That silently masked a real spawn
+    misconfiguration.  Now it must always fail loud so the engine can route
+    via FAIL-edge → retry_target / goal_gate.
+    """
+    coordinator = MockCoordinator(
+        spawn_result={
+            "output": "",
+            "session_id": "c-1",
+            "status": "error",  # not a success status
+            "metadata": {},
+        }
+    )
+    backend = AmplifierBackend(
+        coordinator=coordinator,
+        profiles={"anthropic": "attractor-anthropic"},
+        provider=object(),  # truthy — previously triggered the in-process retry
+    )
+    spy = _install_fallback_spy(backend)
+
+    node = _make_node(attrs={"llm_provider": "anthropic"})
+    result = await backend.run(node, "task", _make_context())
+
+    assert spy["called"] is False, (
+        "spawn returned empty output with no recoverable outcome but the code "
+        "fell back to the direct tool loop instead of returning FAIL."
+    )
+    assert isinstance(result, Outcome)
+    assert result.status == StageStatus.FAIL
+    assert "Empty spawn output" in (result.failure_reason or ""), (
+        f"Expected 'Empty spawn output' in failure_reason, got: {result.failure_reason!r}"
+    )
 
 
 # --- Config forwarding tests ---


### PR DESCRIPTION
## Summary

Follow-up to #51. Removes the spawn→direct-tool-loop FALLBACK in the loop-pipeline engine so genuine spawn failures fail loud and route through the spec's failure machinery, instead of silently re-running the node in a different in-process harness.

- **Trigger A** (spawn raises) → now returns `Outcome(status=FAIL)` (was: in-process re-run when a provider was set).
- **Trigger B** (spawn returns empty output with no recoverable `report_outcome`/success status) → now returns `Outcome(status=FAIL, "Empty spawn output")` (was: in-process fallback).
- **Kept:** #51's `_outcome_from_spawn_result`/`_SPAWN_SUCCESS_STATUSES` recovery, AND the legitimate `run()` Path B direct-provider path used when `session.spawn` is genuinely unavailable (e.g. provider-only backends).

**Rationale:** the removed fallback was undocumented machinery — not in the strongdm nlspec (`attractor-spec.md` §1.4/§4.5 sanction *choosing* a backend mechanism, not a runtime fallback between two), not in `PRINCIPLES.md` "Intentional deltas" (empty), not in `specs/EXTENSIONS.md`. It contradicted the spec's fail-loud/route-on-FAIL model (§3.4 goal gates, §3.5 retry, §3.7 failure routing, EXTENSIONS #6) and could launder a genuine spawn failure into success via a non-equivalent harness (different tools/system-prompt/model).

## Verification

- [x] Unit tests pass — 2 new tests (spawn-raises→FAIL-not-fallback; truly-empty→FAIL-not-fallback), 1 updated (fails-loud), #51 recovery tests preserved, Path B (spawn-unavailable) regression intact. Red→green proven (failed against pre-change code for the right reason). 39 passed / 3 pre-existing-unrelated failures. Re-verified fresh from the module dir.
- [x] Live pipeline run (REQUIRED for engine changes) — DTU `wiki-weaver-fbr`, wiki-weaver on 4 real articles against the fallback-removed working tree: `spawn returned empty output`=0, `falling back/retrying via direct tool loop`=0, `Event loop is closed`=0, **4/4 converged**, `cli lint` PASS (14 pages, 0 broken/0 orphans), healthy compounding merge (sources [1,2,3,4], 0 dups). Loaded module confirmed to be the fallback-removed code (fallback strings absent; `_outcome_from_spawn_result` present). Confirms the fallback was NOT load-bearing post-#51.
- [x] Consumer impact — `amplifier-resolver-dot-graph` (latest main): NEUTRAL. It constructs `AmplifierBackend(coordinator, profiles)` with `provider=None` (resolver.py:901-904), so all fallback branches were already dead code there; the engine already returned the exact `Outcome(FAIL)` this PR makes unconditional. (Its test suite mocks the backend; 21 boundary tests pass.)
- [x] AGENTS.md gates met; backward-compat preserved (spawn-unavailable Path B intact; #51 recovery intact).
- [x] Evidence in PR description.

## Notes for reviewers

Restores the spec's fail-loud contract; no new public API. The pre-existing `--no-sources` packaging blocker (commented on #51) is unrelated and not addressed here.