### PR TITLE
fix(loop-pipeline): edge selection Steps 2 & 3 consider only unconditional edges (spec §3.3)

### DIFF
--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/edge_selection.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/edge_selection.py
@@ -46,17 +46,20 @@ def select_edge(
         return _best_by_weight_then_lexical(condition_matched)
 
     # Step 2: Preferred label match
+    # Spec §3.3 Step 2: only UNCONDITIONAL edges are eligible — a conditional
+    # edge whose condition failed in Step 1 must NOT be selected here by label.
     if outcome.preferred_label:
         norm_pref = _normalize_label(outcome.preferred_label)
         for e in edges:
-            if e.label and _normalize_label(e.label) == norm_pref:
+            if not e.condition and e.label and _normalize_label(e.label) == norm_pref:
                 return e
 
     # Step 3: Suggested next IDs
+    # Spec §3.3 Step 3: only UNCONDITIONAL edges are eligible (same rationale).
     if outcome.suggested_next_ids:
         for suggested_id in outcome.suggested_next_ids:
             for e in edges:
-                if e.to_node == suggested_id:
+                if not e.condition and e.to_node == suggested_id:
                     return e
 
     # Step 4 & 5: Weight with lexical tiebreak (unconditional edges only)

--- a/modules/loop-pipeline/tests/test_edge_selection.py
+++ b/modules/loop-pipeline/tests/test_edge_selection.py
@@ -61,6 +61,40 @@ def test_preferred_label_match():
     assert selected.to_node == "B"
 
 
+def test_step2_skips_conditional_edge_with_matching_label():
+    """Spec §3.3 Step 2: a conditional edge whose condition FAILED in Step 1 must
+    NOT be selected by preferred_label match (B4 — only unconditional edges)."""
+    edges = [
+        Edge("A", "B", condition="outcome=fail", label="go"),  # condition false on SUCCESS
+        Edge("A", "C"),  # unconditional fallback
+    ]
+    graph = _make_graph(edges)
+    outcome = Outcome(status=StageStatus.SUCCESS, preferred_label="go")
+    selected = select_edge("A", outcome, PipelineContext(), graph)
+    assert selected is not None
+    assert selected.to_node == "C", (
+        f"Step 2 selected condition-false edge by label (got {selected.to_node}); "
+        "spec §3.3 Step 2 considers only unconditional edges"
+    )
+
+
+def test_step3_skips_conditional_edge_with_matching_target():
+    """Spec §3.3 Step 3: a conditional edge whose condition FAILED must NOT be
+    selected by suggested_next_ids match (B4 — only unconditional edges)."""
+    edges = [
+        Edge("A", "B", condition="outcome=fail"),  # condition false on SUCCESS
+        Edge("A", "C"),  # unconditional fallback
+    ]
+    graph = _make_graph(edges)
+    outcome = Outcome(status=StageStatus.SUCCESS, suggested_next_ids=["B"])
+    selected = select_edge("A", outcome, PipelineContext(), graph)
+    assert selected is not None
+    assert selected.to_node == "C", (
+        f"Step 3 selected condition-false edge by target id (got {selected.to_node}); "
+        "spec §3.3 Step 3 considers only unconditional edges"
+    )
+
+
 def test_label_normalization():
     """Labels normalized: lowercase, strip accelerators (ESEL-004)."""
     edges = [Edge("A", "B", label="[Y] Tests Pass")]


### PR DESCRIPTION
Per upstream nlspec §3.3 ([attractor-spec.md#L412](https://github.com/strongdm/attractor/blob/fb57a55ed97372a27ac90102f436947e29f48426/attractor-spec.md#L412)), edge-selection **Step 2** (preferred_label match) and **Step 3** (suggested_next_ids match) must consider only **unconditional** edges. The implementation iterated *all* edges, so a conditional edge whose condition **failed** in Step 1 could still be selected by label or target id — silently bypassing its own condition.

**Fix:** add a `not e.condition` guard to both loops in `edge_selection.py`, matching the spec pseudocode exactly.

**Impact-verified zero blast radius:** swept all `.dot` files in `amplifier-bundle-attractor` and `amplifier-resolver-dot-graph`. No pipeline relies on the old behavior — the guard only changes routing when a condition-*false* edge would otherwise be picked by label/id, which no pipeline depends on (resolver routes via condition/Step 1). The full suite stays green, confirming no fixture (incl. `semport.dot`) relied on it.

**Tests:** two regression tests proving Steps 2 and 3 skip condition-false edges. Full `modules/loop-pipeline/tests/` suite: **1191 passed, 7 skipped, 0 failures**.