### PR TITLE
fix(e2e-profiles): emit eval-compatible events.jsonl via file-only context-intelligence

### DIFF
--- a/profiles/attractor-e2e-pipeline-anthropic.yaml
+++ b/profiles/attractor-e2e-pipeline-anthropic.yaml
@@ -56,19 +56,14 @@ tools:
     source: git+https://github.com/microsoft/amplifier-module-tool-search@main
 
 hooks:
-  - module: hooks-logging
+  # File-only context-intelligence: writes an eval-compatible events.jsonl
+  # (llm:response with token usage) to the session dir. NO server/destination
+  # configured -> local JSONL only, zero network. Matches the amplifier-evaluation
+  # harness's expected events.jsonl source.
+  - module: hook-context-intelligence
+    source: git+https://github.com/microsoft/amplifier-bundle-context-intelligence@main#subdirectory=modules/hook-context-intelligence
     config:
-      additional_events:
-        - "pipeline:start"
-        - "pipeline:complete"
-        - "pipeline:node_start"
-        - "pipeline:node_complete"
-        - "pipeline:edge_selected"
-        - "pipeline:checkpoint"
-        - "pipeline:goal_gate_check"
-        - "pipeline:error"
-        - "pipeline:stage_retrying"
-        - "pipeline:stage_failed"
+      log_level: INFO
 
 context:
   include:

--- a/profiles/attractor-e2e-pipeline-gemini.yaml
+++ b/profiles/attractor-e2e-pipeline-gemini.yaml
@@ -55,19 +55,14 @@ tools:
     source: git+https://github.com/microsoft/amplifier-module-tool-search@main
 
 hooks:
-  - module: hooks-logging
+  # File-only context-intelligence: writes an eval-compatible events.jsonl
+  # (llm:response with token usage) to the session dir. NO server/destination
+  # configured -> local JSONL only, zero network. Matches the amplifier-evaluation
+  # harness's expected events.jsonl source.
+  - module: hook-context-intelligence
+    source: git+https://github.com/microsoft/amplifier-bundle-context-intelligence@main#subdirectory=modules/hook-context-intelligence
     config:
-      additional_events:
-        - "pipeline:start"
-        - "pipeline:complete"
-        - "pipeline:node_start"
-        - "pipeline:node_complete"
-        - "pipeline:edge_selected"
-        - "pipeline:checkpoint"
-        - "pipeline:goal_gate_check"
-        - "pipeline:error"
-        - "pipeline:stage_retrying"
-        - "pipeline:stage_failed"
+      log_level: INFO
 
 context:
   include:


### PR DESCRIPTION
## Summary

Fix the e2e pipeline profiles' observability layer. Both profiles declared `hooks-logging` with NO `source:` and included only `attractor-core` (not foundation), causing the event-logging hook to silently fail to mount. Result: no `events.jsonl` or token data written by a pipeline run.

## Changes

Switch both profiles' `hooks:` block from non-functional `hooks-logging` to file-only `hook-context-intelligence`:

- **Source**: git+https://github.com/microsoft/amplifier-bundle-context-intelligence@main#subdirectory=modules/hook-context-intelligence
- **Config**: log_level: INFO
- **Networking**: None (local JSONL file-only)

## Proof

✅ **DTU-tested (anthropic profile)**:
- Pipeline completed: hello.py, status success, no recursion
- Events log written: `.../sessions/<sid>/context-intelligence/events.jsonl`
- **6 llm:response events** with non-zero input/output tokens
- `pipeline:*` events present in parent session (auto-captured via attractor-core's observability.events contribution)
- File-only, zero network traffic

✅ **Compatibility**: Gemini profile receives identical hook change (identical source, config, no server). Not independently DTU-run but structurally identical to anthropic.

✅ **Downstream**: The eval harness (amplifier-evaluation's `compare.py`) reads `llm:response` `data.usage` token counts from `events.jsonl` — this fix writes eval-compatible events via context-intelligence's file-only logging.

✅ **Simplification**: Eliminates redundant manual `additional_events` list; `pipeline:*` events are now auto-contributed via attractor-core's observability.events.

## Files Changed

- `profiles/attractor-e2e-pipeline-anthropic.yaml` — updated hooks block
- `profiles/attractor-e2e-pipeline-gemini.yaml` — updated hooks block (identical change)