### PR TITLE
fix(loop-agent): prevent canonical_provider() from misrouting compound provider names

### DIFF
--- a/modules/loop-agent/amplifier_module_loop_agent/agent_session.py
+++ b/modules/loop-agent/amplifier_module_loop_agent/agent_session.py
@@ -79,6 +79,16 @@ logger = logging.getLogger(__name__)
 # filtering) and AgentOrchestrator (provider-default base-prompt selection).
 KNOWN_PROVIDERS = ("anthropic", "openai", "gemini")
 
+# Compound provider names that legitimately contain a KNOWN_PROVIDERS family
+# name as a substring, but identify a genuinely DISTINCT, differently
+# configured provider (different auth, different endpoint) that must never be
+# absorbed into that family's canonical identity. E.g. "azure-openai" contains
+# "openai" as a substring, but Azure OpenAI is not the same mounted provider as
+# plain OpenAI -- silently treating them as equivalent causes a wrong-provider
+# misroute. Checked before the substring scan below so these names resolve to
+# None (unrecognised) rather than a same-named but incorrect canonical family.
+_DISTINCT_COMPOUND_PROVIDERS = ("azure-openai", "azure_openai", "azureopenai")
+
 
 def canonical_provider(raw: str | None) -> str | None:
     """Normalise a raw provider name to a canonical ID (anthropic/openai/gemini).
@@ -86,10 +96,18 @@ def canonical_provider(raw: str | None) -> str | None:
     Bundle composition may yield provider names like "provider-anthropic" or
     "Provider-OpenAI"; this returns the canonical ID via case-insensitive
     substring match, or None when the provider cannot be identified.
+
+    Compound names that pair a KNOWN_PROVIDERS family name with a
+    distinguishing qualifier (e.g. "azure-openai") are deliberately excluded
+    from the substring match: they name a distinct, differently configured
+    provider and must not be silently absorbed into the base family's
+    canonical identity (see _DISTINCT_COMPOUND_PROVIDERS).
     """
     if not raw:
         return None
     lower = raw.lower()
+    if any(compound in lower for compound in _DISTINCT_COMPOUND_PROVIDERS):
+        return None
     for canonical in KNOWN_PROVIDERS:
         if canonical in lower:
             return canonical

--- a/modules/loop-agent/tests/test_canonical_provider.py
+++ b/modules/loop-agent/tests/test_canonical_provider.py
@@ -1,0 +1,84 @@
+"""Tests for canonical_provider() substring-match false positives.
+
+Bug (confirmed): canonical_provider() does a case-insensitive SUBSTRING
+containment check against KNOWN_PROVIDERS = ("anthropic", "openai", "gemini").
+A compound provider name like "azure-openai" (a real, distinct provider
+module in the ecosystem -- different auth, different endpoint from plain
+OpenAI) contains the substring "openai", so it was incorrectly canonicalized
+to "openai" instead of being recognised as an unknown/distinct provider.
+
+This silently misroutes explicit llm_provider requests: if a pipeline node
+asks for "azure-openai" and only a plain "openai" provider is mounted, the
+exact-match check fails, falls through to the canonical-match scan, and
+WRONGLY resolves to the mounted "openai" instance with no error -- a
+wrong-provider misroute (different API, different auth, different endpoint).
+
+These tests pin down both the unit-level behavior of canonical_provider()
+and the end-to-end fail-loud contract it must preserve.
+"""
+
+from __future__ import annotations
+
+from amplifier_module_loop_agent.agent_session import canonical_provider
+
+
+# ---------------------------------------------------------------------------
+# The bug: compound names must NOT be absorbed into an unrelated family
+# ---------------------------------------------------------------------------
+
+
+def test_azure_openai_does_not_canonicalize_to_openai():
+    """'azure-openai' is a distinct, differently-configured provider.
+
+    It must NOT canonicalize to "openai" -- doing so is exactly the false
+    positive that causes the silent misroute described above.
+    """
+    assert canonical_provider("azure-openai") != "openai"
+
+
+def test_azure_openai_variants_do_not_canonicalize_to_openai():
+    """Case and separator variants of the compound name must not leak through."""
+    for raw in (
+        "azure-openai",
+        "Azure-OpenAI",
+        "AZURE-OPENAI",
+        "azure_openai",
+        "azureopenai",
+    ):
+        assert canonical_provider(raw) != "openai", (
+            f"canonical_provider({raw!r}) incorrectly resolved to 'openai'"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Regression: the 3 legitimate canonical families must still match correctly
+# ---------------------------------------------------------------------------
+
+
+def test_anthropic_prefixed_name_canonicalizes():
+    assert canonical_provider("provider-anthropic") == "anthropic"
+
+
+def test_anthropic_suffixed_model_name_canonicalizes():
+    assert canonical_provider("anthropic-sonnet") == "anthropic"
+
+
+def test_openai_case_insensitive_canonicalizes():
+    assert canonical_provider("Provider-OpenAI") == "openai"
+
+
+def test_plain_openai_canonicalizes():
+    assert canonical_provider("openai") == "openai"
+
+
+def test_gemini_prefixed_name_canonicalizes():
+    assert canonical_provider("provider-gemini") == "gemini"
+
+
+def test_unknown_provider_returns_none():
+    assert canonical_provider("ollama") is None
+
+
+def test_none_and_empty_return_none():
+    assert canonical_provider(None) is None
+    assert canonical_provider("") is None

--- a/modules/loop-agent/tests/test_system_prompt_wiring.py
+++ b/modules/loop-agent/tests/test_system_prompt_wiring.py
@@ -679,6 +679,49 @@ async def test_unset_llm_provider_preserves_first_mounted():
         )
 
 
+@pytest.mark.asyncio
+async def test_node_llm_provider_azure_openai_does_not_misroute_to_openai():
+    """FAIL-LOUD (not silent misroute): "azure-openai" must never resolve to a
+    plainly-mounted "openai" provider.
+
+    canonical_provider() previously did a raw case-insensitive SUBSTRING
+    match against KNOWN_PROVIDERS, so canonical_provider("azure-openai")
+    incorrectly returned "openai" (the string "openai" is a substring of
+    "azure-openai"). With only "openai" mounted (not "azure-openai"), the
+    exact-match check failed, fell through to the canonical-match scan, and
+    WRONGLY resolved to the plain OpenAI-mounted instance -- a silent
+    wrong-provider misroute (different API, different auth, different
+    endpoint) with no error.
+
+    The correct behavior is the same fail-loud contract proven by
+    test_node_llm_provider_not_mounted_fails_loud above: a requested
+    provider that has no mounted match must raise, never silently resolve
+    to a differently-configured provider.
+    """
+    context = MagicMock()
+    openai_provider = AsyncMock()
+    openai_provider.complete = AsyncMock(return_value=_text_response("o"))
+    hooks = _make_hooks()
+    coordinator = MagicMock()
+    coordinator.register_capability = MagicMock()
+
+    orch = AgentOrchestrator(
+        coordinator=coordinator,
+        config={"llm_provider": "azure-openai", "max_tool_rounds_per_input": 1},
+    )
+    with pytest.raises(RuntimeError) as excinfo:
+        # azure-openai requested, but only a plain openai provider is mounted.
+        await orch.execute("hello", context, {"openai": openai_provider}, {}, hooks)
+
+    msg = str(excinfo.value)
+    assert "azure-openai" in msg, "requested provider not named in the error"
+    assert "openai" in msg, "available providers not listed in the error"
+    # The critical assertion: openai must NEVER have been silently called.
+    assert openai_provider.complete.call_count == 0, (
+        "azure-openai request was silently misrouted to the plain openai provider"
+    )
+
+
 # ---------------------------------------------------------------------------
 # _resolve_system_prompt_file: CWD-independent, fail-loud path resolution
 # (must-fix 1 — council BLOCKER)


### PR DESCRIPTION
## Summary
`canonical_provider()` in `agent_session.py` does case-insensitive **substring** containment matching against `KNOWN_PROVIDERS = ("anthropic", "openai", "gemini")`. Since `"openai"` is a substring of `"azure-openai"`, an explicit `llm_provider="azure-openai"` pipeline-node request with only a plain `"openai"` provider mounted silently misrouted to the wrong (differently configured, different-auth, different-endpoint) provider instead of raising the intended "not mounted" `RuntimeError` — because that error only fires on zero canonical matches, not on a semantically-wrong match. Fix adds a `_DISTINCT_COMPOUND_PROVIDERS` exclusion tuple (`"azure-openai"`, `"azure_openai"`, `"azureopenai"`) checked before the substring scan, so these compound names correctly resolve to `None` (unrecognized/not mounted) instead of being absorbed into `"openai"`. Scoped strictly to the 3 existing canonical families — no generalization attempted.

## Verification checklist

- [x] Unit tests pass (`pytest modules/loop-agent/`)
- [x] N/A — this change is confined to `canonical_provider()`, a provider-name-resolution helper in `loop-agent`'s `agent_session.py`. It does not touch `engine.py`, handler dispatch, or subgraph/fan-out logic in `loop-pipeline`. Per this repo's Verification gradient table, the live-pipeline-run requirement applies to `engine.py`/handler/dispatch changes; this PR touches none of those.
- [x] AGENTS.md reviewed; repo-specific gates met (test commands run as documented; dependency-awareness rule checked against the diff — see Notes below)
- [x] Backward-compat path unchanged — the 3 existing canonical families (`anthropic`/`openai`/`gemini`) and all previously-passing resolution cases are unaffected; only the newly-excluded compound names change behavior, and only from *silent wrong-provider misroute* to *correct fail-loud "not mounted"*
- [x] PR body includes verification evidence, not just "tests pass"

## Verification evidence

**Targeted tests** (independently run by the reviewing agent, not just trusting the author):
```
$ uv run pytest modules/loop-agent/tests/test_canonical_provider.py -q
.........
9 passed in 0.01s
```

**Full module suite** (AGENTS.md-documented command scope for this module):
```
$ uv run pytest modules/loop-agent/ -q
........................................................................ [ 14%]
........................................................................ [ 28%]
........................................................................ [ 43%]
........................................................................ [ 57%]
........................................................................ [ 72%]
........................................................................ [ 86%]
....................................................................     [100%]
500 passed in 7.54s
```
Note: no `--ignore` flag was needed for this run. The `tests/e2e/test_gemini_agent.py` suite referenced during implementation lives at the **repo root** `tests/e2e/` (network-dependent, calls the live Gemini API), not nested under `modules/loop-agent/`, so it is outside the scope of this module's documented full-suite command and is unaffected by this change (this PR does not touch any Gemini-related code path). I attempted to independently re-confirm the pre-existing/unrelated status of those e2e failures myself but the run timed out in this environment (network/credential-dependent); the implementing agent's git-stash baseline comparison (identical failures with and without this fix) stands as the evidence for that specific claim, which I did not personally reproduce.

**Red-green regression (independently reproduced by the reviewing agent via `git stash`, not re-run of the author's claim):**
```
$ git stash push -- modules/loop-agent/amplifier_module_loop_agent/agent_session.py
$ uv run pytest modules/loop-agent/tests/test_canonical_provider.py modules/loop-agent/tests/test_system_prompt_wiring.py -q
FAILED modules/loop-agent/tests/test_canonical_provider.py::test_azure_openai_does_not_canonicalize_to_openai
FAILED modules/loop-agent/tests/test_canonical_provider.py::test_azure_openai_variants_do_not_canonicalize_to_openai
FAILED modules/loop-agent/tests/test_system_prompt_wiring.py::test_node_llm_provider_azure_openai_does_not_misroute_to_openai
E       Failed: DID NOT RAISE <class 'RuntimeError'>
3 failed, 31 passed in 0.35s
$ git stash pop
```
Reverting only `agent_session.py` (keeping the new tests) reproduces exactly the 3 expected failures — including the concrete symptom (`DID NOT RAISE RuntimeError`, i.e. the silent misroute). Restoring the fix (`git stash pop`) returns to the clean 500-passed state above. This confirms the tests are genuinely pinned to the fix, not vacuously passing.

## Notes for reviewers

This is a narrow, targeted fix for a discovered silent-misrouting edge case in `canonical_provider()`. It is **not** part of the larger provider-resolution-anti-pattern work happening this session in sibling repos (a bare-type-vs-keyed-instance resolution gap fixed elsewhere in `amplifier-foundation` and `amplifier-bundle-routing-matrix`, plus related work in `amplifier-app-cli`) — deliberately not cross-referenced anywhere in this diff's code, comments, or test names, per this repo's own **Dependency awareness rule** in `AGENTS.md` (checked the diff directly for this: no mentions of other repos, PR numbers, or downstream resolver names — clean).

The bug itself is unrelated in shape to that other work: this is a substring-collision false-positive in a hardcoded 3-family canonicalization helper, not a dict-keyed-instance-lookup gap. It surfaced during that broader sweep but stands on its own as an independent, self-contained fix.
