### PR TITLE
fix(loop-pipeline): restore §3.7 failure-routing conformance (graph-level retry_target is goal-gate-exit only)

### DIFF
--- a/docs/DOT-AUTHORING-GUIDE.md
+++ b/docs/DOT-AUTHORING-GUIDE.md
@@ -130,8 +130,7 @@ retry target. If that also fails, the fallback target catches it.
 digraph {
     graph [
         goal="Generate an RFC 5322 email validation regex",
-        default_max_retry=3,
-        fallback_retry_target="simple_implement"
+        default_max_retry=3
     ]
 
     start [shape=Mdiamond]
@@ -532,7 +531,7 @@ Set these on the `graph` element:
 | `default_fidelity` | String | `compact` | Default context fidelity for all nodes. |
 | `default_max_retry` | Integer | `0` | Global retry ceiling. |
 | `retry_target` | String | `""` | Global retry target when exit has unsatisfied goal gates. |
-| `fallback_retry_target` | String | `""` | Global fallback retry target. |
+| `fallback_retry_target` | String | `""` | Global fallback retry target when exit has unsatisfied goal gates. |
 
 ## Tips for Effective Node Prompts
 

--- a/docs/ROUTING-REFERENCE.md
+++ b/docs/ROUTING-REFERENCE.md
@@ -419,10 +419,20 @@ failed.
    A -> error_handler [condition="outcome=fail",         weight=8]
    ```
 
-2. Set `fallback_retry_target` at the graph level to catch unhandled failures:
+2. Add a node-level `retry_target` on the failing node to redirect on failure:
    ```dot
-   graph [fallback_retry_target="error_handler"]
+   A [retry_target="error_handler"]
    ```
+   This follows spec §3.7 step 2. For per-node or subgraph failure recovery,
+   use a `condition="outcome=fail"` edge (§3.7 step 1) or a node-level
+   `retry_target` / `fallback_retry_target` on the failing node (§3.7 steps 2–3).
+   If neither is present, the engine halts loud with the failure reason (§3.7 step 4).
+
+   > **Scope note:** Graph-level `retry_target` and `fallback_retry_target` apply
+   > **only** to the goal-gate-unsatisfied-at-exit path (§3.4 — *"jump to if exit is
+   > reached with unsatisfied goal gates"*). They are **not** consulted on arbitrary
+   > per-node failure. Relying on them to catch unhandled node failures is off-spec
+   > and will cause the engine to halt loud instead.
 
 3. Use `goal_gate=true` on critical nodes — the engine will not exit the
    pipeline successfully if a goal gate node never reached `SUCCESS`.

--- a/docs/designs/folder-failure-routing-conformance.md
+++ b/docs/designs/folder-failure-routing-conformance.md
@@ -1,0 +1,115 @@
+# §3.7 Failure-Routing Conformance: graph-level `retry_target` is goal-gate-exit only
+
+**Status:** proposed
+**Branch:** `fix/folder-failure-routing-conformance`
+**Motivated by:** PR #54 (robotdad) — surfaced while debugging a pipeline where a failed
+`shape=folder` node silently fell through to the graph-level `retry_target` and restarted a loop.
+
+## TL;DR
+
+The engine's per-node failure path pulls in a **graph-level** `retry_target`/`fallback_retry_target`
+catch-all that the upstream nlspec **does not** put there. Per upstream §3.7, a node failure with no
+fail-edge and no **node-level** retry target must **halt loud** with the failure reason. We drifted.
+The fix is a two-line **subtraction** that restores spec conformance and, as a side effect, delivers
+exactly the failure semantics we want: failures fail loud; recovery is the author's explicit choice.
+
+This is **conformance, not extension.** Our local spec already says the right thing — only the engine
+(and some docs/one example) diverged.
+
+## The upstream contract (verified)
+
+`strongdm/attractor` `attractor-spec.md` §3.7 (commit `fb57a55`, 2026-03-17), verbatim:
+
+> When a stage returns FAIL (or retries are exhausted), the engine attempts failure routing in this order:
+> 1. **Fail edge:** an outgoing edge with `condition="outcome=fail"`. If found, follow it.
+> 2. **Retry target:** Node attribute `retry_target`. Jump to that node.
+> 3. **Fallback retry target:** Node attribute `fallback_retry_target`. Jump to that node.
+> 4. **Pipeline termination:** No failure route found. The pipeline fails with the stage's failure reason.
+
+Steps 2–3 are **node attributes only**. Step 4 is a **loud halt** carrying the stage's failure reason.
+There is **no graph-level tier** in the per-node failure path.
+
+Graph-level `retry_target`/`fallback_retry_target` *is* a real spec concept — but scoped to a
+**different** mechanism: the goal-gate-unsatisfied-at-exit path (§3.4 / §2.5: *"Node ID to jump to if
+exit is reached with unsatisfied goal gates."*). Not arbitrary node failures.
+
+Our local copies (`specs/attractor-spec.md` §3.7, `specs/canonical/attractor-spec-canonical.md` §3.7)
+mirror upstream exactly. `specs/EXTENSIONS.md` documents 14 extensions; **none** declare graph-level
+retry on per-node failure. So the engine behavior is **undocumented drift**, not an intentional extension.
+
+## Subgraph / `shape=folder` semantics (why this is the same bug)
+
+Upstream §4.11 / §9.4: a child sub-pipeline failure → the handler returns `FAIL` → the parent applies
+the **standard §3.7 routing**. Our `PipelineHandler` already does this (returns the child `Outcome`
+verbatim). The caller "leverages errors within for their own routing" by putting a
+`condition="outcome=fail"` edge on the folder node — spec example §10.6: `plan -> fix [condition="outcome=fail"]`.
+
+So folder nodes need **no special handling**. Once §3.7 is conformant, an unhandled folder failure
+halts loud with the child's reason, and a folder failure the caller wired with a fail-edge routes
+exactly where the caller said. Both are already-correct once the graph-level catch-all is gone.
+
+## Root cause (verified)
+
+`modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py` — `_resolve_failure_retry_target`
+(used by the per-node failure path at `engine.py:452` and `:785`):
+
+```python
+target_id = (
+    node.attrs.get("retry_target")              # §3.7 step 2  ✓
+    or node.attrs.get("fallback_retry_target")  # §3.7 step 3  ✓
+    or self.graph.graph_attrs.get("retry_target")           # NOT in §3.7  ✗
+    or self.graph.graph_attrs.get("fallback_retry_target")  # NOT in §3.7  ✗
+)
+```
+
+The `:785` path additionally clears all completed-node state (`completed_nodes`, `node_outcomes`,
+`failed_outputs`) and restarts — i.e. the silent loop-restart that bit the PR #54 author.
+
+The goal-gate path is **independent and untouched by this fix**: `_check_goal_gates()`
+(`engine.py:1068-1074`) resolves its own node→graph cascade and returns the target via
+`Outcome(suggested_next_ids=[...])`; it never calls `_resolve_failure_retry_target`. So stripping the
+graph-level tiers from the failure helper does **not** regress §3.4 goal-gate conformance.
+
+## The change
+
+1. **Engine (the fix):** remove the two graph-level tiers from `_resolve_failure_retry_target`.
+   Per-node failure routing becomes node-level-then-halt, per §3.7. Goal-gate path unchanged.
+
+2. **Tests:** the existing `tests/test_failure_routing.py` cases
+   `test_graph_retry_target_used_when_node_has_none` and `test_graph_fallback_retry_target_last_resort`
+   currently lock in the **drift** — replace them with assertions that an unhandled failure **halts loud**
+   with the failure reason (§3.7 step 4), and that goal-gate graph-level retry still works (§3.4).
+   Add the folder-node coverage from PR #54: keep its **fail-edge-fires** case (§3.7 step 1, the
+   cornerstone), reframe/replace its graph-retry baseline case to assert loud halt.
+
+3. **Docs:** `docs/ROUTING-REFERENCE.md` (teaches graph-level `fallback_retry_target` as a node-failure
+   catch-all — re-scope to goal-gate, point authors at fail-edges/node-level retry for failure recovery);
+   `docs/DOT-AUTHORING-GUIDE.md:535` (add the goal-gate scope qualifier to `fallback_retry_target`) and
+   the "Retry with Fallback" pattern (drop the graph-level `fallback_retry_target`; node-level on
+   `implement` is sufficient and spec-correct).
+
+4. **Example:** `examples/pipelines/04-retry-with-fallback.dot` — remove the graph-level
+   `fallback_retry_target` line (node-level `retry_target`/`fallback_retry_target` on `implement` plus the
+   `validate -[outcome=fail]-> implement` fail-edge are already spec-conformant); update its `.md` writeup.
+
+## Blast radius
+
+Behavior change: any pipeline relying on a **graph-level** `retry_target`/`fallback_retry_target` to
+silently recover from an arbitrary **node** failure will now **halt loud** instead. That reliance was
+off-spec and undocumented as an extension. Authors who want recovery express it explicitly (fail-edge or
+node-level retry target) — which the spec has always intended. Goal-gate-driven graph-level retry is
+unaffected.
+
+## Proof plan (the gate)
+
+Not "tests pass." Run the real engine on a pipeline where a `shape=folder` child fails (via a
+`parallelogram` tool node `tool_command="exit 1"`, no LLM needed) and demonstrate, with the run's
+`events.jsonl` / returned `Outcome`:
+
+1. **Caught:** parent has `reality_check -[outcome=fail]-> handler` → routes to `handler`, child's
+   failure reason preserved.
+2. **Loud halt:** parent has no fail-edge, no node-level retry, but a graph-level `retry_target` present
+   → pipeline **terminates FAIL** with the child's reason (does **not** jump to the graph target, does
+   **not** restart the loop).
+
+Both behaviors are what §3.7 mandates and what we want.

--- a/examples/pipelines/04-retry-with-fallback.dot
+++ b/examples/pipelines/04-retry-with-fallback.dot
@@ -9,7 +9,6 @@ digraph RetryWithFallback {
         goal="Generate a complex regex pattern that validates email addresses per RFC 5322",
         label="Retry with Fallback Pipeline",
         default_max_retry=3,
-        fallback_retry_target="simple_implement",
         default_fidelity="full",
         default_thread_id="retry-with-fallback"
     ]

--- a/examples/pipelines/04-retry-with-fallback.md
+++ b/examples/pipelines/04-retry-with-fallback.md
@@ -3,9 +3,9 @@
 ## What This Exercises
 
 - **`max_retries` attribute**: `implement` has `max_retries=2` meaning up to 3 total executions (1 initial + 2 retries)
-- **`retry_target`**: When `implement` exhausts retries, jump back to `plan` for a fresh approach
-- **`fallback_retry_target`**: If `retry_target` also fails or is invalid, fall back to `simple_implement`
-- **Graph-level `fallback_retry_target`**: The graph itself has `fallback_retry_target="simple_implement"` as a last resort
+- **`retry_target`** (node-level): When `implement` exhausts retries, jump back to `plan` for a fresh approach (spec §3.7 step 2)
+- **`fallback_retry_target`** (node-level on `implement`): If `retry_target` also fails, fall back to `simple_implement` (spec §3.7 step 3)
+- **Fail-edge**: `validate -> implement [condition="outcome=fail"]` — explicit per-node failure routing (spec §3.7 step 1)
 - **Graph-level `default_max_retry`**: Sets the global retry ceiling to 3
 - **`goal_gate` + retry interaction**: Both `implement` and `simple_implement` are goal gates -- the pipeline cannot exit until at least one succeeds
 - **`allow_partial`**: `simple_implement` accepts PARTIAL_SUCCESS when retries exhaust, treating it as good enough
@@ -17,11 +17,11 @@ start --> plan --> implement --> validate --> done
            ^        |                |
            |        | (retry_target) |
            +--------+               |
-                                     | (fail edge)
+                                     | (fail edge: condition="outcome=fail")
                                      +-----------> implement
            
 simple_implement --> validate
-(fallback_retry_target from implement and graph)
+(reached via node-level fallback_retry_target on implement)
 ```
 
 ## Expected Behavior

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py
@@ -1466,16 +1466,15 @@ class PipelineEngine:
         Fallback chain (first match wins):
         1. node.retry_target
         2. node.fallback_retry_target
-        3. graph.retry_target
-        4. graph.fallback_retry_target
+
+        Graph-level retry_target is goal-gate-exit only (spec §3.4); it is
+        intentionally NOT consulted on per-node failure (spec §3.7).
 
         Returns the target Node or None if no valid target exists.
         """
         target_id = (
             node.attrs.get("retry_target")
             or node.attrs.get("fallback_retry_target")
-            or self.graph.graph_attrs.get("retry_target")
-            or self.graph.graph_attrs.get("fallback_retry_target")
         )
         if target_id and target_id in self.graph.nodes:
             return self.graph.nodes[target_id]

--- a/modules/loop-pipeline/tests/conftest.py
+++ b/modules/loop-pipeline/tests/conftest.py
@@ -4,11 +4,22 @@ Provides stubs for optional dependencies (amplifier_foundation, amplifier_core)
 that are not installed in the test virtual environment.  These stubs must be
 registered in sys.modules *before* any test module imports the backend, so this
 file (as a conftest) is processed first by pytest.
+
+Also ensures that the amplifier_module_loop_pipeline package is loaded from
+this source tree, not from a potentially stale editable install elsewhere.
 """
 
+import pathlib
 import sys
 import types
 from dataclasses import dataclass, field
+
+# Ensure the local source directory is resolved first.  An editable install
+# from a different checkout (e.g. modern-bundle-pipeline) would otherwise
+# shadow the changes under test.  Insert before site-packages path entries.
+_MODULE_SRC = str(pathlib.Path(__file__).parent.parent)
+if _MODULE_SRC not in sys.path:
+    sys.path.insert(0, _MODULE_SRC)
 
 
 # ---------------------------------------------------------------------------

--- a/modules/loop-pipeline/tests/test_failure_routing.py
+++ b/modules/loop-pipeline/tests/test_failure_routing.py
@@ -1,13 +1,15 @@
-"""Tests for per-node failure routing (1b2).
+"""Tests for per-node failure routing (spec §3.7).
 
-When no edge matches after node execution, the engine should check
-retry_target and fallback_retry_target on the node and graph before
-returning FAIL.
+When no edge matches after node execution, the engine checks node-level
+retry_target and fallback_retry_target only, then halts loud.
 
-Fallback chain: node.retry_target → node.fallback_retry_target →
-                graph.retry_target → graph.fallback_retry_target → terminate.
+Fallback chain (per-node failure, spec §3.7):
+    node.retry_target → node.fallback_retry_target → FAIL (terminate).
 
-Spec coverage: EXEC-015–018, Section 3.3.
+Graph-level retry_target/fallback_retry_target are goal-gate-exit only
+(spec §3.4) and must NOT be consulted on per-node failure.
+
+Spec coverage: EXEC-015–018, Section 3.7.
 """
 
 import pytest
@@ -116,12 +118,24 @@ class TestNodeRetryTarget:
         assert backend.call_count("fallback") >= 1
 
 
-class TestGraphRetryTarget:
-    """Graph-level retry targets are checked after node-level."""
+class TestGraphRetryTargetNotUsedOnNodeFailure:
+    """Graph-level retry targets must NOT fire on per-node failure (spec §3.7).
+
+    graph.retry_target and graph.fallback_retry_target are goal-gate-exit
+    only (spec §3.4).  A node failure with no fail-edge and no node-level
+    retry target must terminate FAIL loud — NOT jump to the graph target.
+    """
 
     @pytest.mark.asyncio
-    async def test_graph_retry_target_used_when_node_has_none(self, tmp_path):
-        """Graph's retry_target is used when node has no retry targets."""
+    async def test_graph_retry_target_NOT_used_on_node_failure_halts_loud(
+        self, tmp_path
+    ):
+        """Graph retry_target must NOT fire on per-node failure → loud FAIL.
+
+        Regression lock for spec §3.7: when a node has no fail-edge and no
+        node-level retry_target, the engine must TERMINATE FAIL with the
+        node's failure reason — it must NOT jump to graph.retry_target.
+        """
         graph = Graph(
             name="test",
             nodes={
@@ -138,12 +152,21 @@ class TestGraphRetryTarget:
         )
         backend = CountingBackend()
         engine = _make_engine(graph, backend=backend, logs_root=str(tmp_path))
-        await engine.run()
-        assert backend.call_count("graph_recovery") >= 1
+        outcome = await engine.run()
+        # Must terminate FAIL — NOT route to graph_recovery
+        assert outcome.status == StageStatus.FAIL
+        assert backend.call_count("graph_recovery") == 0
 
     @pytest.mark.asyncio
-    async def test_graph_fallback_retry_target_last_resort(self, tmp_path):
-        """Graph's fallback_retry_target is the last resort before terminate."""
+    async def test_graph_fallback_retry_target_NOT_used_on_node_failure_halts_loud(
+        self, tmp_path
+    ):
+        """Graph fallback_retry_target must NOT fire on per-node failure → loud FAIL.
+
+        Regression lock for spec §3.7: graph.fallback_retry_target is
+        goal-gate-exit only; per-node failure with no fail-edge and no
+        node-level targets must TERMINATE FAIL, not enter the graph target.
+        """
         graph = Graph(
             name="test",
             nodes={
@@ -160,8 +183,10 @@ class TestGraphRetryTarget:
         )
         backend = CountingBackend()
         engine = _make_engine(graph, backend=backend, logs_root=str(tmp_path))
-        await engine.run()
-        assert backend.call_count("last_resort") >= 1
+        outcome = await engine.run()
+        # Must terminate FAIL — NOT route to last_resort
+        assert outcome.status == StageStatus.FAIL
+        assert backend.call_count("last_resort") == 0
 
 
 class TestFailureRoutingTerminate:

--- a/modules/loop-pipeline/tests/test_folder_node_failure_routing.py
+++ b/modules/loop-pipeline/tests/test_folder_node_failure_routing.py
@@ -1,0 +1,265 @@
+"""Tests for folder-node failure routing per spec §3.7.
+
+A shape=folder node runs a child sub-pipeline via PipelineHandler.  When
+the child fails, PipelineHandler propagates FAIL verbatim.  The parent
+engine then applies standard §3.7 routing:
+
+  1. condition="outcome=fail" edge on the folder node (step 1 — cornerstone)
+  2. node-level retry_target on the folder node (step 2)
+  3. TERMINATE FAIL if neither — graph-level retry_target must NOT fire here
+
+This supersedes the version proposed in PR #54.
+
+Spec coverage: §3.7 (per-node failure routing), §4.11/§9.4 (subgraph semantics).
+Regression lock for: fix/folder-failure-routing-conformance (graph-level drift).
+"""
+
+import pytest
+
+from amplifier_module_loop_pipeline.context import PipelineContext
+from amplifier_module_loop_pipeline.engine import PipelineEngine
+from amplifier_module_loop_pipeline.graph import Edge, Graph, Node
+from amplifier_module_loop_pipeline.handlers import HandlerRegistry
+from amplifier_module_loop_pipeline.outcome import Outcome, StageStatus
+from amplifier_module_loop_pipeline.handlers.context import HandlerContext
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# A minimal child pipeline that always fails.  shape=parallelogram uses
+# ToolHandler; exit 1 → non-zero exit code → Outcome(status=FAIL).
+# No outgoing edge from fail_step so the child engine terminates FAIL
+# (FAIL outcomes do not traverse unconditional edges per §3.7 / edge_selection.py).
+_CHILD_FAIL_DOT = """\
+digraph child_fail {
+    start [shape=Mdiamond]
+    fail_step [shape=parallelogram, tool_command="exit 1"]
+    done [shape=Msquare]
+    start -> fail_step
+}
+"""
+
+
+class CountingBackend:
+    """Backend that tracks call count per node and returns configurable outcomes."""
+
+    def __init__(self, outcomes: dict[str, list[Outcome | str]] | None = None):
+        self._outcomes = outcomes or {}
+        self._call_counts: dict[str, int] = {}
+
+    async def run(self, node, prompt, context, incoming_edge=None, graph=None) -> str | Outcome:
+        count = self._call_counts.get(node.id, 0)
+        self._call_counts[node.id] = count + 1
+        seq = self._outcomes.get(node.id, ["done"])
+        if count < len(seq):
+            return seq[count]
+        return seq[-1]
+
+    def call_count(self, node_id: str) -> int:
+        return self._call_counts.get(node_id, 0)
+
+
+def _make_engine(
+    graph: Graph,
+    backend: object | None = None,
+    logs_root: str = "/tmp/test-folder-failure-routing",
+) -> PipelineEngine:
+    context = PipelineContext()
+    registry = HandlerRegistry(HandlerContext(backend=backend))
+    return PipelineEngine(
+        graph=graph,
+        context=context,
+        handler_registry=registry,
+        logs_root=logs_root,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Case (a): KEEP from #54 — fail-edge on folder node fires (§3.7 step 1 cornerstone)
+# ---------------------------------------------------------------------------
+
+
+class TestFolderNodeFailEdgeFires:
+    """§3.7 step 1 cornerstone: condition=\"outcome=fail\" edge routes folder failure."""
+
+    @pytest.mark.asyncio
+    async def test_folder_fail_edge_routes_to_handler_not_graph_target(self, tmp_path):
+        """Folder child fails; condition=\"outcome=fail\" edge fires → handler, NOT graph_target.
+
+        With graph.retry_target set but the folder node having a
+        condition="outcome=fail" edge to handler, the fail-edge must take
+        precedence (§3.7 step 1).  The graph_target node must never be entered.
+        """
+        child_dot_path = tmp_path / "child_fail.dot"
+        child_dot_path.write_text(_CHILD_FAIL_DOT)
+
+        graph = Graph(
+            name="test",
+            nodes={
+                "start": Node(id="start", shape="Mdiamond"),
+                "folder_node": Node(
+                    id="folder_node",
+                    shape="folder",
+                    attrs={"dot_file": str(child_dot_path)},
+                ),
+                "handler": Node(id="handler", prompt="handle failure"),
+                "graph_target": Node(
+                    id="graph_target", prompt="graph retry — must NOT run"
+                ),
+                "exit": Node(id="exit", shape="Msquare"),
+            },
+            edges=[
+                Edge(from_node="start", to_node="folder_node"),
+                # fail-edge: explicit opt-in per §3.7 step 1
+                Edge(
+                    from_node="folder_node",
+                    to_node="handler",
+                    condition="outcome=fail",
+                ),
+                Edge(from_node="handler", to_node="exit"),
+                Edge(from_node="graph_target", to_node="exit"),
+            ],
+            graph_attrs={"retry_target": "graph_target"},
+        )
+
+        backend = CountingBackend()
+        engine = _make_engine(graph, backend=backend, logs_root=str(tmp_path / "logs"))
+        await engine.run()
+
+        # fail-edge fires → handler must run
+        assert backend.call_count("handler") >= 1, (
+            "handler must run via the condition='outcome=fail' edge (§3.7 step 1)"
+        )
+        # graph_target must NEVER be entered — it's not in the §3.7 per-node path
+        assert backend.call_count("graph_target") == 0, (
+            "graph_target must NOT run — graph-level retry_target is goal-gate-exit "
+            "only (§3.4), not consulted on per-node failure (§3.7)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Case (b): NEW (replaces #54 baseline) — loud FAIL when no fail-edge and no
+#           node-level retry, even with graph.retry_target present
+# ---------------------------------------------------------------------------
+
+
+class TestFolderNodeLoudFailWhenNoFailEdgeNoNodeRetry:
+    """§3.7 step 4 regression lock: no fail-edge + no node-level retry → TERMINATE FAIL.
+
+    graph.retry_target must NOT fire.  This is the core bug fixed by
+    fix/folder-failure-routing-conformance — the silent loop-restart.
+    """
+
+    @pytest.mark.asyncio
+    async def test_folder_no_fail_edge_with_graph_retry_target_terminates_fail(
+        self, tmp_path
+    ):
+        """Folder fails; no fail-edge; no node-level retry_target; graph retry_target
+        present → engine TERMINATES FAIL with child's failure reason.
+
+        Regression lock: graph.retry_target must NOT enter the graph_target node
+        and must NOT restart the loop.
+        """
+        child_dot_path = tmp_path / "child_fail.dot"
+        child_dot_path.write_text(_CHILD_FAIL_DOT)
+
+        graph = Graph(
+            name="test",
+            nodes={
+                "start": Node(id="start", shape="Mdiamond"),
+                "folder_node": Node(
+                    id="folder_node",
+                    shape="folder",
+                    # No node-level retry_target
+                    attrs={"dot_file": str(child_dot_path)},
+                ),
+                "graph_target": Node(
+                    id="graph_target", prompt="graph retry — must NOT run"
+                ),
+                "exit": Node(id="exit", shape="Msquare"),
+            },
+            edges=[
+                Edge(from_node="start", to_node="folder_node"),
+                # No fail-edge on folder_node
+                Edge(from_node="graph_target", to_node="exit"),
+            ],
+            graph_attrs={"retry_target": "graph_target"},
+        )
+
+        backend = CountingBackend()
+        engine = _make_engine(graph, backend=backend, logs_root=str(tmp_path / "logs"))
+        outcome = await engine.run()
+
+        # Engine must terminate FAIL — not silently route to graph_target
+        assert outcome.status == StageStatus.FAIL, (
+            "pipeline must TERMINATE FAIL loud — graph.retry_target must NOT fire "
+            "on per-node failure (spec §3.7; graph-level is §3.4 goal-gate-exit only)"
+        )
+        # graph_target must NEVER be entered (regression lock for the drift)
+        assert backend.call_count("graph_target") == 0, (
+            "graph_target must NOT run — this was the silent-restart bug being fixed"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Case (c): node-level retry_target on folder node IS honored (§3.7 step 2)
+# ---------------------------------------------------------------------------
+
+
+class TestFolderNodeLevelRetryTargetHonored:
+    """§3.7 step 2: node-level retry_target on a folder node fires even when
+    graph-level retry_target also exists — proving graph-level is ignored on failure.
+    """
+
+    @pytest.mark.asyncio
+    async def test_folder_node_level_retry_target_fires_not_graph_target(self, tmp_path):
+        """Folder fails; node has retry_target; graph also has retry_target →
+        node-level retry_target fires; graph-level is ignored.
+
+        Proves both that node-level still works (§3.7 step 2) and that
+        graph-level is not consulted (§3.4 scope boundary).
+        """
+        child_dot_path = tmp_path / "child_fail.dot"
+        child_dot_path.write_text(_CHILD_FAIL_DOT)
+
+        graph = Graph(
+            name="test",
+            nodes={
+                "start": Node(id="start", shape="Mdiamond"),
+                "folder_node": Node(
+                    id="folder_node",
+                    shape="folder",
+                    attrs={
+                        "dot_file": str(child_dot_path),
+                        "retry_target": "node_recovery",  # §3.7 step 2
+                    },
+                ),
+                "node_recovery": Node(id="node_recovery", prompt="node-level recovery"),
+                "graph_target": Node(
+                    id="graph_target", prompt="graph retry — must NOT run"
+                ),
+                "exit": Node(id="exit", shape="Msquare"),
+            },
+            edges=[
+                Edge(from_node="start", to_node="folder_node"),
+                Edge(from_node="node_recovery", to_node="exit"),
+                Edge(from_node="graph_target", to_node="exit"),
+            ],
+            graph_attrs={"retry_target": "graph_target"},
+        )
+
+        backend = CountingBackend()
+        engine = _make_engine(graph, backend=backend, logs_root=str(tmp_path / "logs"))
+        await engine.run()
+
+        # node-level retry_target fires → node_recovery runs
+        assert backend.call_count("node_recovery") >= 1, (
+            "node_recovery must run — node.retry_target is §3.7 step 2"
+        )
+        # graph_target must NOT run — graph-level not consulted on per-node failure
+        assert backend.call_count("graph_target") == 0, (
+            "graph_target must NOT run — graph-level retry_target not consulted on "
+            "per-node failure (§3.7); it is goal-gate-exit only (§3.4)"
+        )

--- a/modules/loop-pipeline/tests/test_goal_gate_retry_clears_failures.py
+++ b/modules/loop-pipeline/tests/test_goal_gate_retry_clears_failures.py
@@ -1,18 +1,22 @@
-"""Tests for CR-3: goal-gate retry clears failed_outputs.
+"""Tests for CR-3: retry clears failed_outputs / completed_nodes / node_outcomes.
 
 R12 WS-6 — engine node-failure propagation.
 
-CR-3 (COE Phase 4): When goal-gate retry fires (engine.py goal gate path),
-the engine SHALL CLEAR failed_outputs alongside completed_nodes and node_outcomes.
-Without this, skip-propagation from attempt N would block retried nodes in
-attempt N+1.
+CR-3 (COE Phase 4): When a retry fires, the engine SHALL CLEAR failed_outputs
+alongside completed_nodes and node_outcomes.  Without this, skip-propagation
+from attempt N would block retried nodes in attempt N+1.
 
-Goal-gate mechanics (how it works in this engine):
-  - A non-exit node with goal_gate=true is a gate node.
-  - _check_goal_gates() inspects node_outcomes for gate nodes.
-  - If a gate node's outcome is !success, the gate is unsatisfied.
-  - If there is a retry_target, the engine clears per-run state (CR-3)
-    and jumps to the retry target node.
+Retry trigger (spec §3.7 conformance):
+  The failing node carries a NODE-level ``retry_target`` (spec §3.7 step 2 —
+  explicit, author-authored failure handling on that node).  When the node
+  fails with no matching fail-edge, the engine follows the node-level
+  retry_target and clears per-run state (CR-3) before re-executing.
+
+  NOTE: graph-level ``retry_target`` is intentionally NOT consulted on
+  per-node failure (spec §3.7); it applies only to the goal-gate-unsatisfied-
+  at-exit path (spec §3.4).  These tests therefore use node-level retry_target
+  so the retry is triggered the spec-conformant way.  The CR-3 state-clearing
+  contract under test is identical regardless of which retry path fired.
 """
 
 from __future__ import annotations
@@ -54,13 +58,13 @@ def _make_engine(dot_source: str, logs_root: str, hooks: Any = None) -> Pipeline
 
 @pytest.mark.asyncio
 async def test_goal_gate_retry_clears_failed_outputs(tmp_path):
-    """CR-3: failed_outputs cleared alongside completed_nodes on goal-gate retry.
+    """CR-3: failed_outputs cleared alongside completed_nodes on retry.
 
     Pipeline:
       start → work_a [goal_gate, outputs="k", retry_target=work_a] → exit
 
-    Attempt 1: work_a fails → failed_outputs has "k" → exit gate unsatisfied
-              → retry fires (CR-3: state cleared including failed_outputs).
+    Attempt 1: work_a fails → failed_outputs has "k" → node-level retry_target
+              fires (CR-3: state cleared including failed_outputs).
     Attempt 2: work_a succeeds → gate satisfied → pipeline succeeds.
 
     work_a uses a counter file to fail once then succeed.
@@ -77,12 +81,12 @@ async def test_goal_gate_retry_clears_failed_outputs(tmp_path):
     engine = _make_engine(
         f"""
         digraph {{
-            retry_target=work_a
             start [shape=Mdiamond]
             work_a [shape=parallelogram,
                     tool_command="{cmd}",
                     outputs="work.result",
-                    goal_gate=true]
+                    goal_gate=true,
+                    retry_target=work_a]
             exit [shape=Msquare]
             start -> work_a -> exit
         }}
@@ -105,7 +109,7 @@ async def test_goal_gate_retry_clears_failed_outputs(tmp_path):
 
 @pytest.mark.asyncio
 async def test_goal_gate_retry_clears_completed_nodes(tmp_path):
-    """CR-3: completed_nodes and node_outcomes are cleared on goal-gate retry.
+    """CR-3: completed_nodes and node_outcomes are cleared on retry.
 
     Verifies the full state-clearing contract: all three tables reset.
     After retry, work_a must be re-executed (not skipped as already-completed).
@@ -121,12 +125,12 @@ async def test_goal_gate_retry_clears_completed_nodes(tmp_path):
     engine = _make_engine(
         f"""
         digraph {{
-            retry_target=work_a
             start [shape=Mdiamond]
             work_a [shape=parallelogram,
                     tool_command="{cmd}",
                     outputs="work.result",
-                    goal_gate=true]
+                    goal_gate=true,
+                    retry_target=work_a]
             exit [shape=Msquare]
             start -> work_a -> exit
         }}
@@ -150,9 +154,10 @@ async def test_skipped_node_reruns_after_predecessor_succeeds_on_retry(tmp_path)
     executes if its predecessor now succeeds.
 
     Pipeline:
-      start → producer [goal_gate, outputs="k"] → consumer [uses ${k}] → exit
+      start → producer [goal_gate, outputs="k", retry_target=producer]
+            → consumer [uses ${k}] → exit
 
-    Attempt 1: producer fails → consumer SKIPPED → gate unsatisfied → retry.
+    Attempt 1: producer fails → consumer SKIPPED → node-level retry_target fires.
     Attempt 2 (after CR-3 clear): producer succeeds → consumer runs → gate satisfied.
     """
     counter_file = tmp_path / "attempt.txt"
@@ -168,12 +173,12 @@ async def test_skipped_node_reruns_after_predecessor_succeeds_on_retry(tmp_path)
     engine = _make_engine(
         f"""
         digraph {{
-            retry_target=producer
             start [shape=Mdiamond]
             producer [shape=parallelogram,
                       tool_command="{cmd}",
                       outputs="k",
-                      goal_gate=true]
+                      goal_gate=true,
+                      retry_target=producer]
             consumer [shape=parallelogram,
                       tool_command="echo using_${{k}} > {output_file}"]
             exit [shape=Msquare]


### PR DESCRIPTION
## What & why
Per-node failure routing drifted from upstream attractor nlspec §3.7. The engine consulted **graph-level** `retry_target`/`fallback_retry_target` on a per-node failure, so an unhandled node/subgraph failure silently jumped to the graph-level retry target and **restarted the loop** (wiping completed-node state). §3.7 scopes per-node failure routing to **node-level only**, then a **loud halt**; graph-level `retry_target` is the **§3.4** goal-gate-unsatisfied-at-exit mechanism. This was undocumented drift (no entry in `specs/EXTENSIONS.md`), surfaced by #54.

## The change
- **engine:** remove the two graph-level tiers from `_resolve_failure_retry_target`. `_check_goal_gates()` (the §3.4 path, which resolves graph-level retry independently) is untouched.
- **behavior:** unhandled failures now **fail loud** with the real reason. Recovery is explicit and author-owned — a `condition="outcome=fail"` edge or a node-level `retry_target`. For `shape=folder` nodes this is exactly how a caller routes a child-pipeline failure.

## Tests
- `test_failure_routing.py`: the two cases that locked in graph-level-on-failure are replaced with loud-halt assertions.
- `test_folder_node_failure_routing.py` (new, **supersedes #54**): keeps #54's fail-edge case as the §3.7-step-1 cornerstone; replaces its baseline with a loud-halt regression lock; adds a node-level-retry case.
- `test_goal_gate_retry_clears_failures.py`: retry now triggered via node-level `retry_target` (§3.7 step 2); CR-3 state-clearing intent preserved.
- `conftest.py`: ensures the suite imports this source tree rather than a stale editable install (small infra hunk — easy to drop if undesired).

## Verification
- Full `modules/loop-pipeline/tests/` suite: **1175 passed, 7 skipped, 2 failed**. The 2 failures are pre-existing and unrelated (`test_outputs_attribute.py` human-handler output inference) — they fail on `main` with this change reverted (confirmed by isolation).
- Independent live engine run (real subprocess-failing child via `shape=folder`): **(A)** a `condition="outcome=fail"` edge catches the failure and routes to the author's handler; **(B)** with no fail-edge / no node retry (only a graph-level `retry_target`), the pipeline terminates **FAIL** with the child's reason and never enters the graph target.

## Docs
`ROUTING-REFERENCE.md` and `DOT-AUTHORING-GUIDE.md` re-scope graph-level `retry_target` to §3.4; example `04-retry-with-fallback` drops its off-spec graph-level `fallback_retry_target`. Rationale recorded in `docs/designs/folder-failure-routing-conformance.md`.

Supersedes #54.