### PR TITLE
chore: add CODEOWNERS file for directional review gating

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default owners — all changes require review from the bundle's maintainer.
+# More-specific rules below override the catch-all (last match wins).
+* @bkrabach


### PR DESCRIPTION
Adds .github/CODEOWNERS to enforce code-owner review requirement on all changes to the bundle.

This ensures that all pull requests require approval from @bkrabach, the bundle's maintainer, before they can merge. This directional control is essential after external PRs began arriving, particularly those introducing new engine dispatch semantics and event contracts.

After this PR merges, branch protection will be updated to require code-owner review as a gating condition.