### PR TITLE
fix(deps): declare amplifier-unified-llm-client as direct git reference for --no-sources installs

### DIFF
--- a/modules/loop-agent/pyproject.toml
+++ b/modules/loop-agent/pyproject.toml
@@ -9,7 +9,14 @@ authors = [
 ]
 dependencies = [
     "amplifier-core>=0.1.0",
-    "amplifier-unified-llm-client",
+    # Direct git reference (not a bare name) so the dependency resolves even
+    # when the foundation activator installs with `--no-sources`, which strips
+    # the `[tool.uv.sources]` path override below. The package is vendored
+    # in-repo and unpublished (renamed in #50 to avoid a PyPI name collision);
+    # a direct reference keeps that collision-avoidance (uv never queries an
+    # index for the name) while surviving `--no-sources`. The path source is
+    # retained below for local editable development.
+    "amplifier-unified-llm-client @ git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/unified-llm-client",
 ]
 
 [project.entry-points."amplifier.modules"]

--- a/modules/loop-pipeline/pyproject.toml
+++ b/modules/loop-pipeline/pyproject.toml
@@ -9,7 +9,14 @@ authors = [
 ]
 dependencies = [
     "amplifier-core>=0.1.0",
-    "amplifier-unified-llm-client",
+    # Direct git reference (not a bare name) so the dependency resolves even
+    # when the foundation activator installs with `--no-sources`, which strips
+    # the `[tool.uv.sources]` path override below. The package is vendored
+    # in-repo and unpublished (renamed in #50 to avoid a PyPI name collision);
+    # a direct reference keeps that collision-avoidance (uv never queries an
+    # index for the name) while surviving `--no-sources`. The path source is
+    # retained below for local editable development.
+    "amplifier-unified-llm-client @ git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/unified-llm-client",
 ]
 
 [project.entry-points."amplifier.modules"]


### PR DESCRIPTION
## Summary

Fixes a clean-install blocker (the one reported in PR #51's comment). The foundation activator installs modules with `uv pip install -e <module> --no-sources` (intentional: avoids rebuilding heavy/native deps like amplifier-core from git). However, `--no-sources` strips `[tool.uv.sources]`, breaking clean installs of loop-pipeline and loop-agent which depend on the vendored, unpublished `amplifier-unified-llm-client` (renamed in #50 to avoid a PyPI name collision).

**Fix:** declare the dependency as a PEP 508 **direct git reference** in `[project.dependencies]`. Direct references survive `--no-sources`; `allow-direct-references=true` is already set. This also preserves #50's collision-avoidance (uv never queries an index for the name).

**Smallest blast radius:** 2 one-line edits, no foundation change.

## Verification Checklist

- [x] **Live/clean-env verification** — verified two independent ways:
  1. Isolated clean uv venv running the exact failing command `uv pip install --no-sources "amplifier-unified-llm-client @ git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/unified-llm-client"` → succeeds + `import unified_llm` works (before fix: "not found in the package registry")
  2. Clean Digital Twin (`wiki-weaver-pkgfix`) with NO manual unified-llm-client pre-install (enforced by fail-loud negative precondition proving unified_llm was absent pre-activation): the activator's own `--no-sources` install of loop-pipeline+loop-agent resolved the dep on its own (confirmed via amplifier venv python: `import unified_llm` OK; no registry error anywhere), and wiki-weaver ran end-to-end 3/3 converged, `cli lint` PASS, 0 spawn-empty / 0 event-loop-closed
- [x] **AGENTS.md reviewed; backward-compat preserved** — path source kept for local dev; no runtime/code change
- [x] **No foundation/activator change required**
- [x] **Evidence in PR body** — see above

## Notes for Reviewers

- Resolves the follow-up flagged in #51's comment. No code/runtime behavior change — dependency-resolution metadata only.
- Caveat: the direct ref pins `@main`; for full reproducibility a follow-up can pin loop-pipeline, loop-agent, and the bundle module sources to a shared tag/commit. The `[tool.uv.sources]` path entry is retained for local editable dev (it wins locally without `--no-sources`).