### PR TITLE
chore: scrub residual unsupported agents.<name>.bundle: refs from tests + docs

### DIFF
--- a/docs/APP-INTEGRATION-GUIDE.md
+++ b/docs/APP-INTEGRATION-GUIDE.md
@@ -175,30 +175,17 @@ def register_spawn_capability(session: Any, prepared: PreparedBundle) -> None:
                 f"Agent '{agent_name}' not found. Available: {available}"
             )
 
-        # Agent configs arrive in two shapes -- build the child bundle for each:
-        #
-        #   1. Lazy bundle-ref: a single-key dict {"bundle": "<uri>"}. It has
-        #      no inline fields, so you MUST load_bundle() it. Building a
-        #      Bundle(...) from config.get(...) here would produce a
-        #      structurally empty child that inherits the parent's
-        #      orchestrator and falls to a no-tools backend (an
-        #      ImportError / silent fallback at runtime).
-        #
-        #   2. Inline config: a dict of bundle fields (tools/providers/
-        #      instruction/...). Build the child Bundle(...) from those fields.
-        if "bundle" in config and len(config) == 1:
-            child_bundle = await load_bundle(config["bundle"])
-        else:
-            child_bundle = Bundle(
-                name=agent_name,
-                version="1.0.0",
-                session=config.get("session", {}),
-                providers=config.get("providers", []),
-                tools=config.get("tools", []),
-                hooks=config.get("hooks", []),
-                instruction=config.get("instruction")
-                or config.get("system", {}).get("instruction"),
-            )
+        # Build child Bundle from inline agent overlay.
+        child_bundle = Bundle(
+            name=agent_name,
+            version="1.0.0",
+            session=config.get("session", {}),
+            providers=config.get("providers", []),
+            tools=config.get("tools", []),
+            hooks=config.get("hooks", []),
+            instruction=config.get("instruction")
+            or config.get("system", {}).get("instruction"),
+        )
 
         return await prepared.spawn(
             child_bundle=child_bundle,

--- a/docs/plans/track2/track2-2a1-subagent-spawn-rewrite.md
+++ b/docs/plans/track2/track2-2a1-subagent-spawn-rewrite.md
@@ -327,7 +327,7 @@ async def test_wait_uses_session_spawn_capability():
     coordinator = _make_coordinator(
         spawn_fn=mock_spawn,
         session="parent-session-abc",
-        agents={"test-agent": {"bundle": "test:profile"}},
+        agents={"test-agent": {"session": {"orchestrator": {"module": "loop-agent"}}}},
     )
 
     manager = SubagentManager(coordinator, max_depth=2, current_depth=0)
@@ -356,7 +356,7 @@ async def test_wait_uses_session_spawn_capability():
     call_kwargs = mock_spawn.call_args[1]
     assert call_kwargs["instruction"] == "Write hello.py"
     assert call_kwargs["parent_session"] == "parent-session-abc"
-    assert call_kwargs["agent_configs"] == {"test-agent": {"bundle": "test:profile"}}
+    assert call_kwargs["agent_configs"] == {"test-agent": {"session": {"orchestrator": {"module": "loop-agent"}}}}
 
 
 @pytest.mark.asyncio

--- a/docs/plans/track2/track2-2a2-profile-routing.md
+++ b/docs/plans/track2/track2-2a2-profile-routing.md
@@ -285,8 +285,8 @@ def test_profiles_auto_discovered_from_agents():
     coordinator = _make_coordinator(
         has_spawn=True,
         agents={
-            "attractor-anthropic": {"bundle": "attractor:profiles/attractor-profile-anthropic"},
-            "attractor-openai": {"bundle": "attractor:profiles/attractor-profile-openai"},
+            "attractor-anthropic": {"session": {"orchestrator": {"module": "loop-agent"}}},
+            "attractor-openai": {"session": {"orchestrator": {"module": "loop-agent"}}},
         },
     )
     providers = {"anthropic": MagicMock()}
@@ -302,7 +302,7 @@ def test_explicit_profiles_override_auto_discovery():
     """Explicit profiles should take priority over auto-discovery."""
     coordinator = _make_coordinator(
         has_spawn=True,
-        agents={"auto-agent": {"bundle": "something"}},
+        agents={"auto-agent": {"session": {"orchestrator": {"module": "loop-agent"}}}},
     )
     providers = {"anthropic": MagicMock()}
 

--- a/docs/plans/track2/track2-2a3-profile-agent-bundles.md
+++ b/docs/plans/track2/track2-2a3-profile-agent-bundles.md
@@ -1,3 +1,5 @@
+> **Superseded:** the `agents.<name>.bundle:` approach described here was abandoned (it caused pipeline recursion); the sanctioned mechanism is inline `session:` / `agents.include`.
+
 # Profile Agent Bundles Implementation Plan
 
 > **Execution:** Use the subagent-driven-development workflow to implement this plan.
@@ -200,9 +202,9 @@ With Tasks 1 and 2 applied, verify the config chain:
    provider = node.attrs.get("llm_provider", "anthropic")  # -> "anthropic"
    profile_name = self._profiles.get("anthropic", ...)      # -> "attractor-anthropic"
    ```
-3. Spawn call: `agent_name="attractor-anthropic"`, `agent_configs={"attractor-anthropic": {"bundle": "attractor:profiles/attractor-profile-anthropic", ...}}`
-4. App host resolves `"attractor-anthropic"` in configs -> loads `attractor:profiles/attractor-profile-anthropic`
-5. That bundle configures `loop-agent` + `provider-anthropic` + tools -> child session runs
+3. Spawn call: `agent_name="attractor-anthropic"`, `agent_configs={"attractor-anthropic": {"session": {"orchestrator": {"module": "loop-agent"}}, ...}}`
+4. App host resolves `"attractor-anthropic"` in configs -> builds inline child Bundle from agent overlay
+5. That overlay configures `loop-agent` + `provider-anthropic` + tools -> child session runs
 
 Run:
 ```bash

--- a/docs/plans/track2/track2-2b1-spawn-e2e-test.md
+++ b/docs/plans/track2/track2-2b1-spawn-e2e-test.md
@@ -228,7 +228,7 @@ async def test_spawn_path_success():
     coordinator, spawn_fn = _make_coordinator(
         agents={
             "attractor-anthropic": {
-                "bundle": "attractor:profiles/attractor-profile-anthropic"
+                "session": {"orchestrator": {"module": "loop-agent"}}
             }
         }
     )

--- a/examples/programmatic_usage.py
+++ b/examples/programmatic_usage.py
@@ -114,24 +114,14 @@ def register_spawn_capability(session: Any, prepared: Any) -> None:
     amplifier-foundation/examples/07_full_workflow.py which handles
     additional kwargs (tool_inheritance, hook_inheritance, etc.).
 
-    Agent configs come in two shapes, and the child bundle must be built
-    differently for each:
-
-    1. Inline config -- a dict of bundle fields
-       (``{"tools": [...], "providers": [...], "instruction": "..."}``).
-       Build the child ``Bundle(...)`` directly from those fields.
-
-    2. Lazy bundle-ref -- a single-key dict ``{"bundle": "<uri>"}`` that
-       points at a bundle to load. You MUST ``load_bundle(...)`` it: a
-       bundle-ref has no inline fields, so ``config.get(...)`` would return
-       empty for everything, producing a structurally empty child that
-       inherits the parent's orchestrator and ends up on a no-tools backend
-       (an ImportError / silent fallback at runtime).
+    Agent configs are inline bundle overlays -- dicts of bundle fields
+    (``{"session": {...}, "providers": [...], "tools": [...], ...}``).
+    The child ``Bundle(...)`` is built directly from those fields.
 
     Note: hooks composed into the PARENT bundle auto-propagate to every
     spawned child via ``prepared.spawn(compose=True)`` (the default).
     """
-    from amplifier_foundation import Bundle, load_bundle
+    from amplifier_foundation import Bundle
     from amplifier_foundation.bundle import PreparedBundle
 
     assert isinstance(prepared, PreparedBundle)
@@ -157,29 +147,17 @@ def register_spawn_capability(session: Any, prepared: Any) -> None:
             available = list(agent_configs.keys()) + list(prepared.bundle.agents.keys())
             raise ValueError(f"Agent '{agent_name}' not found. Available: {available}")
 
-        # Two agent-config shapes -- build the child bundle accordingly:
-        #
-        #   1. Lazy bundle-ref: a single-key dict {"bundle": "<uri>"}. There
-        #      are NO inline fields, so we must load_bundle() it. Building a
-        #      Bundle(...) from config.get(...) here would yield a structurally
-        #      empty child that inherits the parent's orchestrator and falls to
-        #      a no-tools backend (ImportError / silent fallback at runtime).
-        #
-        #   2. Inline config: a dict of bundle fields (tools/providers/...).
-        #      Build the child Bundle(...) directly from those fields.
-        if "bundle" in config and len(config) == 1:
-            child_bundle = await load_bundle(config["bundle"])
-        else:
-            child_bundle = Bundle(
-                name=agent_name,
-                version="1.0.0",
-                session=config.get("session", {}),
-                providers=config.get("providers", []),
-                tools=config.get("tools", []),
-                hooks=config.get("hooks", []),
-                instruction=config.get("instruction")
-                or config.get("system", {}).get("instruction"),
-            )
+        # Build child Bundle from inline agent overlay.
+        child_bundle = Bundle(
+            name=agent_name,
+            version="1.0.0",
+            session=config.get("session", {}),
+            providers=config.get("providers", []),
+            tools=config.get("tools", []),
+            hooks=config.get("hooks", []),
+            instruction=config.get("instruction")
+            or config.get("system", {}).get("instruction"),
+        )
 
         return await prepared.spawn(
             child_bundle=child_bundle,

--- a/modules/loop-agent/tests/test_subagent_tools.py
+++ b/modules/loop-agent/tests/test_subagent_tools.py
@@ -437,7 +437,7 @@ class TestWait:
         coordinator = _make_coordinator(
             spawn_result={"output": "done", "session_id": "child-123"},
             session="parent-session-abc",
-            agents={"test-agent": {"bundle": "test:profile"}},
+            agents={"test-agent": {"session": {"orchestrator": {"module": "loop-agent"}}}},
         )
         mgr = SubagentManager(coordinator=coordinator)
         spawn_tool = _find_tool(mgr, "spawn_agent")
@@ -455,7 +455,7 @@ class TestWait:
         call_kwargs = coordinator._mock_spawn.call_args[1]
         assert call_kwargs["instruction"] == "Write hello.py"
         assert call_kwargs["parent_session"] == "parent-session-abc"
-        assert call_kwargs["agent_configs"] == {"test-agent": {"bundle": "test:profile"}}
+        assert call_kwargs["agent_configs"] == {"test-agent": {"session": {"orchestrator": {"module": "loop-agent"}}}}
         assert "agent_name" in call_kwargs
 
     @pytest.mark.asyncio

--- a/modules/loop-pipeline/tests/test_profile_routing.py
+++ b/modules/loop-pipeline/tests/test_profile_routing.py
@@ -54,10 +54,10 @@ def test_profiles_auto_discovered_from_agents():
         has_spawn=True,
         agents={
             "attractor-anthropic": {
-                "bundle": "attractor:profiles/attractor-profile-anthropic"
+                "session": {"orchestrator": {"module": "loop-agent"}}
             },
             "attractor-openai": {
-                "bundle": "attractor:profiles/attractor-profile-openai"
+                "session": {"orchestrator": {"module": "loop-agent"}}
             },
         },
     )
@@ -74,7 +74,7 @@ def test_explicit_profiles_override_auto_discovery():
     """Explicit profiles should take priority over auto-discovery."""
     coordinator = _make_coordinator(
         has_spawn=True,
-        agents={"auto-agent": {"bundle": "something"}},
+        agents={"auto-agent": {"session": {"orchestrator": {"module": "loop-agent"}}}},
     )
     providers = {"anthropic": MagicMock()}
 


### PR DESCRIPTION
PR #74 removed the live YAML `agents.<name>.bundle:` form (which the standard runtime never resolved — it caused pipeline recursion). This clears the residue in tests, examples, and plan docs so nothing re-teaches the dead pattern.

- Tests repointed to the sanctioned inline `session.orchestrator` overlay; loop-pipeline (6/6) and loop-agent (28/28) pass.
- examples/programmatic_usage.py + docs/APP-INTEGRATION-GUIDE.md retconned to the sanctioned form; track2 plan docs: snippets updated + "Superseded" banner where central.

Per the context-poisoning doctrine: present only the current sanctioned mechanism.