### PR TITLE
fix(loop-pipeline): treat bare-integer node timeout as seconds

### DIFF
--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/dot_parser.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/dot_parser.py
@@ -38,6 +38,19 @@ _NODE_FIELD_MAP = {"label", "shape", "type", "prompt"}
 # Edge attributes that get promoted to Edge fields
 _EDGE_FIELD_MAP = {"label", "condition", "weight"}
 
+# Node attributes whose value is a duration where a BARE integer (no unit
+# suffix) means SECONDS. Suffixed values (e.g. "300s", "2m") are normalized to
+# milliseconds by _try_parse_duration; a bare "300" would otherwise be stored
+# as the raw int 300, and the engine's `/1000` timeout enforcement would treat
+# it as 0.3s. Treating bare integers as seconds matches the documented node
+# `timeout` contract ("Node execution timeout in seconds, e.g. 600") and
+# Python's own timeout convention (time.sleep / asyncio.timeout take bare
+# seconds). Applied in _parse_attr_block at parse time, where the unit suffix
+# is still visible. Do NOT generalize this into _try_parse_duration: that helper
+# runs on every attribute value, and bare integers like max_agent_turns="22"
+# must stay 22, not become a duration.
+_SECONDS_IF_BARE_DURATION_ATTRS = {"timeout"}
+
 # Known graph-level attribute names (not node IDs)
 _KNOWN_GRAPH_ATTRS = {
     "goal",
@@ -547,7 +560,14 @@ def _parse_attr_block(tokens: list[str], pos: int) -> dict[str, Any]:
                 found_missing_comma = True
             key = _unquote_key(tokens[i])
             raw_val = tokens[i + 2]
-            attrs[key] = _parse_value(raw_val)
+            value = _parse_value(raw_val)
+            if key in _SECONDS_IF_BARE_DURATION_ATTRS and _is_bare_integer(raw_val):
+                # Bare integer duration -> interpret as seconds and store as
+                # milliseconds (consistent with suffixed durations like "300s")
+                # so the engine's `/1000` enforcement yields the intended
+                # wall-clock seconds. Suffixed values are already ms here.
+                value = int(value) * _DURATION_UNITS["s"]
+            attrs[key] = value
             prev_was_value = True
             i += 3
         else:
@@ -672,6 +692,20 @@ def _try_parse_duration(s: str) -> int | None:
         unit = m.group(2)
         return value * _DURATION_UNITS[unit]
     return None
+
+
+def _is_bare_integer(raw: str) -> bool:
+    """Return True if a raw DOT attribute value is an integer with no unit suffix.
+
+    Handles both quoted (``"300"``) and unquoted (``300``) forms. A suffixed
+    duration such as ``"300s"`` or ``"2m"`` is NOT bare -- it carries a unit and
+    is converted to milliseconds by :func:`_try_parse_duration`. A bare float
+    (``"300.5"``) is also not a bare integer and is left untouched.
+    """
+    s = raw
+    if len(s) >= 2 and s[0] == '"' and s[-1] == '"':
+        s = s[1:-1]
+    return re.match(r"^-?\d+$", s) is not None
 
 
 # --- Comment stripping ---

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py
@@ -475,11 +475,14 @@ class PipelineEngine:
             else:
                 # Per-node timeout enforcement: wrap handler execution with
                 # asyncio.timeout when the node declares a timeout attribute.
-                # The DOT parser stores all durations as milliseconds (see
-                # dot_parser._DURATION_UNITS). Divide by 1000 to get seconds
-                # for asyncio.timeout. (Graph-level max_pipeline_duration is
-                # also in ms and is compared against elapsed_ms — do not
-                # change that path.)
+                # The DOT parser stores all node-timeout durations as
+                # milliseconds (see dot_parser._DURATION_UNITS): suffixed values
+                # like "300s" via _try_parse_duration, and BARE integers like
+                # "300" via dot_parser._SECONDS_IF_BARE_DURATION_ATTRS (seconds
+                # -> ms at parse time). Divide by 1000 to get seconds for
+                # asyncio.timeout. (Graph-level max_pipeline_duration is also in
+                # ms and is compared against elapsed_ms — do not change that
+                # path.)
                 node_timeout_raw = current_node.timeout
                 if node_timeout_raw:
                     timeout_s = float(node_timeout_raw) / 1000.0

--- a/modules/loop-pipeline/tests/test_node_timeout_units.py
+++ b/modules/loop-pipeline/tests/test_node_timeout_units.py
@@ -82,3 +82,88 @@ def test_max_pipeline_duration_stored_as_milliseconds():
     """
     graph = parse_dot('digraph { max_pipeline_duration="5m" }')
     assert graph.max_pipeline_duration == 300_000  # 5 * 60 * 1_000 ms
+
+
+# ---------------------------------------------------------------------------
+# Regression: BARE-INTEGER timeout means SECONDS (Fix B)
+#
+# A bare integer (no unit suffix) is the form every shipped pipeline actually
+# uses (e.g. dot-graph pr_feedback.dot timeout="300"). Before this fix the
+# parser stored it as the raw int 300 and the engine's /1000 enforcement made
+# it 0.3s, killing every LLM/tool node on arrival. A bare integer must be
+# interpreted as SECONDS and stored as milliseconds, exactly like "300s".
+#
+# This is the test gap that let the original regression ship: the suite only
+# ever exercised suffixed values.
+# ---------------------------------------------------------------------------
+
+
+def test_bare_integer_timeout_stored_as_milliseconds():
+    """Parser treats bare '300' as 300 seconds -> 300000 ms (like '300s')."""
+    graph = parse_dot('digraph { A [timeout="300"] }')
+    node = graph.nodes["A"]
+    assert node.timeout == 300_000  # 300 seconds * 1_000
+
+
+def test_bare_integer_timeout_yields_effective_300_seconds():
+    """timeout='300' (bare) must yield 300 effective seconds after /1000."""
+    graph = parse_dot('digraph { A [timeout="300"] }')
+    node = graph.nodes["A"]
+    assert node.timeout is not None
+    timeout_s = float(node.timeout) / 1000.0
+    assert timeout_s == 300.0  # NOT 0.3
+
+
+def test_bare_integer_600_matches_documented_600s_intent():
+    """pr_feedback.dot's Decide node 'timeout=\"600\"' must mean 600s, not 0.6s."""
+    graph = parse_dot('digraph { Decide [timeout="600"] }')
+    node = graph.nodes["Decide"]
+    assert node.timeout is not None
+    assert float(node.timeout) / 1000.0 == 600.0
+
+
+def test_bare_integer_unquoted_timeout_is_seconds():
+    """An unquoted bare integer timeout is also seconds."""
+    graph = parse_dot("digraph { A [timeout=300] }")
+    node = graph.nodes["A"]
+    assert node.timeout is not None
+    assert float(node.timeout) / 1000.0 == 300.0
+
+
+def test_suffixed_and_bare_agree_for_same_number():
+    """'300' and '300s' must produce identical effective timeouts."""
+    bare = parse_dot('digraph { A [timeout="300"] }').nodes["A"].timeout
+    suffixed = parse_dot('digraph { A [timeout="300s"] }').nodes["A"].timeout
+    assert bare == suffixed == 300_000
+
+
+def test_subsecond_suffixed_timeout_preserved():
+    """Sub-second suffixed values (e.g. '250ms') are NOT rescaled to seconds."""
+    graph = parse_dot('digraph { A [timeout="250ms"] }')
+    node = graph.nodes["A"]
+    assert node.timeout == 250  # 0.25s — a real, intended sub-second value
+
+
+def test_node_default_bare_integer_timeout_is_seconds():
+    """A bare integer node-default timeout is normalized to seconds too."""
+    graph = parse_dot('digraph { node [timeout="120"]; A; B [timeout="900s"] }')
+    a_timeout = graph.nodes["A"].timeout
+    b_timeout = graph.nodes["B"].timeout
+    assert a_timeout is not None and b_timeout is not None
+    assert float(a_timeout) / 1000.0 == 120.0  # inherited default
+    assert float(b_timeout) / 1000.0 == 900.0  # explicit suffix
+
+
+# ---------------------------------------------------------------------------
+# Guard: the bare-integer rule is TIMEOUT-SPECIFIC and must not leak to other
+# integer-valued attributes (e.g. max_agent_turns), which would be corrupted
+# if _try_parse_duration started treating bare ints as durations globally.
+# ---------------------------------------------------------------------------
+
+
+def test_non_timeout_integer_attr_not_rescaled():
+    """max_agent_turns='22' must stay 22, not become 22000."""
+    graph = parse_dot('digraph { A [timeout="300", max_agent_turns="22"] }')
+    node = graph.nodes["A"]
+    assert str(node.attrs.get("max_agent_turns")) == "22"
+    assert node.timeout == 300_000


### PR DESCRIPTION
## Summary

Fixes a regression where the loop-pipeline engine kills every LLM/tool node on arrival because a bare-integer node `timeout` is enforced 1000× too short. A node declaring `timeout="300"` (300 seconds) was enforced as **0.3 seconds**, killing the node before its first call.

## The regression

Introduced by `b3ad4c6` (2026-06-24, *"fix(loop-pipeline): correct node timeout unit mismatch (ms → seconds)"*). That commit correctly fixed the unit-*suffixed* path but did not account for the bare-integer fallback that every shipped pipeline uses.

Node-timeout enforcement history:
- (≤ Feb) no per-node enforcement
- `c9d4835` (Feb 25): enforcement = `float(raw)` — bare ints worked (`300`→300s), suffixed broke (`300s`→300000s)
- `b3ad4c6` (Jun 24): re-added `/1000` — suffixed works (`300s`→300s), **bare ints break (`300`→0.3s)**

Each prior "fix" repaired one parser path while breaking the other.

## Root cause: dual-unit parser with silent fall-through

`dot_parser._try_parse_duration` regex `^(-?\d+)(ms|s|m|h|d)$`:
- `"300s"` → matches → `300000` (ms)
- `"300"`  → no match → falls through to `int(300)` stored raw

`engine.py` then applies `float(node.timeout) / 1000.0`:
- `"300s"` → 300000/1000 = 300s ✓
- `"300"`  → 300/1000 = 0.3s ✗

## The fix (Fix B)

Treat a bare-integer `timeout` as **seconds** at parse time and store it as milliseconds (identical to the suffixed path), so the engine's `/1000` yields the intended wall-clock seconds.
- Timeout-specific: does NOT change `_try_parse_duration` globally — other integer attributes like `max_agent_turns="22"` must stay 22, not become a duration (covered by a guard test).
- Applied in `_parse_attr_block`, where the unit suffix is still visible.
- Suffixed values (`"300s"`) and sub-second values (`"250ms"`) are unchanged.

## Why fix the engine, not the DOT files

The bare-integer convention is used across the ecosystem:
- `amplifier-resolver-dot-graph`: 27 nodes across 7 pipelines, all bare integers — all currently broken.
- `amplifier-app-repo-weaver` (`repo-weaver-smoke.dot`): suffixed `"300s"` — works today.
- `amplifier-app-wiki-weaver`: no node timeouts.

Removing the `/1000` (the naive revert) would break repo-weaver's `"300s"`. Fix B is the only change that makes bare AND suffixed both mean wall-clock seconds, so nothing outside breaks.

## Observation: spec ↔ authoring-guide contradiction (needs maintainer reconciliation)

This regression shipped because two documents disagree on the node `timeout` unit:

| Document | Says about node `timeout` |
|---|---|
| attractor `specs/attractor-spec.md` (§2.2) | `Duration ::= Integer (ms\|s\|m\|h\|d)` — **unit suffix REQUIRED**; a bare integer is not a valid Duration |
| `amplifier-resolver-dot-graph` `docs/PIPELINE_AUTHORING_GUIDE.md:219` | `timeout` is `int` — *"Node execution timeout in seconds (e.g. \"600\")"* — **bare integer = seconds** |

Every shipped pipeline followed the authoring guide (bare ints); `b3ad4c6` made the engine conform to the attractor-spec grammar (suffix-only), silently breaking them. The dot-graph guide even documents (`:1967`) that attractor changes breaking community `.dot` compatibility "require a strong case and deliberate versioning."

This PR makes the engine **accept both forms** (bare = seconds; suffixed = its unit), unblocking all consumers immediately. The two documents should still be reconciled so the canonical contract lives in one place — that's a maintainer decision and intentionally out of scope here.

## Tests

Adds bare-integer regression tests to `test_node_timeout_units.py` — the gap that let the original regression ship (the suite previously only exercised suffixed values) — plus a guard that non-timeout integer attributes are not rescaled.
- 15 timeout unit tests pass.
- Full loop-pipeline unit suite: 1138 passed (9 unrelated pre-existing env failures: missing `unified_llm` module, a git-identity test).

## Validation against real pipelines

- All 27 dot-graph timeout nodes + repo-weaver's `"300s"` node now resolve to their intended seconds (parse-level).
- End-to-end in an isolated DTU: re-ran the dot-graph `pr_feedback` pipeline on `microsoft/amplifier-resolver-dot-graph#101` with the worker installing this branch. `EnrichFromCI` (`timeout="300"`) went from **FAIL "timed out after 0.3s"** to **success at 103.6s**, and the pipeline advanced through `Decide` to produce a real review decision and parked at the approval gate (no PR mutation).