### PR TITLE
fix(loop-pipeline): spec-conformance safe batch (fail-loud auto_status, goal_gate quoted, retry presets, fan_in key)

### DIFF
--- a/docs/designs/b3-outcome-vs-preferred-label-decision.md
+++ b/docs/designs/b3-outcome-vs-preferred-label-decision.md
@@ -1,0 +1,55 @@
+# B3 decision: `outcome` condition key resolves to `preferred_label || status`
+
+**Status:** OPEN — decision required (do NOT blind-fix)
+**Found by:** full-nlspec conformance audit + .dot impact analysis (resolver + bundle corpora)
+**Why this is a doc, not a fix:** conforming the engine to the spec here would BREAK real pipelines. This is load-bearing drift tangled with an active pipeline bug. It needs a coordinated decision, not a one-line change.
+
+## The discrepancy
+
+Upstream nlspec (`strongdm/attractor@fb57a55`): the `outcome` condition key resolves to the node's **status only**.
+- §3.3 Step 2 / variable resolution: [attractor-spec.md#L412](https://github.com/strongdm/attractor/blob/fb57a55ed97372a27ac90102f436947e29f48426/attractor-spec.md#L412), §10.3–10.4 [~L1684](https://github.com/strongdm/attractor/blob/fb57a55ed97372a27ac90102f436947e29f48426/attractor-spec.md#L1684)
+- The spec has a **separate** `preferred_label` key for label-based routing.
+
+Implementation — `modules/loop-pipeline/amplifier_module_loop_pipeline/conditions.py:80`:
+```python
+if key == "outcome":
+    return outcome.preferred_label or outcome.status.value
+```
+So `condition="outcome=success"` evaluates **False** whenever a handler set any `preferred_label`, and `condition="outcome=<custom-label>"` evaluates True. This is an undocumented divergence (no `specs/EXTENSIONS.md` entry).
+
+## Why it is LOAD-BEARING (conforming to spec would break pipelines)
+
+Pipelines route on **custom outcome labels** via this exact behavior:
+- `modules/loop-pipeline/tests/fixtures/integration/semport.dot` — routes on custom values `yes/retry/process/done/port/skip`.
+- `modules/loop-pipeline/tests/fixtures/integration/consensus_task.dot` — routes on `needs_dod/has_dod/yes/retry`.
+- Resolver pipelines use the sibling `context.preferred_label=` form heavily (`foundry/admissions.dot`, `patterns/*`), which is unaffected — but the `outcome=<label>` form is real and in use.
+
+If `outcome` is made status-only (spec-literal), every `condition="outcome=<custom>"` route silently stops matching. That is a worse failure mode than the current drift.
+
+## The ACTIVE bug it is tangled with
+
+LLM `box` goal_gate nodes that return plain text complete with `status=SUCCESS`. With the current resolution, `condition="outcome=fail"` on such a node is **inert** — it checks `preferred_label` (unset) then status (`success ≠ fail`). The pipeline authors already know:
+
+`amplifier-resolver-dot-graph/src/.../pipelines/experiments/feature_cycle.dot:163-171` (verbatim):
+```
+// INERT: box-node outcome=fail parses as success, so this edge never fires
+SelectWork -> ExitSuccess [condition="outcome=fail", ...]
+// INERT: ... so review failures slip to Commit
+Review -> FixGate [condition="outcome=fail", ...]
+```
+The same latent pattern (without warning comments) appears across `dotpowers.dot` (26 goal_gate nodes), `develop.dot`, and `resolve_validated.dot` — their plan-review / quality-review / fix loops likely never route to the fix path. This is a **pipeline-design** problem (an LLM must *signal* failure via `report_outcome`, a tool `last_line`, or an explicit label — it cannot be inferred from plain text), entangled with the engine's `outcome` semantics.
+
+## Options
+
+1. **Conform to spec (status-only `outcome`).** Cleanest vs upstream. ❌ Breaks all `outcome=<custom-label>` routing (semport, consensus_task, and any resolver pipeline using the form). Rejected unless paired with a migration.
+2. **Document the current behavior as an intentional extension** in `specs/EXTENSIONS.md` (the `&&`/Rust-reference lineage suggests it was deliberate), AND add a distinct **status-only** key (e.g. `status=` or `outcome.status=`) so authors who want true status routing — including reliable `outcome=fail`/`status=fail` — have an unambiguous mechanism. ✅ Non-breaking; gives authors both tools; lets the resolver fix loops route on real failure.
+3. **Hybrid:** keep `outcome` as-is, add the status-only key (option 2), then migrate the genuinely-broken `outcome=fail`-from-box-node edges in the resolver to the status key (or to a `report_outcome`-driven label). Coordinated with resolver owners.
+
+## Recommendation
+
+**Option 3.** Document `outcome = preferred_label || status` as an extension, add an explicit status-only routing key, then coordinate a resolver-side migration of the inert `outcome=fail` edges. This is non-breaking for the engine and actually fixes the dead failure-routing in the resolver's core loops.
+
+**Requires coordination with `amplifier-resolver-dot-graph` owners** before any engine change — the affected pipelines (`dotpowers`, `develop`, `resolve_validated`, `feature_cycle`) are theirs.
+
+## Out of scope for the safe-batch PR
+This decision ships nothing on its own. The safe-batch PR (A1 auto_status, A2 goal_gate-quoted, B6 retry presets, B7 fan_in best_outcome) is independent and carries zero pipeline impact. B3 is recorded here for the decision and the coordinated follow-up.

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py
@@ -584,16 +584,20 @@ class PipelineEngine:
                 )
                 return cancelled_outcome
 
-            # L-9: auto_status — override non-success to SUCCESS when enabled
-            if current_node.auto_status is True and not outcome.is_success:
+            # L-9: auto_status — synthesize SUCCESS only when the handler writes
+            # no status (SKIPPED).  Spec §2.6 / Appendix C: "auto-generates a
+            # SUCCESS outcome" only applies when *no* status was written.
+            # An explicit FAIL or RETRY must pass through unchanged (fail-loud).
+            # Accept both bare true and the quoted string "true" (DOT parser
+            # returns "true" for quoted attribute values).
+            if current_node.auto_status in (True, "true") and outcome.status == StageStatus.SKIPPED:
                 logger.debug(
-                    "Node '%s' has auto_status=true; overriding %s to SUCCESS",
+                    "Node '%s' has auto_status=true; promoting SKIPPED to SUCCESS",
                     current_node.id,
-                    outcome.status.value,
                 )
                 outcome = Outcome(
                     status=StageStatus.SUCCESS,
-                    notes=f"auto_status override (was {outcome.status.value})",
+                    notes="auto_status override (was skipped)",
                     context_updates=outcome.context_updates,
                     preferred_label=outcome.preferred_label,
                     suggested_next_ids=outcome.suggested_next_ids,
@@ -1037,7 +1041,7 @@ class PipelineEngine:
             node = self.graph.nodes.get(node_id)
             if node is None:
                 continue
-            if node.attrs.get("goal_gate") is True:
+            if node.attrs.get("goal_gate") in (True, "true"):
                 if outcome.is_success:
                     satisfied.append(node_id)
                 else:

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/fan_in.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/fan_in.py
@@ -123,6 +123,8 @@ class FanInHandler:
         # Record winner in context
         context.set("parallel.fan_in.best_id", best_id)
         context.set("parallel.fan_in.best_status", best_status)
+        # Spec §4.8: canonical key is best_outcome; keep best_status for compat
+        context.set("parallel.fan_in.best_outcome", best_status)
 
         # If best candidate failed, fan-in fails
         if best_status == "fail":
@@ -138,6 +140,8 @@ class FanInHandler:
             context_updates={
                 "parallel.fan_in.best_id": best_id,
                 "parallel.fan_in.best_status": best_status,
+                # Spec §4.8: canonical key is best_outcome; keep best_status for compat
+                "parallel.fan_in.best_outcome": best_status,
             },
         )
 

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/retry.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/retry.py
@@ -116,24 +116,31 @@ class RetryPolicy:
     def from_preset(cls, name: str) -> RetryPolicy:
         """Create a RetryPolicy from a named preset (L-15).
 
-        Presets:
+        Presets (spec §3.5 table, attractor-spec.md:554-560):
             none       — 1 attempt (no retries).
-            standard   — 3 attempts, exponential backoff.
-            aggressive — 5 attempts, exponential backoff.
-            linear     — 3 attempts, linear backoff (factor=1.0).
-            patient    — 10 attempts, exponential backoff.
+            standard   — 5 attempts, 200ms initial delay, factor 2.0.
+            aggressive — 5 attempts, 500ms initial delay, factor 2.0.
+            linear     — 3 attempts, 500ms initial delay, factor 1.0 (fixed).
+            patient    — 3 attempts, 2000ms initial delay, factor 3.0.
 
         Raises ValueError for unknown preset names.
         """
         presets: dict[str, RetryPolicy] = {
             "none": cls(max_attempts=1),
-            "standard": cls(max_attempts=3),
-            "aggressive": cls(max_attempts=5),
+            # Spec §3.5 preset table (attractor-spec.md:554-560)
+            "standard": cls(max_attempts=5),  # delays 200,400,800,1600,3200 ms
+            "aggressive": cls(
+                max_attempts=5,
+                backoff=BackoffConfig(initial_delay_ms=500),  # delays 500,1000,2000,4000,8000 ms
+            ),
             "linear": cls(
                 max_attempts=3,
-                backoff=BackoffConfig(backoff_factor=1.0),
+                backoff=BackoffConfig(initial_delay_ms=500, backoff_factor=1.0),  # fixed 500ms
             ),
-            "patient": cls(max_attempts=10),
+            "patient": cls(
+                max_attempts=3,
+                backoff=BackoffConfig(initial_delay_ms=2000, backoff_factor=3.0),  # delays 2000,6000,18000 ms
+            ),
         }
         if name not in presets:
             raise ValueError(
@@ -223,6 +230,12 @@ async def execute_with_retry(
 
         # FAIL — return immediately, no retries
         if outcome.status == StageStatus.FAIL:
+            return outcome
+
+        # SKIPPED — return immediately; the engine's auto_status check may
+        # promote this to SUCCESS when auto_status=true (spec §2.6 / Appendix C).
+        # Do not retry a SKIPPED outcome — retrying would not produce a status.
+        if outcome.status == StageStatus.SKIPPED:
             return outcome
 
         # RETRY — retry if attempts remain

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/validation.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/validation.py
@@ -290,7 +290,7 @@ def _check_reachability(graph: Graph, diags: list[Diagnostic]) -> None:
 def _check_goal_gate_has_retry(graph: Graph, diags: list[Diagnostic]) -> None:
     """LINT: goal_gate_has_retry — goal gates should have retry targets."""
     for node in graph.nodes.values():
-        if node.attrs.get("goal_gate") is True:
+        if node.attrs.get("goal_gate") in (True, "true"):
             has_retry = bool(
                 node.attrs.get("retry_target")
                 or node.attrs.get("fallback_retry_target")

--- a/modules/loop-pipeline/tests/test_batch_d_pipeline_infra.py
+++ b/modules/loop-pipeline/tests/test_batch_d_pipeline_infra.py
@@ -901,9 +901,9 @@ class TestL15PresetPolicies:
         assert policy.max_attempts == 1
 
     def test_preset_standard(self):
-        """'standard' preset: 3 attempts."""
+        """'standard' preset: 5 attempts, 200ms initial delay (spec §3.5)."""
         policy = RetryPolicy.from_preset("standard")
-        assert policy.max_attempts == 3
+        assert policy.max_attempts == 5
 
     def test_preset_aggressive(self):
         """'aggressive' preset: 5 attempts."""
@@ -917,9 +917,9 @@ class TestL15PresetPolicies:
         assert policy.backoff.backoff_factor == 1.0
 
     def test_preset_patient(self):
-        """'patient' preset: 10 attempts."""
+        """'patient' preset: 3 attempts, 2000ms initial delay, factor 3.0 (spec §3.5)."""
         policy = RetryPolicy.from_preset("patient")
-        assert policy.max_attempts == 10
+        assert policy.max_attempts == 3
 
     def test_unknown_preset_raises(self):
         """Unknown preset name raises ValueError."""

--- a/modules/loop-pipeline/tests/test_engine.py
+++ b/modules/loop-pipeline/tests/test_engine.py
@@ -361,8 +361,13 @@ async def test_start_node_shape_takes_priority(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_auto_status_overrides_fail_to_success(tmp_path):
-    """auto_status=true overrides non-success outcome to SUCCESS (L-9)."""
+async def test_auto_status_preserves_explicit_fail(tmp_path):
+    """auto_status=true must NOT mask an explicit FAIL — fail-loud (spec §2.6/Appendix C).
+
+    The handler explicitly returns FAIL; auto_status may only synthesize SUCCESS
+    when the handler writes *no* status (SKIPPED sentinel), not when it returns a
+    real failure.
+    """
 
     class FailingBackend:
         async def run(self, node, prompt, context, incoming_edge=None, graph=None):
@@ -384,7 +389,7 @@ async def test_auto_status_overrides_fail_to_success(tmp_path):
         },
         edges=[
             Edge(from_node="start", to_node="auto_node"),
-            Edge(from_node="auto_node", to_node="exit"),
+            Edge(from_node="auto_node", to_node="exit", condition="outcome=fail"),
         ],
     )
     context = PipelineContext()
@@ -395,10 +400,9 @@ async def test_auto_status_overrides_fail_to_success(tmp_path):
         handler_registry=registry,
         logs_root=str(tmp_path),
     )
-    outcome = await engine.run()
-    # auto_status=true should have overridden the FAIL to SUCCESS
-    assert engine.node_outcomes["auto_node"].status == StageStatus.SUCCESS
-    assert outcome.status in (StageStatus.SUCCESS, StageStatus.PARTIAL_SUCCESS)
+    await engine.run()
+    # auto_status must NOT override an explicit FAIL — the failure must be preserved
+    assert engine.node_outcomes["auto_node"].status == StageStatus.FAIL
 
 
 @pytest.mark.asyncio

--- a/modules/loop-pipeline/tests/test_spec_conformance_batch.py
+++ b/modules/loop-pipeline/tests/test_spec_conformance_batch.py
@@ -1,0 +1,428 @@
+"""Regression tests for spec-conformance batch fixes.
+
+Covers four zero-usage fixes that carry no pipeline blast radius:
+
+  A1 — auto_status must NOT mask an explicit FAIL/RETRY (fail-loud)
+  A2 — goal_gate="true" (quoted string) must be recognized
+  B6 — retry preset values must match the spec §3.5 table
+  B7 — fan_in must publish the spec key parallel.fan_in.best_outcome
+"""
+
+import pytest
+
+from amplifier_module_loop_pipeline.context import PipelineContext
+from amplifier_module_loop_pipeline.engine import PipelineEngine
+from amplifier_module_loop_pipeline.graph import Edge, Graph, Node
+from amplifier_module_loop_pipeline.handlers import HandlerRegistry
+from amplifier_module_loop_pipeline.handlers.context import HandlerContext
+from amplifier_module_loop_pipeline.handlers.fan_in import FanInHandler
+from amplifier_module_loop_pipeline.outcome import Outcome, StageStatus
+from amplifier_module_loop_pipeline.retry import BackoffConfig, RetryPolicy
+from amplifier_module_loop_pipeline.validation import validate
+
+# ---------------------------------------------------------------------------
+# A1 — auto_status fail-loud (spec §2.6 / Appendix C)
+# ---------------------------------------------------------------------------
+
+
+class _SkippedBackend:
+    """Backend that returns SKIPPED — the 'no status written' sentinel."""
+
+    async def run(self, node, prompt, context, incoming_edge=None, graph=None):
+        return Outcome(status=StageStatus.SKIPPED)
+
+
+class _FailingBackend:
+    """Backend that always returns an explicit FAIL."""
+
+    async def run(self, node, prompt, context, incoming_edge=None, graph=None):
+        return Outcome(status=StageStatus.FAIL, failure_reason="explicit failure")
+
+
+class _RetryBackend:
+    """Backend that always returns RETRY (exhausts retries → FAIL at engine level)."""
+
+    async def run(self, node, prompt, context, incoming_edge=None, graph=None):
+        return Outcome(status=StageStatus.RETRY, failure_reason="retrying")
+
+
+@pytest.mark.asyncio
+async def test_auto_status_preserves_explicit_fail_a1(tmp_path):
+    """A1: auto_status=true must NOT override an explicit FAIL — fail-loud.
+
+    Spec §2.6 (auto_status) + Appendix C (attractor-spec.md:2078):
+    auto_status synthesizes SUCCESS ONLY when the handler writes no status.
+    """
+    graph = Graph(
+        name="test_a1_fail",
+        nodes={
+            "start": Node(id="start", shape="Mdiamond"),
+            "gate": Node(
+                id="gate",
+                shape="box",
+                prompt="do work",
+                auto_status=True,
+            ),
+            "exit": Node(id="exit", shape="Msquare"),
+        },
+        edges=[
+            Edge(from_node="start", to_node="gate"),
+            Edge(from_node="gate", to_node="exit", condition="outcome=fail"),
+        ],
+    )
+    ctx = PipelineContext()
+    engine = PipelineEngine(
+        graph=graph,
+        context=ctx,
+        handler_registry=HandlerRegistry(HandlerContext(backend=_FailingBackend())),
+        logs_root=str(tmp_path),
+    )
+    await engine.run()
+    # FAIL must remain FAIL — auto_status must not mask it
+    assert engine.node_outcomes["gate"].status == StageStatus.FAIL, (
+        "auto_status=true silently promoted an explicit FAIL to SUCCESS — "
+        "this violates spec §2.6 fail-loud contract"
+    )
+
+
+@pytest.mark.asyncio
+async def test_auto_status_preserves_explicit_retry_a1(tmp_path):
+    """A1: auto_status=true must NOT override an explicit RETRY — fail-loud."""
+    graph = Graph(
+        name="test_a1_retry",
+        nodes={
+            "start": Node(id="start", shape="Mdiamond"),
+            "gate": Node(
+                id="gate",
+                shape="box",
+                prompt="do work",
+                auto_status=True,
+            ),
+            "exit": Node(id="exit", shape="Msquare"),
+        },
+        edges=[
+            Edge(from_node="start", to_node="gate"),
+            # After retries exhaust the engine converts RETRY→FAIL, so route on fail
+            Edge(from_node="gate", to_node="exit", condition="outcome=fail"),
+        ],
+    )
+    ctx = PipelineContext()
+    engine = PipelineEngine(
+        graph=graph,
+        context=ctx,
+        handler_registry=HandlerRegistry(HandlerContext(backend=_RetryBackend())),
+        logs_root=str(tmp_path),
+    )
+    await engine.run()
+    # After exhausting retries the final outcome must not be SUCCESS
+    assert engine.node_outcomes["gate"].status != StageStatus.SUCCESS, (
+        "auto_status=true promoted an explicit RETRY/FAIL to SUCCESS — "
+        "this violates spec §2.6 fail-loud contract"
+    )
+
+
+@pytest.mark.asyncio
+async def test_auto_status_promotes_skipped_to_success_a1(tmp_path):
+    """A1: auto_status=true synthesizes SUCCESS when handler writes no status (SKIPPED).
+
+    SKIPPED is the engine's 'no-status-written' sentinel for the auto_status contract.
+    """
+    graph = Graph(
+        name="test_a1_skipped",
+        nodes={
+            "start": Node(id="start", shape="Mdiamond"),
+            "gate": Node(
+                id="gate",
+                shape="box",
+                prompt="do work",
+                auto_status=True,
+            ),
+            "exit": Node(id="exit", shape="Msquare"),
+        },
+        edges=[
+            Edge(from_node="start", to_node="gate"),
+            Edge(from_node="gate", to_node="exit"),
+        ],
+    )
+    ctx = PipelineContext()
+    engine = PipelineEngine(
+        graph=graph,
+        context=ctx,
+        handler_registry=HandlerRegistry(HandlerContext(backend=_SkippedBackend())),
+        logs_root=str(tmp_path),
+    )
+    await engine.run()
+    # SKIPPED (no-status) must be promoted to SUCCESS when auto_status=true
+    assert engine.node_outcomes["gate"].status == StageStatus.SUCCESS, (
+        "auto_status=true did not promote SKIPPED to SUCCESS — "
+        "spec §2.6 / Appendix C requires SUCCESS synthesis for no-status case"
+    )
+
+
+@pytest.mark.asyncio
+async def test_auto_status_quoted_true_promotes_skipped_a1(tmp_path):
+    """A1: auto_status set as the quoted string 'true' also recognizes SKIPPED.
+
+    DOT parser returns the string "true" for quoted attribute values.
+    The engine must accept both True (bool) and "true" (string).
+    """
+    # Construct node with string "true" stored in the auto_status field directly
+    node = Node(id="gate", shape="box", prompt="do work")
+    # Simulate the DOT-quoted form: the parser returns "true" as a string,
+    # which gets promoted to the auto_status field as a string.
+    object.__setattr__(node, "auto_status", "true")
+
+    graph = Graph(
+        name="test_a1_quoted",
+        nodes={
+            "start": Node(id="start", shape="Mdiamond"),
+            "gate": node,
+            "exit": Node(id="exit", shape="Msquare"),
+        },
+        edges=[
+            Edge(from_node="start", to_node="gate"),
+            Edge(from_node="gate", to_node="exit"),
+        ],
+    )
+    ctx = PipelineContext()
+    engine = PipelineEngine(
+        graph=graph,
+        context=ctx,
+        handler_registry=HandlerRegistry(HandlerContext(backend=_SkippedBackend())),
+        logs_root=str(tmp_path),
+    )
+    await engine.run()
+    assert engine.node_outcomes["gate"].status == StageStatus.SUCCESS, (
+        "auto_status='true' (quoted string form) did not promote SKIPPED to SUCCESS"
+    )
+
+
+# ---------------------------------------------------------------------------
+# A2 — goal_gate="true" (quoted) recognized by both lint and engine
+# ---------------------------------------------------------------------------
+
+
+def test_goal_gate_quoted_string_recognized_by_lint_a2():
+    """A2: validation lint fires for goal_gate='true' (quoted string form).
+
+    DOT quoted `goal_gate="true"` yields the string "true"; the lint rule
+    must treat it the same as the unquoted boolean True.
+    Spec §2.6 (goal_gate Boolean attribute).
+    """
+    # Build a node where goal_gate is the string "true" (quoted DOT form)
+    node = Node(id="quality_gate", shape="box", prompt="check")
+    object.__setattr__(node, "goal_gate", "true")  # simulate quoted DOT form
+
+    graph = Graph(
+        name="test_a2_lint",
+        nodes={
+            "start": Node(id="start", shape="Mdiamond"),
+            "quality_gate": node,
+            "exit": Node(id="exit", shape="Msquare"),
+        },
+        edges=[
+            Edge(from_node="start", to_node="quality_gate"),
+            Edge(from_node="quality_gate", to_node="exit"),
+        ],
+    )
+    diags = validate(graph)
+    rule_names = {d.rule for d in diags}
+    assert "goal_gate_has_retry" in rule_names, (
+        "Lint rule 'goal_gate_has_retry' did not fire for goal_gate='true' (quoted string). "
+        "Spec §2.6: goal_gate is Boolean; quoted 'true' must be recognized."
+    )
+
+
+@pytest.mark.asyncio
+async def test_goal_gate_quoted_string_enforced_by_engine_a2(tmp_path):
+    """A2: engine enforces goal_gate='true' (quoted string) at pipeline exit.
+
+    When a goal_gate node fails and goal_gate is the string "true", the engine
+    must mark the gate as unsatisfied and return FAIL — parity with bare True.
+    """
+
+    class AlwaysFailBackend:
+        async def run(self, node, prompt, context, incoming_edge=None, graph=None):
+            return Outcome(status=StageStatus.FAIL, failure_reason="gate fails")
+
+    # goal_gate as string "true" (simulates DOT quoted form)
+    gate_node = Node(id="quality_gate", shape="box", prompt="check")
+    object.__setattr__(gate_node, "goal_gate", "true")
+
+    graph = Graph(
+        name="test_a2_engine",
+        nodes={
+            "start": Node(id="start", shape="Mdiamond"),
+            "quality_gate": gate_node,
+            "exit": Node(id="exit", shape="Msquare"),
+        },
+        edges=[
+            Edge(from_node="start", to_node="quality_gate"),
+            Edge(from_node="quality_gate", to_node="exit", condition="outcome=fail"),
+        ],
+    )
+    ctx = PipelineContext()
+    engine = PipelineEngine(
+        graph=graph,
+        context=ctx,
+        handler_registry=HandlerRegistry(HandlerContext(backend=AlwaysFailBackend())),
+        logs_root=str(tmp_path),
+    )
+    final = await engine.run()
+    # The pipeline must fail because the goal gate is unsatisfied
+    assert final.status == StageStatus.FAIL, (
+        "Engine did not enforce goal_gate='true' (quoted string) — "
+        "pipeline returned SUCCESS despite a failing gate node"
+    )
+
+
+# ---------------------------------------------------------------------------
+# B6 — retry preset values match spec §3.5 table
+# ---------------------------------------------------------------------------
+
+
+def test_retry_preset_none_b6():
+    """B6: 'none' preset — 1 attempt, no retries."""
+    policy = RetryPolicy.from_preset("none")
+    assert policy.max_attempts == 1
+
+
+def test_retry_preset_standard_b6():
+    """B6: 'standard' preset — 5 attempts, 200ms initial, factor 2.0.
+
+    Spec §3.5: delays 200, 400, 800, 1600, 3200 ms.
+    """
+    policy = RetryPolicy.from_preset("standard")
+    assert policy.max_attempts == 5, (
+        f"standard preset: expected max_attempts=5, got {policy.max_attempts}"
+    )
+    # Default backoff: 200ms initial, factor 2.0
+    assert policy.backoff.initial_delay_ms == 200.0
+    assert policy.backoff.backoff_factor == 2.0
+    # Spot-check first-attempt delay (no jitter)
+    cfg_no_jitter = BackoffConfig(
+        initial_delay_ms=policy.backoff.initial_delay_ms,
+        backoff_factor=policy.backoff.backoff_factor,
+        jitter=False,
+    )
+    assert cfg_no_jitter.delay_for_attempt(1) == 200.0
+
+
+def test_retry_preset_aggressive_b6():
+    """B6: 'aggressive' preset — 5 attempts, 500ms initial, factor 2.0.
+
+    Spec §3.5: delays 500, 1000, 2000, 4000, 8000 ms.
+    """
+    policy = RetryPolicy.from_preset("aggressive")
+    assert policy.max_attempts == 5, (
+        f"aggressive preset: expected max_attempts=5, got {policy.max_attempts}"
+    )
+    assert policy.backoff.initial_delay_ms == 500.0, (
+        f"aggressive preset: expected initial_delay_ms=500, got {policy.backoff.initial_delay_ms}"
+    )
+    assert policy.backoff.backoff_factor == 2.0
+    cfg_no_jitter = BackoffConfig(
+        initial_delay_ms=policy.backoff.initial_delay_ms,
+        backoff_factor=policy.backoff.backoff_factor,
+        jitter=False,
+    )
+    assert cfg_no_jitter.delay_for_attempt(1) == 500.0
+
+
+def test_retry_preset_linear_b6():
+    """B6: 'linear' preset — 3 attempts, 500ms initial, factor 1.0 (fixed delay).
+
+    Spec §3.5: delays 500, 500, 500 ms.
+    """
+    policy = RetryPolicy.from_preset("linear")
+    assert policy.max_attempts == 3, (
+        f"linear preset: expected max_attempts=3, got {policy.max_attempts}"
+    )
+    assert policy.backoff.initial_delay_ms == 500.0, (
+        f"linear preset: expected initial_delay_ms=500, got {policy.backoff.initial_delay_ms}"
+    )
+    assert policy.backoff.backoff_factor == 1.0
+    cfg_no_jitter = BackoffConfig(
+        initial_delay_ms=policy.backoff.initial_delay_ms,
+        backoff_factor=policy.backoff.backoff_factor,
+        jitter=False,
+    )
+    assert cfg_no_jitter.delay_for_attempt(1) == 500.0
+    assert cfg_no_jitter.delay_for_attempt(2) == 500.0  # fixed
+
+
+def test_retry_preset_patient_b6():
+    """B6: 'patient' preset — 3 attempts, 2000ms initial, factor 3.0.
+
+    Spec §3.5: delays 2000, 6000, 18000 ms.
+    """
+    policy = RetryPolicy.from_preset("patient")
+    assert policy.max_attempts == 3, (
+        f"patient preset: expected max_attempts=3, got {policy.max_attempts}"
+    )
+    assert policy.backoff.initial_delay_ms == 2000.0, (
+        f"patient preset: expected initial_delay_ms=2000, got {policy.backoff.initial_delay_ms}"
+    )
+    assert policy.backoff.backoff_factor == 3.0, (
+        f"patient preset: expected backoff_factor=3.0, got {policy.backoff.backoff_factor}"
+    )
+    cfg_no_jitter = BackoffConfig(
+        initial_delay_ms=policy.backoff.initial_delay_ms,
+        backoff_factor=policy.backoff.backoff_factor,
+        jitter=False,
+    )
+    assert cfg_no_jitter.delay_for_attempt(1) == 2000.0
+    assert cfg_no_jitter.delay_for_attempt(2) == 6000.0
+    assert cfg_no_jitter.delay_for_attempt(3) == 18000.0
+
+
+# ---------------------------------------------------------------------------
+# B7 — fan_in publishes spec key parallel.fan_in.best_outcome
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fan_in_publishes_best_outcome_key_b7(tmp_path):
+    """B7: fan_in writes parallel.fan_in.best_outcome to context.
+
+    Spec §4.8 (attractor-spec.md:876): the canonical key is
+    ``parallel.fan_in.best_outcome``.  The implementation also keeps the
+    legacy ``parallel.fan_in.best_status`` for compatibility; both must be
+    present after fan_in executes.
+    """
+    handler = FanInHandler()
+    node = Node(id="fan_in", shape="tripleoctagon")
+    graph = Graph(name="test_b7", nodes={"fan_in": node}, edges=[])
+    ctx = PipelineContext()
+    ctx.set(
+        "parallel.results",
+        [{"node_id": "branch_a", "status": "success", "notes": ""}],
+    )
+
+    outcome = await handler.execute(node, ctx, graph, str(tmp_path))
+
+    assert outcome.status == StageStatus.SUCCESS, (
+        f"fan_in handler failed unexpectedly: {outcome}"
+    )
+
+    # Spec key must be present in context
+    best_outcome_ctx = ctx.get("parallel.fan_in.best_outcome")
+    assert best_outcome_ctx is not None, (
+        "fan_in did not set 'parallel.fan_in.best_outcome' in context — "
+        "spec §4.8 requires this key"
+    )
+    assert best_outcome_ctx == "success", (
+        f"parallel.fan_in.best_outcome expected 'success', got {best_outcome_ctx!r}"
+    )
+
+    # Spec key must also appear in context_updates
+    assert outcome.context_updates is not None
+    assert "parallel.fan_in.best_outcome" in outcome.context_updates, (
+        "fan_in did not include 'parallel.fan_in.best_outcome' in Outcome.context_updates"
+    )
+    assert outcome.context_updates["parallel.fan_in.best_outcome"] == "success"
+
+    # Legacy key still present (backward compat)
+    assert ctx.get("parallel.fan_in.best_status") == "success", (
+        "fan_in removed legacy 'parallel.fan_in.best_status' — it must be kept for compat"
+    )


### PR DESCRIPTION
Four spec-conformance fixes from a full audit of the upstream attractor nlspec (`strongdm/attractor@fb57a55`). **Every fix was impact-analyzed against the resolver (`amplifier-resolver-dot-graph`) and bundle .dot corpora and confirmed to have zero behavioral blast radius** — these features are either unused or used only in the bare/correct form. Each ships with a regression test.

### A1 — fail-loud: `auto_status` no longer masks failures
Per spec §2.6 / Appendix C ([L163](https://github.com/strongdm/attractor/blob/fb57a55ed97372a27ac90102f436947e29f48426/attractor-spec.md#L163), [L2078](https://github.com/strongdm/attractor/blob/fb57a55ed97372a27ac90102f436947e29f48426/attractor-spec.md#L2078)), `auto_status` synthesizes SUCCESS **only when the handler writes no status** (SKIPPED). The old code promoted *any* non-success — silently turning explicit FAIL/RETRY into SUCCESS. Now FAIL and RETRY pass through. Also: `execute_with_retry` returns SKIPPED immediately (matching its own docstring), and the quoted `auto_status="true"` form is accepted.

### A2 — `goal_gate="true"` (quoted) honored
[Spec §2.6 L153](https://github.com/strongdm/attractor/blob/fb57a55ed97372a27ac90102f436947e29f48426/attractor-spec.md#L153). Both the lint rule and the engine used `is True`, so the quoted form was a silently inert gate. Now accepts `True` or `"true"` (same fix pattern as EXTENSIONS §14 for `allow_partial`).

### B6 — retry presets match the spec table
[Spec §3.5 L554-560](https://github.com/strongdm/attractor/blob/fb57a55ed97372a27ac90102f436947e29f48426/attractor-spec.md#L554): `standard`=5; `aggressive`=500ms; `linear`=500ms/1.0; `patient`=3/2000ms/3.0. (No pipeline uses named presets — pure correctness.)

### B7 — fan_in publishes the spec key
[Spec §4.8 L876](https://github.com/strongdm/attractor/blob/fb57a55ed97372a27ac90102f436947e29f48426/attractor-spec.md#L876): adds `parallel.fan_in.best_outcome` alongside the legacy `best_status` (non-breaking; no consumer reads either today).

### Verification
Full `modules/loop-pipeline/tests/` suite: **1189 passed, 7 skipped, 0 failures**. New `test_spec_conformance_batch.py` (12 tests).

### Also included — a decision doc, not a fix
`docs/designs/b3-outcome-vs-preferred-label-decision.md` records B3: the engine resolves `outcome` to `preferred_label || status`, which diverges from spec but is **load-bearing** for custom-label routing and tangled with an active (self-documented) dead-`outcome=fail`-edge bug in resolver pipelines. It must NOT be blind-fixed — it needs a coordinated decision with the resolver owners. Recorded here; no code change.