### PR TITLE
feat(attractor): engine runtime-semantics reference + route .dot authoring to attractor-expert

### DIFF
--- a/agents/attractor-expert.md
+++ b/agents/attractor-expert.md
@@ -2,17 +2,23 @@
 meta:
   name: attractor-expert
   description: >
-    Attractor pipeline design expert and DOT authoring consultant. Use PROACTIVELY
-    when working with Attractor pipelines, DOT graph syntax, pipeline debugging,
-    or programmatic integration.
+    Attractor pipeline design AND authoring expert — the authority on the SHIPPED
+    engine's runtime semantics (routing, substitution, verdict contract, fail-loud
+    behavior), not just DOT syntax. Use PROACTIVELY when working with Attractor
+    pipelines, DOT graph syntax, pipeline debugging, or programmatic integration.
 
     MUST be used when:
-    - Designing or authoring DOT pipeline graphs
+    - Designing OR authoring/editing any .dot pipeline graph — do this BEFORE
+      handing pipeline implementation to a generic builder (e.g. modular-builder).
+      Generic builders carry no attractor engine semantics and will re-discover
+      the foot-guns the hard way.
     - Debugging pipeline failures or unexpected routing
     - Integrating Attractor pipelines into Python applications
     - Choosing between pipeline patterns (linear, parallel, conditional, etc.)
     - Understanding fidelity modes, model stylesheets, or handler types
     - Working with the attractor bundle configuration
+
+    Consult at design START, mid-build, and final review — not once.
 
     Examples:
 
@@ -51,8 +57,13 @@ multi-stage AI workflows built on Amplifier.
 
 ## Your Knowledge Base
 
-You have deep knowledge loaded from these references:
+You have deep knowledge loaded from these references. **Start with the engine
+runtime semantics — it is the source of truth for how the SHIPPED engine actually
+behaves (routing, verdict contract, fail-loud), including the points where it
+diverges from the spec prose. Reasoning from DOT syntax or the spec alone makes you
+confidently wrong about the running engine.**
 
+@attractor:context/engine-semantics.md
 @attractor:docs/DOT-SYNTAX.md
 @attractor:docs/DOT-AUTHORING-GUIDE.md
 @attractor:docs/APP-INTEGRATION-GUIDE.md

--- a/context/engine-semantics.md
+++ b/context/engine-semantics.md
@@ -1,0 +1,157 @@
+# Attractor Engine Runtime Semantics (SHIPPED engine)
+
+Runtime semantics of the **SHIPPED** engine (`AmplifierBackend`), above DOT syntax.
+Where this diverges from the nlspec prose, the **SHIPPED behavior wins**. Each fact is
+cited (`file:line` in `modules/loop-pipeline/amplifier_module_loop_pipeline/`, or nlspec
+`§`). Re-validate any fact whose cite breaks — a broken cite means the engine moved and
+this file is stale.
+
+Cites are relative to `modules/loop-pipeline/amplifier_module_loop_pipeline/`.
+nlspec = `attractor/attractor-spec.md`.
+
+---
+
+## 1. Node-type → handler capability table
+
+Source: nlspec §2.8; `validation.py:24-34` (`SHAPE_TO_HANDLER`).
+
+| shape | handler | LLM? | runs code? | set context / route? | tag |
+|---|---|---|---|---|---|
+| `Mdiamond` | `start` | no | no | no (no-op SUCCESS) `handlers/start.py` | [NLSPEC] |
+| `Msquare` | `exit` | no | no | no (engine checks goal gates) `handlers/exit.py` | [NLSPEC] |
+| `box` | `codergen` | **yes** | no | **YES via backend** (JSON / `report_outcome`) `backend.py:604-637` | [NLSPEC] |
+| `diamond` | `conditional` | no | no | no-op SUCCESS; engine routes `handlers/conditional.py` | [NLSPEC] |
+| `hexagon` | `wait.human` | no | no | yes — `suggested_next_ids` + `human.gate.*` `handlers/human.py` | [NLSPEC] |
+| `component` | `parallel` | no (orchestrates) | no | emits `branch.{i}.outcome` `handlers/parallel.py` | [NLSPEC] |
+| `tripleoctagon` | `parallel.fan_in` | **yes if `prompt` set** | no | yes `handlers/fan_in.py` (§4.9) | [NLSPEC] |
+| `parallelogram` | `tool` | no | **yes (shell)** | yes — `tool.output` + `tool.last_line` `handlers/tool.py` | [NLSPEC] |
+| `house` | `stack.manager_loop` | no | orchestrates child | experimental ("future form TBD" `validation.py:33`) | [EXTENSION] |
+| `folder` | `pipeline` | no (runs child graph) | no | yes — merges child `outputs=` back `handlers/pipeline.py` | [EXTENSION] |
+
+Handler resolution: explicit `type` attr → shape mapping → default `codergen` (nlspec §4.2;
+`node_outputs.py:83-89`).
+
+---
+
+## 2. ★ THE DELTA LIST — engine does X, NOT Y (spec says Y) ★
+
+**HIGHEST-VALUE SECTION.** The nlspec prose describes the *pure* handlers; the *shipped*
+`AmplifierBackend` behaves differently. Reasoning from the spec here makes you confidently
+wrong about the running engine.
+
+1. **`box`/codergen nodes CAN route and set context.** Spec §4.5 shows `CodergenHandler`
+   returning hard-coded SUCCESS. SHIPPED: the backend maps the LLM result to a full
+   `Outcome` (status, `context_updates`, `preferred_label`, `suggested_next_ids`) via
+   (a) a response that is entirely JSON → `_parse_outcome` (`backend.py:903`), or
+   (b) the child calling the **`report_outcome` tool** → `_find_report_outcome_call`
+   (`backend.py:621,827-890`). LLM nodes are NOT routing-inert.
+
+2. **FAIL is fail-fast — it does NOT traverse plain edges.** Spec §3.2 pseudocode advances
+   on any selected edge. SHIPPED (`edge_selection.py:79-101`): on `status==FAIL`, plain
+   unconditional edges are skipped. FAIL routes ONLY via `condition="outcome=fail"`, a
+   downstream node with `runs_on=always|failure`, or `retry_target`/`fallback_retry_target`
+   (§3.7); else the branch halts FAIL. (This is the §3.7 fix merged this session.)
+
+3. **Dotted context keys DO expand** in `tool_command` / `tool_env` / `description`
+   (`substitution.py:90-103`, M5) — `${tool.output}`, `$tool.output` both resolve. The
+   old "dotted keys not expanded" belief is stale. **CAVEAT:** they do NOT expand inside a
+   codergen `prompt` — prompts only expand `$goal`, `$context`, and *plain* (non-dotted)
+   keys (`codergen.py:144-173`).
+
+4. **Tool CWD = `context.target_dir` → `graph.source_dir` → process default** — NOT the
+   engine dir (`tool.py:116-123`). Set `context.target_dir` for the job dir; no `${JOB_DIR}`
+   injection needed.
+
+5. **Verdict fences are tolerated.** Spec implies strict bare JSON. SHIPPED strips
+   ` ```json … ``` ` fences before parsing (`backend.py:614-618,925-927`). (The real
+   foot-gun is prose-before-JSON — see §6.)
+
+6. **No backend / no `llm_model` now RAISE (fail-loud), not silently degrade.**
+   `CodergenHandler` with no backend raises (`codergen.py:88-92`); `_resolve_model` raises
+   with no `llm_model` (`backend.py:772`). The old "silent DirectProviderBackend / silent
+   default model" modes are closed.
+
+7. **Invalid `fidelity=` warns, not silently defaults.** `fidelity.py:78,94,109,192` (M-22)
+   logs a warning then falls back to `compact`.
+
+---
+
+## 3. Routing contract
+
+Source: `edge_selection.py`; `handlers/tool.py`; nlspec §3.3, §3.7, §10.
+
+- **Token channel:** route a tool node via `condition="context.tool.last_line=<token>"`.
+  `tool.last_line` = last non-empty stripped stdout line (`tool.py:210-219`).
+  `tool.output` = **full stdout** (`tool.py:177`) — conditioning on it silently never matches.
+- **Bare-token condition** = truthy lookup: `condition="context.flag"` is true iff the value
+  is non-empty (nlspec §10.5; `conditions.py`).
+- **5-step selection** (§3.3; `edge_selection.py:39-101`): condition-match → `preferred_label`
+  (unconditional edges only) → `suggested_next_ids` (unconditional only) → highest `weight`
+  → **lexical tiebreak on target id**. The lexical tiebreak is silent but specified —
+  >1 unconditional edge from one node picks lexically-first.
+- **Tool non-zero exit → FAIL** (`tool.py:156-174`); needs an explicit FAIL route per #2 above.
+- **No edge selected & outcome≠FAIL → branch terminates SUCCESS** (nlspec §3.2 step 6). It
+  does NOT hard-fail `no_matching_edge` and does NOT loop. "Every LLM node needs an
+  unconditional fallback" is an authoring/lint discipline, not a runtime hard-fail. [MEDIUM]
+
+---
+
+## 4. Substitution + CWD
+
+Source: `substitution.py`; `node_outputs.py:68-75`; `handlers/tool.py:116-123`.
+
+- Both `$key` and `${key}` resolve, including dotted keys. `$$` → literal `$`.
+- **Substitutable attrs only:** `tool_command`, `prompt`, `description`, `tool_env`
+  (`SUBSTITUTABLE_ATTRS`, `node_outputs.py:68`). Other attrs are not scanned.
+- **Prompt caveat (repeat of delta #3):** dotted keys do NOT expand in `prompt`; only
+  `$goal`, `$context`, plain keys do (`codergen.py:144-173`).
+- **Absent key → literal token survives** (`substitution.py:11`, intentional pass-through).
+  Under `set -eu` bash this dies "unbound variable". **Defense:** shell default
+  `${var:-fallback}` in the `tool_command`.
+- **CWD:** `context.target_dir` → `graph.source_dir` (the `.dot`'s dir) → process default.
+
+---
+
+## 5. Verdict contract
+
+Source: `backend.py:604-637, 903-951`.
+
+- A verdict status is taken from the response **only if the entire stripped response is a
+  JSON object** (`stripped.startswith("{")`) or a ` ```json ``` ` fenced block
+  (`backend.py:614-618`). Not "JSON on the last line" — the **whole** message.
+- **KNOWN OPEN BUG (fix planned — design Track 3A):** prose-then-JSON → `startswith("{")` is false → falls
+  through to `report_outcome` args → else **plain prose → silently coerced to SUCCESS**
+  (`backend.py:632-637, 947-951`). A model that "explains, then emits JSON" has its verdict
+  silently dropped. Empty response → FAIL.
+- **Robust path:** have the node call the **`report_outcome` tool** rather than emit
+  free-text JSON.
+
+---
+
+## 6. Remaining real foot-guns
+
+- **`last_response` inter-node carry is ~200 chars** under every fidelity mode except `full`
+  — the truncation is in the handler writing the key (`codergen.py:137`, `response_text[:200]`),
+  not in `compact` specifically. `compact`/`truncate` preambles surface that short key;
+  **`full` bypasses it** via stored transcripts (`backend.py:643-704`). Need the full prior
+  text downstream? Use `fidelity=full`.
+- **`folder`/subgraph checkpoint reuse across loop iterations** `[UNVERIFIED]` — child logs
+  use a node-id-keyed path `subgraph_<node.id>` (`pipeline.py:167`); a folder re-entered in a
+  loop reuses the same child log/checkpoint dir and may restore stale completed-state (the
+  "skips all but the 1st source" symptom). Child-engine resume gate not yet traced; repro
+  `prove_folder_failure.py` pending. Treat as open until confirmed.
+
+---
+
+## 7. Golden Rules
+
+1. **Every inference is an `llm`/`box` node.** Never call `unified_llm` directly, never
+   drop to Python for model calls.
+2. **Code nodes (`parallelogram`/tool) are glue only** — shell/IO/orchestration, not inference.
+3. **Copy the nearest proven pipeline before inventing.** Simplicity applies to the proven
+   pattern, not to a minimal node count built on a wrong engine model.
+4. **Route verdicts via the `report_outcome` tool, not free-text JSON** (§5 bug).
+5. **Run `dot_graph validate` after every edit** — catches isolated nodes, stray quotes,
+   missing fallback edges before an expensive rebuild.
+6. **Author for fail-loud:** explicit FAIL edges (§2 #2), explicit `llm_model`, explicit
+   `${var:-default}` in shell.

--- a/context/pipeline-awareness.md
+++ b/context/pipeline-awareness.md
@@ -98,6 +98,17 @@ When `run_pipeline` returns, the result contains:
 Read the result and tell the user what happened. Do NOT call any follow-up tools
 related to the pipeline — it is already complete.
 
+## Authoring or editing a pipeline? Consult attractor-expert FIRST
+
+Before handing any `.dot` authoring/editing — or any "build an LLM workflow" task —
+to a generic builder (modular-builder, a self-spawn, or inline Python), delegate to
+`attractor:attractor-expert` for BOTH the design and the authoring. Generic builders
+carry **no** attractor engine runtime semantics and will re-discover the foot-guns the
+hard way (routing on `tool.output` vs `last_line`, missing FAIL edges, prose-vs-JSON
+verdicts, `tool_command` CWD, folder checkpoint reuse). The engine's actual runtime
+behavior — including where it diverges from the spec prose — is in
+`@attractor:context/engine-semantics.md`.
+
 ## Deep Questions
 
 For deep pipeline design questions, DOT syntax details, debugging pipeline

--- a/docs/designs/attractor-pipeline-authoring-friction.md
+++ b/docs/designs/attractor-pipeline-authoring-friction.md
@@ -1,0 +1,101 @@
+# Design — Closing the Attractor Pipeline-Authoring Friction
+
+**Status:** PROPOSED (design only — not implemented)
+**Source:** cross-session friction analysis (`analysis/session-friction/SYNTHESIS.md`, 4 sessions × 2 lenses) → 3 expert consults (bundle-design-expert, foundation-expert, attractor-expert) → reviewed through restless-old-brian / cranky-old-sam / crusty-old-engineer.
+
+---
+
+## 0. The critical correction (validate-before-build paid off)
+
+The friction reports were snapshots; **the engine has since moved — much of it from the fail-loud conformance work merged THIS session.** The attractor-expert re-validated every "engine fact" against the live code. Result:
+
+| Synthesis "foot-gun" | Reality (attractor-expert, cited) |
+|---|---|
+| box/LLM nodes have no `report_outcome`, can't set context/labels | **STALE** — true of pure nlspec §4.5, false of the shipped `AmplifierBackend`: box nodes route via bare-JSON response **or** the `report_outcome` tool (`backend.py:621,827`) |
+| silent alphabetical edge fallback → infinite loop on FAIL | **FIXED** — FAIL is now fail-fast (`edge_selection.py:79-101`, our §3.7 work) |
+| dotted keys not expanded; `tool_command` CWD = engine dir | **STALE** — `$key`/`${key}` incl. dotted now resolve in tool_command/tool_env/description; CWD = `target_dir → source_dir → default` (`tool.py:116-123`) |
+| silent DirectProviderBackend fallback (no-tools false-positive) | **MOSTLY CLOSED** — no backend now raises (`codergen.py:88`); no `llm_model` raises (`backend.py:772`); FAILs if neither path available |
+| invalid `fidelity=` silently defaults | **FIXED** — now warns (`fidelity.py:192`) |
+
+**Net: of the ~12 foot-guns, 4 are already fixed (this session), several "facts" were stale, 2 are genuine open bugs.** Had we documented the reports verbatim we'd have shipped a reference describing already-fixed bugs as live. This is the whole reason for the persona+expert pass.
+
+---
+
+## 1. The cut (COSam)
+
+~15 synthesis recommendations + 3 expert proposals → **5 changes in 3 tracks.** What we explicitly did NOT do:
+
+| Cut | Why |
+|---|---|
+| New "attractor authoring" **skill** | Skills are on-demand; the agent can write a foot-gun before deciding to load it. Engine semantics must fire **unconditionally at spawn** → use @-mention, not a skill. (We already have `dot-syntax`/`dot-patterns`/`dot-quality`/`dot-graph-intelligence` — enrich, don't add.) |
+| New **mode** | A mode enforces *tool policy*; "every LLM call is an `llm` node" is a *semantic design rule*. Modes also carry adoption friction. The context file + lint cover it. |
+| Separate `attractor-author` **agent** | **DEFER (YAGNI).** attractor-expert already holds the knowledge; give it the authoring role too. Split into a `coding`-role worker only if authoring volume/model-role mismatch proves it. (Open decision #1.) |
+| Edit `foundation:behaviors/agents` delegation table | Taxes **every** ecosystem session for attractor-only work. Use the attractor bundle's own already-loaded awareness file instead. |
+| Routing-matrix "demote modular-builder on .dot keywords" | **Folklore.** routing-matrix maps `model_role → model`; it has **no agent-selection / keyword mechanism.** Do not build on it. |
+| Durable-design-memory mechanism (synthesis D3) | Higher ceremony; defer until week-long sessions are common. |
+| Enrich general `dot-graph:dot-author` | Different domain (general Graphviz vs attractor engine). It was used 0× in the friction sessions anyway. |
+| Standalone authority-demarcation artifact (Theme 5) | Folded into provenance tags inside the one context file. |
+
+---
+
+## 2. The design — 3 tracks, 5 changes
+
+### TRACK 1 — KNOWLEDGE (kills Themes 1, 4, 5 — highest leverage)
+
+**1A. New `amplifier-bundle-attractor/context/engine-semantics.md`** (tight, ~2–4k tokens, every fact source-cited `file:line`/`§`). Sections:
+- **Node-type → handler capability table** with `[NLSPEC]` / `[EXTENSION]` provenance tags (e.g. `folder`/`pipeline` and `tool.last_line` are extensions).
+- **The "engine does X, NOT Y (spec says Y)" delta list** — the ~7 points where the shipped `AmplifierBackend` diverges from nlspec prose. *attractor-expert: this is the single highest-value piece — it's exactly where a spec-reading agent goes confidently wrong.*
+- Routing contract (`tool.last_line` token channel vs `tool.output` full stdout; bare-token truthy; FAIL fail-fast per §3.7; lexical tiebreak).
+- Substitution + CWD (which attrs substitute; dotted-in-prompt caveat; `${var:-default}` defense; `target_dir` CWD).
+- Verdict contract (response must be **entirely** JSON or use the `report_outcome` tool; prose-then-JSON is silently coerced — see 3A).
+- Remaining real foot-guns (fidelity 200-char `last_response` carry → use `fidelity=full`; folder checkpoint reuse — see 3B).
+- **Golden Rules** (Theme 2): every inference is an `llm`/`box` node; never direct `unified_llm` / drop-to-python; code nodes are glue; copy the nearest proven pipeline before inventing; route verdicts via `report_outcome`, not free-text JSON.
+
+**1B. @-mention `engine-semantics.md` into `agents/attractor-expert.md`** and give attractor-expert the explicit **design + authoring** remit for attractor `.dot` work (it already carries the knowledge; the context-sink loads it fresh on every spawn — compaction-immune, the Theme-4 fix).
+
+### TRACK 2 — ROUTING (kills Theme 3 — near-zero cost)
+
+**2A. Strengthen `context/pipeline-awareness.md`** (already in `context.include` via `attractor-core` → ~0 added tokens). Add an explicit "Before delegating pipeline implementation" block: attractor/`.dot`/pipeline/LLM-workflow work → **consult attractor-expert as Step 0** (design + author) *before* any generic builder; state plainly "modular-builder has no attractor engine semantics and will re-discover foot-guns." (foundation-expert: this is the highest-reliability lever because it's already loaded and fires before the generic implementation path.)
+
+**2B. Strengthen `attractor-expert` meta.description** — MUST be consulted at **design → mid-build → review** (not once); prefer over modular-builder when attractor/`.dot` keywords present. (Secondary reinforcement; real but fires late on its own.)
+
+### TRACK 3 — ENGINE FAIL-LOUD + LINT (kills the silent residue of Themes 1, 6 — REAL, provable, continues merged work)
+
+**3A. FIX-LOUD: verdict prose+JSON silently coerced to SUCCESS** (`backend.py:632-637,947`). A node *asked* for a verdict whose response yields no parseable status should emit FAIL / `PIPELINE_NODE_CONTRACT_VIOLATION`, not SUCCESS. Same family as the `auto_status` fix already merged. Cheap — the parser already knows it found neither JSON nor `report_outcome`.
+
+**3B. FIX-LOUD (verify first): folder/subgraph checkpoint reuse across loop iterations** (`pipeline.py:167`, child logs keyed only on node id). Iteration 2+ can restore iteration 1's checkpoint → silently skips real work. **Repro already exists** in the workspace (`prove_folder_failure.py`). Confirm, then namespace child logs by iteration (or detect a re-entered folder checkpoint and clear/warn). Mark OPEN until the repro is run.
+
+**3C. Promote `test_pipeline_lint.py` to a shipped gate** with: `condition=context.tool.output=` mis-use (vs `last_line`); isolated nodes; >1 unconditional edge from one node (warn); prose-before-JSON verdict. (attractor-expert: most remaining foot-guns are DOCUMENT + warn-level lint, not engine changes — keeps the engine-change surface small.)
+
+---
+
+## 3. Sequencing (ROB — provable first, real over speculative)
+
+1. **3B verify** — run `prove_folder_failure.py` (cheap, confirms the one genuinely-open bug before any code change).
+2. **1A `engine-semantics.md` + 1B @-mention** — the highest-leverage knowledge change; turns S4's "one good upfront briefing pre-empts every foot-gun" into a default.
+3. **2A + 2B routing** — near-zero cost; do alongside Track 1.
+4. **3A + 3B fix + 3C lint** — the engine fail-loud batch; same track as the §3.7 / auto_status / goal_gate fixes already merged. Each independently shippable + provable, with a test.
+
+Each track is independently shippable. Track 1+2 are doc/agent-only (low risk). Track 3 is code with tests (the fail-loud line we've already been holding).
+
+---
+
+## 4. Open decisions (need a call)
+
+1. **Separate `attractor-author` (coding-role worker) vs attractor-expert (reasoning) doing both.** Recommend: **defer** — start with attractor-expert dual-role; split only if authoring volume or a reasoning-vs-coding model mismatch shows up.
+2. **Home repo for `engine-semantics.md`** — recommend `amplifier-bundle-attractor/context/` (where the engine + most changes live). Confirm vs resolver-dot-graph.
+3. **Stale facts in `SYNTHESIS.md` / friction reports** — recommend a one-line "corrected against live engine — see engine-semantics.md" pointer rather than rewriting the reports.
+
+---
+
+## 5. Traceability — change → friction killed
+
+| Change | Theme(s) | Evidence |
+|---|---|---|
+| 1A engine-semantics.md (esp. X-not-Y delta) | 1, 5 | every session; the stale-fact corrections above |
+| 1B @-mention into attractor-expert (context sink) | 4 | S2 "didn't survive as a live belief"; S1 per-subsession re-reads |
+| 2A pipeline-awareness Step-0 routing | 3 | S2 3.7% specialist use; S1/S3 0 specialist calls |
+| 2B meta.description cadence | 3 | reactive consultation clusters |
+| 3A verdict fail-loud | 1 | S3 prose-not-JSON verdict; same class as auto_status |
+| 3B folder checkpoint | 1 | S3 F13 (stale subgraph restore); `prove_folder_failure.py` |
+| 3C lint gate | 1, 6 | S1 routing-condition class (3× hand-fixed); S4 isolated node / stray quote |


### PR DESCRIPTION
First tranche (Tracks 1+2: Knowledge + Routing) of the attractor pipeline-authoring friction design (`docs/designs/attractor-pipeline-authoring-friction.md`). **Docs/agents/context only — no code.**

### Problem
Cross-session friction analysis showed attractor pipeline authoring kept requiring the user as the engine-semantics oracle: authoring went to generic builders that carry DOT syntax but NOT the engine's runtime semantics, so they re-discovered the same foot-guns (routing on `tool.output` vs `last_line`, missing FAIL edges, prose-vs-JSON verdicts, `tool_command` CWD, folder checkpoint reuse) the hard way.

### Changes
- **`context/engine-semantics.md` (new):** tight, source-cited reference for the SHIPPED engine's runtime behavior. Centerpiece is the **"engine does X, NOT Y (spec says Y)" delta list** — where the shipped backend diverges from the nlspec prose. Every fact cites `file:line`/`section`.
- **`agents/attractor-expert.md`:** @-mentions `engine-semantics.md` (context-sink, loads fresh on every spawn — the persistence fix); meta.description now claims design + authoring with a design->mid->review cadence.
- **`context/pipeline-awareness.md`:** adds a "consult attractor-expert FIRST" routing block.

### Validate-before-build paid off
We re-checked every documented foot-gun against the live engine first. ~4 are already fixed (the section-3.7 / auto_status / goal_gate fail-loud work merged this session) and several "facts" were stale. The reference reflects current behavior and tags the one genuinely-open item (folder checkpoint reuse) `[UNVERIFIED]`.

Engine fail-loud fixes (verdict-coercion, folder-checkpoint repro+fix, lint) follow in a separate code PR.