### PR TITLE
feat(pipeline-runner): shared attractor pipeline runner — library + CLI (WIP)

### DIFF
--- a/modules/pipeline-runner/KNOWN_ISSUES.md
+++ b/modules/pipeline-runner/KNOWN_ISSUES.md
@@ -1,0 +1,27 @@
+# Known Issues — pipeline-runner
+
+## Box/agent nodes: run from within `--cwd` (process-cwd alignment)
+
+**Constraint:** for a pipeline that contains **box (LLM/agent) nodes**, invoke `attractor run` with the
+process working directory equal to `--cwd` — e.g.
+
+```sh
+cd <workdir> && attractor run pipeline.dot --cwd .
+```
+
+rather than running from some other directory with `--cwd /elsewhere`.
+
+**Why:** the runner threads `--cwd` into every spawned agent as `session_cwd`, and the agent's
+**tools** (filesystem, bash) are correctly rooted there. But the `loop-agent` orchestrator that drives
+a spawned agent currently derives the agent's *declared* working directory from `os.getcwd()` (the
+runner's process cwd) instead of honoring the `session.working_dir` capability the way its sibling
+`tool-bash` / `tool-filesystem` modules do. When the process cwd differs from `--cwd`, the agent's
+system prompt (and its project-doc discovery) point at the wrong directory, so the agent can look in
+the wrong place and fail to find files that tool nodes wrote at `--cwd`.
+
+Tool-only pipelines are unaffected (tool nodes always root at `--cwd` via `context.target_dir`).
+
+**Status:** this is a `loop-agent` bug, not a runner bug. The fix (have `loop-agent`'s `mount()` honor
+`coordinator.get_capability("session.working_dir")`) is **deferred** — `loop-agent` is a shared
+orchestrator and the change needs downstream-impact analysis before it lands. Tracked as a focused
+follow-up task. Until then, use process-cwd alignment as above.

--- a/modules/pipeline-runner/amplifier_module_pipeline_runner/__init__.py
+++ b/modules/pipeline-runner/amplifier_module_pipeline_runner/__init__.py
@@ -1,0 +1,25 @@
+"""amplifier_module_pipeline_runner: reusable engine-driving library + CLI.
+
+Public API:
+    drive_engine    -- drive the attractor engine directly given an already-built
+                       coordinator (low-level; caller owns session/spawn wiring).
+    run_pipeline     -- high-level convenience: builds the prepared bundle,
+                       session, and spawn wiring, then calls drive_engine.
+    PipelineResult   -- result dataclass returned by run_pipeline.
+    parse_param      -- parse a single ``key=value`` (or ``@file`` / ``@@literal``)
+                       CLI-style param string.
+    DEFAULT_PROFILES -- default llm_provider -> agent-name routing map.
+"""
+
+from __future__ import annotations
+
+from .params import parse_param
+from .runner import DEFAULT_PROFILES, PipelineResult, drive_engine, run_pipeline
+
+__all__ = [
+    "drive_engine",
+    "run_pipeline",
+    "PipelineResult",
+    "parse_param",
+    "DEFAULT_PROFILES",
+]

--- a/modules/pipeline-runner/amplifier_module_pipeline_runner/__main__.py
+++ b/modules/pipeline-runner/amplifier_module_pipeline_runner/__main__.py
@@ -1,0 +1,5 @@
+"""Allow ``python -m amplifier_module_pipeline_runner`` without install."""
+
+from .cli import main
+
+raise SystemExit(main())

--- a/modules/pipeline-runner/amplifier_module_pipeline_runner/cli.py
+++ b/modules/pipeline-runner/amplifier_module_pipeline_runner/cli.py
@@ -1,0 +1,202 @@
+"""attractor: run an arbitrary attractor DOT pipeline standalone.
+
+Thin argv front door over ``run_pipeline`` / ``runner.py``. Fails loud: a
+missing provider API key, missing DOT source, or a pipeline error all print a
+clear message and exit non-zero. No fallbacks, no synthetic success.
+
+Subcommands:
+    run       <dot_file>   run a DOT pipeline
+    doctor                 environment diagnostics
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+from . import runner
+from .params import parse_params
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="attractor", description="Run an attractor DOT pipeline standalone."
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    run = sub.add_parser("run", help="run a DOT pipeline")
+    run.add_argument("dot_file", nargs="?", help="path to a .dot file")
+    run.add_argument(
+        "--dot-source",
+        help="inline DOT digraph string (alternative to dot_file)",
+    )
+    run.add_argument(
+        "--param",
+        action="append",
+        default=[],
+        metavar="k=v",
+        help=(
+            "key=value param for $param expansion in node prompts (repeatable). "
+            "Value may be @path/to/file to read the param's value from a file's "
+            "full contents (curl-style; handy for multi-line content like a "
+            "checkbox worklist or spec). Use @@literal for a literal value "
+            "starting with '@' (e.g. --param handle=@@jdoe -> '@jdoe')."
+        ),
+    )
+    run.add_argument(
+        "--provider",
+        default="anthropic",
+        help="provider whose API key to preflight-check (default: anthropic)",
+    )
+    run.add_argument(
+        "--logs-root",
+        default=None,
+        help="directory for run logs (default: a fresh tempdir)",
+    )
+    run.add_argument(
+        "--cwd",
+        default=None,
+        help=(
+            "working directory for the pipeline -- where box-node agents and "
+            "tool-node commands write files (default: current directory; "
+            "created if it doesn't exist)"
+        ),
+    )
+
+    sub.add_parser("doctor", help="environment diagnostics")
+
+    return parser
+
+
+def cmd_run(args: argparse.Namespace) -> int:
+    # --- Resolve DOT source: --dot-source wins, else read dot_file ---
+    if args.dot_source:
+        dot_source = args.dot_source
+    elif args.dot_file:
+        dot_path = Path(args.dot_file).expanduser()
+        if not dot_path.is_file():
+            print(f"attractor: DOT file not found: {dot_path}", file=sys.stderr)
+            return 1
+        dot_source = dot_path.read_text(encoding="utf-8")
+    else:
+        print(
+            "attractor: either a dot_file argument or --dot-source is required",
+            file=sys.stderr,
+        )
+        return 1
+
+    # --- Parse params (fail loud on malformed entries) ---
+    try:
+        params = parse_params(args.param)
+    except ValueError as e:
+        print(f"attractor: {e}", file=sys.stderr)
+        return 1
+
+    # --- Fail loud: unknown --provider is a CLI-argument error ---
+    if args.provider not in runner.PROVIDER_KEY_ENV:
+        print(
+            f"attractor: unknown provider {args.provider!r}. Known providers: "
+            f"{', '.join(sorted(runner.PROVIDER_KEY_ENV))}",
+            file=sys.stderr,
+        )
+        return 1
+
+    # --- Fail loud: provider API key must be present BEFORE we run anything ---
+    key_env = runner.PROVIDER_KEY_ENV[args.provider]
+    if not os.environ.get(key_env):
+        print(
+            f"attractor: missing API key -- set {key_env} for provider {args.provider!r}",
+            file=sys.stderr,
+        )
+        return 1
+
+    # --- Resolve logs root ---
+    if args.logs_root:
+        logs_root = Path(args.logs_root).expanduser()
+    else:
+        logs_root = Path(tempfile.mkdtemp(prefix="attractor-run-"))
+
+    # --- Resolve pipeline working directory ---
+    if args.cwd:
+        cwd = Path(args.cwd).expanduser().resolve()
+    else:
+        cwd = Path.cwd()
+
+    print(f"attractor: running pipeline (cwd: {cwd}, logs: {logs_root})")
+
+    try:
+        result = asyncio.run(
+            runner.run_pipeline(
+                dot_source,
+                params=params or None,
+                provider=args.provider,
+                logs_root=logs_root,
+                cwd=cwd,
+            )
+        )
+    except Exception as e:  # noqa: BLE001 -- fail loud with the real error, no fallback
+        print(
+            f"attractor: pipeline execution failed: {type(e).__name__}: {e}",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"attractor: status={result.status}")
+    print(f"attractor: logs={result.logs_dir}")
+    if result.notes:
+        print("attractor: notes:")
+        print(result.notes)
+    print(
+        json.dumps(
+            {
+                "status": result.status,
+                "notes": result.notes,
+                "logs_dir": str(result.logs_dir),
+            }
+        )
+    )
+
+    return 0 if result.status == "success" else 1
+
+
+def cmd_doctor(args: argparse.Namespace) -> int:
+    del args  # doctor takes no options today
+
+    ok = True
+
+    try:
+        import amplifier_module_loop_pipeline  # noqa: F401
+    except ImportError as e:
+        print(
+            f"attractor doctor: FAIL -- amplifier_module_loop_pipeline not importable: {e}"
+        )
+        ok = False
+    else:
+        print("attractor doctor: OK -- amplifier_module_loop_pipeline importable")
+
+    for provider, env_name in sorted(runner.PROVIDER_KEY_ENV.items()):
+        present = bool(os.environ.get(env_name))
+        status = "present" if present else "absent"
+        print(f"attractor doctor: {provider} ({env_name}): {status}")
+
+    return 0 if ok else 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    dispatch = {
+        "run": cmd_run,
+        "doctor": cmd_doctor,
+    }
+    return dispatch[args.command](args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/modules/pipeline-runner/amplifier_module_pipeline_runner/cli.py
+++ b/modules/pipeline-runner/amplifier_module_pipeline_runner/cli.py
@@ -64,7 +64,9 @@ def build_parser() -> argparse.ArgumentParser:
         help=(
             "working directory for the pipeline -- where box-node agents and "
             "tool-node commands write files (default: current directory; "
-            "created if it doesn't exist)"
+            "created if it doesn't exist). NOTE: for pipelines with box/agent "
+            "nodes, run from within this directory (e.g. `cd <dir> && attractor "
+            "run pipeline.dot --cwd .`) -- see KNOWN_ISSUES.md (loop-agent cwd)."
         ),
     )
 

--- a/modules/pipeline-runner/amplifier_module_pipeline_runner/cli.py
+++ b/modules/pipeline-runner/amplifier_module_pipeline_runner/cli.py
@@ -69,6 +69,18 @@ def build_parser() -> argparse.ArgumentParser:
             "run pipeline.dot --cwd .`) -- see KNOWN_ISSUES.md (loop-agent cwd)."
         ),
     )
+    run.add_argument(
+        "--on-human-gate",
+        choices=("fail", "auto-approve"),
+        default="fail",
+        help=(
+            "how to handle a human-gate (hexagon) node. 'fail' (default): "
+            "fail loud -- a pipeline that needs a human decision terminates "
+            "with a clear error (run it where a human/UI can answer, or pass "
+            "auto-approve). 'auto-approve': supply an auto-approving interviewer "
+            "that selects the first choice at each gate (opt-in, non-interactive)."
+        ),
+    )
 
     sub.add_parser("doctor", help="environment diagnostics")
 
@@ -129,6 +141,13 @@ def cmd_run(args: argparse.Namespace) -> int:
     else:
         cwd = Path.cwd()
 
+    # --- Human-gate policy: default fail-loud; auto-approve is opt-in ---
+    interviewer = None
+    if args.on_human_gate == "auto-approve":
+        from amplifier_module_loop_pipeline.interviewer import AutoApproveInterviewer
+
+        interviewer = AutoApproveInterviewer()
+
     print(f"attractor: running pipeline (cwd: {cwd}, logs: {logs_root})")
 
     try:
@@ -139,6 +158,7 @@ def cmd_run(args: argparse.Namespace) -> int:
                 provider=args.provider,
                 logs_root=logs_root,
                 cwd=cwd,
+                interviewer=interviewer,
             )
         )
     except Exception as e:  # noqa: BLE001 -- fail loud with the real error, no fallback
@@ -162,6 +182,15 @@ def cmd_run(args: argparse.Namespace) -> int:
             }
         )
     )
+
+    if result.status != "success" and args.on_human_gate == "fail":
+        print(
+            "attractor: hint -- if this pipeline has a human-gate (hexagon) node, "
+            "it fails loud by default. Re-run with --on-human-gate auto-approve to "
+            "auto-approve gates non-interactively, or run it where a human/UI can "
+            "answer the gate.",
+            file=sys.stderr,
+        )
 
     return 0 if result.status == "success" else 1
 

--- a/modules/pipeline-runner/amplifier_module_pipeline_runner/params.py
+++ b/modules/pipeline-runner/amplifier_module_pipeline_runner/params.py
@@ -1,0 +1,92 @@
+"""CLI-style ``key=value`` param parsing.
+
+Extracted (verbatim behavior) from dot-graph-runner's ``cli._parse_param``,
+generalized to raise ``ValueError`` instead of ``argparse.ArgumentTypeError``
+so it is reusable outside argparse (the CLI layer catches ``ValueError`` and
+converts it to a fail-loud exit).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def parse_param(raw: str) -> tuple[str, str]:
+    """Parse a ``key=value`` param argument.
+
+    Splits on the FIRST ``=`` only, so values may themselves contain ``=``.
+
+    Curl-style ``@file`` convention: if ``value`` starts with ``@``, the
+    param value is read from the file at the path after the ``@`` instead of
+    being taken literally. This makes it practical to pass big/multi-line
+    values (a checkbox worklist, a spec) without shell quoting gymnastics,
+    e.g. ``outfile=@./worklist.md``. The path is resolved with
+    ``expanduser()``; if relative, it is resolved relative to the current
+    working directory. A missing or unreadable file raises ``ValueError``
+    (no silent fallback to the literal ``@...`` string).
+
+    To pass a literal value that itself starts with ``@``, escape it with a
+    second ``@``: ``handle=@@jdoe`` yields the literal string ``@jdoe``.
+
+    Args:
+        raw: A ``key=value`` string (see above for value conventions).
+
+    Returns:
+        (key, value) tuple.
+
+    Raises:
+        ValueError: If ``raw`` has no ``=``, an empty key, or an unreadable
+            ``@file`` reference.
+
+    Examples:
+        >>> parse_param("k=v")
+        ('k', 'v')
+        >>> parse_param("k=a=b")
+        ('k', 'a=b')
+        >>> parse_param("k=@@literal")
+        ('k', '@literal')
+    """
+    if "=" not in raw:
+        raise ValueError(f"--param must be key=value, got: {raw!r}")
+    key, _, value = raw.partition("=")
+    key = key.strip()
+    if not key:
+        raise ValueError(f"--param key must be non-empty, got: {raw!r}")
+
+    if value.startswith("@@"):
+        # Escaped literal: @@foo -> literal value "@foo"
+        value = value[1:]
+    elif value.startswith("@"):
+        # curl-style file reference: @path/to/file -> file's full contents
+        raw_path = value[1:]
+        file_path = Path(raw_path).expanduser()
+        try:
+            value = file_path.read_text(encoding="utf-8")
+        except OSError as e:
+            raise ValueError(
+                f"--param {key}=@{raw_path}: could not read file {file_path}: {e}"
+            ) from e
+
+    return key, value
+
+
+def parse_params(raws: list[str]) -> dict[str, str]:
+    """Parse a list of ``key=value`` param strings into a flat dict.
+
+    Later entries overwrite earlier ones for the same key (matches the CLI's
+    ``--param`` (action=append) semantics: last one wins).
+
+    Args:
+        raws: List of raw ``key=value`` strings.
+
+    Returns:
+        Flat dict of parsed params.
+
+    Raises:
+        ValueError: Propagated from ``parse_param`` on any malformed entry.
+    """
+    params: dict[str, str] = {}
+    for raw in raws:
+        key, value = parse_param(raw)
+        params[key] = value
+    return params

--- a/modules/pipeline-runner/amplifier_module_pipeline_runner/runner.py
+++ b/modules/pipeline-runner/amplifier_module_pipeline_runner/runner.py
@@ -554,9 +554,27 @@ async def run_pipeline(
         profiles: llm_provider -> agent-name routing map. Defaults to
             ``DEFAULT_PROFILES`` if not given.
         hooks: Optional hooks object forwarded to the engine.
+        interviewer: Optional interviewer object forwarded to the handler
+            registry (human-in-the-loop gate seam).
         transform: If True (default), run ``apply_transforms`` before
             validation/execution.
         validate: If True (default), run ``validate_or_raise`` before execution.
+        extra_overlays: Additional ``Bundle`` overlays composed AFTER the
+            runtime orchestrator overlay, in order. The generic seam a
+            consumer uses to add cross-cutting configuration to every
+            session and spawned child -- e.g. mounting an observability
+            hook -- without the runner needing to know what the overlay
+            contains.
+        child_constraint: Optional caller-supplied hook that receives the
+            resolved child ``Bundle`` for each spawned agent and returns a
+            (possibly modified) child ``Bundle`` -- the generic seam a
+            consumer uses to constrain a spawned agent (e.g. a filesystem
+            sandbox that denies writes to protected paths, or a read-only
+            tool set for an ask-style pipeline).
+        spawn_timeout: Optional timeout (seconds) wrapping each child spawn
+            in ``asyncio.wait_for`` -- a long-running box node that hangs
+            then fails loud rather than blocking the whole pipeline
+            forever. ``None`` (default) means no timeout.
 
     Returns:
         A ``PipelineResult`` with status, notes, logs_dir, and raw JSON.

--- a/modules/pipeline-runner/amplifier_module_pipeline_runner/runner.py
+++ b/modules/pipeline-runner/amplifier_module_pipeline_runner/runner.py
@@ -31,10 +31,11 @@ own ``loop-agent`` orchestrator + filesystem/bash/search tools) via the
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import tempfile
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -78,6 +79,11 @@ class PipelineResult:
     Attributes:
         status: The pipeline outcome status string (e.g. "success", "fail").
         notes: Outcome notes, truncated to 4000 chars.
+        failure_reason: The outcome's ``failure_reason`` when the engine
+            terminated on a failure (e.g. no-matching-edge routing), else
+            ``None``. Surfaced so a consumer can distinguish/why a run failed
+            without re-parsing ``notes`` -- the direct-engine ``Outcome``
+            carries this where the old mounted-orchestrator JSON did.
         logs_dir: Directory containing this run's logs (including the
             written ``pipeline.dot`` source).
         raw: JSON-serialized ``{"status": ..., "notes": ...}``, truncated to
@@ -88,6 +94,7 @@ class PipelineResult:
     notes: str
     logs_dir: Path
     raw: str
+    failure_reason: str | None = None
 
 
 def seed_context(
@@ -231,50 +238,41 @@ async def drive_engine(
 async def _resolve_agent_bundle(agent_name: str, config: dict[str, Any]) -> Any:
     """Resolve a per-node agent into a full, self-contained child Bundle.
 
-    Adapted verbatim (structurally) from dot-graph-runner's
-    ``_resolve_agent_bundle``. The recursion-avoidance mechanism: every child
-    agent must carry an inline ``session.orchestrator`` set to a
-    NON-pipeline orchestrator (``loop-agent``). Without it the spawned child
-    inherits the parent's ``loop-pipeline`` orchestrator and re-runs the
-    whole DOT (infinite recursion).
+    Adapted structurally from dot-graph-runner's ``_resolve_agent_bundle``.
+    The recursion-avoidance mechanism: every child agent must carry an inline
+    ``session.orchestrator`` set to a NON-pipeline orchestrator
+    (``loop-agent``). Without it the spawned child inherits the parent's
+    ``loop-pipeline`` orchestrator and re-runs the whole DOT (infinite
+    recursion).
 
-    Two ``config`` shapes are accepted:
-    * Inline definition (current) -- a full agent dict with its own
-      ``session`` (inline ``loop-agent`` orchestrator), ``providers``,
-      ``tools``, ``hooks``, ``instruction``. This is what
-      attractor-pipeline's ``agents:`` block declares.
-    * ``{"bundle": "attractor:agents/<name>"}`` reference (legacy) --
-      resolved via ``load_bundle``.
+    Only the **inline** ``config`` shape is accepted -- a full agent dict with
+    its own ``session`` (inline ``loop-agent`` orchestrator), ``providers``,
+    ``tools``, ``hooks``, ``instruction``. This is what attractor-pipeline's
+    ``agents:`` block declares.
+
+    Layer-1 (the child's base/system prompt) is delivered by ``loop-agent``'s
+    provider-default selection (``context/system-<provider>.md``, chosen from
+    the child's ``providers``), or by an explicit ``system_prompt`` /
+    ``system_prompt_file`` in the child's orchestrator config. ``loop-agent``
+    is fail-loud on an empty Layer-1, so a successful spawn proves the real
+    prompt was resolved. Agent ``context.include`` is deliberately NOT
+    processed here -- ``loop-agent`` treats context includes as additive
+    context, never as Layer-1, and every attractor agent leans on the
+    provider default.
+
+    The legacy ``{"bundle": "attractor:agents/<name>"}`` reference shape is no
+    longer supported: attractor-pipeline's agents are all inline, so the
+    indirection was dead. It now fails loud with an actionable message rather
+    than silently carrying a resolution path no shipped config exercises.
     """
-    from amplifier_foundation import load_bundle
-
-    ref = config.get("bundle") if isinstance(config, dict) else None
-    if ref:
-        # e.g. "attractor:agents/attractor-agent-anthropic"
-        _ns, _, rel = str(ref).partition(":")
-        candidates: list[str] = []
-        if rel:
-            repo_root = _attractor_repo_root()
-            if repo_root is not None:
-                local = (repo_root / rel).with_suffix(".yaml")
-                candidates.append(str(local))
-            candidates.append(
-                "git+https://github.com/microsoft/amplifier-bundle-attractor@main"
-                f"#subdirectory={rel}.yaml"
-            )
-        else:
-            candidates = [str(ref)]
-        last_err: Exception | None = None
-        for src in candidates:
-            try:
-                return await load_bundle(src)
-            except Exception as e:  # noqa: BLE001
-                last_err = e
-        raise RuntimeError(
-            f"Could not resolve agent bundle '{agent_name}' ({ref}): {last_err}"
+    if isinstance(config, dict) and config.get("bundle"):
+        raise ValueError(
+            f"Agent '{agent_name}' uses the removed "
+            f'\'{{"bundle": "{config["bundle"]}"}}\' reference shape. '
+            "Inline the agent definition (session/providers/tools/instruction) "
+            "instead -- attractor agents are declared inline."
         )
 
-    # Inline config form (already a full agent definition).
     from amplifier_foundation import Bundle
 
     return Bundle(
@@ -289,7 +287,13 @@ async def _resolve_agent_bundle(agent_name: str, config: dict[str, Any]) -> Any:
     )
 
 
-def make_spawn_fn(prepared: Any, cwd: Path | None = None):
+def make_spawn_fn(
+    prepared: Any,
+    cwd: Path | None = None,
+    *,
+    child_constraint: Callable[[Any], Any] | None = None,
+    spawn_timeout: float | None = None,
+):
     """Build the ``session.spawn`` capability for a prepared bundle.
 
     Adapted from dot-graph-runner's ``make_spawn_fn``. Each pipeline node
@@ -310,6 +314,21 @@ def make_spawn_fn(prepared: Any, cwd: Path | None = None):
     working_dir, which is fragile and leaves box nodes writing to the
     process cwd instead of ``--cwd``. This is the load-bearing host/DTU cwd
     fix -- preserve the ``session_cwd=cwd`` argument exactly.
+
+    ``child_constraint`` (optional) is a caller-supplied hook that receives
+    the resolved child ``Bundle`` and returns a (possibly modified) child
+    ``Bundle`` -- the generic seam a consumer uses to constrain a spawned
+    agent (e.g. a filesystem sandbox that denies writes to protected paths,
+    or a read-only tool set for an ask-style pipeline). It is applied AFTER
+    the per-agent resolve cache, so the constraint can depend on run-scoped
+    state (the cache holds the unconstrained resolve; the constraint is
+    re-applied cheaply per spawn). The runner itself stays domain-agnostic --
+    it never inspects what the constraint does.
+
+    ``spawn_timeout`` (optional) wraps each child spawn in
+    ``asyncio.wait_for`` -- a long-running box node that hangs then fails
+    loud rather than blocking the whole pipeline forever. ``None`` (default)
+    means no timeout.
     """
     _agent_cache: dict[str, Any] = {}
 
@@ -337,7 +356,10 @@ def make_spawn_fn(prepared: Any, cwd: Path | None = None):
             _agent_cache[agent_name] = await _resolve_agent_bundle(agent_name, config)
         child_bundle = _agent_cache[agent_name]
 
-        return await prepared.spawn(
+        if child_constraint is not None:
+            child_bundle = child_constraint(child_bundle)
+
+        spawn_coro = prepared.spawn(
             child_bundle=child_bundle,
             instruction=instruction,
             session_id=sub_session_id,
@@ -348,22 +370,11 @@ def make_spawn_fn(prepared: Any, cwd: Path | None = None):
             self_delegation_depth=self_delegation_depth,
             session_cwd=cwd,
         )
+        if spawn_timeout is not None:
+            return await asyncio.wait_for(spawn_coro, timeout=spawn_timeout)
+        return await spawn_coro
 
     return spawn_capability
-
-
-def _attractor_repo_root() -> Path | None:
-    """Best-effort local checkout root for ``attractor:agents/...`` refs.
-
-    Only meaningful when the base bundle was resolved from a local sibling
-    path (see ``_load_base_bundle``); otherwise agent bundle refs fall
-    through to the git URL candidate in ``_resolve_agent_bundle``.
-    """
-    local = _local_bundle_path()
-    if local is not None and local.exists():
-        # bundles/attractor-pipeline.yaml -> repo root is parent.parent
-        return local.resolve().parent.parent
-    return None
 
 
 def _local_bundle_path() -> Path:
@@ -425,6 +436,7 @@ async def _build_prepared(
     *,
     params: dict[str, str] | None,
     profiles: dict[str, str] | None,
+    extra_overlays: Sequence[Any] | None = None,
 ) -> Any:
     """Compose base + a minimal orchestrator overlay, then prepare.
 
@@ -440,6 +452,12 @@ async def _build_prepared(
     forwarded into its config for parity/possible future use, but are
     otherwise inert for the direct-engine path (``drive_engine`` re-parses
     ``dot_source`` and re-seeds params itself).
+
+    ``extra_overlays`` (optional) are additional ``Bundle`` overlays composed
+    AFTER the runtime orchestrator overlay, in order. This is the generic
+    seam a consumer uses to add cross-cutting configuration to every session
+    and spawned child -- e.g. mounting an observability hook -- without the
+    runner needing to know what the overlay contains.
     """
     global _DEPS_INSTALLED
     from amplifier_foundation import Bundle
@@ -467,6 +485,8 @@ async def _build_prepared(
     )
 
     composed = base.compose(overlay)
+    for extra in extra_overlays or ():
+        composed = composed.compose(extra)
 
     # First prepare in this process resolves/installs modules (slow, first
     # run only); subsequent ones take the offline path. Override with
@@ -494,6 +514,9 @@ async def run_pipeline(
     interviewer: Any = None,
     transform: bool = True,
     validate: bool = True,
+    extra_overlays: Sequence[Any] | None = None,
+    child_constraint: Callable[[Any], Any] | None = None,
+    spawn_timeout: float | None = None,
 ) -> PipelineResult:
     """Run a DOT pipeline through the attractor engine, standalone.
 
@@ -543,10 +566,17 @@ async def run_pipeline(
         logs_dir,
         params=dict(params) if params else None,
         profiles=resolved_profiles,
+        extra_overlays=extra_overlays,
     )
     session = await prepared.create_session(session_cwd=cwd_path)
     session.coordinator.register_capability(
-        "session.spawn", make_spawn_fn(prepared, cwd=cwd_path)
+        "session.spawn",
+        make_spawn_fn(
+            prepared,
+            cwd=cwd_path,
+            child_constraint=child_constraint,
+            spawn_timeout=spawn_timeout,
+        ),
     )
 
     async with session:
@@ -563,6 +593,7 @@ async def run_pipeline(
             validate=validate,
         )
 
+    failure_reason = getattr(outcome, "failure_reason", None)
     data = {
         "status": outcome.status.value,
         "notes": outcome.notes or "",
@@ -574,4 +605,5 @@ async def run_pipeline(
         notes=str(data["notes"])[:4000],
         logs_dir=logs_dir,
         raw=text[:4000],
+        failure_reason=str(failure_reason) if failure_reason else None,
     )

--- a/modules/pipeline-runner/amplifier_module_pipeline_runner/runner.py
+++ b/modules/pipeline-runner/amplifier_module_pipeline_runner/runner.py
@@ -1,0 +1,575 @@
+"""Reusable engine harness: run an arbitrary attractor DOT pipeline.
+
+Two-layer public API:
+
+* ``drive_engine`` -- low-level. Caller supplies an already-built
+  ``coordinator`` (with ``session.spawn`` already registered on it) and this
+  function parses/transforms/validates the graph, seeds context, and drives
+  ``PipelineEngine`` directly. This is the seam a consumer with its own
+  session/bundle lifecycle (e.g. an existing resolver) plugs into.
+* ``run_pipeline`` -- high-level convenience. Builds the prepared bundle,
+  session, and spawn wiring itself, then calls ``drive_engine``. This is what
+  the CLI uses.
+
+Extracted from dot-graph-runner's ``dot_graph_runner/runner.py`` (~429 lines),
+split into this two-function shape per the attractor-runner design (slice 0).
+Uses ONLY the attractor engine's public modules
+(``amplifier_module_loop_pipeline.{context,dot_parser,engine,handlers,backend,
+validation,transforms}``).
+
+Why the direct-engine path: the mounted loop-pipeline orchestrator (driven via
+``session.execute()``) builds its own internal ``PipelineContext`` and exposes
+``params`` only as a nested dict for LLM-prompt ``$key`` expansion -- there is
+no seam to seed flat context keys that way, so a ``--param`` would never reach
+``tool_command``/``tool_env``. Driving the engine directly is what lets a
+``--param`` reach a tool node.
+
+Every LLM (``box``) node spawns a full ``attractor-agent-*`` coding agent (its
+own ``loop-agent`` orchestrator + filesystem/bash/search tools) via the
+``session.spawn`` capability.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from amplifier_module_loop_pipeline.graph import Graph
+    from amplifier_module_loop_pipeline.outcome import Outcome
+
+# Maps llm_provider node values -> child agent name, cribbed from
+# agents/pipeline-runner.yaml / bundles/attractor-pipeline.yaml. This is the
+# default provider->agent map used when the caller doesn't supply its own
+# ``profiles`` (discover_profiles-from-graph is deferred to a later slice).
+DEFAULT_PROFILES: dict[str, str] = {
+    "anthropic": "attractor-agent-anthropic",
+    "openai": "attractor-agent-openai",
+    "gemini": "attractor-agent-gemini",
+}
+
+# Env var name per provider -- used by the CLI's fail-loud preflight check
+# (a provider's API key must be present BEFORE the engine starts running).
+PROVIDER_KEY_ENV: dict[str, str] = {
+    "anthropic": "ANTHROPIC_API_KEY",
+    "openai": "OPENAI_API_KEY",
+    "gemini": "GEMINI_API_KEY",
+}
+
+# Reserved context keys that seed_context sets itself -- a user --param may
+# not collide with these (see seed_context's reserved-key guard).
+_RESERVED_CONTEXT_KEYS: frozenset[str] = frozenset({"context.target_dir"})
+
+# In-process cache: load the base bundle once; install deps once, then reuse
+# the offline path for subsequent runs in the same process.
+_BASE_BUNDLE: Any = None
+_DEPS_INSTALLED = False
+
+
+@dataclass
+class PipelineResult:
+    """Result of a ``run_pipeline`` invocation.
+
+    Attributes:
+        status: The pipeline outcome status string (e.g. "success", "fail").
+        notes: Outcome notes, truncated to 4000 chars.
+        logs_dir: Directory containing this run's logs (including the
+            written ``pipeline.dot`` source).
+        raw: JSON-serialized ``{"status": ..., "notes": ...}``, truncated to
+            4000 chars.
+    """
+
+    status: str
+    notes: str
+    logs_dir: Path
+    raw: str
+
+
+def seed_context(
+    context: Any, params: Mapping[str, str] | None, cwd: Path | str
+) -> None:
+    """Seed a ``PipelineContext`` with flat ``--param`` keys plus reserved keys.
+
+    Each ``params`` entry is set as a flat context key via ``context.set``
+    (this is what lets a ``--param`` reach ``tool_command``/``tool_env`` --
+    see the module docstring). After user params are seeded, the reserved key
+    ``context.target_dir`` is set to ``str(cwd)`` -- tool nodes resolve
+    relative paths against this (handlers/tool.py:
+    ``context.get("context.target_dir") or graph.source_dir``).
+
+    Reserved-key guard: if any user param key collides with a reserved
+    context key, this raises ``ValueError`` BEFORE seeding anything --
+    silently overwriting a reserved key (or being silently overwritten by
+    the reserved-key seed below) would be confusing and non-obvious.
+
+    There is intentionally only ONE reserved key -- ``context.target_dir``.
+    ``context.work_dir`` is deliberately NOT set; the engine does not read it.
+
+    Args:
+        context: A ``PipelineContext``-like object exposing ``.set(key, value)``.
+        params: Flat key->value params to seed (may be None/empty).
+        cwd: The pipeline's working directory.
+
+    Raises:
+        ValueError: If a user param key collides with a reserved context key.
+    """
+    params = params or {}
+    for key in params:
+        if key in _RESERVED_CONTEXT_KEYS:
+            raise ValueError(f"--param key {key!r} collides with reserved context key")
+
+    for key, value in params.items():
+        context.set(key, str(value))
+
+    context.set("context.target_dir", str(cwd))
+
+
+async def drive_engine(
+    graph_or_dot: "Graph | str",
+    coordinator: Any,
+    *,
+    params: Mapping[str, str] | None = None,
+    cwd: Path | str | None = None,
+    logs_root: Path | str,
+    hooks: Any = None,
+    profiles: Mapping[str, str] | None = None,
+    interviewer: Any = None,
+    transform: bool,
+    validate: bool = True,
+) -> "Outcome":
+    """Drive the attractor engine directly against an already-built coordinator.
+
+    Low-level API: the caller is responsible for building the session and
+    registering ``session.spawn`` on ``coordinator`` before calling this
+    (see ``run_pipeline`` for the high-level convenience that does this).
+
+    Backend / session.spawn wiring (the part that had to be gotten right):
+    ``AmplifierBackend._run_with_spawn`` (backend.py) obtains everything it
+    needs from the ``coordinator`` object passed to ``AmplifierBackend()``:
+      - ``coordinator.get_capability("session.spawn")`` -- the spawn fn.
+      - ``getattr(coordinator, "session", None)`` -- the parent session for
+        lineage tracking.
+      - ``getattr(coordinator, "config", None).get("agents", {})`` -- the
+        per-profile agent configs, used both to resolve which bundle to
+        spawn and for the recursion guard (each entry must carry an inline
+        non-pipeline ``session.orchestrator``).
+    The caller's ``coordinator`` must already satisfy all three lookups
+    (this is naturally true of a coordinator built via
+    ``PreparedBundle.create_session()`` against the attractor-pipeline
+    bundle -- see ``run_pipeline``).
+
+    Args:
+        graph_or_dot: A parsed ``Graph``, or raw DOT source text to parse.
+        coordinator: An already-built coordinator with ``session.spawn``
+            already registered on it.
+        params: Flat key->value params seeded into context (see
+            ``seed_context``). Also reaches LLM ``box`` prompts via
+            ``graph.params_values``.
+        cwd: Working directory for the pipeline (tool/box nodes write here).
+            Defaults to ``Path.cwd()`` if not given.
+        logs_root: Directory for this run's engine logs.
+        hooks: Optional hooks object forwarded to the handler registry and engine.
+        profiles: llm_provider -> agent-name routing map. Defaults to
+            ``DEFAULT_PROFILES`` if not given.
+        interviewer: Optional interviewer object forwarded to the handler
+            registry (human-in-the-loop gate seam).
+        transform: Required keyword. If True, run ``apply_transforms`` on the
+            graph before validation/execution (stylesheet routing only fires
+            if the graph sets ``model_stylesheet``).
+        validate: If True (default), run ``validate_or_raise`` on the graph
+            before execution -- fails loud on graph-shape problems before
+            spending an LLM call.
+
+    Returns:
+        The engine's ``Outcome`` (``outcome.status.value``, ``outcome.notes``).
+    """
+    from amplifier_module_loop_pipeline.backend import AmplifierBackend
+    from amplifier_module_loop_pipeline.context import PipelineContext
+    from amplifier_module_loop_pipeline.dot_parser import parse_dot
+    from amplifier_module_loop_pipeline.engine import PipelineEngine
+    from amplifier_module_loop_pipeline.handlers import HandlerContext, HandlerRegistry
+    from amplifier_module_loop_pipeline.transforms import apply_transforms
+    from amplifier_module_loop_pipeline.validation import validate_or_raise
+
+    graph = parse_dot(graph_or_dot) if isinstance(graph_or_dot, str) else graph_or_dot
+
+    resolved_cwd = Path(cwd) if cwd is not None else Path.cwd()
+
+    context = PipelineContext()
+    seed_context(context, params, resolved_cwd)
+
+    if transform:
+        graph = apply_transforms(graph, context)
+
+    if validate:
+        # Fail loud on graph-shape problems before spending an LLM call.
+        validate_or_raise(graph)
+
+    backend = AmplifierBackend(
+        coordinator=coordinator,
+        profiles=dict(profiles or DEFAULT_PROFILES),
+    )
+    registry = HandlerRegistry(
+        HandlerContext(backend=backend, hooks=hooks, interviewer=interviewer)
+    )
+    engine = PipelineEngine(
+        graph=graph,
+        context=context,
+        handler_registry=registry,
+        logs_root=str(logs_root),
+        hooks=hooks,
+    )
+
+    return await engine.run()
+
+
+async def _resolve_agent_bundle(agent_name: str, config: dict[str, Any]) -> Any:
+    """Resolve a per-node agent into a full, self-contained child Bundle.
+
+    Adapted verbatim (structurally) from dot-graph-runner's
+    ``_resolve_agent_bundle``. The recursion-avoidance mechanism: every child
+    agent must carry an inline ``session.orchestrator`` set to a
+    NON-pipeline orchestrator (``loop-agent``). Without it the spawned child
+    inherits the parent's ``loop-pipeline`` orchestrator and re-runs the
+    whole DOT (infinite recursion).
+
+    Two ``config`` shapes are accepted:
+    * Inline definition (current) -- a full agent dict with its own
+      ``session`` (inline ``loop-agent`` orchestrator), ``providers``,
+      ``tools``, ``hooks``, ``instruction``. This is what
+      attractor-pipeline's ``agents:`` block declares.
+    * ``{"bundle": "attractor:agents/<name>"}`` reference (legacy) --
+      resolved via ``load_bundle``.
+    """
+    from amplifier_foundation import load_bundle
+
+    ref = config.get("bundle") if isinstance(config, dict) else None
+    if ref:
+        # e.g. "attractor:agents/attractor-agent-anthropic"
+        _ns, _, rel = str(ref).partition(":")
+        candidates: list[str] = []
+        if rel:
+            repo_root = _attractor_repo_root()
+            if repo_root is not None:
+                local = (repo_root / rel).with_suffix(".yaml")
+                candidates.append(str(local))
+            candidates.append(
+                "git+https://github.com/microsoft/amplifier-bundle-attractor@main"
+                f"#subdirectory={rel}.yaml"
+            )
+        else:
+            candidates = [str(ref)]
+        last_err: Exception | None = None
+        for src in candidates:
+            try:
+                return await load_bundle(src)
+            except Exception as e:  # noqa: BLE001
+                last_err = e
+        raise RuntimeError(
+            f"Could not resolve agent bundle '{agent_name}' ({ref}): {last_err}"
+        )
+
+    # Inline config form (already a full agent definition).
+    from amplifier_foundation import Bundle
+
+    return Bundle(
+        name=agent_name,
+        version="1.0.0",
+        session=config.get("session", {}),
+        providers=config.get("providers", []),
+        tools=config.get("tools", []),
+        hooks=config.get("hooks", []),
+        instruction=config.get("instruction")
+        or config.get("system", {}).get("instruction"),
+    )
+
+
+def make_spawn_fn(prepared: Any, cwd: Path | None = None):
+    """Build the ``session.spawn`` capability for a prepared bundle.
+
+    Adapted from dot-graph-runner's ``make_spawn_fn``. Each pipeline node
+    spawns a full child sub-session built from one of the bundle's
+    per-provider agents (resolved to its own ``loop-agent`` orchestrator +
+    tools).
+
+    This signature matches what ``AmplifierBackend._run_with_spawn`` calls
+    (amplifier_module_loop_pipeline/backend.py) regardless of whether the
+    engine is driven via the mounted orchestrator or directly -- the spawn
+    capability itself is unchanged by that switch.
+
+    ``cwd`` is the pipeline working directory (``--cwd``). It is threaded
+    explicitly into every box-node child session as ``session_cwd`` so the
+    agent's filesystem/bash tools are rooted at ``--cwd`` -- mirroring how
+    tool nodes get ``context.target_dir`` set explicitly. Without this,
+    ``PreparedBundle.spawn`` falls back to inheriting the parent session's
+    working_dir, which is fragile and leaves box nodes writing to the
+    process cwd instead of ``--cwd``. This is the load-bearing host/DTU cwd
+    fix -- preserve the ``session_cwd=cwd`` argument exactly.
+    """
+    _agent_cache: dict[str, Any] = {}
+
+    async def spawn_capability(
+        agent_name: str,
+        instruction: str,
+        parent_session: Any,
+        agent_configs: dict[str, dict[str, Any]],
+        sub_session_id: str | None = None,
+        orchestrator_config: dict[str, Any] | None = None,
+        parent_messages: list[dict[str, Any]] | None = None,
+        provider_preferences: list | None = None,
+        self_delegation_depth: int = 0,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        if agent_name in agent_configs:
+            config = agent_configs[agent_name]
+        elif agent_name in prepared.bundle.agents:
+            config = prepared.bundle.agents[agent_name]
+        else:
+            available = list(agent_configs.keys()) + list(prepared.bundle.agents.keys())
+            raise ValueError(f"Agent '{agent_name}' not found. Available: {available}")
+
+        if agent_name not in _agent_cache:
+            _agent_cache[agent_name] = await _resolve_agent_bundle(agent_name, config)
+        child_bundle = _agent_cache[agent_name]
+
+        return await prepared.spawn(
+            child_bundle=child_bundle,
+            instruction=instruction,
+            session_id=sub_session_id,
+            parent_session=parent_session,
+            orchestrator_config=orchestrator_config,
+            parent_messages=parent_messages,
+            provider_preferences=provider_preferences,
+            self_delegation_depth=self_delegation_depth,
+            session_cwd=cwd,
+        )
+
+    return spawn_capability
+
+
+def _attractor_repo_root() -> Path | None:
+    """Best-effort local checkout root for ``attractor:agents/...`` refs.
+
+    Only meaningful when the base bundle was resolved from a local sibling
+    path (see ``_load_base_bundle``); otherwise agent bundle refs fall
+    through to the git URL candidate in ``_resolve_agent_bundle``.
+    """
+    local = _local_bundle_path()
+    if local is not None and local.exists():
+        # bundles/attractor-pipeline.yaml -> repo root is parent.parent
+        return local.resolve().parent.parent
+    return None
+
+
+def _local_bundle_path() -> Path:
+    """Path to the local sibling attractor-pipeline bundle, if any.
+
+    Computed relative to this file: this module lives at
+    ``<repo>/modules/pipeline-runner/amplifier_module_pipeline_runner/runner.py``,
+    so the repo root is ``parents[3]`` and the bundle is at
+    ``<repo>/bundles/attractor-pipeline.yaml``. Overridable via the
+    ``ATTRACTOR_PIPELINE_BUNDLE`` env var for out-of-tree development.
+    """
+    override = os.environ.get("ATTRACTOR_PIPELINE_BUNDLE")
+    if override:
+        return Path(override).expanduser()
+    repo_root = Path(__file__).resolve().parents[3]
+    return repo_root / "bundles" / "attractor-pipeline.yaml"
+
+
+_ATTRACTOR_PIPELINE_GIT = (
+    "git+https://github.com/microsoft/amplifier-bundle-attractor@main"
+    "#subdirectory=bundles/attractor-pipeline.yaml"
+)
+
+
+async def _load_base_bundle() -> Any:
+    """Load the attractor-pipeline bundle (local sibling preferred, else git).
+
+    Cached in a module global -- loaded once per process.
+    """
+    global _BASE_BUNDLE
+    if _BASE_BUNDLE is not None:
+        return _BASE_BUNDLE
+    from amplifier_foundation import load_bundle
+
+    local = _local_bundle_path()
+    last_err: Exception | None = None
+    if local.exists():
+        try:
+            _BASE_BUNDLE = await load_bundle(str(local))
+            return _BASE_BUNDLE
+        except Exception as e:  # noqa: BLE001
+            last_err = e
+
+    # TODO(slice-1/§8.6): verify local-sibling resolution for a built wheel /
+    # DTU install (non-monorepo) -- this git fallback is the path that
+    # exercises in that environment.
+    try:
+        _BASE_BUNDLE = await load_bundle(_ATTRACTOR_PIPELINE_GIT)
+        return _BASE_BUNDLE
+    except Exception as e:  # noqa: BLE001
+        last_err = e
+
+    raise RuntimeError(f"Could not load attractor-pipeline bundle: {last_err}")
+
+
+async def _build_prepared(
+    dot_source: str,
+    logs_dir: Path,
+    *,
+    params: dict[str, str] | None,
+    profiles: dict[str, str] | None,
+) -> Any:
+    """Compose base + a minimal orchestrator overlay, then prepare.
+
+    We still mount the loop-pipeline module as ``session.orchestrator`` --
+    ``AmplifierSession`` requires SOME orchestrator to be present at
+    construction, and mounting the module is also what makes the
+    attractor-pipeline bundle's static ``agents:`` block land in
+    ``session.coordinator.config["agents"]`` (each entry already carrying
+    its own inline ``loop-agent`` orchestrator -- see ``AmplifierBackend``'s
+    recursion guard). ``drive_engine`` never calls this mounted
+    orchestrator's ``execute()`` though -- it drives ``PipelineEngine``
+    directly instead. ``dot_source``/``params``/``profiles`` are still
+    forwarded into its config for parity/possible future use, but are
+    otherwise inert for the direct-engine path (``drive_engine`` re-parses
+    ``dot_source`` and re-seeds params itself).
+    """
+    global _DEPS_INSTALLED
+    from amplifier_foundation import Bundle
+
+    base = await _load_base_bundle()
+
+    orchestrator_config: dict[str, Any] = {
+        "dot_source": dot_source,
+        "logs_root": str(logs_dir),
+    }
+    if params:
+        orchestrator_config["params"] = params
+    if profiles:
+        orchestrator_config["profiles"] = profiles
+
+    overlay = Bundle(
+        name="pipeline-runner-runtime",
+        version="1.0.0",
+        session={
+            "orchestrator": {
+                "module": "loop-pipeline",
+                "config": orchestrator_config,
+            },
+        },
+    )
+
+    composed = base.compose(overlay)
+
+    # First prepare in this process resolves/installs modules (slow, first
+    # run only); subsequent ones take the offline path. Override with
+    # ATTRACTOR_INSTALL_DEPS=0/1.
+    env = os.environ.get("ATTRACTOR_INSTALL_DEPS")
+    if env is not None:
+        install_deps = env not in ("0", "false", "False", "")
+    else:
+        install_deps = not _DEPS_INSTALLED
+
+    prepared = await composed.prepare(install_deps=install_deps)
+    _DEPS_INSTALLED = True
+    return prepared
+
+
+async def run_pipeline(
+    dot_source: str,
+    *,
+    params: Mapping[str, str] | None = None,
+    cwd: Path | str | None = None,
+    logs_root: Path | str | None = None,
+    provider: str = "anthropic",
+    profiles: Mapping[str, str] | None = None,
+    hooks: Any = None,
+    transform: bool = True,
+    validate: bool = True,
+) -> PipelineResult:
+    """Run a DOT pipeline through the attractor engine, standalone.
+
+    High-level convenience: builds the prepared bundle, session, and spawn
+    wiring itself, then drives the engine via ``drive_engine``.
+
+    Args:
+        dot_source: The DOT digraph source text.
+        params: Key-value map exposed to the pipeline as flat context keys
+            (reaches ``$param`` expansion in LLM node prompts, tool_command
+            substitution, AND tool_env -- see ``seed_context``).
+        cwd: Working directory for the orchestrator session (created if
+            absent). Defaults to ``Path.cwd()`` if not given.
+        logs_root: Directory for this run's logs (created if absent).
+            Defaults to a fresh tempdir if not given.
+        provider: Recorded for parity with the CLI's own preflight checks
+            (e.g. the fail-loud API-key check). Not currently used to alter
+            engine behavior -- the DOT's own llm_provider node attributes
+            and the profiles map determine routing.
+        profiles: llm_provider -> agent-name routing map. Defaults to
+            ``DEFAULT_PROFILES`` if not given.
+        hooks: Optional hooks object forwarded to the engine.
+        transform: If True (default), run ``apply_transforms`` before
+            validation/execution.
+        validate: If True (default), run ``validate_or_raise`` before execution.
+
+    Returns:
+        A ``PipelineResult`` with status, notes, logs_dir, and raw JSON.
+    """
+    del provider  # not yet used inside the engine call; see docstring.
+
+    if logs_root is not None:
+        logs_dir = Path(logs_root).expanduser().resolve()
+    else:
+        logs_dir = Path(tempfile.mkdtemp(prefix="attractor-run-"))
+    logs_dir.mkdir(parents=True, exist_ok=True)
+
+    cwd_path = Path(cwd).expanduser().resolve() if cwd is not None else Path.cwd()
+    cwd_path.mkdir(parents=True, exist_ok=True)
+
+    (logs_dir / "pipeline.dot").write_text(dot_source, encoding="utf-8")
+
+    resolved_profiles = dict(profiles) if profiles else dict(DEFAULT_PROFILES)
+
+    prepared = await _build_prepared(
+        dot_source,
+        logs_dir,
+        params=dict(params) if params else None,
+        profiles=resolved_profiles,
+    )
+    session = await prepared.create_session(session_cwd=cwd_path)
+    session.coordinator.register_capability(
+        "session.spawn", make_spawn_fn(prepared, cwd=cwd_path)
+    )
+
+    async with session:
+        outcome = await drive_engine(
+            dot_source,
+            session.coordinator,
+            params=params,
+            cwd=cwd_path,
+            logs_root=logs_dir,
+            hooks=hooks,
+            profiles=resolved_profiles,
+            transform=transform,
+            validate=validate,
+        )
+
+    data = {
+        "status": outcome.status.value,
+        "notes": outcome.notes or "",
+    }
+    text = json.dumps(data)
+
+    return PipelineResult(
+        status=data["status"],
+        notes=str(data["notes"])[:4000],
+        logs_dir=logs_dir,
+        raw=text[:4000],
+    )

--- a/modules/pipeline-runner/amplifier_module_pipeline_runner/runner.py
+++ b/modules/pipeline-runner/amplifier_module_pipeline_runner/runner.py
@@ -217,19 +217,34 @@ async def drive_engine(
         # Fail loud on graph-shape problems before spending an LLM call.
         validate_or_raise(graph)
 
+    # Default engine/handler observability to the coordinator's own hook stack
+    # when the caller didn't supply hooks. A mounted observability hook (e.g.
+    # a session-level logging/telemetry hook composed onto the bundle) lives on
+    # ``coordinator.hooks``; the mounted-orchestrator path reaches it because
+    # the session hands the orchestrator ``coordinator.hooks`` and it forwards
+    # that same object into ``PipelineEngine(hooks=...)``. Driving the engine
+    # directly, we must do the same, or the engine's ``pipeline:*`` events (and
+    # handler-emitted ``provider:*``/``tool:*`` events) are emitted into nothing
+    # and never reach the session's observers. ``getattr(..., None)`` keeps
+    # bare test-stub coordinators (which may lack ``.hooks``) safe, and the
+    # ``hooks is not None`` guard preserves an explicit caller override.
+    effective_hooks = hooks if hooks is not None else getattr(coordinator, "hooks", None)
+
     backend = AmplifierBackend(
         coordinator=coordinator,
         profiles=dict(profiles or DEFAULT_PROFILES),
     )
     registry = HandlerRegistry(
-        HandlerContext(backend=backend, hooks=hooks, interviewer=interviewer)
+        HandlerContext(
+            backend=backend, hooks=effective_hooks, interviewer=interviewer
+        )
     )
     engine = PipelineEngine(
         graph=graph,
         context=context,
         handler_registry=registry,
         logs_root=str(logs_root),
-        hooks=hooks,
+        hooks=effective_hooks,
     )
 
     return await engine.run()

--- a/modules/pipeline-runner/amplifier_module_pipeline_runner/runner.py
+++ b/modules/pipeline-runner/amplifier_module_pipeline_runner/runner.py
@@ -491,6 +491,7 @@ async def run_pipeline(
     provider: str = "anthropic",
     profiles: Mapping[str, str] | None = None,
     hooks: Any = None,
+    interviewer: Any = None,
     transform: bool = True,
     validate: bool = True,
 ) -> PipelineResult:
@@ -557,6 +558,7 @@ async def run_pipeline(
             logs_root=logs_dir,
             hooks=hooks,
             profiles=resolved_profiles,
+            interviewer=interviewer,
             transform=transform,
             validate=validate,
         )

--- a/modules/pipeline-runner/dtu/acceptance-tests.yaml
+++ b/modules/pipeline-runner/dtu/acceptance-tests.yaml
@@ -1,0 +1,81 @@
+summary: "attractor run honors --param at tool nodes and --cwd for both tool-node and box-node (agent) file writes, end-to-end"
+software_type: cli_tool
+
+# Test type: `other` (routes to reality-check's generic-tester), NOT `cli`.
+# `attractor run` is a NON-INTERACTIVE batch CLI -- every check here is "run a
+# command, check exit code + output files". reality-check's `cli` type routes to
+# terminal-tester, whose specialty is INTERACTIVE TUI/CLI driving
+# (spawn/send_keys/screenshot/wait_for_text) -- the wrong tool for a batch
+# runner. generic-tester (`other`) is the shell/exit-code/filesystem-assertion
+# validator, which is exactly what these tests are.
+
+entry_points:
+  - type: command
+    value: "attractor"
+    label: "attractor CLI (installed as a uv tool from modules/pipeline-runner)"
+
+tests:
+  - id: attractor-doctor-ok
+    description: "attractor CLI is installed and doctor reports environment health"
+    type: other
+    steps:
+      - action: "Run 'attractor doctor'"
+        expect: "Command exits 0 and prints environment/dependency status without an unhandled error or traceback"
+
+  - id: tool-node-param-and-cwd
+    description: >-
+      A tool-node pipeline reads a --param and writes a relative-path file that
+      lands under --cwd (proves the flat-param -> tool-node seam and --cwd rooting)
+    type: other
+    steps:
+      - action: >-
+          Create an empty working directory (e.g. ./work). From the cloned source at
+          /root/attractor-src/modules/pipeline-runner/tests/fixtures, run
+          'attractor run fixture_tool_reads_param.dot --param outfile=proof.txt --param content=ok --cwd ./work'
+        expect: "Command exits 0 and status is success"
+      - action: "List the contents of ./work and show proof.txt"
+        expect: "./work contains proof.txt and its contents are exactly 'ok'"
+
+  - id: box-node-writes-cwd
+    description: >-
+      A box-node (LLM/agent) pipeline writes a relative-path file that lands under
+      --cwd (regression/sanity that a spawned agent roots its file writes at
+      --cwd/session_cwd, and that the runner resolves its base bundle correctly
+      from a wheel install -- no monorepo checkout present)
+    type: other
+    steps:
+      - action: >-
+          Create an empty working directory (e.g. ./work). From the cloned source at
+          /root/attractor-src/modules/pipeline-runner/tests/fixtures, run
+          'attractor run fixture_box_writes_cwd.dot --cwd ./work --provider anthropic'
+        expect: "Command exits 0 and status is success within the iteration cap (a live LLM/agent run; may take a few minutes)"
+      - action: "List the contents of ./work and show agent_proof.txt"
+        expect: "./work contains agent_proof.txt and its contents are exactly 'box-cwd-ok'"
+
+metadata:
+  tags: ["smoke", "regression", "cwd", "param", "pipeline-runner"]
+  test_type_note: >-
+    All tests are type `other` (reality-check generic-tester), not `cli`. attractor run
+    is a non-interactive batch CLI; these are command-exit-code + output-file assertions,
+    which is generic-tester's domain. `cli` routes to terminal-tester (interactive
+    TUI/keystroke driving) and is the wrong validator for this tool.
+
+assumptions:
+  - >-
+    Host-vs-container cwd scope: the box-node -> --cwd guarantee only diverges from the
+    process working directory when the runner is launched from a DIFFERENT directory than
+    --cwd. Inside a DTU the process cwd typically equals the workspace, so the DTU CANNOT
+    reproduce the original divergence; the box-node test here is a REGRESSION/SANITY check
+    that a full box-node + tool-node pipeline runs end-to-end and roots at --cwd -- NOT a
+    reproduction of the host-only divergence (which is proven separately on the host by
+    launching from a parent directory with --cwd pointing elsewhere).
+  - >-
+    Assumes 'attractor' is on PATH (installed via 'uv tool install' from
+    modules/pipeline-runner -- either published @main or a Gitea mirror of local changes).
+  - >-
+    Assumes the shipped runner fixtures are available (the dtu/pipeline-runner.yaml profile
+    clones the repo to /root/attractor-src for this). Adjust the fixtures path if staged elsewhere.
+  - >-
+    Assumes a working '--provider anthropic' backend with valid credentials in the environment
+    for the box-node test; that test requires a live LLM/agent run and may take several minutes.
+    The tool-node test needs no API key.

--- a/modules/pipeline-runner/dtu/pipeline-runner.yaml
+++ b/modules/pipeline-runner/dtu/pipeline-runner.yaml
@@ -1,0 +1,91 @@
+# pipeline-runner Digital Twin profile -- SHIPPED WITH THE MODULE.
+#
+# Stands up an isolated Ubuntu env with a working Amplifier install + the
+# `attractor` CLI (this module), so anyone can run standalone attractor .dot
+# pipelines in a reproducible place -- and so the runner can be smoke-tested
+# before/after changes.
+#
+# Portable by design (unlike a personal, host-tied profile): it installs the
+# runner from its GitHub remote at @main, NOT from a local absolute path, so it
+# works on any machine that has the `amplifier-digital-twin` CLI.
+#
+# PREREQUISITES:
+#   - ANTHROPIC_API_KEY in the host env (forwarded via passthrough.services);
+#     required only for the box-node (agent) smoke, not the tool-node smoke.
+#   - Network on first run: `uv tool install` + the first `attractor run`
+#     resolve amplifier-foundation + the attractor bundle from github.com (can
+#     take several minutes).
+#   - To validate LOCAL, unpushed changes instead of published @main, use the
+#     amplifier-gitea + amplifier-tester flow to mirror the working tree -- do
+#     NOT re-point this profile at a host path.
+#
+# Launch:
+#   amplifier-digital-twin launch dtu/pipeline-runner.yaml --name pipeline-runner
+name: pipeline-runner
+description: >
+  Isolated env with a working Amplifier install + the attractor CLI, for
+  running standalone attractor .dot pipelines (smoke: the shipped runner
+  fixtures under modules/pipeline-runner/tests/fixtures/).
+
+base:
+  image: ubuntu:24.04
+
+passthrough:
+  allow_external: true
+  services:
+    - name: anthropic
+      key_env: ANTHROPIC_API_KEY
+
+provision:
+  setup_cmds:
+    # System deps
+    - apt-get update && apt-get install -y git curl
+
+    # Install uv
+    - curl -LsSf https://astral.sh/uv/install.sh | sh
+
+    # Install Amplifier from upstream (creates ~/.amplifier; provides the
+    # ecosystem + the interpreter the attractor engine composes agents from).
+    - uv tool install -vv git+https://github.com/microsoft/amplifier
+
+    # Configure the Anthropic provider so Amplifier sessions can reach the LLM.
+    # ANTHROPIC_API_KEY is forwarded via passthrough.services.
+    - |
+      mkdir -p /root/.amplifier
+      cat > /root/.amplifier/settings.yaml << EOF
+      config:
+        providers:
+          - module: provider-anthropic
+            source: git+https://github.com/microsoft/amplifier-module-provider-anthropic@main
+            config:
+              api_key: $ANTHROPIC_API_KEY
+      EOF
+
+    # Sanity check amplifier
+    - amplifier --version
+
+    # Install the attractor CLI (this module). It declares
+    # amplifier-module-loop-pipeline as a real dependency, so a plain install
+    # pulls the attractor engine.
+    - uv tool install -vv "git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/pipeline-runner"
+
+    # Verify the CLI is on PATH
+    - attractor doctor
+
+    # Get the shipped runner fixtures (the installed wheel doesn't ship tests/).
+    # Fixtures then live at /root/attractor-src/modules/pipeline-runner/tests/fixtures/
+    # e.g. cd /root/attractor-src/modules/pipeline-runner/tests/fixtures
+    #      attractor run fixture_box_writes_cwd.dot --cwd /root/attractor-out
+    - git clone --depth 1 https://github.com/microsoft/amplifier-bundle-attractor /root/attractor-src
+
+update:
+  cmds:
+    # Pull the latest published runner (and its @main deps).
+    - uv tool install --reinstall -vv "git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/pipeline-runner"
+    - attractor doctor
+
+readiness:
+  - name: attractor-installed
+    command: "command -v attractor"
+  - name: amplifier-installed
+    command: "command -v amplifier"

--- a/modules/pipeline-runner/pyproject.toml
+++ b/modules/pipeline-runner/pyproject.toml
@@ -1,0 +1,48 @@
+[project]
+name = "amplifier-module-pipeline-runner"
+version = "0.1.0"
+description = "Reusable engine-driving library + CLI for standalone attractor DOT pipeline runs"
+license = "MIT"
+requires-python = ">=3.11"
+authors = [
+    { name = "Microsoft MADE:Explorations Team" },
+]
+dependencies = [
+    "amplifier-core>=0.1.0",
+    "amplifier-foundation @ git+https://github.com/microsoft/amplifier-foundation@main",
+    "amplifier-module-loop-pipeline @ git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-pipeline",
+]
+
+[project.scripts]
+attractor = "amplifier_module_pipeline_runner.cli:main"
+
+[build-system]
+requires = [
+    "hatchling",
+]
+build-backend = "hatchling.build"
+
+[tool.uv]
+package = true
+
+[tool.uv.sources]
+amplifier-module-loop-pipeline = { path = "../loop-pipeline" }
+
+[tool.hatch.build.targets.wheel]
+packages = [
+    "amplifier_module_pipeline_runner",
+]
+
+[tool.hatch.metadata]
+allow-direct-references = true
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0.0",
+    "pytest-asyncio>=1.0.0",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--import-mode=importlib"
+asyncio_mode = "strict"

--- a/modules/pipeline-runner/tests/fixtures/README.md
+++ b/modules/pipeline-runner/tests/fixtures/README.md
@@ -1,0 +1,1 @@
+Runner test fixtures — deliberately trivial, NOT usable pipelines. Do not copy into examples/.

--- a/modules/pipeline-runner/tests/fixtures/fixture_box_writes_cwd.dot
+++ b/modules/pipeline-runner/tests/fixtures/fixture_box_writes_cwd.dot
@@ -1,0 +1,36 @@
+// fixture_box_writes_cwd.dot -- runner proof pipeline (slice 1).
+//
+// A single LLM `box` node (an agent session, not a deterministic tool node).
+// The agent is told to write a file at a RELATIVE path. Proves that a spawned
+// box-node agent's filesystem tools are rooted at --cwd (session_cwd), NOT the
+// runner's process working directory.
+//
+// This is the load-bearing check for the cwd host/DTU fix: box-node spawns must
+// receive session_cwd=cwd explicitly (make_spawn_fn) instead of inheriting the
+// parent process's working_dir. On the host, run this from a DIFFERENT process
+// cwd than --cwd -- if the agent_proof.txt lands under --cwd (and not the
+// process cwd), the fix holds.
+//
+// Deterministic on purpose: the agent's only job is to create one file with one
+// exact line, so the assertion is a simple file-exists + content check.
+//
+// Usage:
+//   attractor run fixture_box_writes_cwd.dot --cwd <dir>
+//   -> agent writes <dir>/agent_proof.txt containing "box-cwd-ok"
+
+digraph fixture_box_writes_cwd {
+    graph [goal="Prove a spawned box-node agent roots its file writes at --cwd (session_cwd)"]
+
+    start [shape=Mdiamond, label="Start"]
+
+    write_proof [
+        label="Agent writes a relative-path proof file",
+        llm_provider="anthropic",
+        llm_model="claude-sonnet-4-6",
+        prompt="Create a new file named exactly agent_proof.txt in the current working directory (use a relative path, do not prepend any directory). The file must contain exactly this single line and nothing else: box-cwd-ok\nUse your file-writing tool. Do not create any other files. When the file exists, you are done."
+    ]
+
+    exit [shape=Msquare, label="Exit"]
+
+    start -> write_proof -> exit
+}

--- a/modules/pipeline-runner/tests/fixtures/fixture_human_gate.dot
+++ b/modules/pipeline-runner/tests/fixtures/fixture_human_gate.dot
@@ -1,0 +1,36 @@
+// fixture_human_gate.dot -- runner proof pipeline (slice 3).
+//
+// A minimal pipeline with a single human gate (shape=hexagon -> the engine's
+// wait.human handler) and NO LLM/box nodes, so it is deterministic and needs
+// no API key. It exists to prove the runner's human-gate policy:
+//
+//   * default (no interviewer)        -> FAIL-LOUD: the engine's HumanGateHandler
+//     raises (it requires an interviewer), the engine returns Outcome(FAIL),
+//     and `attractor run` exits non-zero with a clear message.
+//   * `--on-human-gate auto-approve`  -> the runner supplies AutoApproveInterviewer,
+//     which selects the first choice ("[A] Approve"), routing to done -> success.
+//
+// The hexagon derives its choices from its outgoing edge labels (accelerator
+// keys parsed from the [X] prefix). Both choices route to done so the pipeline
+// terminates deterministically regardless of which is picked.
+//
+// Usage:
+//   attractor run fixture_human_gate.dot --cwd <dir>                       # exits non-zero (fail-loud)
+//   attractor run fixture_human_gate.dot --cwd <dir> --on-human-gate auto-approve   # succeeds
+
+digraph fixture_human_gate {
+    graph [goal="Prove the runner's human-gate policy (fail-loud default; auto-approve opt-in)"]
+
+    start [shape=Mdiamond, label="Start"]
+
+    approve_gate [
+        shape=hexagon,
+        label="Approve to finish?"
+    ]
+
+    done [shape=Msquare, label="Done"]
+
+    start -> approve_gate
+    approve_gate -> done [label="[A] Approve"]
+    approve_gate -> done [label="[R] Reject"]
+}

--- a/modules/pipeline-runner/tests/fixtures/fixture_tool_reads_param.dot
+++ b/modules/pipeline-runner/tests/fixtures/fixture_tool_reads_param.dot
@@ -1,0 +1,33 @@
+// fixture_tool_reads_param.dot -- runner proof pipeline (slice 0).
+//
+// One deterministic tool node, no LLM/box node. Proves both:
+//   1. --param reaches a TOOL node ($content / $outfile substitution in
+//      tool_command, per substitute_context -- handlers/tool.py).
+//   2. --cwd sets the pipeline's working directory (a RELATIVE $outfile
+//      path lands under --cwd, not the process cwd).
+//
+// tool_env="content" additionally exposes CONTENT as a real subprocess env
+// var (belt-and-suspenders over the $content substitution, which already
+// resolves the value before the shell ever sees the command).
+//
+// Usage:
+//   attractor run fixture_tool_reads_param.dot \
+//       --param outfile=proof.txt --param content=ok --cwd <dir>
+//   -> writes <dir>/proof.txt containing "ok"
+
+digraph fixture_tool_reads_param {
+    graph [goal="Prove --param reaches a tool node and --cwd roots relative paths"]
+
+    start [shape=Mdiamond, label="Start"]
+
+    write_proof [
+        shape=parallelogram,
+        label="Write param-driven proof file",
+        tool_command="printf '%s\n' \"$content\" > $outfile",
+        tool_env="content"
+    ]
+
+    exit [shape=Msquare, label="Exit"]
+
+    start -> write_proof -> exit
+}

--- a/modules/pipeline-runner/tests/test_extra_overlays.py
+++ b/modules/pipeline-runner/tests/test_extra_overlays.py
@@ -1,0 +1,131 @@
+"""Unit tests for the run_pipeline consumer seam on ``_build_prepared``'s
+``extra_overlays`` parameter.
+
+``extra_overlays`` is the generic seam a consumer (e.g. the wiki-weaver
+consumer) uses to add cross-cutting configuration to every session and
+spawned child -- e.g. mounting an observability hook -- without the runner
+needing to know what the overlay contains. These tests assert that each
+overlay supplied is genuinely composed onto the runtime bundle, in order,
+after the runtime orchestrator overlay -- i.e. it actually reaches the
+prepared bundle used to build the session, not merely accepted and dropped.
+They use fakes and monkeypatching (no real bundle loading, no engine, no
+LLM) so they stay fast and non-brittle, per the module's testing philosophy.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from amplifier_module_pipeline_runner import runner as runner_mod
+
+
+class FakePrepared:
+    """Minimal stand-in for a PreparedBundle -- records what it was composed from."""
+
+    def __init__(self, applied: list) -> None:
+        self.applied = applied
+
+
+class FakeBundle:
+    """Minimal stand-in for ``amplifier_foundation.Bundle`` -- records
+    ``.compose()`` calls in order so a test can confirm an overlay genuinely
+    reaches the final composed bundle used to ``prepare()`` (not just
+    accepted and silently dropped)."""
+
+    def __init__(self, applied: list | None = None) -> None:
+        self.applied = applied or []
+
+    def compose(self, other):
+        return FakeBundle(applied=[*self.applied, other])
+
+    async def prepare(self, *, install_deps):
+        del install_deps
+        return FakePrepared(applied=self.applied)
+
+
+def _patch_base_bundle(monkeypatch) -> None:
+    async def fake_load_base_bundle():
+        return FakeBundle()
+
+    monkeypatch.setattr(runner_mod, "_load_base_bundle", fake_load_base_bundle)
+
+
+def test_extra_overlay_reaches_prepared_bundle_and_is_genuinely_invoked(
+    monkeypatch, tmp_path
+):
+    """An overlay passed via ``extra_overlays`` lands in the composed chain
+    used to build the prepared bundle, positioned AFTER the runtime
+    orchestrator overlay -- and is the exact object a real consumer's
+    hook-mounting overlay would be, proven by invoking it post-composition."""
+    _patch_base_bundle(monkeypatch)
+
+    invoked: list[str] = []
+
+    class ObservabilityOverlay:
+        """Stand-in for a consumer's real overlay (e.g. a hook-mounting
+        ``Bundle``) -- calling it has an observable effect, proving it's the
+        genuine object that was wired through composition, not a copy or a
+        placeholder."""
+
+        def mark(self) -> None:
+            invoked.append("observability-overlay-applied")
+
+    overlay = ObservabilityOverlay()
+
+    prepared = asyncio.run(
+        runner_mod._build_prepared(
+            "digraph { start [shape=box]; }",
+            tmp_path,
+            params=None,
+            profiles=None,
+            extra_overlays=[overlay],
+        )
+    )
+
+    # Runtime orchestrator overlay composed first, caller's overlay second.
+    assert len(prepared.applied) == 2
+    assert prepared.applied[1] is overlay
+
+    # Prove it's genuinely wired in (not merely present in a list): the same
+    # object that reached the prepared bundle is callable and produces the
+    # real effect a consumer's overlay would rely on.
+    prepared.applied[1].mark()
+    assert invoked == ["observability-overlay-applied"]
+
+
+def test_multiple_extra_overlays_composed_in_order(monkeypatch, tmp_path):
+    """Multiple overlays are composed onto the prepared bundle in the exact
+    order supplied -- composition order matters for overlay semantics."""
+    _patch_base_bundle(monkeypatch)
+
+    overlay_a, overlay_b = object(), object()
+
+    prepared = asyncio.run(
+        runner_mod._build_prepared(
+            "digraph { start [shape=box]; }",
+            tmp_path,
+            params=None,
+            profiles=None,
+            extra_overlays=[overlay_a, overlay_b],
+        )
+    )
+
+    assert prepared.applied[1] is overlay_a
+    assert prepared.applied[2] is overlay_b
+
+
+def test_no_extra_overlays_leaves_only_runtime_overlay(monkeypatch, tmp_path):
+    """Without ``extra_overlays``, only the runtime orchestrator overlay is
+    composed -- the seam is a strict addition, not a required parameter."""
+    _patch_base_bundle(monkeypatch)
+
+    prepared = asyncio.run(
+        runner_mod._build_prepared(
+            "digraph { start [shape=box]; }",
+            tmp_path,
+            params=None,
+            profiles=None,
+        )
+    )
+
+    assert len(prepared.applied) == 1

--- a/modules/pipeline-runner/tests/test_hooks_default.py
+++ b/modules/pipeline-runner/tests/test_hooks_default.py
@@ -1,0 +1,126 @@
+"""Unit tests for drive_engine's observability-hook defaulting.
+
+The engine and handler stack emit ``pipeline:*`` / ``provider:*`` / ``tool:*``
+events to whatever ``hooks`` object they're constructed with. A mounted
+observability hook lives on ``coordinator.hooks``; the mounted-orchestrator
+path reaches it because the session hands the orchestrator ``coordinator.hooks``
+and it forwards that same object into the engine. When we drive the engine
+directly we must do the same, or those events are emitted into nothing.
+
+These tests patch the loop-pipeline construction points (no real engine run,
+no LLM) and assert ONLY the defaulting decision: when the caller passes no
+hooks, drive_engine feeds ``coordinator.hooks`` to BOTH the HandlerContext and
+the PipelineEngine; an explicit ``hooks=`` wins; and a coordinator lacking
+``.hooks`` is handled safely.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from amplifier_module_pipeline_runner.runner import drive_engine
+
+
+class _FakeOutcome:
+    class _Status:
+        value = "success"
+
+    status = _Status()
+    notes = ""
+    failure_reason = None
+
+
+class _Captor:
+    """Captures the ``hooks`` value handed to the patched constructors."""
+
+    def __init__(self) -> None:
+        self.handler_hooks: object = "UNSET"
+        self.engine_hooks: object = "UNSET"
+
+
+def _install_patches(monkeypatch, captor: _Captor) -> None:
+    import amplifier_module_loop_pipeline.backend as backend_mod
+    import amplifier_module_loop_pipeline.context as context_mod
+    import amplifier_module_loop_pipeline.engine as engine_mod
+    import amplifier_module_loop_pipeline.handlers as handlers_mod
+
+    class FakeContext:
+        def set(self, *_args, **_kwargs) -> None:
+            pass
+
+    class FakeBackend:
+        def __init__(self, **_kwargs) -> None:
+            pass
+
+    class FakeHandlerContext:
+        def __init__(self, *, backend=None, hooks=None, interviewer=None) -> None:
+            captor.handler_hooks = hooks
+
+    class FakeHandlerRegistry:
+        def __init__(self, _ctx) -> None:
+            pass
+
+    class FakeEngine:
+        def __init__(self, *, graph=None, context=None, handler_registry=None, logs_root=None, hooks=None) -> None:
+            captor.engine_hooks = hooks
+
+        async def run(self):
+            return _FakeOutcome()
+
+    monkeypatch.setattr(context_mod, "PipelineContext", FakeContext)
+    monkeypatch.setattr(backend_mod, "AmplifierBackend", FakeBackend)
+    monkeypatch.setattr(handlers_mod, "HandlerContext", FakeHandlerContext)
+    monkeypatch.setattr(handlers_mod, "HandlerRegistry", FakeHandlerRegistry)
+    monkeypatch.setattr(engine_mod, "PipelineEngine", FakeEngine)
+
+
+class _CoordinatorWithHooks:
+    def __init__(self, hooks_obj) -> None:
+        self.hooks = hooks_obj
+
+
+class _CoordinatorNoHooks:
+    """A bare stub coordinator that does not expose ``.hooks``."""
+
+
+def _run(monkeypatch, coordinator, hooks):
+    captor = _Captor()
+    _install_patches(monkeypatch, captor)
+    # Pass a non-str graph so parse_dot is skipped; transform/validate off so
+    # apply_transforms/validate_or_raise are never called.
+    asyncio.run(
+        drive_engine(
+            object(),  # graph sentinel (not a str)
+            coordinator,
+            logs_root="/tmp/does-not-matter",
+            hooks=hooks,
+            transform=False,
+            validate=False,
+        )
+    )
+    return captor
+
+
+def test_defaults_to_coordinator_hooks_when_none(monkeypatch):
+    sentinel = object()
+    coord = _CoordinatorWithHooks(sentinel)
+    captor = _run(monkeypatch, coord, hooks=None)
+    assert captor.engine_hooks is sentinel
+    assert captor.handler_hooks is sentinel
+
+
+def test_explicit_hooks_override_coordinator(monkeypatch):
+    explicit = object()
+    coord = _CoordinatorWithHooks(object())  # different object
+    captor = _run(monkeypatch, coord, hooks=explicit)
+    assert captor.engine_hooks is explicit
+    assert captor.handler_hooks is explicit
+
+
+def test_coordinator_without_hooks_is_safe(monkeypatch):
+    coord = _CoordinatorNoHooks()
+    captor = _run(monkeypatch, coord, hooks=None)
+    # Both sinks received a real decision (None), not the "UNSET" sentinel --
+    # i.e. the defaulting path ran and getattr(..., None) kept it safe.
+    assert captor.engine_hooks is None
+    assert captor.handler_hooks is None

--- a/modules/pipeline-runner/tests/test_params.py
+++ b/modules/pipeline-runner/tests/test_params.py
@@ -1,0 +1,44 @@
+"""Unit tests for amplifier_module_pipeline_runner.params.parse_param."""
+
+from __future__ import annotations
+
+import pytest
+
+from amplifier_module_pipeline_runner.params import parse_param
+
+
+def test_key_value():
+    assert parse_param("k=v") == ("k", "v")
+
+
+def test_value_containing_equals():
+    assert parse_param("k=a=b=c") == ("k", "a=b=c")
+
+
+def test_at_file_reads_file_contents(tmp_path):
+    file_path = tmp_path / "value.txt"
+    file_path.write_text("file contents here", encoding="utf-8")
+    key, value = parse_param(f"content=@{file_path}")
+    assert key == "content"
+    assert value == "file contents here"
+
+
+def test_at_at_literal_escape():
+    key, value = parse_param("handle=@@jdoe")
+    assert key == "handle"
+    assert value == "@jdoe"
+
+
+def test_empty_key_raises():
+    with pytest.raises(ValueError):
+        parse_param("=value")
+
+
+def test_missing_equals_raises():
+    with pytest.raises(ValueError):
+        parse_param("no_equals_here")
+
+
+def test_missing_file_raises():
+    with pytest.raises(ValueError):
+        parse_param("content=@/nonexistent/path/to/file.txt")

--- a/modules/pipeline-runner/tests/test_seams.py
+++ b/modules/pipeline-runner/tests/test_seams.py
@@ -1,0 +1,144 @@
+"""Unit tests for the run_pipeline consumer seams on ``make_spawn_fn`` and the
+inline-only ``_resolve_agent_bundle`` contract.
+
+These tests assert only the seam wiring -- that a caller-supplied
+``child_constraint`` is applied to the resolved child bundle before spawn, that
+``spawn_timeout`` wraps the spawn, that ``session_cwd`` is still threaded, and
+that the removed legacy ``{"bundle": ...}`` agent shape now fails loud. They use
+fakes and monkeypatching (no engine, no LLM, no DOT/graph/call-order asserts) so
+they stay fast and non-brittle, per the module's testing philosophy.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from amplifier_module_pipeline_runner import runner as runner_mod
+from amplifier_module_pipeline_runner.runner import _resolve_agent_bundle, make_spawn_fn
+
+
+class FakePrepared:
+    """Minimal stand-in for a PreparedBundle -- records the last spawn call."""
+
+    def __init__(self, agents: dict | None = None, spawn_delay: float = 0.0) -> None:
+        self.bundle = type("B", (), {"agents": agents or {}})()
+        self.spawn_delay = spawn_delay
+        self.last_spawn_kwargs: dict | None = None
+
+    async def spawn(self, **kwargs):
+        if self.spawn_delay:
+            await asyncio.sleep(self.spawn_delay)
+        self.last_spawn_kwargs = kwargs
+        return {"status": "ok", "child_bundle": kwargs["child_bundle"]}
+
+
+def test_legacy_bundle_shape_fails_loud():
+    """The removed ``{"bundle": ...}`` reference shape must raise, not resolve."""
+    with pytest.raises(ValueError, match="removed"):
+        asyncio.run(
+            _resolve_agent_bundle(
+                "attractor-agent-anthropic",
+                {"bundle": "attractor:agents/attractor-agent-anthropic"},
+            )
+        )
+
+
+def test_child_constraint_applied_before_spawn(monkeypatch):
+    """A caller ``child_constraint`` transforms the resolved bundle pre-spawn."""
+
+    async def fake_resolve(agent_name, config):
+        return f"unconstrained::{agent_name}"
+
+    monkeypatch.setattr(runner_mod, "_resolve_agent_bundle", fake_resolve)
+
+    prepared = FakePrepared()
+    spawn = make_spawn_fn(
+        prepared,
+        cwd=None,
+        child_constraint=lambda b: f"constrained::{b}",
+    )
+
+    result = asyncio.run(
+        spawn(
+            agent_name="agent-x",
+            instruction="do the thing",
+            parent_session=object(),
+            agent_configs={"agent-x": {}},
+        )
+    )
+
+    assert result["child_bundle"] == "constrained::unconstrained::agent-x"
+    assert prepared.last_spawn_kwargs is not None
+    assert (
+        prepared.last_spawn_kwargs["child_bundle"]
+        == "constrained::unconstrained::agent-x"
+    )
+
+
+def test_no_constraint_passes_bundle_through(monkeypatch):
+    """Without a constraint, the resolved bundle reaches spawn unchanged."""
+
+    async def fake_resolve(agent_name, config):
+        return f"bundle::{agent_name}"
+
+    monkeypatch.setattr(runner_mod, "_resolve_agent_bundle", fake_resolve)
+
+    prepared = FakePrepared()
+    spawn = make_spawn_fn(prepared, cwd=None)
+
+    result = asyncio.run(
+        spawn(
+            agent_name="agent-y",
+            instruction="i",
+            parent_session=object(),
+            agent_configs={"agent-y": {}},
+        )
+    )
+    assert result["child_bundle"] == "bundle::agent-y"
+
+
+def test_spawn_timeout_raises_on_slow_spawn(monkeypatch):
+    """``spawn_timeout`` wraps the spawn and fails loud when it overruns."""
+
+    async def fake_resolve(agent_name, config):
+        return agent_name
+
+    monkeypatch.setattr(runner_mod, "_resolve_agent_bundle", fake_resolve)
+
+    prepared = FakePrepared(spawn_delay=0.2)
+    spawn = make_spawn_fn(prepared, cwd=None, spawn_timeout=0.01)
+
+    with pytest.raises((asyncio.TimeoutError, TimeoutError)):
+        asyncio.run(
+            spawn(
+                agent_name="slow",
+                instruction="i",
+                parent_session=object(),
+                agent_configs={"slow": {}},
+            )
+        )
+
+
+def test_session_cwd_still_threaded(monkeypatch, tmp_path):
+    """The load-bearing ``session_cwd=cwd`` argument survives the new seams."""
+
+    async def fake_resolve(agent_name, config):
+        return agent_name
+
+    monkeypatch.setattr(runner_mod, "_resolve_agent_bundle", fake_resolve)
+
+    prepared = FakePrepared()
+    spawn = make_spawn_fn(prepared, cwd=tmp_path)
+
+    asyncio.run(
+        spawn(
+            agent_name="a",
+            instruction="i",
+            parent_session=object(),
+            agent_configs={"a": {}},
+        )
+    )
+    assert prepared.last_spawn_kwargs is not None
+    assert prepared.last_spawn_kwargs["session_cwd"] == tmp_path

--- a/modules/pipeline-runner/tests/test_seed_context.py
+++ b/modules/pipeline-runner/tests/test_seed_context.py
@@ -1,0 +1,53 @@
+"""Unit tests for amplifier_module_pipeline_runner.runner.seed_context.
+
+Uses a tiny fake context object (not the real PipelineContext) -- these tests
+assert only the seeding contract (flat params + reserved key + collision
+guard), not engine internals. No DOT/graph/call-order assertions.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from amplifier_module_pipeline_runner.runner import seed_context
+
+
+class FakeContext:
+    """Minimal stand-in for PipelineContext -- captures .set() calls."""
+
+    def __init__(self) -> None:
+        self.values: dict[str, str] = {}
+
+    def set(self, key: str, value: str) -> None:
+        self.values[key] = value
+
+
+def test_user_params_seeded_flat():
+    ctx = FakeContext()
+    seed_context(ctx, {"outfile": "proof.txt", "content": "ok"}, "/tmp/work")
+
+    assert ctx.values["outfile"] == "proof.txt"
+    assert ctx.values["content"] == "ok"
+
+
+def test_target_dir_set_to_str_cwd():
+    ctx = FakeContext()
+    seed_context(ctx, {}, "/tmp/work")
+
+    assert ctx.values["context.target_dir"] == "/tmp/work"
+
+
+def test_target_dir_set_with_path_object(tmp_path):
+    ctx = FakeContext()
+    seed_context(ctx, None, tmp_path)
+
+    assert ctx.values["context.target_dir"] == str(tmp_path)
+
+
+def test_reserved_key_collision_raises():
+    ctx = FakeContext()
+    with pytest.raises(ValueError):
+        seed_context(ctx, {"context.target_dir": "/sneaky/path"}, "/tmp/work")
+
+    # Nothing should have been seeded -- guard fires before any context.set call.
+    assert ctx.values == {}


### PR DESCRIPTION
## Summary
Adds a new module `modules/pipeline-runner` (`amplifier_module_pipeline_runner`, console script `attractor`) that consolidates the ~100-line "load bundle → compose DOT overlay → prepare → create session → register session.spawn → seed context → drive PipelineEngine" bootstrap that external consumers currently hand-roll independently (with drift on whether they run `apply_transforms`/`validate_or_raise`). It exposes a two-layer library — `drive_engine()` (drive the engine on a caller-owned coordinator) and `run_pipeline()` (turnkey: builds its own session/coordinator) — plus a thin `attractor run` / `attractor doctor` CLI. No changes to `engine.py` or any handler. This is opened early as WIP to share direction; see "Notes for reviewers" for remaining work.

## Verification checklist
- [x] Unit tests pass — `pytest modules/pipeline-runner/tests/` (11 passing: `--param` parser + reserved-key guard). No changes to `modules/loop-pipeline/`.
- [x] Live pipeline runs exercising the code path — multiple real pipelines run end-to-end on host AND in an isolated Digital Twin (non-monorepo install). Evidence below. No `engine.py`/handler changes.
- [x] AGENTS.md reviewed; dependency-awareness rule honored (runner is generic; no downstream consumer names in code/docs/tests).
- [x] Backward-compat path unchanged — net-new module; nothing existing modified.
- [x] PR body includes verification evidence, not just "tests pass".

## Verification evidence
Library core + CLI:
- `drive_engine()` / `run_pipeline()` + shared helpers: `--param key=value|@file|@@literal` parser, `seed_context` with a reserved-key guard (only `context.target_dir` is reserved), `make_spawn_fn` threading `session_cwd=cwd` into every spawned child, local-sibling base-bundle loading with a git fallback for wheel installs.
- `attractor run --on-human-gate {fail|auto-approve}` (default `fail`): a human-gate (hexagon) node fails loud by default (the engine's gate handler requires an interviewer) and the CLI exits non-zero with a hint; `auto-approve` wires the engine's existing `AutoApproveInterviewer`.

Runs — each proven by real effects, not just an exit code (host + isolated Digital Twin):
1. Tool-node fixture — a `--param` reaches a tool node and a relative path roots at `--cwd` → file written at `--cwd`.
2. Box-node fixture — a spawned agent writes a relative-path file that lands under `--cwd` (session_cwd threading), verified on host with process-cwd ≠ `--cwd`.
3. Base-bundle resolution in a wheel/non-monorepo install — confirmed the git fallback resolves the base bundle when no monorepo checkout is on disk.
4. A real looping autonomous-TODO pipeline — an agent works a checkbox TODO across clean-context iterations, converges to "done", creates the code, and the code passes its own tests.
5. A platform-plumbing pipeline (write files → commit → `git push origin` → assert remote visibility → human gate → summary) — runs FULLY end-to-end with `--on-human-gate auto-approve` against a local throwaway bare remote: files pushed to origin, remote-visibility assertion passes, gate auto-approved, summary node runs, `status=success`.

Shipped for reproducibility: `modules/pipeline-runner/dtu/pipeline-runner.yaml` (a Digital Twin profile) and `modules/pipeline-runner/dtu/acceptance-tests.yaml` (type `other` acceptance checks).

## Notes for reviewers
- **WIP — opened early for direction feedback.** Remaining before ready-for-merge: migrate one real consumer onto the library as an end-to-end proof cycle (validates the caller-owned-coordinator seam), then final polish.
- **Known issue (deferred, documented in `modules/pipeline-runner/KNOWN_ISSUES.md`):** the `loop-agent` orchestrator derives a spawned agent's declared working directory from `os.getcwd()` instead of honoring the `session.working_dir` capability that its sibling `tool-bash`/`tool-filesystem` modules already honor. Masked whenever the process cwd equals `--cwd`, but a box/agent pipeline invoked from a different directory misleads the agent. Fix is a small change to `loop-agent`'s `mount()`, deferred pending downstream-impact analysis; until then the runner documents the process-cwd-alignment workaround.
- Design decision: `transform` (model-stylesheet transforms) is explicit — `run_pipeline` defaults it on (canonical path); `drive_engine` requires the caller to pass it, so a caller can preserve inert-stylesheet behavior.