### PR TITLE
docs(examples): demonstrate self-healing model globs and fix pipeline-run invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,21 @@ includes:
 
 Pick your provider: `attractor-profile-anthropic`, `attractor-profile-openai`, or `attractor-profile-gemini`.
 
-**2. Run a pipeline from the CLI:**
+**2. Point the pipeline orchestrator at a `.dot` file:**
 
-```bash
-amplifier run --agent attractor-profile-anthropic \
-    --goal "Add input validation to the login endpoint" \
-    --dot-file examples/pipelines/02-plan-implement-test.dot
+```yaml
+# .amplifier/config.yaml (or any bundle file)
+includes:
+  - bundle: attractor:bundles/attractor-pipeline
+session:
+  orchestrator:
+    config:
+      dot_file: examples/pipelines/02-plan-implement-test.dot   # or dot_source: "digraph { ... }"
 ```
+
+Then run the configured bundle -- there are no pipeline-specific CLI flags. The
+goal is carried by the DOT graph attribute `graph [goal="Add input validation to
+the login endpoint"]` (or via `params`), not a `--goal` flag.
 
 **3. Or just ask conversationally:**
 
@@ -64,24 +72,42 @@ The agent can generate pipelines on-the-fly or use any of the included examples.
 ## What Can It Do?
 
 **Fix a bug systematically** -- reproduce, diagnose, fix, regression test, verify:
-```bash
-amplifier run --dot-file examples/pipelines/practical/bug-fix.dot \
-    --goal "Fix the NullPointerError in UserService.getProfile()"
+```yaml
+# .amplifier/config.yaml (or any bundle file)
+includes:
+  - bundle: attractor:bundles/attractor-pipeline
+session:
+  orchestrator:
+    config:
+      dot_file: examples/pipelines/practical/bug-fix.dot
 ```
+The goal lives in the DOT itself: `graph [goal="Fix the NullPointerError in UserService.getProfile()"]` (or supply `params` for `$param` substitution).
 
 **Review a PR in parallel** -- analyze diff, then simultaneously check bugs, security,
 performance, and style -- then synthesize review comments:
-```bash
-amplifier run --dot-file examples/pipelines/practical/pr-review.dot \
-    --goal "Review PR #142"
+```yaml
+# .amplifier/config.yaml (or any bundle file)
+includes:
+  - bundle: attractor:bundles/attractor-pipeline
+session:
+  orchestrator:
+    config:
+      dot_file: examples/pipelines/practical/pr-review.dot
 ```
+The goal lives in the DOT itself: `graph [goal="Review PR #142"]` (or supply `params` for `$param` substitution).
 
 **Build a feature safely** -- parse spec, parallel implement (core, API, tests),
 integration test, human review gate:
-```bash
-amplifier run --dot-file examples/pipelines/practical/feature-build.dot \
-    --goal "Add user avatar upload with S3 storage"
+```yaml
+# .amplifier/config.yaml (or any bundle file)
+includes:
+  - bundle: attractor:bundles/attractor-pipeline
+session:
+  orchestrator:
+    config:
+      dot_file: examples/pipelines/practical/feature-build.dot
 ```
+The goal lives in the DOT itself: `graph [goal="Add user avatar upload with S3 storage"]` (or supply `params` for `$param` substitution).
 
 ## Pipeline Gallery
 

--- a/docs/DOT-AUTHORING-GUIDE.md
+++ b/docs/DOT-AUTHORING-GUIDE.md
@@ -263,6 +263,32 @@ digraph {
 Explicit node attributes (`llm_model="..."` on the node) always override
 stylesheet values.
 
+### Model selection: family tokens and globs
+
+A node's `llm_model` -- whether set directly on the node or via
+`model_stylesheet` -- may take three forms:
+
+- a **concrete id**, e.g. `claude-sonnet-4-6`
+- a **family token**, e.g. `sonnet`, `haiku`, `opus`
+- an fnmatch **glob**, e.g. `claude-sonnet-4-*`
+
+Family tokens and globs are resolved at run time to the **newest stable served
+model** in that line, using the provider's live model list. They self-heal as
+providers ship new models and never rot. Resolution fails **loud** -- the node
+fails -- if nothing matches; there is no silent fallback to a default. Concrete
+ids pass through unchanged.
+
+**Caveat -- reproducibility.** Because resolution always picks the latest match,
+the chosen model drifts as providers release new ones. For a locked,
+reproducible evaluation, pin a concrete id (or capture the resolved id -- the
+engine emits a `model:resolved` event recording it). Prefer an explicit-major
+glob like `claude-sonnet-4-*` over a bare family token such as `sonnet`, so the
+major version stays fixed while only the point release floats.
+
+**Scope.** This resolution applies to a node's `llm_model` only. A provider's
+`default_model` (in the providers config) is passed to the SDK verbatim and is
+**not** resolved -- keep `default_model` a concrete served id.
+
 ### Human Approval Gate
 
 Use `shape=hexagon` for human-in-the-loop gates. Choices are derived from

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -24,47 +24,75 @@ Available profiles: `attractor-profile-anthropic`, `attractor-profile-openai`, `
 
 ## Run Your First Pipeline
 
-The simplest pipeline is a linear start-implement-done:
+The simplest pipeline is a linear start-implement-done. Point the pipeline
+orchestrator at a `.dot` file via bundle config:
 
-```bash
-amplifier run -B attractor:bundles/attractor-pipeline \
-    --goal "Create a Python script that prints hello world" \
-    --dot-file examples/pipelines/01-simple-linear.dot
+```yaml
+# .amplifier/config.yaml (or any bundle file)
+includes:
+  - bundle: attractor:bundles/attractor-pipeline
+session:
+  orchestrator:
+    config:
+      dot_file: examples/pipelines/01-simple-linear.dot   # or dot_source: "digraph { ... }"
 ```
 
-This parses the DOT graph, spawns an LLM agent for the `implement` node, and
-runs it to completion.
+Then run the configured bundle -- there are no pipeline-specific CLI flags. The
+goal is carried by the DOT graph attribute
+`graph [goal="Create a Python script that prints hello world"]` (or via
+`params`), not a `--goal` flag. Running parses the DOT graph, spawns an LLM agent
+for the `implement` node, and runs it to completion.
 
 ### Try a Multi-Stage Pipeline
 
-The plan-implement-test pipeline adds structure:
+The plan-implement-test pipeline adds structure -- point the orchestrator at its
+`.dot` file:
 
-```bash
-amplifier run -B attractor:bundles/attractor-pipeline \
-    --goal "Build a Python add(a,b) function with pytest tests" \
-    --dot-file examples/pipelines/02-plan-implement-test.dot
+```yaml
+# .amplifier/config.yaml (or any bundle file)
+includes:
+  - bundle: attractor:bundles/attractor-pipeline
+session:
+  orchestrator:
+    config:
+      dot_file: examples/pipelines/02-plan-implement-test.dot
 ```
+
+Set the goal in the DOT graph attribute
+`graph [goal="Build a Python add(a,b) function with pytest tests"]` (or via
+`params`).
 
 ### Try a Practical Pipeline
 
 Fix a bug systematically (reproduce, diagnose, fix, regression test, verify):
 
-```bash
-amplifier run -B attractor:bundles/attractor-pipeline \
-    --goal "Fix the NullPointerError in UserService.getProfile()" \
-    --dot-file examples/pipelines/practical/bug-fix.dot
+```yaml
+# .amplifier/config.yaml (or any bundle file)
+includes:
+  - bundle: attractor:bundles/attractor-pipeline
+session:
+  orchestrator:
+    config:
+      dot_file: examples/pipelines/practical/bug-fix.dot
 ```
+
+Set the goal in the DOT graph attribute
+`graph [goal="Fix the NullPointerError in UserService.getProfile()"]` (or via
+`params`).
 
 ## Run Interactively
 
 The interactive bundle gives you a conversational agent that can also invoke
-pipelines on demand via the `run_pipeline` tool:
+pipelines on demand via the `run_pipeline` tool. Compose it into your config:
 
-```bash
-amplifier run -B attractor:bundles/attractor-interactive
+```yaml
+# .amplifier/config.yaml (or any bundle file)
+includes:
+  - bundle: attractor:bundles/attractor-interactive
 ```
 
-Then talk to it:
+Then run the bundle and talk to it -- the agent drives pipelines for you via the
+`run_pipeline` tool:
 
 > "Run the plan-implement-test pipeline to add input validation to the login endpoint"
 
@@ -87,11 +115,18 @@ and a system prompt:
 For multi-provider pipelines (different models per node), use the pipeline
 bundle which wires all three:
 
-```bash
-amplifier run -B attractor:bundles/attractor-pipeline \
-    --dot-file examples/pipelines/06-model-stylesheet.dot \
-    --goal "Refactor the auth module"
+```yaml
+# .amplifier/config.yaml (or any bundle file)
+includes:
+  - bundle: attractor:bundles/attractor-pipeline
+session:
+  orchestrator:
+    config:
+      dot_file: examples/pipelines/06-model-stylesheet.dot
 ```
+
+Set the goal in the DOT graph attribute `graph [goal="Refactor the auth
+module"]` (or via `params`).
 
 See [DOT-AUTHORING-GUIDE.md](DOT-AUTHORING-GUIDE.md) for how model stylesheets
 route nodes to providers.

--- a/examples/pipelines/06-model-stylesheet.dot
+++ b/examples/pipelines/06-model-stylesheet.dot
@@ -5,6 +5,11 @@
 // bare shape name.
 // Tests: stylesheet parsing, selector specificity, property application,
 //        explicit node attribute override, class attribute on nodes.
+//
+// Model selection note: the anthropic selectors below use GLOB model ids
+// (e.g. claude-sonnet-4-*) which the engine resolves to the newest stable
+// served model at run time -- so these pins self-heal and never rot. For a
+// locked/reproducible evaluation, pin a concrete id instead.
 
 digraph ModelStylesheet {
     graph [
@@ -12,7 +17,7 @@ digraph ModelStylesheet {
         label="Model Stylesheet Pipeline",
         model_stylesheet="
             * {
-                llm_model: claude-sonnet-4-6;
+                llm_model: claude-sonnet-4-*;
                 llm_provider: anthropic;
                 reasoning_effort: medium;
             }
@@ -22,7 +27,7 @@ digraph ModelStylesheet {
                 reasoning_effort: high;
             }
             .code {
-                llm_model: claude-sonnet-4-6;
+                llm_model: claude-sonnet-4-*;
                 llm_provider: anthropic;
             }
             .fast {
@@ -31,7 +36,7 @@ digraph ModelStylesheet {
                 reasoning_effort: low;
             }
             #critical_review {
-                llm_model: claude-opus-4-20250514;
+                llm_model: claude-opus-4-*;
                 llm_provider: anthropic;
                 reasoning_effort: high;
             }

--- a/examples/pipelines/06-model-stylesheet.md
+++ b/examples/pipelines/06-model-stylesheet.md
@@ -23,9 +23,15 @@ start -> analyze -> refactor -> lint_check -> critical_review -> quick_fix -> do
 | Node | Class | Matching Rules | Winner (by specificity) | Final Model |
 |------|-------|----------------|------------------------|-------------|
 | `analyze` | `planning` | `*`(0), `.planning`(2) | `.planning` | `o3` (openai) |
-| `refactor` | `code` | `*`(0), `.code`(2) | `.code` | `claude-sonnet-4-6` (anthropic) |
+| `refactor` | `code` | `*`(0), `.code`(2) | `.code` | `claude-sonnet-4-*` (anthropic — resolves to latest) |
 | `lint_check` | `fast` | `*`(0), `.fast`(2) | `.fast` | `gemini-2.5-flash-preview-05-20` (gemini, low) |
-| `critical_review` | `code` | `*`(0), `.code`(2), `#critical_review`(3) | `#critical_review` | `claude-opus-4-20250514` (anthropic, high) |
+| `critical_review` | `code` | `*`(0), `.code`(2), `#critical_review`(3) | `#critical_review` | `claude-opus-4-*` (anthropic, high — resolves to latest) |
+
+> **Glob model ids.** The anthropic selectors use glob ids (`claude-sonnet-4-*`,
+> `claude-opus-4-*`). These are copied into `node.attrs["llm_model"]` verbatim by
+> the stylesheet, then resolved by the engine at run time to the newest stable
+> served model in that line — so they self-heal and never rot. Pin a concrete id
+> when you need a locked/reproducible evaluation.
 | `quick_fix` | `code` | `*`(0), `.code`(2) | `.code` BUT node has explicit `llm_model` | `gemini-2.5-flash-preview-05-20` (explicit override) |
 
 ## Expected Behavior
@@ -52,7 +58,7 @@ steps:
 
 - After stylesheet application, inspect node attrs:
   - `analyze.attrs["llm_model"]` == `"o3"`
-  - `critical_review.attrs["llm_model"]` == `"claude-opus-4-20250514"` (ID selector wins over .code class)
+  - `critical_review.attrs["llm_model"]` == `"claude-opus-4-*"` (ID selector wins over .code class; resolved to a concrete opus id at run time)
   - `quick_fix.attrs["llm_model"]` == `"gemini-2.5-flash-preview-05-20"` (explicit attribute wins)
 - Validation passes (stylesheet syntax is valid)
 - Each node's prompt.md is written with the correct model context

--- a/profiles/attractor-e2e-anthropic.yaml
+++ b/profiles/attractor-e2e-anthropic.yaml
@@ -7,6 +7,11 @@ providers:
   - module: provider-anthropic
     source: git+https://github.com/microsoft/amplifier-module-provider-anthropic@main
     config:
+      # Pinned to a concrete id on purpose: this is an E2E test profile and must
+      # be reproducible. A provider `default_model` is passed to the SDK verbatim
+      # (it is NOT routed through the engine's glob/family resolver), so it must
+      # always be a concrete served id. Self-healing globs (e.g. claude-sonnet-4-*)
+      # work on a node's `llm_model`; reproducible evals pin a concrete id.
       default_model: claude-sonnet-4-6
 
 session:


### PR DESCRIPTION
## Summary

Two related documentation and example improvements, no engine code changes:

1. **Self-healing model globs (showcasing merged glob/family resolver):** The `06-model-stylesheet` example now uses glob model ids (`claude-sonnet-4-*`, `claude-opus-4-*`) on anthropic selectors so those pins self-heal to the newest stable served model and never rot. A new **Model selection: family tokens and globs** subsection in DOT-AUTHORING-GUIDE documents that a node's `llm_model` (direct or via model_stylesheet) may be:
   - A concrete id (e.g. `claude-sonnet-4-6`)
   - A family token (e.g. `sonnet`)
   - A glob (e.g. `claude-sonnet-4-*`)
   
   All resolve at run time; fail-loud on no match. **Reproducibility caveat for locked evaluations:** pin a concrete id; the engine also emits a `model:resolved` event recording what it resolved to.

   **Scope note:** This applies to a node's `llm_model` only — a provider `default_model` is passed to the SDK verbatim and is NOT resolved, so stays concrete (commented on the e2e profile for clarity).

2. **Documentation-drift fix:** README.md and docs/GETTING-STARTED.md showed a pipeline-run invocation using flags that don't exist (`--dot-file X`, `--goal Y`, `-B <path>`). Corrected to the repository's real, code-backed mechanism: configure `session.orchestrator.config.dot_file` (or `dot_source`) and run the bundle; the goal travels via the DOT graph attribute `graph [goal="..."]` or `params`, not a `--goal` flag (canonical ref: bundle.md). Historical docs/plans/* left untouched.

## Proof (Live DTU + Real Anthropic Gateway)

A minimal anthropic pipeline whose model comes from a `model_stylesheet` GLOB ran green with durable resolution recorded:

- `model:resolved` event: `{"raw":"claude-opus-4-*","resolved":"claude-opus-4-8","provider":"anthropic"}`
- `claude-sonnet-4-*` re-confirmed resolves to `claude-sonnet-4-6`

Both globs resolved to stable served ids at run time; no brittleness.

## Files Changed

- `examples/pipelines/06-model-stylesheet.dot` — model ids -> globs + header note
- `examples/pipelines/06-model-stylesheet.md` — resolved-model table + assertions updated to globs + glob note
- `docs/DOT-AUTHORING-GUIDE.md` — new Model selection subsection
- `profiles/attractor-e2e-anthropic.yaml` — comment: default_model kept concrete on purpose / reproducibility
- `README.md` — corrected pipeline-run invocation
- `docs/GETTING-STARTED.md` — corrected pipeline-run invocation