### PR TITLE
feat(examples): battle-hardened task-runner exemplar, five-lessons guide, and runnable planted-red fixture

### DIFF
--- a/examples/patterns/task-runner-fixture/README.md
+++ b/examples/patterns/task-runner-fixture/README.md
@@ -1,0 +1,61 @@
+# Task Runner Sample Fixture
+
+A self-contained planted-red demo for the task-runner exemplar. Run it in
+minutes to see the corrective path fire live.
+
+## What it contains
+
+| File | Role |
+|---|---|
+| `sample-task.md` | Task description (goal + DoD + non-goals) |
+| `sample-task.verify.sh` | Executable DoD script (the cheap gate) |
+
+## The planted-red design
+
+The DoD script fails at the runner's **first gate visit by design**. It keys on
+`.ai/iter` — the runner's gate-visit counter, incremented only by the verify
+gate. No matter what the worker does during the work phase, the first gate visit
+goes red.
+
+The second visit goes green if `.ai-demo/answer.txt` contains the sha256 digest
+of `.ai-demo/nonce` (which the script creates on first call and prints in the
+error output).
+
+This guarantees the corrective path (`verify red → triage → attempt → verify
+green`) executes at least once on every first run. A corrective basin that has
+never absorbed a failure is decoration.
+
+## How to run
+
+From the **attractor repo root**:
+
+```bash
+DOT="$PWD/examples/patterns/task-runner.dot"
+cp -r examples/patterns/task-runner-fixture /tmp/task-runner-demo
+cd /tmp/task-runner-demo
+git init -q && git add -A && git commit -qm "fixture baseline"
+attractor run "$DOT" \
+    --param task_file="$PWD/sample-task.md" \
+    --param target_dir="$PWD" \
+    --param max_iterations=6 \
+    --cwd .
+```
+
+We copy to `/tmp` so the committed fixture stays pristine and every run starts
+clean. `$DOT` is captured as an absolute path before `cd`. The `git init`
+matters: the runner's ship path (`package` → `ship_check`) commits the finished
+work to a `task/<id>` branch and verifies a clean tree — the target must be a
+git repository, or the run ends at the `escalate` human gate instead of `done`.
+
+## Expected convergence record
+
+After the run, `.ai/convergence.jsonl` should contain two verify entries:
+
+```jsonl
+{"iteration": 1, "gate": "verify", "pass": false}
+{"iteration": 2, "gate": "verify", "pass": true}
+{"iteration": 2, "gate": "critique", "ship": true}
+```
+
+The first `pass: false` is the planted red. The second `pass: true` is the
+corrective path succeeding. This is the descent curve the guide describes.

--- a/examples/patterns/task-runner-fixture/sample-task.md
+++ b/examples/patterns/task-runner-fixture/sample-task.md
@@ -1,0 +1,56 @@
+---
+id: sample-task
+title: Planted-red demo — write a sha256 answer file
+tier: demo
+effort: minutes
+target_dir: (wherever you run the task runner)
+touches: [.ai-demo/]
+verify: sample-task.verify.sh
+status: ready
+---
+
+# Planted-red demo — write a sha256 answer file
+
+## Goal
+
+A file `.ai-demo/answer.txt` exists in the working directory containing the
+sha256 hex digest of `.ai-demo/nonce`.
+
+## Why this fixture exists
+
+This is a **DRILL-style planted-red fixture**: the DoD script fails at the
+runner's first gate visit by design. It keys on `.ai/iter` — the runner's
+gate-visit counter, incremented only by the verify gate. Pre-running the script
+during the work phase cannot avoid the red, because `.ai/iter` does not exist
+until the gate fires.
+
+The first gate visit always goes red. The second goes green if `answer.txt` is
+correct. This guarantees the corrective path (`verify red -> triage -> attempt
+-> verify green`) executes at least once, live, so you can see the basin absorb
+a failure before trusting it with real work.
+
+The fixture README is honest about this: the first red is planted on purpose.
+
+## Definition of done
+
+**Mechanical** (`sample-task.verify.sh`): `.ai-demo/answer.txt` contains
+`sha256sum(.ai-demo/nonce)`. First invocation always fails (creates the nonce
+and requires a second gate visit).
+
+**Judgment** (critique gate): trivial — confirm the answer was computed from the
+actual nonce (not guessed or hardcoded) and nothing outside `.ai-demo/` was
+touched.
+
+## What the worker should do
+
+When verification fails, read `.ai/verify.log`: it tells you the nonce now
+exists and what the answer must contain. Compute `sha256sum .ai-demo/nonce`,
+write the hex digest into `.ai-demo/answer.txt`, and the next gate visit will
+pass.
+
+## Non-goals
+
+- Touch nothing outside `.ai-demo/`.
+- Do not modify the DoD script (its first-run failure is intentional).
+- Do not read `.ai/iter` directly — the planted red is a property of the gate,
+  not something to work around.

--- a/examples/patterns/task-runner-fixture/sample-task.verify.sh
+++ b/examples/patterns/task-runner-fixture/sample-task.verify.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# DoD script for the task-runner sample fixture (planted-red drill).
+# Run from the target directory (wherever the task runner was pointed).
+#
+# INTENTIONAL: this script fails at the runner's FIRST gate visit no matter
+# what the worker does — it keys on .ai/iter, which only the runner's verify
+# node increments. The worker cannot absorb the red during the work phase.
+#
+# First visit: creates .ai-demo/nonce, prints the required answer, exits 1.
+# Second+ visit: checks .ai-demo/answer.txt contains sha256(.ai-demo/nonce).
+set -u -o pipefail
+
+mkdir -p .ai-demo
+
+# Create the nonce on first call (idempotent — won't overwrite on retry).
+if [ ! -f .ai-demo/nonce ]; then
+    date +%s%N > .ai-demo/nonce
+fi
+
+want=$(sha256sum .ai-demo/nonce | cut -d' ' -f1)
+gate_visits=$(cat .ai/iter 2>/dev/null || echo 0)
+
+if [ "$gate_visits" -lt 2 ]; then
+    echo "PLANTED RED (by design): this is runner gate visit $gate_visits; the drill requires >=2." >&2
+    echo "" >&2
+    echo "Nothing is broken. The corrective path is exercising." >&2
+    echo "Ensure .ai-demo/answer.txt contains:" >&2
+    echo "  sha256(.ai-demo/nonce) = $want" >&2
+    echo "" >&2
+    echo "Compute it with: sha256sum .ai-demo/nonce" >&2
+    echo "Write the hex digest (first field only) to .ai-demo/answer.txt." >&2
+    echo "The NEXT gate visit will pass if the answer is correct." >&2
+    echo "Do not modify .ai/ or this script." >&2
+    exit 1
+fi
+
+if ! grep -q "$want" .ai-demo/answer.txt 2>/dev/null; then
+    echo "WRONG ANSWER: .ai-demo/answer.txt must contain sha256(.ai-demo/nonce) = $want" >&2
+    echo "Current contents:" >&2
+    cat .ai-demo/answer.txt 2>/dev/null || echo "(file missing)" >&2
+    exit 1
+fi
+
+echo "sample-task mechanical DoD: PASS (planted-red corrective path demonstrated)"
+echo "  gate_visits=$gate_visits, nonce=$(cat .ai-demo/nonce), answer=$(cat .ai-demo/answer.txt)"
+exit 0

--- a/examples/patterns/task-runner.dot
+++ b/examples/patterns/task-runner.dot
@@ -1,0 +1,264 @@
+// ============================================================================
+// Task Runner — a battle-hardened convergence attractor
+// ============================================================================
+// Takes ONE task (goal + rationale + executable definition-of-done script) and
+// converges on its completion. The exit is structurally unreachable until the
+// DoD script passes AND the work survives a strict critique.
+//
+// Invocation (per KNOWN_ISSUES: process cwd MUST equal --cwd for box nodes):
+//   cd <target_repo>
+//   DOT=/abs/path/to/task-runner.dot
+//   attractor run "$DOT" \
+//       --param task_file=/abs/path/to/task.md \
+//       --param target_dir=$PWD \
+//       --param max_iterations=6 \
+//       --cwd .
+//
+// Parameters:
+//   task_file        Absolute path to the task description .md file.
+//   target_dir       Absolute path to the target repo (pass $PWD; see note below).
+//   max_iterations   Budget: total verify attempts before the budget wall fires.
+//
+// NOTE on target_dir vs --cwd: tool-node cwd is seeded from --cwd, not from
+// --param target_dir. The $target_dir param is prompt text for box nodes only.
+// The invocation above keeps them identical on purpose.
+//
+// DoD script discovery: the runner looks for a sibling of task_file named
+// <task-basename>.verify.sh (same name as the task file, .md replaced by
+// .verify.sh). Keep the task file and its DoD script as siblings.
+// NOTE: tool_command uses VF="$task_file"; VF="${VF%.md}.verify.sh" — the
+// engine substitutes $name/${name} only; ${name%.suffix} is NOT expanded.
+//
+// SHAPE (the doctrine, made visible):
+//   - INNER loop:  attempt -> verify -(red)-> triage -(novel)-> attempt
+//     Tight mechanical fix cycle. Session continuity (thread_id=work).
+//   - OUTER loop:  verify -(green)-> critique -> verdict -(iterate)->
+//     feedback -(loop_restart)-> attempt
+//     Quality convergence: fresh eyes each iteration + accumulated critique
+//     in .ai/feedback/ = descent, not a coin re-flip.
+//   - ROOT-CAUSE wall: same failure signature twice -> diagnose (stop
+//     patching; an attractor absorbs model drift, not deterministic bugs).
+//   - BUDGET as a decision point: verify itself walls the budget (green
+//     and red paths BOTH spend iterations) -> postmortem -> human gate,
+//     never a bare FAIL.
+//   - Gates are deterministic (parallelogram + exit codes + tool.last_line).
+//     No diamond+outcome= routing (dead-edge trap). Cheap gate (DoD script)
+//     before expensive gate (LLM critique). goal_gate on both gates makes
+//     the exit unearnable without evidence.
+//
+// VERIFIED ENGINE SEMANTICS THIS FILE DEPENDS ON (see task-runner.md):
+//   - STALE-LABEL RULE: a failing tool node does NOT refresh tool.last_line
+//     (ToolHandler returns early on nonzero exit). Therefore any
+//     `context.tool.last_line=X` edge that shares a source node with an
+//     `outcome=fail` edge MUST also assert `&& outcome=success` — otherwise
+//     a stale label + FAIL match two edges at once and the engine takes the
+//     parallel fan-out path. This is the runtime sibling of the diamond
+//     trap, and it only fires on the SECOND+ visit to a gate.
+//   - PARAM NAMESPACE: engine substitution rewrites $name/${name} for any
+//     context/param key, and leaves unknown refs untouched. Shell variables
+//     here (VF, n, rc, sig, B, N, prev, ok, sc) are safe ONLY because no param
+//     shares their name. Never add a param named like a shell var.
+//   - context.target_dir (tool-node cwd) is seeded from --cwd, NOT from
+//     --param target_dir. The $target_dir param is prompt text for box
+//     nodes only. The invocation above keeps them identical on purpose.
+//   - loop_restart clears engine state but NOT backend thread transcripts;
+//     fresh-eyes re-entry is expressed via edge-level fidelity (highest
+//     precedence) on the feedback->attempt edge.
+//   - .ai/iter counts TOTAL verify attempts (inner fixes + outer
+//     iterations); the budget deliberately bounds total verification spend.
+//     Feedback file numbers may skip — they order chronologically.
+//   - On a human-gate timeout/auto-approve, the FIRST edge is chosen:
+//     Abandon is listed first so unattended runs fail safe (honest FAIL +
+//     postmortem) instead of looping on budget bumps.
+//   - SHIP-PATH TRANSIENT RECOVERY + BUDGET WALL AT VERIFY: critique/
+//     feedback/package carry outcome=fail edges back to verify (see the
+//     edge block below). verify increments .ai/iter FIRST and checks the
+//     budget BEFORE running the DoD script, so every re-entry spends an
+//     iteration and a PERSISTENT provider outage drains the budget through
+//     verify and escalates via postmortem->human (verify->postmortem on
+//     last_line=exhausted). The wall must live in verify: triage runs only
+//     on verify FAIL, so a red-path-only budget check would let
+//     critique(FAIL)->verify(PASS)->critique cycle until the engine step
+//     cap kills the run with a bare FAIL, bypassing the postmortem path.
+//     orient stays fail-fast (fails early, cheap to relaunch);
+//     diagnose/postmortem stay fail-fast (already inside failure handling
+//     — a failure there should surface, not loop). Triage keeps its own
+//     exhausted check as a harmless second wall.
+//   - CONVERGENCE RECORD: exactly TWO gates append to .ai/convergence.jsonl
+//     (not every gate). verify appends {"iteration", "gate": "verify",
+//     "pass"} per DoD run, plus {"iteration", "gate": "verify", "budget":
+//     "exhausted"} when the budget wall fires; verdict appends
+//     {"iteration", "gate": "critique", "ship"} per critique round. The
+//     descent curve is kept in files because the engine does not yet
+//     record gate outcomes natively (engine-native convergence records are
+//     proposed in PR #99).
+//
+// MODEL DOCTRINE: the expensive model belongs in the gates (critique,
+// diagnose) — gate quality determines basin depth; maker quality only
+// affects iteration count. Map via model_stylesheet in your deployment, e.g.:
+//   model_stylesheet=".gate { llm_model: <strong-reasoning-model> } .maker { llm_model: <standard-coding-model> }"
+// ============================================================================
+
+digraph TaskRunner {
+    graph [
+        goal="Complete the task described by the task_file parameter to its full definition of done: the task's DoD script passes, and the work survives a strict doctrine critique against the task's judgment criteria.",
+        params="task_file, target_dir, max_iterations",
+        default_max_retries=2,
+        default_fidelity="compact",
+        max_pipeline_duration="14400s",
+        retry_target="attempt"
+    ]
+
+    start [shape=Mdiamond]
+    done  [shape=Msquare]
+
+    // ---------- setup: deterministic preflight ----------
+    setup [shape=parallelogram, class="glue", max_retries=0,
+        tool_command="rm -rf .ai && mkdir -p .ai/feedback .ai/postmortem && B=$max_iterations; echo ${B:-6} > .ai/budget && VF=\"$task_file\"; VF=\"${VF%.md}.verify.sh\"; [ -f \"$task_file\" ] && [ -f \"$VF\" ] && printf ok || printf missing"]
+
+    bad_input [shape=parallelogram, class="glue", max_retries=0,
+        tool_command="echo 'FATAL: task_file or its sibling .verify.sh not found' >&2; exit 1"]
+
+    // ---------- orient: understand before acting ----------
+    orient [shape=box, class="maker",
+        prompt="You are starting a task. Read the task file at $task_file IN FULL, and any doctrine docs it references. Then survey the current state of the target repository at $target_dir: git status, the files and areas the task names. Write .ai/brief.md containing: (1) the goal in your own words, as an end-state of the world; (2) the definition of done — both the mechanical DoD script and the judgment criteria; (3) the quality dimensions that matter and the risks you foresee; (4) the repo's current state, including any partial or dirty work this run must be robust to. Capture understanding, not a step-by-step plan."]
+
+    // ---------- attempt: the maker (inner-loop session continuity) ----------
+    attempt [shape=box, class="maker", thread_id="work", fidelity="full",
+        prompt="Advance the task's goal. Sources of truth: the task file at $task_file, your brief at .ai/brief.md, and ALL files in .ai/feedback/ — accumulated critique from prior iterations; read them FIRST and address them. If .ai/verify.log exists it holds the DoD script's latest output — if it was failing, fix exactly what it reports. If .ai/postmortem/diagnosis.md exists, honor its change of course. Work in the target repository at $target_dir with your file and shell tools; make real changes; honor the repo's own conventions (AGENTS.md, PR templates, design docs) and the task's stated non-goals. Never fabricate evidence or game the DoD script — your work is verified by code, then critiqued against the task's judgment criteria."]
+
+    // ---------- verify: CHEAP deterministic gate (the task's own DoD) ----------
+    verify [shape=parallelogram, class="gate", max_retries=0,
+        goal_gate=true, retry_target="attempt",
+        tool_command="n=$(($(cat .ai/iter 2>/dev/null || echo 0)+1)); echo $n > .ai/iter; B=$(cat .ai/budget 2>/dev/null); B=${B:-6}; if [ \"$n\" -gt \"$B\" ]; then printf '{\"iteration\": %s, \"gate\": \"verify\", \"budget\": \"exhausted\"}\n' \"$n\" >> .ai/convergence.jsonl; printf exhausted; else VF=\"$task_file\"; VF=\"${VF%.md}.verify.sh\"; timeout 1800 bash \"$VF\" > .ai/verify.log 2>&1; rc=$?; [ $rc -eq 124 ] && echo 'VERIFY TIMEOUT after 1800s' >> .ai/verify.log; printf '{\"iteration\": %s, \"gate\": \"verify\", \"pass\": %s}\n' \"$n\" \"$([ $rc -eq 0 ] && echo true || echo false)\" >> .ai/convergence.jsonl; [ $rc -eq 0 ] && printf green || { printf red; exit 1; }; fi"]
+
+    // ---------- triage: root-cause wall + budget check (deterministic) ----------
+    // Signature normalization: volatile tokens (temp run-dir paths, float
+    // timings) are stripped before hashing — a run burned its whole budget
+    // on same-class failures that hashed "novel" every time because a random
+    // /tmp/... path in the hash made every identical failure look novel, so
+    // the root-cause wall never fired (see task-runner.md, lesson 3).
+    triage [shape=parallelogram, class="glue", max_retries=0,
+        tool_command="B=$(cat .ai/budget 2>/dev/null); B=${B:-6}; n=$(cat .ai/iter 2>/dev/null || echo 0); sig=$(tail -20 .ai/verify.log 2>/dev/null | sed -E 's|/tmp/[A-Za-z0-9._-]+|TMPPATH|g; s/[0-9]+\\.[0-9]+s?//g' | md5sum | cut -d' ' -f1); prev=$(cat .ai/last-fail-sig 2>/dev/null || echo none); echo $sig > .ai/last-fail-sig; if [ \"$n\" -ge \"$B\" ]; then printf exhausted; elif [ \"$sig\" = \"$prev\" ]; then printf repeat; else printf novel; fi"]
+
+    diagnose [shape=box, class="gate",
+        prompt="Verification failed twice with the SAME failure signature. Stop patching — find the root cause. Read .ai/verify.log, the task file at $task_file, and the relevant code and docs in $target_dir. Determine what is actually wrong: (a) the current approach, (b) the environment or tooling, (c) the DoD script itself, or (d) the task's assumptions. Write .ai/postmortem/diagnosis.md with the root cause, the evidence, and the single change of course for the next attempt. An attractor absorbs model drift, not deterministic bugs — do not recommend another blind retry. If the blocker cannot be resolved from inside this run (missing access, a genuinely broken DoD script, a contradictory task), include the word BLOCKED on its own line and explain."]
+
+    // Clears the failure signature so the post-diagnosis attempt gets one
+    // clean shot before the root-cause wall can re-fire. BLOCKED grep is
+    // line-start anchored: prose like "not BLOCKED" must not misroute.
+    diagnose_gate [shape=parallelogram, class="glue", max_retries=0,
+        tool_command="rm -f .ai/last-fail-sig; grep -qE '^BLOCKED' .ai/postmortem/diagnosis.md && printf blocked || printf continue"]
+
+    // ---------- critique: EXPENSIVE judgment gate (only on green work) ----------
+    // The verdict grep below is anchored (last line starting 'VERDICT:'):
+    // a critique that merely QUOTES the phrase mid-prose cannot false-ship.
+    critique [shape=box, class="gate",
+        prompt="The mechanical DoD script passed. Now judge the work against the task's FULL definition of done — especially the judgment criteria the script cannot check. Read the task file at $task_file, the brief at .ai/brief.md, and review the ACTUAL changes in $target_dir (git diff, new and changed files; .ai/verify.log for what was verified). Apply the doctrine: evidence over claims — verify that claimed evidence is real; no test-gaming or DoD-script-gaming; docs and paired guides updated; repo conventions honored; non-goals respected; exemplar quality where the task demands it. Write .ai/critique.md: specific findings with file references, then a final line reading exactly 'VERDICT: SHIP' or 'VERDICT: ITERATE'. Be strict — a wrong-but-plausible result that ships is worse than another iteration."]
+
+    // STALL DETECTION: the iteration budget only gates the RED path (triage
+    // runs on verify failure), so a mechanically-green run whose critique
+    // keeps refusing loops unbounded until the wall-clock fuse — 6 consecutive
+    // refusals observed in a live run, with a fresh maximally-strict critic
+    // finding something new each cycle. After 3 total refusals the verdict
+    // routes to postmortem->human: budget-as-decision-point on the OUTER loop.
+    verdict [shape=parallelogram, class="gate", max_retries=0,
+        goal_gate=true, retry_target="attempt",
+        tool_command="n=$(cat .ai/iter 2>/dev/null || echo 0); grep -E '^VERDICT:' .ai/critique.md | tail -1 | grep -q 'SHIP'; ok=$?; printf '{\"iteration\": %s, \"gate\": \"critique\", \"ship\": %s}\n' \"$n\" \"$([ $ok -eq 0 ] && echo true || echo false)\" >> .ai/convergence.jsonl; [ $ok -eq 0 ] && printf ship || { sc=$(($(cat .ai/stall-count 2>/dev/null || echo 0)+1)); echo $sc > .ai/stall-count; if [ \"$sc\" -ge 3 ]; then printf stall; else printf iterate; exit 1; fi; }"]
+
+    // ---------- feedback: accumulate critique -> descent, not re-flip ----------
+    feedback [shape=box, class="maker",
+        prompt="Read .ai/critique.md (and .ai/verify.log if relevant). Distill the SINGLE highest-leverage change for the next iteration into a new file in .ai/feedback/ — read .ai/iter for the current iteration number N and name the file N-next.md. Format: Key finding / What to change / Why it matters. Then curate the channel: consolidate or delete earlier feedback files that are now stale or addressed. Accumulated critique must descend toward the goal, not pile up into sludge."]
+
+    // ---------- package: ship on a branch with real evidence ----------
+    package [shape=box, class="maker",
+        prompt="Both gates passed. Prepare the work for handoff in $target_dir: ensure runner artifacts (.ai/) are excluded from version control via .git/info/exclude (do NOT commit them); create or reuse a branch named task/<task-id> (the id is in the task file's frontmatter at $task_file); commit all task changes with a clear conventional commit message stating WHAT changed and WHY (draw on .ai/brief.md and .ai/critique.md; include the standard Amplifier co-authored-by attribution); and write .ai/SHIPPED.md summarizing the goal, what shipped, where the evidence lives (.ai/verify.log, .ai/convergence.jsonl, run events), and anything a reviewer should know."]
+
+    ship_check [shape=parallelogram, class="gate", max_retries=0,
+        tool_command="[ -z \"$(git status --porcelain | grep -v -E '^\\?\\? \\.ai')\" ] && git log --oneline -1 | grep -q . && printf shipped || printf dirty"]
+
+    // ---------- budget exhaustion: a decision point, not a fuse ----------
+    postmortem [shape=box, class="gate",
+        prompt="The run has hit a decision point without convergence: either the iteration budget is exhausted (repeated verification failures) or the quality loop has stalled (repeated critique refusals on mechanically-green work). Read .ai/convergence.jsonl (the descent record), .ai/critique.md, .ai/verify.log, and .ai/feedback/. Write .ai/postmortem/report.md: what each iteration attempted, whether the loop was DESCENDING, OSCILLATING, or WANDERING (cite the convergence record), your best hypothesis for why it has not converged, and the options (continue with more budget / change approach / split the task / abandon). Be honest — this report is the value salvaged from a non-converging run."]
+
+    // Deterministic guard: the postmortem node has been observed returning
+    // SUCCESS without writing its report. The gate guarantees the file exists
+    // — as a labeled stub if necessary — so abandon never references a missing
+    // artifact (see task-runner.md, lesson 5).
+    pm_gate [shape=parallelogram, class="glue", max_retries=0,
+        tool_command="[ -s .ai/postmortem/report.md ] && printf ok || { echo 'POSTMORTEM REPORT MISSING — the postmortem node completed without writing it. Salvage from .ai/convergence.jsonl, .ai/verify.log, .ai/feedback/.' > .ai/postmortem/report.md; printf stub; }"]
+
+    escalate [shape=hexagon,
+        prompt="The runner could not converge within budget, or could not package cleanly. Review .ai/postmortem/ and .ai/convergence.jsonl before choosing."]
+
+    // Budget bumps are capped so the engine step cap can never become the
+    // real terminator (which would bypass the postmortem path with a bare FAIL).
+    bump_budget [shape=parallelogram, class="glue", max_retries=0,
+        tool_command="B=$(cat .ai/budget 2>/dev/null); B=${B:-6}; N=$((B+3)); [ $N -gt 15 ] && N=15; echo $N > .ai/budget; rm -f .ai/last-fail-sig; printf continue"]
+
+    abandon [shape=parallelogram, class="glue", max_retries=0,
+        tool_command="echo 'ABANDONED: see .ai/postmortem/report.md and .ai/convergence.jsonl' >&2; exit 1"]
+
+    // ================= edges =================
+    start -> setup
+    setup -> orient    [condition="context.tool.last_line=ok"]
+    setup -> bad_input [condition="context.tool.last_line=missing"]
+
+    orient  -> attempt
+    attempt -> verify
+
+    // Cheap gate: green advances, red enters the corrective basin.
+    // NOTE `&& outcome=success`: a failing verify does NOT refresh
+    // tool.last_line, so without the conjunction a stale 'green' + FAIL
+    // would match both edges and fan out (see STALE-LABEL RULE above).
+    verify -> critique [condition="context.tool.last_line=green && outcome=success"]
+    verify -> triage   [condition="outcome=fail"]
+    // Budget wall: verify spends the budget on EVERY entry — green path
+    // and transient re-entries included — and routes exhaustion to the
+    // decision point. `&& outcome=success` is the mandatory STALE-LABEL
+    // conjunction (verify carries an outcome=fail edge, so a stale
+    // 'exhausted' + FAIL would otherwise fan out).
+    verify -> postmortem [condition="context.tool.last_line=exhausted && outcome=success", label="budget exhausted"]
+
+    // Inner loop + root-cause wall + budget wall.
+    triage -> attempt    [condition="context.tool.last_line=novel",     label="fix"]
+    triage -> diagnose   [condition="context.tool.last_line=repeat",    label="same failure twice"]
+    triage -> postmortem [condition="context.tool.last_line=exhausted", label="budget spent"]
+
+    diagnose -> diagnose_gate
+    diagnose_gate -> attempt  [condition="context.tool.last_line=continue", label="change course"]
+    diagnose_gate -> escalate [condition="context.tool.last_line=blocked"]
+
+    // Expensive gate: ship or iterate with accumulated feedback.
+    critique -> verdict
+    verdict  -> package   [condition="context.tool.last_line=ship && outcome=success"]
+    verdict  -> feedback  [condition="outcome=fail",                                    label="iterate"]
+    verdict  -> postmortem [condition="context.tool.last_line=stall && outcome=success", label="quality loop stalled — decision point"]
+    // Edge-level fidelity (highest precedence) forces the fresh-eyes reset:
+    // loop_restart alone does NOT clear the thread_id=work transcript.
+    feedback -> attempt  [loop_restart="true", fidelity="compact", label="fresh iteration, kept learning"]
+
+    // TRANSIENT-RECOVERY routes: a provider error (e.g. overloaded_error) at
+    // a ship-path box node used to fail-fast the whole run after the work was
+    // already done. Route such FAILs back through the cheap gate: verify
+    // re-greens in seconds and the outer loop re-converges. Each re-entry
+    // consumes an iteration, and verify's own budget wall (checked BEFORE
+    // the DoD script runs) means a persistent outage drains the budget and
+    // escalates honestly via postmortem->human instead of looping.
+    critique -> verify [condition="outcome=fail", label="transient — re-enter via cheap gate"]
+    feedback -> verify [condition="outcome=fail", label="transient — re-enter via cheap gate"]
+    package  -> verify [condition="outcome=fail", label="transient — re-enter via cheap gate"]
+
+    // Ship path: evidence of a clean handoff, or a human decides.
+    package    -> ship_check
+    ship_check -> done     [condition="context.tool.last_line=shipped"]
+    ship_check -> escalate [condition="context.tool.last_line=dirty"]
+
+    // Human gate: budget is a decision point. Abandon is FIRST so that
+    // timeout/auto-approve fails safe instead of looping.
+    postmortem -> pm_gate
+    pm_gate -> escalate
+    escalate -> abandon     [label="[A] Abandon — keep the postmortem"]
+    escalate -> bump_budget [label="[C] Continue — raise the budget"]
+    bump_budget -> attempt
+}

--- a/examples/patterns/task-runner.md
+++ b/examples/patterns/task-runner.md
@@ -1,0 +1,393 @@
+# Task Runner — Battle-Hardened Convergence Attractor
+
+A goal+DoD-driven convergence attractor that takes a task description file plus
+an executable definition-of-done script and converges on completion. The exit is
+structurally unreachable until the DoD script passes **and** the work survives a
+strict critique.
+
+This is the battle-hardened big sibling of
+[`convergence-factory.dot`](convergence-factory.dot). Where the factory is a
+clean skeleton, the task runner is a survivor: every corrective structure earned
+its place — four of the five lessons below come from live-run failures, the
+fifth from an empirical engine probe that caught a trap during review, before
+it could bite a run. Its provenance is this repo — it was
+hardened by running real improvement tasks against `amplifier-bundle-attractor`
+itself, and PRs #98, #99, and #101 are its by-products.
+
+---
+
+## Quick start
+
+Copy the fixture to a scratch directory so the committed sample stays pristine,
+then run from the **repo root**:
+
+```bash
+DOT="$PWD/examples/patterns/task-runner.dot"
+cp -r examples/patterns/task-runner-fixture /tmp/task-runner-demo
+cd /tmp/task-runner-demo
+git init -q && git add -A && git commit -qm "fixture baseline"
+attractor run "$DOT" \
+    --param task_file="$PWD/sample-task.md" \
+    --param target_dir="$PWD" \
+    --param max_iterations=6 \
+    --cwd .
+```
+
+The `git init` matters: the ship path (`package` → `ship_check`) commits the
+finished work to a `task/<id>` branch and verifies a clean tree — the target
+must be a git repository, or the run ends at the `escalate` human gate instead
+of `done`.
+
+The fixture uses a **planted-red design**: the DoD script fails on the first
+gate visit by design (it keys on `.ai/iter`, which only the verify gate
+increments). This guarantees the corrective path fires on every first run —
+so you see the basin absorb a failure before trusting it with real work. The
+fixture README explains this honestly.
+
+**Point it at your own task instead:** replace `TASK` with your task `.md` file
+and `target_dir` with your repo root. Keep `$DOT` absolute before `cd`, keep
+`--cwd .` matching the process cwd (see below).
+
+---
+
+## Invocation contract
+
+```bash
+cd <target_repo>
+DOT=/abs/path/to/task-runner.dot
+attractor run "$DOT" \
+    --param task_file=/abs/path/to/task.md \
+    --param target_dir=$PWD \
+    --param max_iterations=6 \
+    --cwd .
+```
+
+**Parameters:**
+
+| Param | What it is |
+|---|---|
+| `task_file` | Absolute path to the task description `.md` file |
+| `target_dir` | Absolute path to the target repo — pass `$PWD` after `cd` |
+| `max_iterations` | Budget: total verify attempts before the budget wall fires |
+
+**The process-cwd == `--cwd` gotcha:** tool-node cwd is seeded from `--cwd`,
+not from `--param target_dir`. The `$target_dir` param is prompt text for box
+nodes only. The invocation above keeps them identical on purpose. If they
+diverge, box nodes write to one place and tool nodes read from another — a
+silent split that surfaces only when a tool node can't find a file a box node
+just wrote. See `modules/pipeline-runner/KNOWN_ISSUES.md`.
+
+**The target must be a git repository:** the ship path (`package` →
+`ship_check`) commits the finished work to a `task/<id>` branch and verifies a
+clean tree. Point the runner only at git-tracked targets (or `git init` a
+scratch directory, as the quick start does).
+
+**DoD script discovery:** the runner looks for a sibling of `task_file` named
+`<task-basename>.verify.sh` (same name as the task file, `.md` replaced by
+`.verify.sh`). Keep the task file and its DoD script as siblings with matching
+basenames.
+
+**Where models come from (the DOT declares none):** the `attractor` CLI path
+never requires a per-node `llm_model`. `attractor run` builds the
+`bundles/attractor-pipeline.yaml` bundle and registers a `session.spawn`
+capability (`run_pipeline` in
+`modules/pipeline-runner/amplifier_module_pipeline_runner/runner.py`), so
+every box node takes the engine's *spawned-agent* path
+(`AmplifierBackend._run_with_spawn`), which explicitly tolerates a missing
+model. Each node's `llm_provider` (default `anthropic`) is routed through the
+profiles map (`anthropic → attractor-agent-anthropic`, `openai →
+attractor-agent-openai`, `gemini → attractor-agent-gemini`) to a
+per-provider child agent, and the model then comes from the bundle's provider
+config — `provider-anthropic` declares `default_model: claude-sonnet-4-6` in
+`bundles/attractor-pipeline.yaml`.
+
+The error `Node 'orient' requires an explicit 'llm_model' attribute` comes
+from the engine's *direct-LLM* path (`_resolve_model` in
+`modules/loop-pipeline/amplifier_module_loop_pipeline/backend.py`), which
+fires only when the engine is driven **without** a `session.spawn` capability
+— e.g. embedding `PipelineEngine`/`AmplifierBackend` directly in your own
+harness. Both behaviors are real; they belong to different entry points.
+
+To take explicit control, set a graph-level `model_stylesheet` (per-node
+`llm_model` also works — on the spawn path it is delivered to the child agent
+via provider preferences, and glob/family tokens are resolved live to the
+newest served model):
+
+```dot
+graph [
+    // Uncomment to route by node class instead of the bundle default:
+    // model_stylesheet=".gate { llm_model: claude-opus-* } .maker { llm_model: claude-sonnet-* }"
+]
+```
+
+**`.ai/convergence.jsonl`:** exactly two gates append records — not every
+gate visit. `verify` appends `{"iteration": N, "gate": "verify", "pass":
+bool}` per DoD run, plus `{"iteration": N, "gate": "verify", "budget":
+"exhausted"}` when its budget wall fires; `verdict` appends `{"iteration": N,
+"gate": "critique", "ship": bool}` per critique round. Together they are the
+descent curve — the file-based workaround for the engine not yet recording
+gate outcomes natively (engine-native convergence records are proposed in
+PR #99) — and the primary evidence artifact for a live run.
+
+---
+
+## Shape
+
+```
+start -> setup -> orient -> attempt -> verify
+                                          |green
+                                       critique -> verdict
+                                          |ship        |iterate
+                                       package      feedback -> attempt (loop_restart)
+                                          |             |fail (transient)
+                                       ship_check -> verify
+                                          |dirty
+                                       escalate
+                                          |
+                                  [A] abandon  [C] bump_budget -> attempt
+
+verify |fail
+triage -> attempt (novel)
+       -> diagnose -> diagnose_gate -> attempt (continue)
+                                    -> escalate (blocked)
+       -> postmortem -> pm_gate -> escalate (exhausted)
+
+verify |exhausted  (budget wall: fires BEFORE the DoD script runs)
+postmortem -> pm_gate -> escalate
+```
+
+**Inner loop** (tight mechanical fix): `attempt -> verify -> triage -> attempt`.
+Session continuity via `thread_id=work` — the maker remembers its work across
+inner iterations.
+
+**Outer loop** (quality convergence): `verify -> critique -> verdict -> feedback
+-> attempt`. Fresh eyes via edge-level `fidelity=compact` on `feedback->attempt`
+— `loop_restart` alone does not clear backend thread transcripts; the edge
+attribute does.
+
+**Root-cause wall:** same failure signature twice → `diagnose` (find the cause,
+never recommend a blind retry) → `diagnose_gate` (clears the signature for one
+clean shot).
+
+**Budget as a decision point:** the budget is checked in `verify` itself —
+every entry (first attempt, inner-loop retry, or transient re-entry)
+increments `.ai/iter`, and the wall fires *before* the DoD script runs.
+Exhaustion → `postmortem` → `pm_gate` → `escalate` → human gate. Never a
+bare FAIL. Abandon is listed first so unattended auto-approve fails safe.
+(`triage` keeps its own exhausted check as a harmless second wall.)
+
+**Stall detection:** 3 consecutive critique refusals on mechanically-green work
+→ `postmortem` → human gate. The outer loop gets a budget too.
+
+---
+
+## Five live-fire lessons
+
+These are not design principles — they are scars. Four come from live runs that
+failed without them; one (the stale-label rule) from an empirical engine probe
+during review.
+
+### 1. Stale-label conjunction
+
+**Doctrine:** Route on evidence — and know how the evidence channel decays.
+
+**Mechanics:** A failing tool node does NOT refresh `tool.last_line`
+(ToolHandler returns early on nonzero exit). Therefore any
+`context.tool.last_line=X` edge that shares a source with an `outcome=fail`
+edge **must** also assert `&& outcome=success` — otherwise a stale label + FAIL
+match two edges at once and the engine takes the parallel fan-out path. This is
+the runtime sibling of the diamond trap. In this graph: `verify->critique`
+carries `last_line=green && outcome=success`; `verdict->package` carries
+`last_line=ship && outcome=success`.
+
+**War story:** In an empirical engine probe, stale "green" + FAIL matched two
+edges and the engine fanned out, critiquing red work. The bug fires only on the
+**second+** gate visit — exactly when the corrective loop first works — so it
+survived topology lints and was caught only by probing the running engine
+during review.
+
+### 2. Transient-recovery routes
+
+**Doctrine:** Survive one node's bad day — including the provider's.
+
+**Mechanics:** Ship-path box nodes (`critique`, `feedback`, `package`) carry
+`outcome=fail` edges back to `verify`. A transient failure re-enters via the
+cheap gate: verify re-greens in seconds and the outer loop re-converges. Each
+re-entry costs an iteration — `verify` increments `.ai/iter` and checks the
+budget *before* running the DoD script — so a **persistent** outage drains
+the budget through `verify` and escalates honestly via
+`verify->postmortem->human` instead of looping forever. `orient` stays
+fail-fast (fails early, cheap to relaunch); `diagnose` and `postmortem` stay
+fail-fast (already inside failure handling — a failure there should surface,
+not loop).
+
+**War story:** An overloaded-error at the `critique` node fail-fasted a live run
+after the work was already done. One edge addition fixed it permanently. A
+cross-provider review then caught the recovery loop's own blind spot: the
+budget check originally lived only in `triage`, which runs only on verify
+FAIL — so a *persistent* critique-stage outage would cycle
+critique(FAIL)→verify(PASS)→critique forever, until the engine's step cap
+killed the run with a bare FAIL, bypassing the postmortem path this graph
+promises. Moving the budget wall into `verify` (checked before the DoD script
+runs) closed it: now every re-entry spends budget on both the red and green
+paths.
+
+### 3. Root-cause wall + signature normalization
+
+**Doctrine:** An attractor absorbs model drift, not deterministic bugs.
+
+**Mechanics:** `triage` hashes the verify-log tail with volatile tokens (tmp
+paths, float timings) stripped via `sed` before `md5sum`. Same signature twice
+→ `diagnose` (find the cause); `diagnose_gate` clears the signature for one
+clean shot. Without normalization, every identical failure hashes "novel" and
+the wall never fires.
+
+**War story:** A run burned its whole budget because a random `/tmp/attractor-run-*/`
+path in the hash made every identical failure look novel. The root-cause wall
+never fired; the budget wall did.
+
+### 4. Stall detection — budget as a decision point on both loops
+
+**Doctrine:** The bound is a decision, not a fuse — and the green path needs
+one too.
+
+**Mechanics:** Every verify entry is bounded by `.ai/iter` vs budget — the
+wall lives in `verify` itself and fires before the DoD script runs
+(`verify->postmortem`; `triage` keeps a second check on the red path). The
+quality loop is additionally bounded by `.ai/stall-count` — 3 critique
+refusals → `stall` → `postmortem` → human gate. Abandon is listed **first**
+so unattended auto-approve fails safe.
+
+**War story:** A mechanically-green run looped 6 consecutive critique refusals
+(a fresh maximally-strict critic always finds something new) until the operator
+killed it at the wall-clock fuse. The stall counter is that fuse, moved inside
+the graph.
+
+### 5. pm_gate — deterministic must-write guard
+
+**Doctrine:** Never let an exit path depend on a box node having actually written
+its artifact.
+
+**Mechanics:** `pm_gate` checks `.ai/postmortem/report.md` is non-empty and
+writes a labeled stub if not, so `abandon` never references a missing file. The
+pattern generalizes: any node whose artifact is required by a downstream path
+should have a deterministic gate after it.
+
+**War story:** The `postmortem` node returned SUCCESS without writing its report
+— twice, in consecutive runs. The gate was added after the second occurrence.
+
+---
+
+## Supporting mechanics
+
+**`loop_restart` does not clear thread transcripts.** Fresh eyes come from
+edge-level `fidelity=compact` on `feedback->attempt` (highest precedence). The
+`loop_restart` attribute resets engine iteration state; the `fidelity` attribute
+compresses the thread context. Both are needed.
+
+**`goal_gate` on both gates.** `verify` and `verdict` both carry `goal_gate=true`.
+This makes the exit unearnable without evidence: the engine requires the goal to
+be met at both the mechanical gate and the judgment gate before `done` is
+reachable.
+
+**Cheap gate before expensive gate.** `verify` (a shell script, seconds) runs
+before `critique` (an LLM call, expensive). Work that fails mechanically never
+reaches the expensive gate.
+
+**`${k:-default}` is shell, not engine.** The engine does NOT expand shell-style
+defaults. `${B:-6}` in a `tool_command` works because `B` is a shell variable in
+the same command — not because the engine expands it. Never name a shell
+variable the same as a param.
+
+**Composing a stronger critique.** When the stakes justify the spend, swap
+the single `critique` stage for two **independent** reviewers from different
+model families — a second box node with `llm_provider="openai"` and an
+explicit `llm_model` — and make `verdict` require consensus: both final
+`VERDICT:` lines must say SHIP. The second reviewer must not read the first's
+critique file; independence is what makes agreement meaningful, and
+cross-family disagreement is signal (this repo's own multi-lens doctrine).
+Two deployment cautions, both verified empirically: (1) the second family's
+provider must be **mounted** in the runner's base bundle — the shipped
+`bundles/attractor-pipeline.yaml` mounts `provider-anthropic` only, and an
+`llm_provider="openai"` node then silently runs on Anthropic (point
+`ATTRACTOR_PIPELINE_BUNDLE` at a bundle that mounts both, and pin
+`llm_provider` in the openai agent's own orchestrator config — verify with an
+identity probe). (2) Run the two reviewers in **sequence, not in parallel**:
+parallel component branches route through `run_subgraph`'s permissive fail
+path (see `context/engine-semantics.md`), which would let a crashed reviewer
+branch pass silently.
+
+**Model doctrine.** The expensive model belongs in the gates (`critique`,
+`diagnose`) — gate quality determines basin depth; maker quality only affects
+iteration count. Use `model_stylesheet` to route nodes by class:
+
+```dot
+model_stylesheet=".gate { llm_model: <strong-reasoning-model> } .maker { llm_model: <standard-coding-model> }"
+```
+
+---
+
+## Live-run evidence
+
+The exemplar has been run end-to-end against its own sample fixture. The
+corrective path fired on the first run as designed.
+
+**Convergence record** (`.ai/convergence.jsonl` from the run):
+
+```jsonl
+{"iteration": 1, "gate": "verify", "pass": false}
+{"iteration": 2, "gate": "verify", "pass": true}
+{"iteration": 2, "gate": "critique", "ship": true}
+```
+
+**Trace** (nodes visited in order):
+`start → setup → orient → attempt → verify(FAIL) → triage → attempt → verify(PASS) → critique → verdict(SHIP) → package → ship_check → done`
+
+The first `verify` failure is the planted red. `triage` routed to `attempt`
+(novel failure, budget not exhausted). The second `attempt` computed
+`sha256sum .ai-demo/nonce` and wrote the hex digest to `.ai-demo/answer.txt`.
+The second `verify` passed. `critique` and `verdict` both cleared. The run
+reached `done` in 2 gate visits.
+
+**Note on DoD script discovery:** during the live run, a bug was found and fixed
+in the `setup` and `verify` nodes. The original used `VF="${task_file%.md}.verify.sh"` —
+the engine substitutes `$task_file` but does not expand shell parameter
+substitutions like `${task_file%.md}` (only `$name` and `${name}` exactly).
+The fix: `VF="$task_file"; VF="${VF%.md}.verify.sh"` — assign first, then strip
+the extension from the shell variable; the engine only rewrites `$name` /
+`${name}` and leaves everything else to the shell.
+
+---
+
+## Fixture design notes
+
+The sample fixture (`task-runner-fixture/`) uses a **planted-red design** keyed
+on `.ai/iter` (the runner's gate-visit counter, incremented only by the verify
+gate). The worker cannot absorb the red during the work phase because it has no
+access to `.ai/iter` before the gate fires — an earlier version keyed on a nonce
+file, and a diligent worker pre-ran the DoD script during the work phase and
+absorbed the red before the gate ever saw it. Good discipline, wrong drill.
+
+The fixture README is honest about this: the first red is planted to demonstrate
+the corrective path, not because anything is broken.
+
+---
+
+## Placement and provenance
+
+This exemplar lives in `examples/patterns/` as the battle-hardened big sibling
+of `convergence-factory.dot`. The `patterns/` directory holds reusable DOT
+structures; this is the first paired `.md` guide here (setting the convention).
+
+**Provenance:** this graph was built and hardened by working a real improvement
+backlog against this repository. It is not a designed diagram — it is a
+survivor. PRs #98, #99, and #101 are its by-products, and each taught it
+something: the run behind #98 shipped only after the critique gate refused a
+mechanically-green first attempt; the run behind #99 stalled at the critique
+gate — the salvaged work became the PR, and the stall became lesson 4; the run
+behind #101 shipped a subtle false historical claim that only human review
+caught (the critique gate bounds review — it does not replace it).
+
+For design principles and routing reference, see
+[`docs/PIPELINE_DESIGN_PRINCIPLES.md`](../../docs/PIPELINE_DESIGN_PRINCIPLES.md)
+and [`docs/ROUTING-REFERENCE.md`](../../docs/ROUTING-REFERENCE.md).

--- a/examples/pipelines/README.md
+++ b/examples/pipelines/README.md
@@ -7,7 +7,7 @@ This folder has three kinds:
 |---------------|-----------|
 | **`01`–`12` (numbered)** | **Tutorials** -- each isolates one concept (linear flow, routing, fan-out, gates, fidelity, model stylesheets, resume). Self-contained: the goal is embedded in the `.dot`, so they run with no target. |
 | [**`practical/`**](practical/) | **Task pipelines** for real work -- bug fix, refactor, test-gen, PR review, feature build, multi-lens review. Three ship a runnable sample. See [practical/README.md](practical/README.md). |
-| [**`patterns/`**](patterns/) | Reusable DOT **snippets** (convergence factory, conversational gates) to drop into your own graphs. |
+| [**`patterns/`**](../patterns/) | Reusable DOT **snippets** (convergence factory, conversational gates) to drop into your own graphs, plus the battle-hardened [task-runner](../patterns/task-runner.md) exemplar with a runnable sample fixture. |
 
 Each pipeline is a pair: a `.dot` (the graph) and a `.md` (the guide -- start there).
 


### PR DESCRIPTION
## Summary

Adds a reusable **task-runner** exemplar to `examples/patterns/`: a goal+DoD-driven
convergence attractor that takes a task description file plus an executable
definition-of-done script and converges on completion — the exit structurally
unreachable until the DoD script passes AND the work survives a strict critique.

**Why:** the repo's examples teach shapes, and the current "true attractor"
exemplar (`convergence-factory.dot`) is a clean 7-node skeleton — no budget
semantics, no transient recovery, no root-cause wall. This PR contributes the
first shipped graph where every corrective structure earned its place under fire,
plus the paired guide that teaches the **five live-fire lessons** it was hardened
by (doctrine + graph mechanics + one-line war story each):

1. **Stale-label conjunction** — a failing tool node does not refresh
   `tool.last_line`; any `last_line=X` edge sharing a source with an
   `outcome=fail` edge must add `&& outcome=success` or a stale label + FAIL
   fan out (fires only on the 2nd+ gate visit — invisible to static checks).
2. **Transient-recovery routes** — ship-path box nodes route `outcome=fail`
   back through the cheap gate instead of fail-fasting a finished run;
   the budget wall lives in `verify` itself (checked before the DoD script
   runs), so persistent outages drain the budget on the green path too and
   escalate honestly via `verify → postmortem → human`.
3. **Root-cause wall + signature normalization** — same failure signature twice
   → diagnose; volatile tokens stripped before hashing so identical failures
   don't masquerade as "novel".
4. **Stall detection** — the green path gets a budget too: 3 critique refusals
   → postmortem → human gate (abandon listed first so auto-approve fails safe).
5. **pm_gate** — deterministic must-write guard; no exit path depends on a box
   node having actually written its artifact.

A self-contained **planted-red fixture** (keyed on `.ai/iter`, runner-only
state) guarantees the corrective path demonstrably fires on every first run —
runnable in minutes. Also fixes a pre-existing broken relative link in
`examples/pipelines/README.md` (`patterns/` → `../patterns/`).

**Provenance (honest):** this graph was built and hardened by working a real
improvement backlog against this very repository; PRs #98, #99, and #101 are its
by-products (the guide states what each run actually did — including that #99's
run stalled at the critique gate and #101's run shipped a subtle false claim only
human review caught). It was agent-built via convergence runs and human-reviewed;
this branch is the human fresh-eyes polish of the run's output.

## Verification checklist

- [x] Unit tests pass (`pytest modules/loop-pipeline/`) — **N/A-adjacent: no
  engine/module code is touched (examples + docs only); the module suite is
  unaffected by this diff.** (Stated per template; see evidence for what WAS run.)
- [x] Live pipeline run exercising changed code path — the shipped exemplar was
  run end-to-end against its shipped fixture, from this exact tree; trace +
  convergence record pasted below
- [x] AGENTS.md reviewed; repo-specific gates met (dot validated after edits;
  paired guide ships in the same change; live-run evidence captured)
- [x] Backward-compat path unchanged (additive: new files + one README line)
- [x] PR body includes verification evidence, not just "tests pass"

## Verification evidence

**Static topology gate** (pydot+networkx; the stale-label lint is the novel check):

```
nodes=20 edges=30 simple-cycles=11; unreachable from start: NONE; done reachable: True;
STALE-LABEL violations: NONE (every last_line edge sharing a source with an
outcome=fail edge carries && outcome=success — incl. the new verify->postmortem edge)
```

`dot -Tsvg examples/patterns/task-runner.dot` renders clean (graphviz parse OK).

**Live run** (isolated eval container, repo checked out at `dc92ebe` — whose
`.dot` is byte-identical to this branch head `d7389cf`; invocation exactly as
documented in the guide's quick start; re-run AFTER the budget-wall change to
prove the green/red logic didn't break):

```bash
DOT="$PWD/examples/patterns/task-runner.dot"
cp -r examples/patterns/task-runner-fixture /tmp/task-runner-demo
cd /tmp/task-runner-demo
git init -q && git add -A && git commit -qm "fixture baseline"
attractor run "$DOT" --param task_file="$PWD/sample-task.md" \
    --param target_dir="$PWD" --param max_iterations=6 --cwd .
```

Result: `attractor: status=success`, exit 0. Node trace (run-dir `trace.jsonl`):

```
start → setup → orient → attempt → verify FAIL (planted red) → triage →
attempt → verify SUCCESS → critique → verdict (SHIP) → package → ship_check → done
```

`.ai/convergence.jsonl` (the descent record the guide documents):

```jsonl
{"iteration": 1, "gate": "verify", "pass": false}
{"iteration": 2, "gate": "verify", "pass": true}
{"iteration": 2, "gate": "critique", "ship": true}
```

`verify.log`: `sample-task mechanical DoD: PASS`, gate_visits=2. Ship path
committed the work on branch `task/sample-task` (commit touched only
`.ai-demo/{nonce,answer.txt}` — the task's non-goals honored), and the answer was
independently re-verified equal to `sha256sum .ai-demo/nonce`.

**Honest scope note:** this demo exercises the inner corrective loop and the full
ship path. The deeper paths (root-cause wall, stall detection, postmortem,
transient recovery) were not triggered by this fixture run — they are backed by
the live-fire runs described in the guide's war stories, not by this demo.

## Notes for reviewers

- **Placement:** `examples/patterns/` as the battle-hardened big sibling of
  `convergence-factory.dot`. This is the first paired `.md` guide in `patterns/`
  (the pair convention is stated repo-wide in `examples/pipelines/README.md`);
  if you'd rather it live in `examples/pipelines/practical/`, say so — the files
  move cleanly.
- **The fixture's first red is planted on purpose** (keyed on `.ai/iter`, which
  only the verify gate increments — a worker cannot absorb it during the work
  phase). Both the fixture README and the task file say so explicitly.
- **The target must be a git repository** — the ship path commits to a
  `task/<id>` branch and verifies a clean tree; the guide and fixture README
  document the `git init` step for scratch-dir demos.
- `.ai/convergence.jsonl` is honestly labeled a file-based workaround pending
  engine-native descent records (proposed in PR #99). If #99 merges first, the
  guide line can be updated to point at the native mechanism — trivial follow-up.
- The `examples/pipelines/README.md` change fixes a pre-existing broken link
  (`patterns/` resolved to `examples/pipelines/patterns/`, which doesn't exist)
  and adds the exemplar to that row for discoverability.

## Reviewer verification commands

```bash
# Topology + stale-label lint (requires pydot+networkx)
dot -Tsvg examples/patterns/task-runner.dot -o /dev/null && echo render-ok

# Run the fixture demo yourself (≈3–5 min, needs ANTHROPIC or OPENAI key)
DOT="$PWD/examples/patterns/task-runner.dot"
cp -r examples/patterns/task-runner-fixture /tmp/task-runner-demo
cd /tmp/task-runner-demo
git init -q && git add -A && git commit -qm "fixture baseline"
attractor run "$DOT" --param task_file="$PWD/sample-task.md" \
    --param target_dir="$PWD" --param max_iterations=6 --cwd .
cat .ai/convergence.jsonl    # expect: verify false → verify true → critique ship
```

---
See: [Per-Repo Conventions](https://github.com/microsoft/amplifier-foundation/blob/main/docs/PER_REPO_CONVENTIONS.md) and this repo's `AGENTS.md` for the verification discipline this checklist enforces.

