### PR TITLE
fix(models): replace retired claude-sonnet-4-20250514 with claude-sonnet-4-6

### DIFF
--- a/bundles/attractor-agent.yaml
+++ b/bundles/attractor-agent.yaml
@@ -19,7 +19,7 @@ providers:
   - module: provider-anthropic
     source: git+https://github.com/microsoft/amplifier-module-provider-anthropic@main
     config:
-      default_model: claude-sonnet-4-20250514
+      default_model: claude-sonnet-4-6
 
 # --- Agent loop orchestrator -------------------------------------------------
 session:

--- a/bundles/attractor-interactive.yaml
+++ b/bundles/attractor-interactive.yaml
@@ -24,7 +24,7 @@ providers:
   - module: provider-anthropic
     source: git+https://github.com/microsoft/amplifier-module-provider-anthropic@main
     config:
-      default_model: claude-sonnet-4-20250514
+      default_model: claude-sonnet-4-6
 
 # Interactive agent loop (not pipeline — the user talks to this)
 session:

--- a/bundles/attractor-pipeline.yaml
+++ b/bundles/attractor-pipeline.yaml
@@ -18,7 +18,7 @@ providers:
   - module: provider-anthropic
     source: git+https://github.com/microsoft/amplifier-module-provider-anthropic@main
     config:
-      default_model: claude-sonnet-4-20250514
+      default_model: claude-sonnet-4-6
 
 # --- Pipeline orchestrator session ------------------------------------------
 session:

--- a/examples/pipelines/06-model-stylesheet.dot
+++ b/examples/pipelines/06-model-stylesheet.dot
@@ -12,7 +12,7 @@ digraph ModelStylesheet {
         label="Model Stylesheet Pipeline",
         model_stylesheet="
             * {
-                llm_model: claude-sonnet-4-20250514;
+                llm_model: claude-sonnet-4-6;
                 llm_provider: anthropic;
                 reasoning_effort: medium;
             }
@@ -22,7 +22,7 @@ digraph ModelStylesheet {
                 reasoning_effort: high;
             }
             .code {
-                llm_model: claude-sonnet-4-20250514;
+                llm_model: claude-sonnet-4-6;
                 llm_provider: anthropic;
             }
             .fast {

--- a/examples/pipelines/06-model-stylesheet.md
+++ b/examples/pipelines/06-model-stylesheet.md
@@ -23,7 +23,7 @@ start -> analyze -> refactor -> lint_check -> critical_review -> quick_fix -> do
 | Node | Class | Matching Rules | Winner (by specificity) | Final Model |
 |------|-------|----------------|------------------------|-------------|
 | `analyze` | `planning` | `*`(0), `.planning`(2) | `.planning` | `o3` (openai) |
-| `refactor` | `code` | `*`(0), `.code`(2) | `.code` | `claude-sonnet-4-20250514` (anthropic) |
+| `refactor` | `code` | `*`(0), `.code`(2) | `.code` | `claude-sonnet-4-6` (anthropic) |
 | `lint_check` | `fast` | `*`(0), `.fast`(2) | `.fast` | `gemini-2.5-flash-preview-05-20` (gemini, low) |
 | `critical_review` | `code` | `*`(0), `.code`(2), `#critical_review`(3) | `#critical_review` | `claude-opus-4-20250514` (anthropic, high) |
 | `quick_fix` | `code` | `*`(0), `.code`(2) | `.code` BUT node has explicit `llm_model` | `gemini-2.5-flash-preview-05-20` (explicit override) |

--- a/examples/pipelines/10-full-attractor.dot
+++ b/examples/pipelines/10-full-attractor.dot
@@ -18,7 +18,7 @@ digraph FullAttractor {
         fallback_retry_target="plan",
         model_stylesheet="
             * {
-                llm_model: claude-sonnet-4-20250514;
+                llm_model: claude-sonnet-4-6;
                 llm_provider: anthropic;
                 reasoning_effort: medium;
             }
@@ -28,7 +28,7 @@ digraph FullAttractor {
                 reasoning_effort: high;
             }
             .code {
-                llm_model: claude-sonnet-4-20250514;
+                llm_model: claude-sonnet-4-6;
                 llm_provider: anthropic;
             }
             .fast {

--- a/examples/pipelines/10-full-attractor.md
+++ b/examples/pipelines/10-full-attractor.md
@@ -80,13 +80,13 @@ done       polish      fix_tests
 | Node | Class | Stylesheet Match | Resolved Model |
 |------|-------|-----------------|----------------|
 | `plan` | planning | `.planning` (specificity=2) | o3 (openai, high) |
-| `implement_backend` | code | `.code` (specificity=2) | claude-sonnet-4-20250514 (anthropic) |
-| `implement_frontend` | code | `.code` (specificity=2) | claude-sonnet-4-20250514 (anthropic) |
-| `integrate` | code | `.code` (specificity=2) | claude-sonnet-4-20250514 (anthropic) |
+| `implement_backend` | code | `.code` (specificity=2) | claude-sonnet-4-6 (anthropic) |
+| `implement_frontend` | code | `.code` (specificity=2) | claude-sonnet-4-6 (anthropic) |
+| `integrate` | code | `.code` (specificity=2) | claude-sonnet-4-6 (anthropic) |
 | `test` | fast | `.fast` (specificity=2) | gemini-2.5-flash-preview-05-20 (gemini, low) |
-| `fix_tests` | code | `.code` (specificity=2) | claude-sonnet-4-20250514 (anthropic) |
+| `fix_tests` | code | `.code` (specificity=2) | claude-sonnet-4-6 (anthropic) |
 | `final_review` | code | `#final_review` (specificity=3) | claude-opus-4-20250514 (anthropic, high) |
-| `polish` | code | `.code` (specificity=2) | claude-sonnet-4-20250514 (anthropic) |
+| `polish` | code | `.code` (specificity=2) | claude-sonnet-4-6 (anthropic) |
 
 ## Expected Behavior
 

--- a/examples/pipelines/practical/pr-review.dot
+++ b/examples/pipelines/practical/pr-review.dot
@@ -8,7 +8,7 @@ digraph PRReview {
     graph [
         goal="$goal",
         label="PR Review Pipeline",
-        model_stylesheet="box { llm_provider: anthropic; llm_model: claude-sonnet-4-20250514 }
+        model_stylesheet="box { llm_provider: anthropic; llm_model: claude-sonnet-4-6 }
                           .reasoning { llm_provider: openai; llm_model: o3-mini; reasoning_effort: high }",
         default_fidelity="full",
         default_thread_id="pr-review"

--- a/profiles/attractor-e2e-anthropic.yaml
+++ b/profiles/attractor-e2e-anthropic.yaml
@@ -7,7 +7,7 @@ providers:
   - module: provider-anthropic
     source: git+https://github.com/microsoft/amplifier-module-provider-anthropic@main
     config:
-      default_model: claude-sonnet-4-20250514
+      default_model: claude-sonnet-4-6
 
 session:
   orchestrator:


### PR DESCRIPTION
## Bug

Anthropic retired the `claude-sonnet-4-20250514` model on 2026-06-15. Out-of-box attractor pipeline runs fail at their first codergen/LLM node with `not_found_error: model claude-sonnet-4-20250514`. This is a loud, blocking failure (correct behavior from the loop-pipeline engine), but it breaks the entire bundle's usability.

## Fix

Bump the bundle's four functional `default_model` pins to `claude-sonnet-4-6` — the repo's own current canonical Anthropic model id. The catalog (`models.json`), tests, and SPEC_CONFORMANCE.md (ULM-15) already moved to `claude-sonnet-4-6` ("verified live on gateway"). This change brings the bundle's executable surface (functional pins + runnable examples) in line with what the rest of the codebase already uses.

## Proof (End-to-End Verification in Live DTU)

1. **Model availability:** `amplifier run -p anthropic -m claude-sonnet-4-6` returned `model-ok` response (served without 404)
2. **Out-of-box pipeline success:** The edited bundle was mirrored to Gitea and installed in a running Digital Twin Universe. A standard attractor pipeline run (`examples/pipelines/01-simple-linear.dot`, NO model override — using the bundle's default_model) returned:
   ```json
   {"status": "success", "node_statuses": {"start": "success", "implement": "success"}}
   ```
   - The `implement` codergen node **previously died** on the retired model
   - Now succeeds on `claude-sonnet-4-6`
   - Log scan: **0 occurrences** of retired id, **0 not_found_error**

## Scope Note (Follow-up PR, Not Included Here)

The retired id still appears in several docs (README.md, docs/GETTING-STARTED.md, docs/DOT-SYNTAX.md, docs/DOT-AUTHORING-GUIDE.md, context/dot-reference.md) and in historical records (docs/plans/*.md). The historical plan docs should remain as point-in-time records. The author-facing current docs deserve a separate cleanup PR for consistency. This PR is deliberately scoped to the **executable surface only** (functional pins + runnable examples) so it stays focused and provable.

Generated with [Amplifier](https://github.com/microsoft/amplifier)