### PR TITLE
test(loop-pipeline): correct stale human-handler output-inference tests to the R12.5 contract

### DIFF
--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/node_outputs.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/node_outputs.py
@@ -8,7 +8,10 @@ the node's ``outputs="key1,key2"`` DOT attribute.  Effective output set is
 SC-2 (COE Phase 4 resolution) — closed inference table:
   ``tool``      → ``tool.output``, ``tool.last_line``
                   (+ keys from ``parse_json`` when declared via ``outputs=``)
-  ``wait.human``→ ``human.input``, ``human.choice``
+  ``wait.human``→ absent by design (R12 R12.5): emits mode-specific keys
+                  (``human.gate.selected`` or ``human.gate.text``) that cannot
+                  be statically inferred without false-positive
+                  PIPELINE_NODE_CONTRACT_VIOLATION events
   ``parallel``  → ``branch.{idx}.outcome`` (per outgoing branch, computed
                   dynamically from the graph's outgoing edges at build time)
   other         → empty set (use explicit ``outputs=`` declaration)

--- a/modules/loop-pipeline/tests/test_outputs_attribute.py
+++ b/modules/loop-pipeline/tests/test_outputs_attribute.py
@@ -26,11 +26,17 @@ def test_tool_handler_infers_tool_output_and_last_line():
     assert "tool.last_line" in inferred
 
 
-def test_human_handler_infers_human_input_and_choice():
-    """SC-2: human handler contributes human.input and human.choice."""
-    inferred = HANDLER_INFERRED_OUTPUTS["wait.human"]
-    assert "human.input" in inferred
-    assert "human.choice" in inferred
+def test_human_handler_not_in_inference_table_by_design():
+    """R12 R12.5: wait.human is intentionally absent from the inference table.
+
+    The human gate handler emits mode-specific outputs — human.gate.selected
+    (selection mode) or human.gate.text (freeform mode) — never both.  Static
+    inference of either key would produce false-positive
+    PIPELINE_NODE_CONTRACT_VIOLATION events for whichever key was not emitted.
+    Fix (R12 R12.5): drop the inferred set entirely; pipeline authors who want
+    contract checking on a human-gate node declare outputs="..." explicitly.
+    """
+    assert "wait.human" not in HANDLER_INFERRED_OUTPUTS
 
 
 def test_other_handlers_not_in_inference_table():
@@ -110,8 +116,14 @@ def test_explicit_outputs_merged_with_inferred():
     assert "tool.last_line" in table["worker"]
 
 
-def test_human_handler_inferred_outputs_in_table():
-    """M1: human handler infers human.input and human.choice."""
+def test_human_handler_no_inferred_outputs_in_table():
+    """R12 R12.5: human gate node (shape=hexagon) has an empty output table.
+
+    wait.human is absent from HANDLER_INFERRED_OUTPUTS by design — the handler
+    emits mode-specific keys (human.gate.selected or human.gate.text) and
+    static inference would produce false-positive contract-violation events.
+    Pipeline authors use explicit outputs= to opt into contract checking.
+    """
     dot = """
     digraph {
         start [shape=Mdiamond]
@@ -122,8 +134,7 @@ def test_human_handler_inferred_outputs_in_table():
     """
     graph = parse_dot(dot)
     table = build_output_table(graph)
-    assert "human.input" in table["gate"]
-    assert "human.choice" in table["gate"]
+    assert table["gate"] == frozenset()
 
 
 def test_parallel_handler_infers_branch_outcomes():


### PR DESCRIPTION
## What & why
Two `test_outputs_attribute.py` tests asserted a **pre-R12.5** contract — that the human gate handler (`wait.human`) contributes inferred outputs (`human.input`, `human.choice`) to `build_output_table`. **R12.5** (commit `fc2ee0e`) intentionally removed `wait.human` from `HANDLER_INFERRED_OUTPUTS`: the handler emits **mode-specific** keys at runtime (`human.gate.selected` OR `human.gate.text`, never both), so a static inference would raise false-positive `PIPELINE_NODE_CONTRACT_VIOLATION` events. The key names the tests asserted (`human.input`/`human.choice`) were never emitted by the handler.

These were pre-existing failures on `main` (surfaced during the #55 work, unrelated to it).

## Change (tests + docstring only — no behavior change)
- `test_human_handler_infers_human_input_and_choice` → `test_human_handler_not_in_inference_table_by_design`: asserts `wait.human` is absent from `HANDLER_INFERRED_OUTPUTS` (positive, fail-loud assertion documenting the R12.5 decision).
- `test_human_handler_inferred_outputs_in_table` → `test_human_handler_no_inferred_outputs_in_table`: asserts a `hexagon` gate node with no explicit `outputs=` yields an empty output set.
- `node_outputs.py`: fix a stale module docstring that still claimed `wait.human → human.input, human.choice` (it contradicted the implementation comment six lines below it).

## Verification
Full `modules/loop-pipeline/tests/` suite: **1177 passed, 7 skipped, 0 failures.**