### PR TITLE
fix(examples): replace dead diamond+outcome= gates with evidence-based routing

### DIFF
--- a/docs/reports/upstream-ecosystem-fixes.md
+++ b/docs/reports/upstream-ecosystem-fixes.md
@@ -194,6 +194,33 @@ if check_first_run():
 
 ---
 
+---
+
+## Fix 8: ConditionalHandler Should NOT Pass Through Upstream Outcomes (T0-1 Upstream Rec)
+
+**Severity:** LOW (the correct fix is at the graph level; this is a spec clarification)
+**Repo:** `amplifier-bundle-attractor` (this repo) — `modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/conditional.py`
+**Discovered by:** T0-1 dead-edge analysis (2026-07)
+**Status:** Resolved at graph level (T0-1). Upstream spec clarification recommended.
+
+**The situation:** `ConditionalHandler.execute()` unconditionally returns `Outcome(status=StageStatus.SUCCESS)`. It does NOT pass through the upstream node's outcome. This means a `shape=diamond` node followed by `condition="outcome!=success"` edges creates a dead edge — the diamond always produces SUCCESS, so the `outcome!=success` branch can never match.
+
+**Why the graph-level fix is correct:** A diamond (`shape=diamond`) is the right tool when routing on `context.*` keys set by *earlier* nodes (e.g., a `preferred_label` from a `report_outcome` call). In that use case, the diamond is a pure routing switch — its own outcome is irrelevant, and unconditional SUCCESS is correct. The bug was in the graph authors using diamonds with `outcome=` conditions, not in ConditionalHandler's behavior.
+
+**The T0-1 fix:** Replace `shape=diamond` + `condition="outcome=..."` with `shape=parallelogram` + `tool_command` that runs the real verifier and prints a routing token, routed via `condition="context.tool.last_line=<token>"`. This is the correct pattern — it routes on observed evidence, not on the handler's synthetic outcome.
+
+**Upstream recommendation (not a code change):** The canonical spec at `github.com/strongdm/attractor` should clarify:
+1. `shape=diamond` (ConditionalHandler) is for routing on `context.*` keys set by earlier nodes — NOT for routing on `outcome=` of the node before it.
+2. `condition="outcome=..."` on edges from a diamond is always a bug (dead edge).
+3. The correct pattern for evidence-based routing is `shape=parallelogram` + `tool_command` + `condition="context.tool.last_line=<token>"`.
+
+**Why NOT change ConditionalHandler to pass through upstream outcomes:** If ConditionalHandler passed through the upstream outcome, it would break the valid use case where a diamond routes on `context.*` keys (e.g., `preferred_label`). The diamond would then need to be SUCCESS for the normal case AND pass through FAIL for the error case — conflating two different routing semantics. The cleaner design is: diamond = context-key routing (always SUCCESS); parallelogram = evidence routing (outcome reflects tool exit code).
+
+**Scope:** Spec documentation PR to `github.com/strongdm/attractor`, no code change.
+**Blocks:** Nothing (already fixed at graph level in T0-1).
+
+---
+
 ## Summary
 
 | # | Repo | Bug | Severity | Status | Blocks |
@@ -205,6 +232,7 @@ if check_first_run():
 | **5** | amplifier-foundation | tool-delegate spawn kwargs vs spawn() params | **MEDIUM** | Not started | Spawn contract clarity |
 | **6** | amplifier-app-cli | Misleading init tip message | **LOW** | Not started | UX |
 | **7** | amplifier-app-cli | No auto-init for non-interactive | **MEDIUM** | Not started | Shadow/CI workflows |
+| **8** | attractor spec | ConditionalHandler/diamond routing semantics clarification | **LOW** | Resolved at graph level (T0-1) | Future graph authors |
 
 ### Recommended Fix Order
 

--- a/examples/pipelines/03-conditional-routing.dot
+++ b/examples/pipelines/03-conditional-routing.dot
@@ -1,8 +1,14 @@
-// 03-conditional-routing.dot -- Diamond gates with condition expressions.
+// 03-conditional-routing.dot -- Evidence-based routing with tool gates.
 //
-// A pipeline where a test result routes through a diamond (conditional) node.
-// Tests: diamond handler (shape=diamond), edge conditions (outcome=success,
-//        outcome!=success), conditional branching, edge weights, retry loops.
+// A pipeline where a test result routes through a parallelogram (tool) gate node.
+// Tests: tool handler (shape=parallelogram), edge conditions on context.tool.last_line,
+//        evidence-based conditional branching, edge weights, retry loops.
+//
+// ROUTING PATTERN: The gate runs the real verifier (pytest) and prints a token
+// ("pass" or "fail") as its last stdout line. Edges condition on that token via
+// context.tool.last_line. This is the correct pattern -- NOT shape=diamond with
+// outcome= conditions (ConditionalHandler always returns SUCCESS, so outcome-based
+// edges from a diamond are dead).
 
 digraph ConditionalRouting {
     graph [
@@ -20,34 +26,38 @@ digraph ConditionalRouting {
     // Work nodes
     implement [
         label="Implement",
-        prompt="Write a Python URL shortener service with shorten() and expand() functions for: $goal"
+        prompt="Write a Python URL shortener service with shorten() and expand() functions for: $goal. Write the implementation to url_shortener.py and write pytest tests to test_url_shortener.py."
     ]
 
     test [
         label="Run Tests",
-        prompt="Write and execute tests for the URL shortener. Report success if all tests pass, failure if any fail."
+        prompt="Run the test suite with: pytest -v --tb=short test_url_shortener.py. Report which tests pass and which fail. If all pass, report success. If any fail, report the failure details."
     ]
 
-    // Conditional gate -- the diamond shape makes this a routing node.
-    // The handler itself is a no-op (returns SUCCESS); the engine evaluates
-    // edge conditions against the previous node's outcome and context.
+    // Evidence gate -- shape=parallelogram runs the real verifier.
+    // The tool_command runs pytest and prints a routing token on its last line:
+    //   "pass" -> all tests green  -> route to done
+    //   "fail" -> tests failing    -> route to fix
+    // Edges condition on context.tool.last_line (the last non-empty stdout line).
     gate [
-        shape=diamond,
-        label="Tests Pass?"
+        shape=parallelogram,
+        label="Tests Pass?",
+        tool_command="pytest -q test_url_shortener.py > /dev/null 2>&1 && printf pass || printf fail"
     ]
 
     // Fix node -- only reached when tests fail
     fix [
         label="Fix Issues",
-        prompt="The tests failed. Review the test output and fix the implementation. Focus on the specific failures reported."
+        prompt="The tests failed. Review the test output and fix the implementation. Focus on the specific failures reported.",
+        retry_target="fix"
     ]
 
-    // Flow: implement -> test -> gate -> (success: done, fail: fix -> test)
+    // Flow: implement -> test -> gate -> (pass: done, fail: fix -> test)
     start -> implement -> test -> gate
 
-    // Condition-matched edges: evaluated first in edge selection (Step 1)
-    gate -> done [label="Yes", condition="outcome=success", weight=10]
-    gate -> fix  [label="No",  condition="outcome!=success", weight=5]
+    // Condition-matched edges: evaluated against context.tool.last_line (Step 1)
+    gate -> done [label="pass", condition="context.tool.last_line=pass", weight=10]
+    gate -> fix  [label="fail", condition="context.tool.last_line=fail", weight=5]
 
     // Fix loops back to test for re-validation
     fix -> test

--- a/examples/pipelines/03-conditional-routing.md
+++ b/examples/pipelines/03-conditional-routing.md
@@ -15,18 +15,39 @@ See [README.md](README.md) in this folder for the run pattern and why the `$DOT`
 
 ## What This Exercises
 
-- **Diamond handler**: `shape=diamond` resolves to the `conditional` handler -- a no-op that returns SUCCESS, letting the engine handle routing via edge conditions
-- **Edge conditions**: `condition="outcome=success"` and `condition="outcome!=success"` are evaluated against the context after the `test` node completes
-- **Condition expression language**: The `=` (equals) and `!=` (not equals) operators, with `outcome` as a built-in variable
+- **Parallelogram (tool) gate**: `shape=parallelogram` + `tool_command` runs the real verifier (pytest) and prints a routing token (`pass`/`fail`) as its last stdout line
+- **Evidence-based routing**: Edges condition on `context.tool.last_line=pass` / `context.tool.last_line=fail` -- the routing token written by the gate's tool command
+- **Why not `shape=diamond` + `outcome=`**: `ConditionalHandler` (the diamond handler) unconditionally returns SUCCESS, overwriting whatever the upstream node produced. A `condition="outcome=success"` edge from a diamond is always true; `condition="outcome!=success"` is always false. Those edges are dead. The correct pattern is a parallelogram that runs the real verifier.
 - **Edge weights**: When multiple condition-matched edges are eligible, higher `weight` wins
 - **Retry loop**: The `fix -> test` edge creates a cycle for iterative fixing
+
+## The Routing Pattern Explained
+
+```dot
+// WRONG (dead edges -- ConditionalHandler always returns SUCCESS):
+gate [shape=diamond, label="Tests Pass?"]
+gate -> done [condition="outcome=success"]   // always fires
+gate -> fix  [condition="outcome!=success"]  // never fires
+
+// RIGHT (evidence-based -- routes on what actually happened):
+gate [shape=parallelogram, label="Tests Pass?",
+      tool_command="pytest -q ... && printf pass || printf fail"]
+gate -> done [condition="context.tool.last_line=pass"]
+gate -> fix  [condition="context.tool.last_line=fail"]
+```
+
+Key facts:
+- `shape=parallelogram` maps to the `tool` handler, which runs `tool_command` as a shell command
+- The last non-empty stdout line is stored in `context["tool.last_line"]` automatically
+- Route on `context.tool.last_line`, never on `tool.output` (full stdout never matches a condition exactly)
+- A diamond is only correct when routing on `context.*` keys set by *earlier* nodes (e.g., a `report_outcome` `preferred_label`) -- never on `outcome=` of the node before it
 
 ## Pipeline Structure
 
 ```
-start --> implement --> test --> gate --[success]--> done
-                        ^       |
-                        |       +--[fail]--> fix
+start --> implement --> test --> gate --[pass]--> done
+                        ^        |
+                        |        +--[fail]--> fix
                         |                     |
                         +---------------------+
 ```
@@ -34,39 +55,27 @@ start --> implement --> test --> gate --[success]--> done
 ## Expected Behavior
 
 ### Happy Path (tests pass)
-1. `implement` writes the URL shortener code -> SUCCESS
-2. `test` runs tests -> SUCCESS (sets `outcome=success` in context)
-3. `gate` handler returns SUCCESS (no-op)
-4. Edge selection evaluates conditions on `gate`'s outgoing edges:
-   - `gate -> done`: condition `outcome=success` -- the context has `outcome=success` from the `test` node -> **TRUE**
-   - `gate -> fix`: condition `outcome!=success` -> **FALSE**
-   - Engine picks `gate -> done` (condition matched, weight=10)
-5. Pipeline exits successfully
+1. `implement` writes the URL shortener code and tests -> SUCCESS
+2. `test` (LLM) runs tests and reports results -> SUCCESS
+3. `gate` (parallelogram) runs `pytest -q test_url_shortener.py` directly:
+   - All tests pass -> exits 0 -> prints "pass" -> `context.tool.last_line = "pass"`
+4. Edge selection: `gate -> done` condition `context.tool.last_line=pass` matches -> **done**
 
 ### Fix Path (tests fail)
 1. `implement` writes code -> SUCCESS
-2. `test` runs tests -> SUCCESS (but the *test* node's handler returned success even though the tests it ran may have found issues)
-   - Note: In practice, the codergen handler always returns SUCCESS unless the backend fails. The *outcome* reflects handler execution, not the semantic meaning of the tests. For real conditional routing, you'd need a backend that returns FAIL when tests fail, or use context values like `context.tests_passed=false`.
-3. If `test` returns with `outcome!=success`, the gate routes to `fix`
-4. `fix` attempts repairs, then loops back to `test`
+2. `test` (LLM) runs tests -> SUCCESS (LLM nodes return SUCCESS unless the backend crashes)
+3. `gate` (parallelogram) runs pytest directly:
+   - Tests fail -> exits non-0 -> prints "fail" -> `context.tool.last_line = "fail"`
+4. Edge selection: `gate -> fix` condition `context.tool.last_line=fail` matches -> **fix loop**
+5. `fix` repairs the implementation, then loops back to `test`
 
-### Key Insight: How Conditions Work
-The `gate` (diamond) node itself always succeeds. But the condition expressions on its outgoing edges look at the **context**, which still holds the `outcome` value set by the *previous* node (`test`). The conditional handler is a pass-through that preserves the routing context from the preceding node.
-
-## Or run from a bundle / recipe
-
-```yaml
-steps:
-  - agent: attractor:pipeline-runner
-    instruction: "Run the conditional routing pipeline"
-    context:
-      pipeline_path: "examples/pipelines/03-conditional-routing.dot"
-```
+### Key Insight: Route on Evidence, Not Opinion
+The gate runs the real verifier. The routing token (`pass`/`fail`) is the literal exit code of pytest, not an LLM's assessment of whether tests passed. This is why the loop actually fires when tests fail -- the gate observes what happened and routes accordingly.
 
 ## What to Look For
 
-- `gate/status.json` shows `"outcome": "success"` (the conditional handler itself always succeeds)
-- Edge selection logs show which condition matched and which edge was taken
-- If the happy path is taken: `checkpoint.json` shows `gate` followed by `done`
+- `gate/output.txt` shows `pass` or `fail` on the last line (the routing token)
+- Edge selection logs show `condition="context.tool.last_line=pass"` matched (or `=fail` matched)
+- If the happy path is taken: execution goes `gate -> done`
 - If the fix path is taken: `fix/` directory appears in logs, then another `test/` execution
-- Weights on edges: if both conditions somehow matched, weight=10 beats weight=5
+- The cycle is real: `fix -> test -> gate -> fix` will iterate until tests pass

--- a/examples/pipelines/09-manager-supervisor.dot
+++ b/examples/pipelines/09-manager-supervisor.dot
@@ -55,9 +55,15 @@ digraph ManagerSupervisor {
         prompt="Run the test suite for the data pipeline. Test CSV parsing, data transformation, and database writing. Report success if all tests pass."
     ]
 
+    // Evidence gate -- shape=parallelogram runs the real verifier.
+    // The tool_command runs pytest and prints a routing token on its last line:
+    //   "pass" -> tests green  -> child subgraph exits (manager evaluates stop_condition)
+    //   "fail" -> tests failing -> route back to implement for another fix attempt
+    // Edges condition on context.tool.last_line (the last non-empty stdout line).
     gate [
-        shape=diamond,
-        label="Tests Pass?"
+        shape=parallelogram,
+        label="Tests Pass?",
+        tool_command="pytest -q > /dev/null 2>&1 && printf pass || printf fail"
     ]
 
     // Report on what the manager accomplished
@@ -74,8 +80,8 @@ digraph ManagerSupervisor {
 
     // Child subgraph flow
     implement -> test -> gate
-    gate -> done [label="Pass", condition="outcome=success"]
-    gate -> implement [label="Fail", condition="outcome!=success"]
+    gate -> done      [label="pass", condition="context.tool.last_line=pass"]
+    gate -> implement [label="fail", condition="context.tool.last_line=fail"]
 
     // After manager completes, continue to report
     manager -> report [weight=0]

--- a/examples/pipelines/09-manager-supervisor.md
+++ b/examples/pipelines/09-manager-supervisor.md
@@ -24,6 +24,7 @@ See [README.md](README.md) in this folder for the run pattern and why the `$DOT`
 - **Child context cloning**: Each cycle gets an isolated context clone
 - **Steering injection**: When `steer` is in actions and a previous cycle failed, the manager injects `manager.steering` into the child context with failure details
 - **Cycle telemetry**: Context is updated with `manager.cycle_N.status`, `manager.last_child_status`, `manager.cycles_completed`
+- **Evidence-based gate**: The child's internal `gate` uses `shape=parallelogram` + `tool_command` to run pytest and route on `context.tool.last_line` -- not a diamond routing on `outcome=`. See routing pattern explanation below.
 
 ## Pipeline Structure
 
@@ -31,10 +32,38 @@ See [README.md](README.md) in this folder for the run pattern and why the `$DOT`
 start -> plan -> manager -> report -> done
                    |
                    v (child subgraph, run each cycle)
-                 implement -> test -> gate --[Pass]--> (child complete)
+                 implement -> test -> gate --[pass]--> done (child exits)
                    ^                  |
-                   +---[Fail]---------+
+                   +---[fail]---------+
 ```
+
+## Routing Pattern: Evidence Gate vs. Diamond
+
+The child's `gate` node uses `shape=parallelogram` (tool gate), not `shape=diamond` (conditional gate):
+
+```dot
+// WRONG (dead edges -- ConditionalHandler always returns SUCCESS):
+gate [shape=diamond, label="Tests Pass?"]
+gate -> done      [condition="outcome=success"]   // always fires
+gate -> implement [condition="outcome!=success"]  // never fires
+
+// RIGHT (evidence-based -- routes on what actually happened):
+gate [shape=parallelogram, label="Tests Pass?",
+      tool_command="pytest -q > /dev/null 2>&1 && printf pass || printf fail"]
+gate -> done      [condition="context.tool.last_line=pass"]
+gate -> implement [condition="context.tool.last_line=fail"]
+```
+
+`ConditionalHandler` (the diamond handler) unconditionally returns SUCCESS, overwriting the upstream node's outcome. A `condition="outcome!=success"` edge from a diamond is always false -- the loop never fires. The parallelogram gate runs the real verifier and routes on observed evidence.
+
+## Two-Level Retry Structure
+
+This pipeline has two levels of retry:
+
+1. **Child-level loop**: `gate` routes `implement -> test -> gate` on failure. The child can loop multiple times within a single manager cycle.
+2. **Manager-level retry**: If the child subgraph fails overall, the manager starts a new cycle (up to `max_cycles=5`) with steering context injected.
+
+The child's evidence gate (level 1) handles within-cycle test failures. The manager's outer loop (level 2) handles cross-cycle retry with LLM steering guidance.
 
 ## Expected Behavior
 

--- a/examples/pipelines/10-full-attractor.dot
+++ b/examples/pipelines/10-full-attractor.dot
@@ -110,9 +110,15 @@ digraph FullAttractor {
         prompt="Run the full test suite:\n- Backend unit tests (WebSocket, email, API)\n- Frontend component tests (NotificationCenter, Toast)\n- Integration tests (end-to-end notification flow)\nReport pass/fail for each category."
     ]
 
+    // Evidence gate -- shape=parallelogram runs the real verifier.
+    // The tool_command runs pytest and prints a routing token on its last line:
+    //   "pass" -> all tests green  -> route to final_review
+    //   "fail" -> tests failing    -> route to fix_tests
+    // Edges condition on context.tool.last_line (the last non-empty stdout line).
     test_gate [
-        shape=diamond,
-        label="All Tests Pass?"
+        shape=parallelogram,
+        label="All Tests Pass?",
+        tool_command="pytest -q > /dev/null 2>&1 && printf pass || printf fail"
     ]
 
     // Fix node for test failures
@@ -166,9 +172,9 @@ digraph FullAttractor {
     // Testing with conditional routing
     integrate -> test -> test_gate
 
-    // Conditional edges with conditions and weights
-    test_gate -> final_review [label="Pass", condition="outcome=success", weight=10]
-    test_gate -> fix_tests    [label="Fail", condition="outcome!=success", weight=5]
+    // Evidence-based edges: condition on context.tool.last_line from the pytest run
+    test_gate -> final_review [label="pass", condition="context.tool.last_line=pass", weight=10]
+    test_gate -> fix_tests    [label="fail", condition="context.tool.last_line=fail", weight=5]
 
     // Fix loops back to test
     fix_tests -> test

--- a/examples/pipelines/10-full-attractor.md
+++ b/examples/pipelines/10-full-attractor.md
@@ -24,7 +24,7 @@ This is a realistic "build a feature" pipeline that exercises **every Attractor 
 | Feature | Where Used |
 |---------|-----------|
 | **Linear traversal** | start -> plan, integrate -> test, final_review -> review_gate |
-| **Conditional routing** | test_gate (diamond) with `outcome=success` / `outcome!=success` |
+| **Evidence-based routing** | test_gate (parallelogram) with `context.tool.last_line=pass` / `context.tool.last_line=fail` |
 | **Parallel fan-out** | parallel_impl (component) -> backend + frontend branches |
 | **Parallel fan-in** | collect (tripleoctagon) consolidates branch results |
 | **Human gate** | review_gate (hexagon) with [S]/[P]/[R] accelerator keys |
@@ -36,7 +36,7 @@ This is a realistic "build a feature" pipeline that exercises **every Attractor 
 | **Thread IDs** | `thread_id="backend-impl"` and `thread_id="frontend-impl"` for session reuse |
 | **$goal expansion** | Used in plan, implement_backend, implement_frontend prompts |
 | **Edge weights** | Pass edge (weight=10) preferred over Fail edge (weight=5) |
-| **Edge conditions** | `outcome=success` and `outcome!=success` on test_gate edges |
+| **Edge conditions** | `context.tool.last_line=pass` and `context.tool.last_line=fail` on test_gate edges |
 | **Accelerator keys** | `[S] Ship it!`, `[P] Polish first`, `[R] Rework needed` |
 | **Class attribute** | `.planning`, `.code`, `.fast` on various nodes |
 | **Join policy** | `wait_all` on parallel_impl |
@@ -71,9 +71,9 @@ integrate (.code, compact fidelity)
 test (.fast, gemini-flash)
   |
   v
-test_gate (diamond)
+test_gate (parallelogram -- runs pytest, routes on context.tool.last_line)
   |                  |
-  | [Pass]           | [Fail]
+  | [pass]           | [fail]
   v                  v
 final_review    fix_tests (summary:high)
 (#id -> opus)       |
@@ -117,18 +117,22 @@ done       polish      fix_tests
 3. `collect` (fan-in) consolidates results, selects best candidate
 4. `integrate` connects the pieces (compact fidelity from graph default)
 5. `test` runs the test suite (gemini-flash for speed)
-6. `test_gate` routes based on outcome:
-   - SUCCESS -> `final_review` (condition match, weight=10)
+6. `test_gate` (parallelogram) runs `pytest -q` directly and routes on the result:
+   - Tests pass -> prints "pass" -> `context.tool.last_line=pass` -> `final_review` (weight=10)
 7. `final_review` performs comprehensive review (claude-opus, summary:high)
 8. `review_gate` presents choices to human:
    - `[S] Ship it!` -> done
 9. Pipeline completes with all goal gates satisfied
 
 ### Test Failure Loop
-At `test_gate`, if outcome != success:
-- Routes to `fix_tests` (summary:high fidelity for detailed failure context)
-- `fix_tests` loops back to `test`
-- Cycle repeats until tests pass
+At `test_gate` (parallelogram), if pytest exits non-0:
+- Prints "fail" -> `context.tool.last_line=fail` -> routes to `fix_tests`
+- `fix_tests` (summary:high fidelity for detailed failure context) loops back to `test`
+- `test` runs again -> `test_gate` re-runs pytest -> cycle repeats until tests pass
+
+**Why parallelogram, not diamond**: `ConditionalHandler` (the diamond handler) unconditionally
+returns SUCCESS, so `condition="outcome!=success"` from a diamond is always false -- the loop
+never fires. The parallelogram gate runs the real verifier and routes on observed evidence.
 
 ### Human Rejection Loops
 At `review_gate`:
@@ -159,7 +163,7 @@ steps:
 1. **Stylesheet application**: Check that node attrs contain the correct model after initialization
 2. **Parallel execution**: Two branch directories in logs, `parallel.results` in context
 3. **Fidelity preambles**: Compare prompt.md content across nodes with different fidelity modes
-4. **Conditional routing**: test_gate edges evaluated, correct branch taken
+4. **Evidence-based routing**: test_gate (parallelogram) runs pytest; `context.tool.last_line` holds `pass` or `fail`; correct branch taken
 5. **Human gate**: review_gate presents 3 options with accelerator keys
 6. **Goal gates**: At exit, both implementation nodes checked for success
 7. **Variable expansion**: All `$goal` references replaced with the graph goal

--- a/examples/pipelines/12-graph-resume.dot
+++ b/examples/pipelines/12-graph-resume.dot
@@ -111,7 +111,15 @@ digraph GraphResume {
         prompt="Run the full test suite (pytest -v --tb=short). Compare results against the baseline in .ai/snapshot.txt. All previously-passing tests must still pass. If ALL tests pass: update .ai/STATE.json to {\"tests_passed\": true} and report success. If any regression: leave .ai/STATE.json as {\"tests_passed\": false} and report failure with details of what broke."
     ]
 
-    test_gate [shape=diamond, label="Tests Pass?"]
+    // Evidence gate -- shape=parallelogram runs the real verifier.
+    // Prints "pass" if pytest exits 0, "fail" otherwise. Edges route on
+    // context.tool.last_line -- the same pattern used by all other guard nodes
+    // in this pipeline (check_smells, check_plan, check_snapshot, check_tests_done).
+    test_gate [
+        shape=parallelogram,
+        label="Tests Pass?",
+        tool_command="pytest -q > /dev/null 2>&1 && printf pass || printf fail"
+    ]
 
     // ── Stage 6: Diff review ──────────────────────────────────────────────────
     // No guard -- diff_review always runs if we reach this stage.
@@ -150,8 +158,8 @@ digraph GraphResume {
     implement_refactor -> run_tests
     run_tests -> test_gate
 
-    test_gate -> diff_review        [label="pass", condition="outcome=success"]
-    test_gate -> implement_refactor [label="fix",  condition="outcome!=success"]
+    test_gate -> diff_review        [label="pass", condition="context.tool.last_line=pass"]
+    test_gate -> implement_refactor [label="fix",  condition="context.tool.last_line=fail"]
 
     // Stage 6 always leads to done
     diff_review -> done

--- a/examples/pipelines/12-graph-resume.md
+++ b/examples/pipelines/12-graph-resume.md
@@ -86,7 +86,7 @@ start
   → check_tests_done       [STATE.json missing → last_line="todo"]
   → implement_refactor     [writes .ai/STATE.json: {"tests_passed": false}]
   → run_tests
-  → test_gate
+  → test_gate              [runs pytest -q; prints "pass" or "fail"]
     → [pass] diff_review   [run_tests also updated STATE.json: {"tests_passed": true}]
     → done
 ```
@@ -112,8 +112,17 @@ The engine ran from Start every time. No goto, no jump, no engine resume API.
 
 ### First run
 All guard nodes print `todo`; all work nodes execute in sequence. The implement+test loop
-may iterate if tests fail (`test_gate → implement_refactor → run_tests`), writing
-`{"tests_passed": false}` each time until all tests pass, then `{"tests_passed": true}`.
+may iterate if tests fail: `test_gate` (parallelogram) runs `pytest -q` directly and prints
+`fail` -> routes back to `implement_refactor`. The loop writes `{"tests_passed": false}` each
+time until all tests pass, then `{"tests_passed": true}`, and `test_gate` prints `pass` -> routes
+to `diff_review`.
+
+**Why `test_gate` is a parallelogram, not a diamond**: All guard nodes in this pipeline
+(`check_smells`, `check_plan`, `check_snapshot`, `check_tests_done`, and now `test_gate`) use
+`shape=parallelogram` + `tool_command` + `context.tool.last_line` routing. This is consistent
+and correct. The diamond handler (`ConditionalHandler`) unconditionally returns SUCCESS, so
+`condition="outcome!=success"` from a diamond is always false -- the implement+test loop would
+never fire. The parallelogram gate runs the real verifier and routes on observed evidence.
 
 ### Resume after crash (any stage)
 Guard nodes for completed stages print `done` (their artifact exists); their work nodes are

--- a/examples/pipelines/practical/bug-fix.dot
+++ b/examples/pipelines/practical/bug-fix.dot
@@ -49,10 +49,17 @@ digraph BugFix {
         prompt="Run the full test suite (pytest -v --tb=short). All tests must pass, including the new regression test. Report results."
     ]
 
-    // Stage 6: Gate -- routes based on test outcome
-    test_gate [shape=diamond, label="Tests Pass?"]
+    // Stage 6: Evidence gate -- runs pytest and routes on the result.
+    // shape=parallelogram runs the tool_command directly (not via LLM).
+    // Prints "pass" (exit 0) or "fail" (exit non-0) as the last stdout line.
+    // Edges condition on context.tool.last_line -- the proven routing pattern.
+    test_gate [
+        shape=parallelogram,
+        label="Tests Pass?",
+        tool_command="pytest -q > /dev/null 2>&1 && printf pass || printf fail"
+    ]
 
     start -> reproduce -> diagnose -> implement_fix -> regression_test -> run_tests -> test_gate
-    test_gate -> done [condition="outcome=success"]
-    test_gate -> implement_fix [condition="outcome!=success", label="fix again"]
+    test_gate -> done          [label="pass", condition="context.tool.last_line=pass"]
+    test_gate -> implement_fix [label="fail", condition="context.tool.last_line=fail"]
 }

--- a/examples/pipelines/practical/bug-fix.md
+++ b/examples/pipelines/practical/bug-fix.md
@@ -44,3 +44,24 @@ Model-agnostic -- every node runs on your configured default provider/model. To 
 ## Key Feature: Disciplined Workflow
 
 Forces the reproduce-first pattern. The regression test ensures the bug stays fixed. The retry loop catches cases where the fix breaks other tests.
+
+## Routing Pattern: Evidence Gate
+
+The `test_gate` node uses `shape=parallelogram` + `tool_command`, not `shape=diamond`:
+
+```dot
+// RIGHT -- runs the real verifier, routes on observed evidence:
+test_gate [shape=parallelogram, label="Tests Pass?",
+           tool_command="pytest -q > /dev/null 2>&1 && printf pass || printf fail"]
+test_gate -> done          [condition="context.tool.last_line=pass"]
+test_gate -> implement_fix [condition="context.tool.last_line=fail"]
+```
+
+**Why not diamond**: `ConditionalHandler` (the diamond handler) unconditionally returns SUCCESS.
+A `condition="outcome!=success"` edge from a diamond is always false -- the fix loop would never
+fire, and the pipeline would report success even when tests are failing. The parallelogram gate
+runs `pytest` directly and routes on the actual exit code.
+
+**FAIL routing**: `implement_fix` has `retry_target="implement_fix"` and the graph sets
+`default_max_retry=3`. If the LLM node crashes (hard FAIL), the engine retries up to 3 times
+before fail-fast termination.

--- a/examples/pipelines/practical/feature-build.dot
+++ b/examples/pipelines/practical/feature-build.dot
@@ -63,8 +63,15 @@ digraph FeatureBuild {
         max_retries=3
     ]
 
-    // Stage 6: Gate -- routes based on test outcome
-    test_gate [shape=diamond, label="Tests Pass?"]
+    // Stage 6: Evidence gate -- runs pytest and routes on the result.
+    // shape=parallelogram runs the tool_command directly (not via LLM).
+    // Prints "pass" (exit 0) or "fail" (exit non-0) as the last stdout line.
+    // Edges condition on context.tool.last_line -- the proven routing pattern.
+    test_gate [
+        shape=parallelogram,
+        label="Tests Pass?",
+        tool_command="pytest -q > /dev/null 2>&1 && printf pass || printf fail"
+    ]
 
     // Stage 7: Human review gate
     review_gate [
@@ -80,8 +87,8 @@ digraph FeatureBuild {
     impl_api -> collect
     impl_tests -> collect
     collect -> integration_test -> test_gate
-    test_gate -> review_gate [condition="outcome=success"]
-    test_gate -> integration_test [condition="outcome!=success", label="fix"]
-    review_gate -> done [label="[S] Ship"]
+    test_gate -> review_gate     [label="pass", condition="context.tool.last_line=pass"]
+    test_gate -> integration_test [label="fail", condition="context.tool.last_line=fail"]
+    review_gate -> done           [label="[S] Ship"]
     review_gate -> integration_test [label="[R] Rework"]
 }

--- a/examples/pipelines/practical/feature-build.md
+++ b/examples/pipelines/practical/feature-build.md
@@ -30,6 +30,27 @@ attractor run examples/pipelines/practical/feature-build.dot \
 - **Human gate** before finalization gives the developer a review checkpoint
 - **Integration test retry** catches cross-branch issues automatically
 
+## Routing Pattern: Evidence Gate
+
+The `test_gate` node uses `shape=parallelogram` + `tool_command`, not `shape=diamond`:
+
+```dot
+// RIGHT -- runs the real verifier, routes on observed evidence:
+test_gate [shape=parallelogram, label="Tests Pass?",
+           tool_command="pytest -q > /dev/null 2>&1 && printf pass || printf fail"]
+test_gate -> review_gate      [condition="context.tool.last_line=pass"]
+test_gate -> integration_test [condition="context.tool.last_line=fail"]
+```
+
+**Why not diamond**: `ConditionalHandler` (the diamond handler) unconditionally returns SUCCESS.
+A `condition="outcome!=success"` edge from a diamond is always false -- the integration test
+retry loop would never fire, and the pipeline would proceed to human review even when tests are
+failing. The parallelogram gate runs `pytest` directly and routes on the actual exit code.
+
+**FAIL routing**: `integration_test` has `retry_target="integration_test"` and `max_retries=3`.
+If the LLM node crashes (hard FAIL), the engine retries up to 3 times before fail-fast
+termination.
+
 ## Models
 
 Model-agnostic -- every node runs on your configured default provider/model. To route the planning step (`parse_spec`) to a stronger model, add a `model_stylesheet` (see `examples/pipelines/06-model-stylesheet.dot`).

--- a/examples/pipelines/practical/refactor.dot
+++ b/examples/pipelines/practical/refactor.dot
@@ -50,8 +50,15 @@ digraph Refactor {
         prompt="Run the full test suite (pytest -v --tb=short). Compare results against the baseline snapshot. All previously-passing tests must still pass. Report any regressions."
     ]
 
-    // Stage 6: Gate -- routes based on test outcome
-    test_gate [shape=diamond, label="Tests Pass?"]
+    // Stage 6: Evidence gate -- runs pytest and routes on the result.
+    // shape=parallelogram runs the tool_command directly (not via LLM).
+    // Prints "pass" (exit 0) or "fail" (exit non-0) as the last stdout line.
+    // Edges condition on context.tool.last_line -- the proven routing pattern.
+    test_gate [
+        shape=parallelogram,
+        label="Tests Pass?",
+        tool_command="pytest -q > /dev/null 2>&1 && printf pass || printf fail"
+    ]
 
     // Stage 7: Diff review (reasoning-heavy)
     diff_review [
@@ -60,7 +67,7 @@ digraph Refactor {
     ]
 
     start -> analyze_smells -> plan_refactor -> snapshot_tests -> implement_refactor -> run_tests -> test_gate
-    test_gate -> diff_review [condition="outcome=success"]
-    test_gate -> implement_refactor [condition="outcome!=success", label="fix regressions"]
+    test_gate -> diff_review        [label="pass", condition="context.tool.last_line=pass"]
+    test_gate -> implement_refactor [label="fail", condition="context.tool.last_line=fail"]
     diff_review -> done
 }

--- a/examples/pipelines/practical/refactor.md
+++ b/examples/pipelines/practical/refactor.md
@@ -46,3 +46,23 @@ Model-agnostic -- every node runs on your configured default provider/model. To 
 ## Key Feature: Snapshot Safety Net
 
 The snapshot-first approach gives a safety net. If the refactoring breaks tests, the retry loop between `run_tests` and `implement_refactor` catches regressions immediately. The diff review confirms behavior preservation.
+
+## Routing Pattern: Evidence Gate
+
+The `test_gate` node uses `shape=parallelogram` + `tool_command`, not `shape=diamond`:
+
+```dot
+// RIGHT -- runs the real verifier, routes on observed evidence:
+test_gate [shape=parallelogram, label="Tests Pass?",
+           tool_command="pytest -q > /dev/null 2>&1 && printf pass || printf fail"]
+test_gate -> diff_review        [condition="context.tool.last_line=pass"]
+test_gate -> implement_refactor [condition="context.tool.last_line=fail"]
+```
+
+**Why not diamond**: `ConditionalHandler` (the diamond handler) unconditionally returns SUCCESS.
+A `condition="outcome!=success"` edge from a diamond is always false -- the fix loop would never
+fire, and the pipeline would proceed to diff review even when tests are failing. The parallelogram
+gate runs `pytest` directly and routes on the actual exit code.
+
+**FAIL routing**: `snapshot_tests` has `retry_target="snapshot_tests"`. If any LLM node crashes
+(hard FAIL), the engine's `default_max_retry=3` provides retry before fail-fast termination.

--- a/examples/pipelines/practical/test-gen.dot
+++ b/examples/pipelines/practical/test-gen.dot
@@ -41,8 +41,15 @@ digraph TestGen {
         prompt="Run the test suite with: pytest -v --tb=short. Report which tests pass and which fail. If all pass, report success. If any fail, report the failure details."
     ]
 
-    // Stage 5: Gate -- routes based on test outcome
-    test_gate [shape=diamond, label="Tests Pass?"]
+    // Stage 5: Evidence gate -- runs pytest and routes on the result.
+    // shape=parallelogram runs the tool_command directly (not via LLM).
+    // Prints "pass" (exit 0) or "fail" (exit non-0) as the last stdout line.
+    // Edges condition on context.tool.last_line -- the proven routing pattern.
+    test_gate [
+        shape=parallelogram,
+        label="Tests Pass?",
+        tool_command="pytest -q > /dev/null 2>&1 && printf pass || printf fail"
+    ]
 
     // Stage 6: Fix failures (only reached via retry loop)
     fix_failures [
@@ -51,7 +58,7 @@ digraph TestGen {
     ]
 
     start -> analyze -> identify_gaps -> write_tests -> run_tests -> test_gate
-    test_gate -> done [condition="outcome=success"]
-    test_gate -> fix_failures [condition="outcome!=success", label="fix"]
+    test_gate -> done         [label="pass", condition="context.tool.last_line=pass"]
+    test_gate -> fix_failures [label="fail", condition="context.tool.last_line=fail"]
     fix_failures -> run_tests [label="retest"]
 }

--- a/examples/pipelines/practical/test-gen.md
+++ b/examples/pipelines/practical/test-gen.md
@@ -41,6 +41,26 @@ for box-node (agent) pipelines -- that's why we `cd` into the copy (see
 
 The retry loop between `run_tests` and `fix_failures` means the pipeline doesn't just generate tests -- it validates them and fixes failures automatically. Up to 3 retry cycles.
 
+## Routing Pattern: Evidence Gate
+
+The `test_gate` node uses `shape=parallelogram` + `tool_command`, not `shape=diamond`:
+
+```dot
+// RIGHT -- runs the real verifier, routes on observed evidence:
+test_gate [shape=parallelogram, label="Tests Pass?",
+           tool_command="pytest -q > /dev/null 2>&1 && printf pass || printf fail"]
+test_gate -> done         [condition="context.tool.last_line=pass"]
+test_gate -> fix_failures [condition="context.tool.last_line=fail"]
+```
+
+**Why not diamond**: `ConditionalHandler` (the diamond handler) unconditionally returns SUCCESS.
+A `condition="outcome!=success"` edge from a diamond is always false -- the self-healing loop
+would never fire, and the pipeline would report success with failing tests. The parallelogram
+gate runs `pytest` directly and routes on the actual exit code.
+
+**FAIL routing**: `write_tests` has `retry_target="fix_failures"`. If any LLM node crashes
+(hard FAIL), the engine's `default_max_retry=3` provides retry before fail-fast termination.
+
 ## Models
 
 Model-agnostic -- every node runs on your configured default provider/model. Add a `model_stylesheet` only if you want to route specific steps to specific models (see `examples/pipelines/06-model-stylesheet.dot`).


### PR DESCRIPTION
## Summary

All 8 shipped example pipelines drew corrective back-edges that could never fire.
`ConditionalHandler` (`modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/conditional.py:47`)
unconditionally returns SUCCESS, overwriting the upstream node's outcome — so a
`shape=diamond` gate followed by `condition="outcome!=success"` is a provably dead
edge. Independently, FAIL is fail-fast and never traverses plain edges, so a real
FAIL never even reaches the diamond. Net effect: the examples people copy had
flowchart reliability while teaching attractor confidence — a probe run of
`bug-fix.dot` showed `run_tests → PARTIAL_SUCCESS → test_gate → SUCCESS → done`,
i.e. **the pipeline reported success with failing tests**. This PR replaces every
diamond+`outcome=` gate with the proven evidence-gate pattern
(`shape=parallelogram` + `tool_command` running the real verifier, routed on
`condition="context.tool.last_line=<token>"`, the pattern already used by
`examples/patterns/convergence-factory.dot`), adds FAIL routing (`retry_target`)
where it was absent, and updates all 8 paired `.md` guides to explain the routing
choice. Scope is examples+guides only — no engine changes (see Notes for
reviewers).

## Verification checklist

- [x] Unit tests pass (`pytest modules/loop-pipeline/`) — 1409 passed, 1 skipped
      (run on this branch via `uv run --extra remote pytest -q`, 20.4s)
- [x] Live pipeline run exercising changed code path — `bug-fix.dot` executed
      end-to-end against its shipped sample post-fix; routing trace pasted below.
      (Not strictly required by the verification gradient — this is an
      examples/docs change — but the whole point of the change is runtime routing
      behavior, so it is included.)
- [x] AGENTS.md reviewed; repo-specific gates met (verification gradient row:
      "Test fixtures, examples, docs — unit tests sufficient"; live run included
      anyway)
- [x] Backward-compat path unchanged — no engine, handler, or spec changes;
      graphs remain valid DOT and parse under the shipped parser
- [x] PR body includes verification evidence, not just "tests pass"

## Verification evidence

**(a) Static dead-pattern check** — pydot+networkx scan of `examples/**/*.dot` on
this branch:

```
found 24 .dot files under examples/

1. dead diamond+outcome= edges: 0
2. parse failures: 0
3. cycles in the 8 affected graphs:
   examples/pipelines/03-conditional-routing.dot: 1 simple cycle(s)
   examples/pipelines/09-manager-supervisor.dot: 1 simple cycle(s)
   examples/pipelines/10-full-attractor.dot: 3 simple cycle(s)
   examples/pipelines/12-graph-resume.dot: 1 simple cycle(s)
   examples/pipelines/practical/bug-fix.dot: 1 simple cycle(s)
   examples/pipelines/practical/feature-build.dot: 2 simple cycle(s)
   examples/pipelines/practical/refactor.dot: 1 simple cycle(s)
   examples/pipelines/practical/test-gen.dot: 1 simple cycle(s)

RESULT: PASS
```

All 24 example graphs parse; zero diamond nodes route on `outcome=` conditions;
every affected graph still contains its corrective cycle(s).

**(b) Live run of the fixed `bug-fix.dot`** — executed post-fix in a clean
isolated environment (fresh clone; the documented invocation from
`examples/pipelines/practical/bug-fix.md`, sample copied to a temp dir,
`--cwd .`):

```
=== t01 live run start: 2026-07-28T23:48:55Z ===
attractor: running pipeline (cwd: /tmp/attractor-bugfix-demo, logs: /tmp/attractor-run-yscrf5cp)
attractor: status=success
{"status": "success", "notes": "Tool completed: pytest -q > /dev/null 2>&1 && printf pass || printf fail", "logs_dir": "/tmp/attractor-run-yscrf5cp"}
=== exit code: 0 at 2026-07-28T23:52:14Z ===
```

Routing trace from the run dir (this attractor CLI version writes per-node
`status.json` + `checkpoint.json` rather than a root `events.jsonl`):

```
checkpoint.json:
  completed order: ['start', 'reproduce', 'diagnose', 'implement_fix',
                    'regression_test', 'run_tests', 'test_gate']
  current: done
  retries: {}
  ctx outcome: success | tool.last_line: pass

test_gate/status.json (the revived evidence gate):
  "node_id": "test_gate",
  "status": "success",
  "context_updates": { "tool.output": "pass", "tool.last_line": "pass" },
  "notes": "Tool completed: pytest -q > /dev/null 2>&1 && printf pass || printf fail"

test_gate/command.txt: pytest -q > /dev/null 2>&1 && printf pass || printf fail
test_gate/output.txt:  pass
```

The gate ran the **real** verifier (`pytest`) and routed `test_gate → done` on
`condition="context.tool.last_line=pass"` — evidence-based routing, not the old
always-SUCCESS diamond. Sample verification after the run (per the guide's
documented check, suite goes 2 → 3 passing):

```
test_user_service.py::test_add_and_get_user PASSED
test_user_service.py::test_display_name_with_avatar PASSED
test_user_service.py::test_display_name_without_avatar PASSED
============================== 3 passed in 0.00s ===============================
```

The agent's fix in the sample was the minimal None-guard in
`user_service.get_display_name()` plus the new None-avatar regression test.

**Honest caveat:** in this run the first fix attempt was correct, so the
corrective edge (`test_gate → implement_fix [context.tool.last_line=fail]`) did
not need to fire — the trace above demonstrates the gate observing real evidence
and routing on it, not the loop re-firing. The corrective path itself was
demonstrated deterministically by a live-execution test (real `ToolHandler`,
sentinel-file mechanism forcing a first-cycle `fail`) run in the same isolated
environment:

```
tests/test_t0_1_corrective_loop_live.py::test_corrective_loop_fires_at_least_twice PASSED
tests/test_t0_1_corrective_loop_live.py::test_corrective_loop_events_jsonl_content PASSED
============================== 2 passed in 0.07s ===============================
```

That test asserts ≥2 executions of the fix node before convergence. It is
**intentionally not included in this PR** — see "Dropped from this PR" below.

**(c) CI expectations:** this repo has no GitHub Actions PR workflows
(`.github/` contains only `PULL_REQUEST_TEMPLATE.md`; the only workflow is the
dynamic dependabot update-graph). The `main` ruleset requires a PR with 1
approving review, review-thread resolution, and linear history — **no required
status checks**. So no automated checks will run on this PR; the evidence above
is the verification. For completeness: the root `tests/` suite has pre-existing,
unrelated local failures (`tests/test_context_include_paths.py` imports `yaml`
but the root `pyproject.toml` declares no dependencies; `tests/e2e/` requires a
live gemini CLI) — untouched by this PR and not exercised by any CI.

## Notes for reviewers

- **Walk upstream first (PRINCIPLES.md):** the deepest fix could arguably live in
  the engine — e.g. `ConditionalHandler` passing through the upstream node's
  outcome instead of unconditionally returning SUCCESS. That option was
  considered and deliberately **not** taken here: passthrough would break the
  valid diamond use case (routing on `context.*` keys set by earlier nodes, where
  the diamond is a pure switch and its own SUCCESS is correct). The analysis and
  the resulting recommendation — a spec clarification at the canonical
  `strongdm/attractor` spec (diamond = context-key routing; `outcome=` conditions
  from a diamond are always a bug; parallelogram+`tool.last_line` is the
  evidence-routing pattern) — is recorded in this PR as Fix 8 of
  `docs/reports/upstream-ecosystem-fixes.md`. This PR is scoped to
  examples+guides; no engine behavior changes.
- **FAIL routing:** where a genuine FAIL from a work node previously ran off the
  rim, `retry_target` + `default_max_retry` now provides the route
  (e.g. `03-conditional-routing.dot`). PARTIAL_SUCCESS and SUCCESS-with-failing-
  work are handled by the evidence gate itself, since it routes on observed
  verifier output rather than the handler's synthetic outcome.
- **Teaching focus preserved:** each tutorial keeps its subject (03 still teaches
  routing — now the right routing; 09 manager, 12 resume unchanged in focus);
  the guides explain *why* evidence gates replace diamonds.

## Dropped from this PR (intentional)

The originating branch bundled a 309-line live-execution test
(`modules/loop-pipeline/tests/test_t0_1_corrective_loop_live.py`) that drives the
fixed `bug-fix.dot` gate pattern through a real `ToolHandler` and asserts the
corrective loop fires ≥2 times before convergence. It was **excluded** here on
review-council guidance ("ship it wired or don't ship it"): as bundled it would
land as a one-off in the unit suite without integration into the repo's live-test
conventions (`tests/e2e/`, `run_e2e.sh`, MANUAL_E2E.md). It passes as written
(output above) and is offered as a follow-up PR where it can be wired in
properly. This PR's verification does not depend on it.

---

## Reviewer verification commands

From a checkout of the branch:

```bash
# 1. Unit suite (matches the checklist box)
cd modules/loop-pipeline && uv run --extra remote pytest -q

# 2. Static dead-pattern check (needs pydot + networkx)
python - <<'EOF'
import pydot, networkx as nx
from pathlib import Path
for f in sorted(Path("examples").rglob("*.dot")):
    g = pydot.graph_from_dot_file(str(f))[0]
    diamonds, edges = set(), []
    def walk(s):
        for n in s.get_nodes():
            if n.get_attributes().get("shape","").strip('"') == "diamond":
                diamonds.add(n.get_name().strip('"'))
        edges.extend(s.get_edges())
        for sub in s.get_subgraphs(): walk(sub)
    walk(g)
    for e in edges:
        c = (e.get_attributes().get("condition","") or "").strip('"').replace(" ","")
        assert not (e.get_source().strip('"') in diamonds and c.startswith(("outcome=","outcome!="))), (f, c)
print("no dead diamond+outcome= edges; all graphs parse")
EOF

# 3. Live run of the flagship (documented invocation from the guide;
#    spawns LLM sessions — needs a configured provider; ~3-5 min)
DOT="$PWD/examples/pipelines/practical/bug-fix.dot"
cp -r examples/pipelines/practical/sample /tmp/attractor-bugfix-demo
cd /tmp/attractor-bugfix-demo
attractor run "$DOT" \
  --param goal="Fix the bug in user_service.py: get_display_name() raises TypeError when a user's avatar is None. Reproduce it first, apply the minimal fix, and add a regression test that covers the None-avatar case." \
  --cwd .
pytest -v   # expect 3 passed (baseline is 2)
# then inspect <logs_dir>/test_gate/status.json for tool.last_line routing
```

Generated with [Amplifier](https://github.com/microsoft/amplifier)
