### PR TITLE
fix: correct agent-visible shape tables; pin SHAPE_TO_HANDLER to upstream nlspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,10 +193,12 @@ Quick version -- pipelines are Graphviz DOT digraphs where node shapes determine
 | `Mdiamond` | Start node (entry point) |
 | `Msquare` | Exit node (pipeline end) |
 | `box` | LLM agent node (default) |
+| `diamond` | Conditional routing point (no-op handler; edges do the routing) |
 | `component` | Parallel fan-out |
 | `tripleoctagon` | Parallel fan-in (collect results) |
 | `hexagon` | Human approval gate |
 | `parallelogram` | External tool execution |
+| `folder` | Nested sub-pipeline (runs a child DOT via `dot_file=`) |
 | `house` | Manager/supervisor loop |
 
 Minimal pipeline:

--- a/context/dot-reference.md
+++ b/context/dot-reference.md
@@ -12,12 +12,19 @@ Quick reference for generating Attractor DOT pipelines.
 | `component` | parallel | Fan-out: runs all outgoing edges concurrently |
 | `tripleoctagon` | parallel.fan_in | Fan-in: collects parallel branch results |
 | `parallelogram` | tool | Direct tool invocation (no LLM) |
+| `diamond` | conditional | Explicit routing point -- no-op handler; the engine's edge selection does the work |
 | `hexagon` | wait.human | Pauses for human approval before proceeding |
-| `house` | stack.manager_loop | Nested sub-pipeline (advanced) |
+| `folder` | pipeline | Nested sub-pipeline -- runs a child DOT via `dot_file=` [EXTENSION] |
+| `house` | stack.manager_loop | Supervisor loop over a child pipeline (experimental) |
 
-**Routing via edge conditions:** There is no separate routing/diamond shape.
-Use `condition=` attributes on outgoing edges from any node to control flow.
-Put your logic in a `box` node, then attach conditional edges to route on outcome.
+Source of truth: `SHAPE_TO_HANDLER` in `modules/loop-pipeline/amplifier_module_loop_pipeline/validation.py`.
+
+**Routing via edge conditions.** `diamond` exists and is the conventional marker for a branch
+point, but it does **no work** -- its handler is a no-op and the actual routing is performed by
+the engine's edge-selection algorithm. So routing is always the same mechanism regardless of
+shape: a node writes a value into context, and `condition=` on the outgoing edges selects the
+path. Use `diamond` when you want the branch to be visually obvious; omit it when the branch
+hangs directly off the node that produced the value.
 
 ## Essential Node Attributes
 
@@ -31,7 +38,7 @@ node_id [
     fidelity="full",             // full|compact|summary:high|summary:low
     llm_provider="anthropic",    // Override provider for this node
     llm_model="claude-sonnet-4-6", // Override model
-    reasoning_effort="high",     // low|medium|high
+    reasoning_effort="high",     // low|medium|high -- NO DEFAULT: unset unless you set it
     auto_status=true,            // Force success regardless of outcome
     timeout=30s                  // Per-node timeout
 ]
@@ -74,7 +81,9 @@ shape_or_class { property: value; property: value; }
 ```
 
 Selectors: `box`, `hexagon`, `parallelogram`, or any shape name; `.my_class` (via `class="my_class"` on node).
-Properties: `llm_provider`, `llm_model`, `reasoning_effort`, `max_retries`, `fidelity`.
+Properties: `llm_provider`, `llm_model`, `reasoning_effort` -- **these three only.**
+Any other property (e.g. `max_retries`, `fidelity`) is **silently ignored**: set those as node
+attributes instead. See `_RECOGNIZED_PROPERTIES` in `stylesheet.py`.
 
 ## Condition Expression Syntax
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -1,0 +1,21 @@
+# Historical implementation plans — NOT current reference
+
+Every file in this directory is a **point-in-time plan or design record**. Plans were often
+superseded, partially implemented, or implemented differently than written. They are kept for
+provenance, not guidance.
+
+**Do not treat anything here as a description of how the system currently works.**
+
+Several of these documents describe interfaces and vocabulary that no longer exist — for
+example, shape tables listing shapes the engine does not support. Reading them as current
+reference is a known way to generate invalid pipelines.
+
+Current, authoritative sources:
+
+| For | Read |
+|---|---|
+| Node shapes and handlers | `SHAPE_TO_HANDLER` in `modules/loop-pipeline/amplifier_module_loop_pipeline/validation.py` (pinned to upstream by test) |
+| Agent-facing reference card | `context/dot-reference.md` (pinned to `SHAPE_TO_HANDLER` by test) |
+| Authoring guidance | `docs/DOT-AUTHORING-GUIDE.md`, `docs/DOT-SYNTAX.md` |
+| Engine semantics and deltas | `context/engine-semantics.md`, `specs/EXTENSIONS.md` |
+| Upstream contract | `specs/canonical/` |

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/backend.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/backend.py
@@ -85,7 +85,8 @@ class AmplifierBackend:
       (LLM call → tool execution → repeat).
 
     Supports fidelity-based context control:
-    - ``full``: Reuses sessions via a thread-keyed session pool.
+    - ``full``: Fresh spawn with prior node exchanges replayed as ``parent_messages``
+      (thread-keyed transcript, NOT a session pool -- see the module docstring above).
     - ``compact``/``truncate``/``summary:*``: Fresh session with preamble.
     """
 
@@ -134,7 +135,9 @@ class AmplifierBackend:
         """Create a clone with shared immutable refs but fresh mutable state.
 
         Used for parallel branch isolation so concurrent branches don't
-        corrupt each other's session pools or completion tracking.
+        corrupt each other's thread transcripts or completion tracking.
+        (``_thread_transcripts`` is reset here, so branches sharing an
+        explicit ``thread_id`` still each start fresh -- EXTENSIONS.md §13.)
         """
         new = AmplifierBackend.__new__(AmplifierBackend)
         # Shared immutable refs

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/fidelity.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/fidelity.py
@@ -7,7 +7,10 @@ window usage across multi-stage pipelines.
 Spec coverage: FID-001–010, Section 5.4.
 
 Modes:
-    full           – Reuse session (same thread), full history preserved.
+    full           – Fresh spawn, prior node exchanges replayed as ``parent_messages``.
+                     NOT session reuse: continuity is a transcript replayed into a new
+                     spawn, at node-exchange granularity, branch-local. See
+                     ``backend.py`` module docstring and EXTENSIONS.md §12–13.
     truncate       – Fresh session, minimal: only graph goal and run ID.
     compact        – Fresh session, structured bullet-point summary.
     summary:low    – Fresh session, ~600 token text summary.
@@ -166,7 +169,8 @@ def build_preamble(
     """Build a context preamble string for a fresh session.
 
     The preamble synthesizes prior execution state for nodes that
-    don't use full fidelity (which reuses sessions instead).
+    don't use full fidelity (which carries prior state as replayed
+    ``parent_messages`` on a fresh spawn instead of as a preamble).
 
     Args:
         fidelity: The resolved fidelity mode.

--- a/modules/loop-pipeline/tests/test_batch_d_pipeline_infra.py
+++ b/modules/loop-pipeline/tests/test_batch_d_pipeline_infra.py
@@ -409,7 +409,7 @@ class TestM21ShapeNameSelectors:
             name="test",
             nodes={
                 "code_node": Node(id="code_node", shape="box", prompt="Code"),
-                "human_node": Node(id="human_node", shape="ellipse", prompt="Review"),
+                "human_node": Node(id="human_node", shape="hexagon", prompt="Review"),
             },
             edges=[],
         )

--- a/modules/loop-pipeline/tests/test_validation.py
+++ b/modules/loop-pipeline/tests/test_validation.py
@@ -919,17 +919,31 @@ def _repo_root():
     return Path(__file__).parent.parent.parent.parent
 
 
-def test_doc_diamond_not_in_dot_reference_shape_table():
-    """context/dot-reference.md must NOT list diamond as a supported shape (D-128).
+def test_doc_shape_tables_match_shape_to_handler():
+    """Agent-visible shape tables must match SHAPE_TO_HANDLER exactly.
 
-    diamond was removed from SHAPE_TO_HANDLER; listing it in the agent-visible
-    reference card causes agents to generate invalid pipelines.
+    Derived from ground truth rather than a hardcoded snapshot, because the
+    hardcoded form went stale and became a guard protecting a false claim:
+
+      2026-04-11  diamond/conditional removed from SHAPE_TO_HANDLER
+      2026-04-17  test added asserting "diamond must NOT appear in docs"
+      2026-05-23  ConditionalHandler implemented -- diamond RE-ADDED
+
+    For two months the test enforced the April state against May's code, so
+    the reference card silently under-documented a supported shape and any
+    attempt to correct it hit a red bar.  A derived assertion cannot drift:
+    add or remove a shape in SHAPE_TO_HANDLER and this test tells you which
+    doc to update.
     """
+    from amplifier_module_loop_pipeline.validation import SHAPE_TO_HANDLER
+
     doc = (_repo_root() / "context" / "dot-reference.md").read_text()
-    # Match a markdown table row whose first cell is exactly `diamond`
-    assert "| `diamond` |" not in doc, (
-        "context/dot-reference.md still lists 'diamond' as a shape in the "
-        "handler table — remove it (D-128)"
+    documented = {s for s in SHAPE_TO_HANDLER if f"| `{s}` |" in doc}
+    missing = set(SHAPE_TO_HANDLER) - documented
+    assert not missing, (
+        f"context/dot-reference.md omits supported shape(s) {sorted(missing)} "
+        f"from its handler table. Agents read this file; an omitted shape is a "
+        f"capability they will never use. Add a row for each."
     )
 
 
@@ -946,13 +960,18 @@ def test_doc_ellipse_not_in_dot_reference_shape_table():
     )
 
 
-def test_doc_diamond_not_in_readme_shape_table():
-    """README.md must NOT list diamond as a supported shape (D-127).
+def test_readme_shape_table_matches_shape_to_handler():
+    """README.md's shape table must not omit a supported shape.
 
-    Same root cause as D-128 — diamond has no registered handler.
+    Superseded D-127, whose premise ("diamond has no registered handler") was
+    invalidated when ConditionalHandler landed -- see
+    test_doc_shape_tables_match_shape_to_handler for the full timeline.
     """
+    from amplifier_module_loop_pipeline.validation import SHAPE_TO_HANDLER
+
     doc = (_repo_root() / "README.md").read_text()
-    assert "| `diamond` |" not in doc, (
-        "README.md still lists 'diamond' as a shape in the handler table "
-        "— remove it (D-127)"
+    documented = {s for s in SHAPE_TO_HANDLER if f"| `{s}` |" in doc}
+    missing = set(SHAPE_TO_HANDLER) - documented
+    assert not missing, (
+        f"README.md omits supported shape(s) {sorted(missing)} from its shape table."
     )

--- a/modules/loop-pipeline/tests/test_validation.py
+++ b/modules/loop-pipeline/tests/test_validation.py
@@ -4,6 +4,8 @@ Covers spec Section 7 (Validation and Linting): diagnostic model,
 built-in lint rules, and validate/validate_or_raise API.
 """
 
+import re
+
 import pytest
 
 from amplifier_module_loop_pipeline.graph import Edge, Graph, Node
@@ -658,12 +660,44 @@ def test_extra_rules_multiple():
 # --- SHAPE_TO_HANDLER / _LLM_SHAPES completeness ---
 
 
-def test_ellipse_removed_from_shape_to_handler():
-    """ellipse shape must NOT be in SHAPE_TO_HANDLER (removed — was never used)."""
+# Shapes this implementation adds beyond the upstream nlspec §2.8 table.
+# Every entry here MUST have a corresponding record in specs/EXTENSIONS.md.
+_INTENTIONAL_SHAPE_EXTENSIONS = {"folder": "pipeline"}
+
+
+def test_shape_to_handler_conforms_to_upstream_nlspec():
+    """SHAPE_TO_HANDLER must equal the upstream §2.8 table plus recorded extensions.
+
+    This is the guard that was missing.  In 2026-04 `diamond`/`conditional` was
+    deleted from SHAPE_TO_HANDLER on the reasoning that a no-op handler is
+    redundant -- but upstream §2.8 lists it and §4.7 specifies it, and being a
+    no-op is the design.  Nothing caught the divergence.  The consequence
+    (found six weeks later, in the commit that restored it): `shape=diamond`
+    silently fell through to the codergen LLM handler, so every routing node
+    became a paid model call.
+
+    Deriving from the spec makes that class of drift impossible to land
+    quietly: remove a spec-mandated shape and this test names it.  Add a new
+    one and you must record it in _INTENTIONAL_SHAPE_EXTENSIONS *and*
+    specs/EXTENSIONS.md.  It also subsumes every "shape X must not exist"
+    assertion -- phantom vocabulary fails set equality without being named.
+    """
     from amplifier_module_loop_pipeline.validation import SHAPE_TO_HANDLER
 
-    assert "ellipse" not in SHAPE_TO_HANDLER, (
-        "ellipse should be removed from SHAPE_TO_HANDLER"
+    spec = (_repo_root() / "specs" / "canonical" / "attractor-spec-canonical.md").read_text()
+    rows = re.findall(r"^\|\s*`([A-Za-z]+)`\s*\|\s*`([a-z_.]+)`", spec, re.M)
+    upstream = {shape: handler for shape, handler in rows}
+    assert upstream, "could not parse the §2.8 shape table from the canonical spec"
+
+    expected = {**upstream, **_INTENTIONAL_SHAPE_EXTENSIONS}
+    assert SHAPE_TO_HANDLER == expected, (
+        f"SHAPE_TO_HANDLER diverges from upstream nlspec §2.8.\n"
+        f"  missing (spec requires): {sorted(set(expected) - set(SHAPE_TO_HANDLER))}\n"
+        f"  unrecorded extras:       {sorted(set(SHAPE_TO_HANDLER) - set(expected))}\n"
+        f"  handler mismatches:      "
+        f"{ {k: (expected[k], SHAPE_TO_HANDLER[k]) for k in set(expected) & set(SHAPE_TO_HANDLER) if expected[k] != SHAPE_TO_HANDLER[k]} }\n"
+        f"An intentional addition must be recorded in _INTENTIONAL_SHAPE_EXTENSIONS "
+        f"and specs/EXTENSIONS.md."
     )
 
 
@@ -938,25 +972,13 @@ def test_doc_shape_tables_match_shape_to_handler():
     from amplifier_module_loop_pipeline.validation import SHAPE_TO_HANDLER
 
     doc = (_repo_root() / "context" / "dot-reference.md").read_text()
-    documented = {s for s in SHAPE_TO_HANDLER if f"| `{s}` |" in doc}
-    missing = set(SHAPE_TO_HANDLER) - documented
-    assert not missing, (
-        f"context/dot-reference.md omits supported shape(s) {sorted(missing)} "
-        f"from its handler table. Agents read this file; an omitted shape is a "
-        f"capability they will never use. Add a row for each."
-    )
-
-
-def test_doc_ellipse_not_in_dot_reference_shape_table():
-    """context/dot-reference.md must NOT list ellipse as a supported shape (D-129).
-
-    ellipse was removed from SHAPE_TO_HANDLER; documenting it as an alias
-    is misleading even though it falls through to the default codergen handler.
-    """
-    doc = (_repo_root() / "context" / "dot-reference.md").read_text()
-    assert "| `ellipse` |" not in doc, (
-        "context/dot-reference.md still lists 'ellipse' as a shape in the "
-        "handler table — remove it (D-129)"
+    documented = set(re.findall(r"^\| `([A-Za-z]+)` \|", doc, re.M))
+    assert documented == set(SHAPE_TO_HANDLER), (
+        f"context/dot-reference.md shape table diverges from SHAPE_TO_HANDLER.\n"
+        f"  omitted (a capability agents will never use): "
+        f"{sorted(set(SHAPE_TO_HANDLER) - documented)}\n"
+        f"  phantom (vocabulary the engine rejects):      "
+        f"{sorted(documented - set(SHAPE_TO_HANDLER))}"
     )
 
 
@@ -970,8 +992,10 @@ def test_readme_shape_table_matches_shape_to_handler():
     from amplifier_module_loop_pipeline.validation import SHAPE_TO_HANDLER
 
     doc = (_repo_root() / "README.md").read_text()
-    documented = {s for s in SHAPE_TO_HANDLER if f"| `{s}` |" in doc}
-    missing = set(SHAPE_TO_HANDLER) - documented
-    assert not missing, (
-        f"README.md omits supported shape(s) {sorted(missing)} from its shape table."
+    table = doc.split("| Shape |")[1].split("\n\n")[0] if "| Shape |" in doc else doc
+    documented = set(re.findall(r"^\| `([A-Za-z]+)` \|", table, re.M))
+    assert documented == set(SHAPE_TO_HANDLER), (
+        f"README.md shape table diverges from SHAPE_TO_HANDLER.\n"
+        f"  omitted: {sorted(set(SHAPE_TO_HANDLER) - documented)}\n"
+        f"  phantom: {sorted(documented - set(SHAPE_TO_HANDLER))}"
     )


### PR DESCRIPTION
## Summary

Corrects factual errors in agent-visible shape documentation and adds the conformance guard whose absence let a spec-mandated node shape get deleted and silently break routing for six weeks. `context/dot-reference.md` is loaded into agent context, so errors in it propagate into every generated pipeline — it omitted two supported shapes (`diamond`, `folder`), falsely stated "there is no separate routing/diamond shape", mislabeled `house` as the nested sub-pipeline (that is `folder`), listed `max_retries`/`fidelity` as stylesheet properties when only three are recognized and the rest are silently ignored, and propagated a `reasoning_effort` default that does not exist in code. Also removes `ellipse` phantom vocabulary per context-poisoning guidance, and replaces hardcoded doc-consistency assertions with checks derived from `SHAPE_TO_HANDLER` and from the upstream nlspec so this class of drift cannot land quietly again.

## Verification checklist

- [x] Unit tests pass (`pytest modules/loop-pipeline/`)
- [ ] Live pipeline run exercising changed code path — **N/A: no executable line changed.** The only edits inside engine files (`backend.py`, `fidelity.py`) are docstring corrections. All behavioral surface in this PR is tests and documentation, which `AGENTS.md` places in the "unit tests sufficient" tier of the verification gradient. Flagging rather than silently checking the box.
- [x] AGENTS.md reviewed; repo-specific gates met
- [x] Backward-compat path unchanged (no runtime behavior modified)
- [x] PR body includes verification evidence, not just "tests pass"

## Verification evidence

**Test suite:**
```
pytest modules/loop-pipeline/ -q
1387 passed, 9 failed, 3 warnings in 21.78s
```

All 9 failures are **pre-existing and unrelated** — `test_model_token_resolution.py`, failing with:
```
AttributeError: module 'unified_llm' has no attribute 'resolve_latest_for'
```
an installed-package version skew against the test's monkeypatch target. Confirmed pre-existing by stashing these changes and re-running on a clean tree: identical 9 failures. Passed count moved 1388 -> 1387 solely because one subsumed test was deleted.

**The new conformance guard was proven to have teeth** — temporarily removed `diamond` from `SHAPE_TO_HANDLER`:
```
E   missing (spec requires): ['diamond']
```
then restored it.

**Shape-set comparison, upstream nlspec vs this implementation:**
```
upstream nlspec : 9 shapes
implementation  : 10 shapes

handler mismatches: NONE
impl-only (delta):  ['folder']   (recorded in specs/EXTENSIONS.md §10)
upstream-only:      NONE
```

## Notes for reviewers

**Why the guard was missing, and what it cost.** In 2026-04, `diamond`/`conditional` was removed from `SHAPE_TO_HANDLER` on the reasoning that a no-op handler is redundant since routing works from any node type. But upstream §2.8 lists the shape and §4.7 specifies it — being a no-op *is* the design. Nothing caught the divergence. The consequence, found six weeks later in the commit that restored it (`aa44fca`): `shape=diamond` silently fell through to the codergen LLM handler, so every routing node became a paid model call.

**A stale test was actively guarding the false claim.** A 2026-04 test asserted "diamond must NOT appear in docs." `ConditionalHandler` landed in 2026-05 and re-added the shape, but the April test was never updated — so for two months it enforced April's state against May's code, and any attempt to correct the reference card hit a red bar. This is the "aspirational contract" bug class from `docs/designs/RECURRING-BUG-CLASSES.md`, with the additional property that it prevented its own fix.

**All three doc/spec guards are now derived, not hardcoded**, so the same drift cannot recur:
- `test_shape_to_handler_conforms_to_upstream_nlspec` — parses `specs/canonical/attractor-spec-canonical.md` and asserts set equality against `SHAPE_TO_HANDLER` plus `_INTENTIONAL_SHAPE_EXTENSIONS`. A new extension must be recorded in both that constant and `specs/EXTENSIONS.md`.
- Doc-table tests now assert **set equality** rather than "no missing shapes", catching omitted shapes *and* phantom shapes in a single assertion.

**Ellipse removal (context poisoning).** Two per-shape negative tests deleted — both are subsumed by set equality, so no removed shape ever needs a named guard again. A stylesheet negative-control fixture used the invalid `shape="ellipse"` purely to be not-`box`; it now uses `hexagon`, a real shape that also matches the fixture's own node name. Four historical plan docs under `docs/plans/` still contain shape tables listing `ellipse`; rather than rewrite dated records and falsify them, that directory now carries a `README.md` marking everything in it as superseded provenance and pointing at the authoritative sources.

**Also corrected: four stale docstrings** claiming `fidelity=full` "reuses sessions" / uses a "thread-keyed session pool". It has done neither since the `parent_messages` rework — continuity is a transcript replayed into a fresh spawn at node-exchange granularity, branch-local, as documented in `specs/EXTENSIONS.md` §12–13 and the `backend.py` module docstring.

**Follow-up not included here:** the `reasoning_effort` default is genuinely ambiguous — code treats it as unset while four docs claim `high`, and the upstream sibling spec calls `medium` the default. That is a decision for a maintainer (fix the docs, or implement the default and record the delta), not something this PR should resolve unilaterally. The reference card now notes the code behavior.