### PR TITLE
docs(context): fix two stale claims in engine-semantics.md; add drift guard

### DIFF
--- a/context/engine-semantics.md
+++ b/context/engine-semantics.md
@@ -81,18 +81,33 @@ wrong about the running engine.
 Source: `edge_selection.py`; `handlers/tool.py`; nlspec §3.3, §3.7, §10.
 
 - **Token channel:** route a tool node via `condition="context.tool.last_line=<token>"`.
-  `tool.last_line` = last non-empty stripped stdout line (`tool.py:210-219`).
-  `tool.output` = **full stdout** (`tool.py:177`) — conditioning on it silently never matches.
+  `tool.last_line` = last non-empty stripped stdout line (`tool.py:212-220`) — set **only on
+  success**. A **failing tool node does NOT refresh `tool.last_line`** (`tool.py:158-176`
+  early FAIL return precedes the `context.set` at `tool.py:220`); the key retains the value
+  from the last *successful* execution. **Stale-label rule:** on the second+ visit to a gate,
+  a stale `tool.last_line` value from a prior successful run can match a
+  `context.tool.last_line=X` edge even when the current run failed, causing an unintended
+  parallel fan-out. **Discipline:** any edge with `condition="context.tool.last_line=X"` that
+  shares a source node with an `outcome=fail` edge MUST also assert `&& outcome=success`;
+  otherwise a stale label plus a FAIL match both edges on the second visit.
+  `tool.output` = **full stdout** (`tool.py:179`) — conditioning on it silently never matches.
 - **Bare-token condition** = truthy lookup: `condition="context.flag"` is true iff the value
   is non-empty (nlspec §10.5; `conditions.py`).
 - **5-step selection** (§3.3; `edge_selection.py:39-101`): condition-match → `preferred_label`
   (unconditional edges only) → `suggested_next_ids` (unconditional only) → highest `weight`
   → **lexical tiebreak on target id**. The lexical tiebreak is silent but specified —
   >1 unconditional edge from one node picks lexically-first.
-- **Tool non-zero exit → FAIL** (`tool.py:156-174`); needs an explicit FAIL route per #2 above.
-- **No edge selected & outcome≠FAIL → branch terminates SUCCESS** (nlspec §3.2 step 6). It
-  does NOT hard-fail `no_matching_edge` and does NOT loop. "Every LLM node needs an
-  unconditional fallback" is an authoring/lint discipline, not a runtime hard-fail. [MEDIUM]
+- **Tool non-zero exit → FAIL** (`tool.py:158-176`); needs an explicit FAIL route per #2 above.
+- **No edge selected — behavior depends on execution context:**
+  - **Main loop** (`engine.py:773-788`): hard-fails with `terminate_pipeline`, emits
+    `PIPELINE_ERROR` with `error_type: no_matching_edge`. This is NOT a silent SUCCESS.
+    (Shipped behavior since the initial engine commit `6c8bf5a`; the earlier claim here
+    transcribed nlspec §3.2 step 6, which the shipped main loop has never followed — an
+    unreconciled spec/engine divergence.)
+  - **Subgraph branches** (`run_subgraph`, `engine.py:917-919`): returns the last outcome on a
+    dead-end — no hard-fail. "Every LLM node needs an unconditional fallback" is an
+    authoring/lint discipline for the main loop; inside `run_subgraph` a dead-end is a
+    graceful termination. [MEDIUM]
 
 ---
 

--- a/modules/loop-pipeline/tests/test_engine_semantics_doc_guard.py
+++ b/modules/loop-pipeline/tests/test_engine_semantics_doc_guard.py
@@ -1,0 +1,346 @@
+"""Drift guard for context/engine-semantics.md — D-200, D-201, D-202.
+
+Guards against doc/engine drift in ``context/engine-semantics.md``, the
+bundle's declared source of truth for shipped-engine behavior.  Two claim
+classes are checked:
+
+  (a) **Text-anchored** (shape b): regex the doc for the claim and assert
+      the corrected language is present.  These verify that the *words* are
+      there, not that the *behavior* is correct.  They catch edits that
+      silently revert a correction.
+
+  (b) **Behavior-anchored** (shape a): execute a minimal graph or inspect
+      source and assert the doc's claim holds in the running code.  These
+      verify actual engine/handler behavior.
+
+Honest limits:
+  - Text-anchored checks (D-200, D-201) can be fooled by wording changes
+    that preserve the wrong meaning.  They are a last-resort gate, not a
+    substitute for behavioral tests.
+  - The no-matching-edge behavioral check (D-202a) exercises the main loop
+    via a full engine run.  The companion ``test_edge_selection_no_silent_
+    fallthrough.py`` covers ``select_edge()`` at the unit level.
+  - The stale-label rule (D-201) has no dedicated behavioral test here: the
+    bug only manifests on the *second visit* to a gate in a corrective loop,
+    which requires a full looping graph — deferred to a future behavioral
+    test (or lint).  The text-anchored check is the right tradeoff for now.
+  - Source-inspection checks (D-202b) verify that the cited line numbers in
+    the doc are in the right ballpark; they are NOT cite-freshness checks
+    (which would break on every harmless refactor) but sanity checks that
+    the referenced behavior exists at a nearby line.
+
+Reference: ``context/engine-semantics.md`` §3 Routing contract.
+Paired behavioral anchors: ``test_edge_selection_no_silent_fallthrough.py``,
+``test_engine.py::test_no_matching_edge_returns_fail``.
+"""
+
+import asyncio
+import re
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+BUNDLE_ROOT = Path(__file__).parent.parent.parent.parent
+DOC_PATH = BUNDLE_ROOT / "context" / "engine-semantics.md"
+ENGINE_PATH = (
+    BUNDLE_ROOT
+    / "modules"
+    / "loop-pipeline"
+    / "amplifier_module_loop_pipeline"
+    / "engine.py"
+)
+TOOL_PATH = (
+    BUNDLE_ROOT
+    / "modules"
+    / "loop-pipeline"
+    / "amplifier_module_loop_pipeline"
+    / "handlers"
+    / "tool.py"
+)
+
+
+def _doc() -> str:
+    return DOC_PATH.read_text()
+
+
+def _engine_src() -> str:
+    return ENGINE_PATH.read_text()
+
+
+def _tool_src() -> str:
+    return TOOL_PATH.read_text()
+
+
+# ---------------------------------------------------------------------------
+# D-200: No-matching-edge claim — text-anchored (shape b)
+#
+# The doc must NOT contain the stale "does NOT hard-fail" assertion.
+# The doc MUST document the main-loop hard-fail AND distinguish the subgraph
+# path.  Both halves are required; over-correcting to "always hard-fails"
+# would be wrong in the other direction.
+# ---------------------------------------------------------------------------
+
+
+def test_d200_stale_no_matching_edge_claim_absent():
+    """D-200a (text-anchored): the stale 'does NOT hard-fail' assertion must
+    be gone from engine-semantics.md.
+
+    The main loop DOES hard-fail on no-matching-edge (engine.py:773-788,
+    PIPELINE_ERROR error_type=no_matching_edge; shipped behavior since the
+    initial engine commit).  Presence of the old claim means the doc has
+    regressed.
+    """
+    doc = _doc()
+    assert not re.search(r"does NOT hard-?fail", doc, re.IGNORECASE), (
+        "engine-semantics.md still contains the stale 'does NOT hard-fail "
+        "no_matching_edge' claim. The main loop DOES hard-fail "
+        "(engine.py:773-788). Remove or correct this claim. (D-200a)"
+    )
+
+
+def test_d200_no_matching_edge_main_loop_documented():
+    """D-200b (text-anchored): the doc must mention no_matching_edge behavior."""
+    doc = _doc()
+    assert re.search(r"no.matching.edge|no_matching_edge", doc, re.IGNORECASE), (
+        "engine-semantics.md does not mention no-matching-edge behavior at all. "
+        "The main loop hard-fails with PIPELINE_ERROR error_type=no_matching_edge "
+        "(engine.py:773-788). Add the corrected claim. (D-200b)"
+    )
+
+
+def test_d200_subgraph_path_distinguished():
+    """D-200c (text-anchored): the doc must distinguish the subgraph path.
+
+    run_subgraph (engine.py:917-919) still returns the last outcome on a
+    dead-end — no hard-fail.  Both halves must be stated to avoid authors
+    over-trusting the hard-fail inside parallel/manager layers.
+    """
+    doc = _doc()
+    assert re.search(r"subgraph|run_subgraph|parallel branch", doc, re.IGNORECASE), (
+        "engine-semantics.md documents no-matching-edge behavior but never "
+        "distinguishes the subgraph path. run_subgraph (engine.py:917-919) still "
+        "returns the last outcome on a dead-end. Both halves must be stated. (D-200c)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# D-201: Stale-label rule — text-anchored (shape b)
+#
+# The doc must document that a failing tool node does NOT refresh
+# tool.last_line.  The key retains the value from the last successful run.
+# On the second visit to a gate, a stale label can match a
+# context.tool.last_line=X edge even when the current run failed, causing
+# an unintended parallel fan-out.
+# ---------------------------------------------------------------------------
+
+
+def test_d201_stale_label_rule_documented():
+    """D-201 (text-anchored): the stale-label rule must be documented near
+    tool.last_line in engine-semantics.md.
+
+    Failing tool nodes do NOT refresh tool.last_line (early FAIL return at
+    tool.py:158-176 precedes the context.set at tool.py:220).  Without this
+    rule documented, authors write 'context.tool.last_line=X' edges beside
+    'outcome=fail' edges and get a parallel fan-out on the second visit to
+    the gate.  (D-201)
+    """
+    doc = _doc()
+    # Find the context around 'last_line' and check for staleness language
+    last_line_sections = []
+    for m in re.finditer(r"last_line", doc, re.IGNORECASE):
+        start = max(0, m.start() - 300)
+        end = min(len(doc), m.end() + 300)
+        last_line_sections.append(doc[start:end])
+
+    assert last_line_sections, (
+        "engine-semantics.md does not mention tool.last_line at all. "
+        "The token channel section is missing. (D-201)"
+    )
+
+    staleness_pattern = re.compile(
+        r"stale|not refresh|does not refresh|not updated|retain|preserv|previous",
+        re.IGNORECASE,
+    )
+    found = any(staleness_pattern.search(section) for section in last_line_sections)
+    assert found, (
+        "engine-semantics.md mentions tool.last_line but does not document the "
+        "stale-label rule: a failing tool node does NOT refresh tool.last_line "
+        "(early FAIL return at tool.py:158-176 precedes context.set at tool.py:220). "
+        "Add the staleness caveat and the '&& outcome=success' discipline. (D-201)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# D-202a: No-matching-edge hard-fail — behavior-anchored (shape a)
+#
+# The main loop MUST emit PIPELINE_ERROR with error_type=no_matching_edge
+# and return a FAIL outcome when a non-terminal node has no matching
+# outgoing edge.  This is the behavioral claim the doc makes.
+#
+# Paired with: test_edge_selection_no_silent_fallthrough.py (select_edge
+# unit level) and test_engine.py::test_no_matching_edge_returns_fail.
+# This test verifies the PIPELINE_ERROR event is also emitted.
+# ---------------------------------------------------------------------------
+
+
+def test_d202a_main_loop_hard_fails_no_matching_edge(tmp_path):
+    """D-202a (behavior-anchored): main loop emits PIPELINE_ERROR with
+    error_type=no_matching_edge and returns FAIL when a non-terminal node
+    has no matching outgoing edge.
+
+    engine-semantics.md §3 claims: 'Main loop hard-fails with
+    terminate_pipeline, emits PIPELINE_ERROR with error_type: no_matching_edge.'
+    This test verifies that claim against the running engine.
+
+    Note: this does NOT test the subgraph path (run_subgraph returns the
+    last outcome on a dead-end — see engine.py:917-919).  The doc documents
+    both halves; this test covers the main-loop half.  (D-202a)
+    """
+    from typing import Any
+
+    from amplifier_module_loop_pipeline.context import PipelineContext
+    from amplifier_module_loop_pipeline.engine import PipelineEngine
+    from amplifier_module_loop_pipeline.graph import Edge, Graph, Node
+    from amplifier_module_loop_pipeline.handlers import HandlerRegistry
+    from amplifier_module_loop_pipeline.handlers.context import HandlerContext
+    from amplifier_module_loop_pipeline.outcome import StageStatus
+    from amplifier_module_loop_pipeline.pipeline_events import PIPELINE_ERROR
+
+    class _MockBackend:
+        async def run(self, node, prompt, context, incoming_edge=None, graph=None):
+            return "ok"
+
+    class _CapturingHooks:
+        """Minimal hooks object that captures emitted events."""
+
+        def __init__(self) -> None:
+            self.events: list[tuple[str, dict[str, Any]]] = []
+
+        async def emit(self, event_name: str, data: dict[str, Any]) -> None:
+            self.events.append((event_name, data))
+
+        def get(self, event_name: str) -> list[dict[str, Any]]:
+            return [d for n, d in self.events if n == event_name]
+
+    # Build a graph where a codergen node has no outgoing edges.
+    # Bypass the validator (which would reject isolated nodes) by building
+    # the graph directly.
+    graph = Graph(
+        name="test",
+        nodes={
+            "start": Node(id="start", shape="Mdiamond"),
+            "dead_end": Node(id="dead_end", prompt="work"),
+        },
+        edges=[
+            Edge(from_node="start", to_node="dead_end"),
+            # dead_end has NO outgoing edges — main loop must hard-fail
+        ],
+    )
+
+    hooks = _CapturingHooks()
+    context = PipelineContext()
+    registry = HandlerRegistry(HandlerContext(backend=_MockBackend()))
+    engine = PipelineEngine(
+        graph=graph,
+        context=context,
+        handler_registry=registry,
+        logs_root=str(tmp_path),
+        hooks=hooks,
+    )
+
+    outcome = asyncio.run(engine.run())
+
+    # Claim 1: outcome must be FAIL (not silent SUCCESS)
+    assert outcome.status == StageStatus.FAIL, (
+        f"engine-semantics.md §3 claims the main loop hard-fails on no-matching-edge. "
+        f"Expected FAIL, got {outcome.status}. (D-202a)"
+    )
+
+    # Claim 2: PIPELINE_ERROR event with error_type=no_matching_edge must be emitted
+    pipeline_errors = hooks.get(PIPELINE_ERROR)
+    no_matching_edge_errors = [
+        e for e in pipeline_errors if e.get("error_type") == "no_matching_edge"
+    ]
+    assert no_matching_edge_errors, (
+        "engine-semantics.md §3 claims the main loop emits PIPELINE_ERROR with "
+        "error_type=no_matching_edge. No such event was emitted. "
+        f"All pipeline:error events: {pipeline_errors}. (D-202a)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# D-202b: Source-inspection checks (shape c, lite)
+#
+# Verify that the behaviors the doc cites actually exist in the source at
+# roughly the cited locations.  These are NOT line-exact cite-freshness
+# checks (which would break on every harmless refactor) — they verify that
+# the key symbols/patterns exist in the source file at all, confirming the
+# doc's claims are grounded in real code.
+# ---------------------------------------------------------------------------
+
+
+def test_d202b_engine_emits_no_matching_edge_error():
+    """D-202b (source-inspection): engine.py must contain the no_matching_edge
+    PIPELINE_ERROR emission that the doc cites.
+
+    engine-semantics.md §3 cites engine.py:773-788 for the hard-fail.
+    This check verifies the cited behavior exists in the source (not the
+    exact line numbers, which may shift on refactors).  (D-202b)
+    """
+    src = _engine_src()
+    assert "no_matching_edge" in src, (
+        "engine.py does not contain 'no_matching_edge'. "
+        "engine-semantics.md §3 cites this as the error_type emitted on "
+        "no-matching-edge hard-fail (engine.py:773-788). The doc's claim is "
+        "now unsupported. (D-202b)"
+    )
+    assert "terminate_pipeline" in src, (
+        "engine.py does not contain 'terminate_pipeline'. "
+        "engine-semantics.md §3 cites this as the mechanism for the hard-fail. "
+        "The doc's claim is now unsupported. (D-202b)"
+    )
+
+
+def test_d202b_tool_handler_sets_last_line_only_on_success():
+    """D-202b (source-inspection): tool.py must set tool.last_line only on
+    the success path, not on the early FAIL return.
+
+    engine-semantics.md §3 cites tool.py:158-176 for the early FAIL return
+    and tool.py:220 for the context.set.  This check verifies that
+    'tool.last_line' appears in the source AFTER the returncode check,
+    confirming the stale-label rule is grounded in real code.  (D-202b)
+    """
+    src = _tool_src()
+
+    # The early FAIL return pattern must exist
+    assert "returncode != 0" in src or "returncode" in src, (
+        "tool.py does not contain a returncode check. "
+        "engine-semantics.md §3 cites tool.py:158-176 for the early FAIL return "
+        "that prevents tool.last_line from being refreshed on failure. (D-202b)"
+    )
+
+    # tool.last_line must be set in the source
+    assert 'context.set("tool.last_line"' in src or "tool.last_line" in src, (
+        "tool.py does not set tool.last_line. "
+        "engine-semantics.md §3 cites tool.py:220 for this. (D-202b)"
+    )
+
+    # The key structural invariant: context.set("tool.last_line") must appear
+    # AFTER the returncode != 0 block in the file (i.e., on the success path).
+    fail_return_pos = src.find("returncode != 0")
+    last_line_set_pos = src.find('context.set("tool.last_line"')
+
+    assert fail_return_pos != -1, "tool.py: 'returncode != 0' check not found. (D-202b)"
+    assert last_line_set_pos != -1, (
+        'tool.py: context.set("tool.last_line") not found. (D-202b)'
+    )
+    assert last_line_set_pos > fail_return_pos, (
+        "tool.py: context.set('tool.last_line') appears BEFORE the "
+        "'returncode != 0' check. The stale-label rule documented in "
+        "engine-semantics.md §3 requires that tool.last_line is set only "
+        "on the success path (after the early FAIL return). "
+        f"returncode check at offset {fail_return_pos}, "
+        f"context.set at offset {last_line_set_pos}. (D-202b)"
+    )


### PR DESCRIPTION
## Summary

`context/engine-semantics.md` is this repo's declared source of truth for
SHIPPED-engine behavior — it exists specifically to out-rank stale spec prose,
and its own header asks readers to re-validate any fact whose cite breaks.
Two claims in its §3 routing contract are wrong against the shipped engine.
This PR corrects both and adds an automated drift guard
(`modules/loop-pipeline/tests/test_engine_semantics_doc_guard.py`) so future
doc/engine drift turns the module suite red instead of silently misleading
pipeline authors. No engine behavior changes; no `specs/EXTENSIONS.md` entry
(documentation-only).

**Claim 1 — no-matching-edge (was WRONG, now corrected).** The doc stated,
verbatim:

> **No edge selected & outcome≠FAIL → branch terminates SUCCESS** (nlspec §3.2
> step 6). It does NOT hard-fail `no_matching_edge` and does NOT loop.

That transcribes nlspec §3.2 step 6 — but the shipped main loop has never
followed it: since the initial engine commit (`6c8bf5a`) it hard-fails via
`terminate_pipeline` and emits `PIPELINE_ERROR` with
`error_type: no_matching_edge` (today at `engine.py:773-788`). Meanwhile
subgraph branches (`run_subgraph`, dead-end return at `engine.py:917-919`)
DO return the last outcome without a hard-fail. The corrected doc states both
halves — main loop hard-fails, subgraphs don't — and names the unreconciled
nlspec divergence explicitly rather than over-correcting.

**Claim 2 — stale-label rule (was MISSING, now documented).** A failing tool
node does NOT refresh `tool.last_line`: the early FAIL return on nonzero exit
(`tool.py:158-176`) precedes the `context.set("tool.last_line", …)` at
`tool.py:220`, so the key retains the value from the last *successful*
execution. Consequence: on the second+ visit to a gate in a corrective loop, a
stale label plus a FAIL outcome match BOTH a `context.tool.last_line=X` edge
and an `outcome=fail` edge, and the engine takes the parallel fan-out path.
The doc's token-channel section documented none of this. Now documented with
the trigger condition and the discipline (`&& outcome=success` conjunctions on
mixed-condition edges). Three rotted cites corrected along the way
(`tool.py:210-219`→`212-220`, `177`→`179`, `156-174`→`158-176`).

**The drift guard.** Four check groups, honest about their limits (docstring
"Honest limits" section):

- **D-200 (text-anchored ×3):** the stale "does NOT hard-fail" assertion must
  be absent; no-matching-edge behavior must be documented; the subgraph path
  must be distinguished (guards against over-correction in either direction).
- **D-201 (text-anchored):** staleness language must appear near `last_line`
  (wording-tolerant regex, not exact-prose overfit).
- **D-202a (behavior-anchored):** runs a real `PipelineEngine` on a dead-end
  graph and asserts FAIL outcome + `PIPELINE_ERROR` with
  `error_type=no_matching_edge` — the doc's central claim, executed.
- **D-202b (source-inspection ×2):** the cited behaviors exist in
  `engine.py`/`tool.py` (symbols present; `tool.last_line` set only on the
  success path, after the returncode check) — ballpark sanity, deliberately
  not line-exact so harmless refactors don't break it.

## Verification checklist

- [x] Unit tests pass (`pytest modules/loop-pipeline/`) — 1416 passed, 1 skipped
- [ ] Live pipeline run — N/A: no `engine.py`/handler changes (docs + tests
  only; per AGENTS.md verification gradient "Test fixtures, examples, docs:
  unit tests sufficient"). Note D-202a nonetheless executes a real
  `PipelineEngine.run()` against the documented path.
- [x] AGENTS.md reviewed; repo-specific gates met (verification gradient;
  dependency-awareness rule — no external-repo references introduced)
- [x] Backward-compat path unchanged — N/A: no code changes
- [x] PR body includes verification evidence, not just "tests pass"

## Verification evidence

**Guard tests (7/7):**

```
tests/test_engine_semantics_doc_guard.py::test_d200_stale_no_matching_edge_claim_absent PASSED
tests/test_engine_semantics_doc_guard.py::test_d200_no_matching_edge_main_loop_documented PASSED
tests/test_engine_semantics_doc_guard.py::test_d200_subgraph_path_distinguished PASSED
tests/test_engine_semantics_doc_guard.py::test_d201_stale_label_rule_documented PASSED
tests/test_engine_semantics_doc_guard.py::test_d202a_main_loop_hard_fails_no_matching_edge PASSED
tests/test_engine_semantics_doc_guard.py::test_d202b_engine_emits_no_matching_edge_error PASSED
tests/test_engine_semantics_doc_guard.py::test_d202b_tool_handler_sets_last_line_only_on_success PASSED
7 passed in 0.04s
```

**Full module suite** (`cd modules/loop-pipeline && uv run pytest -q`):

```
1416 passed, 1 skipped, 3 warnings in 20.08s
```

**Root test subset** (`uv run --with pyyaml --with pytest pytest -q -x --ignore=tests/e2e`):

```
14 passed in 0.04s
```

**Negative control — the guard actually bites.** Temporarily re-inserted the
pre-fix stale claim ("It does NOT hard-fail `no_matching_edge`…") into the
doc and re-ran the guard:

```
FAILED tests/test_engine_semantics_doc_guard.py::test_d200_stale_no_matching_edge_claim_absent
E  AssertionError: engine-semantics.md still contains the stale 'does NOT hard-fail
   no_matching_edge' claim. The main loop DOES hard-fail (engine.py:773-788).
   Remove or correct this claim. (D-200a)
E  assert not <re.Match object; span=(6209, 6227), match='does NOT hard-fail'>
1 failed, 6 passed in 0.03s
```

Restored the corrected text; guard green again (`7 passed in 0.09s`).

**Claim-by-claim source verification** (all against this branch):

| Doc claim | Source evidence |
|---|---|
| Main loop hard-fails, `terminate_pipeline` + `PIPELINE_ERROR error_type=no_matching_edge` | `engine.py:773` (`terminate_pipeline`), `engine.py:784` (`"error_type": "no_matching_edge"`) |
| Behavior predates any recent PR — shipped since initial commit | `git show 6c8bf5a:…/engine.py` — main-loop `edge is None` → `Outcome(FAIL)` + `PIPELINE_ERROR no_matching_edge` + return |
| `run_subgraph` returns last outcome on dead-end | `engine.py:917-919` (`if edge is None: return outcome`, inside `run_subgraph` at 837) |
| Early FAIL return precedes `last_line` set | `tool.py:158` (`if proc.returncode != 0:` → return at 163-176) vs `tool.py:220` (`context.set("tool.last_line", …)`) |
| `tool.output` = full stdout | `tool.py:179` |
| nlspec §3.2 step 6 says break-on-no-edge (SUCCESS) | `specs/attractor-spec.md` §3.2 pseudocode: `IF next_edge is NONE: IF outcome.status == FAIL: RAISE …; BREAK` |

## Notes for reviewers

- **Independence from open PRs:** zero file overlap with #98
  (`fix/revive-dead-corrective-edges`: examples/ + docs/reports only) and #99
  (`feat/convergence-observability`: engine.py/cli.py/docs/specs/other tests).
  Verified with `comm -12` over `git diff --name-only origin/main...<branch>`
  for all three branches: 0 shared files in both pairs. Complementary in
  intent: #98 fixes exemplars that mis-modeled routing semantics; this PR
  fixes the document those semantics come from.
- **The `run_subgraph` permissive path is a live design question**, not
  resolved here — this PR only documents the two-path behavior truthfully.
  The engine-level question (should subgraph dead-ends also fail loud?) was
  raised in the PR #98 discussion:
  https://github.com/microsoft/amplifier-bundle-attractor/pull/98#issuecomment-5112709765
- **Provenance, honestly:** this change was produced by an agent-driven
  convergence-pipeline run (machine-verified gate + LLM critique; shipped in
  one iteration) and then independently re-verified and strictly re-reviewed
  by hand before drafting this PR. That review found one false historical
  claim in the agent's output — the doc correction originally attributed the
  hard-fail to PR #66 (`5ae3118`, 2026-06-22). Checking the actual history:
  #66 only removed a duplicate of the hard-fail block in the deleted
  engine-level-resume path; the main-loop hard-fail exists verbatim in the
  initial commit (`6c8bf5a`) and at the doc's authoring time (#61,
  2026-06-17). The doc was wrong from birth, not made stale by #66. The
  commit was amended to say so. (This is itself a nice demonstration of why
  the doc needs a behavior-anchored guard rather than provenance folklore.)
- **Guard placement/discoverability:** the guard lives in
  `modules/loop-pipeline/tests/`, so it runs in the standard
  `pytest modules/loop-pipeline/` invocation from AGENTS.md — no new test
  entry point. It follows the existing `test_doc_consistency.py`
  doc-regression pattern and pairs with the existing behavioral anchors
  (`test_edge_selection_no_silent_fallthrough.py`,
  `test_engine.py::test_no_matching_edge_returns_fail`).
- **Deliberately NOT included:** cite-freshness checks that pin exact line
  numbers (would break on every harmless refactor — D-202b checks symbol
  presence and ordering instead), and a behavioral test for the stale-label
  second-visit fan-out (needs a full looping graph; the docstring records
  this limit explicitly).

Reviewer verification commands:

```bash
# The guard, alone and in the standard suite
uv run pytest modules/loop-pipeline/tests/test_engine_semantics_doc_guard.py -v
pytest modules/loop-pipeline/

# See the guard bite (temporary edit, then restore):
sed -i 's/This is NOT a silent SUCCESS./This is NOT a silent SUCCESS. It does NOT hard-fail./' context/engine-semantics.md
uv run pytest modules/loop-pipeline/tests/test_engine_semantics_doc_guard.py -q   # D-200a fails
git checkout -- context/engine-semantics.md

# Check the claims against the engine yourself
grep -n 'no_matching_edge' modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py
sed -n '158,180p;212,221p' modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/tool.py
git show 6c8bf5a:modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py | sed -n '243,259p'
```

Generated with [Amplifier](https://github.com/microsoft/amplifier)
