### PR TITLE
feat(engine): remote git+https:// DOT-source support (Milestone 1)

### DIFF
--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/__init__.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/__init__.py
@@ -498,6 +498,7 @@ class PipelineOrchestrator:
             entry_path, _source_cleanup = await materialize_remote_dot(dot_source)
             try:
                 graph = parse_dot(entry_path.read_text(encoding="utf-8"))
+                graph.source_dir = str(entry_path.parent)
             except BaseException:
                 _source_cleanup()
                 raise

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/__init__.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/__init__.py
@@ -17,11 +17,9 @@ import logging
 import os
 import re
 import tempfile
-from collections.abc import Callable
 from typing import Any
 
 from .context import PipelineContext
-from .dot_parser import parse_dot
 from .engine import PipelineEngine
 from .handlers import HandlerRegistry
 from .handlers.context import HandlerContext
@@ -488,22 +486,12 @@ class PipelineOrchestrator:
         dot_source = self._resolve_dot_source()
 
         # 2. Parse the DOT graph — materialize first if it's a remote entry.
-        def _noop_cleanup() -> None:
-            return None
+        # Shared with the direct-engine `drive_engine`/`_load_graph` hook in
+        # pipeline-runner via remote_dot.load_remote_or_local_graph, so the two
+        # engine entry points can't diverge (see that function's docstring).
+        from .remote_dot import load_remote_or_local_graph  # lazy: keeps import net-free
 
-        _source_cleanup: Callable[[], None] = _noop_cleanup
-        if isinstance(dot_source, str) and dot_source.startswith("git+https://"):
-            from .remote_dot import materialize_remote_dot  # lazy: keeps import net-free
-
-            entry_path, _source_cleanup = await materialize_remote_dot(dot_source)
-            try:
-                graph = parse_dot(entry_path.read_text(encoding="utf-8"))
-                graph.source_dir = str(entry_path.parent)
-            except BaseException:
-                _source_cleanup()
-                raise
-        else:
-            graph = parse_dot(dot_source)
+        graph, _source_cleanup = await load_remote_or_local_graph(dot_source)
 
         try:
             # 3. Create pipeline context with goal from the prompt

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/__init__.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/__init__.py
@@ -17,6 +17,7 @@ import logging
 import os
 import re
 import tempfile
+from collections.abc import Callable
 from typing import Any
 
 from .context import PipelineContext
@@ -486,149 +487,166 @@ class PipelineOrchestrator:
         # 1. Get DOT source
         dot_source = self._resolve_dot_source()
 
-        # 2. Parse the DOT graph
-        graph = parse_dot(dot_source)
+        # 2. Parse the DOT graph — materialize first if it's a remote entry.
+        def _noop_cleanup() -> None:
+            return None
 
-        # 3. Create pipeline context with goal from the prompt
-        pipeline_context = PipelineContext()
-        if prompt:
-            pipeline_context.set("graph.goal", prompt)
+        _source_cleanup: Callable[[], None] = _noop_cleanup
+        if isinstance(dot_source, str) and dot_source.startswith("git+https://"):
+            from .remote_dot import materialize_remote_dot  # lazy: keeps import net-free
 
-        # Set params for $param expansion in transforms
-        params = self.config.get("params")
-        if params:
-            pipeline_context.set("graph.params_values", params)
+            entry_path, _source_cleanup = await materialize_remote_dot(dot_source)
+            graph = parse_dot(entry_path.read_text(encoding="utf-8"))
+        else:
+            graph = parse_dot(dot_source)
 
-        # 4. Apply transforms (variable expansion, stylesheet) before validation
-        apply_transforms(graph, pipeline_context)
+        try:
+            # 3. Create pipeline context with goal from the prompt
+            pipeline_context = PipelineContext()
+            if prompt:
+                pipeline_context.set("graph.goal", prompt)
 
-        # 5. Validate the (transformed) graph
-        validate_or_raise(graph)
+            # Set params for $param expansion in transforms
+            params = self.config.get("params")
+            if params:
+                pipeline_context.set("graph.params_values", params)
 
-        # 6. Set up logs directory
-        logs_root = self.config.get(
-            "logs_root", os.path.join(tempfile.gettempdir(), "attractor-pipeline")
-        )
-        os.makedirs(logs_root, exist_ok=True)
+            # 4. Apply transforms (variable expansion, stylesheet) before validation
+            apply_transforms(graph, pipeline_context)
 
-        # 6b. Write the DOT source for dashboard visualization
-        dot_path = os.path.join(logs_root, "graph.dot")
-        with open(dot_path, "w") as f:
-            f.write(dot_source)
+            # 5. Validate the (transformed) graph
+            validate_or_raise(graph)
 
-        # 7. Resolve backend: explicit kwarg \u2192 auto-construct from providers
-        coordinator = kwargs.get("coordinator")
-        backend = kwargs.get("backend")
-        if backend is None:
-            backend = _build_backend(providers, tools, hooks, coordinator, self.config)
+            # 6. Set up logs directory
+            logs_root = self.config.get(
+                "logs_root", os.path.join(tempfile.gettempdir(), "attractor-pipeline")
+            )
+            os.makedirs(logs_root, exist_ok=True)
 
-        # 7b. Environment setup (if configured)
-        env_config: dict[str, Any] | None = self.config.get("execution_environment")
-        container_id = None
-        env_instance_name = "pipeline-workspace"  # default for teardown
-        if env_config:
-            env_instance_name = env_config.get("name", "pipeline-workspace")
-            if "env_create" in tools:
-                env_create_args = dict(env_config)  # copy to avoid mutating config
-                env_create_args.setdefault("type", "docker")
-                env_create_args.setdefault("name", "pipeline-workspace")
-                result = await tools["env_create"].execute(env_create_args)
-                try:
-                    parsed = json.loads(result.output)
-                except (json.JSONDecodeError, TypeError):
-                    logger.warning(
-                        "env_create returned unparseable output: %s", result.output
-                    )
-                    parsed = {}
-                container_id = parsed.get("container_id")
-                if container_id:
-                    pipeline_context.set("internal.env_container_id", container_id)
-                    pipeline_context.set(
-                        "internal.env_type", env_config.get("type", "docker")
-                    )
-                    logger.info(
-                        "Execution environment created: %s (container_id=%s)",
-                        env_instance_name,
-                        container_id,
-                    )
-                else:
-                    logger.warning(
-                        "env_create succeeded but returned no container_id "
-                        "— falling back to local execution"
-                    )
-            else:
-                logger.warning(
-                    "execution_environment configured but env_create tool not "
-                    "available (env-all bundle not composed?) — falling back "
-                    "to local execution"
+            # 6b. Write the DOT source for dashboard visualization
+            dot_path = os.path.join(logs_root, "graph.dot")
+            with open(dot_path, "w") as f:
+                f.write(
+                    dot_source
+                    if not dot_source.startswith("git+https://")
+                    else f"// materialized from {dot_source}\n"
                 )
 
-        # 8. Create registry (no closures, no rewire — engine passes self at call time)
-        registry = HandlerRegistry(
-            HandlerContext(
-                backend=backend,
+            # 7. Resolve backend: explicit kwarg \u2192 auto-construct from providers
+            coordinator = kwargs.get("coordinator")
+            backend = kwargs.get("backend")
+            if backend is None:
+                backend = _build_backend(providers, tools, hooks, coordinator, self.config)
+
+            # 7b. Environment setup (if configured)
+            env_config: dict[str, Any] | None = self.config.get("execution_environment")
+            container_id = None
+            env_instance_name = "pipeline-workspace"  # default for teardown
+            if env_config:
+                env_instance_name = env_config.get("name", "pipeline-workspace")
+                if "env_create" in tools:
+                    env_create_args = dict(env_config)  # copy to avoid mutating config
+                    env_create_args.setdefault("type", "docker")
+                    env_create_args.setdefault("name", "pipeline-workspace")
+                    result = await tools["env_create"].execute(env_create_args)
+                    try:
+                        parsed = json.loads(result.output)
+                    except (json.JSONDecodeError, TypeError):
+                        logger.warning(
+                            "env_create returned unparseable output: %s", result.output
+                        )
+                        parsed = {}
+                    container_id = parsed.get("container_id")
+                    if container_id:
+                        pipeline_context.set("internal.env_container_id", container_id)
+                        pipeline_context.set(
+                            "internal.env_type", env_config.get("type", "docker")
+                        )
+                        logger.info(
+                            "Execution environment created: %s (container_id=%s)",
+                            env_instance_name,
+                            container_id,
+                        )
+                    else:
+                        logger.warning(
+                            "env_create succeeded but returned no container_id "
+                            "— falling back to local execution"
+                        )
+                else:
+                    logger.warning(
+                        "execution_environment configured but env_create tool not "
+                        "available (env-all bundle not composed?) — falling back "
+                        "to local execution"
+                    )
+
+            # 8. Create registry (no closures, no rewire — engine passes self at call time)
+            registry = HandlerRegistry(
+                HandlerContext(
+                    backend=backend,
+                    hooks=hooks,
+                )
+            )
+
+            # 9. Create engine (carries itself to handlers via execute(engine=...))
+            engine = PipelineEngine(
+                graph=graph,
+                context=pipeline_context,
+                handler_registry=registry,
+                logs_root=logs_root,
                 hooks=hooks,
             )
-        )
 
-        # 9. Create engine (carries itself to handlers via execute(engine=...))
-        engine = PipelineEngine(
-            graph=graph,
-            context=pipeline_context,
-            handler_registry=registry,
-            logs_root=logs_root,
-            hooks=hooks,
-        )
+            # 10. Run the engine (with environment teardown in finally)
+            try:
+                outcome = await engine.run(goal=prompt or None)
+            finally:
+                # Backend teardown: release any cached LLM client (e.g. the
+                # AsyncAnthropic/httpx client the fallback path lazily creates)
+                # WITHIN this event loop. Skipping it lets GC run aclose() on a
+                # closed loop later, raising "RuntimeError: Event loop is closed"
+                # (spec finalize contract: attractor-spec.md Section 3.1 step 6).
+                backend_close = getattr(backend, "close", None)
+                if backend_close is not None:
+                    try:
+                        await backend_close()
+                    except Exception:
+                        logger.exception(
+                            "Failed to close backend during finalize - LLM client may leak"
+                        )
 
-        # 10. Run the engine (with environment teardown in finally)
-        try:
-            outcome = await engine.run(goal=prompt or None)
+                # Environment teardown
+                if container_id and "env_destroy" in tools:
+                    try:
+                        await tools["env_destroy"].execute({"instance": env_instance_name})
+                        logger.info(
+                            "Execution environment destroyed: %s",
+                            env_instance_name,
+                        )
+                    except Exception:
+                        logger.exception(
+                            "Failed to destroy execution environment %s "
+                            "— container may need manual cleanup",
+                            env_instance_name,
+                        )
+
+            # 12. Build a meaningful summary from all completed nodes
+            summary = self._build_pipeline_summary(engine, outcome)
+
+            # 13. Return the final outcome as JSON
+            result = {
+                "status": outcome.status.value,
+                "notes": summary,
+                "failure_reason": outcome.failure_reason,
+                "nodes_completed": len(engine.completed_nodes),
+                "node_statuses": {
+                    nid: engine.node_outcomes[nid].status.value
+                    for nid in engine.completed_nodes
+                    if nid in engine.node_outcomes
+                },
+            }
+            return json.dumps(result)
         finally:
-            # Backend teardown: release any cached LLM client (e.g. the
-            # AsyncAnthropic/httpx client the fallback path lazily creates)
-            # WITHIN this event loop. Skipping it lets GC run aclose() on a
-            # closed loop later, raising "RuntimeError: Event loop is closed"
-            # (spec finalize contract: attractor-spec.md Section 3.1 step 6).
-            backend_close = getattr(backend, "close", None)
-            if backend_close is not None:
-                try:
-                    await backend_close()
-                except Exception:
-                    logger.exception(
-                        "Failed to close backend during finalize - LLM client may leak"
-                    )
-
-            # Environment teardown
-            if container_id and "env_destroy" in tools:
-                try:
-                    await tools["env_destroy"].execute({"instance": env_instance_name})
-                    logger.info(
-                        "Execution environment destroyed: %s",
-                        env_instance_name,
-                    )
-                except Exception:
-                    logger.exception(
-                        "Failed to destroy execution environment %s "
-                        "— container may need manual cleanup",
-                        env_instance_name,
-                    )
-
-        # 12. Build a meaningful summary from all completed nodes
-        summary = self._build_pipeline_summary(engine, outcome)
-
-        # 13. Return the final outcome as JSON
-        result = {
-            "status": outcome.status.value,
-            "notes": summary,
-            "failure_reason": outcome.failure_reason,
-            "nodes_completed": len(engine.completed_nodes),
-            "node_statuses": {
-                nid: engine.node_outcomes[nid].status.value
-                for nid in engine.completed_nodes
-                if nid in engine.node_outcomes
-            },
-        }
-        return json.dumps(result)
+            _source_cleanup()
 
     def _build_pipeline_summary(self, engine: PipelineEngine, outcome: Outcome) -> str:
         """Build a human-readable pipeline summary.

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/__init__.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/__init__.py
@@ -496,7 +496,11 @@ class PipelineOrchestrator:
             from .remote_dot import materialize_remote_dot  # lazy: keeps import net-free
 
             entry_path, _source_cleanup = await materialize_remote_dot(dot_source)
-            graph = parse_dot(entry_path.read_text(encoding="utf-8"))
+            try:
+                graph = parse_dot(entry_path.read_text(encoding="utf-8"))
+            except BaseException:
+                _source_cleanup()
+                raise
         else:
             graph = parse_dot(dot_source)
 

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/remote_dot.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/remote_dot.py
@@ -22,6 +22,12 @@ import tempfile
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+from .dot_parser import parse_dot
+
+if TYPE_CHECKING:
+    from .graph import Graph
 
 logger = logging.getLogger(__name__)
 
@@ -46,8 +52,6 @@ def _cross_origin_local_relpath(referrer, child) -> str:
 
 def extract_dot_file_refs(text: str, *, origin) -> list[str]:
     """Return all raw dot_file= values, using the engine's own parser (no regex)."""
-    from .dot_parser import parse_dot  # local package, no network
-
     from amplifier_module_remote_source import RemoteFetchParseError  # lazy
 
     try:
@@ -210,3 +214,47 @@ async def materialize_remote_dot(
     except BaseException:
         shutil.rmtree(view_dir, ignore_errors=True)
         raise
+
+
+async def load_remote_or_local_graph(
+    source: "Graph | str",
+) -> tuple["Graph", Callable[[], None]]:
+    """Return ``(graph, cleanup)`` for a DOT source that may be local or remote.
+
+    This is the single materialize -> parse -> set-``source_dir`` -> cleanup
+    -on-exception sequence shared by both engine entry points --
+    ``pipeline_runner.runner._load_graph`` (the direct-engine path) and the
+    mounted ``PipelineOrchestrator.execute()`` in this package. Both used to
+    maintain their own hand-synced copy of this sequence; keeping it in one
+    place makes the two hooks structurally unable to diverge again (see
+    AGENTS.md's partial-coverage-symmetry note -- this exact divergence risk
+    already cost a regression test once).
+
+    If ``source`` is a ``git+https://`` URL: materializes the remote tree
+    (async, before parse) via ``materialize_remote_dot``, parses the local
+    entry, and sets ``graph.source_dir`` to the materialized entry's parent
+    directory so subgraph ``dot_file=`` refs resolve against the fetched tree
+    rather than cwd. If parsing the materialized entry fails, ``cleanup()`` is
+    called before the exception propagates so the per-run view never leaks.
+
+    Otherwise: ``source`` is treated as local. A ``str`` is parsed as raw DOT
+    text; anything else (an already-parsed ``Graph``) is passed through
+    unchanged. ``cleanup()`` is a no-op in this path.
+
+    Returns:
+        ``(graph, cleanup)``. The caller is responsible for calling
+        ``cleanup()`` (typically in a ``finally:``) once the graph is no
+        longer needed, regardless of which path was taken.
+    """
+    if isinstance(source, str) and source.startswith(_GIT_HTTPS_PREFIX):
+        entry_path, cleanup = await materialize_remote_dot(source)
+        try:
+            graph = parse_dot(entry_path.read_text(encoding="utf-8"))
+            graph.source_dir = str(entry_path.parent)
+            return graph, cleanup
+        except BaseException:
+            cleanup()
+            raise
+
+    graph = parse_dot(source) if isinstance(source, str) else source
+    return graph, (lambda: None)

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/remote_dot.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/remote_dot.py
@@ -132,7 +132,7 @@ async def materialize_remote_dot(
     async def _guarded(origin) -> bytes:
         async with sem:
             content, _sha = await cache.get(
-                origin, token=token, base_url=base_url
+                origin, token=token, base_url=base_url, limits=limits
             )
             return content
 
@@ -146,6 +146,11 @@ async def materialize_remote_dot(
                 raise RemoteFetchLimitError(
                     f"max_depth={limits.max_depth} exceeded at {frontier[0].path!r}"
                 )
+            # `frontier` is already deduped (via the `deduped`/`queued` pass at
+            # the end of the previous iteration, and the initial `[entry]`
+            # list has no duplicates to begin with), so this `not in seen`
+            # filter is a defensive no-op in the current control flow -- kept
+            # as belt-and-suspenders in case that invariant ever changes.
             batch = [o for o in frontier if o.key() not in seen]
             results = await asyncio.gather(*(_guarded(o) for o in batch))
 

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/remote_dot.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/remote_dot.py
@@ -1,0 +1,207 @@
+"""Layer B: DOT-aware recursive materialization of a remote git+https:// pipeline.
+
+Fetches the entry .dot plus every recursively-referenced subgraph (cross-repo
+included) through the Layer A cache, writes a per-run local view with cross-origin
+dot_file= refs rewritten to local paths, and returns (entry_path, cleanup).
+
+The engine then parse_dot()s the local entry and runs the local tree unchanged.
+
+Layer A (amplifier_module_remote_source) is imported LAZILY so importing
+loop-pipeline never pulls in httpx.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import posixpath
+import re
+import shutil
+import tempfile
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_GIT_HTTPS_PREFIX = "git+https://"
+
+
+@dataclass
+class _Ref:
+    origin: object            # Origin (Layer A) — typed loosely to avoid a top-level import
+    local_relpath: str
+    cross_origin: bool
+
+
+def _repo_root_relpath(origin) -> str:
+    return posixpath.join(origin.owner, origin.repo, origin.ref, origin.path)
+
+
+def _cross_origin_local_relpath(referrer, child) -> str:
+    referrer_dir = posixpath.dirname(_repo_root_relpath(referrer))
+    return posixpath.relpath(_repo_root_relpath(child), referrer_dir)
+
+
+def extract_dot_file_refs(text: str, *, origin) -> list[str]:
+    """Return all raw dot_file= values, using the engine's own parser (no regex)."""
+    from .dot_parser import parse_dot  # local package, no network
+
+    from amplifier_module_remote_source import RemoteFetchParseError  # lazy
+
+    try:
+        graph = parse_dot(text)
+    except Exception as exc:  # noqa: BLE001
+        raise RemoteFetchParseError(
+            f"Failed to parse DOT from {origin.owner}/{origin.repo}"
+            f"@{origin.ref}#{origin.path}: {exc}"
+        ) from exc
+    return [n.attrs["dot_file"] for n in graph.nodes.values() if n.attrs.get("dot_file")]
+
+
+def _resolve_ref(raw_ref: str, referrer) -> _Ref | None:
+    """Resolve one raw dot_file= value against its referrer origin. Returns None
+    for an unexpanded $variable (skipped). Raises on absolute / ..-escape."""
+    from amplifier_module_remote_source import (  # lazy
+        Origin,
+        RemoteFetchPathError,
+        parse_uri,
+    )
+
+    if "$" in raw_ref:
+        logger.warning(
+            "Skipping dot_file ref with unexpanded variable (runtime-resolved): %r",
+            raw_ref,
+        )
+        return None
+
+    if raw_ref.startswith(_GIT_HTTPS_PREFIX):
+        child = parse_uri(raw_ref)
+        return _Ref(child, _cross_origin_local_relpath(referrer, child), True)
+
+    if raw_ref.startswith("/"):
+        raise RemoteFetchPathError(
+            f"Absolute dot_file= is not allowed in remote graphs: {raw_ref!r}"
+        )
+
+    joined = posixpath.normpath(posixpath.join(referrer.dir, raw_ref))
+    if joined.startswith("../") or joined == ".." or joined.startswith("/"):
+        raise RemoteFetchPathError(
+            f"Relative dot_file= escapes repo root "
+            f"{referrer.owner}/{referrer.repo}@{referrer.ref}: {raw_ref!r}"
+        )
+    child = Origin(referrer.host, referrer.owner, referrer.repo, referrer.ref, joined)
+    return _Ref(child, raw_ref, False)
+
+
+async def materialize_remote_dot(
+    entry_uri: str,
+    *,
+    limits=None,
+    token: str | None = None,
+    cache=None,
+    base_url: str | None = None,
+) -> tuple[Path, Callable[[], None]]:
+    """Materialize a remote pipeline tree into a per-run local view.
+
+    Returns (entry_local_path, cleanup). Blobs persist in the shared cache;
+    ``cleanup()`` removes only the per-run view dir. On failure the partial view
+    is removed here (nothing has executed yet) and the error propagates.
+    """
+    from amplifier_module_remote_source import (  # lazy — keeps import network-free
+        BlobCache,
+        FetchLimits,
+        parse_uri,
+        resolve_token,
+    )
+
+    limits = limits or FetchLimits()
+    cache = cache or BlobCache()
+    token = token if token is not None else resolve_token()
+
+    entry = parse_uri(entry_uri)
+    view_dir = tempfile.mkdtemp(prefix="attractor-remote-")
+    entry_local_path = Path(view_dir) / _repo_root_relpath(entry)
+
+    seen: dict[tuple, str] = {}
+    total_bytes = 0
+    file_count = 0
+    sem = asyncio.Semaphore(limits.max_concurrency)
+
+    async def _guarded(origin) -> bytes:
+        async with sem:
+            content, _sha = await cache.get(
+                origin, token=token, base_url=base_url
+            )
+            return content
+
+    try:
+        frontier = [entry]
+        depth = 0
+        while frontier:
+            if depth >= limits.max_depth:
+                from amplifier_module_remote_source import RemoteFetchLimitError
+
+                raise RemoteFetchLimitError(
+                    f"max_depth={limits.max_depth} exceeded at {frontier[0].path!r}"
+                )
+            batch = [o for o in frontier if o.key() not in seen]
+            results = await asyncio.gather(*(_guarded(o) for o in batch))
+
+            next_frontier = []
+            for origin, raw in zip(batch, results):
+                file_count += 1
+                total_bytes += len(raw)
+                from amplifier_module_remote_source import RemoteFetchLimitError
+
+                if file_count > limits.max_files:
+                    raise RemoteFetchLimitError(
+                        f"max_files={limits.max_files} exceeded at {origin.path!r}"
+                    )
+                if total_bytes > limits.max_total_bytes:
+                    raise RemoteFetchLimitError(
+                        f"max_total_bytes={limits.max_total_bytes} exceeded "
+                        f"at {origin.path!r}"
+                    )
+
+                text = raw.decode("utf-8")
+                local_path = os.path.join(view_dir, _repo_root_relpath(origin))
+                rewrites = []
+                for raw_ref in extract_dot_file_refs(text, origin=origin):
+                    ref = _resolve_ref(raw_ref, origin)
+                    if ref is None:
+                        continue
+                    if ref.cross_origin:
+                        rewrites.append((raw_ref, ref.local_relpath))
+                    if ref.origin.key() not in seen:
+                        next_frontier.append(ref.origin)
+
+                for old, new in rewrites:
+                    text = re.sub(
+                        r'(dot_file\s*=\s*)"' + re.escape(old) + r'"',
+                        lambda m, _new=new: f'{m.group(1)}"{_new}"',
+                        text,
+                    )
+
+                os.makedirs(os.path.dirname(local_path), exist_ok=True)
+                with open(local_path, "w", encoding="utf-8") as fh:
+                    fh.write(text)
+                seen[origin.key()] = local_path
+
+            deduped, queued = [], set()
+            for o in next_frontier:
+                if o.key() in seen or o.key() in queued:
+                    continue
+                queued.add(o.key())
+                deduped.append(o)
+            frontier = deduped
+            depth += 1
+
+        def _cleanup() -> None:
+            shutil.rmtree(view_dir, ignore_errors=True)
+
+        return entry_local_path, _cleanup
+    except BaseException:
+        shutil.rmtree(view_dir, ignore_errors=True)
+        raise

--- a/modules/loop-pipeline/pyproject.toml
+++ b/modules/loop-pipeline/pyproject.toml
@@ -19,6 +19,14 @@ dependencies = [
     "amplifier-unified-llm-client @ git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/unified-llm-client",
 ]
 
+[project.optional-dependencies]
+# Layer A fetcher — pulled in only when remote git+https:// sources are used.
+# Direct git ref survives `--no-sources`; the [tool.uv.sources] path below is
+# for local editable dev (mirrors the amplifier-unified-llm-client pattern).
+remote = [
+    "amplifier-module-remote-source @ git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/remote-source",
+]
+
 [project.entry-points."amplifier.modules"]
 loop-pipeline = "amplifier_module_loop_pipeline:mount"
 
@@ -33,6 +41,7 @@ package = true
 
 [tool.uv.sources]
 amplifier-unified-llm-client = { path = "../unified-llm-client" }
+amplifier-module-remote-source = { path = "../remote-source" }
 
 [tool.hatch.build.targets.wheel]
 packages = [
@@ -46,6 +55,7 @@ allow-direct-references = true
 dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=1.0.0",
+    "respx>=0.22",
 ]
 
 [tool.pytest.ini_options]

--- a/modules/loop-pipeline/tests/test_no_network_dep.py
+++ b/modules/loop-pipeline/tests/test_no_network_dep.py
@@ -1,0 +1,36 @@
+"""Guard: the engine core stays network-free at import time.
+
+Importing amplifier_module_loop_pipeline must not import httpx. The network logic
+lives only in Layer A (amplifier_module_remote_source), reached lazily.
+"""
+
+import subprocess
+import sys
+
+
+def test_importing_loop_pipeline_does_not_import_httpx():
+    code = (
+        "import sys; import amplifier_module_loop_pipeline; "
+        "assert 'httpx' not in sys.modules, "
+        "'engine core must not import httpx at import time'; "
+        "print('network-free')"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "network-free" in result.stdout
+
+
+def test_httpx_not_a_core_dependency():
+    """httpx must not be a *core* dependency of loop-pipeline (only the optional
+    'remote' extra pulls Layer A, which owns httpx)."""
+    import tomllib
+    from pathlib import Path
+
+    pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    data = tomllib.loads(pyproject.read_text())
+    core_deps = " ".join(data["project"]["dependencies"])
+    assert "httpx" not in core_deps

--- a/modules/loop-pipeline/tests/test_orchestrator_remote_cleanup.py
+++ b/modules/loop-pipeline/tests/test_orchestrator_remote_cleanup.py
@@ -9,15 +9,17 @@ exception propagated from outside the try/finally and cleanup never ran,
 leaking the per-run materialized view directory on disk.
 
 The fix wraps just the materialize->parse window in its own try/except that
-calls cleanup and re-raises, mirroring the sibling hook in
-``amplifier_module_pipeline_runner.runner._load_graph``.
+calls cleanup and re-raises. That sequence now lives in the single shared
+``remote_dot.load_remote_or_local_graph`` helper used by both this mounted
+hook and the sibling direct-engine hook in
+``amplifier_module_pipeline_runner.runner._load_graph`` -- see that
+function's docstring for why the two were unified.
 """
 
 import shutil
 
 import pytest
 
-import amplifier_module_loop_pipeline as lp_pkg
 import amplifier_module_loop_pipeline.remote_dot as remote_dot_mod
 from amplifier_module_loop_pipeline import PipelineOrchestrator
 
@@ -47,14 +49,12 @@ async def test_cleanup_called_when_parse_fails_after_materialize(tmp_path, monke
     def _raising_parse_dot(_source: str):
         raise ValueError("boom: simulated parse failure after materialize")
 
-    # materialize_remote_dot is imported lazily inside execute() via
-    # `from .remote_dot import materialize_remote_dot`, so patching the
-    # attribute on the remote_dot module is what the lazy import will see.
+    # materialize_remote_dot and parse_dot are both referenced as module-level
+    # globals inside remote_dot.load_remote_or_local_graph (which execute()
+    # now delegates to), so patching them on the remote_dot module is what
+    # that shared helper's calls will see.
     monkeypatch.setattr(remote_dot_mod, "materialize_remote_dot", _fake_materialize)
-
-    # parse_dot is imported at module top-level in amplifier_module_loop_pipeline
-    # and referenced directly (as a global) inside execute().
-    monkeypatch.setattr(lp_pkg, "parse_dot", _raising_parse_dot)
+    monkeypatch.setattr(remote_dot_mod, "parse_dot", _raising_parse_dot)
 
     orchestrator = PipelineOrchestrator(
         config={"dot_source": "git+https://github.com/acme/samples@main#pipelines/main.dot"}

--- a/modules/loop-pipeline/tests/test_orchestrator_remote_cleanup.py
+++ b/modules/loop-pipeline/tests/test_orchestrator_remote_cleanup.py
@@ -1,0 +1,79 @@
+"""Regression test for a leak-window bug in the mounted PipelineOrchestrator.
+
+Covers a bug found during Task 12 verification: in the ``git+https://`` branch
+of ``PipelineOrchestrator.execute()``, the materialize call and the parse of
+the materialized entry happened *outside* the outer try/finally that runs
+``_source_cleanup()``. If ``materialize_remote_dot`` succeeded (real cleanup
+callback assigned) but the subsequent ``parse_dot(...)`` call raised, the
+exception propagated from outside the try/finally and cleanup never ran,
+leaking the per-run materialized view directory on disk.
+
+The fix wraps just the materialize->parse window in its own try/except that
+calls cleanup and re-raises, mirroring the sibling hook in
+``amplifier_module_pipeline_runner.runner._load_graph``.
+"""
+
+import shutil
+
+import pytest
+
+import amplifier_module_loop_pipeline as lp_pkg
+import amplifier_module_loop_pipeline.remote_dot as remote_dot_mod
+from amplifier_module_loop_pipeline import PipelineOrchestrator
+
+
+@pytest.mark.asyncio
+async def test_cleanup_called_when_parse_fails_after_materialize(tmp_path, monkeypatch):
+    """If parse_dot raises after a successful materialize, cleanup must still run."""
+    view_dir = tmp_path / "materialized-view"
+    view_dir.mkdir()
+    entry_path = view_dir / "main.dot"
+    entry_path.write_text(
+        "digraph { s [shape=Mdiamond]; d [shape=Msquare]; s -> d }",
+        encoding="utf-8",
+    )
+
+    cleanup_calls: list[bool] = []
+
+    def _cleanup() -> None:
+        cleanup_calls.append(True)
+        # Simulate the real materialize_remote_dot cleanup: remove the
+        # per-run materialized view directory from disk.
+        shutil.rmtree(view_dir, ignore_errors=True)
+
+    async def _fake_materialize(dot_source: str):
+        return entry_path, _cleanup
+
+    def _raising_parse_dot(_source: str):
+        raise ValueError("boom: simulated parse failure after materialize")
+
+    # materialize_remote_dot is imported lazily inside execute() via
+    # `from .remote_dot import materialize_remote_dot`, so patching the
+    # attribute on the remote_dot module is what the lazy import will see.
+    monkeypatch.setattr(remote_dot_mod, "materialize_remote_dot", _fake_materialize)
+
+    # parse_dot is imported at module top-level in amplifier_module_loop_pipeline
+    # and referenced directly (as a global) inside execute().
+    monkeypatch.setattr(lp_pkg, "parse_dot", _raising_parse_dot)
+
+    orchestrator = PipelineOrchestrator(
+        config={"dot_source": "git+https://github.com/acme/samples@main#pipelines/main.dot"}
+    )
+
+    with pytest.raises(ValueError, match="boom"):
+        await orchestrator.execute(
+            prompt="test goal",
+            context=None,
+            providers={},
+            tools={},
+            hooks=None,
+        )
+
+    assert cleanup_calls == [True], (
+        "cleanup must be called exactly once when parse fails after a "
+        "successful materialize"
+    )
+    assert not view_dir.exists(), (
+        "materialized view directory must not leak on disk after the "
+        "parse failure propagates"
+    )

--- a/modules/loop-pipeline/tests/test_remote_dot.py
+++ b/modules/loop-pipeline/tests/test_remote_dot.py
@@ -1,12 +1,19 @@
 import base64
 import os
+import posixpath
+import re
 
 import httpx
 import pytest
 import respx
 
 from amplifier_module_loop_pipeline.remote_dot import materialize_remote_dot
-from amplifier_module_remote_source import BlobCache, FetchLimits, RemoteFetchPathError
+from amplifier_module_remote_source import (
+    BlobCache,
+    FetchLimits,
+    RemoteFetchPathError,
+    parse_uri,
+)
 
 API = "https://api.github.com/repos"
 
@@ -76,10 +83,37 @@ async def test_cross_repo_rewrite(tmp_path):
     entry_path, cleanup = await materialize_remote_dot(ENTRY, cache=BlobCache(tmp_path))
     try:
         text = entry_path.read_text()
-        assert other not in text                 # the URL was rewritten...
-        assert 'dot_file="' in text and ".dot" in text  # ...to a local relpath
+        assert other not in text  # the URL was rewritten...
+
+        match = re.search(r'dot_file\s*=\s*"([^"]+)"', text)
+        assert match, f"expected a rewritten dot_file= attribute, got: {text!r}"
+        rewritten_ref = match.group(1)
+        assert not rewritten_ref.startswith("git+https://")  # ...to a local relpath
+
+        # Resolve the rewritten ref exactly as the engine will: relative to the
+        # entry file's own directory.
+        rewritten_path = (entry_path.parent / rewritten_ref).resolve()
+        assert rewritten_path.exists()
+
+        # Derive the per-run view root from the entry's own repo-root-relative
+        # path (owner/repo/ref/path) instead of a hardcoded parents[N] index, so
+        # this stays correct regardless of how deep the entry's `path` is.
+        entry_origin = parse_uri(ENTRY)
+        entry_relpath = posixpath.join(
+            entry_origin.owner, entry_origin.repo, entry_origin.ref, entry_origin.path
+        )
+        view_dir = entry_path.parents[len(entry_relpath.split("/")) - 1]
+
         # the cross-repo file exists under the mirrored layout
-        assert (entry_path.parents[3] / "acme" / "lib" / "main" / "shared" / "util.dot").exists()
+        expected_cross_repo_path = (
+            view_dir / "acme" / "lib" / "main" / "shared" / "util.dot"
+        )
+        assert expected_cross_repo_path.exists()
+
+        # The rewritten ref must point at exactly that file, not just *some* file,
+        # so this genuinely proves the cross-repo rewrite rather than merely that
+        # a file happens to exist somewhere.
+        assert rewritten_path == expected_cross_repo_path.resolve()
     finally:
         cleanup()
 

--- a/modules/loop-pipeline/tests/test_remote_dot.py
+++ b/modules/loop-pipeline/tests/test_remote_dot.py
@@ -1,0 +1,138 @@
+import base64
+import os
+
+import httpx
+import pytest
+import respx
+
+from amplifier_module_loop_pipeline.remote_dot import materialize_remote_dot
+from amplifier_module_remote_source import BlobCache, FetchLimits, RemoteFetchPathError
+
+API = "https://api.github.com/repos"
+
+
+def _contents(owner, repo, path, body: str):
+    url = f"{API}/{owner}/{repo}/contents/{path}"
+    return respx.get(url__regex=re_escape(url)).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "content": base64.b64encode(body.encode()).decode(),
+                "encoding": "base64",
+                "sha": _blob_sha(body.encode()),
+            },
+        )
+    )
+
+
+def re_escape(s: str) -> str:
+    import re
+
+    return re.escape(s)
+
+
+def _blob_sha(data: bytes) -> str:
+    from amplifier_module_remote_source import git_blob_sha
+
+    return git_blob_sha(data)
+
+
+ENTRY = "git+https://github.com/acme/samples#subdirectory=pipelines/main.dot"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_recursive_walk_in_origin(tmp_path):
+    # main.dot -> child.dot (same repo, relative), child -> leaf.dot
+    _contents("acme", "samples", "pipelines/main.dot",
+              'digraph G { a [dot_file="child.dot"]; }')
+    _contents("acme", "samples", "pipelines/child.dot",
+              'digraph G { b [dot_file="leaf.dot"]; }')
+    _contents("acme", "samples", "pipelines/leaf.dot", "digraph G { c; }")
+
+    entry_path, cleanup = await materialize_remote_dot(
+        ENTRY, cache=BlobCache(tmp_path)
+    )
+    try:
+        assert entry_path.exists()
+        text = entry_path.read_text()
+        assert 'dot_file="child.dot"' in text  # in-origin ref left as-is
+        # sibling file materialized next to the entry
+        assert (entry_path.parent / "child.dot").exists()
+        assert (entry_path.parent / "leaf.dot").exists()
+    finally:
+        cleanup()
+    assert not entry_path.exists()  # cleanup removed the per-run view
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_cross_repo_rewrite(tmp_path):
+    other = "git+https://github.com/acme/lib#subdirectory=shared/util.dot"
+    _contents("acme", "samples", "pipelines/main.dot",
+              f'digraph G {{ a [dot_file="{other}"]; }}')
+    _contents("acme", "lib", "shared/util.dot", "digraph G { u; }")
+
+    entry_path, cleanup = await materialize_remote_dot(ENTRY, cache=BlobCache(tmp_path))
+    try:
+        text = entry_path.read_text()
+        assert other not in text                 # the URL was rewritten...
+        assert 'dot_file="' in text and ".dot" in text  # ...to a local relpath
+        # the cross-repo file exists under the mirrored layout
+        assert (entry_path.parents[3] / "acme" / "lib" / "main" / "shared" / "util.dot").exists()
+    finally:
+        cleanup()
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_variable_ref_skipped(tmp_path):
+    _contents("acme", "samples", "pipelines/main.dot",
+              'digraph G { a [dot_file="$dynamic.dot"]; }')
+    entry_path, cleanup = await materialize_remote_dot(ENTRY, cache=BlobCache(tmp_path))
+    try:
+        assert 'dot_file="$dynamic.dot"' in entry_path.read_text()  # left untouched
+    finally:
+        cleanup()
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_escape_rejected(tmp_path):
+    _contents("acme", "samples", "pipelines/main.dot",
+              'digraph G { a [dot_file="../../etc/passwd"]; }')
+    with pytest.raises(RemoteFetchPathError):
+        await materialize_remote_dot(ENTRY, cache=BlobCache(tmp_path))
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_depth_limit_fail_fast(tmp_path):
+    _contents("acme", "samples", "pipelines/main.dot",
+              'digraph G { a [dot_file="child.dot"]; }')
+    _contents("acme", "samples", "pipelines/child.dot", "digraph G { c; }")
+    from amplifier_module_remote_source import RemoteFetchLimitError
+
+    with pytest.raises(RemoteFetchLimitError):
+        await materialize_remote_dot(
+            ENTRY, cache=BlobCache(tmp_path), limits=FetchLimits(max_depth=1)
+        )
+
+
+# --- ONE REAL recursive fetch against a PINNED public fixture -----------------
+# Fill ATTRACTOR_TEST_REMOTE_ENTRY with a real, immutable (SHA-pinned) entry URI
+# whose tree fetches cleanly. Skipped when unset.
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    not os.environ.get("ATTRACTOR_TEST_REMOTE_ENTRY"),
+    reason="set ATTRACTOR_TEST_REMOTE_ENTRY for the live recursive fetch",
+)
+async def test_real_recursive_fetch(tmp_path):
+    entry_path, cleanup = await materialize_remote_dot(
+        os.environ["ATTRACTOR_TEST_REMOTE_ENTRY"], cache=BlobCache(tmp_path)
+    )
+    try:
+        assert entry_path.exists()
+        assert entry_path.read_text().strip()
+    finally:
+        cleanup()

--- a/modules/loop-pipeline/tests/test_remote_dot.py
+++ b/modules/loop-pipeline/tests/test_remote_dot.py
@@ -153,6 +153,54 @@ async def test_depth_limit_fail_fast(tmp_path):
         )
 
 
+@pytest.mark.asyncio
+@respx.mock
+async def test_diamond_dependency_fetched_once(tmp_path):
+    """main.dot -> {a.dot, b.dot}; both a.dot and b.dot -> shared.dot (same
+    origin+path). shared.dot must be fetched exactly once, and both
+    rewritten dot_file= refs must resolve to the identical materialized path.
+    """
+    main_route = _contents(
+        "acme", "samples", "pipelines/main.dot",
+        'digraph G { a [dot_file="a.dot"]; b [dot_file="b.dot"]; }',
+    )
+    a_route = _contents(
+        "acme", "samples", "pipelines/a.dot",
+        'digraph G { s [dot_file="shared.dot"]; }',
+    )
+    b_route = _contents(
+        "acme", "samples", "pipelines/b.dot",
+        'digraph G { s [dot_file="shared.dot"]; }',
+    )
+    shared_route = _contents(
+        "acme", "samples", "pipelines/shared.dot", "digraph G { leaf; }"
+    )
+
+    entry_path, cleanup = await materialize_remote_dot(ENTRY, cache=BlobCache(tmp_path))
+    try:
+        # shared.dot must be fetched exactly once despite two referrers.
+        assert shared_route.call_count == 1
+        assert main_route.call_count == 1
+        assert a_route.call_count == 1
+        assert b_route.call_count == 1
+
+        a_text = (entry_path.parent / "a.dot").read_text()
+        b_text = (entry_path.parent / "b.dot").read_text()
+
+        match_a = re.search(r'dot_file\s*=\s*"([^"]+)"', a_text)
+        match_b = re.search(r'dot_file\s*=\s*"([^"]+)"', b_text)
+        assert match_a and match_b
+
+        # Both refs are same-origin (in-repo relative refs), left as-is;
+        # both must resolve (relative to their own file) to the same file.
+        resolved_from_a = (entry_path.parent / match_a.group(1)).resolve()
+        resolved_from_b = (entry_path.parent / match_b.group(1)).resolve()
+        assert resolved_from_a == resolved_from_b
+        assert resolved_from_a.exists()
+    finally:
+        cleanup()
+
+
 # --- ONE REAL recursive fetch against a PINNED public fixture -----------------
 # Fill ATTRACTOR_TEST_REMOTE_ENTRY with a real, immutable (SHA-pinned) entry URI
 # whose tree fetches cleanly. Skipped when unset.

--- a/modules/loop-pipeline/tests/test_remote_dot.py
+++ b/modules/loop-pipeline/tests/test_remote_dot.py
@@ -7,7 +7,10 @@ import httpx
 import pytest
 import respx
 
-from amplifier_module_loop_pipeline.remote_dot import materialize_remote_dot
+from amplifier_module_loop_pipeline.remote_dot import (
+    load_remote_or_local_graph,
+    materialize_remote_dot,
+)
 from amplifier_module_remote_source import (
     BlobCache,
     FetchLimits,
@@ -218,3 +221,85 @@ async def test_real_recursive_fetch(tmp_path):
         assert entry_path.read_text().strip()
     finally:
         cleanup()
+
+
+# --- load_remote_or_local_graph: the shared materialize/parse/cleanup hook ---
+# used by both `pipeline_runner.runner._load_graph` and the mounted
+# `PipelineOrchestrator.execute()` -- see that function's docstring for why
+# the two hand-synced copies were unified into this one.
+
+
+@pytest.mark.asyncio
+async def test_load_local_string_parses_and_noop_cleanup():
+    graph, cleanup = await load_remote_or_local_graph(
+        "digraph G { s [shape=Mdiamond]; d [shape=Msquare]; s -> d }"
+    )
+    assert "s" in graph.nodes
+    assert "d" in graph.nodes
+    cleanup()  # must not raise -- no-op for the local path
+
+
+@pytest.mark.asyncio
+async def test_load_local_graph_object_passthrough():
+    from amplifier_module_loop_pipeline.dot_parser import parse_dot
+
+    original = parse_dot("digraph G { s [shape=Mdiamond]; d [shape=Msquare]; s -> d }")
+    graph, cleanup = await load_remote_or_local_graph(original)
+    assert graph is original
+    cleanup()
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_load_remote_sets_source_dir(tmp_path, monkeypatch):
+    # load_remote_or_local_graph -> materialize_remote_dot doesn't take an
+    # explicit cache override (matching both production call sites), so
+    # point the default cache root at tmp_path to keep this hermetic.
+    monkeypatch.setenv("ATTRACTOR_CACHE_DIR", str(tmp_path / "cache"))
+    _contents("acme", "samples", "pipelines/main.dot",
+              "digraph G { s [shape=Mdiamond]; d [shape=Msquare]; s -> d }")
+    graph, cleanup = await load_remote_or_local_graph(ENTRY)
+    try:
+        assert graph.source_dir is not None
+        assert os.path.isdir(graph.source_dir)
+    finally:
+        cleanup()
+
+
+@pytest.mark.asyncio
+async def test_load_remote_cleanup_called_when_parse_fails(tmp_path, monkeypatch):
+    """If parse_dot raises after a successful materialize, cleanup must still
+    run and the per-run view must not leak -- this is the exact regression
+    both call sites (runner.drive_engine and the mounted orchestrator) guard
+    against, now exercised once against the shared implementation."""
+    import amplifier_module_loop_pipeline.remote_dot as remote_dot_mod
+
+    view_dir = tmp_path / "materialized-view"
+    view_dir.mkdir()
+    entry_path = view_dir / "main.dot"
+    entry_path.write_text("not valid dot", encoding="utf-8")
+
+    cleanup_calls: list[bool] = []
+
+    def _cleanup() -> None:
+        cleanup_calls.append(True)
+        import shutil
+
+        shutil.rmtree(view_dir, ignore_errors=True)
+
+    async def _fake_materialize(_source: str):
+        return entry_path, _cleanup
+
+    def _raising_parse_dot(_text: str):
+        raise ValueError("boom: simulated parse failure after materialize")
+
+    monkeypatch.setattr(remote_dot_mod, "materialize_remote_dot", _fake_materialize)
+    monkeypatch.setattr(remote_dot_mod, "parse_dot", _raising_parse_dot)
+
+    with pytest.raises(ValueError, match="boom"):
+        await load_remote_or_local_graph(
+            "git+https://github.com/acme/samples@main#subdirectory=pipelines/main.dot"
+        )
+
+    assert cleanup_calls == [True]
+    assert not view_dir.exists()

--- a/modules/pipeline-runner/amplifier_module_pipeline_runner/runner.py
+++ b/modules/pipeline-runner/amplifier_module_pipeline_runner/runner.py
@@ -136,6 +136,26 @@ def seed_context(
     context.set("context.target_dir", str(cwd))
 
 
+async def _load_graph(graph_or_dot: "Graph | str"):
+    """Return (graph, cleanup). If graph_or_dot is a git+https:// URL, materialize
+    the remote tree (async, before parse) and parse the local entry; otherwise
+    behave exactly as before. cleanup() removes any per-run materialized view."""
+    from amplifier_module_loop_pipeline.dot_parser import parse_dot
+
+    if isinstance(graph_or_dot, str) and graph_or_dot.startswith("git+https://"):
+        from amplifier_module_loop_pipeline.remote_dot import materialize_remote_dot
+
+        entry_path, cleanup = await materialize_remote_dot(graph_or_dot)
+        try:
+            return parse_dot(entry_path.read_text(encoding="utf-8")), cleanup
+        except BaseException:
+            cleanup()
+            raise
+
+    graph = parse_dot(graph_or_dot) if isinstance(graph_or_dot, str) else graph_or_dot
+    return graph, (lambda: None)
+
+
 async def drive_engine(
     graph_or_dot: "Graph | str",
     coordinator: Any,
@@ -203,7 +223,7 @@ async def drive_engine(
     from amplifier_module_loop_pipeline.transforms import apply_transforms
     from amplifier_module_loop_pipeline.validation import validate_or_raise
 
-    graph = parse_dot(graph_or_dot) if isinstance(graph_or_dot, str) else graph_or_dot
+    graph, _source_cleanup = await _load_graph(graph_or_dot)
 
     resolved_cwd = Path(cwd) if cwd is not None else Path.cwd()
 
@@ -247,7 +267,10 @@ async def drive_engine(
         hooks=effective_hooks,
     )
 
-    return await engine.run()
+    try:
+        return await engine.run()
+    finally:
+        _source_cleanup()
 
 
 async def _resolve_agent_bundle(agent_name: str, config: dict[str, Any]) -> Any:
@@ -590,7 +613,10 @@ async def run_pipeline(
     cwd_path = Path(cwd).expanduser().resolve() if cwd is not None else Path.cwd()
     cwd_path.mkdir(parents=True, exist_ok=True)
 
-    (logs_dir / "pipeline.dot").write_text(dot_source, encoding="utf-8")
+    # A git+https:// entry is a URL, not DOT -- don't write it as pipeline.dot.
+    # (drive_engine materializes it; the resolved graph is logged by the engine.)
+    if not dot_source.startswith("git+https://"):
+        (logs_dir / "pipeline.dot").write_text(dot_source, encoding="utf-8")
 
     resolved_profiles = dict(profiles) if profiles else dict(DEFAULT_PROFILES)
 

--- a/modules/pipeline-runner/amplifier_module_pipeline_runner/runner.py
+++ b/modules/pipeline-runner/amplifier_module_pipeline_runner/runner.py
@@ -147,7 +147,9 @@ async def _load_graph(graph_or_dot: "Graph | str"):
 
         entry_path, cleanup = await materialize_remote_dot(graph_or_dot)
         try:
-            return parse_dot(entry_path.read_text(encoding="utf-8")), cleanup
+            graph = parse_dot(entry_path.read_text(encoding="utf-8"))
+            graph.source_dir = str(entry_path.parent)
+            return graph, cleanup
         except BaseException:
             cleanup()
             raise

--- a/modules/pipeline-runner/amplifier_module_pipeline_runner/runner.py
+++ b/modules/pipeline-runner/amplifier_module_pipeline_runner/runner.py
@@ -139,23 +139,18 @@ def seed_context(
 async def _load_graph(graph_or_dot: "Graph | str"):
     """Return (graph, cleanup). If graph_or_dot is a git+https:// URL, materialize
     the remote tree (async, before parse) and parse the local entry; otherwise
-    behave exactly as before. cleanup() removes any per-run materialized view."""
-    from amplifier_module_loop_pipeline.dot_parser import parse_dot
+    behave exactly as before. cleanup() removes any per-run materialized view.
 
-    if isinstance(graph_or_dot, str) and graph_or_dot.startswith("git+https://"):
-        from amplifier_module_loop_pipeline.remote_dot import materialize_remote_dot
+    Thin wrapper around ``amplifier_module_loop_pipeline.remote_dot.
+    load_remote_or_local_graph`` -- the single materialize/parse/cleanup
+    sequence shared with the mounted ``PipelineOrchestrator.execute()`` hook,
+    so the two engine entry points can't diverge. Kept as a module-level
+    function (rather than inlined into ``drive_engine``) so it stays
+    independently monkeypatchable in tests.
+    """
+    from amplifier_module_loop_pipeline.remote_dot import load_remote_or_local_graph
 
-        entry_path, cleanup = await materialize_remote_dot(graph_or_dot)
-        try:
-            graph = parse_dot(entry_path.read_text(encoding="utf-8"))
-            graph.source_dir = str(entry_path.parent)
-            return graph, cleanup
-        except BaseException:
-            cleanup()
-            raise
-
-    graph = parse_dot(graph_or_dot) if isinstance(graph_or_dot, str) else graph_or_dot
-    return graph, (lambda: None)
+    return await load_remote_or_local_graph(graph_or_dot)
 
 
 async def drive_engine(

--- a/modules/pipeline-runner/amplifier_module_pipeline_runner/runner.py
+++ b/modules/pipeline-runner/amplifier_module_pipeline_runner/runner.py
@@ -217,7 +217,6 @@ async def drive_engine(
     """
     from amplifier_module_loop_pipeline.backend import AmplifierBackend
     from amplifier_module_loop_pipeline.context import PipelineContext
-    from amplifier_module_loop_pipeline.dot_parser import parse_dot
     from amplifier_module_loop_pipeline.engine import PipelineEngine
     from amplifier_module_loop_pipeline.handlers import HandlerContext, HandlerRegistry
     from amplifier_module_loop_pipeline.transforms import apply_transforms

--- a/modules/pipeline-runner/amplifier_module_pipeline_runner/runner.py
+++ b/modules/pipeline-runner/amplifier_module_pipeline_runner/runner.py
@@ -226,49 +226,49 @@ async def drive_engine(
 
     graph, _source_cleanup = await _load_graph(graph_or_dot)
 
-    resolved_cwd = Path(cwd) if cwd is not None else Path.cwd()
-
-    context = PipelineContext()
-    seed_context(context, params, resolved_cwd)
-
-    if transform:
-        graph = apply_transforms(graph, context)
-
-    if validate:
-        # Fail loud on graph-shape problems before spending an LLM call.
-        validate_or_raise(graph)
-
-    # Default engine/handler observability to the coordinator's own hook stack
-    # when the caller didn't supply hooks. A mounted observability hook (e.g.
-    # a session-level logging/telemetry hook composed onto the bundle) lives on
-    # ``coordinator.hooks``; the mounted-orchestrator path reaches it because
-    # the session hands the orchestrator ``coordinator.hooks`` and it forwards
-    # that same object into ``PipelineEngine(hooks=...)``. Driving the engine
-    # directly, we must do the same, or the engine's ``pipeline:*`` events (and
-    # handler-emitted ``provider:*``/``tool:*`` events) are emitted into nothing
-    # and never reach the session's observers. ``getattr(..., None)`` keeps
-    # bare test-stub coordinators (which may lack ``.hooks``) safe, and the
-    # ``hooks is not None`` guard preserves an explicit caller override.
-    effective_hooks = hooks if hooks is not None else getattr(coordinator, "hooks", None)
-
-    backend = AmplifierBackend(
-        coordinator=coordinator,
-        profiles=dict(profiles or DEFAULT_PROFILES),
-    )
-    registry = HandlerRegistry(
-        HandlerContext(
-            backend=backend, hooks=effective_hooks, interviewer=interviewer
-        )
-    )
-    engine = PipelineEngine(
-        graph=graph,
-        context=context,
-        handler_registry=registry,
-        logs_root=str(logs_root),
-        hooks=effective_hooks,
-    )
-
     try:
+        resolved_cwd = Path(cwd) if cwd is not None else Path.cwd()
+
+        context = PipelineContext()
+        seed_context(context, params, resolved_cwd)
+
+        if transform:
+            graph = apply_transforms(graph, context)
+
+        if validate:
+            # Fail loud on graph-shape problems before spending an LLM call.
+            validate_or_raise(graph)
+
+        # Default engine/handler observability to the coordinator's own hook stack
+        # when the caller didn't supply hooks. A mounted observability hook (e.g.
+        # a session-level logging/telemetry hook composed onto the bundle) lives on
+        # ``coordinator.hooks``; the mounted-orchestrator path reaches it because
+        # the session hands the orchestrator ``coordinator.hooks`` and it forwards
+        # that same object into ``PipelineEngine(hooks=...)``. Driving the engine
+        # directly, we must do the same, or the engine's ``pipeline:*`` events (and
+        # handler-emitted ``provider:*``/``tool:*`` events) are emitted into nothing
+        # and never reach the session's observers. ``getattr(..., None)`` keeps
+        # bare test-stub coordinators (which may lack ``.hooks``) safe, and the
+        # ``hooks is not None`` guard preserves an explicit caller override.
+        effective_hooks = hooks if hooks is not None else getattr(coordinator, "hooks", None)
+
+        backend = AmplifierBackend(
+            coordinator=coordinator,
+            profiles=dict(profiles or DEFAULT_PROFILES),
+        )
+        registry = HandlerRegistry(
+            HandlerContext(
+                backend=backend, hooks=effective_hooks, interviewer=interviewer
+            )
+        )
+        engine = PipelineEngine(
+            graph=graph,
+            context=context,
+            handler_registry=registry,
+            logs_root=str(logs_root),
+            hooks=effective_hooks,
+        )
+
         return await engine.run()
     finally:
         _source_cleanup()

--- a/modules/pipeline-runner/pyproject.toml
+++ b/modules/pipeline-runner/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 dependencies = [
     "amplifier-core>=0.1.0",
     "amplifier-foundation @ git+https://github.com/microsoft/amplifier-foundation@main",
-    "amplifier-module-loop-pipeline @ git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-pipeline",
+    "amplifier-module-loop-pipeline[remote] @ git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-pipeline",
 ]
 
 [project.scripts]
@@ -27,6 +27,7 @@ package = true
 
 [tool.uv.sources]
 amplifier-module-loop-pipeline = { path = "../loop-pipeline" }
+amplifier-module-remote-source = { path = "../remote-source" }
 
 [tool.hatch.build.targets.wheel]
 packages = [

--- a/modules/pipeline-runner/tests/test_drive_engine_remote_cleanup.py
+++ b/modules/pipeline-runner/tests/test_drive_engine_remote_cleanup.py
@@ -1,0 +1,70 @@
+"""Regression test for a leak-window bug in ``drive_engine``.
+
+Before the fix, only ``engine.run()`` was wrapped in the outer try/finally
+that calls ``_source_cleanup()``. Everything between ``_load_graph`` returning
+and ``engine.run()`` being reached -- context seeding, ``apply_transforms``,
+``validate_or_raise``, and the backend/registry/engine construction -- ran
+OUTSIDE that try/finally. If ``validate_or_raise`` (or any of that setup)
+raised after a successful remote materialize, the exception propagated
+without ``_source_cleanup()`` ever running, leaking the per-run materialized
+view directory on disk.
+
+The fix moves the ``try:`` up to immediately after ``_load_graph`` returns,
+wrapping everything through ``return await engine.run()``.
+"""
+
+import shutil
+
+import pytest
+
+import amplifier_module_pipeline_runner.runner as runner_mod
+
+
+@pytest.mark.asyncio
+async def test_drive_engine_cleanup_called_when_validate_fails_after_materialize(
+    tmp_path, monkeypatch
+):
+    """If validate_or_raise raises after a successful materialize, cleanup must still run."""
+    view_dir = tmp_path / "materialized-view"
+    view_dir.mkdir()
+
+    cleanup_calls: list[bool] = []
+
+    def _cleanup() -> None:
+        cleanup_calls.append(True)
+        # Simulate the real materialize_remote_dot cleanup: remove the
+        # per-run materialized view directory from disk.
+        shutil.rmtree(view_dir, ignore_errors=True)
+
+    class _FakeGraph:
+        source_dir = str(view_dir)
+
+    async def _fake_load_graph(_graph_or_dot):
+        return _FakeGraph(), _cleanup
+
+    def _raising_validate_or_raise(_graph):
+        raise ValueError("boom: simulated validate failure after materialize")
+
+    monkeypatch.setattr(runner_mod, "_load_graph", _fake_load_graph)
+    monkeypatch.setattr(
+        "amplifier_module_loop_pipeline.validation.validate_or_raise",
+        _raising_validate_or_raise,
+    )
+
+    with pytest.raises(ValueError, match="boom"):
+        await runner_mod.drive_engine(
+            "git+https://github.com/acme/samples@main#pipelines/main.dot",
+            coordinator=object(),
+            logs_root=tmp_path / "logs",
+            transform=False,
+            validate=True,
+        )
+
+    assert cleanup_calls == [True], (
+        "cleanup must be called exactly once when validate_or_raise fails "
+        "after a successful materialize"
+    )
+    assert not view_dir.exists(), (
+        "materialized view directory must not leak on disk after the "
+        "validate failure propagates"
+    )

--- a/modules/pipeline-runner/tests/test_remote_ci_smoke.py
+++ b/modules/pipeline-runner/tests/test_remote_ci_smoke.py
@@ -1,0 +1,100 @@
+"""Unconditional CI proof of the materialize -> parse -> engine-run boundary.
+
+The review that shipped alongside this test (PR #96,
+https://github.com/microsoft/amplifier-bundle-attractor/pull/96#issuecomment-5096226946)
+flagged that nothing in CI actually proves the materializer hands off to the
+engine correctly: the only test that drives a remote ``git+https://`` entry
+through to real completion
+(``test_remote_end_to_end.py::test_remote_pipeline_runs_standalone``) is
+gated behind ``ATTRACTOR_TEST_REMOTE_ENTRY`` and skips by default, so CI never
+touches that seam. Everything else is a respx-mocked unit test of the
+materializer in isolation -- and this exact class of bug (mocked tests all
+green, real graph fails) already bit this PR once: ``d220243`` fixed a
+missing ``graph.source_dir`` assignment that every mocked test missed because
+none of them exercised a *real* fetch through to a *real* engine run.
+
+This test closes that gap without needing an external fixture repo or any
+credentials: this repository is itself public on GitHub, so it can fetch one
+of its own files via ``git+https://`` -- a genuinely real, unmocked HTTP round
+trip through the Contents API -- and run it through the engine to real
+completion, unconditionally, on every CI run.
+
+Drives ``drive_engine`` directly (with a bare dummy coordinator) rather than
+the higher-level ``run_pipeline``. ``run_pipeline`` resolves the mounted
+``loop-pipeline`` orchestrator module via the ``attractor-pipeline`` bundle's
+own module manifest (``bundles/attractor-pipeline.yaml``), whose ``source:``
+is hardcoded to ``git+https://...@main`` -- a real, pre-existing, and already
+documented gap (see runner.py's ``# TODO(slice-1/§8.6)`` note) where that
+resolution doesn't yet fall back to the local checkout, so it always
+activates whatever is on ``main`` regardless of which branch is under test.
+That's an orthogonal bundle-activation concern, not something this test is
+about. ``drive_engine`` needs no bundle/session machinery at all for a
+pipeline with no LLM/``box`` nodes (no ``session.spawn`` capability is ever
+invoked), so it runs entirely against the already-imported, already-correct
+in-process ``amplifier_module_loop_pipeline`` -- which is exactly the code
+path (``_load_graph`` -> ``remote_dot.load_remote_or_local_graph`` ->
+materialize -> parse -> engine run) this test needs to prove out.
+
+Fixture choice: ``fixture_tool_reads_param.dot`` (this module's own runner
+proof fixture) is a single deterministic ``tool_command`` node with no
+LLM/box node, so this test needs no API keys, no coordinator capabilities,
+and can't flake on model non-determinism -- it only proves the remote-source
+plumbing.
+
+Pinned to an immutable 40-hex commit SHA already merged to ``main`` (not this
+feature branch) so the reference can never become unreachable/GC'd once this
+branch is deleted post-merge, and so the fetched content can never drift out
+from under this test (``is_immutable()`` in
+``amplifier_module_remote_source.cache`` treats a 40-hex ref as
+zero-network-after-first-fetch, but the *first* fetch in a clean CI cache is
+still a real, unmocked network call).
+"""
+
+from pathlib import Path
+
+import pytest
+
+from amplifier_module_pipeline_runner.runner import drive_engine
+
+# Pinned to a commit already on `main` (not this feature branch) -- see the
+# module docstring for why. `fixture_tool_reads_param.dot` has been
+# unchanged at this path since it landed in #87.
+_PINNED_SHA = "a7369965615629ece6e5eb1724dd15095de8043e"
+_ENTRY = (
+    "git+https://github.com/microsoft/amplifier-bundle-attractor"
+    f"@{_PINNED_SHA}"
+    "#subdirectory=modules/pipeline-runner/tests/fixtures/fixture_tool_reads_param.dot"
+)
+
+
+@pytest.mark.asyncio
+async def test_remote_ci_smoke_real_public_repo_fetch(tmp_path: Path, monkeypatch):
+    """Real (non-mocked) git+https:// fetch -> parse -> engine completion.
+
+    Points ``$ATTRACTOR_CACHE_DIR`` at a fresh directory under ``tmp_path``
+    so this test always exercises a real first-fetch (never silently
+    short-circuited by a warm cache from a previous run/test on the same
+    machine) and never pollutes -- or is polluted by -- the ambient cache.
+
+    ``coordinator=object()``: a bare object is sufficient because
+    ``fixture_tool_reads_param.dot`` has only a deterministic ``tool_command``
+    node (``ToolHandler`` never touches ``coordinator``) -- no LLM/``box``
+    node means ``AmplifierBackend``'s ``session.spawn`` capability lookup is
+    never exercised (mirrors ``test_drive_engine_remote_cleanup.py``'s use of
+    the same bare-coordinator pattern).
+    """
+    monkeypatch.setenv("ATTRACTOR_CACHE_DIR", str(tmp_path / "remote-cache"))
+
+    outcome = await drive_engine(
+        _ENTRY,
+        coordinator=object(),
+        params={"outfile": "proof.txt", "content": "remote-ci-smoke-ok"},
+        cwd=tmp_path,
+        logs_root=tmp_path / "logs",
+        transform=False,
+    )
+
+    assert outcome.status.value == "success", outcome
+    proof = tmp_path / "proof.txt"
+    assert proof.exists()
+    assert proof.read_text().strip() == "remote-ci-smoke-ok"

--- a/modules/pipeline-runner/tests/test_remote_end_to_end.py
+++ b/modules/pipeline-runner/tests/test_remote_end_to_end.py
@@ -1,5 +1,6 @@
-"""Cross-consumer proof: a remote git+https:// pipeline runs through the engine
-with NO resolve platform. Real execution — env-gated + offline-skippable."""
+"""Standalone proof: a remote git+https:// pipeline runs through the engine with
+only the loop-pipeline module loaded — no external resolver or orchestrator.
+Real execution — env-gated + offline-skippable."""
 
 import os
 from pathlib import Path

--- a/modules/pipeline-runner/tests/test_remote_end_to_end.py
+++ b/modules/pipeline-runner/tests/test_remote_end_to_end.py
@@ -1,0 +1,26 @@
+"""Cross-consumer proof: a remote git+https:// pipeline runs through the engine
+with NO resolve platform. Real execution — env-gated + offline-skippable."""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from amplifier_module_pipeline_runner.runner import run_pipeline
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    not os.environ.get("ATTRACTOR_TEST_REMOTE_ENTRY"),
+    reason="set ATTRACTOR_TEST_REMOTE_ENTRY to a pinned public no-LLM pipeline URI",
+)
+async def test_remote_pipeline_runs_standalone(tmp_path: Path):
+    result = await run_pipeline(
+        os.environ["ATTRACTOR_TEST_REMOTE_ENTRY"],
+        cwd=tmp_path,
+        logs_root=tmp_path / "logs",
+        transform=False,
+    )
+    assert result.status in {"success", "partial_success"}, result
+    assert not (tmp_path / "logs" / "pipeline.dot").exists() or \
+        "git+https://" not in (tmp_path / "logs" / "pipeline.dot").read_text()

--- a/modules/pipeline-runner/tests/test_remote_end_to_end.py
+++ b/modules/pipeline-runner/tests/test_remote_end_to_end.py
@@ -21,6 +21,6 @@ async def test_remote_pipeline_runs_standalone(tmp_path: Path):
         logs_root=tmp_path / "logs",
         transform=False,
     )
-    assert result.status in {"success", "partial_success"}, result
-    assert not (tmp_path / "logs" / "pipeline.dot").exists() or \
-        "git+https://" not in (tmp_path / "logs" / "pipeline.dot").read_text()
+    assert result.status == "success", result
+    if (tmp_path / "logs" / "pipeline.dot").exists():
+        assert "git+https://" not in (tmp_path / "logs" / "pipeline.dot").read_text()

--- a/modules/remote-source/amplifier_module_remote_source/__init__.py
+++ b/modules/remote-source/amplifier_module_remote_source/__init__.py
@@ -1,0 +1,3 @@
+"""Layer A: resource-agnostic content-addressed caching git+https:// fetcher."""
+
+from __future__ import annotations

--- a/modules/remote-source/amplifier_module_remote_source/__init__.py
+++ b/modules/remote-source/amplifier_module_remote_source/__init__.py
@@ -1,3 +1,40 @@
-"""Layer A: resource-agnostic content-addressed caching git+https:// fetcher."""
+"""Layer A: resource-agnostic content-addressed caching git+https:// fetcher.
+
+Public surface. No DOT knowledge lives here (that is Layer B, inside
+loop-pipeline). httpx is the only runtime dependency.
+"""
 
 from __future__ import annotations
+
+from .cache import BlobCache, default_cache_root, is_immutable
+from .errors import (
+    RemoteFetchAuthError,
+    RemoteFetchError,
+    RemoteFetchLimitError,
+    RemoteFetchNotFound,
+    RemoteFetchParseError,
+    RemoteFetchPathError,
+)
+from .fetch import FetchResult, fetch_blob, git_blob_sha, resolve_token
+from .limits import FetchLimits
+from .uri import GIT_HTTPS_PREFIX, Origin, parse_uri
+
+__all__ = [
+    "BlobCache",
+    "FetchLimits",
+    "FetchResult",
+    "GIT_HTTPS_PREFIX",
+    "Origin",
+    "RemoteFetchAuthError",
+    "RemoteFetchError",
+    "RemoteFetchLimitError",
+    "RemoteFetchNotFound",
+    "RemoteFetchParseError",
+    "RemoteFetchPathError",
+    "default_cache_root",
+    "fetch_blob",
+    "git_blob_sha",
+    "is_immutable",
+    "parse_uri",
+    "resolve_token",
+]

--- a/modules/remote-source/amplifier_module_remote_source/cache.py
+++ b/modules/remote-source/amplifier_module_remote_source/cache.py
@@ -107,10 +107,25 @@ class BlobCache:
         construction. Each writer writes to its own unique temp path, then
         atomically ``os.replace``s it into place -- concurrent writers race
         harmlessly and the last rename simply wins with identical bytes.
+
+        The "already exists, skip" fast path is only trustworthy if the
+        existing file's bytes still match ``content`` -- an on-disk blob can
+        become corrupted (bitrot, external tampering) independent of any
+        writer here. Without this check, ``get()``'s 304-path self-heal
+        (which re-verifies via ``git_blob_sha`` and re-fetches on mismatch)
+        would fetch correct bytes but then silently fail to persist them,
+        since this method would see the (corrupted) path already exists and
+        return without ever overwriting it -- leaving the cache permanently
+        corrupted for that blob and forcing a repeat self-heal fetch on every
+        subsequent call.
         """
         p = self._blob_path(blob_sha)
         if p.exists():
-            return  # content-addressed: identical bytes stored once
+            try:
+                if p.read_bytes() == content:
+                    return  # content-addressed: identical bytes stored once
+            except OSError:
+                pass  # unreadable existing file -- fall through and rewrite
         p.parent.mkdir(parents=True, exist_ok=True)
         tmp = p.with_name(f"{p.name}.{os.getpid()}.{secrets.token_hex(4)}.tmp")
         try:
@@ -162,14 +177,19 @@ class BlobCache:
 
         if result.not_modified and entry:
             blob = self._read_blob(entry["blob_sha"])
-            if blob is not None:
+            # Re-verify on every 304, not just on fresh 200s: a blob's path
+            # *is* its sha, so re-hashing on read is cheap, and it's the only
+            # thing standing between an on-disk bitrot/corruption event and
+            # silently handing back wrong bytes forever (the 304 path never
+            # touches the network, so nothing else would ever catch it).
+            if blob is not None and git_blob_sha(blob) == entry["blob_sha"]:
                 return blob, entry["blob_sha"]
-            # Cached ref says "not modified" but the blob file is gone from
-            # disk (e.g. externally deleted). Self-heal with a single forced
-            # refetch that skips the etag, guaranteeing a full 200 with
-            # content instead of another 304. No loop: if this second fetch
-            # still yields no content, fall through to the empty-result
-            # error below.
+            # Either the blob file is gone from disk (e.g. externally
+            # deleted) or its content no longer hashes to its own filename
+            # (corrupted). Self-heal with a single forced refetch that skips
+            # the etag, guaranteeing a full 200 with content instead of
+            # another 304. No loop: if this second fetch still yields no
+            # content, fall through to the empty-result error below.
             result = await fetch_fn(
                 origin, token=token, base_url=base_url, etag=None, limits=limits
             )

--- a/modules/remote-source/amplifier_module_remote_source/cache.py
+++ b/modules/remote-source/amplifier_module_remote_source/cache.py
@@ -9,9 +9,13 @@ Freshness:
   * mutable ref (branch/tag name) -> revalidated via If-None-Match (304 = reuse)
   * $ATTRACTOR_RELOAD forces revalidation even for immutable entries
 Integrity: fetched bytes MUST hash to the server-declared sha, else rejected.
-Concurrency: per-blob lock file + atomic rename. Only the process that
-  successfully creates the lock file (the winner) ever deletes it; a losing
-  writer (lock already held) returns without touching the winner's lock/tmp.
+Concurrency: blobs are content-addressed (path == blob sha; bytes are
+  identical by construction), so no lock is needed for correctness -- every
+  writer writes to its own unique temp path, then ``os.replace``s it into
+  place atomically. Concurrent writers of identical content race harmlessly;
+  the last ``os.replace`` wins and produces byte-identical content. A ref is
+  only ever written after its blob is confirmed present on disk, so a
+  crash mid-write can never leave a dangling ref pointing at a missing blob.
 Containment: every filesystem path derived from an Origin (refs/*) or a
   blob-sha (blobs/*) is verified to stay under ``self.root`` before any
   read/write/mkdir — defense in depth against a crafted Origin escaping the
@@ -23,12 +27,14 @@ from __future__ import annotations
 import json
 import os
 import re
+import secrets
 import time
 from collections.abc import Awaitable, Callable
 from pathlib import Path
 
 from .errors import RemoteFetchError, RemoteFetchPathError
 from .fetch import FetchResult, fetch_blob, git_blob_sha
+from .limits import FetchLimits
 from .uri import Origin
 
 _IMMUTABLE_RE = re.compile(r"^[0-9a-f]{40}$")
@@ -94,29 +100,24 @@ class BlobCache:
         return p.read_bytes() if p.exists() else None
 
     def _write_blob(self, blob_sha: str, content: bytes) -> None:
+        """Write ``content`` to the content-addressed blob path.
+
+        No lock is needed: blobs are content-addressed, so any concurrent
+        writer of this ``blob_sha`` is writing byte-identical content by
+        construction. Each writer writes to its own unique temp path, then
+        atomically ``os.replace``s it into place -- concurrent writers race
+        harmlessly and the last rename simply wins with identical bytes.
+        """
         p = self._blob_path(blob_sha)
         if p.exists():
             return  # content-addressed: identical bytes stored once
         p.parent.mkdir(parents=True, exist_ok=True)
-        lock = p.with_suffix(".lock")
-        tmp = p.with_suffix(f".tmp.{os.getpid()}")
-        acquired = False
+        tmp = p.with_name(f"{p.name}.{os.getpid()}.{secrets.token_hex(4)}.tmp")
         try:
-            # per-blob lock: exclusive create; if held, another writer wins
-            # and will produce the blob (content is identical by hash).
-            try:
-                fd = os.open(lock, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
-                os.close(fd)
-                acquired = True
-            except FileExistsError:
-                return  # loser: do NOT touch the winner's lock or tmp file
             tmp.write_bytes(content)
-            os.replace(tmp, p)  # atomic rename
+            os.replace(tmp, p)  # atomic rename; idempotent across writers
         finally:
-            # Only the winner (lock acquired) cleans up its own lock/tmp.
-            if acquired:
-                tmp.unlink(missing_ok=True)
-                lock.unlink(missing_ok=True)
+            tmp.unlink(missing_ok=True)
 
     def _write_ref(self, origin: Origin, blob_sha: str, etag: str | None) -> None:
         p = self._ref_path(origin)
@@ -136,8 +137,14 @@ class BlobCache:
         base_url: str | None = None,
         fetch_fn: FetchFn | None = None,
         reload: bool | None = None,
+        limits: FetchLimits | None = None,
     ) -> tuple[bytes, str]:
-        """Return (content, blob_sha) for ``origin``, honoring the cache."""
+        """Return (content, blob_sha) for ``origin``, honoring the cache.
+
+        ``limits`` (e.g. ``per_request_timeout``) is forwarded to ``fetch_fn``
+        so a caller-configured safety envelope actually reaches the HTTP
+        request, not just the fetch-walk's own depth/file/byte bookkeeping.
+        """
         fetch_fn = fetch_fn or fetch_blob
         reload = reload if reload is not None else bool(os.environ.get("ATTRACTOR_RELOAD"))
         entry = self._read_ref(origin)
@@ -149,7 +156,9 @@ class BlobCache:
                 return blob, entry["blob_sha"]
 
         etag = entry["etag"] if entry else None
-        result = await fetch_fn(origin, token=token, base_url=base_url, etag=etag)
+        result = await fetch_fn(
+            origin, token=token, base_url=base_url, etag=etag, limits=limits
+        )
 
         if result.not_modified and entry:
             blob = self._read_blob(entry["blob_sha"])
@@ -170,5 +179,14 @@ class BlobCache:
             raise RemoteFetchError(f"blob-sha recompute mismatch for {origin.key()}")
 
         self._write_blob(result.blob_sha, result.content)
+        # Only write the ref once the blob is confirmed present on disk --
+        # never write a ref pointing at a blob that isn't there (a dangling
+        # ref would poison the cache permanently: is_immutable() fast-path
+        # reads would keep resolving to a blob_sha with no file).
+        if not self._blob_path(result.blob_sha).exists():
+            raise RemoteFetchError(
+                f"blob {result.blob_sha} missing on disk after write for "
+                f"{origin.key()}; refusing to write a dangling ref"
+            )
         self._write_ref(origin, result.blob_sha, result.etag)
         return result.content, result.blob_sha

--- a/modules/remote-source/amplifier_module_remote_source/cache.py
+++ b/modules/remote-source/amplifier_module_remote_source/cache.py
@@ -9,7 +9,13 @@ Freshness:
   * mutable ref (branch/tag name) -> revalidated via If-None-Match (304 = reuse)
   * $ATTRACTOR_RELOAD forces revalidation even for immutable entries
 Integrity: fetched bytes MUST hash to the server-declared sha, else rejected.
-Concurrency: per-blob lock file + atomic rename.
+Concurrency: per-blob lock file + atomic rename. Only the process that
+  successfully creates the lock file (the winner) ever deletes it; a losing
+  writer (lock already held) returns without touching the winner's lock/tmp.
+Containment: every filesystem path derived from an Origin (refs/*) or a
+  blob-sha (blobs/*) is verified to stay under ``self.root`` before any
+  read/write/mkdir — defense in depth against a crafted Origin escaping the
+  cache root (see uri.py's traversal rejection for the first line of defense).
 """
 
 from __future__ import annotations
@@ -21,7 +27,7 @@ import time
 from collections.abc import Awaitable, Callable
 from pathlib import Path
 
-from .errors import RemoteFetchError
+from .errors import RemoteFetchError, RemoteFetchPathError
 from .fetch import FetchResult, fetch_blob, git_blob_sha
 from .uri import Origin
 
@@ -47,14 +53,32 @@ class BlobCache:
     def __init__(self, root: Path | None = None) -> None:
         self.root = Path(root) if root is not None else default_cache_root()
 
+    def _ensure_within_root(self, path: Path) -> Path:
+        """Containment check: reject any path that resolves outside ``root``.
+
+        Belt-and-suspenders alongside uri.py's traversal rejection — this
+        catches any Origin/blob-sha that somehow still produces an escaping
+        path (e.g. a future caller that bypasses ``parse_uri``). ``resolve()``
+        normalizes '..' segments and symlinks without requiring the path to
+        exist; we compare against it but return the original (unresolved)
+        path so callers still mkdir/read/write at the intended location.
+        """
+        root_resolved = self.root.resolve()
+        resolved = path.resolve()
+        if resolved != root_resolved and not resolved.is_relative_to(root_resolved):
+            raise RemoteFetchPathError(f"Path escapes cache root: {path} (root={self.root})")
+        return path
+
     def _blob_path(self, blob_sha: str) -> Path:
-        return self.root / "blobs" / blob_sha
+        p = self.root / "blobs" / blob_sha
+        return self._ensure_within_root(p)
 
     def _ref_path(self, origin: Origin) -> Path:
-        return (
+        p = (
             self.root / "refs" / origin.host / origin.owner / origin.repo
             / origin.ref / (origin.path + ".json")
         )
+        return self._ensure_within_root(p)
 
     def _read_ref(self, origin: Origin) -> dict | None:
         p = self._ref_path(origin)
@@ -76,18 +100,23 @@ class BlobCache:
         p.parent.mkdir(parents=True, exist_ok=True)
         lock = p.with_suffix(".lock")
         tmp = p.with_suffix(f".tmp.{os.getpid()}")
+        acquired = False
         try:
-            # per-blob lock: exclusive create; if held, another writer wins.
+            # per-blob lock: exclusive create; if held, another writer wins
+            # and will produce the blob (content is identical by hash).
             try:
                 fd = os.open(lock, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
                 os.close(fd)
+                acquired = True
             except FileExistsError:
-                return
+                return  # loser: do NOT touch the winner's lock or tmp file
             tmp.write_bytes(content)
             os.replace(tmp, p)  # atomic rename
         finally:
-            tmp.unlink(missing_ok=True)
-            lock.unlink(missing_ok=True)
+            # Only the winner (lock acquired) cleans up its own lock/tmp.
+            if acquired:
+                tmp.unlink(missing_ok=True)
+                lock.unlink(missing_ok=True)
 
     def _write_ref(self, origin: Origin, blob_sha: str, etag: str | None) -> None:
         p = self._ref_path(origin)

--- a/modules/remote-source/amplifier_module_remote_source/cache.py
+++ b/modules/remote-source/amplifier_module_remote_source/cache.py
@@ -122,7 +122,7 @@ class BlobCache:
     def _write_ref(self, origin: Origin, blob_sha: str, etag: str | None) -> None:
         p = self._ref_path(origin)
         p.parent.mkdir(parents=True, exist_ok=True)
-        tmp = p.with_suffix(f".tmp.{os.getpid()}")
+        tmp = p.with_name(f"{p.name}.{os.getpid()}.{secrets.token_hex(4)}.tmp")
         tmp.write_text(
             json.dumps({"blob_sha": blob_sha, "etag": etag, "fetched_at": time.time()}),
             encoding="utf-8",
@@ -164,6 +164,15 @@ class BlobCache:
             blob = self._read_blob(entry["blob_sha"])
             if blob is not None:
                 return blob, entry["blob_sha"]
+            # Cached ref says "not modified" but the blob file is gone from
+            # disk (e.g. externally deleted). Self-heal with a single forced
+            # refetch that skips the etag, guaranteeing a full 200 with
+            # content instead of another 304. No loop: if this second fetch
+            # still yields no content, fall through to the empty-result
+            # error below.
+            result = await fetch_fn(
+                origin, token=token, base_url=base_url, etag=None, limits=limits
+            )
 
         if result.content is None or result.blob_sha is None:
             raise RemoteFetchError(f"empty fetch result for {origin.key()}")

--- a/modules/remote-source/amplifier_module_remote_source/cache.py
+++ b/modules/remote-source/amplifier_module_remote_source/cache.py
@@ -1,0 +1,145 @@
+"""Greenfield content-addressed blob cache (Layer A).
+
+Layout:
+  <root>/blobs/<blob-sha>                       -- content, dedup + integrity
+  <root>/refs/<host>/<owner>/<repo>/<ref>/<path>.json -> {blob_sha, etag, fetched_at}
+
+Freshness:
+  * immutable ref (40-hex sha) -> served from cache, zero network ever
+  * mutable ref (branch/tag name) -> revalidated via If-None-Match (304 = reuse)
+  * $ATTRACTOR_RELOAD forces revalidation even for immutable entries
+Integrity: fetched bytes MUST hash to the server-declared sha, else rejected.
+Concurrency: per-blob lock file + atomic rename.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import time
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+
+from .errors import RemoteFetchError
+from .fetch import FetchResult, fetch_blob, git_blob_sha
+from .uri import Origin
+
+_IMMUTABLE_RE = re.compile(r"^[0-9a-f]{40}$")
+
+FetchFn = Callable[..., Awaitable[FetchResult]]
+
+
+def default_cache_root() -> Path:
+    env = os.environ.get("ATTRACTOR_CACHE_DIR")
+    if env:
+        return Path(env).expanduser()
+    return Path.home() / ".cache" / "amplifier-attractor"
+
+
+def is_immutable(ref: str) -> bool:
+    """A 40-hex commit/blob SHA is immutable. Named refs (branches, tags) are
+    treated as mutable in v1 (tag-as-immutable optimization is deferred)."""
+    return bool(_IMMUTABLE_RE.match(ref))
+
+
+class BlobCache:
+    def __init__(self, root: Path | None = None) -> None:
+        self.root = Path(root) if root is not None else default_cache_root()
+
+    def _blob_path(self, blob_sha: str) -> Path:
+        return self.root / "blobs" / blob_sha
+
+    def _ref_path(self, origin: Origin) -> Path:
+        return (
+            self.root / "refs" / origin.host / origin.owner / origin.repo
+            / origin.ref / (origin.path + ".json")
+        )
+
+    def _read_ref(self, origin: Origin) -> dict | None:
+        p = self._ref_path(origin)
+        if not p.exists():
+            return None
+        try:
+            return json.loads(p.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            return None
+
+    def _read_blob(self, blob_sha: str) -> bytes | None:
+        p = self._blob_path(blob_sha)
+        return p.read_bytes() if p.exists() else None
+
+    def _write_blob(self, blob_sha: str, content: bytes) -> None:
+        p = self._blob_path(blob_sha)
+        if p.exists():
+            return  # content-addressed: identical bytes stored once
+        p.parent.mkdir(parents=True, exist_ok=True)
+        lock = p.with_suffix(".lock")
+        tmp = p.with_suffix(f".tmp.{os.getpid()}")
+        try:
+            # per-blob lock: exclusive create; if held, another writer wins.
+            try:
+                fd = os.open(lock, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+                os.close(fd)
+            except FileExistsError:
+                return
+            tmp.write_bytes(content)
+            os.replace(tmp, p)  # atomic rename
+        finally:
+            tmp.unlink(missing_ok=True)
+            lock.unlink(missing_ok=True)
+
+    def _write_ref(self, origin: Origin, blob_sha: str, etag: str | None) -> None:
+        p = self._ref_path(origin)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        tmp = p.with_suffix(f".tmp.{os.getpid()}")
+        tmp.write_text(
+            json.dumps({"blob_sha": blob_sha, "etag": etag, "fetched_at": time.time()}),
+            encoding="utf-8",
+        )
+        os.replace(tmp, p)
+
+    async def get(
+        self,
+        origin: Origin,
+        *,
+        token: str | None = None,
+        base_url: str | None = None,
+        fetch_fn: FetchFn | None = None,
+        reload: bool | None = None,
+    ) -> tuple[bytes, str]:
+        """Return (content, blob_sha) for ``origin``, honoring the cache."""
+        fetch_fn = fetch_fn or fetch_blob
+        reload = reload if reload is not None else bool(os.environ.get("ATTRACTOR_RELOAD"))
+        entry = self._read_ref(origin)
+
+        # Fast path: immutable ref already cached -> zero network.
+        if entry and not reload and is_immutable(origin.ref):
+            blob = self._read_blob(entry["blob_sha"])
+            if blob is not None:
+                return blob, entry["blob_sha"]
+
+        etag = entry["etag"] if entry else None
+        result = await fetch_fn(origin, token=token, base_url=base_url, etag=etag)
+
+        if result.not_modified and entry:
+            blob = self._read_blob(entry["blob_sha"])
+            if blob is not None:
+                return blob, entry["blob_sha"]
+
+        if result.content is None or result.blob_sha is None:
+            raise RemoteFetchError(f"empty fetch result for {origin.key()}")
+
+        # Integrity: local blob-sha must match the server-declared sha.
+        if result.server_sha and result.blob_sha != result.server_sha:
+            raise RemoteFetchError(
+                f"integrity check failed for {origin.owner}/{origin.repo}"
+                f"#{origin.path}: local {result.blob_sha} != server {result.server_sha}"
+            )
+        # Defense in depth: recompute from bytes.
+        if git_blob_sha(result.content) != result.blob_sha:
+            raise RemoteFetchError(f"blob-sha recompute mismatch for {origin.key()}")
+
+        self._write_blob(result.blob_sha, result.content)
+        self._write_ref(origin, result.blob_sha, result.etag)
+        return result.content, result.blob_sha

--- a/modules/remote-source/amplifier_module_remote_source/errors.py
+++ b/modules/remote-source/amplifier_module_remote_source/errors.py
@@ -1,0 +1,36 @@
+"""Resource-agnostic fetch error taxonomy (Layer A)."""
+
+from __future__ import annotations
+
+
+class RemoteFetchError(Exception):
+    """Base for all remote-fetch failures.
+
+    Also raised directly for transport/timeout errors, retry exhaustion, and
+    integrity (blob-SHA mismatch) failures.
+    """
+
+
+class RemoteFetchAuthError(RemoteFetchError):
+    """401/403 (non-rate-limit): names the repo and reminds about token scope."""
+
+
+class RemoteFetchNotFound(RemoteFetchError):
+    """404: names the exact owner/repo@ref#path (bad ref vs bad path)."""
+
+
+class RemoteFetchLimitError(RemoteFetchError):
+    """A FetchLimits budget breach (depth / files / bytes)."""
+
+
+class RemoteFetchParseError(RemoteFetchError):
+    """A fetched document failed to parse; names the origin.
+
+    Layer A never parses DOT itself — this is raised by Layer B consumers, but
+    the type lives here so the taxonomy is single-sourced.
+    """
+
+
+class RemoteFetchPathError(RemoteFetchError):
+    """Rejected reference: malformed URI, disallowed scheme, absolute path, or a
+    relative ref that escapes the origin root."""

--- a/modules/remote-source/amplifier_module_remote_source/fetch.py
+++ b/modules/remote-source/amplifier_module_remote_source/fetch.py
@@ -1,0 +1,173 @@
+"""httpx transport for one blob: fetch bytes, compute git blob SHA, ETag support.
+
+Resource-agnostic (Layer A). Uses the git-host "contents" JSON API so the
+server-declared blob sha is available for an integrity check.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import logging
+import os
+import subprocess
+from dataclasses import dataclass
+
+import httpx
+
+from .errors import (
+    RemoteFetchAuthError,
+    RemoteFetchError,
+    RemoteFetchNotFound,
+)
+from .limits import FetchLimits
+from .uri import Origin
+
+logger = logging.getLogger(__name__)
+
+_GITHUB_API_DEFAULT = "https://api.github.com"
+_RETRYABLE_STATUS = frozenset({500, 502, 503, 504})
+_MAX_ATTEMPTS = 3
+
+
+@dataclass
+class FetchResult:
+    """Outcome of one conditional fetch.
+
+    ``not_modified`` is True on an HTTP 304 (caller should reuse cached bytes),
+    in which case ``content``/``blob_sha``/``server_sha`` are None.
+    """
+
+    content: bytes | None
+    blob_sha: str | None        # locally computed git blob SHA
+    server_sha: str | None      # sha the server declared (for integrity compare)
+    etag: str | None
+    not_modified: bool = False
+
+
+def git_blob_sha(data: bytes) -> str:
+    """Compute the git blob SHA-1: sha1("blob " + len + "\\0" + data)."""
+    h = hashlib.sha1()
+    h.update(b"blob " + str(len(data)).encode("ascii") + b"\0")
+    h.update(data)
+    return h.hexdigest()
+
+
+def resolve_token() -> str | None:
+    """Token order: $GITHUB_TOKEN -> $GH_TOKEN -> best-effort `gh auth token`
+    -> None (anonymous, public repos)."""
+    for var in ("GITHUB_TOKEN", "GH_TOKEN"):
+        val = os.environ.get(var)
+        if val:
+            return val
+    try:
+        out = subprocess.run(
+            ["gh", "auth", "token"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        token = out.stdout.strip()
+        if out.returncode == 0 and token:
+            return token
+    except (OSError, subprocess.SubprocessError):
+        pass
+    return None
+
+
+def _api_base(base_url: str | None, origin: Origin) -> str:
+    """Resolve the contents-API base. Explicit base_url wins; else $GITHUB_API_URL;
+    else default GitHub. (Non-GitHub hosts pass base_url explicitly.)"""
+    if base_url:
+        return base_url.rstrip("/")
+    return os.environ.get("GITHUB_API_URL", _GITHUB_API_DEFAULT).rstrip("/")
+
+
+def _contents_url(base: str, origin: Origin) -> str:
+    return f"{base}/repos/{origin.owner}/{origin.repo}/contents/{origin.path}"
+
+
+async def fetch_blob(
+    origin: Origin,
+    *,
+    token: str | None = None,
+    base_url: str | None = None,
+    etag: str | None = None,
+    limits: FetchLimits | None = None,
+) -> FetchResult:
+    """Fetch one file's bytes via the contents JSON API, with bounded retry on
+    transient failures. Sends ``If-None-Match`` when ``etag`` is given.
+
+    Fails fast on 404 (RemoteFetchNotFound) and non-rate-limit 401/403
+    (RemoteFetchAuthError).
+    """
+    limits = limits or FetchLimits()
+    base = _api_base(base_url, origin)
+    url = _contents_url(base, origin)
+    params = {"ref": origin.ref}
+    headers = {"Accept": "application/vnd.github+json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    if etag:
+        headers["If-None-Match"] = etag
+
+    backoff = 1.0
+    last_exc: Exception | None = None
+    async with httpx.AsyncClient() as client:
+        for _ in range(_MAX_ATTEMPTS):
+            try:
+                resp = await client.get(
+                    url, params=params, headers=headers,
+                    timeout=limits.per_request_timeout,
+                )
+            except (httpx.TimeoutException, httpx.TransportError) as exc:
+                last_exc = exc
+                await asyncio.sleep(backoff)
+                backoff *= 2
+                continue
+
+            if resp.status_code == 304:
+                return FetchResult(None, None, None, etag, not_modified=True)
+            if resp.status_code == 200:
+                payload = resp.json()
+                content = base64.b64decode(payload["content"])
+                return FetchResult(
+                    content=content,
+                    blob_sha=git_blob_sha(content),
+                    server_sha=payload.get("sha"),
+                    etag=resp.headers.get("ETag"),
+                )
+            if resp.status_code == 404:
+                raise RemoteFetchNotFound(
+                    f"404 fetching {origin.owner}/{origin.repo}@{origin.ref}"
+                    f"#{origin.path} (check the ref and the file path)"
+                )
+            if resp.status_code in (401, 403):
+                retry_after = resp.headers.get("Retry-After")
+                secondary = resp.status_code == 403 and (
+                    retry_after is not None
+                    or resp.headers.get("x-ratelimit-remaining") == "0"
+                )
+                if secondary:
+                    last_exc = RemoteFetchError(
+                        f"secondary rate limit on {origin.owner}/{origin.repo}"
+                    )
+                    await asyncio.sleep(float(retry_after) if retry_after else backoff)
+                    backoff *= 2
+                    continue
+                raise RemoteFetchAuthError(
+                    f"{resp.status_code} fetching {origin.owner}/{origin.repo}"
+                    f"@{origin.ref} — check the token scope for this repo"
+                )
+            if resp.status_code in _RETRYABLE_STATUS:
+                last_exc = RemoteFetchError(f"{resp.status_code} from {url}")
+                await asyncio.sleep(backoff)
+                backoff *= 2
+                continue
+            raise RemoteFetchError(f"Unexpected {resp.status_code} fetching {url}")
+
+    raise RemoteFetchError(
+        f"Retry exhausted after {_MAX_ATTEMPTS} attempts for "
+        f"{origin.owner}/{origin.repo}@{origin.ref}#{origin.path}: {last_exc}"
+    )

--- a/modules/remote-source/amplifier_module_remote_source/fetch.py
+++ b/modules/remote-source/amplifier_module_remote_source/fetch.py
@@ -77,11 +77,27 @@ def resolve_token() -> str | None:
 
 
 def _api_base(base_url: str | None, origin: Origin) -> str:
-    """Resolve the contents-API base. Explicit base_url wins; else $GITHUB_API_URL;
-    else default GitHub. (Non-GitHub hosts pass base_url explicitly.)"""
+    """Resolve the contents-API base for ``origin``.
+
+    Explicit ``base_url`` wins for any host. Else ``$GITHUB_API_URL`` (also
+    honored for any host -- it is an operator-level override, not
+    github.com-specific). Else, if ``origin.host`` is ``github.com``, default
+    to the public GitHub API. Any other host with no override fails loud
+    instead of silently being routed to api.github.com.
+    """
     if base_url:
         return base_url.rstrip("/")
-    return os.environ.get("GITHUB_API_URL", _GITHUB_API_DEFAULT).rstrip("/")
+    env = os.environ.get("GITHUB_API_URL")
+    if env:
+        return env.rstrip("/")
+    if origin.host == "github.com":
+        return _GITHUB_API_DEFAULT
+    raise RemoteFetchError(
+        f"Cannot route git+https://{origin.host}/{origin.owner}/{origin.repo}: "
+        f"non-github.com hosts require an explicit API base URL "
+        f"(set $GITHUB_API_URL or pass base_url=). Auto-routing for host "
+        f"{origin.host!r} is not supported in this version."
+    )
 
 
 def _contents_url(base: str, origin: Origin) -> str:
@@ -130,8 +146,28 @@ async def fetch_blob(
             if resp.status_code == 304:
                 return FetchResult(None, None, None, etag, not_modified=True)
             if resp.status_code == 200:
-                payload = resp.json()
-                content = base64.b64decode(payload["content"])
+                try:
+                    payload = resp.json()
+                except ValueError as exc:
+                    raise RemoteFetchError(
+                        f"Non-JSON response body fetching {origin.owner}/{origin.repo}"
+                        f"@{origin.ref}#{origin.path}: {exc}"
+                    ) from exc
+                if isinstance(payload, list):
+                    raise RemoteFetchNotFound(
+                        f"path resolves to a directory, not a file: "
+                        f"{origin.owner}/{origin.repo}@{origin.ref}#{origin.path}"
+                    )
+                content_b64 = payload.get("content")
+                encoding = payload.get("encoding")
+                if content_b64 is None or encoding != "base64":
+                    raise RemoteFetchError(
+                        f"file exceeds the Contents API 1MB inline limit (or "
+                        f"has no inline content) for "
+                        f"{origin.owner}/{origin.repo}@{origin.ref}#{origin.path} "
+                        f"(encoding={encoding!r})"
+                    )
+                content = base64.b64decode(content_b64)
                 return FetchResult(
                     content=content,
                     blob_sha=git_blob_sha(content),

--- a/modules/remote-source/amplifier_module_remote_source/limits.py
+++ b/modules/remote-source/amplifier_module_remote_source/limits.py
@@ -10,6 +10,10 @@ class FetchLimits:
     """Safety envelope for a recursive fetch walk. v1 uses these constructor
     defaults; external override config keys are deferred."""
 
+    # Counts fetch levels with the entry file itself as level 0: max_depth=N
+    # allows the entry plus up to (N - 1) further hops before the walk fails
+    # fast. E.g. max_depth=1 allows only the entry (zero further hops); the
+    # first hop away from the entry (depth 1) fails immediately.
     max_depth: int = 10
     max_files: int = 100
     max_total_bytes: int = 10 * 1024 * 1024  # 10 MB

--- a/modules/remote-source/amplifier_module_remote_source/limits.py
+++ b/modules/remote-source/amplifier_module_remote_source/limits.py
@@ -1,0 +1,17 @@
+"""Fetch-walk safety envelope (Layer A)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class FetchLimits:
+    """Safety envelope for a recursive fetch walk. v1 uses these constructor
+    defaults; external override config keys are deferred."""
+
+    max_depth: int = 10
+    max_files: int = 100
+    max_total_bytes: int = 10 * 1024 * 1024  # 10 MB
+    per_request_timeout: float = 30.0
+    max_concurrency: int = 8

--- a/modules/remote-source/amplifier_module_remote_source/uri.py
+++ b/modules/remote-source/amplifier_module_remote_source/uri.py
@@ -1,0 +1,72 @@
+"""git+https:// URI grammar (Layer A, resource-agnostic — no DOT knowledge)."""
+
+from __future__ import annotations
+
+import posixpath
+from dataclasses import dataclass
+from urllib.parse import unquote
+
+from .errors import RemoteFetchPathError
+
+GIT_HTTPS_PREFIX = "git+https://"
+
+
+@dataclass(frozen=True)
+class Origin:
+    """A fetched file's origin. ``path`` is the file path within the repo
+    (POSIX, no leading slash). ``dir`` is its parent dir within the repo."""
+
+    host: str
+    owner: str
+    repo: str
+    ref: str
+    path: str
+
+    @property
+    def dir(self) -> str:
+        return posixpath.dirname(self.path)
+
+    def key(self) -> tuple[str, str, str, str, str]:
+        """Cycle/dedupe identity: a specific file in a specific host/repo@ref."""
+        return (self.host, self.owner, self.repo, self.ref, self.path)
+
+
+def parse_uri(uri: str) -> Origin:
+    """Parse ``git+https://<host>/<owner>/<repo>[@<ref>]#subdirectory=<file-path>``.
+
+    ``ref`` defaults to ``main``. Raises ``RemoteFetchPathError`` on malformed
+    input. Any well-formed host is accepted (host allow-listing is not done
+    here — the fetch layer controls which base URL is actually contacted).
+    """
+    if not uri.startswith(GIT_HTTPS_PREFIX):
+        raise RemoteFetchPathError(f"Not a git+https:// URI: {uri!r}")
+    rest = uri[len(GIT_HTTPS_PREFIX):]
+
+    base, _, fragment = rest.partition("#")
+    segments = base.split("/")
+    if len(segments) != 3 or not all(segments):
+        raise RemoteFetchPathError(
+            f"Malformed git+https:// URI (need exactly host/owner/repo): {uri!r}"
+        )
+
+    host, owner, repo_and_ref = segments
+    repo, at, ref = repo_and_ref.partition("@")
+    if not at:
+        ref = "main"
+    if not repo:
+        raise RemoteFetchPathError(f"Missing repo in git+https:// URI: {uri!r}")
+
+    path = ""
+    if fragment:
+        key, _, value = fragment.partition("=")
+        if key != "subdirectory":
+            raise RemoteFetchPathError(
+                f"Only #subdirectory= is supported, got {fragment!r} in {uri!r}"
+            )
+        path = unquote(value).lstrip("/")
+    if not path:
+        raise RemoteFetchPathError(
+            f"Entry URI must name a file via #subdirectory=: {uri!r}"
+        )
+
+    return Origin(host=host, owner=owner, repo=repo, ref=ref, path=path)

--- a/modules/remote-source/amplifier_module_remote_source/uri.py
+++ b/modules/remote-source/amplifier_module_remote_source/uri.py
@@ -31,12 +31,45 @@ class Origin:
         return (self.host, self.owner, self.repo, self.ref, self.path)
 
 
+def _reject_single_segment_traversal(uri: str, name: str, value: str) -> None:
+    """Validate a single path-tree component (host/owner/repo) — no '/'."""
+    if not value or value in (".", ".."):
+        raise RemoteFetchPathError(f"Invalid {name} segment {value!r} in {uri!r}")
+    if "\x00" in value or "\\" in value:
+        raise RemoteFetchPathError(f"Invalid characters in {name} {value!r} in {uri!r}")
+
+
+def _reject_multi_segment_traversal(uri: str, name: str, value: str) -> None:
+    """Validate a possibly multi-segment (POSIX '/'-separated) field.
+
+    Rejects absolute paths, NUL/backslash, and any '..' path segment. Plain
+    '/'-separated relative paths like ``a/b/c.dot`` remain valid.
+    """
+    if not value:
+        raise RemoteFetchPathError(f"Missing {name} in {uri!r}")
+    if value.startswith("/"):
+        raise RemoteFetchPathError(f"{name} must be relative, got {value!r} in {uri!r}")
+    if "\x00" in value or "\\" in value:
+        raise RemoteFetchPathError(f"Invalid characters in {name} {value!r} in {uri!r}")
+    for seg in value.split("/"):
+        if seg == "..":
+            raise RemoteFetchPathError(
+                f"Path traversal ('..') rejected in {name} {value!r} of {uri!r}"
+            )
+
+
 def parse_uri(uri: str) -> Origin:
     """Parse ``git+https://<host>/<owner>/<repo>[@<ref>]#subdirectory=<file-path>``.
 
     ``ref`` defaults to ``main``. Raises ``RemoteFetchPathError`` on malformed
     input. Any well-formed host is accepted (host allow-listing is not done
     here — the fetch layer controls which base URL is actually contacted).
+
+    Every component (host, owner, repo, ref, path) is validated to reject
+    path traversal ('..' segments), absolute paths, and NUL/backslash
+    characters before an ``Origin`` is constructed — those components are
+    later joined directly into cache filesystem paths (see ``cache.py``), so
+    they must never be able to escape the cache root.
     """
     if not uri.startswith(GIT_HTTPS_PREFIX):
         raise RemoteFetchPathError(f"Not a git+https:// URI: {uri!r}")
@@ -63,10 +96,21 @@ def parse_uri(uri: str) -> Origin:
             raise RemoteFetchPathError(
                 f"Only #subdirectory= is supported, got {fragment!r} in {uri!r}"
             )
-        path = unquote(value).lstrip("/")
+        raw_path = unquote(value)
+        if raw_path.startswith("/"):
+            raise RemoteFetchPathError(
+                f"subdirectory path must be relative, got {raw_path!r} in {uri!r}"
+            )
+        path = raw_path.lstrip("/")
     if not path:
         raise RemoteFetchPathError(
             f"Entry URI must name a file via #subdirectory=: {uri!r}"
         )
+
+    _reject_single_segment_traversal(uri, "host", host)
+    _reject_single_segment_traversal(uri, "owner", owner)
+    _reject_single_segment_traversal(uri, "repo", repo)
+    _reject_multi_segment_traversal(uri, "ref", ref)
+    _reject_multi_segment_traversal(uri, "path", path)
 
     return Origin(host=host, owner=owner, repo=repo, ref=ref, path=path)

--- a/modules/remote-source/amplifier_module_remote_source/uri.py
+++ b/modules/remote-source/amplifier_module_remote_source/uri.py
@@ -63,7 +63,11 @@ def parse_uri(uri: str) -> Origin:
 
     ``ref`` defaults to ``main``. Raises ``RemoteFetchPathError`` on malformed
     input. Any well-formed host is accepted (host allow-listing is not done
-    here — the fetch layer controls which base URL is actually contacted).
+    here) -- the host is captured on the ``Origin``, but the fetch layer does
+    NOT auto-derive a per-host API base URL. For ``github.com`` it defaults to
+    the public GitHub API; for any other host it requires an explicit base
+    URL (``$GITHUB_API_URL`` or ``base_url=``) and raises loudly otherwise --
+    it never silently falls back to contacting github.com.
 
     Every component (host, owner, repo, ref, path) is validated to reject
     path traversal ('..' segments), absolute paths, and NUL/backslash

--- a/modules/remote-source/pyproject.toml
+++ b/modules/remote-source/pyproject.toml
@@ -35,7 +35,7 @@ addopts = "--import-mode=importlib"
 asyncio_mode = "strict"
 
 [tool.ruff.lint.per-file-ignores]
-"tests/*.py" = ["E402"]
+"tests/*.py" = ["E402", "E741"]
 
 [dependency-groups]
 dev = [

--- a/modules/remote-source/pyproject.toml
+++ b/modules/remote-source/pyproject.toml
@@ -1,0 +1,45 @@
+[project]
+name = "amplifier-module-remote-source"
+version = "0.1.0"
+description = "Resource-agnostic content-addressed caching git+https:// fetcher (Layer A)."
+license = "MIT"
+requires-python = ">=3.11"
+authors = [
+    { name = "Microsoft MADE:Explorations Team" },
+]
+dependencies = [
+    "httpx>=0.28",
+]
+
+# NOTE: This is a PURE LIBRARY module — intentionally NO
+# [project.entry-points."amplifier.modules"] mount. It is imported directly by
+# Layer B, never mounted onto a coordinator. It is the first library-only
+# module in modules/; that is by design.
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.uv]
+package = true
+
+[tool.hatch.build.targets.wheel]
+packages = ["amplifier_module_remote_source"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--import-mode=importlib"
+asyncio_mode = "strict"
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*.py" = ["E402"]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0.0",
+    "pytest-asyncio>=1.0.0",
+    "respx>=0.22",
+]

--- a/modules/remote-source/tests/test_cache.py
+++ b/modules/remote-source/tests/test_cache.py
@@ -83,3 +83,78 @@ async def test_reload_forces_revalidation(tmp_path):
     assert f.calls == 1
     await cache.get(_origin(ref=IMMUT), fetch_fn=f, reload=True)
     assert f.calls == 2  # reload bypasses the immutable fast path
+
+
+def _assert_nothing_escaped(tmp_path, cache_root):
+    """Every file under tmp_path must remain inside cache_root."""
+    cache_root_str = str(cache_root)
+    for p in tmp_path.rglob("*"):
+        if p.is_file():
+            assert str(p).startswith(cache_root_str), f"traversal escaped to {p}"
+
+
+@pytest.mark.asyncio
+async def test_traversal_via_crafted_ref_rejected(tmp_path):
+    """A crafted Origin with '..' in ref must not escape the cache root.
+
+    parse_uri() rejects this at construction time, but BlobCache must also
+    defend itself (belt-and-suspenders) against any Origin that reaches it
+    directly — e.g. a future caller that bypasses parse_uri. The ref here
+    has enough '../' segments to walk above the cache root entirely
+    (root/refs/host/owner/repo/<ref-segments>/...).
+    """
+    cache_root = tmp_path / "cache"
+    cache_root.mkdir()
+    cache = BlobCache(cache_root)
+    f = FakeFetcher()
+    traversal_ref = "/".join([".."] * 8)
+    evil_ref_origin = Origin("github.com", "acme", "widgets", traversal_ref, "a.dot")
+    with pytest.raises(RemoteFetchError):
+        await cache.get(evil_ref_origin, fetch_fn=f)
+    _assert_nothing_escaped(tmp_path, cache_root)
+
+
+@pytest.mark.asyncio
+async def test_traversal_via_crafted_path_rejected(tmp_path):
+    """A crafted Origin with '..' in path must not escape the cache root."""
+    cache_root = tmp_path / "cache"
+    cache_root.mkdir()
+    cache = BlobCache(cache_root)
+    f = FakeFetcher()
+    traversal_path = "/".join([".."] * 8) + "/etc/passwd"
+    evil_path_origin = Origin("github.com", "acme", "widgets", "main", traversal_path)
+    with pytest.raises(RemoteFetchError):
+        await cache.get(evil_path_origin, fetch_fn=f)
+    _assert_nothing_escaped(tmp_path, cache_root)
+
+
+def test_write_blob_loser_does_not_delete_winner_lock(tmp_path):
+    """Simulate a losing writer: pre-create the lock file (as if another
+    process holds it), then call _write_blob. The loser must return without
+    deleting the lock or writing the blob — it must not tear down a lock it
+    does not own.
+    """
+    cache = BlobCache(tmp_path)
+    content = b"digraph G {}"
+    sha = git_blob_sha(content)
+    blob_path = cache._blob_path(sha)
+    blob_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = blob_path.with_suffix(".lock")
+    lock_path.write_text("held-by-winner")
+
+    # Loser attempts to write while the lock is held.
+    cache._write_blob(sha, content)
+
+    # The loser must not have deleted the winner's lock, nor written the blob.
+    assert lock_path.exists(), "loser deleted the winner's lock file"
+    assert not blob_path.exists(), "loser wrote the blob despite losing the lock"
+
+    # Now the "winner" finishes: releases the lock and writes the blob itself.
+    lock_path.unlink()
+    cache._write_blob(sha, content)
+    assert blob_path.exists()
+    assert blob_path.read_bytes() == content
+    # Lock and tmp are cleaned up after a real winning write.
+    assert not lock_path.exists()
+    tmp_candidates = list(blob_path.parent.glob(f"{sha}.tmp.*"))
+    assert tmp_candidates == []

--- a/modules/remote-source/tests/test_cache.py
+++ b/modules/remote-source/tests/test_cache.py
@@ -19,9 +19,11 @@ class FakeFetcher:
         self.etag = etag
         self.calls = 0
         self.next_not_modified = False
+        self.seen_limits = []
 
-    async def __call__(self, origin, *, token=None, base_url=None, etag=None):
+    async def __call__(self, origin, *, token=None, base_url=None, etag=None, limits=None):
         self.calls += 1
+        self.seen_limits.append(limits)
         if self.next_not_modified:
             return FetchResult(None, None, None, etag, not_modified=True)
         return FetchResult(self.content, git_blob_sha(self.content), self.server_sha, self.etag)
@@ -85,6 +87,19 @@ async def test_reload_forces_revalidation(tmp_path):
     assert f.calls == 2  # reload bypasses the immutable fast path
 
 
+@pytest.mark.asyncio
+async def test_limits_passed_through_to_fetch_fn(tmp_path):
+    """A caller-supplied FetchLimits must reach fetch_fn -- not be dropped
+    silently on the way through BlobCache.get()."""
+    from amplifier_module_remote_source.limits import FetchLimits
+
+    cache = BlobCache(tmp_path)
+    f = FakeFetcher()
+    custom_limits = FetchLimits(per_request_timeout=5.0)
+    await cache.get(_origin(ref="main"), fetch_fn=f, limits=custom_limits)
+    assert f.seen_limits == [custom_limits]
+
+
 def _assert_nothing_escaped(tmp_path, cache_root):
     """Every file under tmp_path must remain inside cache_root."""
     cache_root_str = str(cache_root)
@@ -128,33 +143,47 @@ async def test_traversal_via_crafted_path_rejected(tmp_path):
     _assert_nothing_escaped(tmp_path, cache_root)
 
 
-def test_write_blob_loser_does_not_delete_winner_lock(tmp_path):
-    """Simulate a losing writer: pre-create the lock file (as if another
-    process holds it), then call _write_blob. The loser must return without
-    deleting the lock or writing the blob — it must not tear down a lock it
-    does not own.
-    """
+def test_write_blob_concurrent_identical_writes_produce_one_blob(tmp_path):
+    """Two writes of identical content must not raise and must produce
+    exactly one blob file on disk (atomic os.replace, no lock needed —
+    blobs are content-addressed so concurrent writers of the same blob_sha
+    are writing byte-identical content by construction)."""
     cache = BlobCache(tmp_path)
     content = b"digraph G {}"
     sha = git_blob_sha(content)
     blob_path = cache._blob_path(sha)
-    blob_path.parent.mkdir(parents=True, exist_ok=True)
-    lock_path = blob_path.with_suffix(".lock")
-    lock_path.write_text("held-by-winner")
 
-    # Loser attempts to write while the lock is held.
+    # Simulate two "concurrent" writers racing to write the same blob —
+    # both must succeed without raising, and no stray tmp files remain.
+    cache._write_blob(sha, content)
     cache._write_blob(sha, content)
 
-    # The loser must not have deleted the winner's lock, nor written the blob.
-    assert lock_path.exists(), "loser deleted the winner's lock file"
-    assert not blob_path.exists(), "loser wrote the blob despite losing the lock"
-
-    # Now the "winner" finishes: releases the lock and writes the blob itself.
-    lock_path.unlink()
-    cache._write_blob(sha, content)
     assert blob_path.exists()
     assert blob_path.read_bytes() == content
-    # Lock and tmp are cleaned up after a real winning write.
-    assert not lock_path.exists()
-    tmp_candidates = list(blob_path.parent.glob(f"{sha}.tmp.*"))
-    assert tmp_candidates == []
+    tmp_candidates = list(blob_path.parent.glob(f"{sha}.*.tmp"))
+    assert tmp_candidates == [], "no tmp files should remain after writes"
+    blob_candidates = [p for p in blob_path.parent.iterdir() if p.is_file()]
+    assert blob_candidates == [blob_path], "exactly one blob file, no duplicates"
+
+
+@pytest.mark.asyncio
+async def test_get_never_writes_ref_pointing_at_missing_blob(tmp_path, monkeypatch):
+    """If the blob write somehow leaves no file on disk (e.g. a crash
+    mid-write in another process), get() must NOT write a ref pointing at
+    that missing blob — a dangling ref would permanently poison the cache
+    (the is_immutable() fast path would keep resolving to a blob_sha with
+    no backing file, forever).
+    """
+    cache = BlobCache(tmp_path)
+    f = FakeFetcher()
+
+    # Simulate _write_blob silently failing to persist the blob (e.g. a
+    # concurrent crash-mid-write elsewhere left nothing on disk).
+    monkeypatch.setattr(cache, "_write_blob", lambda blob_sha, content: None)
+
+    with pytest.raises(RemoteFetchError):
+        await cache.get(_origin(ref=IMMUT), fetch_fn=f)
+
+    # No ref file should exist pointing at the (non-existent) blob.
+    ref_path = cache._ref_path(_origin(ref=IMMUT))
+    assert not ref_path.exists(), "a ref must never be written for a missing blob"

--- a/modules/remote-source/tests/test_cache.py
+++ b/modules/remote-source/tests/test_cache.py
@@ -1,0 +1,85 @@
+import pytest
+
+from amplifier_module_remote_source.cache import BlobCache, is_immutable
+from amplifier_module_remote_source.errors import RemoteFetchError
+from amplifier_module_remote_source.fetch import FetchResult, git_blob_sha
+from amplifier_module_remote_source.uri import Origin
+
+IMMUT = "a" * 40
+
+
+def _origin(ref="main", path="a.dot", host="github.com"):
+    return Origin(host, "acme", "widgets", ref, path)
+
+
+class FakeFetcher:
+    def __init__(self, content=b"digraph G {}", server_sha=None, etag='"e1"'):
+        self.content = content
+        self.server_sha = server_sha if server_sha is not None else git_blob_sha(content)
+        self.etag = etag
+        self.calls = 0
+        self.next_not_modified = False
+
+    async def __call__(self, origin, *, token=None, base_url=None, etag=None):
+        self.calls += 1
+        if self.next_not_modified:
+            return FetchResult(None, None, None, etag, not_modified=True)
+        return FetchResult(self.content, git_blob_sha(self.content), self.server_sha, self.etag)
+
+
+def test_is_immutable():
+    assert is_immutable(IMMUT)
+    assert not is_immutable("main")
+    assert not is_immutable("v1.2.3")
+
+
+@pytest.mark.asyncio
+async def test_first_fetch_then_immutable_zero_network(tmp_path):
+    cache = BlobCache(tmp_path)
+    f = FakeFetcher()
+    content, sha = await cache.get(_origin(ref=IMMUT), fetch_fn=f)
+    assert content == f.content
+    assert f.calls == 1
+    # Second call for an immutable ref must not fetch again.
+    await cache.get(_origin(ref=IMMUT), fetch_fn=f)
+    assert f.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_mutable_revalidates_but_reuses_on_304(tmp_path):
+    cache = BlobCache(tmp_path)
+    f = FakeFetcher()
+    await cache.get(_origin(ref="main"), fetch_fn=f)
+    assert f.calls == 1
+    f.next_not_modified = True  # server says unchanged
+    content, _ = await cache.get(_origin(ref="main"), fetch_fn=f)
+    assert content == f.content       # served from cache
+    assert f.calls == 2               # but it DID revalidate
+
+
+@pytest.mark.asyncio
+async def test_dedup_identical_bytes_one_blob(tmp_path):
+    cache = BlobCache(tmp_path)
+    f = FakeFetcher()
+    await cache.get(_origin(path="a.dot", ref=IMMUT), fetch_fn=f)
+    await cache.get(_origin(path="b.dot", ref=IMMUT), fetch_fn=f)
+    blobs = list((tmp_path / "blobs").iterdir())
+    assert len(blobs) == 1  # same content -> single blob
+
+
+@pytest.mark.asyncio
+async def test_integrity_reject_on_sha_mismatch(tmp_path):
+    cache = BlobCache(tmp_path)
+    f = FakeFetcher(server_sha="deadbeef" * 5)  # server declares a wrong sha
+    with pytest.raises(RemoteFetchError):
+        await cache.get(_origin(ref=IMMUT), fetch_fn=f)
+
+
+@pytest.mark.asyncio
+async def test_reload_forces_revalidation(tmp_path):
+    cache = BlobCache(tmp_path)
+    f = FakeFetcher()
+    await cache.get(_origin(ref=IMMUT), fetch_fn=f)
+    assert f.calls == 1
+    await cache.get(_origin(ref=IMMUT), fetch_fn=f, reload=True)
+    assert f.calls == 2  # reload bypasses the immutable fast path

--- a/modules/remote-source/tests/test_cache.py
+++ b/modules/remote-source/tests/test_cache.py
@@ -29,6 +29,31 @@ class FakeFetcher:
         return FetchResult(self.content, git_blob_sha(self.content), self.server_sha, self.etag)
 
 
+class ThreeOhFourThenContentFetcher:
+    """304 when an etag is sent (any etag), full 200+content when etag is None.
+
+    Models a server that still has the ref unchanged (etag matches) but is
+    used to exercise the self-heal path where the cached blob file has been
+    externally deleted -- the cache must force a no-etag refetch to recover
+    real bytes rather than raising on the empty 304 result.
+    """
+
+    def __init__(self, content=b"digraph G {}", server_sha=None, etag='"e1"'):
+        self.content = content
+        self.server_sha = server_sha if server_sha is not None else git_blob_sha(content)
+        self.etag = etag
+        self.calls = 0
+        self.etags_seen = []
+        self.always_not_modified = False
+
+    async def __call__(self, origin, *, token=None, base_url=None, etag=None, limits=None):
+        self.calls += 1
+        self.etags_seen.append(etag)
+        if self.always_not_modified or etag is not None:
+            return FetchResult(None, None, None, etag, not_modified=True)
+        return FetchResult(self.content, git_blob_sha(self.content), self.server_sha, self.etag)
+
+
 def test_is_immutable():
     assert is_immutable(IMMUT)
     assert not is_immutable("main")
@@ -57,6 +82,63 @@ async def test_mutable_revalidates_but_reuses_on_304(tmp_path):
     content, _ = await cache.get(_origin(ref="main"), fetch_fn=f)
     assert content == f.content       # served from cache
     assert f.calls == 2               # but it DID revalidate
+
+
+@pytest.mark.asyncio
+async def test_reuses_on_304_even_when_cached_blob_deleted_by_self_heal(tmp_path):
+    """304 + externally-deleted blob must self-heal via a forced no-etag
+    refetch, not raise RemoteFetchError("empty fetch result...").
+
+    Fail-before: with the old code, deleting the blob file and then hitting
+    the 304 branch would call _read_blob() -> None and fall through to
+    ``raise RemoteFetchError("empty fetch result...")`` because ``result``
+    still carries ``content=None`` from the 304 response.
+    """
+    cache = BlobCache(tmp_path)
+    f = ThreeOhFourThenContentFetcher()
+
+    # Prime the cache: first fetch (no etag on disk yet) gets full content.
+    content, sha = await cache.get(_origin(ref="main"), fetch_fn=f)
+    assert content == f.content
+    assert f.calls == 1
+    assert f.etags_seen == [None]
+
+    blob_path = cache._blob_path(sha)
+    assert blob_path.exists()
+
+    # Externally delete the blob file -- ref on disk still points at it.
+    blob_path.unlink()
+    assert not blob_path.exists()
+
+    # get() must self-heal: revalidation request (with etag) returns 304,
+    # then a forced no-etag refetch returns full content, which gets
+    # rewritten to disk. No RemoteFetchError.
+    content2, sha2 = await cache.get(_origin(ref="main"), fetch_fn=f)
+
+    assert content2 == f.content
+    assert sha2 == sha
+    assert f.calls == 3  # 1 (prime) + 1 (etag'd 304) + 1 (forced no-etag refetch)
+    assert f.etags_seen == [None, '"e1"', None]
+    assert blob_path.exists(), "blob must be rewritten to disk after self-heal"
+    assert blob_path.read_bytes() == f.content
+
+
+@pytest.mark.asyncio
+async def test_second_fetch_still_empty_after_self_heal_raises(tmp_path):
+    """If the forced no-etag refetch ALSO yields no content, get() must
+    still raise -- self-heal is a single attempt, not a retry loop."""
+    cache = BlobCache(tmp_path)
+    f = ThreeOhFourThenContentFetcher()
+
+    await cache.get(_origin(ref="main"), fetch_fn=f)
+    blob_path = cache._blob_path(f.server_sha)
+    blob_path.unlink()
+
+    # Force even the no-etag refetch to return not_modified/empty.
+    f.always_not_modified = True
+
+    with pytest.raises(RemoteFetchError):
+        await cache.get(_origin(ref="main"), fetch_fn=f)
 
 
 @pytest.mark.asyncio

--- a/modules/remote-source/tests/test_cache.py
+++ b/modules/remote-source/tests/test_cache.py
@@ -124,6 +124,45 @@ async def test_reuses_on_304_even_when_cached_blob_deleted_by_self_heal(tmp_path
 
 
 @pytest.mark.asyncio
+async def test_reuses_on_304_even_when_cached_blob_corrupted_on_disk(tmp_path):
+    """304 + an on-disk blob whose bytes no longer hash to its own filename
+    (e.g. bitrot/external corruption) must self-heal via a forced no-etag
+    refetch, not silently hand back the wrong bytes.
+
+    Fail-before: with the old code, the 304 branch did ``_read_blob() ->
+    return blob`` unconditionally whenever the file existed, with no
+    ``git_blob_sha(blob) == entry["blob_sha"]`` check -- corrupted content
+    would be returned as if it were valid, forever, since a 304 never
+    touches the network.
+    """
+    cache = BlobCache(tmp_path)
+    f = ThreeOhFourThenContentFetcher()
+
+    # Prime the cache: first fetch (no etag on disk yet) gets full content.
+    content, sha = await cache.get(_origin(ref="main"), fetch_fn=f)
+    assert content == f.content
+    assert f.calls == 1
+
+    blob_path = cache._blob_path(sha)
+    assert blob_path.exists()
+
+    # Corrupt the on-disk blob in place -- the ref still points at `sha`,
+    # but the bytes under that path no longer hash to it.
+    blob_path.write_bytes(b"corrupted, does not match its own sha")
+
+    # get() must detect the mismatch on the 304 path and self-heal: the
+    # revalidation request (with etag) returns 304, then a forced no-etag
+    # refetch returns full (correct) content, which gets rewritten to disk.
+    content2, sha2 = await cache.get(_origin(ref="main"), fetch_fn=f)
+
+    assert content2 == f.content
+    assert sha2 == sha
+    assert f.calls == 3  # 1 (prime) + 1 (etag'd 304) + 1 (forced no-etag refetch)
+    assert f.etags_seen == [None, '"e1"', None]
+    assert blob_path.read_bytes() == f.content, "corrupted blob must be overwritten with correct bytes"
+
+
+@pytest.mark.asyncio
 async def test_second_fetch_still_empty_after_self_heal_raises(tmp_path):
     """If the forced no-etag refetch ALSO yields no content, get() must
     still raise -- self-heal is a single attempt, not a retry loop."""

--- a/modules/remote-source/tests/test_fetch.py
+++ b/modules/remote-source/tests/test_fetch.py
@@ -7,6 +7,7 @@ import respx
 
 from amplifier_module_remote_source.errors import (
     RemoteFetchAuthError,
+    RemoteFetchError,
     RemoteFetchNotFound,
 )
 from amplifier_module_remote_source.fetch import (
@@ -14,6 +15,7 @@ from amplifier_module_remote_source.fetch import (
     git_blob_sha,
     resolve_token,
 )
+from amplifier_module_remote_source.limits import FetchLimits
 from amplifier_module_remote_source.uri import Origin
 
 O = Origin("github.com", "acme", "widgets", "main", "a.dot")
@@ -80,6 +82,112 @@ async def test_base_url_reaches_non_github_host():
     ).mock(return_value=httpx.Response(200, json=_json_body(b"x", "s")))
     await fetch_blob(O, token=None, base_url="https://gitea.example.com/api/v1")
     assert route.called
+
+
+_NON_GITHUB_ORIGIN = Origin("gitea.example.com", "acme", "widgets", "main", "a.dot")
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_non_github_host_with_no_override_fails_loud(monkeypatch):
+    """A non-github.com host with no base_url/$GITHUB_API_URL must never
+    silently fall through to api.github.com -- it must fail loud instead."""
+    monkeypatch.delenv("GITHUB_API_URL", raising=False)
+    github_route = respx.get(url__regex=r"https://api\.github\.com/.*").mock(
+        return_value=httpx.Response(200, json=_json_body(b"x", "s"))
+    )
+    with pytest.raises(RemoteFetchError, match="gitea.example.com"):
+        await fetch_blob(_NON_GITHUB_ORIGIN, token=None)
+    assert not github_route.called
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_non_github_host_routes_via_github_api_url_env(monkeypatch):
+    """$GITHUB_API_URL is an operator-level override honored for ANY host,
+    not just github.com."""
+    monkeypatch.setenv("GITHUB_API_URL", "https://gitea.example.com/api/v1")
+    route = respx.get(
+        url__regex=r"https://gitea.example.com/api/v1/repos/acme/widgets/contents/a.dot"
+    ).mock(return_value=httpx.Response(200, json=_json_body(b"x", "s")))
+    res = await fetch_blob(_NON_GITHUB_ORIGIN, token=None)
+    assert route.called
+    assert res.content == b"x"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_github_com_defaults_to_api_github_com(monkeypatch):
+    """github.com origin with no override defaults to api.github.com."""
+    monkeypatch.delenv("GITHUB_API_URL", raising=False)
+    route = respx.get(url__regex=CONTENTS_RE).mock(
+        return_value=httpx.Response(200, json=_json_body(b"digraph G {}", "s"))
+    )
+    res = await fetch_blob(O, token=None)
+    assert route.called
+    assert res.content == b"digraph G {}"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_per_request_timeout_reaches_httpx_call(monkeypatch):
+    """A custom FetchLimits.per_request_timeout must actually be applied to
+    the httpx request, not just carried around unused."""
+    respx.get(url__regex=CONTENTS_RE).mock(
+        return_value=httpx.Response(200, json=_json_body(b"x", "s"))
+    )
+
+    seen_timeouts = []
+    real_get = httpx.AsyncClient.get
+
+    async def _spy_get(self, *args, **kwargs):
+        seen_timeouts.append(kwargs.get("timeout"))
+        return await real_get(self, *args, **kwargs)
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", _spy_get)
+
+    custom_limits = FetchLimits(per_request_timeout=7.5)
+    await fetch_blob(O, token=None, limits=custom_limits)
+
+    assert seen_timeouts == [7.5]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_directory_response_raises_not_found():
+    """A 200 response with a JSON list body means the path resolves to a
+    directory, not a file -- must raise RemoteFetchNotFound."""
+    respx.get(url__regex=CONTENTS_RE).mock(
+        return_value=httpx.Response(200, json=[{"name": "sub.dot", "type": "file"}])
+    )
+    with pytest.raises(RemoteFetchNotFound, match="directory"):
+        await fetch_blob(O, token=None)
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_missing_inline_content_raises_error():
+    """A 200 response with no inline content (e.g. file over the Contents
+    API's 1MB inline limit) must raise RemoteFetchError, not KeyError/TypeError."""
+    respx.get(url__regex=CONTENTS_RE).mock(
+        return_value=httpx.Response(
+            200, json={"name": "a.dot", "encoding": "none", "content": None, "sha": "s"}
+        )
+    )
+    with pytest.raises(RemoteFetchError, match="1MB inline limit"):
+        await fetch_blob(O, token=None)
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_non_json_body_raises_error():
+    """A non-JSON 200 response body must raise RemoteFetchError, not
+    propagate the raw json.JSONDecodeError."""
+    respx.get(url__regex=CONTENTS_RE).mock(
+        return_value=httpx.Response(200, content=b"not json", headers={"content-type": "text/plain"})
+    )
+    with pytest.raises(RemoteFetchError, match="a.dot"):
+        await fetch_blob(O, token=None)
 
 
 def test_resolve_token_prefers_github_token(monkeypatch):

--- a/modules/remote-source/tests/test_fetch.py
+++ b/modules/remote-source/tests/test_fetch.py
@@ -1,0 +1,126 @@
+import base64
+import os
+
+import httpx
+import pytest
+import respx
+
+from amplifier_module_remote_source.errors import (
+    RemoteFetchAuthError,
+    RemoteFetchNotFound,
+)
+from amplifier_module_remote_source.fetch import (
+    fetch_blob,
+    git_blob_sha,
+    resolve_token,
+)
+from amplifier_module_remote_source.uri import Origin
+
+O = Origin("github.com", "acme", "widgets", "main", "a.dot")
+CONTENTS_RE = r"https://api.github.com/repos/acme/widgets/contents/a.dot"
+
+
+def _json_body(content: bytes, sha: str):
+    return {"content": base64.b64encode(content).decode(), "encoding": "base64", "sha": sha}
+
+
+def test_git_blob_sha_matches_git():
+    # Known git blob SHA for the empty file (git hash-object of empty content).
+    assert git_blob_sha(b"") == "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_fetch_200_computes_local_sha():
+    body = b"digraph G {}"
+    respx.get(url__regex=CONTENTS_RE).mock(
+        return_value=httpx.Response(
+            200, json=_json_body(body, "server-sha"), headers={"ETag": '"abc"'}
+        )
+    )
+    res = await fetch_blob(O, token=None)
+    assert res.content == body
+    assert res.blob_sha == git_blob_sha(body)
+    assert res.server_sha == "server-sha"
+    assert res.etag == '"abc"'
+    assert res.not_modified is False
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_fetch_304_not_modified():
+    respx.get(url__regex=CONTENTS_RE).mock(return_value=httpx.Response(304))
+    res = await fetch_blob(O, token=None, etag='"abc"')
+    assert res.not_modified is True
+    assert res.content is None
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_fetch_404_raises_not_found():
+    respx.get(url__regex=CONTENTS_RE).mock(return_value=httpx.Response(404))
+    with pytest.raises(RemoteFetchNotFound):
+        await fetch_blob(O, token=None)
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_fetch_403_auth_error():
+    respx.get(url__regex=CONTENTS_RE).mock(return_value=httpx.Response(403))
+    with pytest.raises(RemoteFetchAuthError):
+        await fetch_blob(O, token=None)
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_base_url_reaches_non_github_host():
+    """Proves the Gitea/GHE seam: base_url routes the request to another host."""
+    route = respx.get(
+        url__regex=r"https://gitea.example.com/api/v1/repos/acme/widgets/contents/a.dot"
+    ).mock(return_value=httpx.Response(200, json=_json_body(b"x", "s")))
+    await fetch_blob(O, token=None, base_url="https://gitea.example.com/api/v1")
+    assert route.called
+
+
+def test_resolve_token_prefers_github_token(monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "tok-a")
+    monkeypatch.setenv("GH_TOKEN", "tok-b")
+    assert resolve_token() == "tok-a"
+
+
+def test_resolve_token_falls_back_to_gh_token(monkeypatch):
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.setenv("GH_TOKEN", "tok-b")
+    assert resolve_token() == "tok-b"
+
+
+def test_resolve_token_anonymous(monkeypatch):
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    # Force the `gh` subprocess to look absent.
+    monkeypatch.setattr(
+        "amplifier_module_remote_source.fetch.subprocess.run",
+        lambda *a, **k: (_ for _ in ()).throw(FileNotFoundError()),
+    )
+    assert resolve_token() is None
+
+
+# --- ONE REAL fetch against a PINNED immutable public commit SHA ---------------
+# Skipped unless the two env vars are set. To pin real values, run:
+#   python -c "import asyncio,os; from amplifier_module_remote_source.fetch import fetch_blob; \
+#     from amplifier_module_remote_source.uri import parse_uri; \
+#     r=asyncio.run(fetch_blob(parse_uri(os.environ['ATTRACTOR_TEST_REMOTE_URI']))); \
+#     print(r.blob_sha)"
+# then export ATTRACTOR_TEST_REMOTE_URI and ATTRACTOR_TEST_BLOB_SHA to the printed value.
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    not os.environ.get("ATTRACTOR_TEST_REMOTE_URI"),
+    reason="set ATTRACTOR_TEST_REMOTE_URI + ATTRACTOR_TEST_BLOB_SHA for the live fetch",
+)
+async def test_real_fetch_pinned_sha():
+    from amplifier_module_remote_source.uri import parse_uri
+
+    uri = os.environ["ATTRACTOR_TEST_REMOTE_URI"]
+    res = await fetch_blob(parse_uri(uri))
+    assert res.content
+    assert res.blob_sha == os.environ["ATTRACTOR_TEST_BLOB_SHA"]

--- a/modules/remote-source/tests/test_limits.py
+++ b/modules/remote-source/tests/test_limits.py
@@ -1,0 +1,24 @@
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from amplifier_module_remote_source.limits import FetchLimits
+
+
+def test_defaults():
+    lim = FetchLimits()
+    assert lim.max_depth == 10
+    assert lim.max_files == 100
+    assert lim.max_total_bytes == 10 * 1024 * 1024
+    assert lim.max_concurrency == 8
+
+
+def test_override():
+    lim = FetchLimits(max_depth=2, max_files=3)
+    assert (lim.max_depth, lim.max_files) == (2, 3)
+
+
+def test_frozen():
+    lim = FetchLimits()
+    with pytest.raises(FrozenInstanceError):
+        lim.max_depth = 99  # type: ignore[misc]

--- a/modules/remote-source/tests/test_uri.py
+++ b/modules/remote-source/tests/test_uri.py
@@ -1,0 +1,41 @@
+import pytest
+
+from amplifier_module_remote_source.errors import RemoteFetchPathError
+from amplifier_module_remote_source.uri import Origin, parse_uri
+
+
+def test_parse_basic_defaults_ref_to_main():
+    o = parse_uri("git+https://github.com/acme/widgets#subdirectory=pipelines/main.dot")
+    assert o == Origin("github.com", "acme", "widgets", "main", "pipelines/main.dot")
+    assert o.dir == "pipelines"
+
+
+def test_parse_explicit_ref():
+    o = parse_uri("git+https://github.com/acme/widgets@v2#subdirectory=a.dot")
+    assert o.ref == "v2"
+    assert o.path == "a.dot"
+    assert o.dir == ""
+
+
+def test_parse_non_github_host_accepted():
+    o = parse_uri("git+https://gitea.example.com/acme/widgets#subdirectory=a.dot")
+    assert o.host == "gitea.example.com"
+
+
+def test_key_includes_host():
+    o = parse_uri("git+https://h/o/r@ref#subdirectory=p/f.dot")
+    assert o.key() == ("h", "o", "r", "ref", "p/f.dot")
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "https://github.com/acme/widgets#subdirectory=a.dot",
+        "git+https://github.com/acme#subdirectory=a.dot",
+        "git+https://github.com/acme/widgets",
+        "git+https://github.com/acme/widgets#branch=main",
+    ],
+)
+def test_parse_rejects_malformed(bad):
+    with pytest.raises(RemoteFetchPathError):
+        parse_uri(bad)

--- a/modules/remote-source/tests/test_uri.py
+++ b/modules/remote-source/tests/test_uri.py
@@ -39,3 +39,37 @@ def test_key_includes_host():
 def test_parse_rejects_malformed(bad):
     with pytest.raises(RemoteFetchPathError):
         parse_uri(bad)
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "git+https://../evil/widgets#subdirectory=a.dot",
+        "git+https://github.com/../widgets#subdirectory=a.dot",
+        "git+https://github.com/acme/..#subdirectory=a.dot",
+    ],
+)
+def test_parse_rejects_traversal_in_host_owner_repo(bad):
+    with pytest.raises(RemoteFetchPathError):
+        parse_uri(bad)
+
+
+def test_parse_rejects_traversal_in_ref():
+    with pytest.raises(RemoteFetchPathError):
+        parse_uri("git+https://github.com/acme/widgets@../../etc#subdirectory=a.dot")
+
+
+def test_parse_rejects_traversal_in_path_segment():
+    with pytest.raises(RemoteFetchPathError):
+        parse_uri("git+https://github.com/acme/widgets#subdirectory=a/../../etc/passwd")
+
+
+def test_parse_rejects_absolute_path():
+    with pytest.raises(RemoteFetchPathError):
+        parse_uri("git+https://github.com/acme/widgets#subdirectory=/etc/passwd")
+
+
+def test_parse_allows_normal_multi_segment_path():
+    o = parse_uri("git+https://github.com/acme/widgets#subdirectory=a/b/c.dot")
+    assert o.path == "a/b/c.dot"
+


### PR DESCRIPTION
## Summary

Adds **remote `git+https://` DOT-source support to the engine itself**, so a pipeline whose entry file *and* recursively-referenced subgraphs (cross-repo included) live in remote git repos can be fetched, materialized, and executed with only the `loop-pipeline` engine loaded — no external resolver or orchestrator required. Delivered as a clean **two-layer** design that keeps the engine core network-free:

- **Layer A — new standalone `modules/remote-source/`** (resource-agnostic, `httpx`-only, zero DOT knowledge): `git+https://` URI grammar, token resolution (`$GITHUB_TOKEN` → `$GH_TOKEN` → best-effort `gh auth token` → anonymous), host-configurable Contents-API transport with local git-blob-SHA integrity, a persistent **content-addressed cache** (immutable refs never re-fetched; `@main` revalidated via ETag/SHA; `$ATTRACTOR_CACHE_DIR`/`$ATTRACTOR_RELOAD`), and a `FetchLimits` safety envelope.
- **Layer B — `loop-pipeline/remote_dot.py`**: async recursive materializer that walks `dot_file=` refs, fetches via Layer A, rewrites cross-origin refs to local cache paths, and mirrors repo layout so the engine's existing `source_dir`-relative resolution works unchanged. Imports Layer A **lazily** (Layer A is an optional `[remote]` extra), so importing the engine core never pulls `httpx`.
- **Engine hooks (both entry points)**: an `await`-before-parse source-loader in `drive_engine` (`pipeline-runner`) **and** the mounted `PipelineOrchestrator.execute()` (`loop-pipeline`), each with a per-run cleanup seam and a guard so a `git+https://` URL is never logged as DOT.

The spec's synchronous `Transform` protocol can't carry an async recursive fetch, so this uses an async source-loader at the entry (mirroring the proven `materialize_dot_tree` flow) rather than a `Transform`. The dot-graph resolver is **not** touched — its migration/deletion is a deliberately-separate follow-up.

## Verification checklist

- [x] Unit tests pass (`pytest modules/loop-pipeline/`)
- [x] Live pipeline run exercising changed code path — required when touching engine/handler; real end-to-end run output pasted below
- [x] AGENTS.md reviewed; repo-specific gates met (incl. the dependency-awareness rule — one downstream-platform reference in a docstring was neutralized in `4681b14`)
- [x] Backward-compat path unchanged — the non-`git+https://` path is byte-identical (only re-indented under the new branch); full pre-existing suites stay green
- [x] PR body includes verification evidence, not just "tests pass"

## Verification evidence

**Unit suites (all three modules):**
```
modules/remote-source   : 36 passed, 1 skipped        (uri/limits/errors + fetch & cache via respx; 1 real SHA-pinned fetch is env-gated)
modules/loop-pipeline   : 1404 passed, 1 skipped, 1 failed
modules/pipeline-runner : 34 passed, 1 skipped
ruff check modules/remote-source modules/loop-pipeline modules/pipeline-runner  → clean (on changed files)
```
The single `loop-pipeline` failure is `test_git_commit_loud_fail.py::test_git_commit_without_identity_fails_loudly` — **pre-existing on `main`, unrelated** to this change (fails because the CI/dev box supplies a git identity, defeating the "no identity" expectation). It fails identically before and after this branch.

**Engine-core stays network-free (Task 13 guard, subprocess-isolated):**
```
$ uv run --extra remote python -c "import sys; import amplifier_module_loop_pipeline; print('httpx' in sys.modules)"
False                      # httpx installed & importable (0.28.1), but the core import never pulls it
```

**Live end-to-end run — the real proof (no external resolver, real public repo).**
A real remote pipeline pinned to an immutable commit, exercising an in-origin subgraph, a nested subgraph, and a cross-repo subgraph, driven straight through `run_pipeline` → `drive_engine`:
```
$ ATTRACTOR_TEST_REMOTE_ENTRY='git+https://github.com/<public-samples>@<pinned-sha>#subdirectory=pipelines/main.dot' \
    uv run pytest tests/test_remote_end_to_end.py -q -rA
1 passed
```
Inspecting the run artifacts confirms the full traversal actually fired (not just a green status):
```
STATUS: success
NOTES : Tool completed: printf 'cross_repo_lib_reached'
logs/Start/…  logs/WriteProof/…  proof.txt="hello"
logs/subgraph_InOriginChild/…            # in-origin subgraph executed
logs/subgraph_InOriginChild/subgraph_GrandchildRef/…   # nested subgraph executed
logs/subgraph_CrossRepoLib/…             # cross-repo subgraph executed
```
This live run is what caught the milestone's most important bug: materialized entries never set `graph.source_dir`, so subgraph refs resolved against cwd instead of the fetched tree — every mocked test passed, the real graph failed at the first subgraph. Fixed in `d220243`; the run above is post-fix. Offline (no env var) the test auto-skips (`1 skipped`), so CI stays deterministic.

## Notes for reviewers

- **Async-Transport vs. spec §9 Transform:** the spec's `Transform.apply(graph)->Graph` is synchronous, so it can't perform the async recursive fetch. This ships an async source-loader at the two engine entry points instead — closer to the existing `materialize_dot_tree` flow. `transforms=`/`extra_handlers=` engine plumbing is intentionally deferred to a future script-harness follow-up.
- **Both entry paths are hooked on purpose** (`drive_engine` and mounted `execute()`); hooking only one silently breaks remote sources for the other consumer.
- **Cleanup seams:** each hook wraps the materialize→parse window with `except BaseException: cleanup(); raise` and the run body with `try/finally: cleanup()`, so a per-run materialized view never leaks (a leak in the mounted path was caught in review and fixed in `3c09222`, with a regression test).
- **Security hardening in Layer A:** path-traversal rejection (URI grammar + a cache containment check) and a corrected per-blob lock so a losing writer can't delete the winner's lock (`b5bb448`, fail-before/pass-after tested).
- **Scope:** the dot-graph resolver's own `remote_dot.py` is untouched. Flipping it to this engine path and deleting its copy — behind a compatibility gate (behavioral parity + a resolution-equivalence differential) — is a separate Milestone 2 PR.
- 20 focused commits; happy to squash on merge if preferred.
