### PR TITLE
fix(loop-pipeline): run from Start on resume for graphs that own resume; re-execute dynamic routers

### DIFF
--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py
@@ -83,6 +83,11 @@ class PipelineEngine:
         self._cancel_event = cancel_event
         self.node_outcomes: dict[str, Outcome] = {}
         self.completed_nodes: list[str] = []
+        # Guard set for the resume re-execution path: tracks nodes that were
+        # already stripped-and-re-queued once during the resume fast-forward
+        # (Step 1b).  A second no-matching-edge for the same node means it is
+        # truly unroutable — terminate rather than loop.
+        self._resume_reexecuted: set[str] = set()
         self.iteration_count: int = 0
         self._node_execution_counts: dict[
             str, int
@@ -362,7 +367,16 @@ class PipelineEngine:
                     self.context,
                     self.graph,
                 )
-                if edge is None:
+                if edge is not None:
+                    # Fast-forward: edge found from restored outcome — skip to next node.
+                    current_node = self.graph.nodes[edge.to_node]
+                    continue
+                # edge is None: the restored checkpoint outcome cannot reproduce the
+                # routing label for this node (common for dynamic routers whose label
+                # is emitted at runtime, e.g. ResumeGate emitting "fresh"/"resume").
+                if current_node.id in self._resume_reexecuted:
+                    # Second no-match for this node on resume — truly unroutable.
+                    # Preserve the original terminate behaviour.
                     fail_outcome = self.terminate_pipeline(
                         node_id=current_node.id,
                         upstream_outcome=None,
@@ -380,8 +394,22 @@ class PipelineEngine:
                     )
                     await self._emit_complete(fail_outcome, pipeline_start_time)
                     return fail_outcome
-                current_node = self.graph.nodes[edge.to_node]
-                continue
+                # First no-match: dynamic router with a stale checkpoint outcome.
+                # Strip it from completed state and fall through to re-execute it
+                # so it can regenerate its routing label at runtime.
+                self._resume_reexecuted.add(current_node.id)
+                self.completed_nodes.remove(current_node.id)
+                self.node_outcomes.pop(current_node.id, None)
+                self.failed_outputs = {
+                    k: v for k, v in self.failed_outputs.items() if v != current_node.id
+                }
+                logger.info(
+                    "Resume: node '%s' has a stale checkpoint outcome (no matching "
+                    "edge); stripping completed state and re-executing to regenerate "
+                    "routing label.",
+                    current_node.id,
+                )
+                # Do NOT continue — fall through to the handler execution path below.
 
             # M2/M3/M4: Eager reference scan — skip if a predecessor failed.
             # Must run BEFORE the handler is invoked so handlers never see
@@ -590,7 +618,10 @@ class PipelineEngine:
             # An explicit FAIL or RETRY must pass through unchanged (fail-loud).
             # Accept both bare true and the quoted string "true" (DOT parser
             # returns "true" for quoted attribute values).
-            if current_node.auto_status in (True, "true") and outcome.status == StageStatus.SKIPPED:
+            if (
+                current_node.auto_status in (True, "true")
+                and outcome.status == StageStatus.SKIPPED
+            ):
                 logger.debug(
                     "Node '%s' has auto_status=true; promoting SKIPPED to SUCCESS",
                     current_node.id,
@@ -1120,7 +1151,19 @@ class PipelineEngine:
         Species S3 for context.
 
         Spec Section 5.3: Resume behavior, T2.4 (RunIdentity hard-fail).
+
+        NOTE: If ``_checkpoint_resume_enabled()`` returns False (the pipeline
+        graph has set ``resume_from_checkpoint="false"``), this method returns
+        False immediately so the engine always runs from Start.  The graph's
+        own resume node (e.g. ResumeGate) takes over all resume logic.
         """
+        if not self._checkpoint_resume_enabled():
+            logger.info(
+                "Checkpoint resume disabled for graph %s; running from Start",
+                self.graph.graph_attrs.get("label", "(unlabelled)"),
+            )
+            return False
+
         if self._checkpoint_path is None or not os.path.exists(self._checkpoint_path):
             return False
 
@@ -1198,6 +1241,28 @@ class PipelineEngine:
             cp.current_node,
         )
         return True
+
+    def _checkpoint_resume_enabled(self) -> bool:
+        """Return True unless the pipeline graph opts out of checkpoint-based resume.
+
+        Pipelines that manage their own resume signal (e.g., Design-A pipelines
+        that use a ResumeGate node reading committed STATE.yaml) should set::
+
+            graph [
+                resume_from_checkpoint = "false",
+            ]
+
+        This instructs the engine to skip the node-level checkpoint fast-forward
+        and run from Start on every launch, delegating all resume logic to the
+        graph itself.  The ``_resume_reexecuted`` dynamic-router safety net
+        (Patch #1) remains in place for graphs that do NOT set this flag.
+
+        Accepted falsy values: "false", "0", "no", "off" (case-insensitive).
+        Any other value, or absence of the attribute, is truthy (checkpoint resume
+        enabled).
+        """
+        raw = self.graph.graph_attrs.get("resume_from_checkpoint", "true")
+        return str(raw).strip().lower() not in {"false", "0", "no", "off"}
 
     def _save_checkpoint(self, current_node_id: str) -> None:
         """Save a checkpoint after a node execution.
@@ -1476,9 +1541,8 @@ class PipelineEngine:
 
         Returns the target Node or None if no valid target exists.
         """
-        target_id = (
-            node.attrs.get("retry_target")
-            or node.attrs.get("fallback_retry_target")
+        target_id = node.attrs.get("retry_target") or node.attrs.get(
+            "fallback_retry_target"
         )
         if target_id and target_id in self.graph.nodes:
             return self.graph.nodes[target_id]

--- a/modules/loop-pipeline/tests/test_checkpoint.py
+++ b/modules/loop-pipeline/tests/test_checkpoint.py
@@ -24,7 +24,7 @@ from amplifier_module_loop_pipeline.dot_parser import parse_dot
 from amplifier_module_loop_pipeline.engine import PipelineEngine
 from amplifier_module_loop_pipeline.graph import Node
 from amplifier_module_loop_pipeline.handlers import HandlerRegistry
-from amplifier_module_loop_pipeline.outcome import StageStatus
+from amplifier_module_loop_pipeline.outcome import Outcome, StageStatus
 from amplifier_module_loop_pipeline.run_identity import RunIdentity
 from amplifier_module_loop_pipeline.validation import validate_or_raise
 from amplifier_module_loop_pipeline.handlers.context import HandlerContext
@@ -191,7 +191,14 @@ class MockBackend:
         self._return_value = return_value
         self.calls: list[str] = []
 
-    async def run(self, node: Node, prompt: str, context: PipelineContext, incoming_edge=None, graph=None) -> str:
+    async def run(
+        self,
+        node: Node,
+        prompt: str,
+        context: PipelineContext,
+        incoming_edge=None,
+        graph=None,
+    ) -> str:
         self.calls.append(node.id)
         return self._return_value
 
@@ -664,3 +671,144 @@ class TestRunIdentityHardFail:
             await engine.run()
 
         assert str(cp_path) in str(exc_info.value)
+
+
+# --- Resume: dynamic router re-execution ---
+
+_DYNAMIC_ROUTER_DOT = """
+digraph {
+    start [shape=Mdiamond]
+    router [shape=box, prompt="Decide route"]
+    branch_a [shape=box, prompt="Branch A"]
+    branch_b [shape=box, prompt="Branch B"]
+    exit [shape=Msquare]
+    start -> router
+    router -> branch_a [condition="preferred_label=route_a"]
+    router -> branch_b [condition="preferred_label=route_b"]
+    branch_a -> exit
+    branch_b -> exit
+}
+"""
+
+
+class _RouterBackend:
+    """Backend that emits a fixed preferred_label for the 'router' node."""
+
+    def __init__(self, label: str = "route_a") -> None:
+        self.calls: list[str] = []
+        self._label = label
+
+    async def run(
+        self,
+        node: Node,
+        prompt: str,
+        context: PipelineContext,
+        incoming_edge=None,
+        graph=None,
+    ) -> Outcome:
+        self.calls.append(node.id)
+        if node.id == "router":
+            return Outcome(status=StageStatus.SUCCESS, preferred_label=self._label)
+        return Outcome(status=StageStatus.SUCCESS)
+
+
+class TestResumeDynamicRouter:
+    """Resume fix: dynamic routers with stale checkpoint outcomes are re-executed.
+
+    Spec coverage: resume fast-forward re-execution (engine.py Step 1b fix).
+    """
+
+    @pytest.mark.asyncio
+    async def test_resume_reexecutes_dynamic_router(self, tmp_path):
+        """A completed router node whose saved outcome has no preferred_label
+        (stale checkpoint) is stripped from completed state and re-executed once,
+        then routes correctly to the branch matching the live preferred_label."""
+        graph = parse_dot(_DYNAMIC_ROUTER_DOT)
+        identity = RunIdentity.from_graph(graph)
+
+        # Checkpoint: router is done, but preferred_label was NOT persisted —
+        # select_edge at Step 1b cannot reproduce the routing signal.
+        cp = Checkpoint(
+            current_node="router",
+            completed_nodes={"start": "success", "router": "success"},
+            context_snapshot={},
+            node_outcomes={
+                "start": {
+                    "status": "success",
+                    "notes": None,
+                    "failure_reason": None,
+                    "preferred_label": None,
+                },
+                "router": {
+                    "status": "success",
+                    "notes": None,
+                    "failure_reason": None,
+                    "preferred_label": None,  # stale — routing label lost
+                },
+            },
+            timestamp="2025-01-01T00:00:00Z",
+            identity=identity,
+        )
+        save_checkpoint(cp, str(tmp_path / "checkpoint.json"))
+
+        backend = _RouterBackend(label="route_a")
+        engine = _make_engine(
+            _DYNAMIC_ROUTER_DOT, backend=backend, logs_root=str(tmp_path)
+        )
+        outcome = await engine.run()
+
+        # Pipeline must succeed — router re-executed and emitted a valid routing label.
+        assert outcome.status in (StageStatus.SUCCESS, StageStatus.PARTIAL_SUCCESS)
+        # Router was re-executed exactly once (not skipped, not run multiple times).
+        assert backend.calls.count("router") == 1
+        # Correct branch taken via the re-emitted label.
+        assert "branch_a" in backend.calls
+        assert "branch_b" not in backend.calls
+
+    @pytest.mark.asyncio
+    async def test_resume_loop_guard_terminates_when_router_still_unroutable(
+        self, tmp_path
+    ):
+        """When a re-executed router still yields no matching edge, the pipeline
+        fails cleanly with a 'no_matching_edge' failure — not a max-steps overflow."""
+        graph = parse_dot(_DYNAMIC_ROUTER_DOT)
+        identity = RunIdentity.from_graph(graph)
+
+        # Same stale checkpoint: router completed with no preferred_label.
+        cp = Checkpoint(
+            current_node="router",
+            completed_nodes={"start": "success", "router": "success"},
+            context_snapshot={},
+            node_outcomes={
+                "start": {
+                    "status": "success",
+                    "notes": None,
+                    "failure_reason": None,
+                    "preferred_label": None,
+                },
+                "router": {
+                    "status": "success",
+                    "notes": None,
+                    "failure_reason": None,
+                    "preferred_label": None,  # stale
+                },
+            },
+            timestamp="2025-01-01T00:00:00Z",
+            identity=identity,
+        )
+        save_checkpoint(cp, str(tmp_path / "checkpoint.json"))
+
+        # Backend always returns a label that matches no outgoing edge.
+        backend = _RouterBackend(label="nonexistent_label")
+        engine = _make_engine(
+            _DYNAMIC_ROUTER_DOT, backend=backend, logs_root=str(tmp_path)
+        )
+        outcome = await engine.run()
+
+        # Must fail, not time out via the step-count safety bound.
+        assert outcome.status == StageStatus.FAIL
+        # Router was invoked exactly once — no infinite re-execution loop.
+        assert backend.calls.count("router") == 1
+        # Failure is 'no matching edge', not 'safety bound exceeded'.
+        assert "no matching edge" in (outcome.failure_reason or "").lower()
+        assert "exceeded" not in (outcome.failure_reason or "").lower()

--- a/modules/loop-pipeline/tests/test_resume_disable_flag.py
+++ b/modules/loop-pipeline/tests/test_resume_disable_flag.py
@@ -1,0 +1,253 @@
+"""Tests for the resume_from_checkpoint="false" graph attribute.
+
+When a pipeline sets ``resume_from_checkpoint="false"`` in its graph block,
+the engine must NOT load or honour any existing checkpoint; it runs from
+Start every time and lets the graph's own resume node (e.g. ResumeGate)
+drive continuation.
+
+Test coverage:
+  T1  -- engine ignores checkpoint and re-executes completed nodes
+  T2  -- parse_dot preserves the graph attr so the engine can read it
+  T3  -- _checkpoint_resume_enabled() semantics table
+"""
+
+import pytest
+
+from amplifier_module_loop_pipeline.checkpoint import (
+    Checkpoint,
+    save_checkpoint,
+)
+from amplifier_module_loop_pipeline.context import PipelineContext
+from amplifier_module_loop_pipeline.dot_parser import parse_dot
+from amplifier_module_loop_pipeline.engine import PipelineEngine
+from amplifier_module_loop_pipeline.graph import Node
+from amplifier_module_loop_pipeline.handlers import HandlerRegistry
+from amplifier_module_loop_pipeline.handlers.context import HandlerContext
+from amplifier_module_loop_pipeline.outcome import StageStatus
+from amplifier_module_loop_pipeline.run_identity import RunIdentity
+from amplifier_module_loop_pipeline.validation import validate_or_raise
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+_DOT_DISABLE_FLAG = """\
+digraph {
+    graph [
+        resume_from_checkpoint = "false",
+    ]
+    start  [shape=Mdiamond]
+    work   [shape=box, prompt="Do work"]
+    finish [shape=Msquare]
+    start -> work -> finish
+}
+"""
+
+_DOT_NO_FLAG = """\
+digraph {
+    start  [shape=Mdiamond]
+    work   [shape=box, prompt="Do work"]
+    finish [shape=Msquare]
+    start -> work -> finish
+}
+"""
+
+
+class _TrackingBackend:
+    """Backend that records every node it was asked to run."""
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    async def run(
+        self,
+        node: Node,
+        prompt: str,
+        context: PipelineContext,
+        incoming_edge=None,
+        graph=None,
+    ) -> str:
+        self.calls.append(node.id)
+        return "done"
+
+
+def _make_engine(
+    dot_source: str,
+    backend: object | None = None,
+    logs_root: str = "/tmp/test-resume-disable",
+) -> PipelineEngine:
+    graph = parse_dot(dot_source)
+    validate_or_raise(graph)
+    context = PipelineContext()
+    registry = HandlerRegistry(HandlerContext(backend=backend))
+    return PipelineEngine(
+        graph=graph,
+        context=context,
+        handler_registry=registry,
+        logs_root=logs_root,
+    )
+
+
+# ---------------------------------------------------------------------------
+# T1 — engine ignores checkpoint and re-executes completed nodes
+# ---------------------------------------------------------------------------
+
+
+class TestCheckpointDisabledFlag:
+    """T1: resume_from_checkpoint=false causes engine to run from Start.
+
+    A checkpoint that marks 'work' as already completed must be IGNORED when
+    the flag is set — the node must be executed (not fast-forwarded past).
+    """
+
+    @pytest.mark.asyncio
+    async def test_completed_node_is_reexecuted_when_flag_set(self, tmp_path):
+        """Engine re-executes a node recorded in the checkpoint when
+        resume_from_checkpoint="false" is present in the graph block."""
+        graph = parse_dot(_DOT_DISABLE_FLAG)
+        identity = RunIdentity.from_graph(graph)
+
+        # Write a checkpoint that says 'work' is done.
+        cp = Checkpoint(
+            current_node="work",
+            completed_nodes={"start": "success", "work": "success"},
+            context_snapshot={},
+            node_outcomes={
+                "start": {
+                    "status": "success",
+                    "notes": None,
+                    "failure_reason": None,
+                    "preferred_label": None,
+                },
+                "work": {
+                    "status": "success",
+                    "notes": None,
+                    "failure_reason": None,
+                    "preferred_label": None,
+                },
+            },
+            timestamp="2025-01-01T00:00:00Z",
+            identity=identity,
+        )
+        save_checkpoint(cp, str(tmp_path / "checkpoint.json"))
+
+        backend = _TrackingBackend()
+        engine = _make_engine(
+            _DOT_DISABLE_FLAG, backend=backend, logs_root=str(tmp_path)
+        )
+        outcome = await engine.run()
+
+        # Pipeline must succeed (ran to completion from Start).
+        assert outcome.status in (StageStatus.SUCCESS, StageStatus.PARTIAL_SUCCESS)
+        # 'work' must have been called — the checkpoint was NOT honoured.
+        assert "work" in backend.calls, (
+            f"Expected 'work' to be executed (checkpoint disabled), "
+            f"but backend.calls={backend.calls}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_checkpoint_not_ignored_without_flag(self, tmp_path):
+        """Sanity: without the flag, the engine DOES honour the checkpoint
+        and skips nodes already recorded as completed."""
+        graph = parse_dot(_DOT_NO_FLAG)
+        identity = RunIdentity.from_graph(graph)
+
+        cp = Checkpoint(
+            current_node="work",
+            completed_nodes={"start": "success", "work": "success"},
+            context_snapshot={},
+            node_outcomes={
+                "start": {
+                    "status": "success",
+                    "notes": None,
+                    "failure_reason": None,
+                    "preferred_label": None,
+                },
+                "work": {
+                    "status": "success",
+                    "notes": None,
+                    "failure_reason": None,
+                    "preferred_label": None,
+                },
+            },
+            timestamp="2025-01-01T00:00:00Z",
+            identity=identity,
+        )
+        save_checkpoint(cp, str(tmp_path / "checkpoint.json"))
+
+        backend = _TrackingBackend()
+        engine = _make_engine(_DOT_NO_FLAG, backend=backend, logs_root=str(tmp_path))
+        await engine.run()
+
+        # Without the flag the checkpoint IS honoured — 'work' is skipped.
+        assert "work" not in backend.calls, (
+            f"Expected 'work' to be SKIPPED (checkpoint active), "
+            f"but backend.calls={backend.calls}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# T2 — parse_dot preserves the graph attribute
+# ---------------------------------------------------------------------------
+
+
+class TestParseDotCarriesFlag:
+    """T2: parse_dot carries resume_from_checkpoint into graph_attrs."""
+
+    def test_flag_present_in_graph_attrs(self):
+        graph = parse_dot(_DOT_DISABLE_FLAG)
+        assert "resume_from_checkpoint" in graph.graph_attrs, (
+            "parse_dot must preserve resume_from_checkpoint in graph_attrs"
+        )
+        assert graph.graph_attrs["resume_from_checkpoint"] == "false"
+
+    def test_flag_absent_when_not_set(self):
+        graph = parse_dot(_DOT_NO_FLAG)
+        assert "resume_from_checkpoint" not in graph.graph_attrs
+
+
+# ---------------------------------------------------------------------------
+# T3 — _checkpoint_resume_enabled() semantics table
+# ---------------------------------------------------------------------------
+
+
+class TestCheckpointResumeEnabledSemantics:
+    """T3: _checkpoint_resume_enabled() returns the right bool for every value.
+
+    Falsy  : "false", "False", "0", "no", "off"  → returns False
+    Truthy : absent, "true", "yes", "1"           → returns True
+    """
+
+    @pytest.mark.parametrize(
+        "attr_value, expected",
+        [
+            (None, True),  # absent — default is enabled
+            ("true", True),
+            ("True", True),
+            ("1", True),
+            ("yes", True),
+            ("false", False),
+            ("False", False),
+            ("0", False),
+            ("no", False),
+            ("off", False),
+        ],
+    )
+    def test_semantics(self, attr_value: str | None, expected: bool, tmp_path):
+        if attr_value is None:
+            dot = _DOT_NO_FLAG
+        else:
+            dot = f"""\
+digraph {{
+    graph [ resume_from_checkpoint = "{attr_value}", ]
+    start  [shape=Mdiamond]
+    finish [shape=Msquare]
+    start -> finish
+}}
+"""
+        engine = _make_engine(dot, backend=_TrackingBackend(), logs_root=str(tmp_path))
+        assert engine._checkpoint_resume_enabled() is expected, (
+            f"attr_value={attr_value!r}: expected {expected}, "
+            f"got {engine._checkpoint_resume_enabled()}"
+        )


### PR DESCRIPTION
## Summary

The attractor engine's checkpoint resume had a fatal flaw: on `/resume`, the engine's node-level fast-forward ('Step 1b') tries to skip already-completed nodes by replaying their saved edge selections. For **DYNAMIC ROUTER nodes** whose outgoing edges depend on a runtime-emitted label (e.g., ResumeGate emitting 'fresh'/'resume', SelectWork emitting 'feature_selected'), the saved Outcome does not capture that label. So `select_edge()` finds NO matching edge and terminates: **"No matching edge from resumed node 'ResumeGate'"**. This blocked resumability for any pipeline that routes on resume state.

## The Fix

Two changes in `engine.py`:

1. **Patch #1 (general safety net):** When a resumed node yields no matching edge at Step 1b, **re-execute it once** instead of terminating (guarded by `_resume_reexecuted` set to bound it). The node can then re-emit its routing label and proceed.

2. **Root fix (opt-in, graph-scoped):** New `_checkpoint_resume_enabled()` method reads the graph attribute `resume_from_checkpoint`; when set to "false"/"0"/"no"/"off", `_try_resume_from_checkpoint()` returns False so the engine runs the full graph **from Start on resume** (no node-level fast-forward). This lets a graph own its resume semantics (e.g., a ResumeGate node reading committed STATE.yaml). Absent attribute defaults to True, preserving existing checkpoint resume for all other pipelines, byte-for-byte compatible. Patch #1 remains the live safety net for default-path dynamic routers.

## Testing

- ✅ 1357 tests pass locally, ruff clean
- ✅ 14 new resume/checkpoint tests (test_checkpoint.py + new test_resume_disable_flag.py)
- ✅ End-to-end proof in Digital Twin instance 52323903c65a:
  ```
  build → commit project-skeleton → /stop → /resume
  RESUME: Start → ResumeGate → "resume (committed progress)" → SelectWork 
          → ApplyState → "re-pick" → Implement (building database-schema)
  STATE.yaml: project-skeleton=done (no clobber), database-schema=in-progress
  resolver: ALIVE, status=running, continuing ✓
  ```
  
  The `"No matching edge from resumed node 'ResumeGate'"` error is **gone**. ResumeGate now re-executes, reads STATE.yaml, emits 'resume', and the graph continues.

## Dependency

**Consumer:** [amplifier-resolver-dot-graph PR #85](https://github.com/microsoft/amplifier-resolver-dot-graph/pull/85) sets `resume_from_checkpoint="false"` in `dev_machine.dot`. That flag is a no-op until this engine change lands, so **this PR should merge before/with PR #85**.

## Commits

- **6fd38d3** fix(loop-pipeline): run from Start on resume for graphs that own resume; re-execute dynamic routers