### PR TITLE
test(loop-pipeline): update stale tests to current fail-loud + routing contracts

### DIFF
--- a/modules/loop-pipeline/tests/fixtures/integration/unified_llm_conditional.dot
+++ b/modules/loop-pipeline/tests/fixtures/integration/unified_llm_conditional.dot
@@ -2,7 +2,7 @@ digraph ConditionalRetry {
     graph [goal="Fix the bug"]
 
     start [shape=Mdiamond]
-    fix [shape=box, prompt="Fix the bug: $goal"]
+    fix [shape=box, llm_model="test-model", prompt="Fix the bug: $goal"]
     done [shape=Msquare]
 
     start -> fix

--- a/modules/loop-pipeline/tests/fixtures/integration/unified_llm_multi_step.dot
+++ b/modules/loop-pipeline/tests/fixtures/integration/unified_llm_multi_step.dot
@@ -2,9 +2,9 @@ digraph MultiStep {
     graph [goal="Build a calculator"]
 
     start [shape=Mdiamond]
-    plan [shape=box, prompt="Create a plan for: $goal"]
-    implement [shape=box, prompt="Implement based on the plan"]
-    review [shape=box, prompt="Review the implementation"]
+    plan [shape=box, llm_model="test-model", prompt="Create a plan for: $goal"]
+    implement [shape=box, llm_model="test-model", prompt="Implement based on the plan"]
+    review [shape=box, llm_model="test-model", prompt="Review the implementation"]
     done [shape=Msquare]
 
     start -> plan -> implement -> review -> done

--- a/modules/loop-pipeline/tests/fixtures/integration/unified_llm_parallel.dot
+++ b/modules/loop-pipeline/tests/fixtures/integration/unified_llm_parallel.dot
@@ -3,11 +3,11 @@ digraph ParallelTest {
 
     start [shape=Mdiamond]
     parallel [shape=component]
-    bugs [shape=box, prompt="Check for bugs"]
-    style_check [shape=box, prompt="Check code style"]
-    security [shape=box, prompt="Check security issues"]
+    bugs [shape=box, llm_model="test-model", prompt="Check for bugs"]
+    style_check [shape=box, llm_model="test-model", prompt="Check code style"]
+    security [shape=box, llm_model="test-model", prompt="Check security issues"]
     collect [shape=tripleoctagon]
-    summarize [shape=box, prompt="Summarize findings"]
+    summarize [shape=box, llm_model="test-model", prompt="Summarize findings"]
     done [shape=Msquare]
 
     start -> parallel

--- a/modules/loop-pipeline/tests/fixtures/integration/unified_llm_simple.dot
+++ b/modules/loop-pipeline/tests/fixtures/integration/unified_llm_simple.dot
@@ -2,7 +2,7 @@ digraph UnifiedSimple {
     graph [goal="Write hello world"]
 
     start [shape=Mdiamond]
-    implement [shape=box, prompt="Write a hello world program"]
+    implement [shape=box, llm_model="test-model", prompt="Write a hello world program"]
     done [shape=Msquare]
 
     start -> implement -> done

--- a/modules/loop-pipeline/tests/fixtures/spec_simple_linear.dot
+++ b/modules/loop-pipeline/tests/fixtures/spec_simple_linear.dot
@@ -5,8 +5,8 @@ digraph Simple {
     start [shape=Mdiamond, label="Start"]
     exit  [shape=Msquare, label="Exit"]
 
-    run_tests [label="Run Tests", prompt="Run the test suite and report results"]
-    report    [label="Report", prompt="Summarize the test results"]
+    run_tests [label="Run Tests", llm_model="test-model", prompt="Run the test suite and report results"]
+    report    [label="Report", llm_model="test-model", prompt="Summarize the test results"]
 
     start -> run_tests -> report -> exit
 }

--- a/modules/loop-pipeline/tests/test_attribute_passthrough.py
+++ b/modules/loop-pipeline/tests/test_attribute_passthrough.py
@@ -204,7 +204,7 @@ async def test_tool_loop_passes_reasoning_effort_all_values(
         profiles={},
         provider=object(),  # truthy sentinel enables Path B
     )
-    node = _make_node(attrs={"llm_provider": "test", "reasoning_effort": effort})
+    node = _make_node(attrs={"llm_provider": "test", "llm_model": "test-model", "reasoning_effort": effort})
     result = await backend.run(node, "task", _make_context())
 
     assert result.status.value == "success"
@@ -230,7 +230,7 @@ async def test_tool_loop_reasoning_effort_defaults_to_none(
         profiles={},
         provider=object(),
     )
-    node = _make_node(attrs={"llm_provider": "test"})
+    node = _make_node(attrs={"llm_provider": "test", "llm_model": "test-model"})
     result = await backend.run(node, "task", _make_context())
 
     assert result.status.value == "success"
@@ -353,7 +353,7 @@ async def test_tool_loop_passes_max_agent_turns(
         profiles={},
         provider=object(),
     )
-    node = _make_node(attrs={"llm_provider": "test", "max_agent_turns": "8"})
+    node = _make_node(attrs={"llm_provider": "test", "llm_model": "test-model", "max_agent_turns": "8"})
     result = await backend.run(node, "task", _make_context())
 
     assert result.status.value == "success"
@@ -379,7 +379,7 @@ async def test_tool_loop_max_agent_turns_defaults_to_constant(
         profiles={},
         provider=object(),
     )
-    node = _make_node(attrs={"llm_provider": "test"})
+    node = _make_node(attrs={"llm_provider": "test", "llm_model": "test-model"})
     result = await backend.run(node, "task", _make_context())
 
     assert result.status.value == "success"

--- a/modules/loop-pipeline/tests/test_backend.py
+++ b/modules/loop-pipeline/tests/test_backend.py
@@ -373,8 +373,18 @@ async def test_backend_passes_agent_configs():
 
 
 @pytest.mark.asyncio
-async def test_backend_uses_sub_session_id_not_session_id():
-    """Session reuse passes 'sub_session_id', not 'session_id'."""
+async def test_backend_uses_parent_messages_not_sub_session_id():
+    """Full-fidelity continuity uses parent_messages, never sub_session_id.
+
+    The former _session_pool re-passed session_id as sub_session_id — a type
+    confusion (an id where a conversation belongs).  The fix (backend.py:398-406)
+    carries the accumulated node-exchange history in _thread_transcripts and
+    passes it as parent_messages to a FRESH spawn.  sub_session_id is NEVER set.
+
+    After node1 executes on thread "t", its (instruction, output) exchange is
+    appended to _thread_transcripts["t"].  When node2 runs on the same thread,
+    _get_parent_messages_for_thread returns two messages that seed the new spawn.
+    """
     coordinator = MockCoordinator(
         spawn_result={"output": "ok", "session_id": "sess-abc"},
     )
@@ -411,10 +421,18 @@ async def test_backend_uses_sub_session_id_not_session_id():
     await backend.run(node1, "First", _make_context(), incoming_edge=edge, graph=graph)
     await backend.run(node2, "Second", _make_context(), incoming_edge=edge, graph=graph)
 
-    # Must use sub_session_id (not session_id) for the CLI spawn capability
-    assert "sub_session_id" in coordinator.last_spawn_kwargs
+    # sub_session_id must NEVER appear — the old re-pass mechanism is gone
+    assert "sub_session_id" not in coordinator.last_spawn_kwargs
     assert "session_id" not in coordinator.last_spawn_kwargs
-    assert coordinator.last_spawn_kwargs["sub_session_id"] == "sess-abc"
+
+    # Instead, node1's exchange is carried as parent_messages into node2's spawn
+    assert "parent_messages" in coordinator.last_spawn_kwargs
+    messages = coordinator.last_spawn_kwargs["parent_messages"]
+    # First turn: node1 received instruction "First", output was "ok"
+    assert messages[0]["role"] == "user"
+    assert messages[0]["content"] == "First"
+    assert messages[1]["role"] == "assistant"
+    assert messages[1]["content"] == "ok"
 
 
 # --- Outcome parsing tests ---
@@ -917,7 +935,7 @@ async def test_reasoning_effort_passed_to_tool_loop(monkeypatch):
         profiles={},
         provider=object(),  # truthy sentinel to enable Path B
     )
-    node = _make_node(attrs={"llm_provider": "test", "reasoning_effort": "low"})
+    node = _make_node(attrs={"llm_provider": "test", "llm_model": "test-model", "reasoning_effort": "low"})
     result = await backend.run(node, "task", _make_context())
 
     assert result.status == StageStatus.SUCCESS
@@ -941,7 +959,7 @@ async def test_reasoning_effort_defaults_to_none(monkeypatch):
         profiles={},
         provider=object(),  # truthy sentinel to enable Path B
     )
-    node = _make_node(attrs={"llm_provider": "test"})
+    node = _make_node(attrs={"llm_provider": "test", "llm_model": "test-model"})
     result = await backend.run(node, "task", _make_context())
 
     assert result.status == StageStatus.SUCCESS

--- a/modules/loop-pipeline/tests/test_dot_integration.py
+++ b/modules/loop-pipeline/tests/test_dot_integration.py
@@ -898,13 +898,11 @@ class TestSemportPipeline:
         assert graph.nodes["Start"].shape == "circle"
         assert graph.nodes["Exit"].shape == "doublecircle"
 
-        # node_type goes to attrs (parser promotes "type", not "node_type")
-        assert graph.nodes["Start"].attrs.get("node_type") == "start"
-        assert graph.nodes["Exit"].attrs.get("node_type") == "exit"
-        assert (
-            graph.nodes["FetchUpstreamSonnet"].attrs.get("node_type") == "stack.steer"
-        )
-        assert graph.nodes["FinalizePlanGPT"].attrs.get("node_type") == "stack.observe"
+        # Parser promotes DOT "type" attribute to node.type directly
+        assert graph.nodes["Start"].type == "start"
+        assert graph.nodes["Exit"].type == "exit"
+        assert graph.nodes["FetchUpstreamSonnet"].type == "stack.steer"
+        assert graph.nodes["FinalizePlanGPT"].type == "stack.observe"
 
         # Graph-level attributes
         assert graph.default_fidelity == "truncate"
@@ -955,8 +953,8 @@ class TestSemportPipeline:
                 _routing_response(),
                 # 4. ImplementPort — port implemented
                 _routing_response(),
-                # 5. TestValidate — tests pass
-                _routing_response(preferred_label="pass"),
+                # 5. TestValidate — tests pass (edge condition: outcome=yes)
+                _routing_response(preferred_label="yes"),
                 # 6. FinalizeAndUpdateLedger — ledger updated, loop back
                 _routing_response(),
                 # 7. FetchUpstreamSonnet (2nd) — no more commits
@@ -1140,22 +1138,25 @@ class TestConsensusPipeline:
     async def test_consensus_has_dod_path(self, tmp_path):
         """has_dod: CheckDoD routes to Plan nodes, skipping DoD definition.
 
-        Start -> CheckDoD(->PlanGemini) -> PlanGemini -> Debate
-        -> Implement -> ReviewGPT -> ReviewConsensus(->Exit) -> Exit
+        Start -> CheckDoD(has_dod) -> PlanGemini+PlanGPT+PlanOpus (parallel)
+        -> DebateConsolidate -> Implement -> ReviewGPT (lexical first)
+        -> ReviewConsensus(yes) -> Exit
 
-        CheckDoD gets codergen handler (type="stack.steer" not in
-        handler registry). suggested_next_ids controls routing since
-        edges have conditions but no labels.
+        preferred_label="has_dod" matches condition="outcome=has_dod" on all
+        three Plan edges, triggering parallel fan-out.
+        ReviewConsensus uses preferred_label="yes" to match condition="outcome=yes".
         """
         hooks = RecordingHooks()
         client = MockUnifiedClient(
             [
-                _routing_response(suggested_next_ids=["PlanGemini"]),  # CheckDoD
-                _routing_response(),  # PlanGemini
+                _routing_response(preferred_label="has_dod"),  # CheckDoD -> 3 Plan nodes parallel
+                _routing_response(),  # PlanGemini (parallel)
+                _routing_response(),  # PlanGPT (parallel)
+                _routing_response(),  # PlanOpus (parallel)
                 _routing_response(),  # DebateConsolidate
-                _routing_response(),  # Implement
-                _routing_response(),  # ReviewGPT (lexical first)
-                _routing_response(suggested_next_ids=["Exit"]),  # ReviewConsensus
+                _routing_response(),  # Implement -> ReviewGPT (lexical: ReviewGPT < ReviewGemini)
+                _routing_response(),  # ReviewGPT
+                _routing_response(preferred_label="yes"),  # ReviewConsensus -> Exit
             ]
         )
         engine = _make_production_engine(self._dot(), client, hooks, str(tmp_path))
@@ -1173,23 +1174,30 @@ class TestConsensusPipeline:
 
     @pytest.mark.asyncio
     async def test_consensus_needs_dod_path(self, tmp_path):
-        """needs_dod: CheckDoD -> DefineDoD -> Consolidate -> Plan -> Exit.
+        """needs_dod: CheckDoD -> DefineDoD (parallel) -> Consolidate -> Plan -> Exit.
 
-        Start -> CheckDoD(->DefineDoD_Gemini) -> DefineDoD_Gemini
-        -> ConsolidateDoD -> PlanGPT -> Debate -> Implement -> ReviewGPT
-        -> ReviewConsensus(->Exit) -> Exit
+        Start -> CheckDoD(needs_dod) -> DefineDoD_Gemini+GPT+Opus (parallel)
+        -> ConsolidateDoD -> PlanGPT (lexical: PlanGPT < PlanGemini) -> Debate
+        -> Implement -> ReviewGPT (lexical first) -> ReviewConsensus(yes) -> Exit
+
+        preferred_label="needs_dod" matches condition="outcome=needs_dod" on all
+        three DoD-definition edges, triggering parallel fan-out.
+        ConsolidateDoD has three unconditional edges to Plan nodes; engine picks
+        PlanGPT (lexically first: 'G'+'P' < 'G'+'e' in ASCII).
         """
         hooks = RecordingHooks()
         client = MockUnifiedClient(
             [
-                _routing_response(suggested_next_ids=["DefineDoD_Gemini"]),  # CheckDoD
-                _routing_response(),  # DefineDoD_Gemini
-                _routing_response(),  # ConsolidateDoD
-                _routing_response(),  # PlanGPT (lexical first)
+                _routing_response(preferred_label="needs_dod"),  # CheckDoD -> 3 DoD nodes parallel
+                _routing_response(),  # DefineDoD_Gemini (parallel)
+                _routing_response(),  # DefineDoD_GPT (parallel)
+                _routing_response(),  # DefineDoD_Opus (parallel)
+                _routing_response(),  # ConsolidateDoD -> PlanGPT (lexical first)
+                _routing_response(),  # PlanGPT -> DebateConsolidate
                 _routing_response(),  # DebateConsolidate
-                _routing_response(),  # Implement
+                _routing_response(),  # Implement -> ReviewGPT (lexical first)
                 _routing_response(),  # ReviewGPT
-                _routing_response(suggested_next_ids=["Exit"]),  # ReviewConsensus
+                _routing_response(preferred_label="yes"),  # ReviewConsensus -> Exit
             ]
         )
         engine = _make_production_engine(self._dot(), client, hooks, str(tmp_path))
@@ -1206,18 +1214,22 @@ class TestConsensusPipeline:
 
     @pytest.mark.asyncio
     async def test_consensus_review_pass(self, tmp_path):
-        """ReviewConsensus with yes -> exits pipeline successfully."""
+        """ReviewConsensus with yes -> exits pipeline successfully.
+
+        has_dod path: CheckDoD -> Plans (parallel) -> Debate -> Implement
+        -> ReviewGPT -> ReviewConsensus(yes) -> Exit
+        """
         hooks = RecordingHooks()
         client = MockUnifiedClient(
             [
-                _routing_response(suggested_next_ids=["PlanGemini"]),  # CheckDoD
-                _routing_response(),  # PlanGemini
+                _routing_response(preferred_label="has_dod"),  # CheckDoD -> 3 Plans parallel
+                _routing_response(),  # PlanGemini (parallel)
+                _routing_response(),  # PlanGPT (parallel)
+                _routing_response(),  # PlanOpus (parallel)
                 _routing_response(),  # DebateConsolidate
-                _routing_response(),  # Implement
+                _routing_response(),  # Implement -> ReviewGPT (lexical first)
                 _routing_response(),  # ReviewGPT
-                _routing_response(
-                    suggested_next_ids=["Exit"]
-                ),  # ReviewConsensus -> Exit
+                _routing_response(preferred_label="yes"),  # ReviewConsensus -> Exit
             ]
         )
         engine = _make_production_engine(self._dot(), client, hooks, str(tmp_path))
@@ -1234,31 +1246,37 @@ class TestConsensusPipeline:
     async def test_consensus_review_retry(self, tmp_path):
         """ReviewConsensus retry -> Postmortem -> Plan* -> pass on 2nd try.
 
-        First pass: ... -> ReviewConsensus(->Postmortem) -> Postmortem
-        -> PlanGPT (lexical first) -> Debate -> Implement -> ReviewGPT
-        Second pass: -> ReviewConsensus(->Exit) -> Exit
+        First pass:
+          CheckDoD(has_dod) -> Plans(parallel) -> Debate -> Implement
+          -> ReviewGPT -> ReviewConsensus(retry) -> Postmortem
+        Second pass:
+          Postmortem -> PlanGPT (lexical first via unconditional loop_restart)
+          -> Debate -> Implement -> ReviewGPT -> ReviewConsensus(yes) -> Exit
+
+        preferred_label="retry" matches condition="outcome=retry" on the
+        ReviewConsensus -> Postmortem edge.
+        Postmortem has three unconditional loop_restart edges to Plan nodes;
+        engine picks PlanGPT (lexically first).
         """
         hooks = RecordingHooks()
         client = MockUnifiedClient(
             [
                 # --- First pass ---
-                _routing_response(suggested_next_ids=["PlanGemini"]),  # CheckDoD
-                _routing_response(),  # PlanGemini
+                _routing_response(preferred_label="has_dod"),  # CheckDoD -> 3 Plans parallel
+                _routing_response(),  # PlanGemini (parallel)
+                _routing_response(),  # PlanGPT (parallel)
+                _routing_response(),  # PlanOpus (parallel)
                 _routing_response(),  # DebateConsolidate
-                _routing_response(),  # Implement
+                _routing_response(),  # Implement -> ReviewGPT (lexical first)
                 _routing_response(),  # ReviewGPT
-                _routing_response(
-                    suggested_next_ids=["Postmortem"]
-                ),  # ReviewConsensus -> retry
-                _routing_response(),  # Postmortem
-                # --- Second pass (Postmortem -> PlanGPT via lexical) ---
-                _routing_response(),  # PlanGPT
+                _routing_response(preferred_label="retry"),  # ReviewConsensus -> Postmortem
+                _routing_response(),  # Postmortem -> PlanGPT (lexical first, loop_restart)
+                # --- Second pass ---
+                _routing_response(),  # PlanGPT -> DebateConsolidate
                 _routing_response(),  # DebateConsolidate
-                _routing_response(),  # Implement
+                _routing_response(),  # Implement -> ReviewGPT (lexical first)
                 _routing_response(),  # ReviewGPT
-                _routing_response(
-                    suggested_next_ids=["Exit"]
-                ),  # ReviewConsensus -> pass
+                _routing_response(preferred_label="yes"),  # ReviewConsensus -> Exit
             ]
         )
         engine = _make_production_engine(self._dot(), client, hooks, str(tmp_path))
@@ -1276,20 +1294,21 @@ class TestConsensusPipeline:
     async def test_consensus_hook_events_include_all_three_providers(self, tmp_path):
         """Hook events show anthropic, openai, AND gemini."""
         hooks = RecordingHooks()
-        # has_dod path through PlanGemini (gemini) + ReviewGPT (openai)
-        # + CheckDoD (anthropic)
+        # has_dod parallel path:
+        #   CheckDoD (anthropic) -> PlanGemini (gemini) + PlanGPT (openai) + PlanOpus (anthropic)
+        #   -> DebateConsolidate (anthropic) -> Implement (anthropic)
+        #   -> ReviewGPT (openai) -> ReviewConsensus (anthropic)
+        # All three providers covered: anthropic, openai, gemini.
         client = MockUnifiedClient(
             [
-                _routing_response(
-                    suggested_next_ids=["PlanGemini"]
-                ),  # CheckDoD (anthropic)
-                _routing_response(),  # PlanGemini (gemini)
+                _routing_response(preferred_label="has_dod"),  # CheckDoD (anthropic)
+                _routing_response(),  # PlanGemini (gemini, parallel)
+                _routing_response(),  # PlanGPT (openai, parallel)
+                _routing_response(),  # PlanOpus (anthropic, parallel)
                 _routing_response(),  # DebateConsolidate (anthropic)
-                _routing_response(),  # Implement (anthropic)
+                _routing_response(),  # Implement (anthropic) -> ReviewGPT (lexical first)
                 _routing_response(),  # ReviewGPT (openai)
-                _routing_response(
-                    suggested_next_ids=["Exit"]
-                ),  # ReviewConsensus (anthropic)
+                _routing_response(preferred_label="yes"),  # ReviewConsensus (anthropic)
             ]
         )
         engine = _make_production_engine(self._dot(), client, hooks, str(tmp_path))


### PR DESCRIPTION
Makes the `modules/loop-pipeline/tests/` suite green again. **TEST-ONLY — no engine source changed.**

### Problem
31 pre-existing failures from tests that were not updated when several fail-loud / routing contracts landed (these failures existed on `main` before this PR — confirmed independently).

### Fixes (all matching CURRENT engine behavior, with code cites)
- **Explicit `llm_model` required** (no silent default model — `backend.py:772`): added `llm_model="test-model"` to box nodes across 5 integration fixtures, the Path-B tests in `test_attribute_passthrough.py`, and the `reasoning_effort` tests in `test_backend.py` — the same convention passing tests already use. (~28 of the 31, incl. cascading FAIL-status assertions.)
- **`test_dot_integration` consensus/semport:** stale routing using `suggested_next_ids` on **conditional** edges (spec §3.3 restricts it to unconditional), stale `preferred_label` display-value vs `condition` value, and a stale `node_type`-attr assertion (the parser promotes `type` → `node.type`).
- **`test_backend` `sub_session_id`:** triaged as a **stale test for an intentional change**, not a regression — the backend now carries node history via `parent_messages` (`backend.py:398-426`) and never sets `sub_session_id`. Renamed to `test_backend_uses_parent_messages_not_sub_session_id` and updated the assertions.

### Verification
Full suite: **1342 passed, 0 failed** (3 warnings). Engine source untouched (verified — only `tests/` and `tests/fixtures/` changed).
