### PR TITLE
fix(loop-agent): omit empty text content blocks in assistant messages

### DIFF
--- a/modules/loop-agent/amplifier_module_loop_agent/messages.py
+++ b/modules/loop-agent/amplifier_module_loop_agent/messages.py
@@ -83,12 +83,27 @@ def _build_assistant_message(turn: AssistantTurn) -> Message:
     """Build a Message from an AssistantTurn with proper content blocks.
 
     If the turn has reasoning, content is a list of blocks:
-        [ThinkingBlock(...), TextBlock(...)]
-    Otherwise content is the text string directly.
+        [ThinkingBlock(...), TextBlock(...)] -- the TextBlock is OMITTED
+        when there is no non-whitespace text (see below).
+    Otherwise content is the text string directly, or an empty list when
+    there is no text but the turn issued tool calls.
+
+    Anthropic's Messages API rejects ANY text content block whose text is
+    empty ("messages: text content blocks must be non-empty"). This bites
+    exactly when the model's response is tool-call-only -- no prose at all
+    (e.g. its very first action is a bash tool_use). Previously this
+    produced content="" (bare string) or
+    content=[ThinkingBlock(...), TextBlock(text="")], and BOTH shapes get
+    unconditionally wrapped/serialized into an empty text content part
+    downstream, which providers reject on the request that follows (once
+    the tool result turn is appended). Omitting the empty/whitespace-only
+    text block here is the fix at the cause: history assembly never
+    produces the invalid shape in the first place.
 
     Tool calls are passed as extra kwargs (Message uses extra="allow").
     """
     kwargs: dict[str, Any] = {"role": "assistant"}
+    has_text = bool(turn.content and turn.content.strip())
 
     # Build content: use blocks when reasoning is present
     if turn.reasoning:
@@ -98,11 +113,25 @@ def _build_assistant_message(turn: AssistantTurn) -> Message:
         if turn.reasoning_signature:
             thinking_kwargs["signature"] = turn.reasoning_signature
         blocks.append(ThinkingBlock(**thinking_kwargs))
-        # Then text
-        blocks.append(TextBlock(text=turn.content or ""))
+        # Then text -- only when there is actual (non-whitespace) text.
+        # An empty TextBlock alongside a tool-call-only response is
+        # exactly the invalid shape described above.
+        if has_text:
+            blocks.append(TextBlock(text=turn.content))
         kwargs["content"] = blocks
+    elif has_text:
+        kwargs["content"] = turn.content
+    elif turn.tool_calls:
+        # No text, no reasoning, but this turn issued tool calls: use an
+        # empty content list rather than a bare "" string. A bare ""
+        # string is auto-wrapped downstream into a TEXT content part with
+        # empty text -- the same bug, one layer up (see
+        # unified_provider_adapter.py::_translate_content).
+        kwargs["content"] = []
     else:
-        kwargs["content"] = turn.content or ""
+        # Genuinely empty turn (no text, no reasoning, no tool calls):
+        # preserve existing behavior of an empty string.
+        kwargs["content"] = ""
 
     # Tool calls (passed as extra field via extra="allow")
     if turn.tool_calls:

--- a/modules/loop-agent/amplifier_module_loop_agent/unified_provider_adapter.py
+++ b/modules/loop-agent/amplifier_module_loop_agent/unified_provider_adapter.py
@@ -79,8 +79,16 @@ class UnifiedProviderAdapter:
     # ------------------------------------------------------------------
 
     def _translate_request(self, request: ChatRequest) -> ULMRequest:
-        """Translate ChatRequest -> unified_llm.Request."""
-        messages = [self._translate_message(m) for m in request.messages]
+        """Translate ChatRequest -> unified_llm.Request.
+
+        Messages that translate to zero content blocks are dropped (see
+        ``_translate_message``); only messages with real content are sent.
+        """
+        messages = [
+            translated
+            for m in request.messages
+            if (translated := self._translate_message(m)) is not None
+        ]
         return ULMRequest(
             model=self._model,
             messages=messages,
@@ -90,15 +98,28 @@ class UnifiedProviderAdapter:
             # We only do single LLM calls via client.complete().
         )
 
-    def _translate_message(self, msg: CoreMessage) -> ULMMessage:
-        """Translate a single amplifier-core Message to unified-llm Message."""
+    def _translate_message(self, msg: CoreMessage) -> ULMMessage | None:
+        """Translate a single amplifier-core Message to unified-llm Message.
+
+        Returns None when the message would serialize to zero content
+        blocks (e.g. a message with only empty/whitespace text and no
+        other content) -- see ``_translate_content`` for why an empty
+        content list must never reach the provider. The one exception is
+        the TOOL_RESULT slot: it is REQUIRED (every tool_use must be
+        paired with exactly one tool_result), so an empty tool output is
+        substituted with a placeholder rather than dropped.
+        """
         role = self._translate_role(msg.role)
 
-        # Tool result messages: wrap string content as TOOL_RESULT part
+        # Tool result messages: wrap string content as TOOL_RESULT part.
+        # This slot is required and is never dropped, even when the tool
+        # produced no output.
         if msg.role == "tool" and msg.tool_call_id:
             content_str = (
                 msg.content if isinstance(msg.content, str) else str(msg.content)
             )
+            if not content_str or not content_str.strip():
+                content_str = "(no output)"
             content = [
                 ContentPart(
                     kind=ContentKind.TOOL_RESULT,
@@ -111,6 +132,12 @@ class UnifiedProviderAdapter:
             return ULMMessage(role=role, content=content, tool_call_id=msg.tool_call_id)
 
         content = self._translate_content(msg.content)
+        if not content:
+            # Zero content blocks after filtering empty/whitespace text --
+            # drop the message. Sending an empty content array is rejected
+            # by every provider; a dropped non-tool-result message carries
+            # no information the model needs anyway.
+            return None
         return ULMMessage(role=role, content=content, tool_call_id=msg.tool_call_id)
 
     @staticmethod
@@ -128,14 +155,31 @@ class UnifiedProviderAdapter:
 
     @staticmethod
     def _translate_content(content: str | list) -> list[ContentPart]:
-        """Translate message content to unified-llm ContentParts."""
+        """Translate message content to unified-llm ContentParts.
+
+        Empty/whitespace-only text is NEVER emitted as a TEXT content
+        part. Anthropic's Messages API rejects any text content block
+        whose text is empty ("messages: text content blocks must be
+        non-empty"), which previously surfaced when an assistant turn
+        contained ONLY tool calls (no prose at all): the bare "" string
+        -- or an empty TextBlock alongside a ThinkingBlock -- was
+        unconditionally wrapped into a TEXT ContentPart here. This guard
+        is the shared/provider-agnostic boundary: every provider routed
+        through the unified LLM client (Anthropic, OpenAI, Gemini) gets
+        its ContentParts built by this one function, so filtering once
+        here gives all of them the same guarantee.
+        """
         if isinstance(content, str):
+            if not content.strip():
+                return []
             return [ContentPart(kind=ContentKind.TEXT, text=content)]
 
         parts: list[ContentPart] = []
         for block in content:
             if isinstance(block, TextBlock):
-                parts.append(ContentPart(kind=ContentKind.TEXT, text=block.text))
+                if block.text and block.text.strip():
+                    parts.append(ContentPart(kind=ContentKind.TEXT, text=block.text))
+                # Empty/whitespace-only TextBlock intentionally omitted.
             elif isinstance(block, ThinkingBlock):
                 parts.append(
                     ContentPart(
@@ -148,7 +192,7 @@ class UnifiedProviderAdapter:
                 )
             # Other block types fall through gracefully.
 
-        return parts or [ContentPart(kind=ContentKind.TEXT, text="")]
+        return parts
 
     # ------------------------------------------------------------------
     # Response translation (non-streaming)

--- a/modules/loop-agent/tests/test_messages.py
+++ b/modules/loop-agent/tests/test_messages.py
@@ -389,3 +389,144 @@ def test_assistant_multiple_tool_calls_emit_name_and_tool_keys():
 # contract (the only side this module owns); the provider-side guarantees are
 # documented in the inline comment in messages.py and proven by the A/B
 # differential artifacts referenced above.
+
+
+# ---------------------------------------------------------------------------
+# Regression: assistant turn with ONLY tool calls (no prose) must never
+# serialize with an empty text content block.  Anthropic's Messages API
+# rejects any text content block whose text is empty ("messages: text
+# content blocks must be non-empty").  This surfaced when the model's
+# response was tool-call-only (e.g. its very first action is a bash
+# tool_use): the assistant turn's empty content was previously carried as
+# a bare "" string (or an empty TextBlock alongside a ThinkingBlock), and
+# BOTH shapes get unconditionally wrapped into a TEXT content part
+# downstream (unified_provider_adapter.py::_translate_content), producing
+# the exact rejected shape observed in the field:
+#   [{"type": "text", "text": ""}, {"type": "tool_use", ...}]
+# See messages.py::_build_assistant_message for the fix at the cause.
+# ---------------------------------------------------------------------------
+
+
+def test_assistant_tool_call_only_no_reasoning_has_no_empty_text_block():
+    """AssistantTurn with tool calls, empty text, no reasoning -> content
+    carries NO text block at all (not even an empty-string block)."""
+    turns = [
+        AssistantTurn(
+            content="",
+            tool_calls=[
+                {"id": "tc1", "name": "bash", "arguments": {"command": "ls"}},
+            ],
+        )
+    ]
+    msgs = convert_history_to_messages(turns)
+    assistant = next(m for m in msgs if m.role == "assistant")
+    content = assistant.content
+    if isinstance(content, list):
+        text_blocks = [b for b in content if isinstance(b, TextBlock)]
+        assert text_blocks == []
+    else:
+        # If content is a bare string, it must not be an empty string --
+        # a bare "" gets auto-wrapped into an empty TEXT content part
+        # downstream, reproducing the bug one layer up.
+        assert content != ""
+
+
+def test_assistant_tool_call_only_whitespace_text_has_no_empty_text_block():
+    """Whitespace-only text alongside tool calls is treated as empty too."""
+    turns = [
+        AssistantTurn(
+            content="   \n\t  ",
+            tool_calls=[
+                {"id": "tc1", "name": "bash", "arguments": {"command": "ls"}},
+            ],
+        )
+    ]
+    msgs = convert_history_to_messages(turns)
+    assistant = next(m for m in msgs if m.role == "assistant")
+    content = assistant.content
+    if isinstance(content, list):
+        text_blocks = [b for b in content if isinstance(b, TextBlock)]
+        assert text_blocks == []
+    else:
+        assert content.strip() == "" and content != "   \n\t  "
+
+
+def test_assistant_tool_call_only_content_is_not_bare_empty_string():
+    """The content field itself must not be the bare "" string when tool
+    calls are present: a bare "" gets auto-wrapped downstream into a TEXT
+    content part with empty text (unified_provider_adapter.py
+    ::_translate_content), reproducing the exact same bug one layer up.
+    """
+    turns = [
+        AssistantTurn(
+            content="",
+            tool_calls=[
+                {"id": "tc1", "name": "bash", "arguments": {"command": "ls"}},
+            ],
+        )
+    ]
+    msgs = convert_history_to_messages(turns)
+    assistant = next(m for m in msgs if m.role == "assistant")
+    assert assistant.content != ""
+
+
+def test_assistant_reasoning_plus_tool_calls_no_text_omits_empty_text_block():
+    """Reasoning present + no text + tool calls -> content has the
+    ThinkingBlock only; no empty TextBlock is appended alongside it."""
+    turns = [
+        AssistantTurn(
+            content="",
+            reasoning="Let me check the files first.",
+            tool_calls=[
+                {"id": "tc1", "name": "bash", "arguments": {"command": "ls"}},
+            ],
+        )
+    ]
+    msgs = convert_history_to_messages(turns)
+    assistant = next(m for m in msgs if m.role == "assistant")
+    content = assistant.content
+    assert isinstance(content, list)
+    thinking_blocks = [b for b in content if isinstance(b, ThinkingBlock)]
+    text_blocks = [b for b in content if isinstance(b, TextBlock)]
+    assert len(thinking_blocks) == 1
+    assert text_blocks == []
+
+
+def test_assistant_text_plus_tool_calls_keeps_text_block():
+    """Positive/pinned case: non-empty text + tool_calls keeps BOTH the
+    text content and the tool call -- the fix must not over-omit."""
+    turns = [
+        AssistantTurn(
+            content="Let me check that.",
+            tool_calls=[
+                {"id": "tc1", "name": "bash", "arguments": {"command": "ls"}},
+            ],
+        )
+    ]
+    msgs = convert_history_to_messages(turns)
+    assistant = next(m for m in msgs if m.role == "assistant")
+    content = assistant.content
+    if isinstance(content, list):
+        text_blocks = [b for b in content if isinstance(b, TextBlock)]
+        assert len(text_blocks) == 1
+        assert text_blocks[0].text == "Let me check that."
+    else:
+        assert content == "Let me check that."
+    tool_calls = assistant.model_dump()["tool_calls"]
+    assert len(tool_calls) == 1
+    assert tool_calls[0]["name"] == "bash"
+
+
+def test_assistant_reasoning_with_text_still_keeps_text_block():
+    """Reasoning + non-empty text (no tool calls) -> both blocks kept.
+
+    Regression guard against over-aggressive omission: the fix must only
+    omit the TextBlock when there is truly no non-whitespace text.
+    """
+    turns = [AssistantTurn(content="Answer", reasoning="Thinking...")]
+    msgs = convert_history_to_messages(turns)
+    content = msgs[0].content
+    assert isinstance(content, list)
+    text_blocks = [b for b in content if isinstance(b, TextBlock)]
+    assert len(text_blocks) == 1
+    assert text_blocks[0].text == "Answer"

--- a/modules/loop-agent/tests/test_unified_provider_adapter.py
+++ b/modules/loop-agent/tests/test_unified_provider_adapter.py
@@ -1150,3 +1150,111 @@ async def test_end_to_end_adapter_with_agent_session():
     assert result == "The file contains hello world."
     assert call_count == 2
     mock_tool.execute.assert_called_once_with({"path": "/tmp/test.py"})
+
+
+# ---------------------------------------------------------------------------
+# Regression: empty/whitespace text content must never reach the provider
+# as a TEXT content part. Anthropic rejects "text content blocks must be
+# non-empty" -- this surfaced when an assistant turn contained ONLY tool
+# calls (no prose). This is the defense-in-depth guard at the shared
+# translation boundary (feeds Anthropic/OpenAI/Gemini alike via the
+# unified LLM client), backstopping the fix at messages.py (the cause).
+# ---------------------------------------------------------------------------
+
+
+def test_translate_content_empty_string_returns_no_parts():
+    """Bare "" content translates to zero ContentParts, not an empty TEXT part."""
+    parts = UnifiedProviderAdapter._translate_content("")
+    assert parts == []
+
+
+def test_translate_content_whitespace_only_string_returns_no_parts():
+    """Whitespace-only content is treated the same as empty."""
+    parts = UnifiedProviderAdapter._translate_content("   \n\t  ")
+    assert parts == []
+
+
+def test_translate_content_empty_text_block_is_filtered():
+    """An empty TextBlock alongside a ThinkingBlock is dropped; only the
+    THINKING part survives."""
+    parts = UnifiedProviderAdapter._translate_content(
+        [
+            ThinkingBlock(thinking="reasoning...", signature="sig1"),
+            TextBlock(text=""),
+        ]
+    )
+    assert len(parts) == 1
+    assert parts[0].kind == ContentKind.THINKING
+
+
+def test_translate_content_whitespace_text_block_is_filtered():
+    """A whitespace-only TextBlock is filtered the same as an empty one."""
+    parts = UnifiedProviderAdapter._translate_content(
+        [TextBlock(text="   \n  ")]
+    )
+    assert parts == []
+
+
+def test_translate_content_nonempty_text_still_passes_through():
+    """Regression guard: real text content is unaffected by the filter."""
+    parts = UnifiedProviderAdapter._translate_content("Hello there")
+    assert len(parts) == 1
+    assert parts[0].kind == ContentKind.TEXT
+    assert parts[0].text == "Hello there"
+
+
+def test_translate_message_drops_assistant_message_with_zero_blocks():
+    """An assistant CoreMessage with empty content and no tool calls
+    translates to None -- the caller must drop it rather than send an
+    empty content array (every provider rejects that)."""
+    adapter = UnifiedProviderAdapter(
+        provider_name="anthropic",
+        model="claude-sonnet-4-20250514",
+        client=MagicMock(),
+    )
+    msg = CoreMessage(role="assistant", content="")
+    assert adapter._translate_message(msg) is None
+
+
+def test_translate_request_drops_zero_block_messages():
+    """_translate_request filters out messages that translate to None,
+    keeping only messages that carry real content."""
+    adapter = UnifiedProviderAdapter(
+        provider_name="anthropic",
+        model="claude-sonnet-4-20250514",
+        client=MagicMock(),
+    )
+    request = ChatRequest(
+        messages=[
+            CoreMessage(role="user", content="Hello"),
+            CoreMessage(role="assistant", content=""),  # dropped: zero blocks
+            CoreMessage(role="assistant", content="Hi there"),
+        ],
+        tools=None,
+    )
+    ulm_request = adapter._translate_request(request)
+    assert len(ulm_request.messages) == 2
+    assert ulm_request.messages[0].content[0].text == "Hello"
+    assert ulm_request.messages[1].content[0].text == "Hi there"
+
+
+def test_translate_tool_result_message_empty_output_gets_placeholder():
+    """A tool_result message is a REQUIRED slot -- it is never dropped, but
+    an empty tool output is substituted with a placeholder so the message
+    still carries a non-empty content block."""
+    adapter = UnifiedProviderAdapter(
+        provider_name="anthropic",
+        model="claude-sonnet-4-20250514",
+        client=MagicMock(),
+    )
+    request = ChatRequest(
+        messages=[
+            CoreMessage(role="tool", content="", tool_call_id="tc_1"),
+        ],
+        tools=None,
+    )
+    ulm_request = adapter._translate_request(request)
+    assert len(ulm_request.messages) == 1
+    msg = ulm_request.messages[0]
+    assert msg.content[0].kind == ContentKind.TOOL_RESULT
+    assert msg.content[0].tool_result.content == "(no output)"


### PR DESCRIPTION
## Summary
loop-agent's history→message serialization emitted an empty text content block alongside tool_use blocks whenever an assistant turn contained ONLY tool calls (no prose) — e.g. a model whose very first response is a bash call. Anthropic's API rejects any empty text block (`messages: text content blocks must be non-empty`), so any loop-agent session whose model leads with a tool call died on its second request (the first tool round-trip). This killed the bundle's own `attractor-expert` agent in real sessions. Two compounding sites fixed: `_build_assistant_message` (messages.py) no longer emits a text block/string when the turn has no non-whitespace text, and the shared `unified_provider_adapter._translate_content` boundary now filters empty text parts instead of injecting an empty-TEXT fallback (with `(no output)` substitution for required tool_result slots, and zero-block messages dropped).

## Verification checklist

- [x] Unit tests pass — `uv run pytest tests/ -q` in `modules/loop-agent`: **514 passed** (500 pre-existing + 14 new); repo gate command `pytest modules/loop-pipeline/` also run: **1397 passed** (no cross-module regression)
- [x] Live pipeline run exercising changed code path — this change touches loop-agent (not engine.py/handlers); live evidence supplied anyway: DTU end-to-end run below reproduces the exact pre-fix death shape and survives it
- [x] AGENTS.md reviewed; repo-specific gates met
- [x] Backward-compat path unchanged — a genuinely empty assistant turn (no text/reasoning/tool_calls) still serializes to `""` per existing `test_none_content_assistant` / `test_empty_content_assistant` (unchanged and green); non-empty text + tool_use keeps both blocks (test-pinned)
- [x] PR body includes verification evidence, not just "tests pass"

## Verification evidence

**The bug, from a real failed session's event log** (extracted from the rejected provider request):
```
REJECTED REQUEST: system=34197 chars, messages=3
  [0] role=user: STRING len=2464
  [1] role=assistant: 2 blocks: text[0] ***EMPTY***; tool_use(bash, input_len=104)
  [2] role=user: 1 blocks: tool_result(...)(str[19625])
→ InvalidRequestError: "messages: text content blocks must be non-empty"
```

**Red-green regression proof** (fix files reverted to main, new tests run, then restored):
```
RED  (bug restored):  11 failed, 60 passed   ← the 11 bug-catching tests fail
GREEN (fix restored): 71 passed              ← incl. 3 positive/pinned-behavior tests that pass either way
```

**Live end-to-end (DTU, real Anthropic calls)** — an isolated environment installing the bundle + modules from this branch; `amplifier run -B attractor --mode single` delegating to `attractor-expert` with a tool-call-first prompt (the exact pre-fix death shape):
```
🔧 [attractor-expert] Using tool: bash    ← first action, no prose = the shape that used to die
✅ [attractor-expert] Tool result: bash
✅ delegate result: "…/tmp contains mostly standard system runtime directories/files — nothing unusual: …"
```
The second Anthropic request — where the pre-fix InvalidRequestError fired — succeeded; the delegation completed with a real grounded answer.

## Notes for reviewers
- Found in a real session: two consecutive `attractor-expert` delegations died identically; root cause confirmed by extracting the rejected request from the child session's events.jsonl.
- Defense-in-depth is at the shared provider-agnostic translation boundary, so OpenAI/Gemini paths get the same no-empty-text guarantee.
- Adjacent gap noticed and deliberately NOT touched (scope): `UnifiedProviderAdapter._translate_message` never translates an assistant Message's `tool_calls` extra into TOOL_CALL ContentParts for outgoing requests — pre-existing, only reachable when `use_unified_llm` is explicitly configured (no shipped config does). Recommend a separate issue.