### PR TITLE
fix(loop-agent): emit tool-call name under both "name" and "tool" keys (OpenAI multi-turn tool use)

### DIFF
--- a/modules/loop-agent/amplifier_module_loop_agent/messages.py
+++ b/modules/loop-agent/amplifier_module_loop_agent/messages.py
@@ -106,9 +106,16 @@ def _build_assistant_message(turn: AssistantTurn) -> Message:
 
     # Tool calls (passed as extra field via extra="allow")
     if turn.tool_calls:
+        # Emit the function name under BOTH "name" and "tool". Provider request
+        # builders disagree on the key: the OpenAI provider reads tc.get("name")
+        # (an empty name silently drops the function_call item from the Responses
+        # API input, orphaning its function_call_output), while the Anthropic
+        # provider reads tc.get("tool"). Carrying both keys is additive and keeps
+        # us compatible with both until the ecosystem canonicalizes on one key.
         kwargs["tool_calls"] = [
             {
                 "id": tc["id"],
+                "name": tc["name"],
                 "tool": tc["name"],
                 "arguments": tc["arguments"],
             }

--- a/modules/loop-agent/tests/test_messages.py
+++ b/modules/loop-agent/tests/test_messages.py
@@ -6,7 +6,6 @@ objects for ChatRequest, with system-first ordering, content blocks,
 ThinkingBlock preservation, and edge case handling.
 """
 
-
 from amplifier_core.message_models import TextBlock, ThinkingBlock
 from amplifier_core.models import ToolResult
 
@@ -293,3 +292,100 @@ def test_full_conversation_round_trip():
     # Then user, assistant, tool, steering(=user), assistant
     roles = [m.role for m in msgs]
     assert roles == ["system", "user", "assistant", "tool", "user", "assistant"]
+
+
+# ---------------------------------------------------------------------------
+# OpenAI multi-turn tool-use regression: assistant tool-call name must be
+# emitted under BOTH "name" (OpenAI provider reads this) and "tool" (Anthropic
+# provider reads this).  See A/B differential
+# .amplifier/evaluation/openai-ab-differential/20260630/VERDICT.md:
+# loop-agent emitted only "tool" -> OpenAI provider's tc.get("name") was empty
+# -> it dropped the function_call item -> orphaned function_call_output ->
+# Responses-API "No tool call found for function call output" hard error.
+# ---------------------------------------------------------------------------
+
+
+def test_assistant_tool_call_emits_name_and_tool_keys():
+    """Single tool call: serialized message carries name AND tool (both == fn name).
+
+    REQUIRED shape test (RED before the fix, GREEN after): the assistant
+    tool-call turn must serialize the function name under both keys, and the
+    assistant(tool_calls) message must sit immediately before the tool message
+    carrying the matching tool_call_id.
+    """
+    turns = [
+        UserTurn(content="create probe.txt"),
+        AssistantTurn(
+            content="",
+            tool_calls=[
+                {
+                    "id": "call_x",
+                    "name": "write_file",
+                    "arguments": '{"file_path":"./probe.txt","content":"hello world"}',
+                }
+            ],
+        ),
+        ToolResultsTurn(
+            results=[ToolResult(success=True, output='{"file_path":"./probe.txt"}')]
+        ),
+    ]
+    msgs = convert_history_to_messages(turns)
+
+    # Find the assistant message and its serialized tool_calls.
+    assistant_idx = next(i for i, m in enumerate(msgs) if m.role == "assistant")
+    assistant = msgs[assistant_idx]
+    dumped = assistant.model_dump()
+    tool_calls = dumped["tool_calls"]
+    assert len(tool_calls) == 1
+    # Both keys present, both equal to the function name (the regression assertion).
+    assert tool_calls[0]["name"] == "write_file"
+    assert tool_calls[0]["tool"] == "write_file"
+    assert tool_calls[0]["id"] == "call_x"
+
+    # The assistant(tool_calls) message is immediately before the tool message
+    # carrying the matching tool_call_id.
+    following = msgs[assistant_idx + 1]
+    assert following.role == "tool"
+    assert following.tool_call_id == "call_x"
+
+
+def test_assistant_multiple_tool_calls_emit_name_and_tool_keys():
+    """Multiple tool calls in one assistant turn: every call carries name AND tool."""
+    turns = [
+        UserTurn(content="read both files"),
+        AssistantTurn(
+            content="",
+            tool_calls=[
+                {"id": "call_a", "name": "read_file", "arguments": '{"path":"a.py"}'},
+                {"id": "call_b", "name": "write_file", "arguments": '{"path":"b.py"}'},
+            ],
+        ),
+        ToolResultsTurn(
+            results=[
+                ToolResult(success=True, output="a contents"),
+                ToolResult(success=True, output="b contents"),
+            ]
+        ),
+    ]
+    msgs = convert_history_to_messages(turns)
+
+    assistant = next(m for m in msgs if m.role == "assistant")
+    tool_calls = assistant.model_dump()["tool_calls"]
+    assert len(tool_calls) == 2
+    assert tool_calls[0]["name"] == tool_calls[0]["tool"] == "read_file"
+    assert tool_calls[1]["name"] == tool_calls[1]["tool"] == "write_file"
+    # Tool results pair to the calls by index/id (unaffected by the name key).
+    tool_msgs = [m for m in msgs if m.role == "tool"]
+    assert [m.tool_call_id for m in tool_msgs] == ["call_a", "call_b"]
+
+
+# NOTE: The provider-contract tests proposed in the fix plan
+# (provider-openai._convert_messages emits function_call before its
+# function_call_output; provider-anthropic still reads "tool") are intentionally
+# OMITTED here: neither amplifier_module_provider_openai nor
+# amplifier_module_provider_anthropic is importable in loop-agent's test
+# environment (verified), and adding them as test dependencies would be a heavy,
+# out-of-module dependency.  The shape tests above pin the loop-agent side of the
+# contract (the only side this module owns); the provider-side guarantees are
+# documented in the inline comment in messages.py and proven by the A/B
+# differential artifacts referenced above.


### PR DESCRIPTION
## Summary

loop-agent-driven pipelines broke on OpenAI multi-turn tool use with `InvalidRequestError: No tool call found for function call output with call_id ...`. Root cause: loop-agent serializes tool names under `"tool"` but OpenAI Responses API expects `"name"`. Fix: emit tool name under BOTH keys (OpenAI reads `"name"`, Anthropic reads `"tool"`, Gemini unaffected). Additive, provider-safe, no provider code touched.

## Verification checklist

- [x] Unit tests pass (`pytest modules/loop-pipeline/`) — loop-agent suite 487 passed
- [x] Live pipeline run exercising changed code path — OpenAI `gpt-4o` multi-turn tool task: request-2 `input` now contains `function_call` immediately before `function_call_output`. Non-regression: Anthropic `claude-sonnet-4-6` and Gemini `gemini-2.5-pro` still pass.
- [x] AGENTS.md reviewed; repo-specific gates met
- [x] Backward-compat path unchanged — serialization additive (both keys present); existing consumers reading `"tool"` unaffected
- [x] PR body includes verification evidence

## Verification evidence

**Tests:** loop-agent suite 487 passed; ruff clean on changed files.

**DTU A/B verification (raw-request differential):**
- **Before fix:** OpenAI request-2 (after tool call): `function_call` item missing from `input` (empty name silently dropped). Request fails with `InvalidRequestError: No tool call found for function_call_output with call_id ...`. All 16 OpenAI models tested show the same failure.
- **After fix:** OpenAI request-2 `input` includes `function_call` immediately before `function_call_output`. Task completes cleanly.
- **Non-regression:** Anthropic `claude-sonnet-4-6` (tool_use carries `name`) and Gemini `gemini-2.5-pro` both pass unchanged.

**Tests added:** 
- Provider-independent serialization-shape assertion (both `"name"` and `"tool"` keys present; assistant tool-call turn precedes tool result)
- Multi-tool-call case (multiple concurrent tools in one turn)

## Notes for reviewers

**Why both keys?** This is the minimal safe unblock. The underlying inconsistency is that provider request builders disagree on the tool-call key (`"name"` vs `"tool"`). A future ecosystem pass should canonicalize on one key across providers; this PR adds the failsafe dual-key emission.

**Why not touch provider code?** loop-agent's serialization is provider-agnostic; fixing at that layer avoids per-provider changes and holds the contract stable for downstream consumers.

**Cross-provider contract tests skipped:** Provider modules aren't importable in loop-agent's test venv; documented inline in tests.

Generated with [Amplifier](https://github.com/microsoft/amplifier)