### PR TITLE
docs: make the attractor examples runnable, discoverable, and rot-proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,29 @@ the login endpoint"]` (or via `params`), not a `--goal` flag.
 
 The agent can generate pipelines on-the-fly or use any of the included examples.
 
+**4. Or run an example directly from the CLI:**
+
+The `attractor run` CLI executes a `.dot` with no config file. The
+`bug-fix` / `refactor` / `test-gen` [practical examples](examples/pipelines/practical/)
+ship a runnable sample target, so they work walk-up. From a clone of this repo:
+
+```bash
+DOT="$PWD/examples/pipelines/practical/bug-fix.dot"
+cp -r examples/pipelines/practical/sample /tmp/attractor-demo
+cd /tmp/attractor-demo
+attractor run "$DOT" \
+    --param goal="Fix the TypeError in get_display_name when a user's avatar is None" \
+    --cwd .
+```
+
+Then `pytest -v` in the copy to see the fix + regression test. The sample is
+copied to a temp dir so the committed fixture stays pristine; `$DOT` is captured
+absolute before `cd` because the `.dot` path resolves from your current directory
+while `--cwd` is where the pipeline reads and writes (the two must match for
+agent pipelines -- see
+[modules/pipeline-runner/KNOWN_ISSUES.md](modules/pipeline-runner/KNOWN_ISSUES.md)).
+See the [practical examples guide](examples/pipelines/practical/) for the full set.
+
 ## What Can It Do?
 
 **Fix a bug systematically** -- reproduce, diagnose, fix, regression test, verify:
@@ -123,11 +146,14 @@ The goal lives in the DOT itself: `graph [goal="Add user avatar upload with S3 s
 | [Human Gate](examples/pipelines/08-human-gate.dot) | Approval gate | Human-in-the-loop |
 | [Manager-Supervisor](examples/pipelines/09-manager-supervisor.dot) | Hierarchical | Agent supervision |
 | [Full Attractor](examples/pipelines/10-full-attractor.dot) | All features | Complete pipeline |
-| [PR Review](examples/pipelines/practical/pr-review.dot) | Parallel analysis | Code review |
-| [Test Generation](examples/pipelines/practical/test-gen.dot) | Retry loop | Test authoring |
-| [Bug Fix](examples/pipelines/practical/bug-fix.dot) | Diagnose + verify | Debugging |
-| [Feature Build](examples/pipelines/practical/feature-build.dot) | Parallel + gate | Feature development |
-| [Refactoring](examples/pipelines/practical/refactor.dot) | Snapshot safety | Code improvement |
+| [PR Review](examples/pipelines/practical/pr-review.md) | Parallel analysis | Code review |
+| [Test Generation](examples/pipelines/practical/test-gen.md) | Retry loop | Test authoring |
+| [Bug Fix](examples/pipelines/practical/bug-fix.md) | Diagnose + verify | Debugging |
+| [Feature Build](examples/pipelines/practical/feature-build.md) | Parallel + gate | Feature development |
+| [Refactoring](examples/pipelines/practical/refactor.md) | Snapshot safety | Code improvement |
+| [Multi-Lens Review](examples/pipelines/practical/multi-lens-review.md) | 3 providers × 3 lenses | Multi-perspective review |
+
+The bottom six are [**practical** task pipelines](examples/pipelines/practical/) -- links go to each one's walk-up guide. `Bug Fix`, `Test Generation`, and `Refactoring` ship a runnable sample, so they work with no setup.
 
 ## How It Works
 

--- a/README.md
+++ b/README.md
@@ -136,16 +136,18 @@ The goal lives in the DOT itself: `graph [goal="Add user avatar upload with S3 s
 
 | Pipeline | Pattern | Use Case |
 |----------|---------|----------|
-| [Simple Linear](examples/pipelines/01-simple-linear.dot) | `A -> B -> C` | Quick single-task |
-| [Plan-Implement-Test](examples/pipelines/02-plan-implement-test.dot) | `plan -> impl -> test` | Standard dev workflow |
-| [Conditional Routing](examples/pipelines/03-conditional-routing.dot) | `if/else` branches | Outcome-based flow |
-| [Retry with Fallback](examples/pipelines/04-retry-with-fallback.dot) | Retry loop | Resilient execution |
-| [Parallel Fan-Out](examples/pipelines/05-parallel-fan-out.dot) | Fork/join | Concurrent work |
-| [Model Stylesheet](examples/pipelines/06-model-stylesheet.dot) | CSS-like config | Multi-provider |
-| [Fidelity Modes](examples/pipelines/07-fidelity-modes.dot) | Context control | Execution fidelity |
-| [Human Gate](examples/pipelines/08-human-gate.dot) | Approval gate | Human-in-the-loop |
-| [Manager-Supervisor](examples/pipelines/09-manager-supervisor.dot) | Hierarchical | Agent supervision |
-| [Full Attractor](examples/pipelines/10-full-attractor.dot) | All features | Complete pipeline |
+| [Simple Linear](examples/pipelines/01-simple-linear.md) | `A -> B -> C` | Quick single-task |
+| [Plan-Implement-Test](examples/pipelines/02-plan-implement-test.md) | `plan -> impl -> test` | Standard dev workflow |
+| [Conditional Routing](examples/pipelines/03-conditional-routing.md) | `if/else` branches | Outcome-based flow |
+| [Retry with Fallback](examples/pipelines/04-retry-with-fallback.md) | Retry loop | Resilient execution |
+| [Parallel Fan-Out](examples/pipelines/05-parallel-fan-out.md) | Fork/join | Concurrent work |
+| [Model Stylesheet](examples/pipelines/06-model-stylesheet.md) | CSS-like config | Multi-provider |
+| [Fidelity Modes](examples/pipelines/07-fidelity-modes.md) | Context control | Execution fidelity |
+| [Human Gate](examples/pipelines/08-human-gate.md) | Approval gate | Human-in-the-loop |
+| [Manager-Supervisor](examples/pipelines/09-manager-supervisor.md) | Hierarchical | Agent supervision |
+| [Full Attractor](examples/pipelines/10-full-attractor.md) | All features | Complete pipeline |
+| [Manager Child + HITL](examples/pipelines/11-manager-child-dotfile-hitl/) | Nested pipeline + gate | Supervised sub-pipeline |
+| [Graph Resume](examples/pipelines/12-graph-resume.md) | File-state guards | Resumable / rewindable |
 | [PR Review](examples/pipelines/practical/pr-review.md) | Parallel analysis | Code review |
 | [Test Generation](examples/pipelines/practical/test-gen.md) | Retry loop | Test authoring |
 | [Bug Fix](examples/pipelines/practical/bug-fix.md) | Diagnose + verify | Debugging |

--- a/context/pipeline-awareness.md
+++ b/context/pipeline-awareness.md
@@ -85,6 +85,7 @@ Run a simple inline pipeline:
 - `@attractor:examples/pipelines/practical/bug-fix.dot` — Systematic reproduce -> diagnose -> fix -> verify
 - `@attractor:examples/pipelines/practical/feature-build.dot` — Parallel implementation with human review gate
 - `@attractor:examples/pipelines/practical/refactor.dot` — Safe refactoring with snapshot tests
+- `@attractor:examples/pipelines/practical/multi-lens-review.dot` — Self-contained 3-provider (anthropic/openai/gemini) parallel review panel with fan-in synthesis
 
 ## After a Pipeline Completes
 

--- a/docs/APP-INTEGRATION-GUIDE.md
+++ b/docs/APP-INTEGRATION-GUIDE.md
@@ -335,8 +335,10 @@ To override the default model at runtime:
 ```python
 session = await prepared.create_session(
     session_cwd=Path.cwd(),
+    # provider_preferences takes a CONCRETE model id -- it's passed to the SDK
+    # verbatim, not glob-resolved like a node's llm_model -- so keep it current.
     provider_preferences=[
-        {"provider": "anthropic", "model": "claude-opus-4-20250514"},
+        {"provider": "anthropic", "model": "claude-opus-4-8"},
     ],
 )
 ```

--- a/docs/DOT-AUTHORING-GUIDE.md
+++ b/docs/DOT-AUTHORING-GUIDE.md
@@ -219,21 +219,21 @@ digraph {
         goal="Refactor legacy code to async patterns",
         model_stylesheet="
             * {
-                llm_model: claude-sonnet-4-6;
+                llm_model: claude-sonnet-*;
                 llm_provider: anthropic;
             }
             .planning {
-                llm_model: o3;
+                llm_model: gpt-[5-9]*;
                 llm_provider: openai;
                 reasoning_effort: high;
             }
             .fast {
-                llm_model: gemini-2.5-flash-preview-05-20;
+                llm_model: gemini-*-flash;
                 llm_provider: gemini;
                 reasoning_effort: low;
             }
             #critical_review {
-                llm_model: claude-opus-4-20250514;
+                llm_model: claude-opus-*;
                 llm_provider: anthropic;
                 reasoning_effort: high;
             }
@@ -263,31 +263,54 @@ digraph {
 Explicit node attributes (`llm_model="..."` on the node) always override
 stylesheet values.
 
-### Model selection: family tokens and globs
+### Model selection: globs and evergreen forms
 
 A node's `llm_model` -- whether set directly on the node or via
-`model_stylesheet` -- may take three forms:
+`model_stylesheet` -- may take two useful forms:
 
-- a **concrete id**, e.g. `claude-sonnet-4-6`
-- a **family token**, e.g. `sonnet`, `haiku`, `opus`
-- an fnmatch **glob**, e.g. `claude-sonnet-4-*`
+- an fnmatch **glob**, e.g. `claude-sonnet-*` -- resolved at run time against the
+  provider's **live** model list (its `/models` endpoint), newest **stable** match
+  wins.
+- a **concrete id**, e.g. `claude-sonnet-4-6` -- **not** resolved; passed to the
+  provider verbatim (and 404s once that id is retired).
 
-Family tokens and globs are resolved at run time to the **newest stable served
-model** in that line, using the provider's live model list. They self-heal as
-providers ship new models and never rot. Resolution fails **loud** -- the node
-fails -- if nothing matches; there is no silent fallback to a default. Concrete
-ids pass through unchanged.
+Only a glob gets live resolution, and it fails **loud** (the node fails) if
+nothing matches -- there is no silent fallback. Concrete ids are the rot vector:
+they look precise but go stale.
 
-**Caveat -- reproducibility.** Because resolution always picks the latest match,
-the chosen model drifts as providers release new ones. For a locked,
-reproducible evaluation, pin a concrete id (or capture the resolved id -- the
-engine emits a `model:resolved` event recording it). Prefer an explicit-major
-glob like `claude-sonnet-4-*` over a bare family token such as `sonnet`, so the
-major version stays fixed while only the point release floats.
+**How evergreen a glob is depends on the provider's naming.** A glob tracks new
+generations only if the provider keeps a stable *tier name*:
+
+| Provider | Persistent tier? | Evergreen form |
+|----------|------------------|----------------|
+| Anthropic | yes (`sonnet`/`opus`/`haiku`) | `claude-sonnet-*`, `claude-opus-*` |
+| Gemini | yes (`flash`/`pro`) | `gemini-*-flash`, `gemini-*-pro` |
+| OpenAI | **no** -- the generation *is* the name | `gpt-[5-9]*` (a range) |
+
+- Widen to the **whole family**: `claude-sonnet-*` tracks Sonnet 4 -> 5 -> ...
+  A version-pinned glob like `claude-sonnet-4-*` is **frozen to gen-4** and misses
+  Sonnet 5 -- avoid it unless you deliberately want to pin the major.
+- OpenAI has no tier that survives `gpt-5 -> gpt-6`, and a bare `gpt-*` matches
+  junk (embeddings, audio, realtime). Use the generation **range** `gpt-[5-9]*`:
+  it tracks the newest through gpt-9 and needs a one-character bump at gpt-10.
+- Prefer an explicit family glob over a bare token like `sonnet`: the glob is
+  unambiguous about provider and family and resolves reliably.
+
+**Overriding a model on a node? Override the provider too.** A glob resolves
+against the node's `llm_provider`, so `llm_model="gemini-*-flash"` needs
+`llm_provider="gemini"` alongside it -- otherwise it inherits the class/default
+provider (e.g. anthropic) and matches nothing. (Concrete ids bypass resolution
+and are provider-inferred, which masks this.)
+
+**Reproducibility.** Because a glob always picks the latest match, the chosen
+model drifts as providers ship new ones. For a locked, reproducible evaluation,
+pin a concrete id (or capture the resolved id -- the engine emits a
+`model:resolved` event recording it).
 
 **Scope.** This resolution applies to a node's `llm_model` only. A provider's
-`default_model` (in the providers config) is passed to the SDK verbatim and is
-**not** resolved -- keep `default_model` a concrete served id.
+`default_model` (providers config) and `provider_preferences` overrides are
+passed to the SDK verbatim and are **not** resolved -- keep those a concrete
+served id.
 
 ### Human Approval Gate
 
@@ -487,7 +510,8 @@ plan [prompt="Plan the implementation of: $goal"]
 // Expands to: "Plan the implementation of: Create a REST API with authentication"
 ```
 
-The `goal` value is passed at runtime via the `--goal` CLI flag or the `goal`
+The `goal` value comes from the graph-level `goal` attribute. Override it at run
+time with `--param goal="..."` on the `attractor run` CLI, or the `goal`
 parameter in `run_pipeline`.
 
 ## Fidelity Modes
@@ -538,10 +562,10 @@ Selector { property: value; property: value; }
 
 ```dot
 graph [model_stylesheet="
-    * { llm_model: claude-sonnet-4-6; llm_provider: anthropic; }
-    .code { llm_model: claude-sonnet-4-6; }
-    .reasoning { llm_model: o3; llm_provider: openai; reasoning_effort: high; }
-    #final_check { llm_model: claude-opus-4-20250514; reasoning_effort: high; }
+    * { llm_model: claude-sonnet-*; llm_provider: anthropic; }
+    .code { llm_model: claude-sonnet-*; }
+    .reasoning { llm_model: gpt-[5-9]*; llm_provider: openai; reasoning_effort: high; }
+    #final_check { llm_model: claude-opus-*; reasoning_effort: high; }
 "]
 ```
 

--- a/docs/DOT-SYNTAX.md
+++ b/docs/DOT-SYNTAX.md
@@ -72,8 +72,8 @@ digraph {
 
 ```dot
 graph [model_stylesheet="
-    box { llm_provider: anthropic; llm_model: claude-sonnet-4-6 }
-    .fast { llm_model: claude-haiku-3-5-20241022 }
+    box { llm_provider: anthropic; llm_model: claude-sonnet-* }
+    .fast { llm_model: claude-haiku-* }
 "]
 ```
 
@@ -158,8 +158,8 @@ digraph {
 digraph {
     graph [
         goal="$goal",
-        model_stylesheet="box { llm_provider: anthropic; llm_model: claude-sonnet-4-6 }
-                          .reasoning { llm_provider: openai; llm_model: o3-mini; reasoning_effort: high }"
+        model_stylesheet="box { llm_provider: anthropic; llm_model: claude-sonnet-* }
+                          .reasoning { llm_provider: openai; llm_model: gpt-[5-9]*; reasoning_effort: high }"
     ]
     start [shape=Mdiamond]; done [shape=Msquare]
     plan [class="reasoning", prompt="Create a plan for: $goal"]

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -43,6 +43,27 @@ goal is carried by the DOT graph attribute
 `params`), not a `--goal` flag. Running parses the DOT graph, spawns an LLM agent
 for the `implement` node, and runs it to completion.
 
+### Or run standalone with the CLI
+
+If you have the `attractor` CLI (from the `pipeline-runner` module), you can run a
+`.dot` directly -- no config file needed. The practical examples ship a runnable
+sample, so this works walk-up from a clone of the repo:
+
+```bash
+DOT="$PWD/examples/pipelines/practical/bug-fix.dot"
+cp -r examples/pipelines/practical/sample /tmp/attractor-demo
+cd /tmp/attractor-demo
+attractor run "$DOT" \
+    --param goal="Fix the TypeError in get_display_name when avatar is None" \
+    --cwd .
+```
+
+The goal defaults to the graph's `goal=` attribute; override it with
+`--param goal="..."`. Run from a scratch dir whose path equals `--cwd` (box-node
+pipelines root their writes at the process cwd). See
+[examples/pipelines/](../examples/pipelines/) for the full run pattern and every
+example's walk-up guide.
+
 ### Try a Multi-Stage Pipeline
 
 The plan-implement-test pipeline adds structure -- point the orchestrator at its
@@ -206,7 +227,7 @@ tools), check for project-level overrides:
 # This overrides global settings for this project only
 settings:
   provider:
-    model: claude-sonnet-4-6
+    model: claude-sonnet-5
 ```
 
 ### `last_response` is truncated to 200 characters
@@ -239,7 +260,7 @@ excludes superpowers, or update your foundation bundle.
 - [DOT-AUTHORING-GUIDE.md](DOT-AUTHORING-GUIDE.md) -- How to design effective pipelines
 - [DOT-SYNTAX.md](DOT-SYNTAX.md) -- Complete DOT syntax reference
 - [APP-INTEGRATION-GUIDE.md](APP-INTEGRATION-GUIDE.md) -- Using pipelines from Python applications
-- [examples/pipelines/](../examples/pipelines/) -- 15 example pipelines to study and reuse
+- [examples/pipelines/](../examples/pipelines/) -- 12 tutorial + 6 practical pipelines to study and reuse
 - [examples/programmatic_usage.py](../examples/programmatic_usage.py) -- Programmatic integration example
 
 ## Development

--- a/examples/pipelines/01-simple-linear.md
+++ b/examples/pipelines/01-simple-linear.md
@@ -1,5 +1,18 @@
 # 01 - Simple Linear Pipeline
 
+## Run it
+
+Self-contained -- the goal is baked into the `.dot`, so no `--param` is needed.
+From the **attractor repo root**:
+
+```bash
+DOT="$PWD/examples/pipelines/01-simple-linear.dot"
+mkdir -p /tmp/attractor-demo && cd /tmp/attractor-demo
+attractor run "$DOT" --cwd .
+```
+
+See [README.md](README.md) in this folder for the run pattern and why the `$DOT` capture + `cd` + `--cwd .` are needed (box-node process-cwd alignment + dot-path resolution).
+
 ## What This Exercises
 
 - **Basic DOT parsing**: digraph with graph-level attributes, node declarations, edge chains
@@ -30,7 +43,7 @@ start --> implement --> done
 6. Exit handler returns SUCCESS
 7. No goal gates exist, so pipeline completes successfully
 
-## How to Run
+## Or run from a bundle / recipe
 
 ```yaml
 # In your bundle YAML or recipe step:

--- a/examples/pipelines/02-plan-implement-test.md
+++ b/examples/pipelines/02-plan-implement-test.md
@@ -1,5 +1,18 @@
 # 02 - Plan-Implement-Test Pipeline
 
+## Run it
+
+Self-contained -- the goal is baked into the `.dot`, so no `--param` is needed.
+From the **attractor repo root**:
+
+```bash
+DOT="$PWD/examples/pipelines/02-plan-implement-test.dot"
+mkdir -p /tmp/attractor-demo && cd /tmp/attractor-demo
+attractor run "$DOT" --cwd .
+```
+
+See [README.md](README.md) in this folder for the run pattern and why the `$DOT` capture + `cd` + `--cwd .` are needed (box-node process-cwd alignment + dot-path resolution).
+
 ## What This Exercises
 
 - **Multi-node traversal**: Three codergen nodes executed sequentially
@@ -34,7 +47,7 @@ start --> plan --> implement --> test --> done
 - At the exit, goal gate check would find `implement` unsatisfied
 - With no `retry_target` configured, the pipeline would fail with "Unsatisfied goal gates: ['implement']"
 
-## How to Run
+## Or run from a bundle / recipe
 
 ```yaml
 steps:

--- a/examples/pipelines/03-conditional-routing.md
+++ b/examples/pipelines/03-conditional-routing.md
@@ -1,5 +1,18 @@
 # 03 - Conditional Routing Pipeline
 
+## Run it
+
+Self-contained -- the goal is baked into the `.dot`, so no `--param` is needed.
+From the **attractor repo root**:
+
+```bash
+DOT="$PWD/examples/pipelines/03-conditional-routing.dot"
+mkdir -p /tmp/attractor-demo && cd /tmp/attractor-demo
+attractor run "$DOT" --cwd .
+```
+
+See [README.md](README.md) in this folder for the run pattern and why the `$DOT` capture + `cd` + `--cwd .` are needed (box-node process-cwd alignment + dot-path resolution).
+
 ## What This Exercises
 
 - **Diamond handler**: `shape=diamond` resolves to the `conditional` handler -- a no-op that returns SUCCESS, letting the engine handle routing via edge conditions
@@ -40,7 +53,7 @@ start --> implement --> test --> gate --[success]--> done
 ### Key Insight: How Conditions Work
 The `gate` (diamond) node itself always succeeds. But the condition expressions on its outgoing edges look at the **context**, which still holds the `outcome` value set by the *previous* node (`test`). The conditional handler is a pass-through that preserves the routing context from the preceding node.
 
-## How to Run
+## Or run from a bundle / recipe
 
 ```yaml
 steps:

--- a/examples/pipelines/04-retry-with-fallback.md
+++ b/examples/pipelines/04-retry-with-fallback.md
@@ -1,5 +1,18 @@
 # 04 - Retry with Fallback Pipeline
 
+## Run it
+
+Self-contained -- the goal is baked into the `.dot`, so no `--param` is needed.
+From the **attractor repo root**:
+
+```bash
+DOT="$PWD/examples/pipelines/04-retry-with-fallback.dot"
+mkdir -p /tmp/attractor-demo && cd /tmp/attractor-demo
+attractor run "$DOT" --cwd .
+```
+
+See [README.md](README.md) in this folder for the run pattern and why the `$DOT` capture + `cd` + `--cwd .` are needed (box-node process-cwd alignment + dot-path resolution).
+
 ## What This Exercises
 
 - **`max_retries` attribute**: `implement` has `max_retries=2` meaning up to 3 total executions (1 initial + 2 retries)
@@ -52,7 +65,7 @@ When reaching `done`, the engine checks:
 - Or was `simple_implement`'s outcome SUCCESS or PARTIAL_SUCCESS?
 - If neither goal gate is satisfied, the engine uses the retry target chain
 
-## How to Run
+## Or run from a bundle / recipe
 
 ```yaml
 steps:

--- a/examples/pipelines/05-parallel-fan-out.md
+++ b/examples/pipelines/05-parallel-fan-out.md
@@ -1,5 +1,18 @@
 # 05 - Parallel Fan-Out Pipeline
 
+## Run it
+
+Self-contained -- the goal is baked into the `.dot`, so no `--param` is needed.
+From the **attractor repo root**:
+
+```bash
+DOT="$PWD/examples/pipelines/05-parallel-fan-out.dot"
+mkdir -p /tmp/attractor-demo && cd /tmp/attractor-demo
+attractor run "$DOT" --cwd .
+```
+
+See [README.md](README.md) in this folder for the run pattern and why the `$DOT` capture + `cd` + `--cwd .` are needed (box-node process-cwd alignment + dot-path resolution).
+
 ## What This Exercises
 
 - **Parallel handler** (`shape=component`): Fans out to multiple branches concurrently
@@ -56,7 +69,7 @@ start -> plan -> parallel +--> test_trig --------+--> collect_results -> summari
 | `fail_fast` | Cancel remaining branches on first failure |
 | `ignore` | Filter out failed branches from results entirely |
 
-## How to Run
+## Or run from a bundle / recipe
 
 ```yaml
 steps:

--- a/examples/pipelines/06-model-stylesheet.dot
+++ b/examples/pipelines/06-model-stylesheet.dot
@@ -6,10 +6,17 @@
 // Tests: stylesheet parsing, selector specificity, property application,
 //        explicit node attribute override, class attribute on nodes.
 //
-// Model selection note: the anthropic selectors below use GLOB model ids
-// (e.g. claude-sonnet-4-*) which the engine resolves to the newest stable
-// served model at run time -- so these pins self-heal and never rot. For a
-// locked/reproducible evaluation, pin a concrete id instead.
+// Model selection note: these selectors use GLOB model ids, which the engine
+// resolves against the provider's LIVE model list at run time (newest stable
+// match wins) -- NOT a static/hardcoded list. How evergreen a glob is depends on
+// whether the provider keeps a stable TIER NAME across generations:
+//   - Anthropic (claude-sonnet-*, claude-opus-*) and Gemini (gemini-*-flash):
+//     the tier name persists, so the glob tracks new generations forever.
+//   - OpenAI has NO persistent tier -- the generation IS the name (gpt-5, gpt-6...),
+//     so the .planning selector below uses a generation RANGE (gpt-[5-9]*) that
+//     tracks the newest through gpt-9 and needs a one-char bump at gpt-10.
+// A bare concrete id (e.g. claude-sonnet-4-6) is NOT resolved -- it is sent to the
+// provider as-is and 404s once retired. Pin a concrete id only for locked evals.
 
 digraph ModelStylesheet {
     graph [
@@ -17,26 +24,26 @@ digraph ModelStylesheet {
         label="Model Stylesheet Pipeline",
         model_stylesheet="
             * {
-                llm_model: claude-sonnet-4-*;
+                llm_model: claude-sonnet-*;
                 llm_provider: anthropic;
                 reasoning_effort: medium;
             }
             .planning {
-                llm_model: o3;
+                llm_model: gpt-[5-9]*;
                 llm_provider: openai;
                 reasoning_effort: high;
             }
             .code {
-                llm_model: claude-sonnet-4-*;
+                llm_model: claude-sonnet-*;
                 llm_provider: anthropic;
             }
             .fast {
-                llm_model: gemini-2.5-flash-preview-05-20;
+                llm_model: gemini-*-flash;
                 llm_provider: gemini;
                 reasoning_effort: low;
             }
             #critical_review {
-                llm_model: claude-opus-4-*;
+                llm_model: claude-opus-*;
                 llm_provider: anthropic;
                 reasoning_effort: high;
             }
@@ -50,7 +57,7 @@ digraph ModelStylesheet {
     start [shape=Mdiamond, label="Start"]
     done  [shape=Msquare, label="Done"]
 
-    // Planning node -- .planning class -> gets o3 with high reasoning
+    // Planning node -- .planning class -> gets a GPT-5-class model, high reasoning
     analyze [
         label="Analyze Codebase",
         class="planning",
@@ -79,11 +86,16 @@ digraph ModelStylesheet {
         prompt="Perform a thorough code review of the async refactoring. Check for race conditions, missing error handling, and proper resource cleanup. This is a critical gate."
     ]
 
-    // Node with explicit attribute override -- node attrs beat stylesheet
+    // Node with explicit attribute override -- node attrs beat stylesheet.
+    // NOTE: override BOTH llm_model and llm_provider together. A glob is resolved
+    // against the node's provider, so a gemini model glob needs llm_provider=gemini
+    // here (the .code class would otherwise supply anthropic and the glob would
+    // match nothing). Concrete ids bypass resolution; globs do not.
     quick_fix [
         label="Quick Fix",
         class="code",
-        llm_model="gemini-2.5-flash-preview-05-20",
+        llm_model="gemini-*-flash",
+        llm_provider="gemini",
         prompt="Apply quick fixes for any issues found in the critical review."
     ]
 

--- a/examples/pipelines/06-model-stylesheet.md
+++ b/examples/pipelines/06-model-stylesheet.md
@@ -1,5 +1,18 @@
 # 06 - Model Stylesheet Pipeline
 
+## Run it
+
+Self-contained -- the goal is baked into the `.dot`, so no `--param` is needed.
+From the **attractor repo root**:
+
+```bash
+DOT="$PWD/examples/pipelines/06-model-stylesheet.dot"
+mkdir -p /tmp/attractor-demo && cd /tmp/attractor-demo
+attractor run "$DOT" --cwd .
+```
+
+See [README.md](README.md) in this folder for the run pattern and why the `$DOT` capture + `cd` + `--cwd .` are needed (box-node process-cwd alignment + dot-path resolution).
+
 ## What This Exercises
 
 - **Stylesheet parsing**: The `model_stylesheet` graph attribute is parsed into `StyleRule` objects with selectors, specificity, and properties
@@ -44,7 +57,7 @@ start -> analyze -> refactor -> lint_check -> critical_review -> quick_fix -> do
 3. During execution, each node's `llm_model`, `llm_provider`, and `reasoning_effort` are available in `node.attrs` for the backend to use
 4. The codergen handler passes these to the backend via the `node` parameter
 
-## How to Run
+## Or run from a bundle / recipe
 
 ```yaml
 steps:

--- a/examples/pipelines/06-model-stylesheet.md
+++ b/examples/pipelines/06-model-stylesheet.md
@@ -35,17 +35,30 @@ start -> analyze -> refactor -> lint_check -> critical_review -> quick_fix -> do
 
 | Node | Class | Matching Rules | Winner (by specificity) | Final Model |
 |------|-------|----------------|------------------------|-------------|
-| `analyze` | `planning` | `*`(0), `.planning`(2) | `.planning` | `o3` (openai) |
-| `refactor` | `code` | `*`(0), `.code`(2) | `.code` | `claude-sonnet-4-*` (anthropic — resolves to latest) |
-| `lint_check` | `fast` | `*`(0), `.fast`(2) | `.fast` | `gemini-2.5-flash-preview-05-20` (gemini, low) |
-| `critical_review` | `code` | `*`(0), `.code`(2), `#critical_review`(3) | `#critical_review` | `claude-opus-4-*` (anthropic, high — resolves to latest) |
+| `analyze` | `planning` | `*`(0), `.planning`(2) | `.planning` | `gpt-[5-9]*` (openai) |
+| `refactor` | `code` | `*`(0), `.code`(2) | `.code` | `claude-sonnet-*` (anthropic) |
+| `lint_check` | `fast` | `*`(0), `.fast`(2) | `.fast` | `gemini-*-flash` (gemini, low) |
+| `critical_review` | `code` | `*`(0), `.code`(2), `#critical_review`(3) | `#critical_review` | `claude-opus-*` (anthropic, high) |
 
-> **Glob model ids.** The anthropic selectors use glob ids (`claude-sonnet-4-*`,
-> `claude-opus-4-*`). These are copied into `node.attrs["llm_model"]` verbatim by
-> the stylesheet, then resolved by the engine at run time to the newest stable
-> served model in that line — so they self-heal and never rot. Pin a concrete id
-> when you need a locked/reproducible evaluation.
-| `quick_fix` | `code` | `*`(0), `.code`(2) | `.code` BUT node has explicit `llm_model` | `gemini-2.5-flash-preview-05-20` (explicit override) |
+> **How these globs resolve — and how evergreen they are.** Each glob is copied into
+> `node.attrs["llm_model"]` verbatim, then the engine resolves it against the
+> provider's LIVE model list at run time (newest stable match wins). Evergreen-ness
+> depends on whether the provider keeps a stable TIER NAME across generations:
+> - Anthropic (`claude-sonnet-*`, `claude-opus-*`) and Gemini (`gemini-*-flash`) —
+>   the tier persists, so the glob tracks new generations indefinitely.
+> - OpenAI has no persistent tier (the generation *is* the name), so `.planning`
+>   uses a generation RANGE `gpt-[5-9]*` — tracks the newest through gpt-9, and needs
+>   a one-char bump at gpt-10.
+>
+> A bare concrete id (e.g. `claude-sonnet-4-6`) is NOT resolved — it's passed to the
+> provider as-is and 404s once retired. Pin a concrete id only for locked evals.
+| `quick_fix` | `code` | `*`(0), `.code`(2) | `.code` BUT node has explicit `llm_model` + `llm_provider` | `gemini-*-flash` on `gemini` (explicit override) |
+
+> **Overriding a model glob on a node?** Override the **provider too**. A glob is
+> resolved against the node's provider, so `llm_model="gemini-*-flash"` needs
+> `llm_provider="gemini"` alongside it — otherwise it inherits `anthropic` from the
+> `.code` class and matches nothing. (Concrete ids bypass resolution and are
+> provider-inferred; globs are not.)
 
 ## Expected Behavior
 
@@ -70,9 +83,9 @@ steps:
 ## What to Look For
 
 - After stylesheet application, inspect node attrs:
-  - `analyze.attrs["llm_model"]` == `"o3"`
-  - `critical_review.attrs["llm_model"]` == `"claude-opus-4-*"` (ID selector wins over .code class; resolved to a concrete opus id at run time)
-  - `quick_fix.attrs["llm_model"]` == `"gemini-2.5-flash-preview-05-20"` (explicit attribute wins)
+  - `analyze.attrs["llm_model"]` == `"gpt-[5-9]*"`
+  - `critical_review.attrs["llm_model"]` == `"claude-opus-*"` (ID selector wins over .code class; resolved to a concrete opus id at run time)
+  - `quick_fix.attrs["llm_model"]` == `"gemini-*-flash"` (explicit attribute wins)
 - Validation passes (stylesheet syntax is valid)
 - Each node's prompt.md is written with the correct model context
 - No stylesheet properties are applied to start/exit nodes (they have no LLM interaction)

--- a/examples/pipelines/07-fidelity-modes.md
+++ b/examples/pipelines/07-fidelity-modes.md
@@ -1,5 +1,18 @@
 # 07 - Fidelity Modes Pipeline
 
+## Run it
+
+Self-contained -- the goal is baked into the `.dot`, so no `--param` is needed.
+From the **attractor repo root**:
+
+```bash
+DOT="$PWD/examples/pipelines/07-fidelity-modes.dot"
+mkdir -p /tmp/attractor-demo && cd /tmp/attractor-demo
+attractor run "$DOT" --cwd .
+```
+
+See [README.md](README.md) in this folder for the run pattern and why the `$DOT` capture + `cd` + `--cwd .` are needed (box-node process-cwd alignment + dot-path resolution).
+
 ## What This Exercises
 
 - **Fidelity attribute on nodes**: Each node explicitly sets how much prior context to carry
@@ -46,7 +59,7 @@ Key: Edge fidelity on `integration_test -> final_review` overrides `final_review
 - `implement_rate_limit` **reuses** that same session -- it sees the full conversation from `implement_auth`
 - This is powerful for multi-step implementations where each step builds on the previous one's context
 
-## How to Run
+## Or run from a bundle / recipe
 
 ```yaml
 steps:

--- a/examples/pipelines/08-human-gate.md
+++ b/examples/pipelines/08-human-gate.md
@@ -1,5 +1,20 @@
 # 08 - Human Gate Pipeline
 
+## Run it
+
+Self-contained -- the goal is baked into the `.dot`, so no `--param` is needed.
+From the **attractor repo root**:
+
+```bash
+DOT="$PWD/examples/pipelines/08-human-gate.dot"
+mkdir -p /tmp/attractor-demo && cd /tmp/attractor-demo
+attractor run "$DOT" --cwd . --on-human-gate auto-approve
+```
+
+`--on-human-gate auto-approve` always takes the gate's first option so the run completes non-interactively; drop it and run interactively if you want the gate to actually branch.
+
+See [README.md](README.md) in this folder for the run pattern and why the `$DOT` capture + `cd` + `--cwd .` are needed (box-node process-cwd alignment + dot-path resolution).
+
 ## What This Exercises
 
 - **Human handler** (`shape=hexagon`): Blocks execution until a human selects an option
@@ -59,7 +74,7 @@ start -> implement -> test -> review_gate --[A] Approve--> deploy_staging -> pro
 | `[N] No, rollback staging` | `N` | `[X] Label` bracket pattern |
 | `[F] Fix issues first` | `F` | `[X] Label` bracket pattern |
 
-## How to Run
+## Or run from a bundle / recipe
 
 ```yaml
 # Interactive mode (will prompt in terminal):

--- a/examples/pipelines/09-manager-supervisor.md
+++ b/examples/pipelines/09-manager-supervisor.md
@@ -1,5 +1,18 @@
 # 09 - Manager Supervisor Pipeline
 
+## Run it
+
+Self-contained -- the goal is baked into the `.dot`, so no `--param` is needed.
+From the **attractor repo root**:
+
+```bash
+DOT="$PWD/examples/pipelines/09-manager-supervisor.dot"
+mkdir -p /tmp/attractor-demo && cd /tmp/attractor-demo
+attractor run "$DOT" --cwd .
+```
+
+See [README.md](README.md) in this folder for the run pattern and why the `$DOT` capture + `cd` + `--cwd .` are needed (box-node process-cwd alignment + dot-path resolution).
+
 ## What This Exercises
 
 - **Manager loop handler** (`shape=house`): Orchestrates an observe/evaluate/act cycle over a child subgraph
@@ -58,7 +71,7 @@ If all 5 cycles fail, the manager returns FAIL with:
 | `steer` | Inject `manager.steering` context with failure details from previous cycle |
 | `wait` | Sleep for `poll_interval` between cycles |
 
-## How to Run
+## Or run from a bundle / recipe
 
 ```yaml
 steps:

--- a/examples/pipelines/10-full-attractor.dot
+++ b/examples/pipelines/10-full-attractor.dot
@@ -18,26 +18,26 @@ digraph FullAttractor {
         fallback_retry_target="plan",
         model_stylesheet="
             * {
-                llm_model: claude-sonnet-4-*;
+                llm_model: claude-sonnet-*;
                 llm_provider: anthropic;
                 reasoning_effort: medium;
             }
             .planning {
-                llm_model: o3;
+                llm_model: gpt-[5-9]*;
                 llm_provider: openai;
                 reasoning_effort: high;
             }
             .code {
-                llm_model: claude-sonnet-4-*;
+                llm_model: claude-sonnet-*;
                 llm_provider: anthropic;
             }
             .fast {
-                llm_model: gemini-2.5-flash-preview-05-20;
+                llm_model: gemini-*-flash;
                 llm_provider: gemini;
                 reasoning_effort: low;
             }
             #final_review {
-                llm_model: claude-opus-4-*;
+                llm_model: claude-opus-*;
                 llm_provider: anthropic;
                 reasoning_effort: high;
             }

--- a/examples/pipelines/10-full-attractor.dot
+++ b/examples/pipelines/10-full-attractor.dot
@@ -18,7 +18,7 @@ digraph FullAttractor {
         fallback_retry_target="plan",
         model_stylesheet="
             * {
-                llm_model: claude-sonnet-4-6;
+                llm_model: claude-sonnet-4-*;
                 llm_provider: anthropic;
                 reasoning_effort: medium;
             }
@@ -28,7 +28,7 @@ digraph FullAttractor {
                 reasoning_effort: high;
             }
             .code {
-                llm_model: claude-sonnet-4-6;
+                llm_model: claude-sonnet-4-*;
                 llm_provider: anthropic;
             }
             .fast {
@@ -37,7 +37,7 @@ digraph FullAttractor {
                 reasoning_effort: low;
             }
             #final_review {
-                llm_model: claude-opus-4-20250514;
+                llm_model: claude-opus-4-*;
                 llm_provider: anthropic;
                 reasoning_effort: high;
             }

--- a/examples/pipelines/10-full-attractor.md
+++ b/examples/pipelines/10-full-attractor.md
@@ -49,7 +49,7 @@ This is a realistic "build a feature" pipeline that exercises **every Attractor 
 start
   |
   v
-plan (.planning, truncate fidelity, o3 model)
+plan (.planning, truncate fidelity, gpt-[5-9]* model)
   |
   v
 parallel_impl (component, wait_all, max_parallel=2)
@@ -94,19 +94,23 @@ done       polish      fix_tests
 
 | Node | Class | Stylesheet Match | Resolved Model |
 |------|-------|-----------------|----------------|
-| `plan` | planning | `.planning` (specificity=2) | o3 (openai, high) |
-| `implement_backend` | code | `.code` (specificity=2) | claude-sonnet-4-6 (anthropic) |
-| `implement_frontend` | code | `.code` (specificity=2) | claude-sonnet-4-6 (anthropic) |
-| `integrate` | code | `.code` (specificity=2) | claude-sonnet-4-6 (anthropic) |
-| `test` | fast | `.fast` (specificity=2) | gemini-2.5-flash-preview-05-20 (gemini, low) |
-| `fix_tests` | code | `.code` (specificity=2) | claude-sonnet-4-6 (anthropic) |
-| `final_review` | code | `#final_review` (specificity=3) | claude-opus-4-20250514 (anthropic, high) |
-| `polish` | code | `.code` (specificity=2) | claude-sonnet-4-6 (anthropic) |
+| `plan` | planning | `.planning` (specificity=2) | gpt-[5-9]* (openai, high) |
+| `implement_backend` | code | `.code` (specificity=2) | claude-sonnet-* (anthropic) |
+| `implement_frontend` | code | `.code` (specificity=2) | claude-sonnet-* (anthropic) |
+| `integrate` | code | `.code` (specificity=2) | claude-sonnet-* (anthropic) |
+| `test` | fast | `.fast` (specificity=2) | gemini-*-flash (gemini, low) |
+| `fix_tests` | code | `.code` (specificity=2) | claude-sonnet-* (anthropic) |
+| `final_review` | code | `#final_review` (specificity=3) | claude-opus-* (anthropic, high) |
+| `polish` | code | `.code` (specificity=2) | claude-sonnet-* (anthropic) |
+
+> These are evergreen glob ids resolved against each provider's live model list at
+> run time. See [06-model-stylesheet.md](06-model-stylesheet.md) for how the forms
+> stay current across generations (and why OpenAI uses the `gpt-[5-9]*` range).
 
 ## Expected Behavior
 
 ### Happy Path
-1. `plan` creates the implementation plan (o3 with high reasoning, truncate fidelity)
+1. `plan` creates the implementation plan (gpt-[5-9]* with high reasoning, truncate fidelity)
 2. `parallel_impl` fans out to 2 branches:
    - `implement_backend` runs with full fidelity on thread "backend-impl"
    - `implement_frontend` runs with full fidelity on thread "frontend-impl"

--- a/examples/pipelines/10-full-attractor.md
+++ b/examples/pipelines/10-full-attractor.md
@@ -1,5 +1,20 @@
 # 10 - Full Attractor (Kitchen Sink)
 
+## Run it
+
+Self-contained -- the goal is baked into the `.dot`, so no `--param` is needed.
+From the **attractor repo root**:
+
+```bash
+DOT="$PWD/examples/pipelines/10-full-attractor.dot"
+mkdir -p /tmp/attractor-demo && cd /tmp/attractor-demo
+attractor run "$DOT" --cwd . --on-human-gate auto-approve
+```
+
+`--on-human-gate auto-approve` always takes the gate's first option so the run completes non-interactively; drop it and run interactively if you want the gate to actually branch.
+
+See [README.md](README.md) in this folder for the run pattern and why the `$DOT` capture + `cd` + `--cwd .` are needed (box-node process-cwd alignment + dot-path resolution).
+
 ## What This Exercises
 
 This is a realistic "build a feature" pipeline that exercises **every Attractor feature** together.
@@ -123,7 +138,7 @@ When reaching `done`:
 - If either failed: engine jumps to their `retry_target="plan"` for a fresh attempt
 - Graph-level `fallback_retry_target="plan"` provides a last resort
 
-## How to Run
+## Or run from a bundle / recipe
 
 ```yaml
 steps:

--- a/examples/pipelines/11-manager-child-dotfile-hitl/README.md
+++ b/examples/pipelines/11-manager-child-dotfile-hitl/README.md
@@ -1,10 +1,20 @@
 # 11 - Manager + Child Dotfile with a Human Gate
 
-A **multi-file** example: a parent pipeline whose `manager` node (a `house`-shaped
-supervisor) runs a **separate child pipeline** that contains a human-in-the-loop
-(HITL) approval gate. It demonstrates that the interviewer driving a gate is wired
-all the way through -- from the top-level run, through the manager, into the child
-pipeline's gate.
+A **multi-file** example -- and a **regression fixture**: a parent pipeline whose
+`manager` node (a `house`-shaped supervisor) runs a **separate child pipeline**
+that contains a human-in-the-loop (HITL) approval gate. Its purpose is to prove the
+interviewer driving a gate is wired all the way through -- from the top-level run,
+through the manager, into the child pipeline's gate.
+
+> **Known issue -- does not run walk-up today.** Driven via standalone
+> `attractor run ... --on-human-gate auto-approve`, this pipeline **fails**: the
+> child pipeline's `HumanGateHandler` does not receive an interviewer through the
+> manager, so the child fails immediately (`Manager exhausted 1 cycle(s)`, last
+> child status: fail). That is the exact failure mode this fixture exists to catch.
+> It is normally driven by a test harness that wires the interviewer end-to-end.
+> Root-causing the standalone-CLI path (real regression vs CLI-only gap) is tracked
+> as a follow-up -- unlike the other numbered examples, this one is **not** a
+> proven walk-up demo.
 
 Unlike the single-file numbered tutorials, this one is a directory of two `.dot`s:
 
@@ -28,10 +38,10 @@ relative to `parent.dot`'s own directory, so the pair travels together.
   (HandlerRegistry -> ManagerLoopHandler -> child HandlerContext -> HumanGateHandler).
   This example is the regression fixture for that path.
 
-## Run it
+## Running it (currently fails -- see Known issue above)
 
-The child pipeline has a human gate, so a non-interactive run needs
-`--on-human-gate auto-approve`. From the **attractor repo root**:
+The intended command, once the standalone path is fixed, is -- from the **attractor
+repo root**:
 
 ```bash
 DOT="$PWD/examples/pipelines/11-manager-child-dotfile-hitl/parent.dot"
@@ -39,11 +49,11 @@ mkdir -p /tmp/attractor-demo && cd /tmp/attractor-demo
 attractor run "$DOT" --cwd . --on-human-gate auto-approve
 ```
 
-`auto-approve` always takes the gate's first option (`[A] Approve`), so the run
-completes non-interactively; drop the flag and run interactively (type `A` at the
-prompt) if you want the gate to actually branch. Point the absolute `$DOT` at
-`parent.dot` -- the child resolves relative to it automatically. See
-[../README.md](../README.md) for why the `$DOT` capture + `cd` + `--cwd .` are needed.
+**Today this exits `status=fail`** -- the manager's child pipeline fails instantly
+because the gate never receives the interviewer (see Known issue above). The child
+resolves relative to `parent.dot` automatically; `--on-human-gate auto-approve`
+would take the gate's first option (`[A] Approve`). See [../README.md](../README.md)
+for why the `$DOT` capture + `cd` + `--cwd .` are needed.
 
 ## Or run from a bundle / recipe
 

--- a/examples/pipelines/11-manager-child-dotfile-hitl/README.md
+++ b/examples/pipelines/11-manager-child-dotfile-hitl/README.md
@@ -1,0 +1,63 @@
+# 11 - Manager + Child Dotfile with a Human Gate
+
+A **multi-file** example: a parent pipeline whose `manager` node (a `house`-shaped
+supervisor) runs a **separate child pipeline** that contains a human-in-the-loop
+(HITL) approval gate. It demonstrates that the interviewer driving a gate is wired
+all the way through -- from the top-level run, through the manager, into the child
+pipeline's gate.
+
+Unlike the single-file numbered tutorials, this one is a directory of two `.dot`s:
+
+| File | Role |
+|------|------|
+| [`parent.dot`](parent.dot) | `start -> manager (shape=house, stack.child_dotfile="child-with-gate.dot") -> done` |
+| [`child-with-gate.dot`](child-with-gate.dot) | `start -> hitl_gate (shape=hexagon) -> approved / rejected -> done` |
+
+The manager references the child by filename; `stack.child_dotfile` resolves
+relative to `parent.dot`'s own directory, so the pair travels together.
+
+## What This Exercises
+
+- **`shape=house` manager node** supervising a child pipeline via
+  `stack.child_dotfile` (rather than inlining every stage in one graph).
+- **`manager.max_cycles=1` / `manager.actions=observe`** -- one deterministic pass,
+  no steering, which is enough to prove the wiring.
+- **HITL gate in the child** (`shape=hexagon`, `type="wait.human"`): edge labels
+  become the choices -- `[A] Approve` -> `approved`, `[R] Reject` -> `rejected`.
+- **Interviewer threading**: the interviewer must reach the child gate
+  (HandlerRegistry -> ManagerLoopHandler -> child HandlerContext -> HumanGateHandler).
+  This example is the regression fixture for that path.
+
+## Run it
+
+The child pipeline has a human gate, so a non-interactive run needs
+`--on-human-gate auto-approve`. From the **attractor repo root**:
+
+```bash
+DOT="$PWD/examples/pipelines/11-manager-child-dotfile-hitl/parent.dot"
+mkdir -p /tmp/attractor-demo && cd /tmp/attractor-demo
+attractor run "$DOT" --cwd . --on-human-gate auto-approve
+```
+
+`auto-approve` always takes the gate's first option (`[A] Approve`), so the run
+completes non-interactively; drop the flag and run interactively (type `A` at the
+prompt) if you want the gate to actually branch. Point the absolute `$DOT` at
+`parent.dot` -- the child resolves relative to it automatically. See
+[../README.md](../README.md) for why the `$DOT` capture + `cd` + `--cwd .` are needed.
+
+## Or run from a bundle / recipe
+
+```yaml
+steps:
+  - agent: attractor:pipeline-runner
+    instruction: "Run the manager + child-dotfile HITL example"
+    context:
+      pipeline_path: "examples/pipelines/11-manager-child-dotfile-hitl/parent.dot"
+```
+
+## DOT parser note
+
+Attribute keys containing dots (`manager.max_cycles`, `stack.child_dotfile`) are
+written **without** surrounding double-quotes -- the attractor DOT parser stores a
+quoted key with its quote characters, which breaks the bare-string lookups the
+handlers use. Correct: `manager.max_cycles=1`. Wrong: `"manager.max_cycles"="1"`.

--- a/examples/pipelines/12-graph-resume.dot
+++ b/examples/pipelines/12-graph-resume.dot
@@ -37,8 +37,7 @@ digraph GraphResume {
         label="Graph-Level Resume Pattern",
         default_fidelity="full",
         default_thread_id="graph-resume",
-        default_max_retry=2,
-        model_stylesheet=".reasoning { llm_provider: openai; llm_model: o3-mini; reasoning_effort: high }"
+        default_max_retry=2
     ]
     rankdir=LR
 
@@ -61,8 +60,8 @@ digraph GraphResume {
 
     // ── Stage 2: Refactoring plan ─────────────────────────────────────────────
     // Guard: check for .ai/refactor-plan.md.
-    // plan_refactor uses the .reasoning class (expensive model) -- deleting
-    // .ai/refactor-plan.md forces a fresh plan without modifying the graph.
+    // plan_refactor is a reasoning-heavy node -- deleting .ai/refactor-plan.md
+    // forces a fresh (full-cost) plan without modifying the graph.
     check_plan [
         shape=parallelogram,
         label="Plan done?",
@@ -71,7 +70,6 @@ digraph GraphResume {
 
     plan_refactor [
         label="Plan Refactoring",
-        class="reasoning",
         prompt="Read .ai/smells.md. Create a step-by-step refactoring plan for $goal. For each step: (1) what changes, (2) why it improves the code, (3) what could break. Order steps safest-first to minimize risk. Write the complete plan to .ai/refactor-plan.md -- this file is the artifact that allows the resume guard to skip this stage on the next run."
     ]
 
@@ -122,7 +120,6 @@ digraph GraphResume {
     //   and diff_review follows naturally.
     diff_review [
         label="Diff Review",
-        class="reasoning",
         prompt="Run git diff and review all changes. Verify: (1) no behavior changes -- this is pure refactoring, (2) the code is genuinely simpler and clearer, (3) no accidental deletions or regressions introduced. Summarize the improvements achieved."
     ]
 

--- a/examples/pipelines/12-graph-resume.md
+++ b/examples/pipelines/12-graph-resume.md
@@ -126,14 +126,17 @@ causing the work node to re-execute. All downstream guards inherit fresh artifac
 re-execute their work nodes as well.
 
 ```bash
+# ($DOT and the goal are as set in "How to Run" below; run these from your repo
+#  so the .ai/ artifacts and --cwd . line up.)
+
 # Re-run only the plan stage and everything after it:
-rm .ai/refactor-plan.md && amplifier run ...
+rm .ai/refactor-plan.md && attractor run "$DOT" --param goal="..." --cwd .
 
 # Re-run the implement+test loop and diff review only:
-rm .ai/STATE.json && amplifier run ...
+rm .ai/STATE.json && attractor run "$DOT" --param goal="..." --cwd .
 
 # Start completely fresh:
-rm -rf .ai/ && amplifier run ...
+rm -rf .ai/ && attractor run "$DOT" --param goal="..." --cwd .
 ```
 
 ## How to Run
@@ -147,13 +150,22 @@ steps:
       goal: "Refactor src/legacy.py to eliminate god-class anti-patterns"
 ```
 
-Or with the CLI directly:
+Or with the `attractor run` CLI directly. This example refactors a real module
+(`src/legacy.py`) in **your own repo**, so point it there -- capture the pipeline's
+absolute path, `cd` into your repo, and keep `--cwd .`:
 
 ```bash
-amplifier run \
-  --dot-file examples/pipelines/12-graph-resume.dot \
-  --goal "Refactor src/legacy.py to eliminate god-class anti-patterns"
+DOT="/path/to/attractor/examples/pipelines/12-graph-resume.dot"
+cd /path/to/your/repo        # must contain src/legacy.py and a test suite
+attractor run "$DOT" \
+    --param goal="Refactor src/legacy.py to eliminate god-class anti-patterns" \
+    --cwd .
 ```
+
+The `.dot` path resolves from your current directory, but box-node (agent) pipelines
+need process cwd to equal `--cwd` -- so `cd` into your repo, give `$DOT` an absolute
+path, and keep `--cwd .` (see [`../../modules/pipeline-runner/KNOWN_ISSUES.md`](../../modules/pipeline-runner/KNOWN_ISSUES.md)).
+The resume artifacts (`.ai/`) are written under `--cwd`.
 
 ## What to Look For
 

--- a/examples/pipelines/README.md
+++ b/examples/pipelines/README.md
@@ -25,7 +25,7 @@ Each pipeline is a pair: a `.dot` (the graph) and a `.md` (the guide -- start th
 | 08 | [08-human-gate.md](08-human-gate.md) | `hexagon` human-approval gate |
 | 09 | [09-manager-supervisor.md](09-manager-supervisor.md) | `house` manager/supervisor loop |
 | 10 | [10-full-attractor.md](10-full-attractor.md) | Kitchen-sink -- every feature together |
-| 11 | [11-manager-child-dotfile-hitl/](11-manager-child-dotfile-hitl/) | Multi-file: a parent pipeline spawns a child pipeline with its own gate |
+| 11 | [11-manager-child-dotfile-hitl/](11-manager-child-dotfile-hitl/) | Multi-file: a parent pipeline spawns a child pipeline with its own gate. **Regression fixture -- known to fail via standalone `attractor run`; see its README.** |
 | 12 | [12-graph-resume.md](12-graph-resume.md) | Graph-level resume via file-state guard nodes |
 
 ## Run any example from the CLI

--- a/examples/pipelines/README.md
+++ b/examples/pipelines/README.md
@@ -1,0 +1,73 @@
+# Example Pipelines
+
+Every pipeline is a Graphviz DOT graph the attractor engine walks node-by-node.
+This folder has three kinds:
+
+| Folder / file | What it is |
+|---------------|-----------|
+| **`01`–`12` (numbered)** | **Tutorials** -- each isolates one concept (linear flow, routing, fan-out, gates, fidelity, model stylesheets, resume). Self-contained: the goal is embedded in the `.dot`, so they run with no target. |
+| [**`practical/`**](practical/) | **Task pipelines** for real work -- bug fix, refactor, test-gen, PR review, feature build, multi-lens review. Three ship a runnable sample. See [practical/README.md](practical/README.md). |
+| [**`patterns/`**](patterns/) | Reusable DOT **snippets** (convergence factory, conversational gates) to drop into your own graphs. |
+
+Each pipeline is a pair: a `.dot` (the graph) and a `.md` (the guide -- start there).
+
+## The tutorials
+
+| # | Guide | Concept it teaches |
+|---|-------|--------------------|
+| 01 | [01-simple-linear.md](01-simple-linear.md) | Linear `A -> B -> C` |
+| 02 | [02-plan-implement-test.md](02-plan-implement-test.md) | `plan -> implement (goal_gate) -> test` |
+| 03 | [03-conditional-routing.md](03-conditional-routing.md) | Diamond gate / outcome-based routing |
+| 04 | [04-retry-with-fallback.md](04-retry-with-fallback.md) | Retry loop with fallback |
+| 05 | [05-parallel-fan-out.md](05-parallel-fan-out.md) | `component` fan-out / `tripleoctagon` fan-in |
+| 06 | [06-model-stylesheet.md](06-model-stylesheet.md) | CSS-like per-node model routing |
+| 07 | [07-fidelity-modes.md](07-fidelity-modes.md) | Fidelity + `thread_id` context control |
+| 08 | [08-human-gate.md](08-human-gate.md) | `hexagon` human-approval gate |
+| 09 | [09-manager-supervisor.md](09-manager-supervisor.md) | `house` manager/supervisor loop |
+| 10 | [10-full-attractor.md](10-full-attractor.md) | Kitchen-sink -- every feature together |
+| 11 | [11-manager-child-dotfile-hitl/](11-manager-child-dotfile-hitl/) | Multi-file: a parent pipeline spawns a child pipeline with its own gate |
+| 12 | [12-graph-resume.md](12-graph-resume.md) | Graph-level resume via file-state guard nodes |
+
+## Run any example from the CLI
+
+The `attractor run` CLI executes a `.dot` directly. Because these pipelines have
+**box (agent) nodes**, the run command has a specific shape -- run it **from the
+attractor repo root**:
+
+```bash
+DOT="$PWD/examples/pipelines/01-simple-linear.dot"
+mkdir -p /tmp/attractor-demo && cd /tmp/attractor-demo
+attractor run "$DOT" --cwd .
+```
+
+The tutorials are self-contained (the goal is baked into the `.dot`), so no
+`--param goal=...` is needed. Two things about the command shape:
+
+- **`$DOT` is captured absolute before `cd`** -- the `.dot` path resolves from your
+  *current* directory, so once you `cd` into the run dir a relative path won't find it.
+- **Process cwd must equal `--cwd`** for box-node pipelines -- the agent orchestrator
+  roots writes at the process cwd, so we `cd` into the run dir and pass `--cwd .`
+  (see [../../modules/pipeline-runner/KNOWN_ISSUES.md](../../modules/pipeline-runner/KNOWN_ISSUES.md)).
+
+We run in a scratch dir (`/tmp/attractor-demo`) so any files a pipeline generates
+don't land in your checkout. A couple of exceptions:
+
+- **Human-gate pipelines** (`08`, `10`) block on a hexagon node. Add
+  `--on-human-gate auto-approve` to run non-interactively -- it always takes the
+  gate's first option, so run it interactively (drop the flag) if you want the
+  gate to actually branch.
+- **`12-graph-resume`** refactors a real module in **your own repo** -- point
+  `--cwd` at your repo instead of a scratch dir. Its guide has the details.
+
+## Or run from a bundle / recipe
+
+Each tutorial guide also shows the **config** form -- pointing the `loop-pipeline`
+orchestrator at the `.dot` from a bundle, or invoking `attractor:pipeline-runner`
+from a recipe step. Use that when you're embedding a pipeline in an app or
+composing it into a larger workflow rather than running it ad-hoc from the CLI.
+
+## Models
+
+Every pipeline here is **model-agnostic** except the practical `multi-lens-review`
+(which pins one provider per lens on purpose). To route specific nodes to specific
+models, add a `model_stylesheet` -- see [06-model-stylesheet.dot](06-model-stylesheet.dot).

--- a/examples/pipelines/practical/README.md
+++ b/examples/pipelines/practical/README.md
@@ -1,0 +1,53 @@
+# Practical Pipelines
+
+Task-oriented pipelines for everyday development work -- bug fixing, refactoring,
+test generation, PR review, feature building, and multi-lens code review. Each
+one is a real, runnable `attractor run` workflow, not a toy.
+
+Each pipeline is a pair: a `.dot` (the graph) and a `.md` (the **walk-up guide** --
+start there). The links below point at the guides.
+
+| Pipeline | Guide | What it does | Target |
+|----------|-------|--------------|--------|
+| Bug Fix | [bug-fix.md](bug-fix.md) | Reproduce → diagnose → fix → regression test → verify | **ships a sample** |
+| Refactoring | [refactor.md](refactor.md) | Analyze smells → plan → snapshot tests → refactor → verify no regressions | **ships a sample** |
+| Test Generation | [test-gen.md](test-gen.md) | Analyze module → find coverage gaps → write tests → self-healing retry loop | **ships a sample** |
+| PR Review | [pr-review.md](pr-review.md) | Analyze diff → parallel bug/security/perf/style review → prioritize → comment | bring-your-own branch |
+| Feature Build | [feature-build.md](feature-build.md) | Parse spec → parallel implement → integration test → human review gate | bring-your-own repo |
+| Multi-Lens Review | [multi-lens-review.md](multi-lens-review.md) | Same code reviewed by 3 providers wearing 3 lenses → synthesized verdict | self-contained |
+
+## Run one walk-up
+
+`bug-fix`, `refactor`, and `test-gen` ship a runnable target in [`sample/`](sample/)
+-- a tiny `user_service.py` package with a planted bug, a code smell, and thin
+tests -- so they work with no setup. From the **repo root**:
+
+```bash
+DOT="$PWD/examples/pipelines/practical/bug-fix.dot"
+cp -r examples/pipelines/practical/sample /tmp/attractor-demo
+cd /tmp/attractor-demo
+attractor run "$DOT" \
+    --param goal="Fix the TypeError in get_display_name when a user's avatar is None" \
+    --cwd .
+```
+
+We copy the sample to a temp dir first so the committed fixture stays pristine.
+`$DOT` is captured as an absolute path before `cd`, because the `.dot` path
+resolves from your current directory while `--cwd` is where the pipeline reads
+and writes -- and for box-node (agent) pipelines the two must match (see
+[`../../../modules/pipeline-runner/KNOWN_ISSUES.md`](../../../modules/pipeline-runner/KNOWN_ISSUES.md)).
+
+To point any of these at your own code instead, `cd` into your repo, keep `$DOT`
+absolute, keep `--cwd .`, and swap in your own `goal`. Each guide has the details.
+
+## Targets at a glance
+
+- **Ships a sample** (`bug-fix`, `refactor`, `test-gen`) -- runs walk-up against [`sample/`](sample/).
+- **Bring-your-own** (`pr-review`, `feature-build`) -- point at a real repo/branch; the guide states the requirements.
+- **Self-contained** (`multi-lens-review`) -- reviews an embedded snippet; needs all three provider keys set (`attractor doctor`).
+
+## Models
+
+Every pipeline here is **model-agnostic** except `multi-lens-review`, which pins
+one provider per lens on purpose. To route specific steps to specific models, add
+a `model_stylesheet` (see [`../06-model-stylesheet.dot`](../06-model-stylesheet.dot)).

--- a/examples/pipelines/practical/bug-fix.dot
+++ b/examples/pipelines/practical/bug-fix.dot
@@ -1,14 +1,13 @@
 // bug-fix.dot -- Systematic bug fix pipeline.
 //
 // Reproduce, diagnose, fix, write regression test, verify.
-// Uses o3-mini for diagnosis (reasoning-heavy) via model stylesheet class.
+// Model-agnostic: every node runs on your configured default provider/model.
 
 digraph BugFix {
     graph [
         goal="$goal",
         label="Bug Fix Pipeline",
         default_max_retry=3,
-        model_stylesheet=".reasoning { llm_provider: openai; llm_model: o3-mini; reasoning_effort: high }",
         default_fidelity="full",
         default_thread_id="bug-fix"
     ]
@@ -22,10 +21,11 @@ digraph BugFix {
         prompt="Attempt to reproduce the bug described in the goal. Write a minimal reproduction script and run it. Capture the error output. If you cannot reproduce it, document what you tried."
     ]
 
-    // Stage 2: Diagnose the root cause (reasoning-heavy -- uses o3-mini via class)
+    // Stage 2: Diagnose the root cause (reasoning-heavy).
+    // Want a stronger reasoning model just for this step? Add a model_stylesheet
+    // and tag this node with a class -- see examples/pipelines/06-model-stylesheet.dot.
     diagnose [
         label="Diagnose",
-        class="reasoning",
         prompt="Analyze the reproduction results and the relevant source code. Identify the root cause. Explain: (1) what is happening, (2) why it is happening, (3) which file(s) and line(s) are responsible."
     ]
 

--- a/examples/pipelines/practical/bug-fix.md
+++ b/examples/pipelines/practical/bug-fix.md
@@ -4,13 +4,30 @@ Systematic debugging: reproduce, diagnose, fix, write regression test, verify.
 
 ## Usage
 
+This example ships a target: `examples/pipelines/practical/sample/` contains a
+`user_service.py` with a planted bug -- `get_display_name()` raises `TypeError`
+when a user's `avatar` is `None`. Run the block below **from the attractor repo
+root** and it works walk-up, no setup:
+
 ```bash
-attractor run examples/pipelines/practical/bug-fix.dot \
-    --param goal="<describe the bug to fix, e.g. a crash when a user has no avatar>" \
+DOT="$PWD/examples/pipelines/practical/bug-fix.dot"
+cp -r examples/pipelines/practical/sample /tmp/attractor-bugfix-demo
+cd /tmp/attractor-bugfix-demo
+attractor run "$DOT" \
+    --param goal="Fix the bug in user_service.py: get_display_name() raises TypeError when a user's avatar is None. Reproduce it first, apply the minimal fix, and add a regression test that covers the None-avatar case." \
     --cwd .
 ```
 
-Point this at your own repo: `cd` into it, replace the goal with your bug, and keep `--cwd .` (that's where the pipeline reads and writes). This example doesn't ship a target codebase. Running from the repo root also keeps box-node agents rooted correctly (see `modules/pipeline-runner/KNOWN_ISSUES.md`).
+We copy the sample to a temp dir first so the committed fixture stays pristine
+and every run starts clean. `$DOT` captures the pipeline's absolute path before
+`cd`, because the `.dot` path is resolved from your current directory while
+`--cwd` is where the pipeline reads and writes. Process cwd must equal `--cwd`
+for box-node (agent) pipelines -- that's why we `cd` into the copy (see
+`modules/pipeline-runner/KNOWN_ISSUES.md`).
+
+**Point it at your own repo instead:** replace the `cp`/`cd` with `cd /path/to/your/repo`, keep `$DOT` absolute, keep `--cwd .`, and swap in your bug.
+
+**Verify the result:** `cd /tmp/attractor-bugfix-demo && pytest -v` -- the suite goes from 2 passing to 3 (the added None-avatar regression test), and `get_display_name` now handles the missing avatar.
 
 ## What It Does
 

--- a/examples/pipelines/practical/bug-fix.md
+++ b/examples/pipelines/practical/bug-fix.md
@@ -5,22 +5,24 @@ Systematic debugging: reproduce, diagnose, fix, write regression test, verify.
 ## Usage
 
 ```bash
-amp run --dot-file examples/pipelines/practical/bug-fix.dot \
-    --goal "Fix the NullPointerError in UserService.getProfile() when user has no avatar"
+attractor run examples/pipelines/practical/bug-fix.dot \
+    --param goal="Fix the NullPointerError in UserService.getProfile() when user has no avatar" \
+    --cwd .
 ```
+
+Run from the repo root so box-node agents root their writes at `--cwd .` (see `modules/pipeline-runner/KNOWN_ISSUES.md`).
 
 ## What It Does
 
 1. **Reproduce** -- Writes and runs a minimal reproduction script
-2. **Diagnose** -- Analyzes root cause using o3-mini (reasoning-heavy, via model stylesheet class)
+2. **Diagnose** -- Analyzes the root cause (reasoning-heavy step)
 3. **Implement Fix** -- Makes the minimal code change to resolve the issue
 4. **Regression Test** -- Writes a test that proves the fix works
 5. **Run Tests** -- Verifies all tests pass (retries fix if not)
 
-## Model Stylesheet
+## Models
 
-- **.reasoning class** (diagnose): o3-mini with high reasoning effort -- deep root cause analysis
-- **box nodes** (all others): Default provider (Claude Sonnet recommended) -- code modification and tool use
+Model-agnostic -- every node runs on your configured default provider/model. To route the reasoning-heavy `diagnose` step to a stronger model, add a `model_stylesheet` and tag the node with a class (see `examples/pipelines/06-model-stylesheet.dot`).
 
 ## Key Feature: Disciplined Workflow
 

--- a/examples/pipelines/practical/bug-fix.md
+++ b/examples/pipelines/practical/bug-fix.md
@@ -6,11 +6,11 @@ Systematic debugging: reproduce, diagnose, fix, write regression test, verify.
 
 ```bash
 attractor run examples/pipelines/practical/bug-fix.dot \
-    --param goal="Fix the NullPointerError in UserService.getProfile() when user has no avatar" \
+    --param goal="<describe the bug to fix, e.g. a crash when a user has no avatar>" \
     --cwd .
 ```
 
-Run from the repo root so box-node agents root their writes at `--cwd .` (see `modules/pipeline-runner/KNOWN_ISSUES.md`).
+Point this at your own repo: `cd` into it, replace the goal with your bug, and keep `--cwd .` (that's where the pipeline reads and writes). This example doesn't ship a target codebase. Running from the repo root also keeps box-node agents rooted correctly (see `modules/pipeline-runner/KNOWN_ISSUES.md`).
 
 ## What It Does
 

--- a/examples/pipelines/practical/feature-build.md
+++ b/examples/pipelines/practical/feature-build.md
@@ -6,11 +6,12 @@ Parse a spec, break into subtasks, implement in parallel, integration test, huma
 
 ```bash
 attractor run examples/pipelines/practical/feature-build.dot \
-    --param goal="Add user avatar upload with S3 storage and thumbnail generation" \
-    --cwd .
+    --param goal="<describe the feature to build, e.g. avatar upload with thumbnails>" \
+    --cwd . \
+    --on-human-gate auto-approve
 ```
 
-Run from the repo root so box-node agents root their writes at `--cwd .` (see `modules/pipeline-runner/KNOWN_ISSUES.md`). This pipeline has a human-gate (hexagon) node; add `--on-human-gate auto-approve` to run it non-interactively.
+`--on-human-gate auto-approve` is required to run non-interactively: this pipeline has a human-review gate (hexagon) that otherwise waits for a person. Point it at your own repo: `cd` in, replace the goal, and keep `--cwd .` (that's where the pipeline reads and writes). This example doesn't ship a target codebase. Running from the repo root also keeps box-node agents rooted correctly (see `modules/pipeline-runner/KNOWN_ISSUES.md`).
 
 ## What It Does
 

--- a/examples/pipelines/practical/feature-build.md
+++ b/examples/pipelines/practical/feature-build.md
@@ -5,9 +5,12 @@ Parse a spec, break into subtasks, implement in parallel, integration test, huma
 ## Usage
 
 ```bash
-amp run --dot-file examples/pipelines/practical/feature-build.dot \
-    --goal "Add user avatar upload with S3 storage and thumbnail generation"
+attractor run examples/pipelines/practical/feature-build.dot \
+    --param goal="Add user avatar upload with S3 storage and thumbnail generation" \
+    --cwd .
 ```
+
+Run from the repo root so box-node agents root their writes at `--cwd .` (see `modules/pipeline-runner/KNOWN_ISSUES.md`). This pipeline has a human-gate (hexagon) node; add `--on-human-gate auto-approve` to run it non-interactively.
 
 ## What It Does
 
@@ -24,6 +27,6 @@ amp run --dot-file examples/pipelines/practical/feature-build.dot \
 - **Human gate** before finalization gives the developer a review checkpoint
 - **Integration test retry** catches cross-branch issues automatically
 
-## Model Recommendation
+## Models
 
-Claude Sonnet for all implementation nodes (strong tool use). Optionally add a model stylesheet with o3-mini for parse_spec if you want stronger planning.
+Model-agnostic -- every node runs on your configured default provider/model. To route the planning step (`parse_spec`) to a stronger model, add a `model_stylesheet` (see `examples/pipelines/06-model-stylesheet.dot`).

--- a/examples/pipelines/practical/feature-build.md
+++ b/examples/pipelines/practical/feature-build.md
@@ -11,7 +11,9 @@ attractor run examples/pipelines/practical/feature-build.dot \
     --on-human-gate auto-approve
 ```
 
-`--on-human-gate auto-approve` is required to run non-interactively: this pipeline has a human-review gate (hexagon) that otherwise waits for a person. Point it at your own repo: `cd` in, replace the goal, and keep `--cwd .` (that's where the pipeline reads and writes). This example doesn't ship a target codebase. Running from the repo root also keeps box-node agents rooted correctly (see `modules/pipeline-runner/KNOWN_ISSUES.md`).
+**About `--on-human-gate auto-approve`:** this pipeline has a human-review gate (hexagon) that blocks a non-interactive run. `auto-approve` unblocks it by always taking the gate's **first** option — which here is **Ship** — so it *never* exercises the Rework path. It lets the demo run to completion, but the review checkpoint becomes a no-op that ships every time. Drop the flag and run interactively if you actually want the gate to mean something.
+
+**Pointing at your own repo:** the `.dot` path is resolved relative to your *current* directory, while `--cwd` is where the pipeline reads and writes code. Give the pipeline file an absolute (or attractor-repo-relative) path and point `--cwd` at your repo — e.g. `attractor run /path/to/attractor/examples/pipelines/practical/feature-build.dot --cwd /path/to/your/repo`. This example doesn't ship a target codebase. See `modules/pipeline-runner/KNOWN_ISSUES.md` for the box-node cwd caveat.
 
 ## What It Does
 

--- a/examples/pipelines/practical/multi-lens-review.md
+++ b/examples/pipelines/practical/multi-lens-review.md
@@ -12,8 +12,10 @@ disagreement) is itself signal.
 ## Usage
 
 ```bash
-amp run --dot-file examples/pipelines/practical/multi-lens-review.dot
+attractor run examples/pipelines/practical/multi-lens-review.dot --cwd .
 ```
+
+Self-contained, so no `--param goal=...` is needed. Run from the repo root so box-node agents root their writes at `--cwd .` (see `modules/pipeline-runner/KNOWN_ISSUES.md`). Needs all three provider keys set (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`) — check with `attractor doctor`.
 
 Or via the interactive agent:
 > "Run the multi-lens review pipeline"

--- a/examples/pipelines/practical/pr-review.dot
+++ b/examples/pipelines/practical/pr-review.dot
@@ -8,8 +8,6 @@ digraph PRReview {
     graph [
         goal="$goal",
         label="PR Review Pipeline",
-        model_stylesheet="box { llm_provider: anthropic; llm_model: claude-sonnet-4-6 }
-                          .reasoning { llm_provider: openai; llm_model: o3-mini; reasoning_effort: high }",
         default_fidelity="full",
         default_thread_id="pr-review"
     ]
@@ -55,10 +53,11 @@ digraph PRReview {
     // Stage 3: Fan-in and collect
     collect [shape=tripleoctagon, label="Collect Reviews"]
 
-    // Stage 4: Prioritize findings (reasoning-heavy -- uses o3-mini via class)
+    // Stage 4: Prioritize findings (reasoning-heavy).
+    // To route this step to a stronger reasoning model, add a model_stylesheet
+    // and tag it with a class -- see examples/pipelines/06-model-stylesheet.dot.
     prioritize [
         label="Prioritize",
-        class="reasoning",
         prompt="Given the parallel review results, prioritize findings: (1) Must-fix before merge (bugs, security), (2) Should-fix (perf), (3) Consider (style). Create a ranked list."
     ]
 

--- a/examples/pipelines/practical/pr-review.md
+++ b/examples/pipelines/practical/pr-review.md
@@ -5,9 +5,12 @@ Multi-dimensional pull request review with parallel analysis streams.
 ## Usage
 
 ```bash
-amp run --dot-file examples/pipelines/practical/pr-review.dot \
-    --goal "Review the changes in this PR for quality and security"
+attractor run examples/pipelines/practical/pr-review.dot \
+    --param goal="Review the changes in this PR for quality and security" \
+    --cwd .
 ```
+
+Run from the repo root so box-node agents root their writes at `--cwd .` (see `modules/pipeline-runner/KNOWN_ISSUES.md`).
 
 Or via the interactive agent:
 > "Run the PR review pipeline on the current branch"
@@ -19,10 +22,9 @@ Or via the interactive agent:
 3. **Prioritize** -- Ranks all findings by severity (must-fix -> should-fix -> consider)
 4. **Generate Comments** -- Creates actionable PR review comments with file paths and suggested fixes
 
-## Model Stylesheet
+## Models
 
-- **box nodes** (review_bugs, review_style, review_security, review_perf, generate_comments): Claude Sonnet -- strong at code reading and tool use
-- **.reasoning class** (prioritize): o3-mini with high reasoning effort -- better at ranking and prioritization tasks
+Model-agnostic -- every node runs on your configured default provider/model. To route the reasoning-heavy `prioritize` step to a stronger model, add a `model_stylesheet` and tag the node with a class (see `examples/pipelines/06-model-stylesheet.dot`).
 
 ## Expected Behavior
 

--- a/examples/pipelines/practical/pr-review.md
+++ b/examples/pipelines/practical/pr-review.md
@@ -6,11 +6,11 @@ Multi-dimensional pull request review with parallel analysis streams.
 
 ```bash
 attractor run examples/pipelines/practical/pr-review.dot \
-    --param goal="Review the changes in this PR for quality and security" \
+    --param goal="Review the changes on this branch for quality and security" \
     --cwd .
 ```
 
-Run from the repo root so box-node agents root their writes at `--cwd .` (see `modules/pipeline-runner/KNOWN_ISSUES.md`).
+Run from the root of your repo, checked out on the feature branch you want reviewed: the pipeline reviews `git diff main...HEAD`, so it needs a `main` branch to diff against and a non-empty diff. If your default branch isn't `main` (or you're sitting on `main`), edit the `git diff` command in `pr-review.dot`. `--cwd .` is where box-node agents read and write (see `modules/pipeline-runner/KNOWN_ISSUES.md`).
 
 Or via the interactive agent:
 > "Run the PR review pipeline on the current branch"

--- a/examples/pipelines/practical/pr-review.md
+++ b/examples/pipelines/practical/pr-review.md
@@ -4,13 +4,24 @@ Multi-dimensional pull request review with parallel analysis streams.
 
 ## Usage
 
+Unlike bug-fix/refactor/test-gen, this pipeline is inherently **bring-your-own**:
+it reviews `git diff main...HEAD`, so it needs a real repo with a feature branch
+to review. Point it at your repo:
+
 ```bash
-attractor run examples/pipelines/practical/pr-review.dot \
+DOT="/path/to/attractor/examples/pipelines/practical/pr-review.dot"
+cd /path/to/your/repo          # checked out on the feature branch to review
+attractor run "$DOT" \
     --param goal="Review the changes on this branch for quality and security" \
     --cwd .
 ```
 
-Run from the root of your repo, checked out on the feature branch you want reviewed: the pipeline reviews `git diff main...HEAD`, so it needs a `main` branch to diff against and a non-empty diff. If your default branch isn't `main` (or you're sitting on `main`), edit the `git diff` command in `pr-review.dot`. `--cwd .` is where box-node agents read and write (see `modules/pipeline-runner/KNOWN_ISSUES.md`).
+The `.dot` path is resolved from your *current* directory, but you need to `cd`
+into your repo so process cwd equals `--cwd` (required for box-node agents -- see
+`modules/pipeline-runner/KNOWN_ISSUES.md`). So give `$DOT` an absolute (or
+attractor-repo-relative) path, `cd` into your repo, and keep `--cwd .`.
+
+Requirements: a `main` branch to diff against and a non-empty `git diff main...HEAD`. If your default branch isn't `main` (or you're sitting on `main`), edit the `git diff` command in `pr-review.dot`.
 
 Or via the interactive agent:
 > "Run the PR review pipeline on the current branch"

--- a/examples/pipelines/practical/refactor.dot
+++ b/examples/pipelines/practical/refactor.dot
@@ -2,14 +2,13 @@
 //
 // Analyze smells, plan refactoring, capture baseline tests,
 // implement changes, verify no regressions, review diff.
-// Uses o3-mini for planning and diff review (reasoning-heavy) via class.
+// Model-agnostic: every node runs on your configured default provider/model.
 
 digraph Refactor {
     graph [
         goal="$goal",
         label="Safe Refactoring Pipeline",
         default_max_retry=3,
-        model_stylesheet=".reasoning { llm_provider: openai; llm_model: o3-mini; reasoning_effort: high }",
         default_fidelity="full",
         default_thread_id="refactor"
     ]
@@ -23,10 +22,11 @@ digraph Refactor {
         prompt="Analyze the code specified in the goal for code smells: long methods, deep nesting, duplicated logic, god classes, feature envy, primitive obsession. Rank by impact and effort to fix."
     ]
 
-    // Stage 2: Plan the refactoring (reasoning-heavy)
+    // Stage 2: Plan the refactoring (reasoning-heavy).
+    // To route reasoning-heavy steps (plan, diff review) to a stronger model,
+    // add a model_stylesheet -- see examples/pipelines/06-model-stylesheet.dot.
     plan_refactor [
         label="Plan Refactoring",
-        class="reasoning",
         prompt="Create a step-by-step refactoring plan that preserves behavior. For each step: (1) what changes, (2) why it improves the code, (3) what could break. Order steps to minimize risk -- easiest/safest first."
     ]
 
@@ -56,7 +56,6 @@ digraph Refactor {
     // Stage 7: Diff review (reasoning-heavy)
     diff_review [
         label="Diff Review",
-        class="reasoning",
         prompt="Run git diff and review all changes. Verify: (1) no behavior changes (pure refactoring), (2) code is genuinely simpler/clearer, (3) no accidental deletions or regressions. Summarize the improvements."
     ]
 

--- a/examples/pipelines/practical/refactor.md
+++ b/examples/pipelines/practical/refactor.md
@@ -6,11 +6,11 @@ Analyze code smells, plan refactoring, execute with snapshot test safety net.
 
 ```bash
 attractor run examples/pipelines/practical/refactor.dot \
-    --param goal="Refactor src/auth/handler.py to reduce complexity and extract helper functions" \
+    --param goal="<describe the refactor, e.g. reduce complexity in a module and extract helpers>" \
     --cwd .
 ```
 
-Run from the repo root so box-node agents root their writes at `--cwd .` (see `modules/pipeline-runner/KNOWN_ISSUES.md`).
+Point this at your own repo: `cd` into it, replace the goal with the code you want refactored, and keep `--cwd .` (that's where the pipeline reads and writes). This example doesn't ship a target codebase. Running from the repo root also keeps box-node agents rooted correctly (see `modules/pipeline-runner/KNOWN_ISSUES.md`).
 
 ## What It Does
 

--- a/examples/pipelines/practical/refactor.md
+++ b/examples/pipelines/practical/refactor.md
@@ -5,23 +5,25 @@ Analyze code smells, plan refactoring, execute with snapshot test safety net.
 ## Usage
 
 ```bash
-amp run --dot-file examples/pipelines/practical/refactor.dot \
-    --goal "Refactor src/auth/handler.py to reduce complexity and extract helper functions"
+attractor run examples/pipelines/practical/refactor.dot \
+    --param goal="Refactor src/auth/handler.py to reduce complexity and extract helper functions" \
+    --cwd .
 ```
+
+Run from the repo root so box-node agents root their writes at `--cwd .` (see `modules/pipeline-runner/KNOWN_ISSUES.md`).
 
 ## What It Does
 
 1. **Analyze Smells** -- Identifies code smells ranked by impact
-2. **Plan Refactoring** -- Creates a risk-ordered plan using o3-mini (reasoning-heavy)
+2. **Plan Refactoring** -- Creates a risk-ordered plan (reasoning-heavy step)
 3. **Snapshot Tests** -- Captures baseline test results (or writes characterization tests)
 4. **Implement** -- Executes the plan with small, atomic edits
 5. **Run Tests** -- Verifies no regressions against baseline (retries if failures, max 2 attempts)
-6. **Diff Review** -- Uses o3-mini to verify behavior preservation
+6. **Diff Review** -- Verifies behavior preservation
 
-## Model Stylesheet
+## Models
 
-- **.reasoning class** (plan_refactor, diff_review): o3-mini with high reasoning effort -- planning and verification
-- **box nodes** (all others): Default provider (Claude Sonnet recommended) -- code analysis and modification
+Model-agnostic -- every node runs on your configured default provider/model. To route the reasoning-heavy steps (`plan_refactor`, `diff_review`) to a stronger model, add a `model_stylesheet` and tag those nodes with a class (see `examples/pipelines/06-model-stylesheet.dot`).
 
 ## Key Feature: Snapshot Safety Net
 

--- a/examples/pipelines/practical/refactor.md
+++ b/examples/pipelines/practical/refactor.md
@@ -4,13 +4,31 @@ Analyze code smells, plan refactoring, execute with snapshot test safety net.
 
 ## Usage
 
+This example ships a target: `examples/pipelines/practical/sample/` contains a
+`user_service.py` whose `validate_user()` is a long, deeply-nested method with
+duplicated validation blocks -- and a green test suite to prove the refactor
+preserves behavior. Run the block below **from the attractor repo root** and it
+works walk-up, no setup:
+
 ```bash
-attractor run examples/pipelines/practical/refactor.dot \
-    --param goal="<describe the refactor, e.g. reduce complexity in a module and extract helpers>" \
+DOT="$PWD/examples/pipelines/practical/refactor.dot"
+cp -r examples/pipelines/practical/sample /tmp/attractor-refactor-demo
+cd /tmp/attractor-refactor-demo
+attractor run "$DOT" \
+    --param goal="Refactor validate_user() in user_service.py: remove the deep nesting and the duplicated username/email validation blocks by extracting a helper. Preserve behavior exactly -- the existing tests must still pass." \
     --cwd .
 ```
 
-Point this at your own repo: `cd` into it, replace the goal with the code you want refactored, and keep `--cwd .` (that's where the pipeline reads and writes). This example doesn't ship a target codebase. Running from the repo root also keeps box-node agents rooted correctly (see `modules/pipeline-runner/KNOWN_ISSUES.md`).
+We copy the sample to a temp dir first so the committed fixture stays pristine
+and every run starts clean. `$DOT` captures the pipeline's absolute path before
+`cd`, because the `.dot` path is resolved from your current directory while
+`--cwd` is where the pipeline reads and writes. Process cwd must equal `--cwd`
+for box-node (agent) pipelines -- that's why we `cd` into the copy (see
+`modules/pipeline-runner/KNOWN_ISSUES.md`).
+
+**Point it at your own repo instead:** replace the `cp`/`cd` with `cd /path/to/your/repo`, keep `$DOT` absolute, keep `--cwd .`, and swap in your refactor goal.
+
+**Verify the result:** `cd /tmp/attractor-refactor-demo && pytest -v` -- the suite stays green (behavior preserved), and `validate_user()` is flatter with the duplication extracted.
 
 ## What It Does
 

--- a/examples/pipelines/practical/sample/README.md
+++ b/examples/pipelines/practical/sample/README.md
@@ -1,0 +1,40 @@
+# Sample target for the practical pipelines
+
+A tiny, self-contained Python package that the **bug-fix**, **refactor**, and
+**test-gen** examples run against, so those pipelines work walk-up with no
+"bring your own repo" setup.
+
+It ships with three planted problems -- one for each pipeline:
+
+| Pipeline | Planted problem | Where |
+|----------|-----------------|-------|
+| `bug-fix` | `get_display_name()` raises `TypeError` when a user's `avatar` is `None` | `user_service.py` |
+| `refactor` | `validate_user()` is a long, deeply-nested method with duplicated blocks | `user_service.py` |
+| `test-gen` | Only the happy path is tested; the None-avatar, missing-user, and validation paths are uncovered | `test_user_service.py` |
+
+The shipped suite is **green** (`pytest` passes) -- the bug is latent because no
+existing test exercises the None-avatar path.
+
+## Run the tests directly
+
+```bash
+cd examples/pipelines/practical/sample
+pytest -v
+```
+
+## Don't mutate the committed fixture
+
+The example commands copy this directory to a temp location before running a
+pipeline, so the committed sample stays pristine and each run starts clean:
+
+```bash
+cp -r examples/pipelines/practical/sample /tmp/attractor-demo
+attractor run examples/pipelines/practical/bug-fix.dot \
+    --param goal="Fix the TypeError in get_display_name when avatar is None" \
+    --cwd /tmp/attractor-demo
+```
+
+Run the command from the **attractor repo root** so the `.dot` path resolves
+(it's relative to your current directory) while `--cwd` points the pipeline at
+the temp copy (that's where it reads and writes). See
+`modules/pipeline-runner/KNOWN_ISSUES.md` for the box-node cwd caveat.

--- a/examples/pipelines/practical/sample/test_user_service.py
+++ b/examples/pipelines/practical/sample/test_user_service.py
@@ -1,0 +1,27 @@
+"""Thin, happy-path-only tests for user_service.
+
+These pass out of the box (green baseline) but deliberately leave gaps:
+  - get_display_name() is only tested WITH an avatar (the None path -- the
+    planted bug -- is untested)
+  - get_user() miss (unknown username) is untested
+  - validate_user() is entirely untested
+
+The test-gen pipeline exists to close gaps like these; the bug-fix pipeline
+adds the missing None-avatar regression test; the refactor pipeline uses this
+suite as its behavior-preservation snapshot.
+"""
+
+from user_service import User, UserService
+
+
+def test_add_and_get_user():
+    svc = UserService()
+    user = User(username="alice", email="alice@example.com", avatar="a1b2c3d4")
+    svc.add_user(user)
+    assert svc.get_user("alice") is user
+
+
+def test_display_name_with_avatar():
+    svc = UserService()
+    svc.add_user(User(username="bob", email="bob@example.com", avatar="deadbeef"))
+    assert svc.get_display_name("bob") == "bob [avatar: dead]"

--- a/examples/pipelines/practical/sample/user_service.py
+++ b/examples/pipelines/practical/sample/user_service.py
@@ -1,0 +1,86 @@
+"""A tiny in-memory user service -- the shared target for the practical pipelines.
+
+This module is intentionally imperfect so the example pipelines have something
+real to work on. It ships with three planted problems:
+
+  1. A latent BUG   -- `get_display_name()` raises TypeError when a user's
+     avatar is None (see bug-fix.dot). The shipped tests never exercise that
+     path, so the suite is green and the bug stays hidden until reproduced.
+  2. A CODE SMELL   -- `validate_user()` is a long, deeply-nested method with
+     duplicated validation blocks (see refactor.dot).
+  3. THIN COVERAGE  -- test_user_service.py covers only the happy path, leaving
+     the None-avatar path, the missing-user path, and all of validate_user()
+     untested (see test-gen.dot).
+
+Keep it flat (no __init__.py) so `import user_service` works when pytest is run
+from inside a copy of this directory.
+"""
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class User:
+    username: str
+    email: str
+    avatar: str | None = None
+    roles: list[str] = field(default_factory=list)
+
+
+class UserService:
+    """A minimal username-keyed user store."""
+
+    def __init__(self) -> None:
+        self._users: dict[str, User] = {}
+
+    def add_user(self, user: User) -> None:
+        self._users[user.username] = user
+
+    def get_user(self, username: str) -> User | None:
+        return self._users.get(username)
+
+    def get_display_name(self, username: str) -> str:
+        """Return a display string like ``alice [avatar: a1b2]``.
+
+        BUG: this assumes ``avatar`` is always set. When a user was created
+        without an avatar (``avatar=None``), ``user.avatar[:4]`` raises
+        ``TypeError: 'NoneType' object is not subscriptable``.
+        """
+        user = self._users[username]
+        return f"{user.username} [avatar: {user.avatar[:4]}]"
+
+    def validate_user(self, user: User) -> list[str]:
+        """Validate a user and return a list of human-readable error strings.
+
+        CODE SMELL: long method, deep nesting, and duplicated shape between the
+        username and email validation blocks. A good refactor extracts the
+        repeated "required / non-empty / rule" ladder into a helper without
+        changing behavior.
+        """
+        errors: list[str] = []
+
+        if user.username is not None:
+            if len(user.username) > 0:
+                if len(user.username) < 3:
+                    errors.append("username too short")
+                else:
+                    if not user.username.isalnum():
+                        errors.append("username must be alphanumeric")
+            else:
+                errors.append("username is empty")
+        else:
+            errors.append("username is required")
+
+        if user.email is not None:
+            if len(user.email) > 0:
+                if "@" not in user.email:
+                    errors.append("email must contain @")
+                else:
+                    if "." not in user.email.split("@")[1]:
+                        errors.append("email domain invalid")
+            else:
+                errors.append("email is empty")
+        else:
+            errors.append("email is required")
+
+        return errors

--- a/examples/pipelines/practical/test-gen.md
+++ b/examples/pipelines/practical/test-gen.md
@@ -4,13 +4,30 @@ Generate tests, run them, and fix failures in a self-healing retry loop.
 
 ## Usage
 
+This example ships a target: `examples/pipelines/practical/sample/` contains a
+`user_service.py` with only happy-path tests -- the None-avatar path, the
+missing-user path, and all of `validate_user()` are uncovered. Run the block
+below **from the attractor repo root** and it works walk-up, no setup:
+
 ```bash
-attractor run examples/pipelines/practical/test-gen.dot \
-    --param goal="<describe what to test, e.g. the authentication module>" \
+DOT="$PWD/examples/pipelines/practical/test-gen.dot"
+cp -r examples/pipelines/practical/sample /tmp/attractor-testgen-demo
+cd /tmp/attractor-testgen-demo
+attractor run "$DOT" \
+    --param goal="Expand test coverage for user_service.py. The existing suite only covers the happy path -- add tests for the untested paths: get_display_name() with a None avatar, get_user() for an unknown username, and the validate_user() rules (short/empty/non-alphanumeric username, missing/malformed email)." \
     --cwd .
 ```
 
-Point this at your own repo: `cd` into it, replace the goal with the module you want tested, and keep `--cwd .` (that's where the pipeline reads and writes). This example doesn't ship a target codebase. Running from the repo root also keeps box-node agents rooted correctly (see `modules/pipeline-runner/KNOWN_ISSUES.md`).
+We copy the sample to a temp dir first so the committed fixture stays pristine
+and every run starts clean. `$DOT` captures the pipeline's absolute path before
+`cd`, because the `.dot` path is resolved from your current directory while
+`--cwd` is where the pipeline reads and writes. Process cwd must equal `--cwd`
+for box-node (agent) pipelines -- that's why we `cd` into the copy (see
+`modules/pipeline-runner/KNOWN_ISSUES.md`).
+
+**Point it at your own repo instead:** replace the `cp`/`cd` with `cd /path/to/your/repo`, keep `$DOT` absolute, keep `--cwd .`, and swap in the module you want tested.
+
+**Verify the result:** `cd /tmp/attractor-testgen-demo && pytest -v` -- the suite grows well past the original 2 happy-path tests and stays green.
 
 ## What It Does
 

--- a/examples/pipelines/practical/test-gen.md
+++ b/examples/pipelines/practical/test-gen.md
@@ -6,11 +6,11 @@ Generate tests, run them, and fix failures in a self-healing retry loop.
 
 ```bash
 attractor run examples/pipelines/practical/test-gen.dot \
-    --param goal="Generate comprehensive tests for the user authentication module in src/auth/" \
+    --param goal="<describe what to test, e.g. the authentication module>" \
     --cwd .
 ```
 
-Run from the repo root so box-node agents root their writes at `--cwd .` (see `modules/pipeline-runner/KNOWN_ISSUES.md`).
+Point this at your own repo: `cd` into it, replace the goal with the module you want tested, and keep `--cwd .` (that's where the pipeline reads and writes). This example doesn't ship a target codebase. Running from the repo root also keeps box-node agents rooted correctly (see `modules/pipeline-runner/KNOWN_ISSUES.md`).
 
 ## What It Does
 

--- a/examples/pipelines/practical/test-gen.md
+++ b/examples/pipelines/practical/test-gen.md
@@ -5,9 +5,12 @@ Generate tests, run them, and fix failures in a self-healing retry loop.
 ## Usage
 
 ```bash
-amp run --dot-file examples/pipelines/practical/test-gen.dot \
-    --goal "Generate comprehensive tests for the user authentication module in src/auth/"
+attractor run examples/pipelines/practical/test-gen.dot \
+    --param goal="Generate comprehensive tests for the user authentication module in src/auth/" \
+    --cwd .
 ```
+
+Run from the repo root so box-node agents root their writes at `--cwd .` (see `modules/pipeline-runner/KNOWN_ISSUES.md`).
 
 ## What It Does
 
@@ -21,6 +24,6 @@ amp run --dot-file examples/pipelines/practical/test-gen.dot \
 
 The retry loop between `run_tests` and `fix_failures` means the pipeline doesn't just generate tests -- it validates them and fixes failures automatically. Up to 3 retry cycles.
 
-## Model Recommendation
+## Models
 
-Claude Sonnet for all nodes (strong at code generation and tool use). No model stylesheet needed -- the default provider works well for all stages.
+Model-agnostic -- every node runs on your configured default provider/model. Add a `model_stylesheet` only if you want to route specific steps to specific models (see `examples/pipelines/06-model-stylesheet.dot`).


### PR DESCRIPTION
## Summary

Primarily a documentation and examples pass, on the heels of the new standalone
`attractor run` CLI. The numbered and practical examples predate that CLI (they
carried a placeholder `amp run` invocation), so this brings them onto the real
CLI and proves each one runs walk-up. Separately — and unrelated to the CLI —
several examples had simply gone stale on model names; those are fixed durably,
not just bumped to today's ids. And the examples tree is now easy to navigate.

No module or engine code is changed — this is examples + docs only. Everything
here was verified by actually running it, not just edited.

## What changed

**Examples brought onto the new CLI and proven end-to-end**
- Replaced the placeholder `amp run` in the examples with the real
  `attractor run <dot> --param goal=... --cwd .` and made them model-agnostic.
- Shipped a small runnable sample (`examples/pipelines/practical/sample/`) so
  bug-fix / refactor / test-gen work with no setup.
- Proved all 6 practical + all 12 numbered examples end-to-end (see Verification).

**Discoverability**
- New `examples/pipelines/README.md` and `practical/README.md` indexes.
- Root-README gallery links now point at the `.md` guides (not raw `.dot`), and
  the two examples missing from the gallery (11, 12) were added.
- Every numbered example gained a CLI "Run it" block; added a guide for the
  previously-undocumented `11-manager-child-dotfile-hitl/`.

**Durable fix for model rot**
- Only 06 and 10 pinned models; both had dated ids and generation-frozen globs.
  Switched to evergreen glob forms verified against the live resolver — these
  track each provider's newest stable model automatically (whole-family for
  Anthropic/Gemini: `claude-sonnet-*`, `claude-opus-*`, `gemini-*-flash`; a
  generation range `gpt-[5-9]*` for OpenAI, which has no persistent tier name) —
  rather than re-pinning today's ids, which would just rot again. The docs now
  explain the resolution mechanism and how evergreen each form is.

**Docs synced to reality**
- GETTING-STARTED, DOT-AUTHORING-GUIDE, DOT-SYNTAX, APP-INTEGRATION updated to
  reference the new `attractor run` CLI (it appeared in no user-facing doc) and
  to teach the evergreen-model forms. Fixed a doc error claiming a `--goal` flag
  exists (the goal comes from the graph attribute or `--param goal=`).

## Issues fixed along the way

- **12-graph-resume**: documented a broken `amplifier run --dot-file/--goal`
  command (4x) plus a stale `o3-mini` pin.
- **10-full-attractor**: a dated `claude-opus-4-20250514` pin made the run fail
  outright with `NotFoundError`.
- **06 quick_fix**: a model glob resolves against the node's provider — the
  gemini override was missing its `llm_provider`, so it matched nothing.

## Known issue (surfaced, not fixed here)

`11-manager-child-dotfile-hitl` is a regression fixture that currently fails via
standalone `attractor run` — the child pipeline's human-gate isn't reached with
the correct working directory. It's documented as a known issue in its README;
the root cause is an engine-side follow-up, deliberately out of scope for this
docs/examples PR.

## Verification

Ran all 12 numbered + 6 practical examples end-to-end against real providers.
11/12 numbered pass (11 is the known-issue fixture above); all 6 practical pass —
e.g. bug-fix added a regression test (3 passed), test-gen grew the suite 2 -> 36,
and the model-stylesheet examples 06 & 10 run green with the evergreen globs.