### PR TITLE
docs: replace retired claude-sonnet-4-20250514 with claude-sonnet-4-6 in guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ See [DOT Authoring Guide](docs/DOT-AUTHORING-GUIDE.md) for complete patterns and
 - **Model stylesheets** -- override provider, model, and reasoning effort per-node via CSS-like selectors:
   ```dot
   graph [model_stylesheet="
-      box { llm_provider: anthropic; llm_model: claude-sonnet-4-20250514 }
+      box { llm_provider: anthropic; llm_model: claude-sonnet-4-6 }
       .fast { llm_model: claude-haiku-3-5-20241022 }
   "]
   ```

--- a/context/dot-reference.md
+++ b/context/dot-reference.md
@@ -30,7 +30,7 @@ node_id [
     retry_target="node_id",      // Where to jump on gate failure
     fidelity="full",             // full|compact|summary:high|summary:low
     llm_provider="anthropic",    // Override provider for this node
-    llm_model="claude-sonnet-4-20250514", // Override model
+    llm_model="claude-sonnet-4-6", // Override model
     reasoning_effort="high",     // low|medium|high
     auto_status=true,            // Force success regardless of outcome
     timeout=30s                  // Per-node timeout
@@ -59,7 +59,7 @@ digraph MyPipeline {
         default_max_retry=3,
         retry_target="some_node",          // Retry target when exit has unsatisfied goal gates (spec §3.4); NOT a per-node failure catch-all
         max_pipeline_duration=5m,          // Abort if exceeded
-        model_stylesheet="box { llm_provider: anthropic; llm_model: claude-sonnet-4-20250514 }
+        model_stylesheet="box { llm_provider: anthropic; llm_model: claude-sonnet-4-6 }
                           .fast { llm_model: claude-haiku-3-5-20241022 }"
     ]
 }

--- a/docs/DOT-AUTHORING-GUIDE.md
+++ b/docs/DOT-AUTHORING-GUIDE.md
@@ -219,7 +219,7 @@ digraph {
         goal="Refactor legacy code to async patterns",
         model_stylesheet="
             * {
-                llm_model: claude-sonnet-4-20250514;
+                llm_model: claude-sonnet-4-6;
                 llm_provider: anthropic;
             }
             .planning {
@@ -512,8 +512,8 @@ Selector { property: value; property: value; }
 
 ```dot
 graph [model_stylesheet="
-    * { llm_model: claude-sonnet-4-20250514; llm_provider: anthropic; }
-    .code { llm_model: claude-sonnet-4-20250514; }
+    * { llm_model: claude-sonnet-4-6; llm_provider: anthropic; }
+    .code { llm_model: claude-sonnet-4-6; }
     .reasoning { llm_model: o3; llm_provider: openai; reasoning_effort: high; }
     #final_check { llm_model: claude-opus-4-20250514; reasoning_effort: high; }
 "]

--- a/docs/DOT-SYNTAX.md
+++ b/docs/DOT-SYNTAX.md
@@ -72,7 +72,7 @@ digraph {
 
 ```dot
 graph [model_stylesheet="
-    box { llm_provider: anthropic; llm_model: claude-sonnet-4-20250514 }
+    box { llm_provider: anthropic; llm_model: claude-sonnet-4-6 }
     .fast { llm_model: claude-haiku-3-5-20241022 }
 "]
 ```
@@ -158,7 +158,7 @@ digraph {
 digraph {
     graph [
         goal="$goal",
-        model_stylesheet="box { llm_provider: anthropic; llm_model: claude-sonnet-4-20250514 }
+        model_stylesheet="box { llm_provider: anthropic; llm_model: claude-sonnet-4-6 }
                           .reasoning { llm_provider: openai; llm_model: o3-mini; reasoning_effort: high }"
     ]
     start [shape=Mdiamond]; done [shape=Msquare]

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -171,7 +171,7 @@ tools), check for project-level overrides:
 # This overrides global settings for this project only
 settings:
   provider:
-    model: claude-sonnet-4-20250514
+    model: claude-sonnet-4-6
 ```
 
 ### `last_response` is truncated to 200 characters


### PR DESCRIPTION
## Summary

This PR retires stale model references from author-facing documentation. The model id `claude-sonnet-4-20250514` is no longer available; copy-pasted examples from these guides would fail with 404 errors.

## Rationale

Follow-up to #76 (which fixed functional pins + runnable examples). This removes historical baggage per [CONTEXT_POISONING.md](https://github.com/microsoft/amplifier-foundation/blob/main/context/CONTEXT_POISONING.md) guidance: stale docs + historical references are a vector for context poisoning and must be removed from current author-facing guides so copy-pasted examples don't fail.

## Scope

- ✅ Updated author-facing current docs: README.md, GETTING-STARTED.md, DOT-SYNTAX.md, DOT-AUTHORING-GUIDE.md, dot-reference.md
- ❌ Intentionally left untouched: historical records (docs/plans/*, docs/designs/*, SPEC_CONFORMANCE.md) and test fixtures — preserved as point-in-time records

Generated with [Amplifier](https://github.com/microsoft/amplifier)