### PR TITLE
feat(pipeline-runner): add --on-human-gate console, wiring the engine's ConsoleInterviewer

### DIFF
--- a/modules/pipeline-runner/amplifier_module_pipeline_runner/cli.py
+++ b/modules/pipeline-runner/amplifier_module_pipeline_runner/cli.py
@@ -71,20 +71,50 @@ def build_parser() -> argparse.ArgumentParser:
     )
     run.add_argument(
         "--on-human-gate",
-        choices=("fail", "auto-approve"),
+        choices=("fail", "auto-approve", "console"),
         default="fail",
         help=(
             "how to handle a human-gate (hexagon) node. 'fail' (default): "
             "fail loud -- a pipeline that needs a human decision terminates "
             "with a clear error (run it where a human/UI can answer, or pass "
-            "auto-approve). 'auto-approve': supply an auto-approving interviewer "
-            "that selects the first choice at each gate (opt-in, non-interactive)."
+            "auto-approve or console). 'auto-approve': supply an "
+            "auto-approving interviewer that selects the first choice at "
+            "each gate (opt-in, non-interactive). 'console': answer gates "
+            "interactively in this terminal (wires the engine's "
+            "ConsoleInterviewer; requires a usable stdin)."
         ),
     )
 
     sub.add_parser("doctor", help="environment diagnostics")
 
     return parser
+
+
+def _stdin_is_usable() -> bool:
+    """Return True if ``sys.stdin`` is present and safe to read from.
+
+    Piped (non-tty) stdin is explicitly allowed -- scripted/non-interactive
+    answers via a pipe are a legitimate way to drive ``--on-human-gate
+    console`` (e.g. in a script or a test). This function deliberately does
+    NOT call ``isatty()`` -- a non-tty stream is not the same as an unusable
+    one. Only a genuinely absent or closed stdin fails this check.
+    """
+    stdin = sys.stdin
+    if stdin is None:
+        return False
+    try:
+        if stdin.closed:
+            return False
+    except ValueError:
+        # Some closed-stream implementations raise on `.closed` access.
+        return False
+    readable = getattr(stdin, "readable", None)
+    if readable is None:
+        return True
+    try:
+        return bool(readable())
+    except ValueError:
+        return False
 
 
 def cmd_run(args: argparse.Namespace) -> int:
@@ -141,12 +171,46 @@ def cmd_run(args: argparse.Namespace) -> int:
     else:
         cwd = Path.cwd()
 
-    # --- Human-gate policy: default fail-loud; auto-approve is opt-in ---
+    # --- Human-gate policy: default fail-loud; auto-approve/console are opt-in ---
+    #
+    # Spec basis (specs/canonical/attractor-spec-canonical.md -- identical to
+    # the fresh upstream clone at attractor/attractor-spec.md):
+    #   Section 6.1 -- Interviewer interface (ask/ask_multiple/inform).
+    #   Section 6.4 -- "ConsoleInterviewer (CLI): Reads from standard input.
+    #     Displays formatted prompts with option keys."
+    #   Conformance checklist (~line 1865): "ConsoleInterviewer prompts in
+    #     terminal and reads user input."
+    #   Section 9.5 -- human gates must be operable via CLI (web controls are
+    #     additive on top of that baseline).
+    # ConsoleInterviewer is an existing, public, spec-conformant
+    # implementation (amplifier_module_loop_pipeline.interviewer); this wires
+    # it into the runner the same way --on-human-gate auto-approve already
+    # wires AutoApproveInterviewer -- no new interviewer behavior is added.
+    # Freeform gate text (specs/EXTENSIONS.md Section 19, a declared bundle
+    # extension) is already handled by ConsoleInterviewer.ask()'s FREEFORM
+    # branch; nothing further to wire for it here.
     interviewer = None
     if args.on_human_gate == "auto-approve":
         from amplifier_module_loop_pipeline.interviewer import AutoApproveInterviewer
 
         interviewer = AutoApproveInterviewer()
+    elif args.on_human_gate == "console":
+        from amplifier_module_loop_pipeline.interviewer import ConsoleInterviewer
+
+        # Fail loud at startup -- not at the first gate -- when stdin can't be
+        # read at all. A piped, non-tty stdin is explicitly fine (scripted
+        # answers are a legitimate way to drive this mode).
+        if not _stdin_is_usable():
+            print(
+                "attractor: --on-human-gate console requires a usable stdin, "
+                "but stdin is closed or unavailable. Run interactively, pipe "
+                "scripted answers in (e.g. `printf 'A\\n' | attractor run "
+                "... --on-human-gate console`), or use --on-human-gate "
+                "auto-approve instead.",
+                file=sys.stderr,
+            )
+            return 1
+        interviewer = ConsoleInterviewer()
 
     print(f"attractor: running pipeline (cwd: {cwd}, logs: {logs_root})")
 
@@ -187,8 +251,9 @@ def cmd_run(args: argparse.Namespace) -> int:
         print(
             "attractor: hint -- if this pipeline has a human-gate (hexagon) node, "
             "it fails loud by default. Re-run with --on-human-gate auto-approve to "
-            "auto-approve gates non-interactively, or run it where a human/UI can "
-            "answer the gate.",
+            "auto-approve gates non-interactively, --on-human-gate console to "
+            "answer gates interactively in this terminal, or run it where a "
+            "human/UI can answer the gate.",
             file=sys.stderr,
         )
 

--- a/modules/pipeline-runner/tests/test_cli_on_human_gate.py
+++ b/modules/pipeline-runner/tests/test_cli_on_human_gate.py
@@ -1,0 +1,176 @@
+"""Tests for ``--on-human-gate console`` -- argparse wiring, interviewer
+selection, and the fail-loud stdin guard.
+
+Spec basis (specs/canonical/attractor-spec-canonical.md, identical to the
+fresh upstream clone at attractor/attractor-spec.md):
+    Section 6.1  -- Interviewer interface.
+    Section 6.4  -- "ConsoleInterviewer (CLI): Reads from standard input.
+                     Displays formatted prompts with option keys."
+    Conformance checklist (~line 1865): "ConsoleInterviewer prompts in
+                     terminal and reads user input."
+    Section 9.5  -- human gates must be operable via CLI (web controls are
+                     additive on top of that baseline).
+
+These tests assert only the CLI-level wiring seam -- that 'console' is an
+accepted choice, that it resolves to a real ConsoleInterviewer via the same
+seam auto-approve already uses (``runner.run_pipeline(..., interviewer=...)``),
+and that an unusable stdin fails loud at startup rather than hanging at the
+first gate. ``runner.run_pipeline`` itself is monkeypatched in these tests
+(the engine run is exercised separately, with NO interviewer mock, in
+test_console_gate_integration.py).
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+
+import pytest
+
+from amplifier_module_pipeline_runner import cli
+from amplifier_module_pipeline_runner import runner as runner_mod
+from amplifier_module_pipeline_runner.runner import PipelineResult
+
+
+# --- argparse: choice accepted + help text ---------------------------------
+
+
+def test_console_choice_accepted_by_argparse():
+    parser = cli.build_parser()
+    args = parser.parse_args(["run", "dummy.dot", "--on-human-gate", "console"])
+    assert args.on_human_gate == "console"
+
+
+def test_unknown_on_human_gate_choice_still_rejected():
+    """'console' is additive -- an unrelated bogus value must still fail loud."""
+    parser = cli.build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["run", "dummy.dot", "--on-human-gate", "bogus"])
+
+
+def test_help_text_documents_console_mode(capsys):
+    parser = cli.build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["run", "--help"])
+    out = capsys.readouterr().out
+    assert "console" in out
+    assert "ConsoleInterviewer" in out
+    assert "stdin" in out
+
+
+# --- _stdin_is_usable() unit tests ------------------------------------------
+
+
+def test_stdin_usable_none_is_unusable(monkeypatch):
+    monkeypatch.setattr(sys, "stdin", None)
+    assert cli._stdin_is_usable() is False
+
+
+def test_stdin_usable_closed_file_is_unusable(monkeypatch, tmp_path):
+    f = open(tmp_path / "x.txt", "w", encoding="utf-8")
+    f.close()
+    monkeypatch.setattr(sys, "stdin", f)
+    assert cli._stdin_is_usable() is False
+
+
+def test_stdin_usable_piped_stringio_is_usable(monkeypatch):
+    """Piped (non-tty) stdin MUST be allowed -- scripted answers are legitimate."""
+    piped = io.StringIO("A\n")
+    monkeypatch.setattr(sys, "stdin", piped)
+    assert piped.isatty() is False  # sanity: this really is a non-tty stream
+    assert cli._stdin_is_usable() is True
+
+
+# --- cmd_run: interviewer selection per --on-human-gate choice --------------
+
+
+def _make_dot_file(tmp_path) -> str:
+    dot_file = tmp_path / "pipeline.dot"
+    dot_file.write_text(
+        "digraph T { start [shape=Mdiamond]; done [shape=Msquare]; start -> done; }",
+        encoding="utf-8",
+    )
+    return str(dot_file)
+
+
+def _run_cmd_run(monkeypatch, tmp_path, on_human_gate: str, *, patch_run_pipeline=True):
+    """Parse real argv through build_parser() and invoke cmd_run, capturing
+    the ``interviewer`` kwarg handed to ``runner.run_pipeline`` (never actually
+    running the engine -- that's covered by test_console_gate_integration.py).
+    """
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key-not-real")
+    dot_path = _make_dot_file(tmp_path)
+
+    captured: dict = {}
+
+    async def fake_run_pipeline(dot_source, **kwargs):
+        captured["interviewer"] = kwargs.get("interviewer")
+        return PipelineResult(status="success", notes="", logs_dir=tmp_path, raw="{}")
+
+    if patch_run_pipeline:
+        monkeypatch.setattr(runner_mod, "run_pipeline", fake_run_pipeline)
+
+    parser = cli.build_parser()
+    args = parser.parse_args(
+        ["run", dot_path, "--on-human-gate", on_human_gate, "--cwd", str(tmp_path)]
+    )
+    rc = cli.cmd_run(args)
+    return rc, captured
+
+
+def test_fail_mode_passes_no_interviewer(monkeypatch, tmp_path):
+    rc, captured = _run_cmd_run(monkeypatch, tmp_path, "fail")
+    assert rc == 0
+    assert captured["interviewer"] is None
+
+
+def test_auto_approve_mode_passes_auto_approve_interviewer(monkeypatch, tmp_path):
+    from amplifier_module_loop_pipeline.interviewer import AutoApproveInterviewer
+
+    rc, captured = _run_cmd_run(monkeypatch, tmp_path, "auto-approve")
+    assert rc == 0
+    assert isinstance(captured["interviewer"], AutoApproveInterviewer)
+
+
+def test_console_mode_with_usable_stdin_passes_console_interviewer(
+    monkeypatch, tmp_path
+):
+    from amplifier_module_loop_pipeline.interviewer import ConsoleInterviewer
+
+    monkeypatch.setattr(sys, "stdin", io.StringIO("A\n"))
+    rc, captured = _run_cmd_run(monkeypatch, tmp_path, "console")
+    assert rc == 0
+    assert isinstance(captured["interviewer"], ConsoleInterviewer)
+
+
+# --- fail-loud stdin guard ---------------------------------------------------
+
+
+def test_console_mode_fails_loud_at_startup_when_stdin_unusable(
+    monkeypatch, tmp_path, capsys
+):
+    """Closed/absent stdin must error BEFORE any pipeline run is attempted --
+    never hang waiting on the first gate.
+    """
+    monkeypatch.setattr(sys, "stdin", None)
+
+    async def must_not_be_called(*_args, **_kwargs):
+        raise AssertionError(
+            "run_pipeline must NOT be called when stdin is unusable -- "
+            "the guard must fire at startup, before any gate is reached"
+        )
+
+    monkeypatch.setattr(runner_mod, "run_pipeline", must_not_be_called)
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key-not-real")
+    dot_path = _make_dot_file(tmp_path)
+    parser = cli.build_parser()
+    args = parser.parse_args(
+        ["run", dot_path, "--on-human-gate", "console", "--cwd", str(tmp_path)]
+    )
+
+    rc = cli.cmd_run(args)
+
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "stdin" in err

--- a/modules/pipeline-runner/tests/test_console_gate_integration.py
+++ b/modules/pipeline-runner/tests/test_console_gate_integration.py
@@ -1,0 +1,124 @@
+"""Integration test: console-mode human gate driven end-to-end through the
+runner's real engine machinery, with a REAL ``ConsoleInterviewer`` (never
+mocked) and only ``sys.stdin`` faked (piped, scripted input).
+
+This proves the ``--on-human-gate console`` wiring does real stdin-driven
+edge selection -- not a silent auto-approve/first-choice fallback -- by
+running a minimal two-choice hexagon gate and asserting the SECOND choice's
+edge is the one actually taken when "B\\n" is piped in.
+
+Spec basis (specs/canonical/attractor-spec-canonical.md, identical to the
+fresh upstream clone at attractor/attractor-spec.md):
+    Section 6.1  -- Interviewer interface (``ask``/``ask_multiple``/``inform``).
+    Section 6.4  -- "ConsoleInterviewer (CLI): Reads from standard input.
+                     Displays formatted prompts with option keys."
+    Conformance checklist (~line 1865): "ConsoleInterviewer prompts in
+                     terminal and reads user input."
+    Section 9.5  -- human gates must be operable via CLI.
+
+Uses ``drive_engine`` (the low-level seam ``run_pipeline``/the CLI itself
+build on -- see runner.py's module docstring) with a bare ``coordinator``
+stand-in: this graph has no box/agent nodes, so the coordinator is never
+touched (only the human-gate handler and exit handler fire).
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+
+import pytest
+
+from amplifier_module_loop_pipeline.interviewer import ConsoleInterviewer
+from amplifier_module_loop_pipeline.pipeline_events import PIPELINE_NODE_COMPLETE
+from amplifier_module_pipeline_runner.runner import drive_engine
+
+_GATE_DOT = """
+digraph ConsoleGateIntegration {
+    graph [goal="prove console-mode edge selection"]
+    start  [shape=Mdiamond]
+    gate   [shape=hexagon, label="Pick one"]
+    path_a [shape=parallelogram, tool_command="true"]
+    path_b [shape=parallelogram, tool_command="true"]
+    done   [shape=Msquare]
+
+    start -> gate
+    gate -> path_a [label="[A] First choice"]
+    gate -> path_b [label="[B] Second choice"]
+    path_a -> done
+    path_b -> done
+}
+"""
+# Exactly one exit (Msquare) node is a hard validation requirement (see
+# ValidationError "exactly one is required"), so the two choices are
+# distinguished by which intermediate tool node (path_a/path_b) executes on
+# the way to the single shared exit -- not by distinct exit nodes.
+
+
+class _RecordingHooks:
+    """Minimal hooks stand-in -- records every emitted pipeline event."""
+
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict]] = []
+
+    async def emit(self, event_name: str, data: dict) -> None:
+        self.events.append((event_name, dict(data)))
+
+
+def _completed_node_ids(hooks: "_RecordingHooks") -> list[str]:
+    return [
+        data["node_id"] for name, data in hooks.events if name == PIPELINE_NODE_COMPLETE
+    ]
+
+
+@pytest.mark.asyncio
+async def test_console_mode_scripted_stdin_takes_second_choice(monkeypatch, tmp_path):
+    """Piped stdin "B\\n" through a REAL ConsoleInterviewer routes to path_b.
+
+    If console mode silently behaved like auto-approve (which always picks
+    the FIRST edge), this would incorrectly route through path_a instead --
+    so this assertion proves real stdin-driven selection, not a fallback.
+    """
+    monkeypatch.setattr(sys, "stdin", io.StringIO("B\n"))
+    hooks = _RecordingHooks()
+
+    outcome = await drive_engine(
+        _GATE_DOT,
+        coordinator=object(),  # never touched -- no box/agent nodes here
+        interviewer=ConsoleInterviewer(),
+        hooks=hooks,
+        logs_root=str(tmp_path),
+        transform=True,
+        validate=True,
+    )
+
+    assert outcome.status.value == "success"
+    completed = _completed_node_ids(hooks)
+    # The exit node itself doesn't emit its own node_complete event (the
+    # engine's main loop returns as soon as it reaches an exit node), so the
+    # last *handler* to complete is the branch-specific tool node -- which is
+    # exactly what proves which edge was taken.
+    assert completed[-1] == "path_b"
+    assert "path_a" not in completed
+
+
+@pytest.mark.asyncio
+async def test_console_mode_scripted_stdin_takes_first_choice(monkeypatch, tmp_path):
+    """Complementary case: piped stdin "A\\n" routes through path_a."""
+    monkeypatch.setattr(sys, "stdin", io.StringIO("A\n"))
+    hooks = _RecordingHooks()
+
+    outcome = await drive_engine(
+        _GATE_DOT,
+        coordinator=object(),
+        interviewer=ConsoleInterviewer(),
+        hooks=hooks,
+        logs_root=str(tmp_path),
+        transform=True,
+        validate=True,
+    )
+
+    assert outcome.status.value == "success"
+    completed = _completed_node_ids(hooks)
+    assert completed[-1] == "path_a"
+    assert "path_b" not in completed


### PR DESCRIPTION
## Summary
The standalone runner CLI supported only `--on-human-gate {fail, auto-approve}`, so a hexagon (wait.human) gate could never actually be answered by a human from the CLI — arguably the gate's primary use case. This adds `--on-human-gate console`, wiring the engine's existing, public `ConsoleInterviewer` (loop-pipeline `interviewer.py:170-229`) through the exact seam auto-approve already uses (`cli.py` builds the interviewer, `run_pipeline(..., interviewer=...)` — no engine changes, no new config keys). Spec basis: the canonical attractor spec names `ConsoleInterviewer (CLI)` as a built-in implementation (§6.4, line 1305: "Reads from standard input. Displays formatted prompts with option keys."), its conformance checklist requires "ConsoleInterviewer prompts in terminal and reads user input" (line 1865), and §9.5 expects human gates operable via CLI. Includes a fail-loud startup guard when console is selected but stdin is unusable (closed/None) — piped, non-tty stdin is deliberately allowed (scripted answers are legitimate). Freeform gate text continues to flow through the bundle's declared `wait.human` freeform extension (specs/EXTENSIONS.md §19); the ConsoleInterviewer's FREEFORM branch already handled it — wired, not modified.

## Verification checklist

- [x] Unit tests pass — pipeline-runner suite: **34 passed** (22 pre-existing + 12 new, TDD-first); repo gate `pytest modules/loop-pipeline/`: **1197 passed, 11 skipped, 9 pre-existing failures** (`test_model_token_resolution.py` `ModuleNotFoundError: unified_llm` — identical count on clean main before this change; nothing in that module touched)
- [x] Live pipeline run exercising changed code path — two live runs below (scripted-stdin second-choice selection + a real production pipeline's gate answered interactively)
- [x] AGENTS.md reviewed; repo-specific gates met
- [x] Backward-compat path unchanged — `fail` remains the default; `auto-approve` untouched; new choice is purely additive
- [x] PR body includes verification evidence, not just "tests pass"

## Verification evidence

**Live run 1 — scripted stdin proves real selection (not first-choice fallback).** Throwaway 2-choice gate pipeline, piping the SECOND choice:
```
$ printf 'B\n' | uv run attractor run console-gate-live-demo.dot --on-human-gate console ...
[Pipeline Question] Pick one
  [A] [A] First choice
  [B] [B] Second choice
Choose: attractor: status=success
notes: Tool completed: echo TOOK_PATH_B
```
`checkpoint.json`: `"completed_nodes": ["start", "gate", "path_b"]`, `"human.gate.selected": "[B] Second choice"` — `path_a/` (the auto-approve/first-choice fallback) never created.

**Live run 2 — a real production pipeline's gate answered interactively end-to-end.** A 41-node research pipeline (hexagon gate with `[A] Approve / [R] Request revision / [E] End` + freeform §19 feedback) driven in a real PTY: chose `[R]`, typed multi-sentence freeform feedback (consumed by the downstream revision node, which regenerated its artifact honoring the feedback), gate re-prompted, chose `[A]`:
```
[Pipeline Question] Approve, Revise, or End?
  [A] [A] Approve the spec
  [R] [R] Request a revision pass
  [E] [E] End without approving
Choose: A
attractor: status=success
notes: Human gate 'gate': selected '[A] Approve the spec'
```

**Install-path check** (how downstream consumers get this module): pip/uv install from `git+…#subdirectory=modules/pipeline-runner` at this branch into a clean venv → `attractor run --help` shows `--on-human-gate {fail,auto-approve,console}`.

**Integration tests** (no interviewer mocks — real ConsoleInterviewer, real drive_engine, real DOT parse/dispatch; only sys.stdin faked): `test_console_mode_scripted_stdin_takes_second_choice`, `test_console_mode_scripted_stdin_takes_first_choice`. Unit tests cover argparse choice + help text, interviewer type passed per choice (fail→none, auto-approve→AutoApprove, console→Console), and the stdin-unusable fail-loud guard.

## Notes for reviewers
- Motivation: found while building an attractor pipeline whose human gate could only be auto-approved or failed — `--on-human-gate fail` told users to "run it where a human/UI can answer the gate," but no such CLI mode existed. The engine's ConsoleInterviewer was already spec-conformant and public; the runner just never offered it.
- The failure-hint text now mentions `console` alongside `auto-approve`.
- Pre-existing, untouched: `runner.py` and `tests/test_hooks_default.py` fail `ruff format --check` (unrelated); the 9 `test_model_token_resolution.py` env failures predate this change.