### PR TITLE
feat(observability): emit and record model:resolved event for resolution auditability

### DIFF
--- a/modules/hooks-pipeline-observability/amplifier_module_hooks_pipeline_observability/__init__.py
+++ b/modules/hooks-pipeline-observability/amplifier_module_hooks_pipeline_observability/__init__.py
@@ -33,6 +33,7 @@ _PIPELINE_EVENTS = [
     "pipeline:stage_retrying",
     "pipeline:stage_failed",
     "provider:response",
+    "model:resolved",
 ]
 
 # Map event names to StateAggregator handler method names
@@ -55,6 +56,7 @@ _AGGREGATOR_HANDLER_MAP: dict[str, str] = {
     "pipeline:stage_retrying": "handle_stage_retrying",
     "pipeline:stage_failed": "handle_stage_failed",
     "provider:response": "handle_provider_response",
+    "model:resolved": "handle_model_resolved",
 }
 
 

--- a/modules/hooks-pipeline-observability/amplifier_module_hooks_pipeline_observability/aggregator.py
+++ b/modules/hooks-pipeline-observability/amplifier_module_hooks_pipeline_observability/aggregator.py
@@ -73,6 +73,19 @@ class StateAggregator:
         )
         return HookResult()
 
+    async def handle_model_resolved(
+        self, event: str, data: dict[str, Any]
+    ) -> HookResult:
+        """Handle model:resolved — record which concrete model a family-token /
+        glob ``llm_model`` resolved to, for audit / eval reproducibility."""
+        if self.state is None:
+            return HookResult()
+        raw = data.get("raw")
+        resolved = data.get("resolved")
+        if raw and resolved:
+            self.state.resolved_models[raw] = resolved
+        return HookResult()
+
     # -- Node lifecycle ----------------------------------------------------
 
     async def handle_node_start(self, event: str, data: dict[str, Any]) -> HookResult:

--- a/modules/hooks-pipeline-observability/amplifier_module_hooks_pipeline_observability/models.py
+++ b/modules/hooks-pipeline-observability/amplifier_module_hooks_pipeline_observability/models.py
@@ -143,6 +143,9 @@ class PipelineRunState:
     # Subgraph execution (recursive — for nested DOT subgraphs)
     subgraph_runs: dict[str, Any] = field(default_factory=dict)
 
+    # Model token/glob resolutions: raw llm_model pattern -> concrete served id
+    resolved_models: dict[str, str] = field(default_factory=dict)
+
     # Human gate interactions
     human_interactions: list[HumanInteraction] = field(default_factory=list)
 

--- a/modules/hooks-pipeline-observability/tests/test_model_resolved_event.py
+++ b/modules/hooks-pipeline-observability/tests/test_model_resolved_event.py
@@ -1,0 +1,49 @@
+"""model:resolved wiring — discovery contribution, aggregator subscription, and state capture.
+
+The same ``_PIPELINE_EVENTS`` entry that the aggregator subscribes to is also
+contributed to the ``observability.events`` channel, which is what Context
+Intelligence / any logging recorder discovers. So this one event name closes
+both the live-state gap (StateAggregator) and the durable-capture gap (recorders).
+"""
+
+import pytest
+
+import amplifier_module_hooks_pipeline_observability as obs
+from amplifier_module_hooks_pipeline_observability.aggregator import StateAggregator
+
+
+def test_model_resolved_is_discoverable_and_subscribed():
+    # observability.events discovery contribution (CI + any recorder read this)
+    assert "model:resolved" in obs._PIPELINE_EVENTS
+    # aggregator handler subscription
+    assert obs._AGGREGATOR_HANDLER_MAP["model:resolved"] == "handle_model_resolved"
+
+
+@pytest.mark.asyncio
+async def test_aggregator_records_resolution():
+    agg = StateAggregator()
+    await agg.handle_pipeline_start(
+        "pipeline:start", {"graph_name": "g", "node_count": 1}
+    )
+    await agg.handle_model_resolved(
+        "model:resolved",
+        {
+            "raw": "claude-sonnet-4-*",
+            "resolved": "claude-sonnet-4-6",
+            "provider": "anthropic",
+            "pattern": "claude-sonnet-4-*",
+        },
+    )
+    state = agg.get_state()
+    assert state is not None
+    assert state.resolved_models == {"claude-sonnet-4-*": "claude-sonnet-4-6"}
+
+
+@pytest.mark.asyncio
+async def test_resolution_is_safe_noop_without_pipeline_state():
+    agg = StateAggregator()
+    # No pipeline:start yet -> no state -> must be a safe no-op, never raise.
+    await agg.handle_model_resolved(
+        "model:resolved", {"raw": "sonnet", "resolved": "claude-sonnet-4-6"}
+    )
+    assert agg.get_state() is None

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/__init__.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/__init__.py
@@ -105,7 +105,9 @@ class DirectProviderBackend:
             if hasattr(node, "llm_provider") and node.llm_provider
             else node.attrs.get("llm_provider", "anthropic")
         )
-        model = await _resolve_concrete_model(provider_name, _resolve_model(node))
+        model = await _resolve_concrete_model(
+            provider_name, _resolve_model(node), emit=self._emit
+        )
         reasoning_effort = node.attrs.get("reasoning_effort")
         max_agent_turns_raw = node.attrs.get("max_agent_turns")
         max_agent_turns = (

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/backend.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/backend.py
@@ -55,7 +55,12 @@ from .fidelity import build_preamble, resolve_fidelity, resolve_thread_key
 from .graph import Edge, Graph, Node
 from .outcome import Outcome, StageStatus
 from .hook_bridge import _current_node_context, set_node_context
-from .pipeline_events import PROVIDER_ERROR, PROVIDER_REQUEST, PROVIDER_RESPONSE
+from .pipeline_events import (
+    MODEL_RESOLVED,
+    PROVIDER_ERROR,
+    PROVIDER_REQUEST,
+    PROVIDER_RESPONSE,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -227,7 +232,7 @@ class AmplifierBackend:
         # 2. Resolve provider and profile from node attributes
         provider = node.attrs.get("llm_provider", "anthropic")
         model = node.attrs.get("llm_model")
-        model = await _resolve_concrete_model(provider, model)
+        model = await _resolve_concrete_model(provider, model, emit=self._emit)
         reasoning_effort = node.attrs.get("reasoning_effort")
         max_agent_turns_raw = node.attrs.get("max_agent_turns")
         max_agent_turns = (
@@ -575,7 +580,9 @@ class AmplifierBackend:
 
         client = self._get_or_create_unified_client()
         provider_name = node.llm_provider or node.attrs.get("llm_provider", "anthropic")
-        model = await _resolve_concrete_model(provider_name, _resolve_model(node))
+        model = await _resolve_concrete_model(
+            provider_name, _resolve_model(node), emit=self._emit
+        )
         tools = _build_unified_tools(self._tools)
 
         # EXT-23: Build response_format when response_schema is set
@@ -919,10 +926,16 @@ def _is_model_pattern(model: str) -> bool:
 
 
 @overload
-async def _resolve_concrete_model(provider: str, model: str) -> str: ...
+async def _resolve_concrete_model(
+    provider: str, model: str, *, emit: Any = None
+) -> str: ...
 @overload
-async def _resolve_concrete_model(provider: str, model: str | None) -> str | None: ...
-async def _resolve_concrete_model(provider: str, model: str | None) -> str | None:
+async def _resolve_concrete_model(
+    provider: str, model: str | None, *, emit: Any = None
+) -> str | None: ...
+async def _resolve_concrete_model(
+    provider: str, model: str | None, *, emit: Any = None
+) -> str | None:
     """Resolve a node's ``llm_model`` token to a concrete served model id.
 
     - ``None``/empty  -> returned unchanged (spawn path tolerates a missing
@@ -957,6 +970,19 @@ async def _resolve_concrete_model(provider: str, model: str | None) -> str | Non
         provider,
         pattern,
     )
+    # Emit the resolution as a pipeline event so the run's event stream records
+    # exactly which concrete model a pattern/family token resolved to (audit /
+    # eval reproducibility). Fires once per distinct resolution (cache miss).
+    if emit is not None:
+        await emit(
+            MODEL_RESOLVED,
+            {
+                "raw": model,
+                "resolved": concrete,
+                "provider": provider,
+                "pattern": pattern,
+            },
+        )
     return concrete
 
 

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/pipeline_events.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/pipeline_events.py
@@ -89,6 +89,10 @@ PIPELINE_STAGE_FAILED: str = "pipeline:stage_failed"
 PROVIDER_REQUEST: str = "provider:request"
 PROVIDER_RESPONSE: str = "provider:response"
 PROVIDER_ERROR: str = "provider:error"
+# Emitted when a node's llm_model family-token/glob is resolved to a concrete
+# served model id. Records {raw, resolved, provider, pattern} for audit /
+# eval reproducibility. Fires once per distinct resolution per run.
+MODEL_RESOLVED: str = "model:resolved"
 
 # ---------------------------------------------------------------------------
 # Subgraph execution (nested pipeline nodes)

--- a/modules/loop-pipeline/tests/test_model_token_resolution.py
+++ b/modules/loop-pipeline/tests/test_model_token_resolution.py
@@ -102,3 +102,69 @@ def test_is_model_pattern_classification():
     assert not backend._is_model_pattern("claude-sonnet-4-5")
     assert not backend._is_model_pattern("claude-haiku-4-5-20251001")
     assert not backend._is_model_pattern("gpt-5.4")
+
+
+@pytest.mark.asyncio
+async def test_emit_fires_once_on_resolution(monkeypatch):
+    """A resolution emits a model:resolved event with the raw + concrete id."""
+    from amplifier_module_loop_pipeline.pipeline_events import MODEL_RESOLVED
+
+    async def _stub(provider, pattern, *, stable_only):
+        return "claude-sonnet-4-6"
+
+    monkeypatch.setattr("unified_llm.resolve_latest_for", _stub)
+
+    events = []
+
+    async def _emit(event_name, data):
+        events.append((event_name, data))
+
+    out = await backend._resolve_concrete_model(
+        "anthropic", "claude-sonnet-4-*", emit=_emit
+    )
+    assert out == "claude-sonnet-4-6"
+    assert len(events) == 1
+    name, data = events[0]
+    assert name == MODEL_RESOLVED
+    assert data == {
+        "raw": "claude-sonnet-4-*",
+        "resolved": "claude-sonnet-4-6",
+        "provider": "anthropic",
+        "pattern": "claude-sonnet-4-*",
+    }
+
+
+@pytest.mark.asyncio
+async def test_emit_not_called_for_concrete_id(monkeypatch):
+    async def _boom(*a, **k):
+        raise AssertionError("resolver must NOT be called for a concrete id")
+
+    monkeypatch.setattr("unified_llm.resolve_latest_for", _boom)
+
+    called = []
+
+    async def _emit(event_name, data):
+        called.append(event_name)
+
+    out = await backend._resolve_concrete_model(
+        "anthropic", "claude-sonnet-4-5", emit=_emit
+    )
+    assert out == "claude-sonnet-4-5"
+    assert called == []  # no resolution -> no event
+
+
+@pytest.mark.asyncio
+async def test_emit_not_called_on_cache_hit(monkeypatch):
+    async def _stub(provider, pattern, *, stable_only):
+        return "claude-sonnet-4-6"
+
+    monkeypatch.setattr("unified_llm.resolve_latest_for", _stub)
+
+    events = []
+
+    async def _emit(event_name, data):
+        events.append(event_name)
+
+    await backend._resolve_concrete_model("anthropic", "sonnet", emit=_emit)
+    await backend._resolve_concrete_model("anthropic", "sonnet", emit=_emit)
+    assert len(events) == 1  # second call served from cache, no re-emit


### PR DESCRIPTION
## Summary

Follow-up to #78 (model-resolution feature merge). Loop-pipeline now resolves family-token/glob `llm_model` values to concrete served IDs, but this resolution was only logged — not auditable. This PR makes the resolution a first-class, durably-recorded event for audit and eval reproducibility.

## Changes

- **Producer**: loop-pipeline now EMITS a `model:resolved` pipeline event (`{raw, resolved, provider, pattern}`) once per distinct resolution (cache miss), via the same hook bus as every other pipeline event.
- **Consumer**: hooks-pipeline-observability adds `model:resolved` to its `_PIPELINE_EVENTS` (the list discoverable by all recorders/Context Intelligence) AND aggregates into `PipelineRunState.resolved_models`. The single `_PIPELINE_EVENTS` entry closes both the live-state gap and the durable-recorder discovery gap.

## Proof

**Unit Tests**: loop-pipeline 10/10, observability 3/3.

**End-to-End Durable Recording** (verified in live DTU against real Anthropic gateway):
- Composed: attractor-pipeline + hooks-pipeline-observability + foundation logging recorder
- Ran: glob pipeline (`llm_model="claude-sonnet-4-*"`)
- Result: green run with recorded event persisted to disk in `events.jsonl`:
```json
{"event":"model:resolved","session_id":"9013d119-...","data":{"raw":"claude-sonnet-4-*","resolved":"claude-sonnet-4-6","provider":"anthropic","pattern":"claude-sonnet-4-*"}}
```

## Composition Note

`attractor:bundles/attractor-pipeline` alone does NOT record events — durable recording requires composing a recorder hook (e.g., foundation `logging` behavior or Context Intelligence) alongside `hooks-pipeline-observability`. This change makes `model:resolved` discoverable and recordable; whether it persists depends on a recorder being composed. The Amplifier Resolve worker already captures it via the resolver's event bridge.

## Files Changed

- `modules/loop-pipeline/amplifier_module_loop_pipeline/pipeline_events.py` — new MODEL_RESOLVED constant
- `modules/loop-pipeline/amplifier_module_loop_pipeline/backend.py` — emit callback param + emit block + import + 2 call-sites
- `modules/loop-pipeline/amplifier_module_loop_pipeline/__init__.py` — 1 call-site passes emit
- `modules/loop-pipeline/tests/test_model_token_resolution.py` — +3 emit unit tests
- `modules/hooks-pipeline-observability/amplifier_module_hooks_pipeline_observability/__init__.py` — model:resolved added to _PIPELINE_EVENTS + handler map
- `modules/hooks-pipeline-observability/amplifier_module_hooks_pipeline_observability/aggregator.py` — handle_model_resolved
- `modules/hooks-pipeline-observability/amplifier_module_hooks_pipeline_observability/models.py` — PipelineRunState.resolved_models
- `modules/hooks-pipeline-observability/tests/test_model_resolved_event.py` — new integration test