### PR TITLE
feat(unified-llm-client): live family/glob model resolution via adapter.list_models (id-seam closed by construction)

### DIFF
--- a/modules/unified-llm-client/tests/dod/test_resolver_live_smoke.py
+++ b/modules/unified-llm-client/tests/dod/test_resolver_live_smoke.py
@@ -1,0 +1,177 @@
+"""Resolver live smoke tests — resolve-then-generate proof per provider.
+
+For each provider whose API key is present in the environment:
+  1. Call resolve_latest(adapter, "<family glob>") to get a live-resolved id.
+  2. Call adapter.complete() with that id for 1 token.
+  3. Assert output_tokens > 0 (proves the resolved id is generation-compatible).
+
+Skip-LOUD when key absent: the skip message explicitly states that
+"resolve-then-generate <provider> smoke SKIPPED: <KEY> not set — id-seam NOT
+validated live".  No silent green passes.
+
+Run with:
+    pytest tests/dod/test_resolver_live_smoke.py -m integration
+
+Requires: ANTHROPIC_API_KEY, OPENAI_API_KEY, GEMINI_API_KEY (or GOOGLE_API_KEY)
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from unified_llm.resolver import resolve_latest
+from unified_llm.types import ContentKind, ContentPart, Message, Request, Role
+
+pytestmark = pytest.mark.integration
+
+
+# ---------------------------------------------------------------------------
+# Anthropic
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_resolve_then_generate_anthropic() -> None:
+    """resolve-then-generate smoke — anthropic: *sonnet* family.
+
+    Resolves the latest stable *sonnet* model from the live Anthropic API,
+    then completes 1 token to prove the resolved id is generation-compatible.
+    The same ``AnthropicAdapter`` instance is used for both list and generate,
+    which is the structural id-seam guarantee.
+    """
+    key = os.environ.get("ANTHROPIC_API_KEY")
+    if not key:
+        pytest.skip(
+            "resolve-then-generate anthropic smoke SKIPPED: "
+            "ANTHROPIC_API_KEY not set — id-seam NOT validated live"
+        )
+
+    from unified_llm.adapters.anthropic import AnthropicAdapter
+
+    adapter = AnthropicAdapter()
+
+    # Part 1: live resolution
+    resolved = await resolve_latest(adapter, "*sonnet*", stable_only=True)
+    assert resolved, "resolve_latest returned empty string"
+    assert "preview" not in resolved.lower(), (
+        f"resolve_latest(stable_only=True) returned non-stable id: {resolved!r}"
+    )
+
+    # Part 2: prove the resolved id is generation-compatible (same adapter instance)
+    request = Request(
+        model=resolved,
+        messages=[
+            Message(
+                role=Role.USER,
+                content=[
+                    ContentPart(kind=ContentKind.TEXT, text="Reply with just 'ok'.")
+                ],
+            )
+        ],
+        max_tokens=16,
+    )
+    response = await adapter.complete(request)
+    assert response.usage.output_tokens > 0, (
+        f"Zero output tokens with resolved id {resolved!r} — id-seam failure: "
+        "the resolved id may not be accepted by the same adapter's complete()"
+    )
+
+
+# ---------------------------------------------------------------------------
+# OpenAI
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_resolve_then_generate_openai() -> None:
+    """resolve-then-generate smoke — openai: gpt-4o* family.
+
+    Resolves the latest stable gpt-4o* model from the live OpenAI API,
+    then completes 1 token via the same adapter instance.
+    """
+    key = os.environ.get("OPENAI_API_KEY")
+    if not key:
+        pytest.skip(
+            "resolve-then-generate openai smoke SKIPPED: "
+            "OPENAI_API_KEY not set — id-seam NOT validated live"
+        )
+
+    from unified_llm.adapters.openai import OpenAIAdapter
+
+    adapter = OpenAIAdapter()
+
+    # Part 1: live resolution
+    resolved = await resolve_latest(adapter, "gpt-4o*", stable_only=True)
+    assert resolved, "resolve_latest returned empty string"
+    assert "preview" not in resolved.lower(), (
+        f"resolve_latest(stable_only=True) returned non-stable id: {resolved!r}"
+    )
+
+    # Part 2: prove generation-compatible (same adapter instance)
+    request = Request(
+        model=resolved,
+        messages=[
+            Message(
+                role=Role.USER,
+                content=[
+                    ContentPart(kind=ContentKind.TEXT, text="Reply with just 'ok'.")
+                ],
+            )
+        ],
+        max_tokens=16,
+    )
+    response = await adapter.complete(request)
+    assert response.usage.output_tokens > 0, (
+        f"Zero output tokens with resolved id {resolved!r} — id-seam failure"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Gemini
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_resolve_then_generate_gemini() -> None:
+    """resolve-then-generate smoke — gemini: *flash* family.
+
+    Resolves the latest stable *flash* model from the live Gemini API,
+    then completes 1 token via the same adapter instance.
+    """
+    key = os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")
+    if not key:
+        pytest.skip(
+            "resolve-then-generate gemini smoke SKIPPED: "
+            "GEMINI_API_KEY / GOOGLE_API_KEY not set — id-seam NOT validated live"
+        )
+
+    from unified_llm.adapters.gemini import GeminiAdapter
+
+    adapter = GeminiAdapter()
+
+    # Part 1: live resolution
+    resolved = await resolve_latest(adapter, "*flash*", stable_only=True)
+    assert resolved, "resolve_latest returned empty string"
+    assert "preview" not in resolved.lower(), (
+        f"resolve_latest(stable_only=True) returned non-stable id: {resolved!r}"
+    )
+
+    # Part 2: prove generation-compatible (same adapter instance)
+    request = Request(
+        model=resolved,
+        messages=[
+            Message(
+                role=Role.USER,
+                content=[
+                    ContentPart(kind=ContentKind.TEXT, text="Reply with just 'ok'.")
+                ],
+            )
+        ],
+        max_tokens=16,
+    )
+    response = await adapter.complete(request)
+    assert response.usage.output_tokens > 0, (
+        f"Zero output tokens with resolved id {resolved!r} — id-seam failure"
+    )

--- a/modules/unified-llm-client/tests/unit/test_resolver.py
+++ b/modules/unified-llm-client/tests/unit/test_resolver.py
@@ -1,0 +1,243 @@
+"""Gate tests for unified_llm/resolver.py.
+
+These 4 tests encode tester-breaker's bug inputs.  They FAIL before
+``unified_llm/resolver.py`` exists; they all PASS once the selector is
+implemented correctly.
+
+Run: uv run pytest tests/unit/test_resolver.py -v
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from unified_llm.resolver import _is_glob, _version_key, select_latest
+
+
+# ---------------------------------------------------------------------------
+# Gate #2 — OpenAI mixed date shapes
+# ---------------------------------------------------------------------------
+
+
+class TestGate2OpenAIDateShapes:
+    """Mixed dated/undated/gpt-4-0613 model ids do not crash; newest dated wins."""
+
+    def test_picks_newest_dated_version(self) -> None:
+        """gpt-4o-2024-08-06 wins because it has the latest date suffix.
+
+        Key semantics documented here so this never drifts silently:
+        - Candidates after fnmatch("gpt-4o*"): gpt-4o-2024-05-13,
+          gpt-4o-2024-08-06, gpt-4o  (gpt-4-0613 is filtered out by glob)
+        - _version_key strips the date suffix and stores it as a low-priority
+          tiebreak AFTER the structural version tokens.
+        - All three have identical structural tokens for 'gpt-4o'.
+        - date tiebreak: (2024,8,6) > (2024,5,13) > () (no-date = empty tuple,
+          which sorts LOWER than any non-empty tuple in Python).
+        - Winner: gpt-4o-2024-08-06.
+        """
+        result = select_latest(
+            ["gpt-4o-2024-05-13", "gpt-4o-2024-08-06", "gpt-4o", "gpt-4-0613"],
+            "gpt-4o*",
+        )
+        assert result == "gpt-4o-2024-08-06"
+
+    def test_no_crash_on_mixed_shapes(self) -> None:
+        """All id shapes are handled without TypeError."""
+        # Just calling the function is the assertion; any exception = fail.
+        result = select_latest(
+            ["gpt-4o-2024-05-13", "gpt-4o-2024-08-06", "gpt-4o", "gpt-4-0613"],
+            "gpt-4o*",
+        )
+        assert isinstance(result, str)
+
+
+# ---------------------------------------------------------------------------
+# Gate #3 — Preview exclusion
+# ---------------------------------------------------------------------------
+
+
+class TestGate3PreviewExclusion:
+    """stable_only=True excludes preview ids; stable_only=False includes them."""
+
+    def test_stable_only_excludes_preview(self) -> None:
+        """Preview id is filtered when stable_only=True."""
+        result = select_latest(
+            ["claude-opus-4-8", "claude-opus-4-9-preview"],
+            "*opus*",
+            stable_only=True,
+        )
+        assert result == "claude-opus-4-8"
+
+    def test_stable_false_includes_preview(self) -> None:
+        """Preview id survives and wins when stable_only=False.
+
+        claude-opus-4-9 > claude-opus-4-8 in structural version sort (9 > 8),
+        even though the id has the '-preview' suffix.
+        """
+        result = select_latest(
+            ["claude-opus-4-8", "claude-opus-4-9-preview"],
+            "*opus*",
+            stable_only=False,
+        )
+        assert result == "claude-opus-4-9-preview"
+
+
+# ---------------------------------------------------------------------------
+# Gate #4 — Tokenizer totality: 3.x → 4 rename does not raise TypeError
+# ---------------------------------------------------------------------------
+
+
+class TestGate4TokenizerTotality:
+    """_version_key is total — never raises TypeError on any mixed input."""
+
+    def test_sorted_does_not_raise(self) -> None:
+        """sorted() over mixed claude-3.x / claude-sonnet-4 shapes must not raise."""
+        mixed = ["claude-3-5-sonnet-20241022", "claude-sonnet-4-20250514"]
+        # This line is the gate: TypeError here means int/str comparison in key.
+        sorted_result = sorted(mixed, key=_version_key)
+        assert isinstance(sorted_result, list)
+        assert len(sorted_result) == 2
+
+    def test_select_latest_picks_sonnet4(self) -> None:
+        """claude-sonnet-4-20250514 wins over claude-3-5-sonnet-20241022.
+
+        Version key explanation:
+        - claude-3-5-sonnet-20241022: strip -20241022, tokens for 'claude-3-5-sonnet'.
+          First triple: (0, 0, 'claude-').
+        - claude-sonnet-4-20250514: strip -20250514, tokens for 'claude-sonnet-4'.
+          First triple: (0, 0, 'claude-sonnet-').
+        - 'claude-sonnet-' > 'claude-' (longer prefix, 'sonnet' chars follow '-').
+        - Therefore claude-sonnet-4-20250514 has the larger key → wins.
+        """
+        result = select_latest(
+            ["claude-3-5-sonnet-20241022", "claude-sonnet-4-20250514"],
+            "*sonnet*",
+        )
+        assert result == "claude-sonnet-4-20250514"
+
+
+# ---------------------------------------------------------------------------
+# Gate: empty/raise — unmatched pattern and all-filtered each raise ValueError
+# with a message that mentions the pattern.
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyRaisesLegibleError:
+    """select_latest raises ValueError (mentioning the pattern) on empty results."""
+
+    def test_unmatched_pattern_raises(self) -> None:
+        """No candidates after glob filter → ValueError naming the pattern."""
+        with pytest.raises(ValueError, match="does-not-exist-pattern"):
+            select_latest(["gpt-4o", "gpt-4-turbo"], "does-not-exist-pattern*")
+
+    def test_all_filtered_stable_raises(self) -> None:
+        """All candidates are non-stable → ValueError with mention of stable_only."""
+        with pytest.raises(ValueError, match="stable_only"):
+            select_latest(
+                ["claude-opus-4-9-preview"],
+                "*opus*",
+                stable_only=True,
+            )
+
+    def test_error_mentions_pattern_on_filter(self) -> None:
+        """ValueError from stable filter must mention the pattern string."""
+        pattern = "*experimental-model*"
+        with pytest.raises(ValueError) as exc_info:
+            select_latest(
+                ["model-experimental-v1", "model-experimental-v2"],
+                pattern,
+                stable_only=True,
+            )
+        assert "experimental-model" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Structural unit tests for the helper functions
+# ---------------------------------------------------------------------------
+
+
+class TestIsGlob:
+    def test_star(self) -> None:
+        assert _is_glob("*opus*") is True
+
+    def test_question(self) -> None:
+        assert _is_glob("claude-?") is True
+
+    def test_bracket(self) -> None:
+        assert _is_glob("gpt-[34]") is True
+
+    def test_plain_id(self) -> None:
+        assert _is_glob("claude-sonnet-4-20250514") is False
+
+    def test_empty(self) -> None:
+        assert _is_glob("") is False
+
+
+class TestExactIdMatch:
+    """When pattern is not a glob, exact id membership is used."""
+
+    def test_exact_match(self) -> None:
+        result = select_latest(
+            ["gpt-4o", "gpt-4o-mini", "gpt-4-turbo"],
+            "gpt-4o",
+        )
+        assert result == "gpt-4o"
+
+    def test_exact_no_match_raises(self) -> None:
+        with pytest.raises(ValueError):
+            select_latest(["gpt-4o", "gpt-4-turbo"], "gpt-4o-mini")
+
+
+# ---------------------------------------------------------------------------
+# Part C — id-seam structural test (resolve_latest)
+# ---------------------------------------------------------------------------
+
+
+class TestIdSeamStructural:
+    """resolve_latest must return an id that is in the adapter's own list_models().
+
+    This encodes the 'lister == generator' invariant without any network call.
+    """
+
+    @pytest.mark.asyncio
+    async def test_resolve_latest_id_in_lister_namespace(self) -> None:
+        """Resolved id is always a member of the adapter's own list_models() output."""
+        from unified_llm.resolver import resolve_latest
+
+        known_ids = [
+            "claude-opus-4-5",
+            "claude-opus-4-8",
+            "claude-opus-4-9-preview",
+        ]
+
+        class FakeAdapter:
+            async def list_models(self) -> list[str]:
+                return list(known_ids)
+
+        fake = FakeAdapter()
+        resolved = await resolve_latest(fake, "*opus*", stable_only=True)
+
+        # The resolved id MUST be a member of the lister's own namespace
+        assert resolved in known_ids, (
+            f"resolve_latest returned {resolved!r} which is not in the adapter's "
+            f"list_models() output {known_ids!r} — id-seam violation"
+        )
+
+    @pytest.mark.asyncio
+    async def test_resolve_latest_stable_excludes_preview(self) -> None:
+        """Resolved id under stable_only=True is never a preview/experimental."""
+        from unified_llm.resolver import resolve_latest
+
+        class FakeAdapter:
+            async def list_models(self) -> list[str]:
+                return [
+                    "claude-opus-4-5",
+                    "claude-opus-4-8",
+                    "claude-opus-4-9-preview",
+                ]
+
+        resolved = await resolve_latest(FakeAdapter(), "*opus*", stable_only=True)
+        assert "preview" not in resolved.lower(), (
+            f"resolve_latest(stable_only=True) resolved to non-stable: {resolved!r}"
+        )
+        assert resolved == "claude-opus-4-8"

--- a/modules/unified-llm-client/unified_llm/__init__.py
+++ b/modules/unified-llm-client/unified_llm/__init__.py
@@ -77,6 +77,9 @@ from unified_llm.retry import RetryPolicy
 # Catalog
 from unified_llm.catalog import get_latest_model, get_model_info, list_models
 
+# Resolver — live-backed model selection (eliminates id-seam)
+from unified_llm.resolver import resolve_latest, resolve_latest_for, select_latest
+
 # Adapters
 from unified_llm.adapters import ProviderAdapter
 
@@ -150,6 +153,10 @@ __all__ = [
     "get_model_info",
     "list_models",
     "get_latest_model",
+    # Resolver — live-backed model selection
+    "select_latest",
+    "resolve_latest",
+    "resolve_latest_for",
     # Adapter interface
     "ProviderAdapter",
 ]

--- a/modules/unified-llm-client/unified_llm/adapters/anthropic.py
+++ b/modules/unified-llm-client/unified_llm/adapters/anthropic.py
@@ -196,6 +196,20 @@ class AnthropicAdapter:
     async def initialize(self) -> None:
         """Validate configuration on startup."""
 
+    async def list_models(self) -> list[str]:
+        """Return the live list of model ids served by this Anthropic client.
+
+        Uses the same ``self._client`` instance used for ``complete()`` and
+        ``stream()``, so the returned ids are in the same namespace as what
+        the adapter passes to ``messages.create(model=...)``.  This is the
+        foundation of the id-seam guarantee: the lister IS the generator.
+
+        Returns first page only (Anthropic serves all current models on
+        the first page — no autopagination needed in practice).
+        """
+        page = await self._client.models.list()
+        return [m.id for m in page.data]
+
     def supports_tool_choice(self, mode: str) -> bool:
         """Check if a particular tool choice mode is supported."""
         return mode in ("auto", "none", "required", "named")

--- a/modules/unified-llm-client/unified_llm/adapters/gemini.py
+++ b/modules/unified-llm-client/unified_llm/adapters/gemini.py
@@ -186,6 +186,29 @@ class GeminiAdapter:
     async def initialize(self) -> None:
         """Validate configuration on startup."""
 
+    async def list_models(self) -> list[str]:
+        """Return the live list of model ids served by this Gemini client.
+
+        Uses the same ``self._client`` (``genai.Client``) instance used for
+        ``complete()`` and ``stream()``, so the returned ids are in the same
+        namespace as what the adapter passes to
+        ``aio.models.generate_content(model=...)``.  This is the foundation
+        of the id-seam guarantee: the lister IS the generator.
+
+        The google-genai SDK returns model names as ``"models/<id>"``
+        (e.g. ``"models/gemini-2.0-flash"``).  We strip the ``"models/"``
+        prefix to match the short form accepted by ``generate_content``.
+        """
+        ids: list[str] = []
+        pager = await self._client.aio.models.list()
+        async for model in pager:
+            name: str = getattr(model, "name", "") or ""
+            if name.startswith("models/"):
+                name = name[len("models/") :]
+            if name:
+                ids.append(name)
+        return ids
+
     def supports_tool_choice(self, mode: str) -> bool:
         """Check if a particular tool choice mode is supported."""
         return mode in ("auto", "none", "required")

--- a/modules/unified-llm-client/unified_llm/adapters/openai.py
+++ b/modules/unified-llm-client/unified_llm/adapters/openai.py
@@ -222,6 +222,20 @@ class OpenAIAdapter:
     async def initialize(self) -> None:
         """Validate configuration on startup."""
 
+    async def list_models(self) -> list[str]:
+        """Return the live list of model ids served by this OpenAI client.
+
+        Uses the same ``self._client`` (``AsyncOpenAI``) instance used for
+        ``complete()`` and ``stream()``, so the returned ids are in the same
+        namespace as what the adapter passes to ``responses.create(model=...)``.
+        This is the foundation of the id-seam guarantee: the lister IS the
+        generator.
+
+        Returns the first page (openai serves all current models on one page).
+        """
+        page = await self._client.models.list()
+        return [m.id for m in page.data]
+
     def supports_tool_choice(self, mode: str) -> bool:
         """Check if a particular tool choice mode is supported."""
         return mode in ("auto", "none", "required", "named")

--- a/modules/unified-llm-client/unified_llm/resolver.py
+++ b/modules/unified-llm-client/unified_llm/resolver.py
@@ -1,0 +1,308 @@
+"""Live-backed model resolver for unified-llm-client.
+
+Provides ``select_latest`` (source-agnostic selector) and ``resolve_latest``
+(select against an adapter's own live list, eliminating the id-seam).
+
+The version-sort approach — numeric/date-aware tokenization, uniform triple
+representation to prevent int/str TypeError — is adapted from the
+amplifier-bundle-routing-matrix ``resolver.py``.  Credit to that work for
+proving the correct ordering across the claude-3.x → claude-sonnet-4 rename
+and for the fnmatch-based family matching pattern.
+
+# TODO: get_latest_model() live-backing is a thin future follow-up —
+# replace the static models.json lookup in catalog.py with
+# resolve_latest_for(provider, family_glob).
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import re
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    pass
+
+# ---------------------------------------------------------------------------
+# Non-stable marker tokens
+# ---------------------------------------------------------------------------
+# A model id containing any of these substrings is considered NON-stable.
+#
+# IMPORTANT: a bare date embedded in an id (e.g. "gpt-4o-2024-08-06" or
+# "claude-sonnet-4-20250514") is STABLE.  Dates are stripped by _version_key
+# and used only as a low-priority tiebreak — they are NOT listed here.
+#
+# "-latest" is included because it denotes a rolling alias that tracks HEAD,
+# not a specific stable release.
+# ---------------------------------------------------------------------------
+
+_NON_STABLE_MARKERS: frozenset[str] = frozenset(
+    {
+        "preview",
+        "experimental",
+        "exp",
+        "beta",
+        "alpha",
+        "rc",
+        "snapshot",
+        "canary",
+        "nightly",
+        "-latest",
+    }
+)
+
+# ---------------------------------------------------------------------------
+# Date-suffix regexes
+# ---------------------------------------------------------------------------
+# Two formats are supported:
+#   -YYYYMMDD      (e.g. "claude-sonnet-4-20250514", "claude-3-5-sonnet-20241022")
+#   -YYYY-MM-DD    (e.g. "gpt-4o-2024-08-06")
+#
+# These are applied by _version_key to strip the date before tokenizing the
+# structural part of the model id, so that version ordering is driven by the
+# *name* tokens (which model family/generation) and the date is only a
+# low-priority tiebreak.
+#
+# The ISO pattern (-YYYY-MM-DD) is tried first because "-2024-08-06" would
+# trivially not match the 8-digit pattern (it has hyphens between segments).
+# ---------------------------------------------------------------------------
+
+_DATE_ISO_RE = re.compile(r"-(\d{4})-(\d{2})-(\d{2})$")  # -YYYY-MM-DD
+_DATE_8_RE = re.compile(r"-(\d{4})(\d{2})(\d{2})$")  # -YYYYMMDD
+
+# Splits a string into alternating text/digit runs
+_DIGIT_SPLIT_RE = re.compile(r"(\d+)")
+
+
+# ---------------------------------------------------------------------------
+# Public helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_glob(s: str) -> bool:
+    """Return True if *s* contains shell-glob special characters (``* ? [``)."""
+    return bool(set(s) & {"*", "?", "["})
+
+
+def _version_key(model_id: str) -> tuple[Any, ...]:
+    """Return a sortable key for *model_id*.
+
+    Properties guaranteed by this implementation:
+
+    **TOTAL** — never raises ``TypeError: '<' not supported between 'int' and 'str'``
+    on any mix of model-id shapes (e.g. ``gpt-4o``, ``gpt-4o-2024-08-06``,
+    ``claude-3-5-sonnet-20241022``, ``claude-sonnet-4-20250514``).
+
+    **Date-aware tiebreak** — trailing ``-YYYYMMDD`` or ``-YYYY-MM-DD`` suffixes
+    are stripped and stored as a low-priority ``(year, month, day)`` tiebreak,
+    so models in the *same family* are sorted by date when their structural
+    version tokens are identical.  Ids without a date suffix have ``date_key=()``
+    which sorts *lower* than any real date (empty tuple < any non-empty tuple
+    in Python).
+
+    **Uniform triples** — each remaining token is mapped to a 3-tuple of uniform
+    type so positions never compare int to str:
+      - digit run → ``(1, int(run), "")``
+      - text  run → ``(0, 0, run.lower())``
+
+    Returned key layout (for ``max()`` — larger = newer):
+      ``(tuple_of_triples, date_key_tuple, full_model_id)``
+
+    Examples of ordering (ascending, so newer is LAST here):
+
+    >>> sorted([
+    ...     "claude-3-5-sonnet-20241022",
+    ...     "claude-sonnet-4-20250514",
+    ... ], key=_version_key)
+    ['claude-3-5-sonnet-20241022', 'claude-sonnet-4-20250514']
+
+    >>> sorted([
+    ...     "gpt-4o-2024-05-13",
+    ...     "gpt-4o-2024-08-06",
+    ...     "gpt-4o",
+    ... ], key=_version_key)
+    ['gpt-4o', 'gpt-4o-2024-05-13', 'gpt-4o-2024-08-06']
+    """
+    lo = model_id.lower()
+
+    # --- strip trailing date suffix (ISO preferred; fall back to 8-digit) ---
+    date_key: tuple[int, ...] = ()  # empty < any real date when used in max()
+    m = _DATE_ISO_RE.search(lo)
+    if m:
+        date_key = (int(m.group(1)), int(m.group(2)), int(m.group(3)))
+        lo = lo[: m.start()]
+    else:
+        m2 = _DATE_8_RE.search(lo)
+        if m2:
+            date_key = (int(m2.group(1)), int(m2.group(2)), int(m2.group(3)))
+            lo = lo[: m2.start()]
+
+    # --- tokenize remaining string into alternating text / digit runs ---
+    parts = _DIGIT_SPLIT_RE.split(lo)
+    triples: list[tuple[int, int, str]] = []
+    for i, part in enumerate(parts):
+        if not part:
+            continue
+        if i % 2 == 1:
+            # Odd-index: captured digit group
+            triples.append((1, int(part), ""))
+        else:
+            # Even-index: text run
+            triples.append((0, 0, part))
+
+    return (tuple(triples), date_key, model_id)
+
+
+def _is_non_stable(model_id: str) -> bool:
+    """Return True if *model_id* contains any non-stable marker token."""
+    lo = model_id.lower()
+    for marker in _NON_STABLE_MARKERS:
+        if marker in lo:
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Core selector — source-agnostic (Part A)
+# ---------------------------------------------------------------------------
+
+
+def select_latest(
+    model_ids: list[str],
+    pattern: str,
+    *,
+    stable_only: bool = True,
+) -> str:
+    """Select the latest model from *model_ids* matching *pattern*.
+
+    This is a **pure function** (no I/O, stdlib-only).  It can be composed
+    with any source of model ids — a live API list, a static catalog, a test
+    fixture.
+
+    Args:
+        model_ids: List of candidate model id strings.
+        pattern: Either an exact model id (membership check, case-sensitive)
+            or a shell-glob (``fnmatch``, both sides lowercased).  Glob
+            characters are ``*``, ``?``, ``[``.
+        stable_only: When ``True`` (default), model ids whose lowercased form
+            contains any non-stable marker token are excluded before picking
+            the latest.  See ``_NON_STABLE_MARKERS`` for the full list.
+
+    Returns:
+        The latest matching model id (as it appears in *model_ids*).
+
+    Raises:
+        ValueError: If no model ids match *pattern*, or if *stable_only=True*
+            and all matching ids are non-stable.  The message names *pattern*
+            and (for the stable-filter case) states ``stable_only=True`` so
+            callers can diagnose the problem immediately.
+    """
+    # --- candidate selection ---
+    if _is_glob(pattern):
+        lo_pattern = pattern.lower()
+        candidates = [m for m in model_ids if fnmatch.fnmatch(m.lower(), lo_pattern)]
+    else:
+        candidates = [m for m in model_ids if m == pattern]
+
+    if not candidates:
+        raise ValueError(
+            f"select_latest: no model ids match pattern {pattern!r}. "
+            f"Checked {len(model_ids)} model id(s).  "
+            f"Verify the pattern and ensure the model list is not empty."
+        )
+
+    # --- stable filter ---
+    if stable_only:
+        stable_candidates = [m for m in candidates if not _is_non_stable(m)]
+        if not stable_candidates:
+            raise ValueError(
+                f"select_latest: pattern {pattern!r} matched {len(candidates)} "
+                f"model id(s) but all were filtered as non-stable "
+                f"(stable_only=True).  "
+                f"Matched ids: {candidates}.  "
+                f"Set stable_only=False to include preview/experimental models."
+            )
+        candidates = stable_candidates
+
+    # --- pick latest ---
+    return max(candidates, key=_version_key)
+
+
+# ---------------------------------------------------------------------------
+# Adapter-coupled resolver — eliminates the id-seam (Part C)
+# ---------------------------------------------------------------------------
+
+
+async def resolve_latest(
+    adapter: Any,
+    pattern: str,
+    *,
+    stable_only: bool = True,
+) -> str:
+    """Resolve the latest model matching *pattern* from *adapter*'s own live list.
+
+    The adapter's ``list_models()`` and ``complete()``/``stream()`` use the
+    **same SDK client**, so the returned id is guaranteed to be in the same
+    id namespace as what the adapter uses for generation.  This eliminates the
+    *id-seam* — the bug where a lister from one source returns different id
+    shapes than a generator from another (e.g. list returns ``gpt-4o-2024-08-06``
+    but generation expects ``gpt-4o``, causing a silent 404).
+
+    Args:
+        adapter: A provider adapter instance with an async ``list_models()``
+            method that returns ``list[str]``.
+        pattern: Exact model id or shell-glob (e.g. ``"*sonnet*"``,
+            ``"claude-opus-4-*"``).
+        stable_only: Exclude non-stable variants (preview, experimental, …)
+            when ``True`` (default).
+
+    Returns:
+        Latest stable (or any, if *stable_only=False*) model id matching
+        *pattern* from the adapter's live list.
+
+    Raises:
+        ValueError: If no model matches, or all matches are filtered.
+        AttributeError: If *adapter* does not have ``list_models()``.
+    """
+    model_ids: list[str] = await adapter.list_models()
+    return select_latest(model_ids, pattern, stable_only=stable_only)
+
+
+async def resolve_latest_for(
+    provider: str,
+    pattern: str,
+    *,
+    stable_only: bool = True,
+) -> str:
+    """Convenience: build adapter from environment and resolve latest model.
+
+    Uses ``Client.from_env()`` — the same factory used for generation — to
+    obtain the adapter for *provider*, then calls ``resolve_latest``.  Because
+    the lister and generator share the same adapter instance, ids are
+    generation-compatible by construction.
+
+    Args:
+        provider: Provider name matching an env-key-detected adapter, e.g.
+            ``"anthropic"``, ``"openai"``, ``"gemini"``.
+        pattern: Exact model id or shell-glob.
+        stable_only: Exclude non-stable variants when ``True`` (default).
+
+    Returns:
+        Latest stable model id matching *pattern* for *provider*.
+
+    Raises:
+        ValueError: If the provider has no adapter (API key absent) or no
+            model matches the pattern.
+        ConfigurationError: If no API keys are found at all.
+    """
+    from unified_llm.client import Client
+
+    client = Client.from_env()
+    adapter = client.providers.get(provider)
+    if adapter is None:
+        available = list(client.providers.keys())
+        raise ValueError(
+            f"resolve_latest_for: no adapter found for provider {provider!r}.  "
+            f"Providers available (check that API key is set): {available}"
+        )
+    return await resolve_latest(adapter, pattern, stable_only=stable_only)


### PR DESCRIPTION
## Summary
- New cross-provider 'latest model in a family/glob' resolution: adapter lists its own served models and source-agnostic selector picks the latest
- Each provider (anthropic/openai/gemini) uses its own SDK client for both listing and generation — no id-seam by construction
- Static `models.json` + `get_latest_model` from #67 unchanged; this adds the live-backed path alongside

## Test plan
- [x] 18/18 gate tests pass (test_resolver.py: id-seam, openai date shapes, preview exclusion, tokenizer totality + structural)
- [x] 276 unit suite, no regressions
- [x] ruff + pyright clean
- [x] LIVE proof: anthropic `list_models()` → resolve `*opus*`/`*sonnet*`/`*haiku*` → newest served ids (`claude-opus-4-8`, `claude-sonnet-4-6`, `claude-haiku-4-5-20251001`) → 1-token generation through the resolved id COMPLETED, no 404; resolved id verified ∈ adapter's own list

## Root cause
The static `models.json` + `get_latest_model` (fixed for recency in #67) is a hand-maintained catalog that can't express 'latest opus/sonnet across providers' and can ship ids that 404.

This adds a LIVE path: each adapter lists its own served models via the same SDK client it generates with, and a source-agnostic selector (fnmatch + stable-only + numeric version sort) picks the latest — so a resolved id is always generation-compatible (no id-seam).

Approved by a 6-lens council (verdict: invariant 'the object that lists must be the object that generates'; ship for anthropic/openai/gemini now; defer chat-completions/copilot convergence). This is the PR #67 'live-backed catalog' follow-up. `get_latest_model`/`models.json` are unchanged (static path stays alongside).