### PR TITLE
docs(loop-pipeline): scope graph-level retry_target to goal-gate-exit (§3.4)

### DIFF
--- a/context/dot-reference.md
+++ b/context/dot-reference.md
@@ -57,7 +57,7 @@ digraph MyPipeline {
         goal="The overall objective -- replaces $goal in prompts",
         default_fidelity="compact",
         default_max_retry=3,
-        retry_target="some_node",          // Global fallback retry target
+        retry_target="some_node",          // Retry target when exit has unsatisfied goal gates (spec §3.4); NOT a per-node failure catch-all
         max_pipeline_duration=5m,          // Abort if exceeded
         model_stylesheet="box { llm_provider: anthropic; llm_model: claude-sonnet-4-20250514 }
                           .fast { llm_model: claude-haiku-3-5-20241022 }"

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -52,9 +52,10 @@ spec.
 
 **Behavior:** When a node produces `outcome.status=FAIL`, unconditional outgoing edges
 are NOT followed. The engine checks for explicit failure routing: a
-`condition="outcome=fail"` edge, a declared `retry_target` / `fallback_retry_target`, or
+`condition="outcome=fail"` edge, a declared **node-level** `retry_target` / `fallback_retry_target`, or
 a downstream node with `runs_on=always` or `runs_on=failure`. If none apply, the pipeline
-terminates with the FAIL outcome.
+terminates with the FAIL outcome. (Graph-level `retry_target` is goal-gate-exit only, spec §3.4 —
+it is not consulted on per-node failure.)
 
 **Implication for consumers:** Failures are loud by default. Downstream nodes that
 depend on missing inputs don't silently receive nothing — they don't run at all. Pipeline

--- a/docs/DOT-SYNTAX.md
+++ b/docs/DOT-SYNTAX.md
@@ -63,7 +63,7 @@ digraph {
 | `goal` | string | Pipeline objective. Expands `$goal` in prompts. |
 | `default_fidelity` | string | Default fidelity for all nodes |
 | `default_max_retry` | int | Default retry count for all nodes |
-| `retry_target` | string | Global fallback retry target |
+| `retry_target` | string | Retry target when exit has unsatisfied goal gates (spec §3.4); not consulted on per-node failure |
 | `max_pipeline_duration` | string | Timeout for entire pipeline (e.g. "10m") |
 | `model_stylesheet` | string | CSS-like rules for model/provider config |
 | `params` | string | Comma-separated list of `$param` names (documentation) |


### PR DESCRIPTION
Follow-up to #55. Three docs still described the **graph-level** `retry_target` as a general "Global fallback retry target" without the §3.4 goal-gate-exit scope — now inconsistent with the merged §3.7 conformance fix (per-node failures fail loud; graph-level `retry_target` is **not** a per-node failure catch-all).

- `context/dot-reference.md`: qualify the graph-attr comment
- `docs/DOT-SYNTAX.md`: qualify the graph-attribute table row
- `docs/CONTRACTS.md`: clarify per-node failure routing uses **node-level** `retry_target`/`fallback_retry_target`; graph-level is goal-gate-exit only

Docs-only — no code or behavior change.