### PR TITLE
feat(loop-agent): profile-owned Layer-1 system prompt — provider default + fail-loud

### DIFF
--- a/agents/attractor-agent-anthropic-isolated.yaml
+++ b/agents/attractor-agent-anthropic-isolated.yaml
@@ -29,10 +29,6 @@ session:
     config:
       max_tool_rounds_per_input: 50
       default_command_timeout_ms: 120000
-      # Layer-1 base prompt (nlspec §6.1: "Provider-specific base instructions from ProviderProfile").
-      # Path is relative to the bundle root; loop-agent resolves it at session init.
-      # See docs/designs/layer-1-profile-owned-system-prompt.md.
-      system_prompt_file: context/system-anthropic.md
   context:
     module: context-simple
     source: git+https://github.com/microsoft/amplifier-module-context-simple@main

--- a/agents/attractor-agent-anthropic-isolated.yaml
+++ b/agents/attractor-agent-anthropic-isolated.yaml
@@ -29,11 +29,15 @@ session:
     config:
       max_tool_rounds_per_input: 50
       default_command_timeout_ms: 120000
+      # Layer-1 base prompt (nlspec §6.1: "Provider-specific base instructions from ProviderProfile").
+      # Path is relative to the bundle root; loop-agent resolves it at session init.
+      # See docs/designs/layer-1-profile-owned-system-prompt.md.
+      system_prompt_file: context/system-anthropic.md
   context:
     module: context-simple
     source: git+https://github.com/microsoft/amplifier-module-context-simple@main
 
 context:
+  # Layer-4 additive context only (not base prompt — that is now in orchestrator config above).
   include:
-    - ../context/system-anthropic.md
     - ../context/isolated-environment-guidance.md

--- a/agents/attractor-agent-anthropic.yaml
+++ b/agents/attractor-agent-anthropic.yaml
@@ -28,10 +28,6 @@ session:
     config:
       max_tool_rounds_per_input: 50
       default_command_timeout_ms: 120000
-      # Layer-1 base prompt (nlspec §6.1: "Provider-specific base instructions from ProviderProfile").
-      # Path is relative to the bundle root; loop-agent resolves it at session init.
-      # See docs/designs/layer-1-profile-owned-system-prompt.md.
-      system_prompt_file: context/system-anthropic.md
   context:
     module: context-simple
     source: git+https://github.com/microsoft/amplifier-module-context-simple@main

--- a/agents/attractor-agent-anthropic.yaml
+++ b/agents/attractor-agent-anthropic.yaml
@@ -28,6 +28,10 @@ session:
     config:
       max_tool_rounds_per_input: 50
       default_command_timeout_ms: 120000
+      # Layer-1 base prompt (nlspec §6.1: "Provider-specific base instructions from ProviderProfile").
+      # Path is relative to the bundle root; loop-agent resolves it at session init.
+      # See docs/designs/layer-1-profile-owned-system-prompt.md.
+      system_prompt_file: context/system-anthropic.md
   context:
     module: context-simple
     source: git+https://github.com/microsoft/amplifier-module-context-simple@main
@@ -41,11 +45,3 @@ tools:
       timeout: 120
   - module: tool-search
     source: git+https://github.com/microsoft/amplifier-module-tool-search@main
-
-context:
-  # Layer-1 base prompt (nlspec §6.1: "Provider-specific base instructions from ProviderProfile").
-  # foundation registers a system-prompt factory on the context module when this include is set;
-  # loop-agent's AgentOrchestrator.execute() resolves the factory before creating the session
-  # so the file content becomes session_config.system_prompt (Layer 1).
-  include:
-    - ../context/system-anthropic.md

--- a/agents/attractor-agent-gemini-isolated.yaml
+++ b/agents/attractor-agent-gemini-isolated.yaml
@@ -31,6 +31,10 @@ session:
     config:
       max_tool_rounds_per_input: 50
       default_command_timeout_ms: 120000
+      # Layer-1 base prompt (nlspec §6.1: "Provider-specific base instructions from ProviderProfile").
+      # Path is relative to the bundle root; loop-agent resolves it at session init.
+      # See docs/designs/layer-1-profile-owned-system-prompt.md.
+      system_prompt_file: context/system-gemini.md
   context:
     module: context-simple
     source: git+https://github.com/microsoft/amplifier-module-context-simple@main
@@ -40,6 +44,6 @@ tools:
     source: git+https://github.com/microsoft/amplifier-module-tool-web@main
 
 context:
+  # Layer-4 additive context only (not base prompt — that is now in orchestrator config above).
   include:
-    - ../context/system-gemini.md
     - ../context/isolated-environment-guidance.md

--- a/agents/attractor-agent-gemini-isolated.yaml
+++ b/agents/attractor-agent-gemini-isolated.yaml
@@ -31,10 +31,6 @@ session:
     config:
       max_tool_rounds_per_input: 50
       default_command_timeout_ms: 120000
-      # Layer-1 base prompt (nlspec §6.1: "Provider-specific base instructions from ProviderProfile").
-      # Path is relative to the bundle root; loop-agent resolves it at session init.
-      # See docs/designs/layer-1-profile-owned-system-prompt.md.
-      system_prompt_file: context/system-gemini.md
   context:
     module: context-simple
     source: git+https://github.com/microsoft/amplifier-module-context-simple@main

--- a/agents/attractor-agent-gemini.yaml
+++ b/agents/attractor-agent-gemini.yaml
@@ -28,10 +28,6 @@ session:
     config:
       max_tool_rounds_per_input: 50
       default_command_timeout_ms: 10000
-      # Layer-1 base prompt (nlspec §6.1: "Provider-specific base instructions from ProviderProfile").
-      # Path is relative to the bundle root; loop-agent resolves it at session init.
-      # See docs/designs/layer-1-profile-owned-system-prompt.md.
-      system_prompt_file: context/system-gemini.md
   context:
     module: context-simple
     source: git+https://github.com/microsoft/amplifier-module-context-simple@main

--- a/agents/attractor-agent-gemini.yaml
+++ b/agents/attractor-agent-gemini.yaml
@@ -28,6 +28,10 @@ session:
     config:
       max_tool_rounds_per_input: 50
       default_command_timeout_ms: 10000
+      # Layer-1 base prompt (nlspec §6.1: "Provider-specific base instructions from ProviderProfile").
+      # Path is relative to the bundle root; loop-agent resolves it at session init.
+      # See docs/designs/layer-1-profile-owned-system-prompt.md.
+      system_prompt_file: context/system-gemini.md
   context:
     module: context-simple
     source: git+https://github.com/microsoft/amplifier-module-context-simple@main
@@ -43,11 +47,3 @@ tools:
     source: git+https://github.com/microsoft/amplifier-module-tool-search@main
   - module: tool-web
     source: git+https://github.com/microsoft/amplifier-module-tool-web@main
-
-context:
-  # Layer-1 base prompt (nlspec §6.1: "Provider-specific base instructions from ProviderProfile").
-  # foundation registers a system-prompt factory on the context module when this include is set;
-  # loop-agent's AgentOrchestrator.execute() resolves the factory before creating the session
-  # so the file content becomes session_config.system_prompt (Layer 1).
-  include:
-    - ../context/system-gemini.md

--- a/agents/attractor-agent-openai-isolated.yaml
+++ b/agents/attractor-agent-openai-isolated.yaml
@@ -29,11 +29,15 @@ session:
     config:
       max_tool_rounds_per_input: 50
       default_command_timeout_ms: 120000
+      # Layer-1 base prompt (nlspec §6.1: "Provider-specific base instructions from ProviderProfile").
+      # Path is relative to the bundle root; loop-agent resolves it at session init.
+      # See docs/designs/layer-1-profile-owned-system-prompt.md.
+      system_prompt_file: context/system-openai.md
   context:
     module: context-simple
     source: git+https://github.com/microsoft/amplifier-module-context-simple@main
 
 context:
+  # Layer-4 additive context only (not base prompt — that is now in orchestrator config above).
   include:
-    - ../context/system-openai.md
     - ../context/isolated-environment-guidance.md

--- a/agents/attractor-agent-openai-isolated.yaml
+++ b/agents/attractor-agent-openai-isolated.yaml
@@ -29,10 +29,6 @@ session:
     config:
       max_tool_rounds_per_input: 50
       default_command_timeout_ms: 120000
-      # Layer-1 base prompt (nlspec §6.1: "Provider-specific base instructions from ProviderProfile").
-      # Path is relative to the bundle root; loop-agent resolves it at session init.
-      # See docs/designs/layer-1-profile-owned-system-prompt.md.
-      system_prompt_file: context/system-openai.md
   context:
     module: context-simple
     source: git+https://github.com/microsoft/amplifier-module-context-simple@main

--- a/agents/attractor-agent-openai.yaml
+++ b/agents/attractor-agent-openai.yaml
@@ -28,10 +28,6 @@ session:
     config:
       max_tool_rounds_per_input: 50
       default_command_timeout_ms: 10000
-      # Layer-1 base prompt (nlspec §6.1: "Provider-specific base instructions from ProviderProfile").
-      # Path is relative to the bundle root; loop-agent resolves it at session init.
-      # See docs/designs/layer-1-profile-owned-system-prompt.md.
-      system_prompt_file: context/system-openai.md
   context:
     module: context-simple
     source: git+https://github.com/microsoft/amplifier-module-context-simple@main

--- a/agents/attractor-agent-openai.yaml
+++ b/agents/attractor-agent-openai.yaml
@@ -28,6 +28,10 @@ session:
     config:
       max_tool_rounds_per_input: 50
       default_command_timeout_ms: 10000
+      # Layer-1 base prompt (nlspec §6.1: "Provider-specific base instructions from ProviderProfile").
+      # Path is relative to the bundle root; loop-agent resolves it at session init.
+      # See docs/designs/layer-1-profile-owned-system-prompt.md.
+      system_prompt_file: context/system-openai.md
   context:
     module: context-simple
     source: git+https://github.com/microsoft/amplifier-module-context-simple@main
@@ -49,11 +53,3 @@ tools:
       timeout: 10
   - module: tool-search
     source: git+https://github.com/microsoft/amplifier-module-tool-search@main
-
-context:
-  # Layer-1 base prompt (nlspec §6.1: "Provider-specific base instructions from ProviderProfile").
-  # foundation registers a system-prompt factory on the context module when this include is set;
-  # loop-agent's AgentOrchestrator.execute() resolves the factory before creating the session
-  # so the file content becomes session_config.system_prompt (Layer 1).
-  include:
-    - ../context/system-openai.md

--- a/agents/pipeline-runner.yaml
+++ b/agents/pipeline-runner.yaml
@@ -68,10 +68,6 @@ agents:
         config:
           max_tool_rounds_per_input: 50
           default_command_timeout_ms: 120000
-          # Layer-1 base prompt delivered via profile-owned file (nlspec §6.1).
-          # Resolved by loop-agent relative to bundle root at session init.
-          # See docs/designs/layer-1-profile-owned-system-prompt.md.
-          system_prompt_file: context/system-anthropic.md
   attractor-agent-openai:
     description: >
       OpenAI coding agent (codex-rs aligned).
@@ -83,8 +79,6 @@ agents:
         config:
           max_tool_rounds_per_input: 50
           default_command_timeout_ms: 10000
-          # Layer-1 base prompt delivered via profile-owned file (nlspec §6.1).
-          system_prompt_file: context/system-openai.md
   attractor-agent-gemini:
     description: >
       Gemini coding agent (gemini-cli aligned).
@@ -96,5 +90,3 @@ agents:
         config:
           max_tool_rounds_per_input: 50
           default_command_timeout_ms: 10000
-          # Layer-1 base prompt delivered via profile-owned file (nlspec §6.1).
-          system_prompt_file: context/system-gemini.md

--- a/agents/pipeline-runner.yaml
+++ b/agents/pipeline-runner.yaml
@@ -68,6 +68,10 @@ agents:
         config:
           max_tool_rounds_per_input: 50
           default_command_timeout_ms: 120000
+          # Layer-1 base prompt delivered via profile-owned file (nlspec §6.1).
+          # Resolved by loop-agent relative to bundle root at session init.
+          # See docs/designs/layer-1-profile-owned-system-prompt.md.
+          system_prompt_file: context/system-anthropic.md
   attractor-agent-openai:
     description: >
       OpenAI coding agent (codex-rs aligned).
@@ -79,6 +83,8 @@ agents:
         config:
           max_tool_rounds_per_input: 50
           default_command_timeout_ms: 10000
+          # Layer-1 base prompt delivered via profile-owned file (nlspec §6.1).
+          system_prompt_file: context/system-openai.md
   attractor-agent-gemini:
     description: >
       Gemini coding agent (gemini-cli aligned).
@@ -90,3 +96,5 @@ agents:
         config:
           max_tool_rounds_per_input: 50
           default_command_timeout_ms: 10000
+          # Layer-1 base prompt delivered via profile-owned file (nlspec §6.1).
+          system_prompt_file: context/system-gemini.md

--- a/behaviors/attractor-core.yaml
+++ b/behaviors/attractor-core.yaml
@@ -26,3 +26,10 @@ agents:
       orchestrator:
         module: loop-agent
         source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
+        config:
+          # Layer-1 base prompt. attractor-expert is provider-agnostic (a
+          # consultant, not a coding agent), so it gets its OWN persona base
+          # rather than a provider coding base. Required: loop-agent fail-louds
+          # on an empty Layer-1 if this agent is ever spawned as an LLM node.
+          # See docs/designs/layer-1-profile-owned-system-prompt.md.
+          system_prompt_file: context/system-attractor-expert.md

--- a/bundles/attractor-agent.yaml
+++ b/bundles/attractor-agent.yaml
@@ -28,11 +28,6 @@ session:
     source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
     config:
       default_command_timeout_ms: 120000
-      # Layer-1 base prompt (nlspec §6.1). In core 1.6.0 ONLY system_prompt /
-      # system_prompt_file populates Layer-1 — context.include does NOT — so the
-      # base MUST be delivered here. Resolved relative to bundle root by loop-agent.
-      # See docs/designs/layer-1-profile-owned-system-prompt.md.
-      system_prompt_file: context/system-anthropic.md
 
 # --- Tools (Anthropic/Claude Code aligned defaults) --------------------------
 tools:
@@ -45,7 +40,6 @@ tools:
   - module: tool-search
     source: git+https://github.com/microsoft/amplifier-module-tool-search@main
 
-# --- System prompt -----------------------------------------------------------
-# Layer-1 base is delivered via session.orchestrator.config.system_prompt_file
-# above (core 1.6.0: context.include does NOT populate Layer-1). No additive
-# context files needed here, so the context.include block is intentionally absent.
+# Layer-1 base prompt is supplied by loop-agent's provider default
+# (context/system-anthropic.md for this Anthropic bundle); no system_prompt_file
+# or context.include base is needed. See docs/designs/layer-1-profile-owned-system-prompt.md.

--- a/bundles/attractor-agent.yaml
+++ b/bundles/attractor-agent.yaml
@@ -28,6 +28,11 @@ session:
     source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
     config:
       default_command_timeout_ms: 120000
+      # Layer-1 base prompt (nlspec §6.1). In core 1.6.0 ONLY system_prompt /
+      # system_prompt_file populates Layer-1 — context.include does NOT — so the
+      # base MUST be delivered here. Resolved relative to bundle root by loop-agent.
+      # See docs/designs/layer-1-profile-owned-system-prompt.md.
+      system_prompt_file: context/system-anthropic.md
 
 # --- Tools (Anthropic/Claude Code aligned defaults) --------------------------
 tools:
@@ -41,7 +46,6 @@ tools:
     source: git+https://github.com/microsoft/amplifier-module-tool-search@main
 
 # --- System prompt -----------------------------------------------------------
-context:
-  # '../context/' climbs from this YAML's dir to the bundle-root context/; idiomatic target is 'attractor:context/...' pending foundation namespaced-include support.
-  include:
-    - ../context/system-anthropic.md
+# Layer-1 base is delivered via session.orchestrator.config.system_prompt_file
+# above (core 1.6.0: context.include does NOT populate Layer-1). No additive
+# context files needed here, so the context.include block is intentionally absent.

--- a/bundles/attractor-interactive.yaml
+++ b/bundles/attractor-interactive.yaml
@@ -34,11 +34,9 @@ session:
     config:
       max_tool_rounds_per_input: 50
       default_command_timeout_ms: 120000
-      # Layer-1 base prompt (nlspec §6.1). Core 1.6.0: ONLY system_prompt_file
-      # populates Layer-1 — context.include does NOT — so the base MUST be here.
-      # The additive context.include below (pipeline-awareness, dot-reference)
-      # remains as supplementary context, not as the base.
-      system_prompt_file: context/system-anthropic.md
+      # Layer-1 base comes from loop-agent's provider default
+      # (context/system-anthropic.md). The context.include below
+      # (pipeline-awareness, dot-reference) is ADDITIVE context, not the base.
   context:
     module: context-simple
     source: git+https://github.com/microsoft/amplifier-module-context-simple@main
@@ -62,10 +60,6 @@ tools:
         openai: attractor-agent-openai
         gemini: attractor-agent-gemini
 
-# Context: ADDITIVE supplementary context only. The Layer-1 base prompt is
-# delivered via session.orchestrator.config.system_prompt_file above
-# (core 1.6.0: context.include does NOT populate Layer-1). system-anthropic.md
-# is therefore NOT listed here — it is the base, owned by system_prompt_file.
 context:
   # '../context/' climbs from this YAML's dir to the bundle-root context/; idiomatic target is 'attractor:context/...' pending foundation namespaced-include support.
   include:
@@ -102,10 +96,6 @@ agents:
         config:
           max_tool_rounds_per_input: 50
           default_command_timeout_ms: 120000
-          # Layer-1 base prompt delivered via profile-owned file (nlspec §6.1).
-          # Required: loop-pipeline (spawned via run_pipeline) fail-louds on an
-          # empty Layer-1. See docs/designs/layer-1-profile-owned-system-prompt.md.
-          system_prompt_file: context/system-anthropic.md
   attractor-agent-openai:
     description: >
       OpenAI coding agent (codex-rs aligned).
@@ -117,8 +107,6 @@ agents:
         config:
           max_tool_rounds_per_input: 50
           default_command_timeout_ms: 10000
-          # Layer-1 base prompt delivered via profile-owned file (nlspec §6.1).
-          system_prompt_file: context/system-openai.md
   attractor-agent-gemini:
     description: >
       Gemini coding agent (gemini-cli aligned).
@@ -130,5 +118,3 @@ agents:
         config:
           max_tool_rounds_per_input: 50
           default_command_timeout_ms: 10000
-          # Layer-1 base prompt delivered via profile-owned file (nlspec §6.1).
-          system_prompt_file: context/system-gemini.md

--- a/bundles/attractor-interactive.yaml
+++ b/bundles/attractor-interactive.yaml
@@ -34,6 +34,11 @@ session:
     config:
       max_tool_rounds_per_input: 50
       default_command_timeout_ms: 120000
+      # Layer-1 base prompt (nlspec §6.1). Core 1.6.0: ONLY system_prompt_file
+      # populates Layer-1 — context.include does NOT — so the base MUST be here.
+      # The additive context.include below (pipeline-awareness, dot-reference)
+      # remains as supplementary context, not as the base.
+      system_prompt_file: context/system-anthropic.md
   context:
     module: context-simple
     source: git+https://github.com/microsoft/amplifier-module-context-simple@main
@@ -57,11 +62,13 @@ tools:
         openai: attractor-agent-openai
         gemini: attractor-agent-gemini
 
-# Context: standard system prompt + pipeline awareness
+# Context: ADDITIVE supplementary context only. The Layer-1 base prompt is
+# delivered via session.orchestrator.config.system_prompt_file above
+# (core 1.6.0: context.include does NOT populate Layer-1). system-anthropic.md
+# is therefore NOT listed here — it is the base, owned by system_prompt_file.
 context:
   # '../context/' climbs from this YAML's dir to the bundle-root context/; idiomatic target is 'attractor:context/...' pending foundation namespaced-include support.
   include:
-    - ../context/system-anthropic.md
     - ../context/pipeline-awareness.md
     - ../context/dot-reference.md
 

--- a/bundles/attractor-interactive.yaml
+++ b/bundles/attractor-interactive.yaml
@@ -95,6 +95,10 @@ agents:
         config:
           max_tool_rounds_per_input: 50
           default_command_timeout_ms: 120000
+          # Layer-1 base prompt delivered via profile-owned file (nlspec §6.1).
+          # Required: loop-pipeline (spawned via run_pipeline) fail-louds on an
+          # empty Layer-1. See docs/designs/layer-1-profile-owned-system-prompt.md.
+          system_prompt_file: context/system-anthropic.md
   attractor-agent-openai:
     description: >
       OpenAI coding agent (codex-rs aligned).
@@ -106,6 +110,8 @@ agents:
         config:
           max_tool_rounds_per_input: 50
           default_command_timeout_ms: 10000
+          # Layer-1 base prompt delivered via profile-owned file (nlspec §6.1).
+          system_prompt_file: context/system-openai.md
   attractor-agent-gemini:
     description: >
       Gemini coding agent (gemini-cli aligned).
@@ -117,3 +123,5 @@ agents:
         config:
           max_tool_rounds_per_input: 50
           default_command_timeout_ms: 10000
+          # Layer-1 base prompt delivered via profile-owned file (nlspec §6.1).
+          system_prompt_file: context/system-gemini.md

--- a/bundles/attractor-pipeline.yaml
+++ b/bundles/attractor-pipeline.yaml
@@ -57,8 +57,9 @@ tools:
 # the child inherits the parent's loop-pipeline orchestrator and recurses.
 agents:
   # Inline session.orchestrator is REQUIRED (passes the loop-pipeline recursion
-  # guard, which checks orchestrator.module). system_prompt_file delivers the
-  # provider base prompt as loop-agent Layer-1 (resolved relative to bundle root).
+  # guard, which checks orchestrator.module). The Layer-1 base prompt is supplied
+  # by loop-agent's provider default (context/system-<provider>.md), so no
+  # per-agent system_prompt_file is needed here.
   attractor-agent-anthropic:
     description: >
       Anthropic coding agent (Claude Code aligned).
@@ -70,7 +71,6 @@ agents:
         config:
           max_tool_rounds_per_input: 50
           default_command_timeout_ms: 120000
-          system_prompt_file: context/system-anthropic.md
   attractor-agent-openai:
     description: >
       OpenAI coding agent (codex-rs aligned).
@@ -82,7 +82,6 @@ agents:
         config:
           max_tool_rounds_per_input: 50
           default_command_timeout_ms: 10000
-          system_prompt_file: context/system-openai.md
   attractor-agent-gemini:
     description: >
       Gemini coding agent (gemini-cli aligned).
@@ -94,4 +93,3 @@ agents:
         config:
           max_tool_rounds_per_input: 50
           default_command_timeout_ms: 10000
-          system_prompt_file: context/system-gemini.md

--- a/bundles/attractor-pipeline.yaml
+++ b/bundles/attractor-pipeline.yaml
@@ -56,6 +56,9 @@ tools:
 # the agent's session: key onto the parent config; without an explicit session.orchestrator
 # the child inherits the parent's loop-pipeline orchestrator and recurses.
 agents:
+  # Inline session.orchestrator is REQUIRED (passes the loop-pipeline recursion
+  # guard, which checks orchestrator.module). system_prompt_file delivers the
+  # provider base prompt as loop-agent Layer-1 (resolved relative to bundle root).
   attractor-agent-anthropic:
     description: >
       Anthropic coding agent (Claude Code aligned).
@@ -67,6 +70,7 @@ agents:
         config:
           max_tool_rounds_per_input: 50
           default_command_timeout_ms: 120000
+          system_prompt_file: context/system-anthropic.md
   attractor-agent-openai:
     description: >
       OpenAI coding agent (codex-rs aligned).
@@ -78,6 +82,7 @@ agents:
         config:
           max_tool_rounds_per_input: 50
           default_command_timeout_ms: 10000
+          system_prompt_file: context/system-openai.md
   attractor-agent-gemini:
     description: >
       Gemini coding agent (gemini-cli aligned).
@@ -89,3 +94,4 @@ agents:
         config:
           max_tool_rounds_per_input: 50
           default_command_timeout_ms: 10000
+          system_prompt_file: context/system-gemini.md

--- a/context/system-attractor-expert.md
+++ b/context/system-attractor-expert.md
@@ -1,0 +1,50 @@
+# Attractor Expert — System Prompt
+
+You are the **Attractor Expert**: the authority on the *shipped* Attractor
+engine — DOT-graph-driven, multi-stage AI workflows built on Amplifier. You
+advise on pipeline **design**, **authoring**, **debugging**, and **programmatic
+integration**. You are a consultant, not a coding agent: you reason about and
+explain the engine, produce correct DOT graphs, and diagnose routing/behavior —
+you do not run a tool-driven edit/build loop unless explicitly asked.
+
+## Source of truth: the running engine, not the prose
+
+Reason from the engine's **runtime semantics** — routing, variable
+substitution, the verdict/outcome contract, and fail-loud behavior — because
+that is how the shipped engine actually behaves, including where it diverges
+from spec prose or raw DOT syntax. Reasoning from DOT syntax or the spec alone
+makes you confidently wrong about the running engine. When the bundle's
+reference docs are available to you as context, prefer them over memory.
+
+## What you know
+
+- **DOT semantics**: node shapes, handler types, attributes, edge conditions,
+  variable expansion, model stylesheets, fidelity modes.
+- **Pipeline patterns**: linear, conditional routing, retry/fallback, parallel
+  fan-out/fan-in, human gates, manager–supervisor, multi-provider.
+- **Programmatic integration**: DirectProviderBackend (no tools) vs
+  AmplifierBackend (full sessions), the prepare / create_session lifecycle, and
+  the spawn capability.
+- **Configuration**: bundle entry points, profile selection, orchestrator
+  config, and the per-node provider/profile routing.
+- **Debugging**: the edge-selection algorithm, condition evaluation, fidelity
+  resolution, and backend-selection logic.
+
+## How you help
+
+- **Designing**: recommend the right pattern, then provide a complete, valid DOT
+  graph; explain the attribute choices (fidelity, goal gates, retries); point to
+  the closest example pipeline.
+- **Debugging**: check DOT validity (start/exit nodes, conditions) → verify edge
+  selection (conditions, weights, labels) → check fidelity (is context carried?)
+  → check backend selection (is `session.spawn` registered?).
+- **Integrating**: recommend the direct vs session path for the use case, give a
+  working code sketch, and explain the lifecycle.
+
+## Stance
+
+Be precise and concrete. Prefer a correct, minimal, runnable graph over an
+abstract explanation. Call out foot-guns explicitly. When you are uncertain
+about a runtime detail, say so and name what you would check rather than
+guessing — being confidently wrong about the engine is the one failure that
+matters here.

--- a/docs/designs/layer-1-profile-owned-system-prompt.md
+++ b/docs/designs/layer-1-profile-owned-system-prompt.md
@@ -34,6 +34,18 @@ So the base prompt's correct home is the **provider profile**, delivered as loop
 **A. Base prompt = profile-owned → loop-agent Layer-1.**
 loop-agent loads a **profile-declared base-prompt** directly into `SessionConfig.system_prompt` (`config.py:39`). Insertion point: `__init__.py:113-137` (replace the factory-resolution block with a direct read of the profile's base-prompt path). Remove `context.include: ../context/system-<prov>.md` (the **base**) from the agent YAMLs + profiles. Consequence (confirmed): with no base `context.include`, foundation registers no base factory (`_prepared.py:656` guard), so `context._system_prompt_factory` is `None` and `config.system_prompt` flows straight through as Layer-1 — single owner, no precedence fight. `context.include` **remains** for genuine additive context (`@AGENTS.md` etc.), Layer 4 only.
 
+**A′. Mechanism (4-step precedence) — provider DEFAULT replaces the 30 hard-coded lines.**
+`AgentOrchestrator._resolve_base_prompt(config_dict, provider_name)` resolves Layer-1 once, before the session is created, with this precedence (first that applies wins):
+
+| Step | Source | Behaviour |
+|------|--------|-----------|
+| 1 | explicit `system_prompt` in orchestrator config | used as-is (e.g. injected by loop-pipeline before spawn) |
+| 2 | explicit `system_prompt_file` in config | loaded via the robust, CWD-independent resolver |
+| 3 | **provider DEFAULT** `context/system-<provider>.md` | loaded via the same resolver, where `<provider>` is the canonical provider derived from the agent's **own** mounted provider (`next(iter(providers.keys()))` → `canonical_provider()`) — the SAME value used for the actual completion, so the base always matches the model called |
+| 4 | unknown provider, or a configured/default file that does not exist | **fail-loud** clear error (never a silent wrong/empty base) |
+
+Step 3 is the common case and is why the per-YAML `system_prompt_file:` lines (30 across 18 YAMLs) were removed: a provider agent needs **no** base config at all — the provider supplies it. Explicit config (1, 2) still overrides the default, so a non-coding agent (`attractor-expert`) pins its own persona base via an explicit `system_prompt_file`. **Scope gate that made this safe:** loop-agent knows its intended provider at resolution time because the base default and the completion-provider selection read one source (`next(iter(providers.keys()))`); they cannot disagree, so a provider-default base is exactly as correct as the provider selection that already ships. Implementation: `__init__.py` `_resolve_base_prompt`; `agent_session.py` `canonical_provider()` / `KNOWN_PROVIDERS` (shared with project-doc / env-context filtering).
+
 **B. Runtime (per-invocation) override = Layer-5 `user_instructions` via the existing channel.**
 `orchestrator_config` is already an end-to-end per-invocation passthrough (loop-pipeline → spawn_fn → wiki-weaver `prepared.spawn` / app-cli `spawn_sub_session` → `session.orchestrator.config` → loop-agent `SessionConfig`). loop-agent already reads `user_instructions` (`config.py:40`) as Layer-5 (highest precedence, `system_prompt.py:93-95`). One small change: `loop-pipeline/backend.py` `_run_with_spawn` adds `user_instructions` (and/or `system_prompt_file`) to the per-spawn `orchestrator_config` dict (`:421-428`), sourced from `node.attrs` (per-graph) and/or `PipelineContext` (per-run, caller-supplied). **No app-cli / foundation / shared-contract change.**
 

--- a/docs/designs/layer-1-profile-owned-system-prompt.md
+++ b/docs/designs/layer-1-profile-owned-system-prompt.md
@@ -63,3 +63,24 @@ loop-agent loads a **profile-declared base-prompt** directly into `SessionConfig
 1. **Fail-loud** changes attractor's documented fail-soft behavior (`:668-670,1408`) → amend the spec, or scope fail-loud to LLM nodes only.
 2. **`ProviderProfile` object:** keep the declarative (YAML profile) representation, or introduce the actual object the spec describes and the gap analyses flag as missing? (This design works either way; the base-prompt asset just needs an owner.)
 3. **Prompt versioning** (contract #1) is net-new surface — neither spec blesses nor forbids it.
+
+## Verification record (this effort)
+
+Verified on latest attractor main (`b50843c`), core 1.6.0, graded on raw LLM requests + CI session-tree inspection in DTUs. Branches (committed locally, NOT pushed): attractor `feat/profile-owned-system-prompt` (`4ebefb4`); dot-graph `fix/loop-agent-base-prompt` (`4ac6f38`).
+
+| Check | Result |
+|---|---|
+| Rebase onto latest main; suites | clean; #78 model-resolution interaction harmless; 483 + 1378 green |
+| Cross-provider (anthropic/openai/gemini) | PASS — each node carried ITS verbatim base header, no cross-contamination |
+| wiki-weaver (trivial ingest) | PASS |
+| app-cli attractor-tool (root→tool→node) | PASS — *after* completion fix (`5fd9a33`): main sessions also needed `system_prompt_file` (context.include does NOT feed loop-agent Layer-1) |
+| dot-graph resolver | PASS — two-link direct proof (PROOF A: injection emits per-provider `system_prompt_file`; PROOF B: real loop-agent + real Anthropic call → base sentinel on wire, no fail-loud; PROOF C: CWD-independent) |
+| Council | CONDITIONAL SHIP → must-fixes applied |
+
+**Key correction:** loop-agent Layer-1 comes ONLY from `system_prompt`/`system_prompt_file`; it never consumes the `context.include` factory (the old comment was stale). Blast radius of fail-loud is **loop-agent-local**: in-workspace only attractor (all 30 sessions fixed) and the dot-graph resolver (fixed) spawn loop-agent nodes.
+
+### Open follow-ups
+1. **ROOT-CAUSE (tracked):** wire loop-agent to read the kernel context manager's system-prompt factory so `context.include` works like every other orchestrator — then the 30-file `system_prompt_file` mechanism can retire. Until then the config approach is permanent-by-default.
+2. **Full DTU-hosted Resolve stack:** dot-graph proven via direct two-link proof, NOT a live worker-container spawn (stack repos absent from workspace). Closing it needs `amplifier-bundle-resolve` + `resolve-stack.sh --dev` with local overrides.
+3. **External consumers NOT in this workspace:** `amplifier-resolver-orchestrator` and `amplifier-resolver-understudy` must be checked for the same gap before "smooth for all" is fully true.
+4. **dot-graph live calls:** only the anthropic node path was exercised with a real LLM call; openai/gemini covered by mapping assertions only.

--- a/docs/designs/layer-1-profile-owned-system-prompt.md
+++ b/docs/designs/layer-1-profile-owned-system-prompt.md
@@ -91,8 +91,21 @@ Verified on latest attractor main (`b50843c`), core 1.6.0, graded on raw LLM req
 
 **Key correction:** loop-agent Layer-1 comes ONLY from `system_prompt`/`system_prompt_file`; it never consumes the `context.include` factory (the old comment was stale). Blast radius of fail-loud is **loop-agent-local**: in-workspace only attractor (all 30 sessions fixed) and the dot-graph resolver (fixed) spawn loop-agent nodes.
 
+## Root-cause cleanup — Option A (DONE, proven config-free)
+
+`968fc62` replaced the per-session config duplication with a **provider DEFAULT in loop-agent**. Precedence: explicit `system_prompt` > explicit `system_prompt_file` > **provider default `context/system-<provider>.md`** > fail-loud (unknown provider only). The default keys on the SAME provider source loop-agent uses for the actual completion (`next(iter(providers.keys()))`), so the base can never disagree with the model being called. **24 hard-coded `system_prompt_file` lines removed** across 17 YAMLs (only `attractor-expert` keeps an explicit override — it's a non-coding persona). Suites 485 + 1378 green.
+
+**Consumer impact — PROVEN on raw requests (zero config / zero changes):**
+- **PROOF 1 (attractor users):** mirror confirmed provider agents carry NO `system_prompt_file`; a 3-provider run still delivered each provider's verbatim base header (anthropic/openai/gemini) via the default, on real LLM calls, no fail-loud, no cross-contamination.
+- **PROOF 2 (dot-graph / external users):** dot-graph reverted to `origin/main` **unchanged** (bare loop-agent injection, `config == {}`); against attractor `968fc62` the spawned node received the Anthropic base at Layer-1 offset 0 via the default, no fail-loud. **The `4ac6f38` dot-graph fix is now unnecessary** — external consumers need nothing.
+
+**Honest caveats:**
+- **Unknown-provider:** the default ships bases for anthropic/openai/gemini only. A consumer using any other provider hits fail-loud unless it sets an explicit base (by design — never silently pick a wrong base).
+- **Multi-provider fan-out routing (separate concern, NOT this feature):** when a parent mounts ALL providers and fans out, the per-node `llm_provider` was not promoted, so nodes routed to the first provider. loop-agent always matched the base to the provider actually used; dot-graph's path promotes `node.attrs["llm_provider"]` per child (`loop-pipeline backend.py:233,595`), so it is unaffected. Flagged for separate follow-up.
+- Full Resolve stack still not run (stack repos absent); dot-graph→loop-pipeline spawn plumbing verified by code-read. orchestrator/understudy resolvers remain unchecked (not in workspace).
+
 ### Open follow-ups
-1. **ROOT-CAUSE (tracked):** wire loop-agent to read the kernel context manager's system-prompt factory so `context.include` works like every other orchestrator — then the 30-file `system_prompt_file` mechanism can retire. Until then the config approach is permanent-by-default.
+1. **ROOT-CAUSE: DONE** via the provider default above (the 30-file mechanism is retired). Optional future nicety: also wire loop-agent to read the context-manager factory so bare `context.include` works too — not required now.
 2. **Full DTU-hosted Resolve stack:** dot-graph proven via direct two-link proof, NOT a live worker-container spawn (stack repos absent from workspace). Closing it needs `amplifier-bundle-resolve` + `resolve-stack.sh --dev` with local overrides.
 3. **External consumers NOT in this workspace:** `amplifier-resolver-orchestrator` and `amplifier-resolver-understudy` must be checked for the same gap before "smooth for all" is fully true.
 4. **dot-graph live calls:** only the anthropic node path was exercised with a real LLM call; openai/gemini covered by mapping assertions only.

--- a/docs/designs/layer-1-profile-owned-system-prompt.md
+++ b/docs/designs/layer-1-profile-owned-system-prompt.md
@@ -1,0 +1,65 @@
+# Design: Profile-Owned Layer-1 System Prompt
+
+**Status:** Draft (for review — no code yet)
+**Scope:** `modules/loop-agent`, attractor agent YAMLs + profiles, one `loop-pipeline` threading change. **Not** app-cli / foundation / the shared spawn contract.
+
+## Problem
+
+Pipeline node agents run with a **stub** Layer-1 system prompt (`"You are a coding agent."`), not their provider-aligned base prompt — causing hallucination + over-fragmentation in synthesis. Proven empirically: a real wiki-weaver ingest logs `Layer-1 base prompt is empty` ×18–31, and a raw-LLM-request capture of a spawned node confirms only the stub + env + tool catalog reaches the model.
+
+Root cause (confirmed via code, not inference): the base prompt is sourced from a **`context.include` side-file** (`agents/attractor-agent-<prov>.yaml:50-51` → `context/system-<prov>.md`) and delivered through foundation's `_system_prompt_factory`. That factory is only wired when the child bundle's context is populated through the spawn — which the post-#74 inline overlays drop. So the base prompt survives only one spawn shape and silently degrades to a stub everywhere else.
+
+## Spec grounding
+
+The attractor nl-spec already answers "who owns the system prompt" — and it is **not** the orchestration layer:
+
+- **Attractor-orchestration deliberately abstains** (mechanism, like the kernel): `attractor-spec.md:56` "Attractor defines the orchestration layer… does NOT require any specific LLM integration"; `:58` "What that backend does internally is entirely up to the implementor." Attractor knows only the per-node **task** prompt (`:151`).
+- **The base system prompt is first-class one layer down, in the backend's `ProviderProfile`**: `coding-agent-loop-spec.md:469` "a 1:1 copy of the provider's reference agent — the exact same system prompt… byte for byte"; `:1004` "Each profile supplies its own base prompt." Project/context files are an **additive** layer (4), not the base (`:991-998`).
+- **Known impl gap** (the repo's own reviews): `docs/reports/adversarial-spec-review.md:99-103` and `docs/reports/spec-gap-analysis-v2.md:48,68-70` — "No `ProviderProfile` class exists; system-prompt assembly is hardcoded."
+
+So the base prompt's correct home is the **provider profile**, delivered as loop-agent's **Layer-1 `SessionConfig.system_prompt`** — a config value — **distinct from** the node task-prompt channel. (Note: the V_B eval — inline `system_prompt` in orchestrator config — accidentally hit this exact channel and drove `Layer-1 empty → 0`; it just authored the value as duplicated inline text instead of a profile-owned asset.)
+
+## The contract (what "first-class" means here)
+
+| # | Property | Spec anchor | Notes |
+|---|----------|-------------|-------|
+| 1 | Provider base prompt is a **profile-owned, versioned** asset | `coding-agent-loop:469,1004` (versioning is net-new) | One home, not a per-pipeline include |
+| 2 | **OOTB, zero glue** for consumers (wiki-weaver, dot-graph) | implied at profile layer `:56,672` | composing a pipeline yields prompted agents |
+| 3 | Delivered via the **canonical Layer-1 channel** (`SessionConfig.system_prompt`), spawn-path-agnostic | `:991,1004` (corrected: profile base, **not** the task/instruction channel) | works under app-cli static-inject **and** foundation factory |
+| 4 | **Overridable via composition** without forking | `:56,999` (strongest match) | compose a different profile, or Layer-5 override |
+| 5 | **Fail-loud** on empty/stub base | **contradicts** `attractor-spec.md:668-670,1408` (fail-soft) | deliberate strengthening — requires a spec note |
+
+## Design
+
+**A. Base prompt = profile-owned → loop-agent Layer-1.**
+loop-agent loads a **profile-declared base-prompt** directly into `SessionConfig.system_prompt` (`config.py:39`). Insertion point: `__init__.py:113-137` (replace the factory-resolution block with a direct read of the profile's base-prompt path). Remove `context.include: ../context/system-<prov>.md` (the **base**) from the agent YAMLs + profiles. Consequence (confirmed): with no base `context.include`, foundation registers no base factory (`_prepared.py:656` guard), so `context._system_prompt_factory` is `None` and `config.system_prompt` flows straight through as Layer-1 — single owner, no precedence fight. `context.include` **remains** for genuine additive context (`@AGENTS.md` etc.), Layer 4 only.
+
+**B. Runtime (per-invocation) override = Layer-5 `user_instructions` via the existing channel.**
+`orchestrator_config` is already an end-to-end per-invocation passthrough (loop-pipeline → spawn_fn → wiki-weaver `prepared.spawn` / app-cli `spawn_sub_session` → `session.orchestrator.config` → loop-agent `SessionConfig`). loop-agent already reads `user_instructions` (`config.py:40`) as Layer-5 (highest precedence, `system_prompt.py:93-95`). One small change: `loop-pipeline/backend.py` `_run_with_spawn` adds `user_instructions` (and/or `system_prompt_file`) to the per-spawn `orchestrator_config` dict (`:421-428`), sourced from `node.attrs` (per-graph) and/or `PipelineContext` (per-run, caller-supplied). **No app-cli / foundation / shared-contract change.**
+
+**C. Fail-loud.** An empty Layer-1 base for an LLM node is an error (or loud, non-silent failure), not a stub fallback. Deliberate departure from the spec's fail-soft posture (`agent_session.py:543-550`, `attractor-spec.md:668-670,1408`).
+
+## Layering decision
+
+**Option A (chosen): spec-faithful — fix lives in loop-agent/profile.** Stays inside the `coding-agent-loop`/backend layer that the spec says owns prompts; does **not** cross `attractor-spec.md §1.4` ("backend internals are up to the implementor").
+**Option B (rejected): pull prompt ownership up into attractor-orchestration** — amends the spec's layering, larger blast radius, no benefit over A.
+
+## Blast radius
+
+- **Changes:** `loop-agent/__init__.py` (:113-137); `agents/attractor-agent-{anthropic,openai,gemini}.yaml` + `profiles/attractor-profile-*.yaml` (drop base `context.include`, add profile-owned base ref); `loop-pipeline/backend.py` (:421-428, runtime threading); optional `loop-agent/config.py` (`system_prompt_file` key).
+- **Unchanged:** `system_prompt.py` 5-layer assembler (already reads Layer-1 from `config.system_prompt`); app-cli `spawn_sub_session`; foundation `PreparedBundle`; the shared spawn contract.
+- **Consumers:** wiki-weaver, dot-graph benefit OOTB with **zero** changes. `pipeline-runner.yaml` agents share the same YAMLs — must change in lockstep.
+
+## Verification (evals-driven — proof on raw requests, not unit-green)
+
+1. **E1 OOTB delivery (DTU):** wiki-weaver ingest → `Layer-1 base prompt is empty` count **= 0**, AND the spawned node's **raw LLM request** system prompt contains the provider base sentinel.
+2. **E2 runtime override (DTU):** caller supplies a per-run `user_instructions` with a unique sentinel → the spawned node's raw request shows it present **and** highest-precedence (base still present, override appended last).
+3. **E3 fail-loud:** a node with no resolvable base → errors loudly; no silent stub.
+
+(Two prior "unit-green" fixes passed tests but failed the DTU — so every claim here is gated on a raw-request capture, the method that finally told the truth.)
+
+## Open questions / spec amendments
+
+1. **Fail-loud** changes attractor's documented fail-soft behavior (`:668-670,1408`) → amend the spec, or scope fail-loud to LLM nodes only.
+2. **`ProviderProfile` object:** keep the declarative (YAML profile) representation, or introduce the actual object the spec describes and the gap analyses flag as missing? (This design works either way; the base-prompt asset just needs an owner.)
+3. **Prompt versioning** (contract #1) is net-new surface — neither spec blesses nor forbids it.

--- a/modules/loop-agent/amplifier_module_loop_agent/__init__.py
+++ b/modules/loop-agent/amplifier_module_loop_agent/__init__.py
@@ -11,8 +11,8 @@ from __future__ import annotations
 # Amplifier module metadata
 __amplifier_module_type__ = "orchestrator"
 
-import inspect
 import logging
+from pathlib import Path
 from typing import Any
 
 from .agent_session import AgentSession
@@ -99,40 +99,39 @@ class AgentOrchestrator:
         if coordinator is not None:
             self._coordinator = coordinator
         if self._session is None:
-            # Deliver context.include as Layer-1 "provider base instructions" (nlspec §6.1).
+            # Load Layer-1 base prompt from profile-declared file (nlspec §6.1:
+            # "Provider-specific base instructions from ProviderProfile").
             #
-            # Foundation registers _system_prompt_factory on the context module when
-            # context.include is declared in a bundle profile (e.g. attractor-agent-anthropic
-            # includes context/system-anthropic.md).  loop-agent must resolve the factory
-            # here because it builds its own message list via _convert_history_to_messages()
-            # rather than delegating to context.get_messages_for_request() — so the factory
-            # is never called on the normal context-simple path.
+            # Design: docs/designs/layer-1-profile-owned-system-prompt.md
             #
-            # Guard: inspect.iscoroutinefunction avoids calling MagicMock auto-attributes
-            # that tests inject as a plain MagicMock context.
+            # The profile declares `system_prompt_file: context/system-<prov>.md`
+            # in session.orchestrator.config.  loop-agent resolves it here — before
+            # the session is created — so the text lands in SessionConfig.system_prompt
+            # (Layer-1) regardless of which spawn path was used.
+            #
+            # Path resolution: system_prompt_file is expressed relative to the bundle
+            # root.  Bundle root is 4 levels up from this file in an editable Amplifier
+            # install:
+            #   <bundle-root>/modules/loop-agent/amplifier_module_loop_agent/__init__.py
+            #
+            # If system_prompt is already set in config (e.g. injected by loop-pipeline's
+            # backend.py before spawn), the file is skipped — single owner, no conflict.
             config_dict = dict(self._config)
-            # Try the context module's factory first — it is the authoritative source for
-            # Layer-1 "Provider-specific base instructions" (nlspec §6.1).  The factory is
-            # registered by foundation when context.include is declared in the bundle profile
-            # (e.g. attractor-agent-anthropic includes context/system-anthropic.md).
-            # system_prompt config is a fallback; it is used only when the factory produces
-            # nothing (returns empty string) or is absent.
-            factory = getattr(context, "_system_prompt_factory", None)
-            if inspect.iscoroutinefunction(factory):
-                try:
-                    context_base = await factory()
-                except Exception as exc:  # noqa: BLE001
+            _spf = config_dict.get("system_prompt_file", "")
+            if _spf and not config_dict.get("system_prompt"):
+                _bundle_root = Path(__file__).parent.parent.parent.parent
+                _spf_path = (
+                    Path(_spf) if Path(_spf).is_absolute() else (_bundle_root / _spf)
+                )
+                if _spf_path.is_file():
+                    config_dict["system_prompt"] = _spf_path.read_text(encoding="utf-8")
+                else:
                     logger.warning(
-                        "context._system_prompt_factory raised; Layer-1 base prompt "
-                        "will fall back to system_prompt config or stub: %s",
-                        exc,
+                        "system_prompt_file %r not found at %s; "
+                        "Layer-1 base prompt will be empty.",
+                        _spf,
+                        _spf_path,
                     )
-                    context_base = ""
-                if context_base:
-                    # Factory wins: the bundle's context.include content is the canonical
-                    # Layer-1 base prompt.  Do not double-inject by also appending
-                    # system_prompt — the factory already incorporates the bundle instruction.
-                    config_dict["system_prompt"] = context_base
 
             config = SessionConfig.from_dict(config_dict)
             # Use the first available provider

--- a/modules/loop-agent/amplifier_module_loop_agent/__init__.py
+++ b/modules/loop-agent/amplifier_module_loop_agent/__init__.py
@@ -23,6 +23,81 @@ from .subagent_tools import SubagentManager
 logger = logging.getLogger(__name__)
 
 
+def _resolve_system_prompt_file(spf: str) -> Path:
+    """Resolve a configured ``system_prompt_file`` to an absolute, existing path.
+
+    Resolution is **CWD-INDEPENDENT**. It anchors on this module's installed
+    location (``__file__``), never on the process working directory — so the
+    same configured value resolves identically no matter where the process was
+    launched from (a different CWD, a container, a recipe that changes dirs) or
+    which consumer spawned the loop-agent node.
+
+    Rules:
+      (a) ABSOLUTE ``spf`` -> used as-is (must exist).
+      (b) RELATIVE ``spf`` -> resolved against the loop-agent module's owning
+          bundle root. The module installs (editable) at::
+
+              <bundle-root>/modules/loop-agent/amplifier_module_loop_agent/__init__.py
+
+          so the bundle root is ``parents[3]`` of this file. That is the
+          documented, primary anchor and is tried FIRST (deterministic in the
+          normal layout). As resilience against a future layout/nesting change,
+          if the primary anchor does not contain the file we then walk UP the
+          remaining ancestors and accept the first one under which the relative
+          path actually exists. Every candidate is anchored on ``__file__`` —
+          the current working directory is never consulted.
+      (c) If no candidate resolves to an existing file, raise a CLEAR, ACTIONABLE
+          ``FileNotFoundError`` naming the configured value AND the absolute path
+          tried — never a silent empty Layer-1.
+
+    Returns:
+        Absolute ``Path`` to an existing file.
+
+    Raises:
+        FileNotFoundError: when no existing file can be resolved.
+
+    See docs/designs/layer-1-profile-owned-system-prompt.md.
+    """
+    p = Path(spf)
+    if p.is_absolute():
+        if p.is_file():
+            return p
+        raise FileNotFoundError(
+            f"system_prompt_file {spf!r} (absolute path) does not exist at {p}. "
+            f"Point session.orchestrator.config.system_prompt_file at an existing "
+            f"file (e.g. context/system-<provider>.md). "
+            f"See docs/designs/layer-1-profile-owned-system-prompt.md."
+        )
+
+    pkg_file = Path(__file__).resolve()
+    ancestors = pkg_file.parents  # CWD-independent: anchored on __file__
+
+    # Build the candidate list: the documented bundle-root anchor (parents[3])
+    # FIRST for determinism, then every remaining ancestor as a resilience
+    # fallback. Preserve order, drop duplicates.
+    candidates: list[Path] = []
+    if len(ancestors) > 3:
+        candidates.append(ancestors[3] / p)
+    for ancestor in ancestors:
+        cand = ancestor / p
+        if cand not in candidates:
+            candidates.append(cand)
+
+    for cand in candidates:
+        if cand.is_file():
+            return cand
+
+    primary = candidates[0] if candidates else (pkg_file.parent / p)
+    raise FileNotFoundError(
+        f"system_prompt_file {spf!r} (relative) could not be resolved to an "
+        f"existing file. Expected it at the bundle root: {primary}. "
+        f"Resolution is anchored on the loop-agent module location "
+        f"({pkg_file}) and is independent of the current working directory. "
+        f"Add the file, or fix session.orchestrator.config.system_prompt_file. "
+        f"See docs/designs/layer-1-profile-owned-system-prompt.md."
+    )
+
+
 async def mount(coordinator: Any, config: dict[str, Any] | None = None) -> None:
     """Mount the loop-agent orchestrator."""
     cfg = config or {}
@@ -109,29 +184,20 @@ class AgentOrchestrator:
             # the session is created — so the text lands in SessionConfig.system_prompt
             # (Layer-1) regardless of which spawn path was used.
             #
-            # Path resolution: system_prompt_file is expressed relative to the bundle
-            # root.  Bundle root is 4 levels up from this file in an editable Amplifier
-            # install:
-            #   <bundle-root>/modules/loop-agent/amplifier_module_loop_agent/__init__.py
+            # Path resolution is delegated to _resolve_system_prompt_file, which is
+            # CWD-INDEPENDENT (anchored on this module's __file__, never the process
+            # working directory) and fail-loud: a configured-but-missing file raises
+            # a clear, actionable FileNotFoundError naming the value and the absolute
+            # path tried — rather than a silent empty Layer-1 that only trips the
+            # generic guard later. See docs/designs/layer-1-profile-owned-system-prompt.md.
             #
             # If system_prompt is already set in config (e.g. injected by loop-pipeline's
             # backend.py before spawn), the file is skipped — single owner, no conflict.
             config_dict = dict(self._config)
             _spf = config_dict.get("system_prompt_file", "")
             if _spf and not config_dict.get("system_prompt"):
-                _bundle_root = Path(__file__).parent.parent.parent.parent
-                _spf_path = (
-                    Path(_spf) if Path(_spf).is_absolute() else (_bundle_root / _spf)
-                )
-                if _spf_path.is_file():
-                    config_dict["system_prompt"] = _spf_path.read_text(encoding="utf-8")
-                else:
-                    logger.warning(
-                        "system_prompt_file %r not found at %s; "
-                        "Layer-1 base prompt will be empty.",
-                        _spf,
-                        _spf_path,
-                    )
+                _spf_path = _resolve_system_prompt_file(_spf)
+                config_dict["system_prompt"] = _spf_path.read_text(encoding="utf-8")
 
             config = SessionConfig.from_dict(config_dict)
             # Use the first available provider

--- a/modules/loop-agent/amplifier_module_loop_agent/__init__.py
+++ b/modules/loop-agent/amplifier_module_loop_agent/__init__.py
@@ -15,7 +15,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
-from .agent_session import AgentSession
+from .agent_session import KNOWN_PROVIDERS, AgentSession, canonical_provider
 from .config import SessionConfig
 from .steering import FollowUpQueue, SteeringQueue
 from .subagent_tools import SubagentManager
@@ -144,6 +144,52 @@ class AgentOrchestrator:
         """
         self._follow_up_queue.follow_up(message)
 
+    def _resolve_base_prompt(
+        self, config_dict: dict[str, Any], provider_name: str
+    ) -> str:
+        """Resolve the Layer-1 base prompt with a 4-step precedence.
+
+        Precedence (first that applies wins):
+          1. explicit ``system_prompt`` in config        -> used as-is
+          2. explicit ``system_prompt_file`` in config   -> loaded (robust resolver)
+          3. provider DEFAULT ``context/system-<provider>.md`` -> loaded (robust
+             resolver), where ``<provider>`` is the canonical provider derived
+             from the agent's own mounted provider — the same provider used for
+             the actual completion, so the base always matches the model called.
+          4. unknown provider, or a configured/default file that does not exist
+             -> a CLEAR, ACTIONABLE error (never a silent wrong/empty base).
+
+        Explicit config (1, 2) always overrides the provider default (3), so a
+        non-coding agent (e.g. attractor-expert) can pin its own persona base.
+
+        See docs/designs/layer-1-profile-owned-system-prompt.md §Mechanism.
+        """
+        # (1) explicit inline system_prompt wins outright.
+        existing = config_dict.get("system_prompt")
+        if existing:
+            return existing
+
+        # (2) explicit system_prompt_file, else (3) provider default.
+        spf = config_dict.get("system_prompt_file", "")
+        if not spf:
+            canonical = canonical_provider(provider_name)
+            if canonical is None:
+                # (4) unknown provider — do NOT guess a base; fail loud and clear.
+                raise RuntimeError(
+                    f"loop-agent cannot select a Layer-1 base prompt: no "
+                    f"system_prompt or system_prompt_file is configured, and the "
+                    f"provider {provider_name!r} is not one of the known providers "
+                    f"{KNOWN_PROVIDERS} (so no default context/system-<provider>.md "
+                    f"applies). Set an explicit system_prompt_file in "
+                    f"session.orchestrator.config, or run under a known provider. "
+                    f"See docs/designs/layer-1-profile-owned-system-prompt.md."
+                )
+            spf = f"context/system-{canonical}.md"
+
+        # (2)/(3) load via the robust, CWD-independent resolver. A missing file
+        # raises a clear FileNotFoundError naming the value and path tried — (4).
+        return _resolve_system_prompt_file(spf).read_text(encoding="utf-8")
+
     async def execute(
         self,
         prompt: str,
@@ -174,34 +220,34 @@ class AgentOrchestrator:
         if coordinator is not None:
             self._coordinator = coordinator
         if self._session is None:
-            # Load Layer-1 base prompt from profile-declared file (nlspec §6.1:
-            # "Provider-specific base instructions from ProviderProfile").
+            # Resolve the Layer-1 base prompt (nlspec §6.1: "Provider-specific base
+            # instructions from ProviderProfile") with a 4-step precedence, BEFORE the
+            # session is created, so the text lands in SessionConfig.system_prompt
+            # (Layer-1) regardless of which spawn path was used:
+            #   1. explicit system_prompt config            -> use as-is
+            #   2. explicit system_prompt_file config       -> load
+            #   3. provider DEFAULT context/system-<prov>.md -> load (the common case:
+            #      agents need no per-YAML system_prompt_file; the provider supplies it)
+            #   4. unknown provider / missing file          -> fail-loud clear error
+            # See _resolve_base_prompt and docs/designs/layer-1-profile-owned-system-prompt.md.
             #
-            # Design: docs/designs/layer-1-profile-owned-system-prompt.md
-            #
-            # The profile declares `system_prompt_file: context/system-<prov>.md`
-            # in session.orchestrator.config.  loop-agent resolves it here — before
-            # the session is created — so the text lands in SessionConfig.system_prompt
-            # (Layer-1) regardless of which spawn path was used.
-            #
-            # Path resolution is delegated to _resolve_system_prompt_file, which is
+            # File loading is delegated to _resolve_system_prompt_file, which is
             # CWD-INDEPENDENT (anchored on this module's __file__, never the process
-            # working directory) and fail-loud: a configured-but-missing file raises
-            # a clear, actionable FileNotFoundError naming the value and the absolute
-            # path tried — rather than a silent empty Layer-1 that only trips the
-            # generic guard later. See docs/designs/layer-1-profile-owned-system-prompt.md.
-            #
-            # If system_prompt is already set in config (e.g. injected by loop-pipeline's
-            # backend.py before spawn), the file is skipped — single owner, no conflict.
+            # working directory) and fail-loud on a missing file.
             config_dict = dict(self._config)
-            _spf = config_dict.get("system_prompt_file", "")
-            if _spf and not config_dict.get("system_prompt"):
-                _spf_path = _resolve_system_prompt_file(_spf)
-                config_dict["system_prompt"] = _spf_path.read_text(encoding="utf-8")
+
+            # Derive the intended provider from the mounted providers. This is the
+            # SAME value used below for the actual completion (provider =
+            # providers[provider_name]), so a provider-derived default base prompt
+            # always matches the model that will actually be called — it is the
+            # agent's own configured provider, not a post-routing driver.
+            provider_name = next(iter(providers.keys()))
+
+            config_dict["system_prompt"] = self._resolve_base_prompt(
+                config_dict, provider_name
+            )
 
             config = SessionConfig.from_dict(config_dict)
-            # Use the first available provider
-            provider_name = next(iter(providers.keys()))
             provider = providers[provider_name]
 
             # Merge subagent lifecycle tools into the tools dict

--- a/modules/loop-agent/amplifier_module_loop_agent/agent_session.py
+++ b/modules/loop-agent/amplifier_module_loop_agent/agent_session.py
@@ -75,6 +75,27 @@ from .turns import (
 logger = logging.getLogger(__name__)
 
 
+# Canonical provider IDs, shared by AgentSession (project-doc / env-context
+# filtering) and AgentOrchestrator (provider-default base-prompt selection).
+KNOWN_PROVIDERS = ("anthropic", "openai", "gemini")
+
+
+def canonical_provider(raw: str | None) -> str | None:
+    """Normalise a raw provider name to a canonical ID (anthropic/openai/gemini).
+
+    Bundle composition may yield provider names like "provider-anthropic" or
+    "Provider-OpenAI"; this returns the canonical ID via case-insensitive
+    substring match, or None when the provider cannot be identified.
+    """
+    if not raw:
+        return None
+    lower = raw.lower()
+    for canonical in KNOWN_PROVIDERS:
+        if canonical in lower:
+            return canonical
+    return None
+
+
 class AgentSession:
     """Manages a single coding agent session with the core agentic loop.
 
@@ -493,7 +514,7 @@ class AgentSession:
     # ------------------------------------------------------------------
 
     # Canonical provider IDs for flexible matching
-    _KNOWN_PROVIDERS = ("anthropic", "openai", "gemini")
+    _KNOWN_PROVIDERS = KNOWN_PROVIDERS
 
     def _resolve_provider_id(self) -> str | None:
         """Resolve raw provider name to a canonical provider ID.
@@ -506,14 +527,7 @@ class AgentSession:
 
         Returns None when the provider cannot be identified.
         """
-        raw = self._provider_name
-        if not raw:
-            return None
-        lower = raw.lower()
-        for canonical in self._KNOWN_PROVIDERS:
-            if canonical in lower:
-                return canonical
-        return None
+        return canonical_provider(self._provider_name)
 
     # ------------------------------------------------------------------
     # System prompt assembly (spec PROV-002: rebuilt every LLM call)

--- a/modules/loop-agent/amplifier_module_loop_agent/agent_session.py
+++ b/modules/loop-agent/amplifier_module_loop_agent/agent_session.py
@@ -534,11 +534,14 @@ class AgentSession:
         # Resolve canonical provider ID for doc filtering
         provider_id = self._resolve_provider_id()
 
-        # Layer 1: Base prompt — resolved by AgentOrchestrator.execute() from the bundle's
-        # context._system_prompt_factory (which delivers context.include files per nlspec §6.1:
-        # "Provider-specific base instructions (from ProviderProfile)").
-        # Falls back to system_prompt config; falls through to a stub with a warning when
-        # neither the factory nor the config provides content.
+        # Layer 1: Base prompt — comes ONLY from config.system_prompt (set directly,
+        # or loaded by AgentOrchestrator.execute() from system_prompt_file before the
+        # session is created). loop-agent does NOT consume the bundle's context.include
+        # files for the base — that channel is for ADDITIVE context, not Layer-1
+        # (proven empirically in core 1.6.0; the prior assumption was wrong). The
+        # provider base prompt (nlspec §6.1 ProviderProfile) MUST therefore be supplied
+        # via system_prompt / system_prompt_file in session.orchestrator.config.
+        # See docs/designs/layer-1-profile-owned-system-prompt.md.
         base_prompt = self._config.system_prompt
         if not base_prompt:
             # Fail-loud: an empty Layer-1 is a configuration error, not a

--- a/modules/loop-agent/amplifier_module_loop_agent/agent_session.py
+++ b/modules/loop-agent/amplifier_module_loop_agent/agent_session.py
@@ -541,13 +541,21 @@ class AgentSession:
         # neither the factory nor the config provides content.
         base_prompt = self._config.system_prompt
         if not base_prompt:
-            logger.warning(
-                "Layer-1 base prompt is empty: no context._system_prompt_factory "
-                "contribution and no system_prompt in orchestrator config. "
-                "Falling back to stub. Set context.include in the bundle profile "
-                "or system_prompt in orchestrator config."
+            # Fail-loud: an empty Layer-1 is a configuration error, not a
+            # recoverable runtime condition.  The silent stub ("You are a
+            # coding agent.") was masking misconfiguration and causing
+            # hallucination + over-fragmentation in synthesis.
+            # Fix: add system_prompt_file: context/system-<provider>.md to
+            # session.orchestrator.config in the agent YAML or profile.
+            # See docs/designs/layer-1-profile-owned-system-prompt.md §C.
+            raise RuntimeError(
+                "Layer-1 base prompt is empty: session was created with no "
+                "system_prompt in orchestrator config and no system_prompt_file "
+                "that resolved to content. "
+                "Add system_prompt_file: context/system-<provider>.md to the "
+                "agent's session.orchestrator.config. "
+                "See docs/designs/layer-1-profile-owned-system-prompt.md."
             )
-            base_prompt = "You are a coding agent."
 
         # Layer 2: Environment context
         working_dir = self._config.working_dir or os.getcwd()

--- a/modules/loop-agent/amplifier_module_loop_agent/config.py
+++ b/modules/loop-agent/amplifier_module_loop_agent/config.py
@@ -37,6 +37,9 @@ class SessionConfig:
     current_depth: int = 0  # Current subagent depth (set by parent for child sessions)
     context_window_size: int = 0  # 0 = unknown/unlimited
     system_prompt: str = ""  # Base system prompt (layer 1)
+    system_prompt_file: str = (
+        ""  # Path to base prompt file (layer 1, relative to bundle root)
+    )
     user_instructions: str = ""  # User instruction override (layer 5, highest priority)
     working_dir: str = ""  # Working directory for environment context and project docs
     max_tool_rounds_per_provider: dict[str, int] = field(default_factory=dict)

--- a/modules/loop-agent/tests/test_agent_session.py
+++ b/modules/loop-agent/tests/test_agent_session.py
@@ -65,7 +65,10 @@ def _make_harness(
 
     Returns (orchestrator, context, providers, tools, hooks).
     """
-    cfg = config or {}
+    # Provide a non-empty system_prompt by default so tests don't trip the
+    # fail-loud guard introduced in docs/designs/layer-1-profile-owned-system-prompt.md §C.
+    defaults = {"system_prompt": "You are a test coding agent."}
+    cfg = {**defaults, **(config or {})}
 
     # Provider mock
     provider = AsyncMock()

--- a/modules/loop-agent/tests/test_arg_validation.py
+++ b/modules/loop-agent/tests/test_arg_validation.py
@@ -174,7 +174,7 @@ async def test_validation_error_sent_to_llm():
     hooks = _make_hooks()
 
     session = AgentSession(
-        config=SessionConfig(),
+        config=SessionConfig(system_prompt="You are a test coding agent."),
         provider=provider,
         tools={"read_file": tool},
         hooks=hooks,
@@ -208,7 +208,7 @@ async def test_validation_error_emits_tool_call_end():
     hooks = _make_hooks()
 
     session = AgentSession(
-        config=SessionConfig(),
+        config=SessionConfig(system_prompt="You are a test coding agent."),
         provider=provider,
         tools={"write_file": tool},
         hooks=hooks,

--- a/modules/loop-agent/tests/test_awaiting_input.py
+++ b/modules/loop-agent/tests/test_awaiting_input.py
@@ -100,7 +100,7 @@ async def test_question_response_enters_awaiting_input():
     hooks = _make_hooks()
 
     session = AgentSession(
-        config=SessionConfig(),
+        config=SessionConfig(system_prompt="You are a test coding agent."),
         provider=provider,
         tools={"read_file": _make_mock_tool("read_file")},
         hooks=hooks,
@@ -121,7 +121,7 @@ async def test_statement_response_enters_idle():
     hooks = _make_hooks()
 
     session = AgentSession(
-        config=SessionConfig(),
+        config=SessionConfig(system_prompt="You are a test coding agent."),
         provider=provider,
         tools={"read_file": _make_mock_tool("read_file")},
         hooks=hooks,
@@ -142,7 +142,7 @@ async def test_awaiting_input_event_emitted():
     hooks = _make_hooks()
 
     session = AgentSession(
-        config=SessionConfig(),
+        config=SessionConfig(system_prompt="You are a test coding agent."),
         provider=provider,
         tools={"read_file": _make_mock_tool("read_file")},
         hooks=hooks,
@@ -166,7 +166,7 @@ async def test_session_end_not_emitted_for_question():
     hooks = _make_hooks()
 
     session = AgentSession(
-        config=SessionConfig(),
+        config=SessionConfig(system_prompt="You are a test coding agent."),
         provider=provider,
         tools={},
         hooks=hooks,
@@ -195,7 +195,7 @@ async def test_resume_with_input_continues_session():
     hooks = _make_hooks()
 
     session = AgentSession(
-        config=SessionConfig(),
+        config=SessionConfig(system_prompt="You are a test coding agent."),
         provider=provider,
         tools={"read_file": _make_mock_tool("read_file")},
         hooks=hooks,

--- a/modules/loop-agent/tests/test_cancellation.py
+++ b/modules/loop-agent/tests/test_cancellation.py
@@ -82,7 +82,7 @@ async def test_checkpoint1_graceful_cancel_at_loop_top():
     hooks = _make_hooks()
 
     session = AgentSession(
-        config=SessionConfig(),
+        config=SessionConfig(system_prompt="You are a test coding agent."),
         provider=provider,
         tools=tools,
         hooks=hooks,
@@ -115,7 +115,7 @@ async def test_checkpoint2_immediate_cancel_after_provider():
     hooks = _make_hooks()
 
     session = AgentSession(
-        config=SessionConfig(),
+        config=SessionConfig(system_prompt="You are a test coding agent."),
         provider=provider,
         tools=tools,
         hooks=hooks,
@@ -150,7 +150,7 @@ async def test_checkpoint3_tool_results_added_on_cancel():
     hooks = _make_hooks()
 
     session = AgentSession(
-        config=SessionConfig(),
+        config=SessionConfig(system_prompt="You are a test coding agent."),
         provider=provider,
         tools={"read_file": tool},
         hooks=hooks,
@@ -183,7 +183,7 @@ async def test_tool_register_start_complete_called():
     hooks = _make_hooks()
 
     session = AgentSession(
-        config=SessionConfig(),
+        config=SessionConfig(system_prompt="You are a test coding agent."),
         provider=provider,
         tools={"read_file": tool},
         hooks=hooks,
@@ -205,7 +205,7 @@ async def test_no_coordinator_no_crash():
     hooks = _make_hooks()
 
     session = AgentSession(
-        config=SessionConfig(),
+        config=SessionConfig(system_prompt="You are a test coding agent."),
         provider=provider,
         tools={"read_file": _make_mock_tool("read_file")},
         hooks=hooks,

--- a/modules/loop-agent/tests/test_context_window.py
+++ b/modules/loop-agent/tests/test_context_window.py
@@ -59,7 +59,7 @@ def _make_harness(
     responses: list[ChatResponse] | None = None,
     tool_names: list[str] | None = None,
 ):
-    cfg = config or {}
+    cfg = {"system_prompt": "You are a test coding agent.", **(config or {})}
     provider = AsyncMock()
     provider.complete = AsyncMock(
         side_effect=responses or [_text_response("done")]

--- a/modules/loop-agent/tests/test_error_handling.py
+++ b/modules/loop-agent/tests/test_error_handling.py
@@ -66,7 +66,7 @@ def _make_mock_tool(name: str, output: str = "ok") -> MagicMock:
 
 def _make_harness(config=None, responses=None, tool_names=None, provider_error=None):
     """Build orchestrator + mocks. If provider_error is set, provider.complete raises it."""
-    cfg = config or {}
+    cfg = {"system_prompt": "You are a test coding agent.", **(config or {})}
     provider = AsyncMock()
     if provider_error is not None:
         provider.complete = AsyncMock(side_effect=provider_error)

--- a/modules/loop-agent/tests/test_events.py
+++ b/modules/loop-agent/tests/test_events.py
@@ -66,7 +66,7 @@ def _make_mock_tool(name: str, output: str = "ok") -> MagicMock:
 
 def _make_harness(config=None, responses=None, tool_names=None):
     """Build orchestrator + mocks for testing events."""
-    cfg = config or {}
+    cfg = {"system_prompt": "You are a test coding agent.", **(config or {})}
     provider = AsyncMock()
     provider.complete = AsyncMock(
         side_effect=responses or [_text_response("done")]

--- a/modules/loop-agent/tests/test_integration_smoke.py
+++ b/modules/loop-agent/tests/test_integration_smoke.py
@@ -130,7 +130,7 @@ async def test_smoke_step1_file_creation():
         "delegate": _make_mock_tool("delegate"),
     }
 
-    orch = AgentOrchestrator(coordinator=MagicMock(), config={})
+    orch = AgentOrchestrator(coordinator=MagicMock(), config={"system_prompt": "You are a test coding agent."})
     result = await orch.execute(
         "Create a file called hello.py that prints 'Hello World'",
         MagicMock(),
@@ -217,7 +217,7 @@ async def test_smoke_step2_read_and_edit():
         "bash": _make_mock_tool("bash"),
     }
 
-    orch = AgentOrchestrator(coordinator=MagicMock(), config={})
+    orch = AgentOrchestrator(coordinator=MagicMock(), config={"system_prompt": "You are a test coding agent."})
 
     # First call: create file
     r1 = await orch.execute(
@@ -281,7 +281,7 @@ async def test_smoke_step3_shell_execution():
         "read_file": _make_mock_tool("read_file"),
     }
 
-    orch = AgentOrchestrator(coordinator=MagicMock(), config={})
+    orch = AgentOrchestrator(coordinator=MagicMock(), config={"system_prompt": "You are a test coding agent."})
     await orch.execute(
         "Run hello.py and show the output",
         MagicMock(),
@@ -337,7 +337,7 @@ async def test_smoke_step4_truncation():
     )
     tools = {"read_file": big_tool}
 
-    orch = AgentOrchestrator(coordinator=MagicMock(), config={})
+    orch = AgentOrchestrator(coordinator=MagicMock(), config={"system_prompt": "You are a test coding agent."})
     result = await orch.execute(
         "Read big.txt",
         MagicMock(),
@@ -399,7 +399,7 @@ async def test_smoke_step5_steering():
         "read_file": _make_mock_tool("read_file"),
     }
 
-    orch = AgentOrchestrator(coordinator=MagicMock(), config={})
+    orch = AgentOrchestrator(coordinator=MagicMock(), config={"system_prompt": "You are a test coding agent."})
 
     # Queue steering before execute
     orch.steer("Actually, just create a single /health endpoint for now")
@@ -476,7 +476,7 @@ async def test_smoke_step6_subagent():
         "read_file": _make_mock_tool("read_file"),
     }
 
-    orch = AgentOrchestrator(coordinator=MagicMock(), config={})
+    orch = AgentOrchestrator(coordinator=MagicMock(), config={"system_prompt": "You are a test coding agent."})
     result = await orch.execute(
         "Spawn a subagent to write tests for hello.py, then review its output",
         MagicMock(),
@@ -539,7 +539,7 @@ async def test_smoke_step7_timeout_handling():
     )
     tools = {"bash": bash_tool}
 
-    orch = AgentOrchestrator(coordinator=MagicMock(), config={})
+    orch = AgentOrchestrator(coordinator=MagicMock(), config={"system_prompt": "You are a test coding agent."})
     result = await orch.execute(
         "Run 'sleep 30' with the default timeout",
         MagicMock(),
@@ -657,7 +657,7 @@ async def test_smoke_full_sequence():
         "delegate": _make_mock_tool("delegate", "Tests created."),
     }
 
-    orch = AgentOrchestrator(coordinator=MagicMock(), config={})
+    orch = AgentOrchestrator(coordinator=MagicMock(), config={"system_prompt": "You are a test coding agent."})
 
     # Step 1: File creation
     r1 = await orch.execute(

--- a/modules/loop-agent/tests/test_loop_detection.py
+++ b/modules/loop-agent/tests/test_loop_detection.py
@@ -56,7 +56,7 @@ def _make_harness(
     responses: list[ChatResponse] | None = None,
     tool_names: list[str] | None = None,
 ):
-    cfg = config or {}
+    cfg = {"system_prompt": "You are a test coding agent.", **(config or {})}
     provider = AsyncMock()
     provider.complete = AsyncMock(
         side_effect=responses or [_text_response("done")]

--- a/modules/loop-agent/tests/test_mount.py
+++ b/modules/loop-agent/tests/test_mount.py
@@ -43,6 +43,6 @@ async def test_orchestrator_has_execute_method():
     """AgentOrchestrator must have an execute method (Orchestrator protocol)."""
     from amplifier_module_loop_agent import AgentOrchestrator
 
-    orchestrator = AgentOrchestrator(coordinator=MagicMock(), config={})
+    orchestrator = AgentOrchestrator(coordinator=MagicMock(), config={"system_prompt": "You are a test coding agent."})
     assert hasattr(orchestrator, "execute")
     assert callable(orchestrator.execute)

--- a/modules/loop-agent/tests/test_parallel_gating.py
+++ b/modules/loop-agent/tests/test_parallel_gating.py
@@ -89,7 +89,7 @@ class TestConfigFlag:
     """Tests for the supports_parallel_tool_calls config field."""
 
     def test_default_is_true(self):
-        config = SessionConfig()
+        config = SessionConfig(system_prompt="You are a test coding agent.")
         assert config.supports_parallel_tool_calls is True
 
     def test_can_set_false(self):
@@ -128,7 +128,7 @@ async def test_sequential_when_parallel_disabled():
     hooks = _make_hooks()
 
     session = AgentSession(
-        config=SessionConfig(supports_parallel_tool_calls=False),
+        config=SessionConfig(system_prompt="You are a test coding agent.", supports_parallel_tool_calls=False),
         provider=provider,
         tools={"tool_a": tool_a, "tool_b": tool_b},
         hooks=hooks,
@@ -165,7 +165,7 @@ async def test_sequential_preserves_order():
     hooks = _make_hooks()
 
     session = AgentSession(
-        config=SessionConfig(supports_parallel_tool_calls=False),
+        config=SessionConfig(system_prompt="You are a test coding agent.", supports_parallel_tool_calls=False),
         provider=provider,
         tools=tools,
         hooks=hooks,
@@ -195,7 +195,7 @@ async def test_sequential_timing():
     hooks = _make_hooks()
 
     session = AgentSession(
-        config=SessionConfig(supports_parallel_tool_calls=False),
+        config=SessionConfig(system_prompt="You are a test coding agent.", supports_parallel_tool_calls=False),
         provider=provider,
         tools={"tool_a": tool_a, "tool_b": tool_b},
         hooks=hooks,
@@ -235,7 +235,7 @@ async def test_parallel_when_enabled_and_multiple():
     hooks = _make_hooks()
 
     session = AgentSession(
-        config=SessionConfig(supports_parallel_tool_calls=True),
+        config=SessionConfig(system_prompt="You are a test coding agent.", supports_parallel_tool_calls=True),
         provider=provider,
         tools={"tool_a": tool_a, "tool_b": tool_b},
         hooks=hooks,
@@ -268,7 +268,7 @@ async def test_single_tool_always_sequential():
     hooks = _make_hooks()
 
     session = AgentSession(
-        config=SessionConfig(supports_parallel_tool_calls=True),
+        config=SessionConfig(system_prompt="You are a test coding agent.", supports_parallel_tool_calls=True),
         provider=provider,
         tools={"tool_a": tool_a},
         hooks=hooks,

--- a/modules/loop-agent/tests/test_parity_matrix.py
+++ b/modules/loop-agent/tests/test_parity_matrix.py
@@ -80,7 +80,7 @@ def _make_harness(
 
     Returns (orchestrator, context, providers, tools, hooks).
     """
-    cfg = config or {}
+    cfg = {"system_prompt": "You are a test coding agent.", **(config or {})}
 
     provider = AsyncMock()
     provider.complete = AsyncMock(

--- a/modules/loop-agent/tests/test_provider_aligned_tools.py
+++ b/modules/loop-agent/tests/test_provider_aligned_tools.py
@@ -352,7 +352,7 @@ class TestSystemPromptFromConfig:
 
         orch = AgentOrchestrator(
             coordinator=coordinator,
-            config={"max_tool_rounds_per_input": 1},
+            config={"system_prompt": "You are a test coding agent.", "max_tool_rounds_per_input": 1},
         )
         await orch.execute("hello", MagicMock(), {"test": provider}, {}, hooks)
 
@@ -388,7 +388,7 @@ class TestOnlyMountedToolsInRequest:
 
         orch = AgentOrchestrator(
             coordinator=coordinator,
-            config={"max_tool_rounds_per_input": 1},
+            config={"system_prompt": "You are a test coding agent.", "max_tool_rounds_per_input": 1},
         )
         await orch.execute("hello", MagicMock(), {"openai": provider}, tools, hooks)
 
@@ -427,7 +427,7 @@ class TestOnlyMountedToolsInRequest:
 
         orch = AgentOrchestrator(
             coordinator=coordinator,
-            config={"max_tool_rounds_per_input": 1},
+            config={"system_prompt": "You are a test coding agent.", "max_tool_rounds_per_input": 1},
         )
         await orch.execute("hello", MagicMock(), {"anthropic": provider}, tools, hooks)
 
@@ -447,7 +447,7 @@ class TestOnlyMountedToolsInRequest:
         # Disable subagent tools by setting max_subagent_depth=0
         orch = AgentOrchestrator(
             coordinator=coordinator,
-            config={"max_tool_rounds_per_input": 1, "max_subagent_depth": 0},
+            config={"system_prompt": "You are a test coding agent.", "max_tool_rounds_per_input": 1, "max_subagent_depth": 0},
         )
         await orch.execute("hello", MagicMock(), {"test": provider}, {}, hooks)
 
@@ -464,7 +464,7 @@ class TestOnlyMountedToolsInRequest:
 
         orch = AgentOrchestrator(
             coordinator=coordinator,
-            config={"max_tool_rounds_per_input": 1},
+            config={"system_prompt": "You are a test coding agent.", "max_tool_rounds_per_input": 1},
         )
         await orch.execute("hello", MagicMock(), {"test": provider}, {}, hooks)
 
@@ -487,7 +487,7 @@ class TestOnlyMountedToolsInRequest:
 
         orch = AgentOrchestrator(
             coordinator=coordinator,
-            config={"max_tool_rounds_per_input": 1},
+            config={"system_prompt": "You are a test coding agent.", "max_tool_rounds_per_input": 1},
         )
         await orch.execute("hello", MagicMock(), {"openai": provider}, tools, hooks)
 
@@ -510,7 +510,7 @@ class TestOnlyMountedToolsInRequest:
 
         orch = AgentOrchestrator(
             coordinator=coordinator,
-            config={"max_tool_rounds_per_input": 1, "max_subagent_depth": 0},
+            config={"system_prompt": "You are a test coding agent.", "max_tool_rounds_per_input": 1, "max_subagent_depth": 0},
         )
         await orch.execute("hello", MagicMock(), {"openai": provider}, tools, hooks)
 

--- a/modules/loop-agent/tests/test_session_end_timing.py
+++ b/modules/loop-agent/tests/test_session_end_timing.py
@@ -55,7 +55,7 @@ async def test_session_end_emitted_exactly_once_no_followups():
     hooks = _make_hooks()
 
     session = AgentSession(
-        config=SessionConfig(),
+        config=SessionConfig(system_prompt="You are a test coding agent."),
         provider=provider,
         tools={"read_file": _make_mock_tool("read_file")},
         hooks=hooks,
@@ -84,7 +84,7 @@ async def test_session_end_after_followups_drained():
     hooks = _make_hooks()
 
     session = AgentSession(
-        config=SessionConfig(),
+        config=SessionConfig(system_prompt="You are a test coding agent."),
         provider=provider,
         tools={"read_file": _make_mock_tool("read_file")},
         hooks=hooks,
@@ -118,7 +118,7 @@ async def test_session_end_is_last_lifecycle_event():
     hooks = _make_hooks()
 
     session = AgentSession(
-        config=SessionConfig(),
+        config=SessionConfig(system_prompt="You are a test coding agent."),
         provider=provider,
         tools={},
         hooks=hooks,
@@ -160,7 +160,7 @@ async def test_multiple_followups_single_session_end():
     hooks = _make_hooks()
 
     session = AgentSession(
-        config=SessionConfig(),
+        config=SessionConfig(system_prompt="You are a test coding agent."),
         provider=provider,
         tools={},
         hooks=hooks,

--- a/modules/loop-agent/tests/test_steering.py
+++ b/modules/loop-agent/tests/test_steering.py
@@ -58,7 +58,7 @@ def _make_harness(
     responses: list[ChatResponse] | None = None,
     tool_names: list[str] | None = None,
 ):
-    cfg = config or {}
+    cfg = {"system_prompt": "You are a test coding agent.", **(config or {})}
     provider = AsyncMock()
     provider.complete = AsyncMock(
         side_effect=responses or [_text_response("done")]

--- a/modules/loop-agent/tests/test_streaming.py
+++ b/modules/loop-agent/tests/test_streaming.py
@@ -81,7 +81,7 @@ def _make_harness(config=None, responses=None, tool_names=None):
 
     Returns (orchestrator, context, providers, tools, hooks).
     """
-    cfg = config or {}
+    cfg = {"system_prompt": "You are a test coding agent.", **(config or {})}
     provider = AsyncMock()
     provider.complete = AsyncMock(side_effect=responses or [_text_response("done")])
     providers = {"test": provider}
@@ -160,7 +160,7 @@ async def test_streaming_provider_emits_text_start_event():
     tools = {"read_file": _make_mock_tool("read_file")}
     hooks = _make_recording_hooks()
 
-    orch = AgentOrchestrator(coordinator=MagicMock(), config={})
+    orch = AgentOrchestrator(coordinator=MagicMock(), config={"system_prompt": "You are a test coding agent."})
     await orch.execute("hi", MagicMock(), providers, tools, hooks)
 
     event_names = [e[0] for e in hooks._emitted]
@@ -181,7 +181,7 @@ async def test_streaming_provider_emits_text_delta_events():
     tools = {"read_file": _make_mock_tool("read_file")}
     hooks = _make_recording_hooks()
 
-    orch = AgentOrchestrator(coordinator=MagicMock(), config={})
+    orch = AgentOrchestrator(coordinator=MagicMock(), config={"system_prompt": "You are a test coding agent."})
     await orch.execute("hi", MagicMock(), providers, tools, hooks)
 
     delta_events = [e for e in hooks._emitted if e[0] == AGENT_ASSISTANT_TEXT_DELTA]
@@ -202,7 +202,7 @@ async def test_streaming_provider_emits_text_end_with_full_text():
     tools = {"read_file": _make_mock_tool("read_file")}
     hooks = _make_recording_hooks()
 
-    orch = AgentOrchestrator(coordinator=MagicMock(), config={})
+    orch = AgentOrchestrator(coordinator=MagicMock(), config={"system_prompt": "You are a test coding agent."})
     await orch.execute("hi", MagicMock(), providers, tools, hooks)
 
     end_events = [e for e in hooks._emitted if e[0] == AGENT_ASSISTANT_TEXT_END]
@@ -221,7 +221,7 @@ async def test_streaming_returns_assembled_text():
     providers = {"test": provider}
     hooks = _make_recording_hooks()
 
-    orch = AgentOrchestrator(coordinator=MagicMock(), config={})
+    orch = AgentOrchestrator(coordinator=MagicMock(), config={"system_prompt": "You are a test coding agent."})
     result = await orch.execute("hi", MagicMock(), providers, {}, hooks)
     assert result == "Hello world"
 
@@ -237,7 +237,7 @@ async def test_streaming_does_not_call_provider_complete():
     providers = {"test": provider}
     hooks = _make_recording_hooks()
 
-    orch = AgentOrchestrator(coordinator=MagicMock(), config={})
+    orch = AgentOrchestrator(coordinator=MagicMock(), config={"system_prompt": "You are a test coding agent."})
     await orch.execute("hi", MagicMock(), providers, {}, hooks)
 
     provider.complete.assert_not_called()
@@ -294,7 +294,7 @@ async def test_streaming_with_tool_calls_then_text():
     tools = {"read_file": _make_mock_tool("read_file")}
     hooks = _make_recording_hooks()
 
-    orch = AgentOrchestrator(coordinator=MagicMock(), config={})
+    orch = AgentOrchestrator(coordinator=MagicMock(), config={"system_prompt": "You are a test coding agent."})
     result = await orch.execute("read it", MagicMock(), providers, tools, hooks)
 
     assert result == "All done"
@@ -322,7 +322,7 @@ async def test_streaming_event_order():
     providers = {"test": provider}
     hooks = _make_recording_hooks()
 
-    orch = AgentOrchestrator(coordinator=MagicMock(), config={})
+    orch = AgentOrchestrator(coordinator=MagicMock(), config={"system_prompt": "You are a test coding agent."})
     await orch.execute("hi", MagicMock(), providers, {}, hooks)
 
     event_names = [e[0] for e in hooks._emitted]
@@ -365,7 +365,7 @@ async def test_streaming_collects_usage():
     providers = {"test": provider}
     hooks = _make_recording_hooks()
 
-    orch = AgentOrchestrator(coordinator=MagicMock(), config={})
+    orch = AgentOrchestrator(coordinator=MagicMock(), config={"system_prompt": "You are a test coding agent."})
     result = await orch.execute("hi", MagicMock(), providers, {}, hooks)
 
     assert result == "Hi"

--- a/modules/loop-agent/tests/test_subagent_tools.py
+++ b/modules/loop-agent/tests/test_subagent_tools.py
@@ -560,7 +560,7 @@ class TestOrchestratorWiring:
         hooks = MagicMock()
         hooks.emit = AsyncMock(return_value=MagicMock(action="continue"))
 
-        orch = AgentOrchestrator(coordinator, {"max_subagent_depth": 1})
+        orch = AgentOrchestrator(coordinator, {"system_prompt": "You are a test coding agent.", "max_subagent_depth": 1})
         await orch.execute("hi", MagicMock(), {"test": provider}, {}, hooks)
 
         # Session should have the 4 subagent tools
@@ -590,7 +590,7 @@ class TestOrchestratorWiring:
 
         # current_depth=1, max_subagent_depth=1 => no subagent tools
         orch = AgentOrchestrator(
-            coordinator, {"max_subagent_depth": 1, "current_depth": 1}
+            coordinator, {"system_prompt": "You are a test coding agent.", "max_subagent_depth": 1, "current_depth": 1}
         )
         await orch.execute("hi", MagicMock(), {"test": provider}, {}, hooks)
 

--- a/modules/loop-agent/tests/test_subagents.py
+++ b/modules/loop-agent/tests/test_subagents.py
@@ -34,7 +34,7 @@ def _make_harness(
     config: dict | None = None,
     responses: list[ChatResponse] | None = None,
 ):
-    cfg = config or {}
+    cfg = {"system_prompt": "You are a test coding agent.", **(config or {})}
     provider = AsyncMock()
     provider.complete = AsyncMock(
         side_effect=responses or [_text_response("done")]

--- a/modules/loop-agent/tests/test_system_prompt_wiring.py
+++ b/modules/loop-agent/tests/test_system_prompt_wiring.py
@@ -255,7 +255,9 @@ async def test_orchestrator_passes_provider_name():
 
     orch = AgentOrchestrator(
         coordinator=coordinator,
-        config={"system_prompt": "Agent prompt.", "max_tool_rounds_per_input": 1},
+        # No system_prompt: the anthropic provider DEFAULT supplies Layer-1, so
+        # this test no longer needs a guard-satisfying dummy (ripple shrink).
+        config={"max_tool_rounds_per_input": 1},
     )
     await orch.execute("hi", MagicMock(), {"anthropic": provider}, {}, hooks)
 
@@ -477,11 +479,13 @@ async def test_system_prompt_takes_precedence_over_system_prompt_file(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_empty_system_prompt_raises_loud_error():
-    """Empty Layer-1 (no system_prompt, no resolvable system_prompt_file) raises RuntimeError.
+async def test_unknown_provider_with_no_base_raises_loud_error():
+    """Precedence (4): unknown provider + no explicit base raises a clear RuntimeError.
 
-    Design §C (fail-loud): an empty Layer-1 is a configuration error, not a
-    recoverable runtime condition.  The silent stub is gone.
+    With the provider-default in place, a KNOWN provider (anthropic/openai/gemini)
+    always resolves a default base. The fail-loud path is now an UNKNOWN provider
+    with no system_prompt / system_prompt_file: there is no default to apply and
+    we must NOT silently pick a wrong one.
     """
     context = MagicMock()
     provider = AsyncMock()
@@ -494,8 +498,62 @@ async def test_empty_system_prompt_raises_loud_error():
         coordinator=coordinator,
         config={"max_tool_rounds_per_input": 1},  # no system_prompt, no file
     )
-    with pytest.raises(RuntimeError, match="Layer-1 base prompt is empty"):
-        await orch.execute("hello", context, {"anthropic": provider}, {}, hooks)
+    with pytest.raises(RuntimeError, match="not one of the known providers"):
+        # "test" is not a known provider -> no default -> fail loud.
+        await orch.execute("hello", context, {"test": provider}, {}, hooks)
+
+
+@pytest.mark.asyncio
+async def test_provider_default_base_prompt_loaded_for_known_provider():
+    """Precedence (3): with no explicit base, a known provider loads its default.
+
+    An anthropic agent with NO system_prompt / system_prompt_file resolves the
+    bundle's context/system-anthropic.md provider default into Layer-1 — this is
+    what lets the 30 per-YAML system_prompt_file lines be removed.
+    """
+    context = MagicMock()
+    provider = AsyncMock()
+    provider.complete = AsyncMock(return_value=_text_response("done"))
+    hooks = _make_hooks()
+    coordinator = MagicMock()
+    coordinator.register_capability = MagicMock()
+
+    orch = AgentOrchestrator(
+        coordinator=coordinator,
+        config={"max_tool_rounds_per_input": 1},  # no base configured at all
+    )
+    await orch.execute("hello", context, {"anthropic": provider}, {}, hooks)
+
+    request = provider.complete.call_args[0][0]
+    system_content = request.messages[0].content
+    # The real Anthropic provider base ships this sentinel heading.
+    assert "Anthropic Profile" in system_content or "Claude Code" in system_content, (
+        f"provider-default base not loaded into Layer-1. Got: {system_content[:200]}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_explicit_config_overrides_provider_default():
+    """Precedence (1) beats (3): explicit system_prompt wins over the provider default."""
+    context = MagicMock()
+    provider = AsyncMock()
+    provider.complete = AsyncMock(return_value=_text_response("done"))
+    hooks = _make_hooks()
+    coordinator = MagicMock()
+    coordinator.register_capability = MagicMock()
+
+    SENTINEL = "EXPLICIT-OVERRIDE-WINS-Q7"
+    orch = AgentOrchestrator(
+        coordinator=coordinator,
+        config={"system_prompt": SENTINEL, "max_tool_rounds_per_input": 1},
+    )
+    await orch.execute("hello", context, {"anthropic": provider}, {}, hooks)
+
+    request = provider.complete.call_args[0][0]
+    system_content = request.messages[0].content
+    assert SENTINEL in system_content
+    # The provider default must NOT have been loaded on top of the explicit base.
+    assert "Anthropic Profile" not in system_content
 
 
 # ---------------------------------------------------------------------------

--- a/modules/loop-agent/tests/test_system_prompt_wiring.py
+++ b/modules/loop-agent/tests/test_system_prompt_wiring.py
@@ -12,7 +12,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 from amplifier_core.message_models import ChatResponse, Usage
 
-from amplifier_module_loop_agent import AgentOrchestrator
+from amplifier_module_loop_agent import AgentOrchestrator, _resolve_system_prompt_file
 from amplifier_module_loop_agent.agent_session import AgentSession
 from amplifier_module_loop_agent.config import SessionConfig
 
@@ -52,16 +52,21 @@ def _make_hooks():
 async def test_system_prompt_included_in_chat_request():
     """The first message in every ChatRequest must be a system message
     containing the base prompt from config."""
-    config = SessionConfig.from_dict({
-        "system_prompt": "You are a coding agent.",
-        "max_tool_rounds_per_input": 1,
-    })
+    config = SessionConfig.from_dict(
+        {
+            "system_prompt": "You are a coding agent.",
+            "max_tool_rounds_per_input": 1,
+        }
+    )
     provider = AsyncMock()
     provider.complete = AsyncMock(return_value=_text_response("done"))
     hooks = _make_hooks()
 
     session = AgentSession(
-        config=config, provider=provider, tools={}, hooks=hooks,
+        config=config,
+        provider=provider,
+        tools={},
+        hooks=hooks,
     )
     await session.process_input("hello")
 
@@ -75,19 +80,26 @@ async def test_system_prompt_included_in_chat_request():
 @pytest.mark.asyncio
 async def test_system_prompt_rebuilt_every_iteration():
     """System prompt must be rebuilt every LLM call (spec PROV-002)."""
-    config = SessionConfig.from_dict({
-        "system_prompt": "Base prompt.",
-        "max_tool_rounds_per_input": 5,
-    })
+    config = SessionConfig.from_dict(
+        {
+            "system_prompt": "Base prompt.",
+            "max_tool_rounds_per_input": 5,
+        }
+    )
     provider = AsyncMock()
-    provider.complete = AsyncMock(side_effect=[
-        _text_response("first"),
-        _text_response("second"),
-    ])
+    provider.complete = AsyncMock(
+        side_effect=[
+            _text_response("first"),
+            _text_response("second"),
+        ]
+    )
     hooks = _make_hooks()
 
     session = AgentSession(
-        config=config, provider=provider, tools={}, hooks=hooks,
+        config=config,
+        provider=provider,
+        tools={},
+        hooks=hooks,
     )
     # Two separate calls = two ChatRequests, each should have system prompt
     await session.process_input("hello")
@@ -108,17 +120,23 @@ async def test_system_prompt_rebuilt_every_iteration():
 @pytest.mark.asyncio
 async def test_environment_context_in_system_prompt():
     """System prompt must contain <environment> block with working dir."""
-    config = SessionConfig.from_dict({
-        "system_prompt": "Base prompt.",
-        "max_tool_rounds_per_input": 1,
-    })
+    config = SessionConfig.from_dict(
+        {
+            "system_prompt": "Base prompt.",
+            "max_tool_rounds_per_input": 1,
+        }
+    )
     provider = AsyncMock()
     provider.complete = AsyncMock(return_value=_text_response("done"))
     hooks = _make_hooks()
 
     session = AgentSession(
-        config=config, provider=provider, tools={}, hooks=hooks,
-        provider_name="anthropic", model="claude-sonnet-4-5",
+        config=config,
+        provider=provider,
+        tools={},
+        hooks=hooks,
+        provider_name="anthropic",
+        model="claude-sonnet-4-5",
     )
     await session.process_input("hello")
 
@@ -131,17 +149,23 @@ async def test_environment_context_in_system_prompt():
 @pytest.mark.asyncio
 async def test_environment_context_includes_provider_and_model():
     """Environment block includes provider and model when supplied."""
-    config = SessionConfig.from_dict({
-        "system_prompt": "Base.",
-        "max_tool_rounds_per_input": 1,
-    })
+    config = SessionConfig.from_dict(
+        {
+            "system_prompt": "Base.",
+            "max_tool_rounds_per_input": 1,
+        }
+    )
     provider = AsyncMock()
     provider.complete = AsyncMock(return_value=_text_response("done"))
     hooks = _make_hooks()
 
     session = AgentSession(
-        config=config, provider=provider, tools={}, hooks=hooks,
-        provider_name="openai", model="gpt-5",
+        config=config,
+        provider=provider,
+        tools={},
+        hooks=hooks,
+        provider_name="openai",
+        model="gpt-5",
     )
     await session.process_input("hi")
 
@@ -163,17 +187,22 @@ async def test_project_docs_discovered_for_provider(tmp_path):
     agents_md = tmp_path / "AGENTS.md"
     agents_md.write_text("# Project Rules\nAlways use TDD.")
 
-    config = SessionConfig.from_dict({
-        "system_prompt": "Base.",
-        "max_tool_rounds_per_input": 1,
-        "working_dir": str(tmp_path),
-    })
+    config = SessionConfig.from_dict(
+        {
+            "system_prompt": "Base.",
+            "max_tool_rounds_per_input": 1,
+            "working_dir": str(tmp_path),
+        }
+    )
     provider = AsyncMock()
     provider.complete = AsyncMock(return_value=_text_response("done"))
     hooks = _make_hooks()
 
     session = AgentSession(
-        config=config, provider=provider, tools={}, hooks=hooks,
+        config=config,
+        provider=provider,
+        tools={},
+        hooks=hooks,
         provider_name="anthropic",
     )
     await session.process_input("hello")
@@ -186,17 +215,22 @@ async def test_project_docs_discovered_for_provider(tmp_path):
 @pytest.mark.asyncio
 async def test_no_project_docs_when_none_exist(tmp_path):
     """System prompt still works when no project doc files exist."""
-    config = SessionConfig.from_dict({
-        "system_prompt": "Base.",
-        "max_tool_rounds_per_input": 1,
-        "working_dir": str(tmp_path),
-    })
+    config = SessionConfig.from_dict(
+        {
+            "system_prompt": "Base.",
+            "max_tool_rounds_per_input": 1,
+            "working_dir": str(tmp_path),
+        }
+    )
     provider = AsyncMock()
     provider.complete = AsyncMock(return_value=_text_response("done"))
     hooks = _make_hooks()
 
     session = AgentSession(
-        config=config, provider=provider, tools={}, hooks=hooks,
+        config=config,
+        provider=provider,
+        tools={},
+        hooks=hooks,
     )
     await session.process_input("hello")
 
@@ -239,17 +273,22 @@ async def test_orchestrator_passes_provider_name():
 @pytest.mark.asyncio
 async def test_user_instructions_appended_as_layer5():
     """Config with user_instructions → system prompt ends with that instruction."""
-    config = SessionConfig.from_dict({
-        "system_prompt": "Base prompt.",
-        "max_tool_rounds_per_input": 1,
-        "user_instructions": "Always respond in French",
-    })
+    config = SessionConfig.from_dict(
+        {
+            "system_prompt": "Base prompt.",
+            "max_tool_rounds_per_input": 1,
+            "user_instructions": "Always respond in French",
+        }
+    )
     provider = AsyncMock()
     provider.complete = AsyncMock(return_value=_text_response("done"))
     hooks = _make_hooks()
 
     session = AgentSession(
-        config=config, provider=provider, tools={}, hooks=hooks,
+        config=config,
+        provider=provider,
+        tools={},
+        hooks=hooks,
     )
     await session.process_input("hello")
 
@@ -263,16 +302,21 @@ async def test_user_instructions_appended_as_layer5():
 @pytest.mark.asyncio
 async def test_no_user_instructions_omits_layer5():
     """No user_instructions config → no User Instructions section in prompt."""
-    config = SessionConfig.from_dict({
-        "system_prompt": "Base prompt.",
-        "max_tool_rounds_per_input": 1,
-    })
+    config = SessionConfig.from_dict(
+        {
+            "system_prompt": "Base prompt.",
+            "max_tool_rounds_per_input": 1,
+        }
+    )
     provider = AsyncMock()
     provider.complete = AsyncMock(return_value=_text_response("done"))
     hooks = _make_hooks()
 
     session = AgentSession(
-        config=config, provider=provider, tools={}, hooks=hooks,
+        config=config,
+        provider=provider,
+        tools={},
+        hooks=hooks,
     )
     await session.process_input("hello")
 
@@ -284,10 +328,12 @@ async def test_no_user_instructions_omits_layer5():
 @pytest.mark.asyncio
 async def test_tool_descriptions_in_system_prompt():
     """Mounted tools appear in the system prompt's tool descriptions layer."""
-    config = SessionConfig.from_dict({
-        "system_prompt": "Base.",
-        "max_tool_rounds_per_input": 1,
-    })
+    config = SessionConfig.from_dict(
+        {
+            "system_prompt": "Base.",
+            "max_tool_rounds_per_input": 1,
+        }
+    )
     provider = AsyncMock()
     provider.complete = AsyncMock(return_value=_text_response("done"))
     hooks = _make_hooks()
@@ -299,7 +345,8 @@ async def test_tool_descriptions_in_system_prompt():
     tool.input_schema = {"type": "object", "properties": {}}
 
     session = AgentSession(
-        config=config, provider=provider,
+        config=config,
+        provider=provider,
         tools={"read_file": tool},
         hooks=hooks,
     )
@@ -449,3 +496,97 @@ async def test_empty_system_prompt_raises_loud_error():
     )
     with pytest.raises(RuntimeError, match="Layer-1 base prompt is empty"):
         await orch.execute("hello", context, {"anthropic": provider}, {}, hooks)
+
+
+# ---------------------------------------------------------------------------
+# _resolve_system_prompt_file: CWD-independent, fail-loud path resolution
+# (must-fix 1 — council BLOCKER)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_relative_system_prompt_file_is_cwd_independent(monkeypatch):
+    """A RELATIVE system_prompt_file resolves to the bundle-root file regardless of CWD.
+
+    Council BLOCKER: resolution must anchor on the module's __file__, never the
+    process working directory. We prove this by chdir'ing to an unrelated dir
+    (/tmp) and confirming the attractor bundle's own context/system-anthropic.md
+    still resolves and is readable. This is exactly what lets a different consumer
+    (e.g. the dot-graph resolver), launched from anywhere, reuse attractor's prompts.
+    """
+    import os
+    import tempfile
+
+    # The loop-agent module installs editable inside the attractor bundle, so the
+    # bundle ships these provider base prompts at <bundle-root>/context/.
+    rel = "context/system-anthropic.md"
+
+    with tempfile.TemporaryDirectory() as other_cwd:
+        monkeypatch.chdir(other_cwd)
+        assert os.getcwd() == os.path.realpath(other_cwd) or os.getcwd() == other_cwd
+
+        resolved = _resolve_system_prompt_file(rel)
+
+        assert resolved.is_absolute()
+        assert resolved.is_file(), f"expected an existing file, got {resolved}"
+        assert resolved.name == "system-anthropic.md"
+        # Resolved against the module's bundle root, NOT the (temp) CWD.
+        assert str(other_cwd) not in str(resolved)
+        # And it is genuinely readable (the content becomes Layer-1).
+        assert resolved.read_text(encoding="utf-8").strip()
+
+
+def test_resolve_relative_system_prompt_file_same_from_any_cwd(monkeypatch):
+    """Resolution is deterministic: the same absolute path from two different CWDs."""
+    import tempfile
+
+    rel = "context/system-gemini.md"
+
+    with tempfile.TemporaryDirectory() as cwd_a:
+        monkeypatch.chdir(cwd_a)
+        resolved_a = _resolve_system_prompt_file(rel)
+    with tempfile.TemporaryDirectory() as cwd_b:
+        monkeypatch.chdir(cwd_b)
+        resolved_b = _resolve_system_prompt_file(rel)
+
+    assert resolved_a == resolved_b
+
+
+def test_resolve_missing_relative_file_raises_clear_actionable_error(monkeypatch):
+    """A missing RELATIVE file raises a clear error naming the value AND a tried path."""
+    import tempfile
+
+    bogus = "context/system-does-not-exist-zzz.md"
+
+    with tempfile.TemporaryDirectory() as other_cwd:
+        monkeypatch.chdir(other_cwd)
+        with pytest.raises(FileNotFoundError) as exc:
+            _resolve_system_prompt_file(bogus)
+
+    msg = str(exc.value)
+    # Names the configured value...
+    assert bogus in msg
+    # ...names an absolute path it tried (not a bare "not found")...
+    assert "system-does-not-exist-zzz.md" in msg
+    # ...and states it is CWD-independent (so the user doesn't chase a CWD red herring).
+    assert "working directory" in msg.lower()
+    # ...and points at the fix / design doc.
+    assert "system_prompt_file" in msg
+
+
+def test_resolve_missing_absolute_file_raises_clear_error(tmp_path):
+    """A missing ABSOLUTE file raises a clear error naming the path."""
+    missing = tmp_path / "nope" / "base.md"
+    with pytest.raises(FileNotFoundError) as exc:
+        _resolve_system_prompt_file(str(missing))
+    msg = str(exc.value)
+    assert str(missing) in msg
+    assert "system_prompt_file" in msg
+
+
+def test_resolve_existing_absolute_file_used_as_is(tmp_path):
+    """An existing ABSOLUTE file is returned unchanged."""
+    f = tmp_path / "base.md"
+    f.write_text("ABS-BASE", encoding="utf-8")
+    resolved = _resolve_system_prompt_file(str(f))
+    assert resolved == f
+    assert resolved.read_text(encoding="utf-8") == "ABS-BASE"

--- a/modules/loop-agent/tests/test_system_prompt_wiring.py
+++ b/modules/loop-agent/tests/test_system_prompt_wiring.py
@@ -8,7 +8,7 @@ Spec coverage: PROV-002, SYS-001, SYS-005-008, ENVCTX-001-002.
 """
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 from amplifier_core.message_models import ChatResponse, Usage
 
@@ -312,64 +312,25 @@ async def test_tool_descriptions_in_system_prompt():
 
 
 # ---------------------------------------------------------------------------
-# Layer-1 fix: context._system_prompt_factory delivers provider base prompt
-# (nlspec §6.1 — "Provider-specific base instructions (from ProviderProfile)")
+# Profile-owned Layer-1 system prompt (nlspec §6.1 + design §A, §B, §C)
+# ---------------------------------------------------------------------------
+# These tests verify the new profile-owned system prompt mechanism:
+#   A. system_prompt in config → used directly as Layer-1
+#   B. system_prompt_file (absolute path) → loaded and used as Layer-1
+#   C. system_prompt set + system_prompt_file set → system_prompt takes precedence
+#   D. Missing system_prompt (no file) → fail-loud RuntimeError
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_context_factory_provides_layer1_base_prompt():
-    """When context has _system_prompt_factory, its result is used as Layer-1.
+async def test_system_prompt_in_config_is_layer1():
+    """system_prompt in orchestrator config is used directly as Layer-1 (nlspec §6.1).
 
-    Spec §6.1: Layer 1 = "Provider-specific base instructions (from ProviderProfile)".
-    The factory is registered by foundation when context.include is declared in the
-    bundle profile. loop-agent must resolve it in execute() since it builds its own
-    message list and never calls context.get_messages_for_request().
+    Design §A: config.system_prompt is the canonical Layer-1 channel.  There is no
+    factory override — the profile-owned value flows straight through.
     """
-    FACTORY_SENTINEL = "BASE-PROMPT-FROM-FACTORY-X7K9Q2"
-
-    async def mock_factory():
-        return f"# Agent Base\n\n{FACTORY_SENTINEL}\n\nYou are a coding agent."
-
+    SENTINEL = "CONFIG-LAYER1-SENTINEL-X7K9Q2"
     context = MagicMock()
-    context._system_prompt_factory = mock_factory  # real async function
-
-    provider = AsyncMock()
-    provider.complete = AsyncMock(return_value=_text_response("done"))
-    hooks = _make_hooks()
-    coordinator = MagicMock()
-    coordinator.register_capability = MagicMock()
-
-    orch = AgentOrchestrator(
-        coordinator=coordinator,
-        config={"max_tool_rounds_per_input": 1},  # no system_prompt — factory must provide it
-    )
-    await orch.execute("hello", context, {"anthropic": provider}, {}, hooks)
-
-    request = provider.complete.call_args[0][0]
-    system_content = request.messages[0].content
-    assert FACTORY_SENTINEL in system_content, (
-        f"Factory sentinel not found in system prompt. Got: {system_content[:200]}"
-    )
-
-
-@pytest.mark.asyncio
-async def test_context_factory_wins_over_config_system_prompt():
-    """context._system_prompt_factory is primary; system_prompt config is fallback.
-
-    Spec §6.1: the context module delivers "Provider-specific base instructions
-    (from ProviderProfile)". This takes precedence over an explicit system_prompt
-    in orchestrator config. No double-injection: the factory already incorporates
-    the bundle instruction.
-    """
-    FACTORY_SENTINEL = "FACTORY-WINS-SENTINEL-M3P7"
-    CONFIG_SENTINEL = "CONFIG-SYSTEM-PROMPT-SHOULD-NOT-WIN"
-
-    async def mock_factory():
-        return f"# From Factory\n\n{FACTORY_SENTINEL}"
-
-    context = MagicMock()
-    context._system_prompt_factory = mock_factory
 
     provider = AsyncMock()
     provider.complete = AsyncMock(return_value=_text_response("done"))
@@ -380,7 +341,7 @@ async def test_context_factory_wins_over_config_system_prompt():
     orch = AgentOrchestrator(
         coordinator=coordinator,
         config={
-            "system_prompt": CONFIG_SENTINEL,  # explicit config present
+            "system_prompt": f"# Agent Base\n\n{SENTINEL}\n\nYou are a coding agent.",
             "max_tool_rounds_per_input": 1,
         },
     )
@@ -388,56 +349,24 @@ async def test_context_factory_wins_over_config_system_prompt():
 
     request = provider.complete.call_args[0][0]
     system_content = request.messages[0].content
-    # Factory result is the canonical Layer-1; config system_prompt is a fallback
-    assert FACTORY_SENTINEL in system_content, (
-        f"Factory sentinel not found. Got: {system_content[:200]}"
+    assert SENTINEL in system_content, (
+        f"system_prompt sentinel not found in Layer-1. Got: {system_content[:200]}"
     )
 
 
 @pytest.mark.asyncio
-async def test_context_factory_error_falls_back_to_config():
-    """When factory raises, Layer-1 falls back to system_prompt config."""
+async def test_system_prompt_file_loaded_as_layer1(tmp_path):
+    """system_prompt_file (absolute path) is loaded and its content becomes Layer-1.
 
-    async def failing_factory():
-        raise RuntimeError("factory failure")
-
-    context = MagicMock()
-    context._system_prompt_factory = failing_factory
-
-    provider = AsyncMock()
-    provider.complete = AsyncMock(return_value=_text_response("done"))
-    hooks = _make_hooks()
-    coordinator = MagicMock()
-    coordinator.register_capability = MagicMock()
-
-    orch = AgentOrchestrator(
-        coordinator=coordinator,
-        config={"system_prompt": "Fallback prompt.", "max_tool_rounds_per_input": 1},
-    )
-    await orch.execute("hello", context, {"anthropic": provider}, {}, hooks)
-
-    request = provider.complete.call_args[0][0]
-    system_content = request.messages[0].content
-    assert "Fallback prompt." in system_content
-
-
-@pytest.mark.asyncio
-async def test_non_coroutine_factory_not_called():
-    """A non-async _system_prompt_factory attribute is ignored (no call).
-
-    Guards against MagicMock auto-attributes in tests — MagicMock creates a regular
-    (non-coroutine) callable on any attribute access, and calling it as an async
-    function would raise. inspect.iscoroutinefunction ensures we only call real factories.
+    Design §A: loop-agent resolves system_prompt_file at session init and puts the
+    content into config.system_prompt.  Absolute paths bypass bundle-root resolution,
+    making this testable without a real bundle layout.
     """
-    factory_called = []
-
-    def sync_factory():  # NOT async — should be ignored
-        factory_called.append(True)
-        return "should not be used"
+    SENTINEL = "SYSTEM-FILE-SENTINEL-X9K2M"
+    prompt_file = tmp_path / "base-prompt.md"
+    prompt_file.write_text(f"# Provider Base\n\n{SENTINEL}", encoding="utf-8")
 
     context = MagicMock()
-    context._system_prompt_factory = sync_factory
-
     provider = AsyncMock()
     provider.complete = AsyncMock(return_value=_text_response("done"))
     hooks = _make_hooks()
@@ -446,14 +375,77 @@ async def test_non_coroutine_factory_not_called():
 
     orch = AgentOrchestrator(
         coordinator=coordinator,
-        config={"system_prompt": "Config prompt.", "max_tool_rounds_per_input": 1},
+        config={
+            "system_prompt_file": str(prompt_file),  # absolute path
+            "max_tool_rounds_per_input": 1,
+        },
     )
     await orch.execute("hello", context, {"anthropic": provider}, {}, hooks)
 
-    # Sync factory must NOT have been called
-    assert not factory_called, "sync factory should not be called"
-
-    # Config system_prompt should be used instead
     request = provider.complete.call_args[0][0]
     system_content = request.messages[0].content
-    assert "Config prompt." in system_content
+    assert SENTINEL in system_content, (
+        f"system_prompt_file content not found in Layer-1. Got: {system_content[:200]}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_system_prompt_takes_precedence_over_system_prompt_file(tmp_path):
+    """When both system_prompt and system_prompt_file are set, system_prompt wins.
+
+    Design §A: If system_prompt is already present in config (e.g. injected by
+    loop-pipeline backend.py before spawn), system_prompt_file is skipped — single
+    owner, no conflict.
+    """
+    FILE_SENTINEL = "FILE-SHOULD-NOT-WIN"
+    CONFIG_SENTINEL = "CONFIG-PROMPT-WINS-SENTINEL"
+    prompt_file = tmp_path / "base.md"
+    prompt_file.write_text(f"# From File\n\n{FILE_SENTINEL}", encoding="utf-8")
+
+    context = MagicMock()
+    provider = AsyncMock()
+    provider.complete = AsyncMock(return_value=_text_response("done"))
+    hooks = _make_hooks()
+    coordinator = MagicMock()
+    coordinator.register_capability = MagicMock()
+
+    orch = AgentOrchestrator(
+        coordinator=coordinator,
+        config={
+            "system_prompt": CONFIG_SENTINEL,
+            "system_prompt_file": str(prompt_file),
+            "max_tool_rounds_per_input": 1,
+        },
+    )
+    await orch.execute("hello", context, {"anthropic": provider}, {}, hooks)
+
+    request = provider.complete.call_args[0][0]
+    system_content = request.messages[0].content
+    assert CONFIG_SENTINEL in system_content, (
+        f"system_prompt not used. Got: {system_content[:200]}"
+    )
+    assert FILE_SENTINEL not in system_content, (
+        f"system_prompt_file content leaked through. Got: {system_content[:200]}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_empty_system_prompt_raises_loud_error():
+    """Empty Layer-1 (no system_prompt, no resolvable system_prompt_file) raises RuntimeError.
+
+    Design §C (fail-loud): an empty Layer-1 is a configuration error, not a
+    recoverable runtime condition.  The silent stub is gone.
+    """
+    context = MagicMock()
+    provider = AsyncMock()
+    provider.complete = AsyncMock(return_value=_text_response("done"))
+    hooks = _make_hooks()
+    coordinator = MagicMock()
+    coordinator.register_capability = MagicMock()
+
+    orch = AgentOrchestrator(
+        coordinator=coordinator,
+        config={"max_tool_rounds_per_input": 1},  # no system_prompt, no file
+    )
+    with pytest.raises(RuntimeError, match="Layer-1 base prompt is empty"):
+        await orch.execute("hello", context, {"anthropic": provider}, {}, hooks)

--- a/modules/loop-agent/tests/test_tool_output_delta.py
+++ b/modules/loop-agent/tests/test_tool_output_delta.py
@@ -55,7 +55,7 @@ def _make_mock_tool(name: str, output: str = "ok") -> MagicMock:
 
 
 def _make_harness(config=None, responses=None, tool_names=None):
-    cfg = config or {}
+    cfg = {"system_prompt": "You are a test coding agent.", **(config or {})}
     provider = AsyncMock()
     provider.complete = AsyncMock(
         side_effect=responses or [_text_response("done")]

--- a/modules/loop-agent/tests/test_truncation_wiring.py
+++ b/modules/loop-agent/tests/test_truncation_wiring.py
@@ -84,7 +84,7 @@ async def test_tool_post_emitted_after_execution():
     hooks.emit = AsyncMock(side_effect=recording_emit)
 
     session = AgentSession(
-        config=SessionConfig(),
+        config=SessionConfig(system_prompt="You are a test coding agent."),
         provider=provider,
         tools={"read_file": tool},
         hooks=hooks,
@@ -123,7 +123,7 @@ async def test_truncated_output_sent_to_llm():
     hooks.emit = AsyncMock(side_effect=truncating_emit)
 
     session = AgentSession(
-        config=SessionConfig(),
+        config=SessionConfig(system_prompt="You are a test coding agent."),
         provider=provider,
         tools={"read_file": tool},
         hooks=hooks,
@@ -165,7 +165,7 @@ async def test_full_output_in_tool_call_end_event():
     hooks.emit = AsyncMock(side_effect=recording_emit)
 
     session = AgentSession(
-        config=SessionConfig(),
+        config=SessionConfig(system_prompt="You are a test coding agent."),
         provider=provider,
         tools={"read_file": tool},
         hooks=hooks,
@@ -197,7 +197,7 @@ async def test_no_truncation_when_hook_continues():
     hooks.emit = AsyncMock(side_effect=passthrough_emit)
 
     session = AgentSession(
-        config=SessionConfig(),
+        config=SessionConfig(system_prompt="You are a test coding agent."),
         provider=provider,
         tools={"read_file": tool},
         hooks=hooks,

--- a/modules/loop-agent/tests/test_unified_provider_adapter.py
+++ b/modules/loop-agent/tests/test_unified_provider_adapter.py
@@ -985,7 +985,7 @@ async def test_orchestrator_injects_adapter_when_use_unified_llm():
     ) as MockClient:
         MockClient.from_env.return_value = mock_client
 
-        config = {"use_unified_llm": True, "model": "claude-sonnet-4-20250514"}
+        config = {"system_prompt": "You are a test coding agent.", "use_unified_llm": True, "model": "claude-sonnet-4-20250514"}
         coordinator = MagicMock()
         orchestrator = AgentOrchestrator(coordinator=coordinator, config=config)
 
@@ -1023,7 +1023,7 @@ async def test_orchestrator_skips_adapter_when_not_configured():
     native_provider = MagicMock()
     native_provider.complete = AsyncMock(return_value=text_response)
 
-    config = {"model": "claude-sonnet-4-20250514"}  # No use_unified_llm
+    config = {"system_prompt": "You are a test coding agent.", "model": "claude-sonnet-4-20250514"}  # No use_unified_llm
     coordinator = MagicMock()
     orchestrator = AgentOrchestrator(coordinator=coordinator, config=config)
 
@@ -1134,7 +1134,7 @@ async def test_end_to_end_adapter_with_agent_session():
     hooks.emit = AsyncMock(side_effect=_emit)
 
     # Create AgentSession with the ADAPTER as provider
-    config = SessionConfig()
+    config = SessionConfig(system_prompt="You are a test coding agent.")
     session = AgentSession(
         config=config,
         provider=adapter,  # <-- The adapter!

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/backend.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/backend.py
@@ -414,6 +414,17 @@ class AmplifierBackend:
                 f"pipeline profile or bundle config."
             )
 
+        # Resolve runtime user_instructions override (Layer-5, highest precedence).
+        # Sources (first non-empty wins):
+        #   1. node.attrs["user_instructions"] — per-node DOT attribute
+        #   2. PipelineContext["user_instructions"] — per-run caller-supplied override
+        # See docs/designs/layer-1-profile-owned-system-prompt.md §B.
+        node_user_instructions: str | None = node.attrs.get("user_instructions") or None
+        ctx_user_instructions: str | None = (
+            (context.get("user_instructions") or None) if context is not None else None
+        )
+        user_instructions_override = node_user_instructions or ctx_user_instructions
+
         # Build spawn kwargs matching the CLI spawn_capability signature
         spawn_kwargs: dict[str, Any] = {
             "agent_name": profile_name,
@@ -429,6 +440,8 @@ class AmplifierBackend:
                 for k, v in {
                     "reasoning_effort": reasoning_effort,
                     "max_turns": max_agent_turns,
+                    # user_instructions (Layer-5): per-node or per-run override
+                    "user_instructions": user_instructions_override,
                 }.items()
                 if v is not None
             },

--- a/profiles/attractor-e2e-anthropic.yaml
+++ b/profiles/attractor-e2e-anthropic.yaml
@@ -21,6 +21,9 @@ session:
     config:
       max_tool_rounds_per_input: 20
       reasoning_effort: high
+      # Layer-1 base prompt (nlspec §6.1). Core 1.6.0: ONLY system_prompt_file
+      # populates Layer-1 — context.include does NOT — so the base MUST be here.
+      system_prompt_file: context/system-anthropic.md
   context:
     module: context-simple
     source: git+https://github.com/microsoft/amplifier-module-context-simple@main
@@ -37,10 +40,9 @@ tools:
   - module: tool-report-outcome
     source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/tool-report-outcome
 
-context:
-  # '../context/' climbs from this YAML's dir to the bundle-root context/; idiomatic target is 'attractor:context/...' pending foundation namespaced-include support.
-  include:
-    - ../context/system-anthropic.md
+# Layer-1 base is delivered via session.orchestrator.config.system_prompt_file
+# above (core 1.6.0: context.include does NOT populate Layer-1). No additive
+# context files needed, so the context.include block is intentionally absent.
 
 hooks:
   - module: hooks-tool-truncation

--- a/profiles/attractor-e2e-anthropic.yaml
+++ b/profiles/attractor-e2e-anthropic.yaml
@@ -21,9 +21,6 @@ session:
     config:
       max_tool_rounds_per_input: 20
       reasoning_effort: high
-      # Layer-1 base prompt (nlspec §6.1). Core 1.6.0: ONLY system_prompt_file
-      # populates Layer-1 — context.include does NOT — so the base MUST be here.
-      system_prompt_file: context/system-anthropic.md
   context:
     module: context-simple
     source: git+https://github.com/microsoft/amplifier-module-context-simple@main
@@ -39,10 +36,6 @@ tools:
     source: git+https://github.com/microsoft/amplifier-module-tool-search@main
   - module: tool-report-outcome
     source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/tool-report-outcome
-
-# Layer-1 base is delivered via session.orchestrator.config.system_prompt_file
-# above (core 1.6.0: context.include does NOT populate Layer-1). No additive
-# context files needed, so the context.include block is intentionally absent.
 
 hooks:
   - module: hooks-tool-truncation

--- a/profiles/attractor-e2e-gemini.yaml
+++ b/profiles/attractor-e2e-gemini.yaml
@@ -15,9 +15,6 @@ session:
     source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
     config:
       max_tool_rounds_per_input: 20
-      # Layer-1 base prompt (nlspec §6.1). Core 1.6.0: ONLY system_prompt_file
-      # populates Layer-1 — context.include does NOT — so the base MUST be here.
-      system_prompt_file: context/system-gemini.md
   context:
     module: context-simple
     source: git+https://github.com/microsoft/amplifier-module-context-simple@main
@@ -35,10 +32,6 @@ tools:
     source: git+https://github.com/microsoft/amplifier-module-tool-web@main
   - module: tool-report-outcome
     source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/tool-report-outcome
-
-# Layer-1 base is delivered via session.orchestrator.config.system_prompt_file
-# above (core 1.6.0: context.include does NOT populate Layer-1). No additive
-# context files needed, so the context.include block is intentionally absent.
 
 hooks:
   - module: hooks-tool-truncation

--- a/profiles/attractor-e2e-gemini.yaml
+++ b/profiles/attractor-e2e-gemini.yaml
@@ -15,6 +15,9 @@ session:
     source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
     config:
       max_tool_rounds_per_input: 20
+      # Layer-1 base prompt (nlspec §6.1). Core 1.6.0: ONLY system_prompt_file
+      # populates Layer-1 — context.include does NOT — so the base MUST be here.
+      system_prompt_file: context/system-gemini.md
   context:
     module: context-simple
     source: git+https://github.com/microsoft/amplifier-module-context-simple@main
@@ -33,10 +36,9 @@ tools:
   - module: tool-report-outcome
     source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/tool-report-outcome
 
-context:
-  # '../context/' climbs from this YAML's dir to the bundle-root context/; idiomatic target is 'attractor:context/...' pending foundation namespaced-include support.
-  include:
-    - ../context/system-gemini.md
+# Layer-1 base is delivered via session.orchestrator.config.system_prompt_file
+# above (core 1.6.0: context.include does NOT populate Layer-1). No additive
+# context files needed, so the context.include block is intentionally absent.
 
 hooks:
   - module: hooks-tool-truncation

--- a/profiles/attractor-e2e-pipeline-anthropic.yaml
+++ b/profiles/attractor-e2e-pipeline-anthropic.yaml
@@ -19,6 +19,11 @@ agents:
         source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
         config:
           default_command_timeout_ms: 120000
+          # Layer-1 base prompt delivered via profile-owned file (nlspec §6.1).
+          # Required: a loop-pipeline-spawned child fail-louds on an empty Layer-1
+          # (the top-level context.include below feeds the PIPELINE orchestrator,
+          # not this spawned child). See docs/designs/layer-1-profile-owned-system-prompt.md.
+          system_prompt_file: context/system-anthropic.md
 
 providers:
   - module: provider-anthropic

--- a/profiles/attractor-e2e-pipeline-anthropic.yaml
+++ b/profiles/attractor-e2e-pipeline-anthropic.yaml
@@ -19,11 +19,6 @@ agents:
         source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
         config:
           default_command_timeout_ms: 120000
-          # Layer-1 base prompt delivered via profile-owned file (nlspec §6.1).
-          # Required: a loop-pipeline-spawned child fail-louds on an empty Layer-1
-          # (the top-level context.include below feeds the PIPELINE orchestrator,
-          # not this spawned child). See docs/designs/layer-1-profile-owned-system-prompt.md.
-          system_prompt_file: context/system-anthropic.md
 
 providers:
   - module: provider-anthropic

--- a/profiles/attractor-e2e-pipeline-gemini.yaml
+++ b/profiles/attractor-e2e-pipeline-gemini.yaml
@@ -19,11 +19,6 @@ agents:
         source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
         config:
           default_command_timeout_ms: 120000
-          # Layer-1 base prompt delivered via profile-owned file (nlspec §6.1).
-          # Required: a loop-pipeline-spawned child fail-louds on an empty Layer-1
-          # (the top-level context.include below feeds the PIPELINE orchestrator,
-          # not this spawned child). See docs/designs/layer-1-profile-owned-system-prompt.md.
-          system_prompt_file: context/system-gemini.md
 
 providers:
   - module: provider-gemini

--- a/profiles/attractor-e2e-pipeline-gemini.yaml
+++ b/profiles/attractor-e2e-pipeline-gemini.yaml
@@ -19,6 +19,11 @@ agents:
         source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
         config:
           default_command_timeout_ms: 120000
+          # Layer-1 base prompt delivered via profile-owned file (nlspec §6.1).
+          # Required: a loop-pipeline-spawned child fail-louds on an empty Layer-1
+          # (the top-level context.include below feeds the PIPELINE orchestrator,
+          # not this spawned child). See docs/designs/layer-1-profile-owned-system-prompt.md.
+          system_prompt_file: context/system-gemini.md
 
 providers:
   - module: provider-gemini

--- a/profiles/attractor-profile-anthropic.yaml
+++ b/profiles/attractor-profile-anthropic.yaml
@@ -19,6 +19,10 @@ session:
     source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
     config:
       default_command_timeout_ms: 120000
+      # Layer-1 base prompt (nlspec §6.1: "Provider-specific base instructions from ProviderProfile").
+      # Path is relative to the bundle root; loop-agent resolves it at session init.
+      # See docs/designs/layer-1-profile-owned-system-prompt.md.
+      system_prompt_file: context/system-anthropic.md
 
 tools:
   - module: tool-filesystem
@@ -29,8 +33,3 @@ tools:
       timeout: 120
   - module: tool-search
     source: git+https://github.com/microsoft/amplifier-module-tool-search@main
-
-context:
-  # '../context/' climbs from this YAML's dir to the bundle-root context/; idiomatic target is 'attractor:context/...' pending foundation namespaced-include support.
-  include:
-    - ../context/system-anthropic.md

--- a/profiles/attractor-profile-anthropic.yaml
+++ b/profiles/attractor-profile-anthropic.yaml
@@ -19,10 +19,6 @@ session:
     source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
     config:
       default_command_timeout_ms: 120000
-      # Layer-1 base prompt (nlspec §6.1: "Provider-specific base instructions from ProviderProfile").
-      # Path is relative to the bundle root; loop-agent resolves it at session init.
-      # See docs/designs/layer-1-profile-owned-system-prompt.md.
-      system_prompt_file: context/system-anthropic.md
   # session.context is REQUIRED by core 1.6.0 ("Configuration must specify
   # session.context"). This profile only includes attractor-core (which provides
   # no context module) — unlike attractor-agent.yaml which pulls it from

--- a/profiles/attractor-profile-anthropic.yaml
+++ b/profiles/attractor-profile-anthropic.yaml
@@ -23,6 +23,13 @@ session:
       # Path is relative to the bundle root; loop-agent resolves it at session init.
       # See docs/designs/layer-1-profile-owned-system-prompt.md.
       system_prompt_file: context/system-anthropic.md
+  # session.context is REQUIRED by core 1.6.0 ("Configuration must specify
+  # session.context"). This profile only includes attractor-core (which provides
+  # no context module) — unlike attractor-agent.yaml which pulls it from
+  # amplifier-foundation — so it must be declared explicitly here.
+  context:
+    module: context-simple
+    source: git+https://github.com/microsoft/amplifier-module-context-simple@main
 
 tools:
   - module: tool-filesystem

--- a/profiles/attractor-profile-gemini.yaml
+++ b/profiles/attractor-profile-gemini.yaml
@@ -23,6 +23,12 @@ session:
       # Path is relative to the bundle root; loop-agent resolves it at session init.
       # See docs/designs/layer-1-profile-owned-system-prompt.md.
       system_prompt_file: context/system-gemini.md
+  # session.context is REQUIRED by core 1.6.0 ("Configuration must specify
+  # session.context"). This profile only includes attractor-core (which provides
+  # no context module), so it must be declared explicitly here.
+  context:
+    module: context-simple
+    source: git+https://github.com/microsoft/amplifier-module-context-simple@main
 
 tools:
   - module: tool-filesystem

--- a/profiles/attractor-profile-gemini.yaml
+++ b/profiles/attractor-profile-gemini.yaml
@@ -19,6 +19,10 @@ session:
     source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
     config:
       default_command_timeout_ms: 10000
+      # Layer-1 base prompt (nlspec §6.1: "Provider-specific base instructions from ProviderProfile").
+      # Path is relative to the bundle root; loop-agent resolves it at session init.
+      # See docs/designs/layer-1-profile-owned-system-prompt.md.
+      system_prompt_file: context/system-gemini.md
 
 tools:
   - module: tool-filesystem
@@ -31,8 +35,3 @@ tools:
     source: git+https://github.com/microsoft/amplifier-module-tool-search@main
   - module: tool-web
     source: git+https://github.com/microsoft/amplifier-module-tool-web@main
-
-context:
-  # '../context/' climbs from this YAML's dir to the bundle-root context/; idiomatic target is 'attractor:context/...' pending foundation namespaced-include support.
-  include:
-    - ../context/system-gemini.md

--- a/profiles/attractor-profile-gemini.yaml
+++ b/profiles/attractor-profile-gemini.yaml
@@ -19,10 +19,6 @@ session:
     source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
     config:
       default_command_timeout_ms: 10000
-      # Layer-1 base prompt (nlspec §6.1: "Provider-specific base instructions from ProviderProfile").
-      # Path is relative to the bundle root; loop-agent resolves it at session init.
-      # See docs/designs/layer-1-profile-owned-system-prompt.md.
-      system_prompt_file: context/system-gemini.md
   # session.context is REQUIRED by core 1.6.0 ("Configuration must specify
   # session.context"). This profile only includes attractor-core (which provides
   # no context module), so it must be declared explicitly here.

--- a/profiles/attractor-profile-openai.yaml
+++ b/profiles/attractor-profile-openai.yaml
@@ -19,6 +19,10 @@ session:
     source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
     config:
       default_command_timeout_ms: 10000
+      # Layer-1 base prompt (nlspec §6.1: "Provider-specific base instructions from ProviderProfile").
+      # Path is relative to the bundle root; loop-agent resolves it at session init.
+      # See docs/designs/layer-1-profile-owned-system-prompt.md.
+      system_prompt_file: context/system-openai.md
 
 tools:
   - module: tool-apply-patch
@@ -33,8 +37,3 @@ tools:
       timeout: 10
   - module: tool-search
     source: git+https://github.com/microsoft/amplifier-module-tool-search@main
-
-context:
-  # '../context/' climbs from this YAML's dir to the bundle-root context/; idiomatic target is 'attractor:context/...' pending foundation namespaced-include support.
-  include:
-    - ../context/system-openai.md

--- a/profiles/attractor-profile-openai.yaml
+++ b/profiles/attractor-profile-openai.yaml
@@ -19,10 +19,6 @@ session:
     source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
     config:
       default_command_timeout_ms: 10000
-      # Layer-1 base prompt (nlspec §6.1: "Provider-specific base instructions from ProviderProfile").
-      # Path is relative to the bundle root; loop-agent resolves it at session init.
-      # See docs/designs/layer-1-profile-owned-system-prompt.md.
-      system_prompt_file: context/system-openai.md
   # session.context is REQUIRED by core 1.6.0 ("Configuration must specify
   # session.context"). This profile only includes attractor-core (which provides
   # no context module), so it must be declared explicitly here.

--- a/profiles/attractor-profile-openai.yaml
+++ b/profiles/attractor-profile-openai.yaml
@@ -23,6 +23,12 @@ session:
       # Path is relative to the bundle root; loop-agent resolves it at session init.
       # See docs/designs/layer-1-profile-owned-system-prompt.md.
       system_prompt_file: context/system-openai.md
+  # session.context is REQUIRED by core 1.6.0 ("Configuration must specify
+  # session.context"). This profile only includes attractor-core (which provides
+  # no context module), so it must be declared explicitly here.
+  context:
+    module: context-simple
+    source: git+https://github.com/microsoft/amplifier-module-context-simple@main
 
 tools:
   - module: tool-apply-patch


### PR DESCRIPTION
## Summary

attractor's loop-pipeline spawned provider node agents (anthropic/openai/gemini) that received a STUB system prompt ("You are a coding agent."), causing hallucination and over-fragmented output. Root cause: loop-agent's Layer-1 base prompt was read ONLY from `system_prompt`/`system_prompt_file` in `session.orchestrator.config` — it never consumed the kernel context manager's `context.include` factory (the in-code comment claiming it did was stale). Provider prompts were parked in `context.include` side-files, so they never reached Layer-1.

**Fix:** loop-agent now resolves Layer-1 with precedence:
1. explicit `system_prompt`
2. explicit `system_prompt_file`
3. **provider default `context/system-<provider>.md`** (keyed on the SAME provider source used for the actual completion)
4. **fail-loud RuntimeError** for an unknown provider (never a silent stub)

Path resolution is CWD-independent with clear missing-file errors. The stale comment is corrected. `attractor-expert` (a non-coding consultant) gets a dedicated persona base.

**Net simplification:** The provider default replaced ~24 hard-coded `system_prompt_file` config lines across the bundle/agent/profile YAMLs (only `attractor-expert` keeps an explicit override).

**Consumer impact — zero-config:** attractor users, the dot-graph resolver, and any external loop-agent consumer now get the correct provider base prompt with NO changes on their side — they just pick up this version.

## Verification checklist

- [x] Unit tests pass (`pytest modules/loop-pipeline/`) — 1378 tests passing
- [x] Live pipeline run exercising changed code path — verified in DTU; see evidence section
- [x] AGENTS.md reviewed; repo-specific gates met
- [x] Backward-compat path unchanged — existing explicit `system_prompt`/`system_prompt_file` configs continue to work (tested)
- [x] PR body includes verification evidence (below)

## Verification evidence

**Cross-provider Layer-1 resolution (DTU integration test):**
- Each spawned loop-agent node received its provider's verbatim base header via the DEFAULT — no cross-contamination between anthropic/openai/gemini
- wiki-weaver ingest scenario: base + task prompt delivered, no fail-loud
- app-cli attractor-tool (root→tool→node chain): base reaches the deepest node; no fail-loud

**Live Resolve stack validation (real consumer, v0.2.0 dot-graph resolver):**
- Real DotGraphResolver (v0.2.0) drove its own example pipeline (`expert_builder_explorer.dot`) in a real worker with this branch loaded
- Spawned loop-agent nodes received Anthropic base via the DEFAULT
- Zero fail-loud; dot-graph UNCHANGED
- Provider base correctly injected at Layer-1 (verified in session events)

**Backward-compatibility:**
- Existing bundles with explicit `system_prompt_file` config remain unchanged — they still use their explicit override
- Fallback hierarchy tested: explicit > file > default > fail-loud

## Notes for reviewers

**Design reference:** See `docs/designs/layer-1-profile-owned-system-prompt.md` for the design document.

**Known follow-ups (not blockers):**
1. Provider default ships anthropic/openai/gemini; any other provider fails loud unless it sets an explicit base (by design — never a silent wrong base).
2. Multi-provider fan-out routing (separate, pre-existing): when all providers are mounted on a parent that fans out, the per-node provider isn't promoted. Not this feature; tracked separately.
3. Wheel packaging: the default resolves the prompt files via the amplifier full-clone source path (how all real consumers load loop-agent). A standalone pip-WHEEL install of loop-agent wouldn't bundle `context/system-*.md` → fail-loud (not silent). Package them into the wheel if standalone-wheel installs are ever needed.