### PR TITLE
fix: correct Layer-1 system-prompt include paths across all attractor YAMLs + guard test

### DIFF
--- a/agents/attractor-agent-anthropic-isolated.yaml
+++ b/agents/attractor-agent-anthropic-isolated.yaml
@@ -35,5 +35,5 @@ session:
 
 context:
   include:
-    - context/system-anthropic.md
-    - context/isolated-environment-guidance.md
+    - ../context/system-anthropic.md
+    - ../context/isolated-environment-guidance.md

--- a/agents/attractor-agent-anthropic.yaml
+++ b/agents/attractor-agent-anthropic.yaml
@@ -48,4 +48,4 @@ context:
   # loop-agent's AgentOrchestrator.execute() resolves the factory before creating the session
   # so the file content becomes session_config.system_prompt (Layer 1).
   include:
-    - context/system-anthropic.md
+    - ../context/system-anthropic.md

--- a/agents/attractor-agent-gemini-isolated.yaml
+++ b/agents/attractor-agent-gemini-isolated.yaml
@@ -41,5 +41,5 @@ tools:
 
 context:
   include:
-    - context/system-gemini.md
-    - context/isolated-environment-guidance.md
+    - ../context/system-gemini.md
+    - ../context/isolated-environment-guidance.md

--- a/agents/attractor-agent-gemini.yaml
+++ b/agents/attractor-agent-gemini.yaml
@@ -50,4 +50,4 @@ context:
   # loop-agent's AgentOrchestrator.execute() resolves the factory before creating the session
   # so the file content becomes session_config.system_prompt (Layer 1).
   include:
-    - context/system-gemini.md
+    - ../context/system-gemini.md

--- a/agents/attractor-agent-openai-isolated.yaml
+++ b/agents/attractor-agent-openai-isolated.yaml
@@ -35,5 +35,5 @@ session:
 
 context:
   include:
-    - context/system-openai.md
-    - context/isolated-environment-guidance.md
+    - ../context/system-openai.md
+    - ../context/isolated-environment-guidance.md

--- a/agents/attractor-agent-openai.yaml
+++ b/agents/attractor-agent-openai.yaml
@@ -56,4 +56,4 @@ context:
   # loop-agent's AgentOrchestrator.execute() resolves the factory before creating the session
   # so the file content becomes session_config.system_prompt (Layer 1).
   include:
-    - context/system-openai.md
+    - ../context/system-openai.md

--- a/bundles/attractor-agent.yaml
+++ b/bundles/attractor-agent.yaml
@@ -42,5 +42,6 @@ tools:
 
 # --- System prompt -----------------------------------------------------------
 context:
+  # '../context/' climbs from this YAML's dir to the bundle-root context/; idiomatic target is 'attractor:context/...' pending foundation namespaced-include support.
   include:
-    - context/system-anthropic.md
+    - ../context/system-anthropic.md

--- a/bundles/attractor-interactive.yaml
+++ b/bundles/attractor-interactive.yaml
@@ -59,10 +59,11 @@ tools:
 
 # Context: standard system prompt + pipeline awareness
 context:
+  # '../context/' climbs from this YAML's dir to the bundle-root context/; idiomatic target is 'attractor:context/...' pending foundation namespaced-include support.
   include:
-    - context/system-anthropic.md
-    - context/pipeline-awareness.md
-    - context/dot-reference.md
+    - ../context/system-anthropic.md
+    - ../context/pipeline-awareness.md
+    - ../context/dot-reference.md
 
 # Agents: pipeline runner + per-provider child agents
 agents:

--- a/profiles/attractor-e2e-anthropic.yaml
+++ b/profiles/attractor-e2e-anthropic.yaml
@@ -33,8 +33,9 @@ tools:
     source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/tool-report-outcome
 
 context:
+  # '../context/' climbs from this YAML's dir to the bundle-root context/; idiomatic target is 'attractor:context/...' pending foundation namespaced-include support.
   include:
-    - context/system-anthropic.md
+    - ../context/system-anthropic.md
 
 hooks:
   - module: hooks-tool-truncation

--- a/profiles/attractor-e2e-gemini.yaml
+++ b/profiles/attractor-e2e-gemini.yaml
@@ -34,8 +34,9 @@ tools:
     source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/tool-report-outcome
 
 context:
+  # '../context/' climbs from this YAML's dir to the bundle-root context/; idiomatic target is 'attractor:context/...' pending foundation namespaced-include support.
   include:
-    - context/system-gemini.md
+    - ../context/system-gemini.md
 
 hooks:
   - module: hooks-tool-truncation

--- a/profiles/attractor-e2e-pipeline-anthropic.yaml
+++ b/profiles/attractor-e2e-pipeline-anthropic.yaml
@@ -61,5 +61,6 @@ hooks:
         - "pipeline:stage_failed"
 
 context:
+  # '../context/' climbs from this YAML's dir to the bundle-root context/; idiomatic target is 'attractor:context/...' pending foundation namespaced-include support.
   include:
-    - context/system-anthropic.md
+    - ../context/system-anthropic.md

--- a/profiles/attractor-e2e-pipeline-gemini.yaml
+++ b/profiles/attractor-e2e-pipeline-gemini.yaml
@@ -61,5 +61,6 @@ hooks:
         - "pipeline:stage_failed"
 
 context:
+  # '../context/' climbs from this YAML's dir to the bundle-root context/; idiomatic target is 'attractor:context/...' pending foundation namespaced-include support.
   include:
-    - context/system-gemini.md
+    - ../context/system-gemini.md

--- a/profiles/attractor-profile-anthropic.yaml
+++ b/profiles/attractor-profile-anthropic.yaml
@@ -31,5 +31,6 @@ tools:
     source: git+https://github.com/microsoft/amplifier-module-tool-search@main
 
 context:
+  # '../context/' climbs from this YAML's dir to the bundle-root context/; idiomatic target is 'attractor:context/...' pending foundation namespaced-include support.
   include:
-    - context/system-anthropic.md
+    - ../context/system-anthropic.md

--- a/profiles/attractor-profile-gemini.yaml
+++ b/profiles/attractor-profile-gemini.yaml
@@ -33,5 +33,6 @@ tools:
     source: git+https://github.com/microsoft/amplifier-module-tool-web@main
 
 context:
+  # '../context/' climbs from this YAML's dir to the bundle-root context/; idiomatic target is 'attractor:context/...' pending foundation namespaced-include support.
   include:
-    - context/system-gemini.md
+    - ../context/system-gemini.md

--- a/profiles/attractor-profile-openai.yaml
+++ b/profiles/attractor-profile-openai.yaml
@@ -35,5 +35,6 @@ tools:
     source: git+https://github.com/microsoft/amplifier-module-tool-search@main
 
 context:
+  # '../context/' climbs from this YAML's dir to the bundle-root context/; idiomatic target is 'attractor:context/...' pending foundation namespaced-include support.
   include:
-    - context/system-openai.md
+    - ../context/system-openai.md

--- a/tests/test_context_include_paths.py
+++ b/tests/test_context_include_paths.py
@@ -1,0 +1,83 @@
+"""
+Guard test: every context.include path in agents/, profiles/, and bundles/ YAML
+files must resolve to an existing file when treated as a path relative to the
+YAML file's own directory.
+
+WHY THIS TEST EXISTS
+--------------------
+The loader (_prepared.py:421) does ``if context_path.exists(): read_text(...)``
+and silently skips non-existent paths (comment at :451 confirms "silently
+skipped").  A bare ``context/system-anthropic.md`` in a file under ``agents/``
+resolves to ``agents/context/system-anthropic.md``, which does not exist — so
+the system prompt is never set and the "Layer-1 base prompt is empty" warning
+fires every LLM turn.  The loader gives no error; this test is the only
+regression guard.
+
+Namespaced refs (``attractor:context/...``) are framework-resolved and skipped
+here — only plain relative paths are checked.
+"""
+
+import pytest
+import yaml
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+SEARCH_DIRS = ["agents", "profiles", "bundles"]
+
+
+def _collect_yaml_includes():
+    """Return a list of (yaml_path, include_entry) pairs for all context.include items."""
+    cases = []
+    for dir_name in SEARCH_DIRS:
+        search_dir = REPO_ROOT / dir_name
+        if not search_dir.exists():
+            continue
+        for yaml_path in sorted(search_dir.rglob("*.yaml")):
+            try:
+                data = yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
+            except Exception:
+                continue
+            if not isinstance(data, dict):
+                continue
+            context = data.get("context")
+            if not isinstance(context, dict):
+                continue
+            includes = context.get("include")
+            if not isinstance(includes, list):
+                continue
+            for entry in includes:
+                if isinstance(entry, str):
+                    cases.append(
+                        pytest.param(
+                            yaml_path,
+                            entry,
+                            id=f"{yaml_path.relative_to(REPO_ROOT)}::{entry}",
+                        )
+                    )
+    return cases
+
+
+@pytest.mark.parametrize("yaml_path,include_entry", _collect_yaml_includes())
+def test_context_include_resolves(yaml_path: Path, include_entry: str) -> None:
+    """Every non-namespaced context.include must resolve to an existing file.
+
+    A namespaced ref (containing ``:``) is handled by the framework and skipped.
+    All other entries are treated as paths relative to the YAML file's own
+    directory — the same resolution the loader uses — and must exist on disk.
+    Failure message names the offending YAML + include so a regression is
+    immediately actionable.
+    """
+    if ":" in include_entry:
+        pytest.skip(f"Namespaced ref (framework-resolved), skipping: {include_entry!r}")
+
+    resolved = (yaml_path.parent / include_entry).resolve()
+    assert resolved.exists(), (
+        f"\nMissing context include:\n"
+        f"  YAML:    {yaml_path.relative_to(REPO_ROOT)}\n"
+        f"  include: {include_entry!r}\n"
+        f"  resolves to: {resolved}\n"
+        f"  (file does not exist)\n\n"
+        f"Hint: bare paths are resolved relative to the YAML's own directory.\n"
+        f"If the file lives at bundle-root context/, use '../context/<file>' "
+        f"(or a namespaced ref once foundation supports it)."
+    )


### PR DESCRIPTION
## Problem

Provider-agent, profile, and bundle YAMLs declared their Layer-1 provider system prompt as a bare include `context/system-<provider>.md`, which the loader resolves relative to the YAML's OWN directory → the non-existent `<dir>/context/system-<provider>.md` (the files live at the repo-root `context/`). Net effect: every SPAWNED attractor LLM node ran WITHOUT its provider system prompt; `loop-agent` logged `Layer-1 base prompt is empty` and fell back to a stub "You are a coding agent."

## Fix

Changed all bare `context/*.md` includes to `../context/*.md` (resolves to bundle-root `context/`). 

- **91c5f1a** did `agents/` (6 files)
- **b9e31ac** did the remaining 9 profile/bundle files + 2 bonus includes in `attractor-interactive.yaml` that the guard test caught

Plus a guard test (`tests/test_context_include_paths.py`, 20 entries) asserting every `agents/|profiles/|bundles/` `context.include` resolves to an existing file — the loader skips missing includes SILENTLY (`_prepared.py:421`), so this test is the regression guard.

## Evidence

wiki-weaver before/after A/B (DTU per variant, identical source): 
- `Layer-1 base prompt is empty` **20 → 0** ✓
- both runs converge and write a wiki (no regression)

Two blind, order-swapped quality judges BOTH preferred the fixed output — without the system prompt the agent hallucinated (invented detail cited as if from the source) and over-fragmented (thin stub pages); with it, faithful and well-scoped. **So this is a correctness/quality fix, not just a silenced log line.**

## Honest caveats

- The bug is **SPAWN-PATH-specific**: it does NOT reproduce on the direct `amplifier run -B <agent>` create_session path, so direct-run smoke tests won't catch it.
- Cross-consumer DTU runs confirmed the bug reproduces on the spawn path (attractor e2e pipeline = 41, dot-graph `ralph_loop` = 3), but the FIXED cross-consumer spawn runs were blocked by environmental issues (the recursion guard discovered in microsoft/amplifier#305; a hardcoded `/opt/uv-tools/.../python3` path in `ralph_loop`) before a child spawned. **So cross-consumer fix-clears are PROOF-BY-CONSTRUCTION** (no consumer relocates the agent YAMLs, so `../context/` resolves identically everywhere) rather than a second clean end-to-end clear; the clean end-to-end proof is wiki-weaver.
- `../context/` is a workaround for the loader's YAML-dir-relative bare-path resolution; the idiomatic target is `attractor:context/...` pending foundation namespaced-include support in the spawn path.

## Review

Validated via a 6-lens council review (unanimous: extend the fix to all bare-path files, add the guard test, file the recursion-guard bug separately).

## Related

Recursion-guard issue filed at microsoft/amplifier#305 — reference for follow-up investigation.

---

**Do not merge yet — holding for final sign-off.**