### PR TITLE
fix(unified-llm-client): select latest model by release_date, not catalog file order

### DIFF
--- a/modules/unified-llm-client/docs/FOLLOWUP-live-model-catalog.md
+++ b/modules/unified-llm-client/docs/FOLLOWUP-live-model-catalog.md
@@ -1,0 +1,43 @@
+# Follow-up: Live Model Catalog via Provider Adapters
+
+## What was deferred
+
+The ideal implementation of `get_latest_model()` and `list_models()` would
+source freshness directly from each provider's **live API** rather than from
+the hand-maintained static `data/models.json`. Amplifier-core's
+`Provider.list_models() -> list[ModelInfo]` protocol already requires every
+adapter to implement live model discovery. The adapters in
+`src/unified_llm/adapters/` (`anthropic.py`, `openai.py`, `gemini.py`,
+`copilot.py`) would each need a `list_models()` method that calls
+`client.models.list()` (or equivalent) and maps the live results to
+`ModelInfo` objects with real `release_date` values.
+
+## Why deferred
+
+1. **Scope**: adding `list_models()` to all four adapters is a cross-adapter
+   change, not a single-file fix, and touches every adapter's public surface.
+2. **Zero live callers today**: all 23 `get_latest_model` call-sites are
+   catalog internals, tests, or `__init__` exports — no production code
+   consumes it yet.  The risk of a footgun hurting users is currently low.
+3. **The recency fix + §8.10 smoke remove the footgun now**: `get_latest_model`
+   now selects by `max(release_date, id)` deterministically, fails loudly for
+   unknown providers, and the §8.10 staleness guard catches a dead id whenever
+   keys are present.  This is a solid floor while the live-catalog work matures.
+
+## How to implement when ready
+
+1. Add `list_models() -> list[ModelInfo]` to each adapter, calling the
+   provider's native model-list endpoint and mapping to `ModelInfo` with a
+   typed `release_date` derived from the model id or the provider's metadata.
+2. Update `catalog.py`'s `list_models(provider)` to call the active adapter's
+   `list_models()` when available, falling back to `models.json` when the
+   adapter is not loaded or the call fails.
+3. Add an adapter-level test per provider that asserts the live-fetched list
+   is non-empty and every entry has a valid `release_date`.
+
+## References
+
+- Amplifier-core `Provider.list_models()` contract: `amplifier-core` →
+  `docs/contracts/PROVIDER_CONTRACT.md`
+- Original unified-llm nlspec freshness intent: `strongdm-attractor` →
+  `unified-llm-spec.md` §2.9 and App C

--- a/modules/unified-llm-client/tests/dod/test_8_10_integration_smoke.py
+++ b/modules/unified-llm-client/tests/dod/test_8_10_integration_smoke.py
@@ -3,6 +3,11 @@
 6 end-to-end tests that require real API keys.
 Run with: pytest tests/dod/test_8_10_integration_smoke.py -m integration
 Requires: OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY (or GOOGLE_API_KEY)
+
+Also contains ``TestModelIdStalenessGuard``: per-provider, individually key-gated
+tests that verify ``get_latest_model(provider).id`` is a live, working model id.
+When a key is absent the test emits an explicit skip message stating that
+**model-id staleness was NOT validated** for that provider — no silent green.
 """
 
 from __future__ import annotations
@@ -286,3 +291,94 @@ class TestIntegrationSmoke:
                 max_retries=0,
                 max_tokens=100,
             )
+
+
+# ---------------------------------------------------------------------------
+# §8.10 model-id staleness guard — per-provider, individually key-gated
+# ---------------------------------------------------------------------------
+
+
+class TestModelIdStalenessGuard:
+    """Per-provider freshness guard.
+
+    Each test is individually key-gated and skips loudly when its API key is
+    absent, making it explicit that **model-id staleness was NOT validated**
+    for that provider.  When a key IS present the test proves that
+    ``get_latest_model(provider).id`` is a working, live model id by
+    performing a real 1-token completion — a dead id must fail here.
+
+    Run with: pytest tests/dod/test_8_10_integration_smoke.py -m integration -k staleness
+    """
+
+    @pytest.mark.asyncio(loop_scope="function")
+    @pytest.mark.integration
+    async def test_anthropic_model_id_is_live(self) -> None:
+        """§8.10 staleness guard — anthropic: get_latest_model().id must be a live model."""
+        if not os.environ.get("ANTHROPIC_API_KEY"):
+            pytest.skip(
+                "§8.10 anthropic smoke SKIPPED: ANTHROPIC_API_KEY not set "
+                "— model-id staleness NOT validated"
+            )
+        latest = get_latest_model("anthropic")
+        client = Client.from_env()
+        result = await generate(
+            model=latest.id,
+            prompt="Reply with just 'ok'.",
+            max_tokens=16,  # 16 avoids provider min-token floors on reasoning models
+            provider="anthropic",
+            client=client,
+            max_retries=0,
+        )
+        assert result.usage.output_tokens > 0, (
+            f"Zero output tokens from anthropic/{latest.id!r} — "
+            "model id may be stale or rejected by the endpoint"
+        )
+
+    @pytest.mark.asyncio(loop_scope="function")
+    @pytest.mark.integration
+    async def test_openai_model_id_is_live(self) -> None:
+        """§8.10 staleness guard — openai: get_latest_model().id must be a live model."""
+        if not os.environ.get("OPENAI_API_KEY"):
+            pytest.skip(
+                "§8.10 openai smoke SKIPPED: OPENAI_API_KEY not set "
+                "— model-id staleness NOT validated"
+            )
+        latest = get_latest_model("openai")
+        client = Client.from_env()
+        result = await generate(
+            model=latest.id,
+            prompt="Reply with just 'ok'.",
+            max_tokens=16,  # 16 satisfies o4-mini's minimum of 16 max_output_tokens
+            provider="openai",
+            client=client,
+            max_retries=0,
+        )
+        assert result.usage.output_tokens > 0, (
+            f"Zero output tokens from openai/{latest.id!r} — "
+            "model id may be stale or rejected by the endpoint"
+        )
+
+    @pytest.mark.asyncio(loop_scope="function")
+    @pytest.mark.integration
+    async def test_gemini_model_id_is_live(self) -> None:
+        """§8.10 staleness guard — gemini: get_latest_model().id must be a live model."""
+        key = os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")
+        if not key:
+            pytest.skip(
+                "§8.10 gemini smoke SKIPPED: GEMINI_API_KEY / GOOGLE_API_KEY not set "
+                "— model-id staleness NOT validated"
+            )
+        latest = get_latest_model("gemini")
+        client = Client.from_env()
+        result = await generate(
+            model=latest.id,
+            prompt="Reply with just 'ok'.",
+            max_tokens=16,  # 16 avoids 0-output edge case from max_tokens=1 truncation
+            provider="gemini",
+            client=client,
+            max_retries=0,
+        )
+        assert result.usage.output_tokens > 0, (
+            f"Zero output tokens from gemini/{latest.id!r} — "
+            "model id may be stale or rejected by the endpoint"
+        )

--- a/modules/unified-llm-client/tests/unit/test_catalog.py
+++ b/modules/unified-llm-client/tests/unit/test_catalog.py
@@ -1,6 +1,54 @@
 """Tests for unified_llm.catalog — model catalog and lookup functions."""
 
-from unified_llm.catalog import get_latest_model, get_model_info, list_models
+from datetime import date
+
+import pytest
+
+import unified_llm.catalog as _cat
+from unified_llm.catalog import _parse_catalog, get_latest_model, get_model_info, list_models
+from unified_llm.types import ModelInfo
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _model(
+    id: str,
+    provider: str,
+    release_date: date,
+    *,
+    supports_reasoning: bool = False,
+    supports_vision: bool = True,
+    supports_tools: bool = True,
+) -> ModelInfo:
+    """Build a minimal ModelInfo for in-memory catalog tests."""
+    return ModelInfo(
+        id=id,
+        provider=provider,
+        display_name=f"Test {id}",
+        context_window=100_000,
+        supports_tools=supports_tools,
+        supports_vision=supports_vision,
+        supports_reasoning=supports_reasoning,
+        release_date=release_date,
+    )
+
+
+def _inject_catalog(monkeypatch, models: list[ModelInfo]) -> None:
+    """Replace the module-level catalog cache with *models* for one test."""
+    aliases: dict[str, str] = {}
+    for m in models:
+        for a in m.aliases:
+            aliases[a] = m.id
+    monkeypatch.setattr(_cat, "_CATALOG", models)
+    monkeypatch.setattr(_cat, "_ALIAS_MAP", aliases)
+
+
+# ---------------------------------------------------------------------------
+# Existing test classes (unchanged behaviour, updated for new contract)
+# ---------------------------------------------------------------------------
 
 
 class TestGetModelInfo:
@@ -50,23 +98,198 @@ class TestGetLatestModel:
 
     def test_latest_anthropic(self) -> None:
         model = get_latest_model("anthropic")
-        assert model is not None
         assert model.provider == "anthropic"
 
     def test_latest_openai(self) -> None:
         model = get_latest_model("openai")
-        assert model is not None
         assert model.provider == "openai"
 
     def test_latest_gemini(self) -> None:
         model = get_latest_model("gemini")
-        assert model is not None
         assert model.provider == "gemini"
 
-    def test_latest_unknown_provider(self) -> None:
-        assert get_latest_model("nonexistent") is None
+    def test_latest_unknown_provider_raises(self) -> None:
+        """Unknown provider must raise ValueError, NOT return None."""
+        with pytest.raises(ValueError, match="provider="):
+            get_latest_model("nonexistent")
 
     def test_latest_with_capability_filter(self) -> None:
         model = get_latest_model("anthropic", capability="reasoning")
-        assert model is not None
         assert model.supports_reasoning is True
+
+
+# ---------------------------------------------------------------------------
+# New backstop tests — all keyless, exercising recency + hardening
+# ---------------------------------------------------------------------------
+
+
+class TestGetLatestModelRecency:
+    """The core red→green proof: recency, not file order."""
+
+    def test_get_latest_model_uses_recency_not_file_order(
+        self, monkeypatch
+    ) -> None:
+        """An older model listed FIRST must NOT beat a newer model listed SECOND.
+
+        This test FAILS against the original candidates[0] implementation and
+        PASSES against the release_date-based max() implementation.
+        """
+        older = _model("model-2023", "testprov", date(2023, 1, 1))
+        newer = _model("model-2025", "testprov", date(2025, 6, 1))
+        # Deliberate: older appears FIRST in the list (as it would in the old JSON)
+        _inject_catalog(monkeypatch, [older, newer])
+
+        result = get_latest_model("testprov")
+        assert result.id == "model-2025", (
+            f"Expected newer model 'model-2025' but got {result.id!r} — "
+            "get_latest_model is using file order instead of release_date"
+        )
+
+    def test_list_models_returns_newest_first(self, monkeypatch) -> None:
+        """list_models() must return descending by release_date."""
+        older = _model("old", "testprov", date(2022, 3, 1))
+        newer = _model("new", "testprov", date(2024, 11, 1))
+        _inject_catalog(monkeypatch, [older, newer])
+
+        result = list_models(provider="testprov")
+        assert result[0].id == "new"
+        assert result[1].id == "old"
+
+
+class TestGetLatestModelTiebreak:
+    """Equal release_date resolves deterministically by id."""
+
+    def test_get_latest_model_deterministic_on_tie(self, monkeypatch) -> None:
+        """Two models with the same release_date must always yield the same winner.
+
+        Tiebreak rule: lexicographically GREATER id wins (matches key in max()).
+        Calling twice must return the identical result regardless of list order.
+        """
+        same_date = date(2025, 1, 15)
+        alpha = _model("zzz-model", "testprov", same_date)
+        beta = _model("aaa-model", "testprov", same_date)
+
+        # First ordering
+        _inject_catalog(monkeypatch, [alpha, beta])
+        result_1 = get_latest_model("testprov")
+
+        # Reversed ordering
+        _inject_catalog(monkeypatch, [beta, alpha])
+        result_2 = get_latest_model("testprov")
+
+        assert result_1.id == result_2.id, (
+            "get_latest_model returned different winners for identical catalogs "
+            "in different order — tiebreak is not deterministic"
+        )
+        # "zzz" > "aaa" lexicographically, so zzz-model must win
+        assert result_1.id == "zzz-model", (
+            f"Tiebreak rule: greater id wins; expected 'zzz-model', got {result_1.id!r}"
+        )
+
+
+class TestCatalogIntegrity:
+    """The real catalog must satisfy structural invariants."""
+
+    def test_every_catalog_model_has_valid_release_date(self) -> None:
+        """Every entry in the real models.json must have a valid date object."""
+        models = list_models()
+        assert models, "Catalog is empty — models.json missing?"
+        for m in models:
+            assert isinstance(m.release_date, date), (
+                f"Model {m.id!r}: release_date is {type(m.release_date)!r}, "
+                f"expected datetime.date"
+            )
+            # Sanity bound: no model exists before 2020 or in the far future
+            assert m.release_date >= date(2020, 1, 1), (
+                f"Model {m.id!r}: release_date {m.release_date} looks wrong "
+                f"(earlier than 2020-01-01)"
+            )
+            assert m.release_date <= date(2030, 1, 1), (
+                f"Model {m.id!r}: release_date {m.release_date} looks wrong "
+                f"(later than 2030-01-01)"
+            )
+
+
+class TestGetLatestModelFailLoud:
+    """get_latest_model must raise, never return None or raise bare max() error."""
+
+    def test_get_latest_model_empty_provider_raises(self, monkeypatch) -> None:
+        """Unknown provider → legible ValueError mentioning provider=."""
+        _inject_catalog(monkeypatch, [])  # completely empty catalog
+        with pytest.raises(ValueError) as exc_info:
+            get_latest_model("ghost-provider")
+        msg = str(exc_info.value)
+        assert "provider=" in msg, (
+            f"Error message must mention provider=, got: {msg!r}"
+        )
+        assert "ghost-provider" in msg, (
+            f"Error message must include the provider name, got: {msg!r}"
+        )
+
+    def test_get_latest_model_unknown_provider_from_real_catalog_raises(
+        self,
+    ) -> None:
+        """Real catalog + unknown provider → legible ValueError."""
+        with pytest.raises(ValueError) as exc_info:
+            get_latest_model("definitely-not-a-real-provider")
+        msg = str(exc_info.value)
+        assert "provider=" in msg
+
+    def test_get_latest_model_impossible_capability_raises(
+        self, monkeypatch
+    ) -> None:
+        """Valid provider + capability that no model satisfies → legible ValueError."""
+        no_reasoning = _model("plain-model", "testprov", date(2025, 1, 1), supports_reasoning=False)
+        _inject_catalog(monkeypatch, [no_reasoning])
+        with pytest.raises(ValueError) as exc_info:
+            get_latest_model("testprov", capability="reasoning")
+        msg = str(exc_info.value)
+        assert "provider=" in msg
+        assert "capability=" in msg
+
+
+class TestParseFailLoud:
+    """_parse_catalog raises loudly on bad input, naming the offending id."""
+
+    def test_missing_release_date_fails_loud(self) -> None:
+        """An entry without release_date must raise ValueError naming the model id."""
+        raw = [
+            {
+                "id": "bad-model-no-date",
+                "provider": "testprov",
+                "display_name": "Bad",
+                "context_window": 100000,
+                "supports_tools": True,
+                "supports_vision": False,
+                "supports_reasoning": False,
+                # deliberately omitted: "release_date"
+            }
+        ]
+        with pytest.raises(ValueError) as exc_info:
+            _parse_catalog(raw)
+        msg = str(exc_info.value)
+        assert "bad-model-no-date" in msg, (
+            f"Error must name the offending model id; got: {msg!r}"
+        )
+        assert "release_date" in msg, (
+            f"Error must mention 'release_date'; got: {msg!r}"
+        )
+
+    def test_malformed_release_date_fails_loud(self) -> None:
+        """An entry with an unparseable release_date must raise ValueError."""
+        raw = [
+            {
+                "id": "bad-date-model",
+                "provider": "testprov",
+                "display_name": "Bad Date",
+                "context_window": 100000,
+                "supports_tools": True,
+                "supports_vision": False,
+                "supports_reasoning": False,
+                "release_date": "not-a-date",
+            }
+        ]
+        with pytest.raises(ValueError) as exc_info:
+            _parse_catalog(raw)
+        msg = str(exc_info.value)
+        assert "bad-date-model" in msg

--- a/modules/unified-llm-client/tests/unit/test_types.py
+++ b/modules/unified-llm-client/tests/unit/test_types.py
@@ -657,6 +657,8 @@ class TestGenerateResult:
         assert result.output is None
 
 
+from datetime import date
+
 from unified_llm.types import AdapterTimeout, ModelInfo, TimeoutConfig
 
 
@@ -691,8 +693,10 @@ class TestModelInfo:
             supports_tools=True,
             supports_vision=True,
             supports_reasoning=True,
+            release_date=date(2025, 5, 14),
         )
         assert mi.id == "claude-sonnet-4-20250514"
+        assert mi.release_date == date(2025, 5, 14)
         assert mi.max_output is None
         assert mi.input_cost_per_million is None
         assert mi.aliases == []

--- a/modules/unified-llm-client/unified_llm/catalog.py
+++ b/modules/unified-llm-client/unified_llm/catalog.py
@@ -1,11 +1,20 @@
 """Model catalog — advisory model lookup (Spec §2.9).
 
 Unknown model strings pass through. The catalog is not restrictive.
+
+``get_latest_model()`` selects by **release_date** (max, descending) with a
+deterministic tiebreak on **model id** (lexicographic, descending).  It raises
+``ValueError`` loudly when no candidate matches — never silently returns None.
+
+Loading fails loudly if any catalog entry is missing or has a malformed
+``release_date`` field; this ensures stale/incomplete data never silently
+degrades "latest" selection.
 """
 
 from __future__ import annotations
 
 import json
+from datetime import date
 from pathlib import Path
 from typing import Any
 
@@ -15,21 +24,41 @@ _CATALOG: list[ModelInfo] | None = None
 _ALIAS_MAP: dict[str, str] | None = None
 
 
-def _load_catalog() -> tuple[list[ModelInfo], dict[str, str]]:
-    """Load the catalog from the shipped JSON data file."""
-    global _CATALOG, _ALIAS_MAP
-    if _CATALOG is not None and _ALIAS_MAP is not None:
-        return _CATALOG, _ALIAS_MAP
+def _parse_catalog(
+    raw: list[dict[str, Any]],
+) -> tuple[list[ModelInfo], dict[str, str]]:
+    """Parse raw JSON catalog entries into ModelInfo objects.
 
-    data_path = Path(__file__).parent / "data" / "models.json"
-    raw: list[dict[str, Any]] = json.loads(data_path.read_text())
-
+    Raises:
+        ValueError: If any entry is missing ``release_date`` or it cannot be
+            parsed as an ISO-8601 date.  The error message names the offending
+            model id so problems are easy to locate and fix.
+    """
     models: list[ModelInfo] = []
     aliases: dict[str, str] = {}
 
     for entry in raw:
+        model_id: str = entry.get("id", "<unknown>")
+
+        # --- fail-loud on missing release_date ---
+        if "release_date" not in entry:
+            raise ValueError(
+                f"unified_llm catalog: model {model_id!r} is missing required "
+                f"'release_date' field.  Add an ISO-8601 date (YYYY-MM-DD) to "
+                f"unified_llm/data/models.json."
+            )
+
+        raw_date = entry["release_date"]
+        try:
+            release_date = date.fromisoformat(str(raw_date))
+        except (ValueError, TypeError) as exc:
+            raise ValueError(
+                f"unified_llm catalog: model {model_id!r} has malformed "
+                f"'release_date' {raw_date!r} — expected ISO-8601 YYYY-MM-DD: {exc}"
+            ) from exc
+
         model = ModelInfo(
-            id=entry["id"],
+            id=model_id,
             provider=entry["provider"],
             display_name=entry["display_name"],
             context_window=entry["context_window"],
@@ -40,10 +69,25 @@ def _load_catalog() -> tuple[list[ModelInfo], dict[str, str]]:
             input_cost_per_million=entry.get("input_cost_per_million"),
             output_cost_per_million=entry.get("output_cost_per_million"),
             aliases=entry.get("aliases", []),
+            release_date=release_date,
         )
         models.append(model)
         for alias in model.aliases:
             aliases[alias] = model.id
+
+    return models, aliases
+
+
+def _load_catalog() -> tuple[list[ModelInfo], dict[str, str]]:
+    """Load the catalog from the shipped JSON data file (cached after first load)."""
+    global _CATALOG, _ALIAS_MAP
+    if _CATALOG is not None and _ALIAS_MAP is not None:
+        return _CATALOG, _ALIAS_MAP
+
+    data_path = Path(__file__).parent / "data" / "models.json"
+    raw: list[dict[str, Any]] = json.loads(data_path.read_text())
+
+    models, aliases = _parse_catalog(raw)
 
     _CATALOG = models
     _ALIAS_MAP = aliases
@@ -67,19 +111,43 @@ def get_model_info(model_id: str) -> ModelInfo | None:
 
 
 def list_models(provider: str | None = None) -> list[ModelInfo]:
-    """List all known models, optionally filtered by provider."""
+    """List all known models, optionally filtered by provider.
+
+    Returns models sorted by ``(release_date, id)`` descending — newest first,
+    ties broken deterministically by id.
+    """
     models, _ = _load_catalog()
-    if provider is None:
-        return list(models)
-    return [m for m in models if m.provider == provider]
+    if provider is not None:
+        models = [m for m in models if m.provider == provider]
+    return sorted(models, key=lambda m: (m.release_date, m.id), reverse=True)
 
 
 def get_latest_model(
     provider: str,
     capability: str | None = None,
-) -> ModelInfo | None:
-    """Get the newest/best model for a provider, optionally filtered by capability."""
+) -> ModelInfo:
+    """Return the most recently released model for *provider*.
+
+    Selection is by **max ``release_date``** with a deterministic tiebreak on
+    **model id** (lexicographic, descending), so equal-dated models always
+    resolve to the same one regardless of JSON file order.
+
+    Args:
+        provider: Provider name (e.g. ``"anthropic"``, ``"openai"``,
+            ``"gemini"``).
+        capability: Optional capability filter — one of ``"reasoning"``,
+            ``"vision"``, ``"tools"``.
+
+    Returns:
+        The newest matching ``ModelInfo``.
+
+    Raises:
+        ValueError: When no model matches *provider* (or the combination of
+            *provider* + *capability*).  The message names both arguments so
+            the caller can diagnose the problem immediately.
+    """
     candidates = list_models(provider)
+
     if capability:
         cap_map = {
             "reasoning": lambda m: m.supports_reasoning,
@@ -89,4 +157,18 @@ def get_latest_model(
         filter_fn = cap_map.get(capability)
         if filter_fn:
             candidates = [m for m in candidates if filter_fn(m)]
-    return candidates[0] if candidates else None
+
+    if not candidates:
+        raise ValueError(
+            f"unified_llm.get_latest_model: no model found for "
+            f"provider={provider!r} capability={capability!r}.  "
+            f"Check that the provider name is correct and that models.json "
+            f"contains at least one entry for this provider"
+            + (f" with {capability!r} support" if capability else "")
+            + "."
+        )
+
+    # Deterministic selection: max release_date, tiebreak by id (descending).
+    # list_models() already returns sorted descending, so candidates[0] is correct
+    # — but we use max() with an explicit key to be unambiguous about the contract.
+    return max(candidates, key=lambda m: (m.release_date, m.id))

--- a/modules/unified-llm-client/unified_llm/data/models.json
+++ b/modules/unified-llm-client/unified_llm/data/models.json
@@ -10,6 +10,7 @@
     "supports_reasoning": true,
     "input_cost_per_million": 3.0,
     "output_cost_per_million": 15.0,
+    "release_date": "2025-05-14",
     "aliases": ["claude-sonnet", "sonnet"]
   },
   {
@@ -23,6 +24,7 @@
     "supports_reasoning": false,
     "input_cost_per_million": 0.80,
     "output_cost_per_million": 4.0,
+    "release_date": "2024-10-22",
     "aliases": ["claude-haiku", "haiku"]
   },
   {
@@ -36,6 +38,8 @@
     "supports_reasoning": false,
     "input_cost_per_million": 2.0,
     "output_cost_per_million": 8.0,
+    "release_date": "2025-04-14",
+    "_release_date_note": "approximate",
     "aliases": ["gpt4.1"]
   },
   {
@@ -49,6 +53,8 @@
     "supports_reasoning": true,
     "input_cost_per_million": 1.10,
     "output_cost_per_million": 4.40,
+    "release_date": "2025-04-16",
+    "_release_date_note": "approximate",
     "aliases": ["o4mini"]
   },
   {
@@ -62,6 +68,8 @@
     "supports_reasoning": true,
     "input_cost_per_million": 0.15,
     "output_cost_per_million": 0.60,
+    "release_date": "2025-05-20",
+    "_release_date_note": "approximate",
     "aliases": ["gemini-flash"]
   },
   {
@@ -75,6 +83,8 @@
     "supports_reasoning": true,
     "input_cost_per_million": 1.25,
     "output_cost_per_million": 10.0,
+    "release_date": "2025-03-25",
+    "_release_date_note": "approximate",
     "aliases": ["gemini-pro"]
   }
 ]

--- a/modules/unified-llm-client/unified_llm/types.py
+++ b/modules/unified-llm-client/unified_llm/types.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import date, datetime
 from enum import Enum
 from typing import Any
 
@@ -611,7 +611,13 @@ class AdapterTimeout:
 
 @dataclass
 class ModelInfo:
-    """A model catalog entry."""
+    """A model catalog entry.
+
+    ``release_date`` is the authoritative recency field used by
+    ``get_latest_model()`` to select the newest model without depending on
+    JSON file order.  It is typed, required (no default), and must be an ISO
+    8601 date string in the source ``models.json``.
+    """
 
     id: str
     provider: str
@@ -620,6 +626,7 @@ class ModelInfo:
     supports_tools: bool
     supports_vision: bool
     supports_reasoning: bool
+    release_date: date  # required; used for recency selection — no default
     max_output: int | None = None
     input_cost_per_million: float | None = None
     output_cost_per_million: float | None = None


### PR DESCRIPTION
## Summary

- **Root cause:** `get_latest_model(provider)` returned `candidates[0]` — the FIRST entry of a hand-maintained static models.json (file order, no recency), and ModelInfo had no date field. This inverted the original unified-llm nlspec's freshness intent.
- **Fix:** ModelInfo gains typed REQUIRED `release_date: date`. `get_latest_model()` selects by max release_date with deterministic (release_date, id) tiebreak—never file order.
- **Impact:** Non-breaking (zero live callers). All 7 changed files under modules/unified-llm-client/.

## Testing

- ✅ RED→GREEN proven: reverting recency makes test fail with 'Expected newer model model-2025 but got model-2023'; restored → passes
- ✅ 20/20 catalog tests
- ✅ 258/258 full unit suite  
- ✅ ruff clean
- ✅ pyright clean (0 errors in package env)
- ✅ External caller audit: zero live callers (non-breaking)

## Important Caveat

**Model id VALUES are intentionally unchanged** — this PR does not change which models are in the catalog, only HOW we select the "latest." The `§8.10 Integration Smoke` is the freshness guard: it calls `get_latest_model(p).id` and verifies it produces a WORKING completion. Id currency is NOT validated in this PR.

## Deferred Follow-Up

`docs/FOLLOWUP-live-model-catalog.md` documents the spec-ideal: source freshness from provider live API per amplifier-core's `Provider.list_models()` design. This PR does NOT implement live sourcing—it only fixes the immediate bug (file-order fallacy) and establishes the release_date contract.

---

Generated with [Amplifier](https://github.com/microsoft/amplifier)