### PR TITLE
fix(loop-agent): resolve context.include factory for Layer-1 base prompt (nlspec §6.1)

### DIFF
--- a/agents/attractor-agent-anthropic.yaml
+++ b/agents/attractor-agent-anthropic.yaml
@@ -43,5 +43,9 @@ tools:
     source: git+https://github.com/microsoft/amplifier-module-tool-search@main
 
 context:
+  # Layer-1 base prompt (nlspec §6.1: "Provider-specific base instructions from ProviderProfile").
+  # foundation registers a system-prompt factory on the context module when this include is set;
+  # loop-agent's AgentOrchestrator.execute() resolves the factory before creating the session
+  # so the file content becomes session_config.system_prompt (Layer 1).
   include:
     - context/system-anthropic.md

--- a/agents/attractor-agent-gemini.yaml
+++ b/agents/attractor-agent-gemini.yaml
@@ -45,5 +45,9 @@ tools:
     source: git+https://github.com/microsoft/amplifier-module-tool-web@main
 
 context:
+  # Layer-1 base prompt (nlspec §6.1: "Provider-specific base instructions from ProviderProfile").
+  # foundation registers a system-prompt factory on the context module when this include is set;
+  # loop-agent's AgentOrchestrator.execute() resolves the factory before creating the session
+  # so the file content becomes session_config.system_prompt (Layer 1).
   include:
     - context/system-gemini.md

--- a/agents/attractor-agent-openai.yaml
+++ b/agents/attractor-agent-openai.yaml
@@ -51,5 +51,9 @@ tools:
     source: git+https://github.com/microsoft/amplifier-module-tool-search@main
 
 context:
+  # Layer-1 base prompt (nlspec §6.1: "Provider-specific base instructions from ProviderProfile").
+  # foundation registers a system-prompt factory on the context module when this include is set;
+  # loop-agent's AgentOrchestrator.execute() resolves the factory before creating the session
+  # so the file content becomes session_config.system_prompt (Layer 1).
   include:
     - context/system-openai.md

--- a/modules/loop-agent/amplifier_module_loop_agent/__init__.py
+++ b/modules/loop-agent/amplifier_module_loop_agent/__init__.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 # Amplifier module metadata
 __amplifier_module_type__ = "orchestrator"
 
+import inspect
 import logging
 from typing import Any
 
@@ -98,7 +99,42 @@ class AgentOrchestrator:
         if coordinator is not None:
             self._coordinator = coordinator
         if self._session is None:
-            config = SessionConfig.from_dict(self._config)
+            # Deliver context.include as Layer-1 "provider base instructions" (nlspec §6.1).
+            #
+            # Foundation registers _system_prompt_factory on the context module when
+            # context.include is declared in a bundle profile (e.g. attractor-agent-anthropic
+            # includes context/system-anthropic.md).  loop-agent must resolve the factory
+            # here because it builds its own message list via _convert_history_to_messages()
+            # rather than delegating to context.get_messages_for_request() — so the factory
+            # is never called on the normal context-simple path.
+            #
+            # Guard: inspect.iscoroutinefunction avoids calling MagicMock auto-attributes
+            # that tests inject as a plain MagicMock context.
+            config_dict = dict(self._config)
+            # Try the context module's factory first — it is the authoritative source for
+            # Layer-1 "Provider-specific base instructions" (nlspec §6.1).  The factory is
+            # registered by foundation when context.include is declared in the bundle profile
+            # (e.g. attractor-agent-anthropic includes context/system-anthropic.md).
+            # system_prompt config is a fallback; it is used only when the factory produces
+            # nothing (returns empty string) or is absent.
+            factory = getattr(context, "_system_prompt_factory", None)
+            if inspect.iscoroutinefunction(factory):
+                try:
+                    context_base = await factory()
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning(
+                        "context._system_prompt_factory raised; Layer-1 base prompt "
+                        "will fall back to system_prompt config or stub: %s",
+                        exc,
+                    )
+                    context_base = ""
+                if context_base:
+                    # Factory wins: the bundle's context.include content is the canonical
+                    # Layer-1 base prompt.  Do not double-inject by also appending
+                    # system_prompt — the factory already incorporates the bundle instruction.
+                    config_dict["system_prompt"] = context_base
+
+            config = SessionConfig.from_dict(config_dict)
             # Use the first available provider
             provider_name = next(iter(providers.keys()))
             provider = providers[provider_name]

--- a/modules/loop-agent/amplifier_module_loop_agent/agent_session.py
+++ b/modules/loop-agent/amplifier_module_loop_agent/agent_session.py
@@ -509,8 +509,20 @@ class AgentSession:
         # Resolve canonical provider ID for doc filtering
         provider_id = self._resolve_provider_id()
 
-        # Layer 1: Base prompt
-        base_prompt = self._config.system_prompt or "You are a coding agent."
+        # Layer 1: Base prompt — resolved by AgentOrchestrator.execute() from the bundle's
+        # context._system_prompt_factory (which delivers context.include files per nlspec §6.1:
+        # "Provider-specific base instructions (from ProviderProfile)").
+        # Falls back to system_prompt config; falls through to a stub with a warning when
+        # neither the factory nor the config provides content.
+        base_prompt = self._config.system_prompt
+        if not base_prompt:
+            logger.warning(
+                "Layer-1 base prompt is empty: no context._system_prompt_factory "
+                "contribution and no system_prompt in orchestrator config. "
+                "Falling back to stub. Set context.include in the bundle profile "
+                "or system_prompt in orchestrator config."
+            )
+            base_prompt = "You are a coding agent."
 
         # Layer 2: Environment context
         working_dir = self._config.working_dir or os.getcwd()

--- a/modules/loop-agent/tests/test_system_prompt_wiring.py
+++ b/modules/loop-agent/tests/test_system_prompt_wiring.py
@@ -309,3 +309,151 @@ async def test_tool_descriptions_in_system_prompt():
     system_content = request.messages[0].content
     assert "read_file" in system_content
     assert "Reads a file from disk" in system_content
+
+
+# ---------------------------------------------------------------------------
+# Layer-1 fix: context._system_prompt_factory delivers provider base prompt
+# (nlspec §6.1 — "Provider-specific base instructions (from ProviderProfile)")
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_context_factory_provides_layer1_base_prompt():
+    """When context has _system_prompt_factory, its result is used as Layer-1.
+
+    Spec §6.1: Layer 1 = "Provider-specific base instructions (from ProviderProfile)".
+    The factory is registered by foundation when context.include is declared in the
+    bundle profile. loop-agent must resolve it in execute() since it builds its own
+    message list and never calls context.get_messages_for_request().
+    """
+    FACTORY_SENTINEL = "BASE-PROMPT-FROM-FACTORY-X7K9Q2"
+
+    async def mock_factory():
+        return f"# Agent Base\n\n{FACTORY_SENTINEL}\n\nYou are a coding agent."
+
+    context = MagicMock()
+    context._system_prompt_factory = mock_factory  # real async function
+
+    provider = AsyncMock()
+    provider.complete = AsyncMock(return_value=_text_response("done"))
+    hooks = _make_hooks()
+    coordinator = MagicMock()
+    coordinator.register_capability = MagicMock()
+
+    orch = AgentOrchestrator(
+        coordinator=coordinator,
+        config={"max_tool_rounds_per_input": 1},  # no system_prompt — factory must provide it
+    )
+    await orch.execute("hello", context, {"anthropic": provider}, {}, hooks)
+
+    request = provider.complete.call_args[0][0]
+    system_content = request.messages[0].content
+    assert FACTORY_SENTINEL in system_content, (
+        f"Factory sentinel not found in system prompt. Got: {system_content[:200]}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_context_factory_wins_over_config_system_prompt():
+    """context._system_prompt_factory is primary; system_prompt config is fallback.
+
+    Spec §6.1: the context module delivers "Provider-specific base instructions
+    (from ProviderProfile)". This takes precedence over an explicit system_prompt
+    in orchestrator config. No double-injection: the factory already incorporates
+    the bundle instruction.
+    """
+    FACTORY_SENTINEL = "FACTORY-WINS-SENTINEL-M3P7"
+    CONFIG_SENTINEL = "CONFIG-SYSTEM-PROMPT-SHOULD-NOT-WIN"
+
+    async def mock_factory():
+        return f"# From Factory\n\n{FACTORY_SENTINEL}"
+
+    context = MagicMock()
+    context._system_prompt_factory = mock_factory
+
+    provider = AsyncMock()
+    provider.complete = AsyncMock(return_value=_text_response("done"))
+    hooks = _make_hooks()
+    coordinator = MagicMock()
+    coordinator.register_capability = MagicMock()
+
+    orch = AgentOrchestrator(
+        coordinator=coordinator,
+        config={
+            "system_prompt": CONFIG_SENTINEL,  # explicit config present
+            "max_tool_rounds_per_input": 1,
+        },
+    )
+    await orch.execute("hello", context, {"anthropic": provider}, {}, hooks)
+
+    request = provider.complete.call_args[0][0]
+    system_content = request.messages[0].content
+    # Factory result is the canonical Layer-1; config system_prompt is a fallback
+    assert FACTORY_SENTINEL in system_content, (
+        f"Factory sentinel not found. Got: {system_content[:200]}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_context_factory_error_falls_back_to_config():
+    """When factory raises, Layer-1 falls back to system_prompt config."""
+
+    async def failing_factory():
+        raise RuntimeError("factory failure")
+
+    context = MagicMock()
+    context._system_prompt_factory = failing_factory
+
+    provider = AsyncMock()
+    provider.complete = AsyncMock(return_value=_text_response("done"))
+    hooks = _make_hooks()
+    coordinator = MagicMock()
+    coordinator.register_capability = MagicMock()
+
+    orch = AgentOrchestrator(
+        coordinator=coordinator,
+        config={"system_prompt": "Fallback prompt.", "max_tool_rounds_per_input": 1},
+    )
+    await orch.execute("hello", context, {"anthropic": provider}, {}, hooks)
+
+    request = provider.complete.call_args[0][0]
+    system_content = request.messages[0].content
+    assert "Fallback prompt." in system_content
+
+
+@pytest.mark.asyncio
+async def test_non_coroutine_factory_not_called():
+    """A non-async _system_prompt_factory attribute is ignored (no call).
+
+    Guards against MagicMock auto-attributes in tests — MagicMock creates a regular
+    (non-coroutine) callable on any attribute access, and calling it as an async
+    function would raise. inspect.iscoroutinefunction ensures we only call real factories.
+    """
+    factory_called = []
+
+    def sync_factory():  # NOT async — should be ignored
+        factory_called.append(True)
+        return "should not be used"
+
+    context = MagicMock()
+    context._system_prompt_factory = sync_factory
+
+    provider = AsyncMock()
+    provider.complete = AsyncMock(return_value=_text_response("done"))
+    hooks = _make_hooks()
+    coordinator = MagicMock()
+    coordinator.register_capability = MagicMock()
+
+    orch = AgentOrchestrator(
+        coordinator=coordinator,
+        config={"system_prompt": "Config prompt.", "max_tool_rounds_per_input": 1},
+    )
+    await orch.execute("hello", context, {"anthropic": provider}, {}, hooks)
+
+    # Sync factory must NOT have been called
+    assert not factory_called, "sync factory should not be called"
+
+    # Config system_prompt should be used instead
+    request = provider.complete.call_args[0][0]
+    system_content = request.messages[0].content
+    assert "Config prompt." in system_content


### PR DESCRIPTION
## Problem
loop-agent builds its own message list (`_convert_history_to_messages`) and never calls the mounted context module, so the foundation system-prompt factory — the Amplifier channel that delivers a bundle's `context.include` — was dropped. Layer 1 fell back to the stub `"You are a coding agent."`. Impact: **every attractor coding agent (pipeline + interactive) was running without its intended base system prompt.** The bundle's own `context/system-anthropic.md` (Claude Code-aligned base prompt) was silently never delivered.

## Spec fidelity
`coding-agent-loop-spec.md §6.1` defines Layer 1 = "Provider base instructions (from ProviderProfile)". This change implements Layer 1 faithfully — the Amplifier delivery of that base prompt is the context module's system-prompt contribution. No new layer is introduced; the 5-layer model is unchanged.

## Fix
`AgentOrchestrator.execute()` resolves `context._system_prompt_factory` (when present, async) and uses its output as the Layer-1 base prompt; `config.system_prompt` becomes the fallback, and an empty result now logs a loud warning before the stub (no silent default).

## Proof
- Before: sentinel placed in `system-anthropic.md` is NOT echoed by a spawned box node (drop reproduced).
- After: same sentinel IS echoed end-to-end through the real spawn path.
- `uv run pytest tests/` in modules/loop-agent: **490 passed** (incl. 4 new wiring tests covering factory-as-Layer-1, factory-wins-over-config, factory-error-fallback, sync-attr-not-called).
- Regression: a downstream pipeline whose profile declares no `context.include` falls back and warns correctly (unchanged behavior).

## Known follow-up (not blocking)
Reads the private `context._system_prompt_factory` attribute — pragmatic and consistent with how `context-simple` uses it internally, but a public accessor on the foundation context contract would be cleaner long-term.