### PR TITLE
fix(loop-pipeline): fail-loud on prose-wrapped verdicts and folder checkpoint reuse

### DIFF
--- a/context/engine-semantics.md
+++ b/context/engine-semantics.md
@@ -119,10 +119,11 @@ Source: `backend.py:604-637, 903-951`.
 - A verdict status is taken from the response **only if the entire stripped response is a
   JSON object** (`stripped.startswith("{")`) or a ` ```json ``` ` fenced block
   (`backend.py:614-618`). Not "JSON on the last line" — the **whole** message.
-- **KNOWN OPEN BUG (fix planned — design Track 3A):** prose-then-JSON → `startswith("{")` is false → falls
-  through to `report_outcome` args → else **plain prose → silently coerced to SUCCESS**
-  (`backend.py:632-637, 947-951`). A model that "explains, then emits JSON" has its verdict
-  silently dropped. Empty response → FAIL.
+- **Prose-then-JSON recovery (FIXED):** if a response is prose with a trailing/embedded JSON
+  verdict object, the engine now extracts the LAST balanced `{...}` and, if it carries a recognized
+  `status`, HONORS it (with a logged warning) instead of coercing to SUCCESS (`backend.py:947-994`).
+  An explicit FAIL/RETRY is no longer silently dropped. Empty response → FAIL. (Still prefer pure
+  JSON / `report_outcome` — the recovery is a safety net, not a contract.)
 - **Robust path:** have the node call the **`report_outcome` tool** rather than emit
   free-text JSON.
 
@@ -135,11 +136,12 @@ Source: `backend.py:604-637, 903-951`.
   not in `compact` specifically. `compact`/`truncate` preambles surface that short key;
   **`full` bypasses it** via stored transcripts (`backend.py:643-704`). Need the full prior
   text downstream? Use `fidelity=full`.
-- **`folder`/subgraph checkpoint reuse across loop iterations** `[UNVERIFIED]` — child logs
-  use a node-id-keyed path `subgraph_<node.id>` (`pipeline.py:167`); a folder re-entered in a
-  loop reuses the same child log/checkpoint dir and may restore stale completed-state (the
-  "skips all but the 1st source" symptom). Child-engine resume gate not yet traced; repro
-  `prove_folder_failure.py` pending. Treat as open until confirmed.
+- **`folder`/subgraph checkpoint reuse across loop iterations (CONFIRMED + FIXED):** child logs
+  were keyed on node id alone (`subgraph_<node.id>`), so a folder re-entered in a loop restored the
+  prior iteration's completed checkpoint and silently skipped work (the "skips all but the 1st
+  source" symptom). Now namespaced per invocation — `subgraph_<node.id>` then `__iter1`, `__iter2`…
+  (`pipeline.py:168-200`) — so each iteration runs fresh while a single child run can still resume.
+  Regression test: `tests/test_folder_checkpoint_reuse_repro.py`.
 
 ---
 

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/backend.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/backend.py
@@ -944,6 +944,55 @@ def _parse_outcome(output: str) -> Outcome:
         except (json.JSONDecodeError, KeyError, TypeError):
             pass
 
+    # Before falling through to the SUCCESS default, attempt to RECOVER an
+    # embedded verdict from prose-wrapped responses.  Models sometimes emit prose
+    # followed by a JSON verdict object (e.g. "Here's my verdict:\n{...}") rather
+    # than pure JSON.  We find the LAST balanced {...} in the string and, if it
+    # contains a recognised status, honour it rather than silently coercing to
+    # SUCCESS.  Pure-JSON and fenced-JSON paths above are unchanged; this only
+    # fires when both prior branches were skipped (stripped does NOT start with
+    # "{" or a code fence).
+    #
+    # Spec invariant: an explicit FAIL/RETRY verdict MUST NOT be silently coerced
+    # to SUCCESS.  Verdict nodes that want reliable parsing should emit pure JSON
+    # or call the report_outcome tool.
+    last_open = stripped.rfind("{")
+    if last_open != -1:
+        depth = 0
+        end_pos = -1
+        for _i in range(last_open, len(stripped)):
+            _ch = stripped[_i]
+            if _ch == "{":
+                depth += 1
+            elif _ch == "}":
+                depth -= 1
+                if depth == 0:
+                    end_pos = _i
+                    break
+        if end_pos != -1:
+            candidate = stripped[last_open : end_pos + 1]
+            try:
+                _embedded = json.loads(candidate)
+                if isinstance(_embedded, dict) and "status" in _embedded:
+                    _recovered_status = _STATUS_MAP.get(_embedded["status"])
+                    if _recovered_status is not None:
+                        logger.warning(
+                            "Verdict recovered from prose-wrapped response "
+                            "(embedded status=%r).  Verdict nodes should emit "
+                            "pure JSON or call the report_outcome tool.",
+                            _embedded["status"],
+                        )
+                        return Outcome(
+                            status=_recovered_status,
+                            failure_reason=_embedded.get("failure_reason"),
+                            notes=_embedded.get("notes"),
+                            preferred_label=_embedded.get("preferred_label"),
+                            suggested_next_ids=_embedded.get("suggested_next_ids"),
+                            context_updates=_embedded.get("context_updates"),
+                        )
+            except (json.JSONDecodeError, KeyError, TypeError):
+                pass
+
     # Plain text response — per spec Section 4.5, treat as SUCCESS
     return Outcome(
         status=StageStatus.SUCCESS,

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/pipeline.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/pipeline.py
@@ -86,6 +86,11 @@ class PipelineHandler:
         self._backend = backend
         self._interviewer = interviewer
         self._subgraph_runs: dict[str, Any] = {}
+        # Per-invocation counter used when engine is None (test-harness path).
+        # Key: (logs_root, node.id) so distinct run roots don't share counts.
+        # When engine is not None, the counter lives on the engine itself so
+        # it persists correctly across loop iterations within one parent run.
+        self._folder_invocation_counts: dict[tuple[str, str], int] = {}
 
     async def _emit(self, event_name: str, data: dict[str, Any]) -> None:
         """Emit an event via hooks, if provided."""
@@ -163,8 +168,35 @@ class PipelineHandler:
                 child_key = attr_key[len("context.") :]
                 child_context.set(child_key, str(attr_value))
 
-        # (7) Create child logs dir
-        child_logs = os.path.join(logs_root, f"subgraph_{node.id}")
+        # (7) Create child logs dir — namespaced per invocation so that a folder
+        # node re-entered across loop iterations always gets a FRESH checkpoint
+        # directory instead of resuming the completed state from iteration 1.
+        #
+        # When engine is not None (production path), track the count on the
+        # engine itself; the engine object persists across all loop iterations
+        # of one parent run, so the counter increments correctly.
+        #
+        # When engine is None (test-harness path), fall back to a counter on
+        # this handler instance, keyed by (logs_root, node.id), so distinct
+        # run roots don't share counts and the existing single-dir behaviour is
+        # preserved for callers that never re-enter the same (root, node.id).
+        #
+        # First invocation uses the canonical name subgraph_{node.id} for
+        # back-compat; subsequent invocations append __iter{n}.
+        if engine is not None:
+            if not hasattr(engine, "_folder_invocation_counts"):
+                engine._folder_invocation_counts: dict[str, int] = {}  # type: ignore[attr-defined]
+            _inv = engine._folder_invocation_counts.get(node.id, 0)
+            engine._folder_invocation_counts[node.id] = _inv + 1
+        else:
+            _key = (logs_root, node.id)
+            _inv = self._folder_invocation_counts.get(_key, 0)
+            self._folder_invocation_counts[_key] = _inv + 1
+
+        if _inv == 0:
+            child_logs = os.path.join(logs_root, f"subgraph_{node.id}")
+        else:
+            child_logs = os.path.join(logs_root, f"subgraph_{node.id}__iter{_inv}")
         os.makedirs(child_logs, exist_ok=True)
 
         # (8) Create child HandlerRegistry.

--- a/modules/loop-pipeline/tests/test_folder_checkpoint_reuse_repro.py
+++ b/modules/loop-pipeline/tests/test_folder_checkpoint_reuse_repro.py
@@ -1,0 +1,277 @@
+"""FIX 3B — folder/subgraph checkpoint reuse across loop iterations.
+
+After the fix (handlers/pipeline.py PipelineHandler.execute): the child logs
+directory is namespaced per invocation of the folder node within a parent run.
+Each loop iteration receives a FRESH checkpoint directory (e.g.
+subgraph_{id}__iter1, subgraph_{id}__iter2, …), so the child engine cannot
+find and resume the completed checkpoint from a previous iteration.
+
+Strategy:
+  Call PipelineHandler.execute() twice with the SAME stub engine and the same
+  logs_root + node.id.  This directly mirrors the real loop scenario where the
+  parent engine re-enters the folder node on every iteration.  A CountingBackend
+  records backend.run() calls.  After both executions the worker node's call
+  count must be 2 (one per iteration).
+
+  The control test uses separate logs_root dirs per execution — verifies that
+  the counting mechanism and child pipeline are correct independently of the fix.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import pytest
+
+from amplifier_module_loop_pipeline.context import PipelineContext
+from amplifier_module_loop_pipeline.graph import Edge, Graph, Node
+from amplifier_module_loop_pipeline.handlers.pipeline import PipelineHandler
+from amplifier_module_loop_pipeline.outcome import Outcome, StageStatus
+
+
+# ---------------------------------------------------------------------------
+# Child DOT pipeline — one observable box (worker) between start and exit
+# ---------------------------------------------------------------------------
+
+_CHILD_DOT = """\
+digraph child_work {
+    start [shape=Mdiamond]
+    worker [prompt="Do the work for this iteration"]
+    done [shape=Msquare]
+    start -> worker
+    worker -> done
+}
+"""
+
+
+# ---------------------------------------------------------------------------
+# Counting backend — tracks backend.run() calls per node id
+# ---------------------------------------------------------------------------
+
+
+class CountingBackend:
+    """Stub backend that counts run() calls per node and returns SUCCESS."""
+
+    def __init__(self) -> None:
+        self.calls: dict[str, int] = {}
+
+    async def run(
+        self,
+        node: Node,
+        prompt: str,
+        context: PipelineContext,
+        incoming_edge: Any = None,
+        graph: Any = None,
+    ) -> Outcome:
+        self.calls[node.id] = self.calls.get(node.id, 0) + 1
+        return Outcome(
+            status=StageStatus.SUCCESS,
+            notes=f"{node.id} ran (count {self.calls[node.id]})",
+        )
+
+    def n(self, node_id: str) -> int:
+        return self.calls.get(node_id, 0)
+
+
+# ---------------------------------------------------------------------------
+# Minimal parent graph (needed by PipelineHandler.execute signature)
+# ---------------------------------------------------------------------------
+
+
+def _make_parent_graph(folder_node: Node) -> Graph:
+    """Build a minimal parent graph containing only the folder node."""
+    start = Node(id="start", shape="Mdiamond")
+    exit_ = Node(id="exit", shape="Msquare")
+    return Graph(
+        name="parent",
+        nodes={
+            "start": start,
+            "folder_check": folder_node,
+            "exit": exit_,
+        },
+        edges=[
+            Edge(from_node="start", to_node="folder_check"),
+            Edge(from_node="folder_check", to_node="exit"),
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Stub engine — mirrors what the real PipelineEngine provides to execute()
+#
+# In production, PipelineHandler.execute() receives the parent engine and
+# calls engine.handler_registry.get_backend() to obtain the backend for the
+# child HandlerRegistry.  The fix also lazily attaches
+# engine._folder_invocation_counts on the engine so that the per-node counter
+# persists across loop iterations within one parent run.
+# ---------------------------------------------------------------------------
+
+
+class _StubRegistry:
+    """Minimal HandlerRegistry stub: exposes get_backend()."""
+
+    def __init__(self, backend: CountingBackend) -> None:
+        self._backend = backend
+
+    def get_backend(self) -> CountingBackend:
+        return self._backend
+
+
+class _StubEngine:
+    """Minimal engine stub that satisfies the requirements of execute().
+
+    - Provides handler_registry.get_backend() so the child HandlerRegistry can
+      be seeded with the shared CountingBackend.
+    - Has NO _folder_invocation_counts attribute initially; the handler adds it
+      lazily on first execute() call (via hasattr guard in pipeline.py).
+    - The SAME instance is passed to both execute() calls, mirroring the real
+      loop where the parent engine object is identical across iterations.
+    """
+
+    def __init__(self, backend: CountingBackend) -> None:
+        self.handler_registry = _StubRegistry(backend)
+
+
+# ---------------------------------------------------------------------------
+# FIX 3B regression test — same engine, same logs_root, same node.id
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_folder_checkpoint_reuse_across_runs(tmp_path):
+    """FIX 3B: each loop iteration of a folder node runs the child pipeline fresh.
+
+    FIXED BEHAVIOR:
+        PipelineHandler.execute() now tracks an invocation counter keyed on
+        node.id on the parent engine object.
+
+        * Invocation 0 → child_logs = logs_root/subgraph_{node.id}
+        * Invocation 1 → child_logs = logs_root/subgraph_{node.id}__iter1
+
+        Because each iteration writes to a different directory, the child
+        engine started for iteration 1 finds no checkpoint and executes the
+        child pipeline from scratch.  The worker node is called twice in total.
+
+    This test mirrors the real loop scenario: the SAME stub engine (and the
+    same logs_root + node.id) is passed to both execute() calls, exactly as the
+    parent PipelineEngine would behave when visiting the folder node on
+    successive iterations.
+    """
+    # Write child DOT to a temp file
+    child_dot_path = tmp_path / "child_work.dot"
+    child_dot_path.write_text(_CHILD_DOT)
+
+    # Shared counting backend — persists across both handler invocations
+    backend = CountingBackend()
+
+    # The folder node — same node.id used in both calls
+    folder_node = Node(
+        id="folder_check",
+        shape="folder",
+        attrs={"dot_file": str(child_dot_path)},
+    )
+    parent_graph = _make_parent_graph(folder_node)
+    parent_graph.source_dir = str(tmp_path)
+
+    # Stub engine — same object passed to both execute() calls (the real loop)
+    stub_engine = _StubEngine(backend)
+
+    handler = PipelineHandler(backend=backend)
+
+    # ── Run 1 (iteration 0) ──────────────────────────────────────────────────
+    ctx1 = PipelineContext()
+    outcome1 = await handler.execute(
+        folder_node, ctx1, parent_graph, str(tmp_path), engine=stub_engine
+    )
+    worker_after_run1 = backend.n("worker")
+
+    assert outcome1.status == StageStatus.SUCCESS, (
+        f"Run 1 expected SUCCESS, got {outcome1.status!r} "
+        f"(failure_reason: {outcome1.failure_reason!r})"
+    )
+    assert worker_after_run1 == 1, (
+        f"Run 1: worker should have been called once, got {worker_after_run1}"
+    )
+
+    # Verify first-iteration checkpoint is in the canonical (back-compat) dir
+    child_logs_iter0 = os.path.join(str(tmp_path), f"subgraph_{folder_node.id}")
+    assert os.path.isdir(child_logs_iter0), (
+        f"Iteration-0 child logs dir not created: {child_logs_iter0}"
+    )
+    assert os.path.isfile(os.path.join(child_logs_iter0, "checkpoint.json")), (
+        f"Checkpoint not written after iteration 0: {child_logs_iter0}/checkpoint.json"
+    )
+
+    # ── Run 2 (iteration 1) ──────────────────────────────────────────────────
+    ctx2 = PipelineContext()
+    outcome2 = await handler.execute(
+        folder_node, ctx2, parent_graph, str(tmp_path), engine=stub_engine
+    )
+    worker_after_run2 = backend.n("worker")
+
+    assert outcome2.status == StageStatus.SUCCESS, (
+        f"Run 2 expected SUCCESS, got {outcome2.status!r} "
+        f"(failure_reason: {outcome2.failure_reason!r})"
+    )
+
+    # Core assertion: worker ran on BOTH iterations — fix confirmed
+    assert worker_after_run2 == 2, (
+        f"FIX 3B REGRESSION: worker ran only {worker_after_run2} time(s) across "
+        "two iterations.  The second execution likely reused the stale checkpoint "
+        "from iteration 0 and exited without re-executing the child pipeline.\n\n"
+        "Expected worker call count: 2 (once per execute() call)\n"
+        f"Actual worker call count:   {worker_after_run2}"
+    )
+
+    # Verify second-iteration checkpoint is in the namespaced dir
+    child_logs_iter1 = os.path.join(str(tmp_path), f"subgraph_{folder_node.id}__iter1")
+    assert os.path.isdir(child_logs_iter1), (
+        f"Iteration-1 child logs dir not created: {child_logs_iter1}.  "
+        "FIX 3B did not namespace the child_logs dir for the second invocation."
+    )
+
+
+@pytest.mark.asyncio
+async def test_folder_checkpoint_reuse_different_logs_root_runs_twice(tmp_path):
+    """Control test: separate logs_root per run → worker executes twice.
+
+    This verifies that the counting mechanism and child pipeline itself are
+    correct.  With distinct logs_root directories the checkpoint from run 1
+    cannot be found by run 2, so both runs must execute worker independently.
+    """
+    child_dot_path = tmp_path / "child_work.dot"
+    child_dot_path.write_text(_CHILD_DOT)
+
+    backend = CountingBackend()
+    folder_node = Node(
+        id="folder_check",
+        shape="folder",
+        attrs={"dot_file": str(child_dot_path)},
+    )
+    parent_graph = _make_parent_graph(folder_node)
+    parent_graph.source_dir = str(tmp_path)
+
+    handler = PipelineHandler(backend=backend)
+
+    # Run 1 with logs_root_1
+    logs_root_1 = tmp_path / "run1"
+    logs_root_1.mkdir()
+    outcome1 = await handler.execute(
+        folder_node, PipelineContext(), parent_graph, str(logs_root_1), engine=None
+    )
+    assert outcome1.status == StageStatus.SUCCESS, f"Control run 1 failed: {outcome1!r}"
+
+    # Run 2 with logs_root_2 (no shared checkpoint)
+    logs_root_2 = tmp_path / "run2"
+    logs_root_2.mkdir()
+    outcome2 = await handler.execute(
+        folder_node, PipelineContext(), parent_graph, str(logs_root_2), engine=None
+    )
+    assert outcome2.status == StageStatus.SUCCESS, f"Control run 2 failed: {outcome2!r}"
+
+    worker_count = backend.n("worker")
+    assert worker_count == 2, (
+        f"Control test failed: expected worker to run twice (distinct logs_root), "
+        f"got count={worker_count}.  The child pipeline or counting backend is broken."
+    )

--- a/modules/loop-pipeline/tests/test_verdict_coercion_repro.py
+++ b/modules/loop-pipeline/tests/test_verdict_coercion_repro.py
@@ -1,0 +1,246 @@
+"""FIX 3A — verdict node prose-then-JSON no longer coerced to SUCCESS.
+
+After the fix (backend.py `_parse_outcome`): when the model emits prose
+followed by a JSON verdict object, the LAST balanced `{...}` block is
+extracted and, if it contains a recognised status, that status is honoured
+rather than silently coerced to SUCCESS.
+
+Invariant: an explicit FAIL/RETRY verdict MUST NOT be silently dropped.
+Pure-JSON and fenced-JSON paths are unchanged; genuine plain prose with no
+status-JSON still returns SUCCESS; prose containing a JSON object without a
+recognised status also returns SUCCESS.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+unified_llm = pytest.importorskip("unified_llm")
+
+from amplifier_module_loop_pipeline.backend import AmplifierBackend, _parse_outcome  # noqa: E402
+from amplifier_module_loop_pipeline.context import PipelineContext  # noqa: E402
+from amplifier_module_loop_pipeline.graph import Node  # noqa: E402
+from amplifier_module_loop_pipeline.outcome import StageStatus  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Specimens
+# ---------------------------------------------------------------------------
+_PROSE_THEN_JSON_FAIL = "Here's my verdict:\n" + json.dumps(
+    {
+        "status": "fail",
+        "failure_reason": "Tests did not pass",
+        "notes": "3 of 5 assertions failed",
+    }
+)
+
+_PROSE_THEN_JSON_RETRY = "Let me explain my decision:\n" + json.dumps(
+    {
+        "status": "retry",
+        "failure_reason": "Incomplete implementation",
+        "preferred_label": "needs_more_work",
+    }
+)
+
+_PLAIN_PROSE = "The work looks good overall, no JSON here at all."
+
+_PROSE_WITH_NON_STATUS_JSON = "Here is some context:\n" + json.dumps(
+    {"key": "value", "count": 42}
+)
+
+
+# ---------------------------------------------------------------------------
+# Helper: minimal GenerateResult with no tool-call steps
+# ---------------------------------------------------------------------------
+
+
+def _make_generate_result(text: str) -> Any:
+    """Build a minimal unified_llm.GenerateResult for mocking generate()."""
+    usage = unified_llm.Usage(
+        input_tokens=10,
+        output_tokens=20,
+        total_tokens=30,
+    )
+    response = unified_llm.Response(
+        id="resp-mock",
+        model="test-model",
+        provider="test",
+        message=unified_llm.Message.assistant(text),
+        finish_reason=unified_llm.FinishReason(reason="stop"),
+        usage=usage,
+    )
+    return unified_llm.GenerateResult(
+        text=text,
+        finish_reason=unified_llm.FinishReason(reason="stop"),
+        usage=usage,
+        total_usage=usage,
+        steps=[],  # ← no report_outcome tool calls in steps
+        response=response,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Stub coordinator — no session.spawn capability (forces Path B tool loop)
+# ---------------------------------------------------------------------------
+
+
+class _NoSpawnCoordinator:
+    session: Any = type("S", (), {"config": {}})()
+    config: dict = {"agents": {}}
+
+    def get_capability(self, name: str) -> Any:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Direct unit tests on _parse_outcome (FIXED behavior)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_outcome_prose_then_json_fail_recovered():
+    """_parse_outcome recovers FAIL verdict from prose-then-JSON response.
+
+    FIXED BEHAVIOR (FIX 3A):
+        The LAST balanced {...} in the stripped string is extracted.
+        It contains "status": "fail" which maps to StageStatus.FAIL via
+        _STATUS_MAP.  _parse_outcome now returns Outcome(status=FAIL) and
+        emits a logger.warning that the verdict was recovered.
+    """
+    result = _parse_outcome(_PROSE_THEN_JSON_FAIL)
+
+    assert result.status == StageStatus.FAIL, (
+        f"Expected FAIL after fix, got {result.status!r}. FIX 3A may not be applied."
+    )
+    assert result.failure_reason == "Tests did not pass", (
+        f"Expected failure_reason from embedded JSON, got {result.failure_reason!r}"
+    )
+    assert result.notes == "3 of 5 assertions failed", (
+        f"Expected notes from embedded JSON, got {result.notes!r}"
+    )
+
+
+def test_parse_outcome_prose_then_json_retry_recovered():
+    """_parse_outcome recovers RETRY verdict from prose-then-JSON response."""
+    result = _parse_outcome(_PROSE_THEN_JSON_RETRY)
+
+    assert result.status == StageStatus.RETRY, (
+        f"Expected RETRY after fix, got {result.status!r}. FIX 3A may not be applied."
+    )
+    assert result.failure_reason == "Incomplete implementation", (
+        f"Expected failure_reason from embedded JSON, got {result.failure_reason!r}"
+    )
+    assert result.preferred_label == "needs_more_work", (
+        f"Expected preferred_label from embedded JSON, got {result.preferred_label!r}"
+    )
+
+
+def test_parse_outcome_clean_json_still_works():
+    """Sanity check: bare JSON (no prose prefix) is still parsed correctly."""
+    payload = json.dumps({"status": "fail", "failure_reason": "deliberate"})
+    result = _parse_outcome(payload)
+    assert result.status == StageStatus.FAIL
+    assert result.failure_reason == "deliberate"
+
+
+def test_parse_outcome_fenced_json_still_works():
+    """Sanity check: ```json ... ``` fenced JSON is still parsed correctly."""
+    payload = (
+        "```json\n"
+        + json.dumps({"status": "fail", "failure_reason": "fenced"})
+        + "\n```"
+    )
+    result = _parse_outcome(payload)
+    assert result.status == StageStatus.FAIL
+    assert result.failure_reason == "fenced"
+
+
+def test_parse_outcome_plain_prose_no_json_is_success():
+    """Genuine plain prose with no JSON object returns SUCCESS (spec §4.5)."""
+    result = _parse_outcome(_PLAIN_PROSE)
+    assert result.status == StageStatus.SUCCESS, (
+        f"Plain prose should still return SUCCESS, got {result.status!r}"
+    )
+
+
+def test_parse_outcome_prose_with_non_status_json_is_success():
+    """Prose containing a JSON object without a recognised status → SUCCESS.
+
+    The embedded JSON has keys "key" and "count" but no "status" key.
+    The recovery logic should find the JSON, fail the status check, and
+    fall through to the plain-text SUCCESS default.
+    """
+    result = _parse_outcome(_PROSE_WITH_NON_STATUS_JSON)
+    assert result.status == StageStatus.SUCCESS, (
+        f"Prose with non-status JSON should return SUCCESS, got {result.status!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 2: Full Path-B backend run (monkeypatched unified_llm.generate)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_backend_tool_loop_prose_then_json_fail_recovered(monkeypatch):
+    """Path-B backend correctly propagates FAIL from prose-then-JSON response.
+
+    FIXED BEHAVIOR (FIX 3A):
+        The decision logic at backend.py:612-637 passes prose-then-JSON to
+        _parse_outcome() (line 633).  _parse_outcome now recovers the
+        embedded FAIL verdict and returns Outcome(status=FAIL).
+    """
+
+    async def _fake_generate(**kwargs: Any) -> Any:
+        return _make_generate_result(_PROSE_THEN_JSON_FAIL)
+
+    monkeypatch.setattr(unified_llm, "generate", _fake_generate)
+
+    coordinator = _NoSpawnCoordinator()
+    backend = AmplifierBackend(
+        coordinator=coordinator,
+        profiles={},
+        provider=object(),  # truthy sentinel enables Path B (tool loop)
+    )
+    node = Node(
+        id="verdict_node",
+        llm_model="test-model",
+        attrs={"llm_provider": "test"},
+    )
+    context = PipelineContext()
+
+    outcome = await backend.run(node, "Evaluate the implementation", context)
+
+    assert outcome.status == StageStatus.FAIL, (
+        f"Expected FAIL after fix, got {outcome.status!r}. "
+        "FIX 3A may not be applied or Path B routing is broken."
+    )
+    assert outcome.failure_reason == "Tests did not pass", (
+        f"Expected failure_reason from embedded JSON, got {outcome.failure_reason!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_backend_tool_loop_clean_json_fail_correctly_parsed(monkeypatch):
+    """Sanity: bare JSON FAIL (no prose) is still parsed correctly on Path B."""
+
+    async def _fake_generate(**kwargs: Any) -> Any:
+        return _make_generate_result(
+            json.dumps({"status": "fail", "failure_reason": "clean json fail"})
+        )
+
+    monkeypatch.setattr(unified_llm, "generate", _fake_generate)
+
+    coordinator = _NoSpawnCoordinator()
+    backend = AmplifierBackend(
+        coordinator=coordinator,
+        profiles={},
+        provider=object(),
+    )
+    node = Node(id="judge", llm_model="test-model", attrs={"llm_provider": "test"})
+    outcome = await backend.run(node, "Judge", PipelineContext())
+
+    # Clean JSON should still work correctly (this verifies the parser is fine)
+    assert outcome.status == StageStatus.FAIL
+    assert outcome.failure_reason == "clean json fail"


### PR DESCRIPTION
Track 3 of the attractor pipeline-authoring friction design (`docs/designs/attractor-pipeline-authoring-friction.md`) — two **confirmed** silent-failure engine bugs, each reproduced first then fixed. Continues the fail-loud line (§3.7, auto_status, goal_gate).

### 3A — prose-then-JSON verdict silently coerced to SUCCESS
`_parse_outcome` only took a status when the **entire** response was JSON or a full ```json fence. A response like `Here's my verdict:\n{"status":"fail",...}` fell through to the plain-text default → **SUCCESS**, silently dropping the FAIL. Fix: before the SUCCESS default, extract the **last balanced `{...}`** and, if it has a recognized `status`, honor it (logged warning). Pure-JSON/fenced paths unchanged; genuine prose with no status-JSON still SUCCESS. (`backend.py`)

### 3B — folder/subgraph checkpoint reuse across loop iterations
Child logs were keyed on `node.id` alone, so a `folder` node re-entered in a loop restored iteration 1's completed checkpoint and **silently skipped** every later iteration. Fix: namespace child logs per invocation (`subgraph_<id>` then `__iter1`, `__iter2`…), counter tracked on the executing engine — fresh each iteration, single-run resume preserved. (`handlers/pipeline.py`)

### Tests & verification
- New regression tests: `test_verdict_coercion_repro.py` and `test_folder_checkpoint_reuse_repro.py`.
- `context/engine-semantics.md` §5/§6 updated in the same PR to mark both FIXED (doc-in-lockstep-with-code).

### Pre-existing failures (out of scope — flagged honestly)
The full `modules/loop-pipeline/tests/` suite has **31 pre-existing failures** in `test_attribute_passthrough.py`, `test_backend.py`, `test_dot_integration.py` — all the `requires an explicit 'llm_model'` fail-loud signature (stale tests from the no-default-model change). Confirmed via `git stash -u` they fail identically on clean main and are untouched here. Worth a separate cleanup PR.

(3C — promoting the pipeline lint to a gate — deferred: that lint lives in `amplifier-resolver-dot-graph`.)
