### PR TITLE
feat(lint): attractor lint — five topological basin-lint rules + CLI

### DIFF
--- a/docs/DOT-AUTHORING-GUIDE.md
+++ b/docs/DOT-AUTHORING-GUIDE.md
@@ -753,9 +753,219 @@ digraph FeatureBuild {
 }
 ```
 
+## Static Lint Rules (`attractor lint`)
+
+Run `attractor lint <file.dot>` to check a pipeline file before running it.
+Lint is static (no API calls, sub-second), safe to run in CI, and does not
+change run-time validation behaviour.
+
+**Exit-code contract:**
+- Errors (ERROR severity) → exit 1 (pipeline will not execute correctly)
+- Warnings only → exit 0 (use `--strict` to treat warnings as errors)
+
+**Spec note:** These lint rules are lint-only — they do not change run-time
+behaviour and require no `specs/EXTENSIONS.md` entry.  They enforce the
+canonical attractor spec's routing semantics statically, at author time.
+
+---
+
+### TOPO-001 — Dead conditional edge out of a diamond node
+
+**What it detects:** An edge out of a `diamond` (ConditionalHandler) node
+whose condition is `outcome!=success` or `outcome=fail`.
+
+**Why it's wrong:** `ConditionalHandler` (shape=`diamond`) always returns
+`SUCCESS` unconditionally (`handlers/conditional.py`).  Additionally, `FAIL`
+is fail-fast — it never reaches a diamond via plain edges
+(`edge_selection.py`).  Therefore, `outcome!=success` and `outcome=fail`
+edges out of a diamond can **never fire**.  The corrective branch is silently
+dead.  This was the root cause of 8 shipped examples having dead corrective
+edges for months.
+
+**Severity:** ERROR — the edge is provably unreachable.
+
+**Fix:** Replace the `outcome=` condition with an evidence-based condition set
+by a preceding tool or LLM node:
+
+```dot
+// WRONG — dead edge: ConditionalHandler always returns SUCCESS
+gate -> fix [condition="outcome!=success"]
+
+// CORRECT — route on evidence set by the preceding tool/LLM node
+gate -> fix [condition="context.preferred_label=retry"]
+gate -> done [condition="context.preferred_label=done"]
+```
+
+Diamond nodes are pure routing hubs.  They do not execute logic and cannot
+observe upstream outcomes.  Use `context.preferred_label` (set via
+`report_outcome`) or `context.tool.last_line` (set by a tool node) to route.
+
+---
+
+### TOPO-002 — Stale-label collision on a tool node
+
+**What it detects:** A `parallelogram` (ToolHandler) node that has BOTH:
+- an outgoing edge conditioned on `context.tool.last_line=X` (without also
+  asserting `&& outcome=success`), AND
+- an outgoing edge conditioned on `outcome=fail`
+
+**Why it's wrong:** `ToolHandler` sets `context.tool.last_line` only on
+success (`tool.py`).  On failure, it returns `FAIL` early before setting the
+label.  On the second visit after a failure, `tool.last_line` still holds the
+stale value from the prior success.  Both edges then match simultaneously —
+the stale `last_line` edge AND the `outcome=fail` edge — causing a silent
+double-dispatch.  This bug is invisible in single-pass testing.
+
+**Severity:** ERROR — silent correctness bug on the second visit.
+
+**Fix:** Add `&& outcome=success` to the `last_line` edge so it only fires
+when the tool actually succeeded and the label is fresh:
+
+```dot
+// WRONG — stale-label collision on second visit
+tool -> done [condition="context.tool.last_line=green"]
+tool -> fix  [condition="outcome=fail"]
+
+// CORRECT — conjunction ensures label is fresh
+tool -> done [condition="context.tool.last_line=green && outcome=success"]
+tool -> fix  [condition="outcome=fail"]
+```
+
+---
+
+### TOPO-003 — Acyclic graph (no corrective cycle)
+
+**What it detects:** A pipeline with no back-edge (no cycle at all).
+
+**Why it matters:** An attractor pipeline should have at least one corrective
+loop that allows it to retry, self-correct, or converge.  A pipeline with no
+cycle is a linear one-pass analysis — which may be deliberate (a "recipe") but
+is more likely a design gap.  12 of 24 shipped examples were acyclic.
+
+**Severity:** WARNING — deliberate one-pass pipelines are legitimate
+(single-pass analysis, no retry needed).
+
+**Fix:** If convergence is needed, add a corrective back-edge:
+
+```dot
+// Add a back-edge with evidence-based exit condition
+validate -> work  [condition="outcome=fail"]
+validate -> done  [condition="context.tool.last_line=pass && outcome=success"]
+```
+
+If the pipeline is deliberately linear, ignore this warning.  Consider whether
+it should be a recipe (a staged, human-approved sequence) rather than an
+attractor.
+
+---
+
+### TOPO-004 — Cycle with no explicitly-gated exit
+
+**What it detects:** A cycle (strongly-connected component) where no edge
+**exiting the cycle** (from a cycle node to a node outside the cycle) carries
+an explicit gate.  Two edge forms count as explicitly gated:
+
+- an exit edge with a `condition` expression, or
+- a **labeled** exit edge from a human-gate (`hexagon`) node — the human's
+  selection routes on edge labels, an explicit gate without a `condition`.
+
+Note: conditional edges that route *within* the cycle do not count — only an
+exit edge leaving the SCC provides a gated termination path.
+
+**Why it matters:** Without an explicit gate, termination rests on implicit
+routing mechanics (unconditional-edge weight/lexical tiebreaks, fail-fast
+halts) or on budget caps (`max_retries`, `max_pipeline_duration`).  That may
+work, but the convergence criterion is invisible to a reader of the graph —
+make the exit explicit.
+
+**Severity:** WARNING — implicitly-routed and budget-capped loops are
+legitimate in some contexts (bounded exploration).
+
+**Fix:** Add a condition expression to the cycle's exit edge:
+
+```dot
+// WRONG — unconditional exit, budget-cap only
+validate -> done  // no condition
+
+// CORRECT — evidence-gated exit
+validate -> done [condition="context.tool.last_line=pass && outcome=success"]
+validate -> work [condition="outcome=fail"]
+```
+
+The check runs per strongly-connected component (SCC) so that a compliant
+loop does not suppress diagnostics for a separate non-compliant loop in the
+same graph.
+
+---
+
+### TOPO-005 — Cycle with no deterministic evidence gate
+
+**What it detects:** A cycle (SCC) whose continuation/exit decisions rest
+solely on LLM say-so — no `parallelogram` (tool) node on the cycle whose
+evidence actually gates control flow, and no human gate on the cycle.
+
+**Why it matters:** LLMs may claim success prematurely (wrong-but-plausible
+work exits the loop) or loop indefinitely.  The corrective loop only descends
+when a mechanical gate on the cycle forces bad work back around — or halts it
+loudly.
+
+A tool node counts as a deterministic evidence gate when its outcome or
+output participates in routing.  Grounded in engine semantics, that happens
+in two ways:
+
+1. **Evidence-conditioned edges:** an outgoing edge routing on `outcome`
+   (a tool's outcome is its command's exit status — mechanical) or on a
+   `context.tool.*` key (set from the tool's output).
+2. **A plain (unconditional) outgoing edge:** plain edges only traverse on
+   SUCCESS — FAIL is fail-fast — so a failing tool mechanically halts the
+   pipeline.  That is an implicit `outcome=success` gate.  (Exception: a
+   plain edge to a `runs_on=always` / `runs_on=failure` target traverses on
+   FAIL too, and gates nothing.)
+
+A tool merely *being present* on the cycle is NOT enough.  A no-op router
+tool whose outgoing edges are all conditioned on LLM-set context keys (e.g.
+`context.preferred_label`) leaves the loop LLM-gated — its own evidence is
+unused — and this rule fires.
+
+A human-gate (`hexagon`) node on the cycle also counts as a real gate: every
+iteration passes through external human judgment, which is exactly the check
+that catches wrong-but-plausible output.  Human-gated loops do not warn.
+
+**The honest limit of static analysis:** lint credits the topology, not the
+command.  A tool whose command is a meaningless no-op that always succeeds
+(e.g. `echo ok`) followed by a plain edge satisfies form 2 syntactically;
+whether the command performs a real check is not statically decidable.
+
+**Severity:** WARNING — LLM-gated loops are legitimate in some contexts
+(goal_gate with retry_target).
+
+**Fix:** Put a tool node on the cycle whose evidence gates routing:
+
+```dot
+// WRONG — LLM-only cycle, exit gated on LLM outcome
+generate -> assess
+assess -> done [condition="outcome=success"]   // LLM says "done"
+assess -> generate [condition="outcome!=success"]
+
+// CORRECT — tool on cycle, routing gated on tool evidence
+generate -> validate  // validate is shape=parallelogram
+validate -> done    [condition="context.tool.last_line=pass && outcome=success"]
+validate -> generate [condition="outcome=fail"]
+```
+
+See `examples/patterns/convergence-factory.dot` for the canonical pattern:
+its `validate` tool has a plain out-edge, so a failing validation halts the
+loop via fail-fast before the LLM assessor ever judges the work.
+
+The check runs per SCC so that a compliant loop does not suppress diagnostics
+for a separate non-compliant loop.
+
+---
+
 ## Further Reading
 
 - [DOT-SYNTAX.md](DOT-SYNTAX.md) -- Quick reference tables and copy-paste patterns
 - [APP-INTEGRATION-GUIDE.md](APP-INTEGRATION-GUIDE.md) -- Using pipelines from Python code
 - [GETTING-STARTED.md](GETTING-STARTED.md) -- Installation and first run
 - [examples/pipelines/](../examples/pipelines/) -- 10 tutorial + 5 practical pipeline examples
+- [examples/LINT-SWEEP.md](../examples/LINT-SWEEP.md) -- Full corpus sweep results

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/conditions.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/conditions.py
@@ -12,6 +12,47 @@ from .context import PipelineContext
 from .outcome import Outcome
 
 
+def parse_condition(condition: str) -> list[tuple[str, str, str]]:
+    """Parse a condition expression into ``(key, op, value)`` clause triples.
+
+    This is the single grammar entry point for the condition expression
+    language.  Both the runtime evaluator (``evaluate_condition``) and the
+    static lint rules (``validation.py`` TOPO-001..005) consume it, so the
+    grammar cannot drift between engine routing and lint analysis.
+
+    The grammar (spec Section 10): one or more clauses joined by ``&&``
+    (the ONLY conjunction operator — comma is NOT an AND separator; a value
+    containing a comma is compared literally as a single clause, e.g.
+    ``context.x=a,b`` matches the value ``"a,b"``).  Each clause is one of:
+
+      - ``key!=value``  — inequality check  → ``(key, "!=", value)``
+      - ``key=value``   — equality check    → ``(key, "=", value)``
+      - ``key``         — truthiness check  → ``(key, "truthy", "")``
+
+    ``!=`` is checked before ``=`` (since ``=`` is a substring of ``!=``).
+    Whitespace around ``&&`` and around operators is stripped.  Clauses that
+    are empty after stripping are silently skipped.  An empty condition
+    yields an empty clause list (which evaluates as always-true).
+    """
+    clauses: list[tuple[str, str, str]] = []
+    if not condition:
+        return clauses
+    for piece in condition.split("&&"):
+        clause = piece.strip()
+        if not clause:
+            continue
+        if "!=" in clause:
+            key, value = clause.split("!=", maxsplit=1)
+            clauses.append((key.strip(), "!=", value.strip()))
+        elif "=" in clause:
+            key, value = clause.split("=", maxsplit=1)
+            clauses.append((key.strip(), "=", value.strip()))
+        else:
+            # Bare key: truthiness check
+            clauses.append((clause, "truthy", ""))
+    return clauses
+
+
 def evaluate_condition(
     condition: str,
     outcome: Outcome,
@@ -22,45 +63,36 @@ def evaluate_condition(
     Returns True if the condition passes (edge is eligible).
     An empty condition always returns True.
 
-    Spec Section 10.5: Evaluation algorithm.
+    Spec Section 10.5: Evaluation algorithm.  Parsing is delegated to
+    ``parse_condition`` (the shared grammar entry point).
     """
     if not condition or not condition.strip():
         return True
 
-    # Split on '&&' — the ONLY conjunction operator (spec §10, §10.7).
-    # Comma is NOT an AND separator; a value containing a comma is compared
-    # literally as a single clause (e.g. context.x=a,b matches the value "a,b").
-    raw_clauses: list[str] = []
-    for piece in condition.split("&&"):
-        piece = piece.strip()
-        if piece:
-            raw_clauses.append(piece)
-
-    for clause in raw_clauses:
-        if not _evaluate_clause(clause, outcome, context):
+    for key, op, value in parse_condition(condition):
+        if not _evaluate_clause(key, op, value, outcome, context):
             return False
     return True
 
 
 def _evaluate_clause(
-    clause: str,
+    key: str,
+    op: str,
+    value: str,
     outcome: Outcome,
     context: PipelineContext,
 ) -> bool:
-    """Evaluate a single Key Operator Value clause.
+    """Evaluate a single parsed ``(key, op, value)`` clause.
 
     Spec Section 10.5: evaluate_clause algorithm.
     """
-    # Check for != before = (since = is a substring of !=)
-    if "!=" in clause:
-        key, value = clause.split("!=", maxsplit=1)
-        return _resolve_key(key.strip(), outcome, context) != value.strip()
-    elif "=" in clause:
-        key, value = clause.split("=", maxsplit=1)
-        return _resolve_key(key.strip(), outcome, context) == value.strip()
-    else:
-        # Bare key: check if truthy
-        return bool(_resolve_key(clause.strip(), outcome, context))
+    resolved = _resolve_key(key, outcome, context)
+    if op == "!=":
+        return resolved != value
+    if op == "=":
+        return resolved == value
+    # "truthy": bare key — check if truthy
+    return bool(resolved)
 
 
 def _resolve_key(

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/validation.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/validation.py
@@ -4,7 +4,9 @@ Validates parsed Graph models against the rules defined in
 spec Section 7 (Validation and Linting). Produces Diagnostic objects
 with severity ERROR (blocks execution) or WARNING (informational).
 
-Spec coverage: LINT-001–018
+Spec coverage: LINT-001–018.  TOPO-001–005 are topological basin-lint rules
+implemented here beyond the canonical spec; they are lint-only (exposed via
+``lint()``, not ``validate()``) and do not change run-time behaviour.
 """
 
 from __future__ import annotations
@@ -13,10 +15,10 @@ from collections import deque
 from collections.abc import Callable
 from dataclasses import dataclass
 
-from .conditions import evaluate_condition
+from .conditions import evaluate_condition, parse_condition
 from .context import PipelineContext
 from .fidelity import VALID_FIDELITY_MODES
-from .graph import Graph
+from .graph import Graph, Node
 from .outcome import Outcome, StageStatus
 from .stylesheet import parse_stylesheet
 
@@ -99,6 +101,33 @@ def validate(
     for rule in extra_rules or []:
         diags.extend(rule(graph))
 
+    return diags
+
+
+def lint(graph: Graph) -> list[Diagnostic]:
+    """Run topological (basin-lint) rules in addition to structural rules.
+
+    This is the entry point for the ``attractor lint`` CLI command.  It runs
+    the full structural ``validate()`` suite plus the five new topological
+    rules (TOPO-001–005) that reason about cycle structure, handler semantics,
+    and evidence-routing patterns.
+
+    Topological rules are lint-only: they do not change run-time validation
+    behaviour.  Existing graphs that execute today will not start failing at
+    ``run`` time because of new WARNINGs produced here.
+
+    Exit-code contract (for CLI use):
+        ERROR-severity diagnostics → non-zero exit.
+        WARNING-only (or clean) → zero exit.
+
+    Returns the combined list of all Diagnostic objects.
+    """
+    diags = validate(graph)
+    _check_dead_conditional_edge(graph, diags)
+    _check_stale_label_collision(graph, diags)
+    _check_acyclic_graph(graph, diags)
+    _check_cycle_no_conditional_exit(graph, diags)
+    _check_cycle_no_deterministic_exit(graph, diags)
     return diags
 
 
@@ -589,3 +618,616 @@ def _check_response_schema(graph: Graph, diags: list[Diagnostic]) -> None:
                     ),
                 )
             )
+
+
+# ---------------------------------------------------------------------------
+# Topological (basin-lint) rules — TOPO-001 through TOPO-005
+#
+# These rules reason about cycle structure and handler semantics, not just
+# graph topology.  They are exposed via ``lint()`` (not ``validate()``) so
+# they remain lint-only and do not change run-time validation behaviour.
+#
+# Every rule is traceable to a real, observed failure mode (dead corrective
+# edges shipped in 8 examples; the stale-label collision; acyclic "attractor"
+# pipelines).  Speculative rules are intentionally excluded.
+#
+# Condition expressions are parsed with ``conditions.parse_condition`` — the
+# same grammar entry point the runtime evaluator uses — so lint analysis and
+# engine routing cannot drift apart.
+# ---------------------------------------------------------------------------
+
+# Shape set for diamond (ConditionalHandler) nodes.
+_DIAMOND_SHAPES: frozenset[str] = frozenset({"diamond"})
+
+# Shape set for parallelogram (ToolHandler) nodes.
+_TOOL_SHAPES: frozenset[str] = frozenset({"parallelogram"})
+
+
+def _is_diamond(node: Node) -> bool:
+    """Return True if the node is a ConditionalHandler (diamond) node."""
+    return node.shape in _DIAMOND_SHAPES or node.type == "conditional"
+
+
+def _is_tool(node: Node) -> bool:
+    """Return True if the node is a ToolHandler (parallelogram) node."""
+    return node.shape in _TOOL_SHAPES or node.type == "tool"
+
+
+def _is_human_gate(node: Node) -> bool:
+    """Return True if the node is a human-gate (hexagon / wait.human) node."""
+    return node.shape == "hexagon" or node.type == "wait.human"
+
+
+def _find_back_edges(graph: Graph) -> set[tuple[str, str]]:
+    """Return the set of back-edges (source, target) in the graph using DFS.
+
+    A back-edge is an edge from a node to an ancestor in the DFS tree,
+    indicating a cycle.  Uses iterative DFS to avoid recursion limits on
+    large graphs.
+    """
+    visited: set[str] = set()
+    in_stack: set[str] = set()
+    back_edges: set[tuple[str, str]] = set()
+
+    def dfs(start: str) -> None:
+        stack: list[tuple[str, list[str]]] = [(start, [])]
+        while stack:
+            node_id, neighbors_iter_state = stack[-1]
+            if node_id not in visited:
+                visited.add(node_id)
+                in_stack.add(node_id)
+                # Build neighbor list on first visit
+                neighbors = [
+                    e.to_node
+                    for e in graph.outgoing_edges(node_id)
+                    if e.to_node in graph.nodes
+                ]
+                stack[-1] = (node_id, neighbors)
+            else:
+                # Continuing after returning from a child
+                neighbors = neighbors_iter_state
+
+            # Find next unprocessed neighbor
+            found_child = False
+            while neighbors:
+                neighbor = neighbors.pop(0)
+                stack[-1] = (node_id, neighbors)
+                if neighbor in in_stack:
+                    back_edges.add((node_id, neighbor))
+                elif neighbor not in visited:
+                    stack.append((neighbor, []))
+                    found_child = True
+                    break
+
+            if not found_child:
+                stack.pop()
+                in_stack.discard(node_id)
+
+    for node_id in graph.nodes:
+        if node_id not in visited:
+            dfs(node_id)
+
+    return back_edges
+
+
+def _has_cycle(graph: Graph) -> bool:
+    """Return True if the graph contains at least one cycle."""
+    return bool(_find_back_edges(graph))
+
+
+def _compute_sccs(graph: Graph) -> list[set[str]]:
+    """Return a list of strongly-connected components (SCCs) with size >= 2,
+    or size == 1 with a self-loop.  Uses Kosaraju's two-pass algorithm.
+
+    Each returned SCC is a set of node IDs that form a cycle together.
+    SCCs of size 1 with no self-loop are trivial (no cycle) and are excluded.
+
+    This is the correct granularity for per-cycle analysis: TOPO-004 and
+    TOPO-005 must check each SCC independently so that a compliant SCC does
+    not suppress diagnostics for a non-compliant sibling SCC.
+    """
+    node_ids = list(graph.nodes.keys())
+    if not node_ids:
+        return []
+
+    # Build adjacency and reverse adjacency
+    adj: dict[str, list[str]] = {n: [] for n in node_ids}
+    radj: dict[str, list[str]] = {n: [] for n in node_ids}
+    for edge in graph.edges:
+        if edge.from_node in graph.nodes and edge.to_node in graph.nodes:
+            adj[edge.from_node].append(edge.to_node)
+            radj[edge.to_node].append(edge.from_node)
+
+    # Self-loop check helper
+    self_loop_nodes: set[str] = {
+        edge.from_node
+        for edge in graph.edges
+        if edge.from_node == edge.to_node and edge.from_node in graph.nodes
+    }
+
+    # Pass 1: DFS on original graph, collect finish order
+    visited: set[str] = set()
+    finish_order: list[str] = []
+
+    def dfs1(start: str) -> None:
+        stack: list[tuple[str, int]] = [(start, 0)]
+        while stack:
+            node, idx = stack[-1]
+            if node not in visited:
+                visited.add(node)
+            neighbors = adj[node]
+            if idx < len(neighbors):
+                stack[-1] = (node, idx + 1)
+                nxt = neighbors[idx]
+                if nxt not in visited:
+                    stack.append((nxt, 0))
+            else:
+                stack.pop()
+                finish_order.append(node)
+
+    for n in node_ids:
+        if n not in visited:
+            dfs1(n)
+
+    # Pass 2: DFS on reversed graph in reverse finish order
+    visited2: set[str] = set()
+    sccs: list[set[str]] = []
+
+    def dfs2(start: str) -> set[str]:
+        component: set[str] = set()
+        stack: list[str] = [start]
+        while stack:
+            node = stack.pop()
+            if node in visited2:
+                continue
+            visited2.add(node)
+            component.add(node)
+            for nxt in radj[node]:
+                if nxt not in visited2:
+                    stack.append(nxt)
+        return component
+
+    for n in reversed(finish_order):
+        if n not in visited2:
+            scc = dfs2(n)
+            # Include SCCs with a cycle: size >= 2, or size == 1 with self-loop
+            if len(scc) >= 2 or (len(scc) == 1 and next(iter(scc)) in self_loop_nodes):
+                sccs.append(scc)
+
+    return sccs
+
+
+def _nodes_on_cycles(graph: Graph) -> set[str]:
+    """Return the set of node IDs that participate in at least one cycle.
+
+    Delegates to ``_compute_sccs`` for correctness: any node in a non-trivial
+    SCC (size >= 2 or self-loop) is on a cycle.
+    """
+    result: set[str] = set()
+    for scc in _compute_sccs(graph):
+        result.update(scc)
+    return result
+
+
+def _check_dead_conditional_edge(graph: Graph, diags: list[Diagnostic]) -> None:
+    """TOPO-001: Dead conditional edge out of a diamond node.
+
+    ConditionalHandler (shape=diamond) always returns SUCCESS unconditionally
+    (handlers/conditional.py:47).  Additionally, FAIL is fail-fast: it never
+    reaches a diamond node via plain edges (edge_selection.py:79-101).
+
+    Therefore any edge out of a diamond that conditions on ``outcome!=success``
+    can NEVER fire — the diamond always emits SUCCESS, so the negation is
+    always false.  Similarly, ``outcome=fail`` edges are dead for the same
+    reason.
+
+    This is the root cause of the dead-corrective-edge bug class that shipped
+    in 8 examples (fixed upstream).  The correct pattern is to route on
+    evidence (e.g. ``context.tool.last_line=X`` or ``context.preferred_label``
+    set by a preceding tool/LLM node) rather than on ``outcome=`` through a
+    diamond.
+
+    Severity: ERROR — the edge is provably unreachable; the corrective branch
+    will never execute.
+    """
+    for node in graph.nodes.values():
+        if not _is_diamond(node):
+            continue
+        if node.is_start_node() or node.is_exit_node():
+            continue
+
+        for edge in graph.outgoing_edges(node.id):
+            cond = edge.condition.strip() if edge.condition else ""
+            if not cond:
+                continue
+
+            # Check each clause for outcome!=success or outcome=fail patterns
+            for key, op, val in parse_condition(cond):
+                dead = (op == "!=" and key == "outcome" and val == "success") or (
+                    op == "=" and key == "outcome" and val in ("fail", "error")
+                )
+
+                if dead:
+                    diags.append(
+                        Diagnostic(
+                            rule="dead_conditional_edge",
+                            severity="ERROR",
+                            message=(
+                                f"Node '{node.id}' (diamond/ConditionalHandler) has a "
+                                f"dead outgoing edge to '{edge.to_node}' with condition "
+                                f"'{cond}': ConditionalHandler always returns SUCCESS "
+                                f"unconditionally, so outcome!=success / outcome=fail "
+                                f"edges from a diamond can never fire."
+                            ),
+                            node_id=node.id,
+                            edge=(edge.from_node, edge.to_node),
+                            fix=(
+                                f"Replace the outcome= condition on the edge from "
+                                f"'{node.id}' to '{edge.to_node}' with an evidence-based "
+                                f"condition (e.g. context.tool.last_line=X or "
+                                f"context.preferred_label=Y set by a preceding tool or "
+                                f"LLM node). Diamond nodes are pure routing hubs — they "
+                                f"do not execute logic and cannot observe upstream "
+                                f"outcomes. See DOT-AUTHORING-GUIDE.md for the "
+                                f"evidence-routing pattern."
+                            ),
+                        )
+                    )
+                    break  # one diagnostic per edge is enough
+
+
+def _check_stale_label_collision(graph: Graph, diags: list[Diagnostic]) -> None:
+    """TOPO-002: Stale-label collision on a tool node.
+
+    When a ToolHandler (shape=parallelogram) fails, it returns FAIL early
+    (handlers/tool.py:158-176) BEFORE setting ``context.tool.last_line``
+    (tool.py:220).  On the second visit after a failure, ``tool.last_line``
+    still holds the stale value from the prior successful run.
+
+    If the same source tool node has BOTH:
+      - an outgoing edge conditioned on ``context.tool.last_line=X`` (without
+        also asserting ``&& outcome=success``), AND
+      - an outgoing edge conditioned on ``outcome=fail``
+
+    then on the second visit after a failure, BOTH edges match simultaneously:
+    the ``last_line`` edge matches the stale value AND the ``outcome=fail``
+    edge matches the current FAIL outcome.  The engine fans out to both
+    targets — a silent double-dispatch.
+
+    The fix is to add ``&& outcome=success`` to the ``last_line`` edge so it
+    only fires when the tool actually succeeded (and the label is fresh).
+
+    Severity: ERROR — the double-dispatch is a silent correctness bug that
+    only manifests on the second visit (invisible in single-pass testing).
+
+    Traceable to: handlers/tool.py (early FAIL return precedes the
+    context.set of tool.last_line); context/engine-semantics.md.
+    """
+    for node in graph.nodes.values():
+        if not _is_tool(node):
+            continue
+        if node.is_start_node() or node.is_exit_node():
+            continue
+
+        outgoing = graph.outgoing_edges(node.id)
+        if not outgoing:
+            continue
+
+        # Collect edges with context.tool.last_line= conditions (without && outcome=success)
+        last_line_edges_without_success: list = []
+        has_outcome_fail_edge = False
+
+        for edge in outgoing:
+            cond = edge.condition.strip() if edge.condition else ""
+            if not cond:
+                continue
+
+            clauses = parse_condition(cond)
+            has_outcome_success = False
+            has_last_line = False
+
+            for key, op, val in clauses:
+                if op == "=" and key == "outcome" and val == "success":
+                    has_outcome_success = True
+                if key in ("context.tool.last_line", "tool.last_line"):
+                    has_last_line = True
+
+            if has_last_line and not has_outcome_success:
+                last_line_edges_without_success.append(edge)
+
+            # Check for outcome=fail edge (or outcome!=success equivalent)
+            for key, op, val in clauses:
+                if key == "outcome" and (
+                    (op == "=" and val == "fail") or (op == "!=" and val == "success")
+                ):
+                    has_outcome_fail_edge = True
+
+        if last_line_edges_without_success and has_outcome_fail_edge:
+            for edge in last_line_edges_without_success:
+                diags.append(
+                    Diagnostic(
+                        rule="stale_label_collision",
+                        severity="ERROR",
+                        message=(
+                            f"Node '{node.id}' (tool/parallelogram) has a "
+                            f"stale-label collision: edge to '{edge.to_node}' "
+                            f"conditions on 'context.tool.last_line=...' without "
+                            f"'&& outcome=success', while another outgoing edge "
+                            f"conditions on 'outcome=fail'. On the second visit "
+                            f"after a failure, tool.last_line holds a stale value "
+                            f"from the prior success, causing both edges to match "
+                            f"simultaneously (silent double-dispatch)."
+                        ),
+                        node_id=node.id,
+                        edge=(edge.from_node, edge.to_node),
+                        fix=(
+                            f"Add '&& outcome=success' to the condition on the edge "
+                            f"from '{node.id}' to '{edge.to_node}' so it reads "
+                            f"'context.tool.last_line=X && outcome=success'. This "
+                            f"ensures the label edge only fires when the tool "
+                            f"succeeded and the label is fresh. The 'outcome=fail' "
+                            f"edge handles the failure case exclusively. See "
+                            f"DOT-AUTHORING-GUIDE.md for the evidence-routing pattern."
+                        ),
+                    )
+                )
+
+
+def _check_acyclic_graph(graph: Graph, diags: list[Diagnostic]) -> None:
+    """TOPO-003: Acyclic graph warning — no corrective cycle found.
+
+    An attractor pipeline should have at least one back-edge (cycle) that
+    allows it to retry, correct, or converge.  A pipeline with no cycle is
+    a linear one-pass analysis — which may be deliberate (a single-pass
+    review is a legitimate shape) but is more likely a recipe that should
+    not be an attractor.
+
+    Half of the originally-shipped examples were acyclic.  This warning
+    surfaces the question at author time.
+
+    Severity: WARNING — deliberate one-pass pipelines are legitimate.  The
+    fix text acknowledges this.
+    """
+    if _has_cycle(graph):
+        return
+
+    diags.append(
+        Diagnostic(
+            rule="acyclic_graph",
+            severity="WARNING",
+            message=(
+                "This graph has no cycle (no back-edge): it is a linear, "
+                "one-pass pipeline.  An attractor should have at least one "
+                "corrective loop that allows it to retry, self-correct, or "
+                "converge.  If this is intentional (a deliberate single-pass "
+                "analysis), this warning can be ignored — but consider whether "
+                "this pipeline should be a recipe instead."
+            ),
+            fix=(
+                "Add a corrective back-edge from a validation/gate node back to "
+                "an earlier work node so the pipeline can retry on failure.  "
+                "Use evidence-based conditions (context.tool.last_line or "
+                "context.preferred_label) on the exit edge to gate convergence.  "
+                "If this is a deliberate one-pass pipeline, no change is needed — "
+                "this is a WARNING, not an error."
+            ),
+        )
+    )
+
+
+def _check_cycle_no_conditional_exit(graph: Graph, diags: list[Diagnostic]) -> None:
+    """TOPO-004: Cycle with no explicitly-gated exit edge.
+
+    A cycle (SCC) where NO edge leaving the cycle carries an explicit gate
+    has no stated convergence criterion.  Termination then rests on implicit
+    routing mechanics — unconditional-edge weight/lexical tiebreaks,
+    fail-fast halts — or on budget caps (max_retries,
+    max_pipeline_duration).  That may work, but the convergence criterion
+    is invisible to a reader of the graph.  This is a design smell: make
+    the exit explicit.
+
+    Two edge forms count as an explicitly-gated exit:
+      - an exit edge with a ``condition`` expression, or
+      - a *labeled* exit edge whose source is a human-gate (hexagon /
+        wait.human) node — the human's selection routes on edge labels,
+        which is an explicit (human) gate even without a condition attr.
+
+    The check runs per strongly-connected component (SCC) so that a compliant
+    SCC does not suppress diagnostics for a separate non-compliant SCC.
+
+    Note: ``goal_gate_has_retry`` (an existing WARNING) already covers the
+    case where a goal_gate node lacks retry_target.  This rule covers the
+    orthogonal case where no gated exit exists on the cycle at all.
+
+    Severity: WARNING — implicitly-routed and budget-capped loops are
+    legitimate in some contexts (e.g. bounded exploration).
+    """
+    sccs = _compute_sccs(graph)
+    if not sccs:
+        return
+
+    for scc in sccs:
+        # Find edges that exit this SCC (from an SCC node to a non-SCC node)
+        # and check if any of them are explicitly gated.
+        has_gated_exit = False
+        for node_id in scc:
+            node = graph.nodes.get(node_id)
+            for edge in graph.outgoing_edges(node_id):
+                if edge.to_node not in scc and edge.to_node in graph.nodes:
+                    if edge.condition and edge.condition.strip():
+                        has_gated_exit = True
+                        break
+                    # Labeled exit from a human gate: the human's selection
+                    # routes on edge labels — an explicit gate.
+                    if (
+                        node is not None
+                        and _is_human_gate(node)
+                        and edge.label
+                        and edge.label.strip()
+                    ):
+                        has_gated_exit = True
+                        break
+            if has_gated_exit:
+                break
+
+        if not has_gated_exit:
+            cycle_list = ", ".join(sorted(scc))
+            diags.append(
+                Diagnostic(
+                    rule="cycle_no_conditional_exit",
+                    severity="WARNING",
+                    message=(
+                        f"The cycle involving nodes [{cycle_list}] has no explicitly-"
+                        f"gated exit edge: no edge leaving the cycle carries a "
+                        f"condition expression (or a labeled human-gate choice).  "
+                        f"Termination rests on implicit routing mechanics "
+                        f"(unconditional-edge tiebreaks, fail-fast halts) or budget "
+                        f"caps (max_retries, max_pipeline_duration) — the convergence "
+                        f"criterion is invisible to a reader of the graph."
+                    ),
+                    fix=(
+                        "Add a condition expression to the cycle's exit edge(s) so the "
+                        "pipeline exits based on evidence (e.g. "
+                        "context.tool.last_line=done or context.preferred_label=converged). "
+                        "This makes convergence explicit and independent of budget "
+                        "caps.  See DOT-AUTHORING-GUIDE.md for the evidence-routing pattern."
+                    ),
+                )
+            )
+
+
+def _tool_evidence_gates_flow(graph: Graph, node_id: str) -> bool:
+    """Return True if a tool node's own evidence can gate control flow.
+
+    A parallelogram (ToolHandler) node counts as a deterministic evidence
+    gate when its outcome or output actually participates in routing.  Two
+    engine-semantics-grounded ways this happens:
+
+    (i)  An outgoing edge whose condition references the tool's own evidence:
+         ``outcome`` (a tool's outcome is its command's exit status —
+         mechanical, not LLM say-so) or a ``tool.*`` / ``context.tool.*``
+         key (set from the tool's output).
+
+    (ii) A plain (unconditional) outgoing edge to a default node.  Plain
+         edges only traverse on SUCCESS — FAIL is fail-fast
+         (edge_selection.py, spec §3.7) — so the tool mechanically halts
+         the pipeline on failure: an implicit ``outcome=success`` gate.
+         Exception: a plain edge to a node with ``runs_on=always`` or
+         ``runs_on=failure`` traverses on FAIL too, so it gates nothing.
+
+    A tool whose outgoing edges are all conditioned solely on non-tool
+    context keys (e.g. ``context.preferred_label`` set by an LLM node via
+    report_outcome) does NOT gate anything: its own evidence is unused, and
+    those context conditions can even match on FAIL against stale context
+    values (the stale-label trap, TOPO-002).
+
+    Note the honest limit of static analysis: lint credits the topology,
+    not the command.  A tool whose command is a no-op that always succeeds
+    (e.g. ``echo ok``) satisfies (ii) syntactically; whether the command
+    performs a meaningful check is not statically decidable.
+    """
+    for edge in graph.outgoing_edges(node_id):
+        cond = edge.condition.strip() if edge.condition else ""
+        if not cond:
+            # (ii) plain edge — implicit outcome=success gate via fail-fast,
+            # unless the target opts into failure routing via runs_on.
+            target = graph.nodes.get(edge.to_node)
+            runs_on = "success"
+            if target is not None:
+                runs_on = str(target.attrs.get("runs_on", "success") or "success")
+                runs_on = runs_on.strip().lower()
+            if runs_on not in ("always", "failure"):
+                return True
+            continue
+        # (i) conditional edge referencing the tool's own evidence
+        for key, _op, _val in parse_condition(cond):
+            if key == "outcome" or key.startswith(("tool.", "context.tool.")):
+                return True
+    return False
+
+
+def _check_cycle_no_deterministic_exit(graph: Graph, diags: list[Diagnostic]) -> None:
+    """TOPO-005: Loop with no deterministic evidence gate on the cycle.
+
+    A cycle (SCC) whose continuation/exit decisions rest solely on LLM
+    say-so lacks a deterministic convergence criterion: the LLM can claim
+    success prematurely (wrong-but-plausible work exits the loop) or loop
+    forever.  The corrective loop only descends when a mechanical gate on
+    the cycle forces bad work back around (or halts it loudly).
+
+    An SCC is compliant when it contains at least one parallelogram
+    (ToolHandler) node whose evidence actually gates control flow — see
+    ``_tool_evidence_gates_flow`` for the two engine-grounded forms this
+    takes (evidence-conditioned edges, or a plain edge whose traversal is
+    itself gated by fail-fast semantics).
+
+    A tool merely *being present* on the cycle is NOT enough: a no-op tool
+    whose outgoing edges route solely on LLM-set context keys (e.g.
+    ``context.preferred_label``) leaves the loop LLM-gated, and this rule
+    fires.
+
+    A human-gate (hexagon / wait.human) node on the cycle also counts as a
+    real gate: every iteration passes through a human decision, which is
+    external judgment — precisely the check that catches wrong-but-plausible
+    LLM output.  Warning on the canonical conversational-gate pattern would
+    be a false positive that trains authors to ignore the rule.
+
+    The check runs per strongly-connected component (SCC) so that a compliant
+    SCC does not suppress diagnostics for a separate non-compliant SCC.
+
+    Severity: WARNING — LLM-gated loops are legitimate in some contexts
+    (e.g. goal_gate nodes with retry_target).  This is a design smell, not
+    a hard error.
+    """
+    sccs = _compute_sccs(graph)
+    if not sccs:
+        return
+
+    for scc in sccs:
+        # A human gate on the cycle is real external judgment — not LLM
+        # say-so.  The loop is human-gated by design; do not warn.
+        if any(_is_human_gate(graph.nodes[n]) for n in scc if n in graph.nodes):
+            continue
+
+        tools_on_scc = [n for n in scc if n in graph.nodes and _is_tool(graph.nodes[n])]
+
+        if any(_tool_evidence_gates_flow(graph, n) for n in tools_on_scc):
+            continue  # This SCC has a deterministic evidence gate — clean.
+
+        cycle_list = ", ".join(sorted(scc))
+        if not tools_on_scc:
+            detail = (
+                "no parallelogram (tool) node on the cycle provides "
+                "mechanically-verifiable evidence for convergence"
+            )
+        else:
+            # Tool(s) exist but their evidence never gates routing
+            detail = (
+                "parallelogram (tool) node(s) exist on the cycle but their "
+                "evidence never gates routing: every outgoing edge is "
+                "conditioned on non-tool context keys (e.g. LLM-set "
+                "context.preferred_label), so the tool outcome/output is "
+                "unused and the loop remains LLM-gated"
+            )
+
+        diags.append(
+            Diagnostic(
+                rule="cycle_no_deterministic_exit",
+                severity="WARNING",
+                message=(
+                    f"The cycle involving nodes [{cycle_list}] has no deterministic "
+                    f"evidence gate: {detail}.  The loop's "
+                    f"continuation/exit relies solely on LLM judgment."
+                ),
+                fix=(
+                    "Put a parallelogram (tool) node on the cycle whose evidence "
+                    "gates routing: either route on its outcome/output "
+                    "(condition='context.tool.last_line=done && outcome=success' "
+                    "to exit, condition='outcome=fail' back to the work node), or "
+                    "give it a plain edge so a failing check halts the loop via "
+                    "fail-fast instead of letting unverified work continue.  "
+                    "See DOT-AUTHORING-GUIDE.md (TOPO-005) and "
+                    "examples/patterns/convergence-factory.dot."
+                ),
+            )
+        )

--- a/modules/loop-pipeline/tests/test_conditions.py
+++ b/modules/loop-pipeline/tests/test_conditions.py
@@ -3,7 +3,10 @@
 Spec coverage: CEXPR-001–011 (Section 10).
 """
 
-from amplifier_module_loop_pipeline.conditions import evaluate_condition
+from amplifier_module_loop_pipeline.conditions import (
+    evaluate_condition,
+    parse_condition,
+)
 from amplifier_module_loop_pipeline.context import PipelineContext
 from amplifier_module_loop_pipeline.outcome import Outcome, StageStatus
 
@@ -285,10 +288,16 @@ def test_ampersand_and_both_clauses_must_pass():
     ctx = PipelineContext()
     ctx.set("state", "ready")
     # Both clauses pass → True
-    assert evaluate_condition("outcome=success && context.state=ready", outcome, ctx) is True
+    assert (
+        evaluate_condition("outcome=success && context.state=ready", outcome, ctx)
+        is True
+    )
     # Second clause fails → False
     ctx.set("state", "busy")
-    assert evaluate_condition("outcome=success && context.state=ready", outcome, ctx) is False
+    assert (
+        evaluate_condition("outcome=success && context.state=ready", outcome, ctx)
+        is False
+    )
 
 
 def test_comma_in_value_is_literal_not_and_separator():
@@ -302,3 +311,108 @@ def test_comma_in_value_is_literal_not_and_separator():
     # Different value → no match
     ctx.set("tag", "a,c")
     assert evaluate_condition("context.tag=a,b", outcome, ctx) is False
+
+
+# --- shared grammar entry point: parse_condition ---
+#
+# parse_condition is the single condition-grammar parser shared by the
+# runtime evaluator (evaluate_condition) and the static lint rules
+# (validation.py TOPO-001..005).  These tests pin the parser's output and
+# its parity with the evaluator so the two can never drift apart.
+
+
+def test_parse_condition_equality_clause():
+    """key=value parses to (key, '=', value)."""
+    assert parse_condition("outcome=success") == [("outcome", "=", "success")]
+
+
+def test_parse_condition_inequality_clause():
+    """key!=value parses to (key, '!=', value) — != checked before =."""
+    assert parse_condition("outcome!=success") == [("outcome", "!=", "success")]
+
+
+def test_parse_condition_bare_key_is_truthy():
+    """A bare key parses to a truthy clause, matching engine truthiness."""
+    assert parse_condition("context.flag") == [("context.flag", "truthy", "")]
+
+
+def test_parse_condition_conjunction_order_preserved():
+    """&& conjunction yields clauses in source order."""
+    assert parse_condition("context.tool.last_line=green && outcome=success") == [
+        ("context.tool.last_line", "=", "green"),
+        ("outcome", "=", "success"),
+    ]
+
+
+def test_parse_condition_whitespace_stripped():
+    """Whitespace around && and operators is stripped."""
+    assert parse_condition("  context.x =  y  &&  outcome != fail ") == [
+        ("context.x", "=", "y"),
+        ("outcome", "!=", "fail"),
+    ]
+
+
+def test_parse_condition_empty_and_blank_clauses_skipped():
+    """Empty conditions and empty clauses yield no triples."""
+    assert parse_condition("") == []
+    assert parse_condition("   ") == []
+    assert parse_condition("outcome=success && ") == [("outcome", "=", "success")]
+
+
+def test_parse_condition_comma_value_is_literal():
+    """Spec §10.7: a comma stays inside the value — one clause, not two."""
+    assert parse_condition("context.tag=a,b") == [("context.tag", "=", "a,b")]
+
+
+def test_parse_condition_value_containing_equals():
+    """maxsplit=1: only the first = splits key from value."""
+    assert parse_condition("context.expr=a=b") == [("context.expr", "=", "a=b")]
+
+
+def test_parse_condition_parity_with_evaluator():
+    """Parity: evaluate_condition agrees with a manual walk of parse_condition.
+
+    Guards against the two-parallel-parsers drift class: if the evaluator's
+    grammar ever diverges from parse_condition, this test fails.
+    """
+    outcome = Outcome(status=StageStatus.SUCCESS)
+    ctx = PipelineContext()
+    ctx.set("state", "ready")
+    ctx.set("flag", "yes")
+
+    cases = [
+        "outcome=success",
+        "outcome!=fail",
+        "context.state=ready",
+        "context.state!=busy",
+        "context.flag",
+        "outcome=success && context.state=ready",
+        "  context.state = ready  &&  outcome != fail ",
+        "context.missing",
+        "context.missing=x",
+    ]
+
+    def resolve(key: str) -> str:
+        if key == "outcome":
+            return outcome.preferred_label or outcome.status.value
+        if key == "preferred_label":
+            return outcome.preferred_label or ""
+        if key.startswith("context."):
+            v = ctx.get(key)
+            if v is None:
+                v = ctx.get(key[len("context.") :])
+            return "" if v is None else str(v)
+        v = ctx.get(key)
+        return "" if v is None else str(v)
+
+    for cond in cases:
+        expected = True
+        for key, op, value in parse_condition(cond):
+            if op == "=":
+                ok = resolve(key) == value
+            elif op == "!=":
+                ok = resolve(key) != value
+            else:
+                ok = bool(resolve(key))
+            expected = expected and ok
+        assert evaluate_condition(cond, outcome, ctx) is expected, cond

--- a/modules/loop-pipeline/tests/test_examples_lint_clean.py
+++ b/modules/loop-pipeline/tests/test_examples_lint_clean.py
@@ -1,0 +1,57 @@
+"""Sweep the shipped examples/ corpus through lint() — no ERRORs allowed.
+
+This is the enforcement arm for the examples corpus: the dead-corrective-edge
+bug class (TOPO-001) shipped in 8 examples for months because nothing could
+see topology.  This test keeps the corpus honest — if a future example
+reintroduces a dead diamond edge or a stale-label collision, the suite goes
+red at author time instead of the bug shipping.
+
+WARNING-severity diagnostics are allowed: deliberately linear examples
+(TOPO-003) and LLM-gated loops (TOPO-004/005) are legitimate patterns and
+warnings are informational.  ERROR-severity diagnostics are provable defects.
+
+The examples tree lives at the repository root, outside the installed
+package, so this test runs against a source checkout and skips gracefully
+when the examples directory is not present (e.g. installed-package test runs).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from amplifier_module_loop_pipeline.dot_parser import parse_dot
+from amplifier_module_loop_pipeline.validation import lint
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_EXAMPLES_DIR = _REPO_ROOT / "examples"
+
+
+def _example_dot_files() -> list[Path]:
+    if not _EXAMPLES_DIR.is_dir():
+        return []
+    return sorted(_EXAMPLES_DIR.rglob("*.dot"))
+
+
+_DOT_FILES = _example_dot_files()
+
+
+@pytest.mark.skipif(
+    not _DOT_FILES,
+    reason="examples/ directory not present (installed-package run)",
+)
+@pytest.mark.parametrize(
+    "dot_path",
+    _DOT_FILES,
+    ids=lambda p: str(p.relative_to(_EXAMPLES_DIR)),
+)
+def test_example_lints_without_errors(dot_path: Path) -> None:
+    """Every shipped example must be free of ERROR-severity lint findings."""
+    graph = parse_dot(dot_path.read_text(encoding="utf-8"))
+    diags = lint(graph)
+    errors = [d for d in diags if d.severity == "ERROR"]
+    assert not errors, (
+        f"{dot_path.relative_to(_REPO_ROOT)} has ERROR-severity lint findings:\n"
+        + "\n".join(f"  [{d.rule}] {d.message}" for d in errors)
+    )

--- a/modules/loop-pipeline/tests/test_topological_lint.py
+++ b/modules/loop-pipeline/tests/test_topological_lint.py
@@ -1,0 +1,1019 @@
+"""Tests for topological (basin-lint) rules — TOPO-001 through TOPO-005.
+
+These rules reason about cycle structure and handler semantics, not just
+graph topology.  They are exposed via ``lint()`` (not ``validate()``) so
+they remain lint-only and do not affect run-time validation behaviour.
+
+Test pattern follows test_validation.py: construct Graph/Node/Edge objects
+directly (no DOT parsing) for speed and isolation.
+"""
+
+from __future__ import annotations
+
+from amplifier_module_loop_pipeline.graph import Edge, Graph, Node
+from amplifier_module_loop_pipeline.validation import (
+    Diagnostic,
+    lint,
+    validate,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers — mirrors test_validation.py's pattern
+# ---------------------------------------------------------------------------
+
+
+def _mdiamond(node_id: str = "start") -> Node:
+    return Node(id=node_id, shape="Mdiamond", label="Start")
+
+
+def _msquare(node_id: str = "exit") -> Node:
+    return Node(id=node_id, shape="Msquare", label="Exit")
+
+
+def _box(node_id: str = "work", **kwargs) -> Node:
+    return Node(id=node_id, shape="box", **kwargs)
+
+
+def _diamond(node_id: str = "gate", **kwargs) -> Node:
+    return Node(id=node_id, shape="diamond", **kwargs)
+
+
+def _tool(node_id: str = "tool", **kwargs) -> Node:
+    return Node(id=node_id, shape="parallelogram", **kwargs)
+
+
+def _graph(
+    nodes: dict[str, Node] | None = None,
+    edges: list[Edge] | None = None,
+    **kwargs,
+) -> Graph:
+    return Graph(
+        name="test",
+        nodes=nodes or {},
+        edges=edges or [],
+        **kwargs,
+    )
+
+
+def _diag(diags: list[Diagnostic], rule: str) -> list[Diagnostic]:
+    """Return diagnostics matching the given rule name."""
+    return [d for d in diags if d.rule == rule]
+
+
+# ---------------------------------------------------------------------------
+# TOPO-001: dead_conditional_edge
+# ---------------------------------------------------------------------------
+
+
+class TestDeadConditionalEdge:
+    """TOPO-001: outcome!=success / outcome=fail edges out of diamond are dead."""
+
+    def test_outcome_not_success_flagged(self):
+        """ERROR: outcome!=success edge out of a diamond is dead."""
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "work": _tool("work"),
+                "gate": _diamond("gate"),
+                "fix": _box("fix"),
+                "exit": _msquare(),
+            },
+            edges=[
+                Edge("start", "work"),
+                Edge("work", "gate"),
+                Edge("gate", "exit", condition="outcome=success"),
+                Edge("gate", "fix", condition="outcome!=success"),
+                Edge("fix", "work"),
+            ],
+        )
+        diags = lint(g)
+        dead = _diag(diags, "dead_conditional_edge")
+        assert dead, "Expected dead_conditional_edge diagnostic"
+        assert all(d.severity == "ERROR" for d in dead)
+        assert any(d.node_id == "gate" for d in dead)
+
+    def test_outcome_fail_flagged(self):
+        """ERROR: outcome=fail edge out of a diamond is dead."""
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "gate": _diamond("gate"),
+                "ok": _box("ok"),
+                "bad": _box("bad"),
+                "exit": _msquare(),
+            },
+            edges=[
+                Edge("start", "gate"),
+                Edge("gate", "ok", condition="outcome=success"),
+                Edge("gate", "bad", condition="outcome=fail"),
+                Edge("ok", "exit"),
+                Edge("bad", "exit"),
+            ],
+        )
+        diags = lint(g)
+        dead = _diag(diags, "dead_conditional_edge")
+        assert dead, "Expected dead_conditional_edge diagnostic"
+        assert any(d.node_id == "gate" for d in dead)
+
+    def test_outcome_success_not_flagged(self):
+        """No false-positive: outcome=success edge out of a diamond is fine."""
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "gate": _diamond("gate"),
+                "ok": _box("ok"),
+                "exit": _msquare(),
+            },
+            edges=[
+                Edge("start", "gate"),
+                Edge("gate", "ok", condition="outcome=success"),
+                Edge("ok", "exit"),
+            ],
+        )
+        diags = lint(g)
+        dead = _diag(diags, "dead_conditional_edge")
+        assert not dead, f"False positive: {dead}"
+
+    def test_outcome_not_success_on_box_not_flagged(self):
+        """No false-positive: outcome!=success on a box (LLM) node is legitimate."""
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "work": _box("work"),
+                "fix": _box("fix"),
+                "exit": _msquare(),
+            },
+            edges=[
+                Edge("start", "work"),
+                Edge("work", "exit", condition="outcome=success"),
+                Edge("work", "fix", condition="outcome!=success"),
+                Edge("fix", "work"),
+            ],
+        )
+        diags = lint(g)
+        dead = _diag(diags, "dead_conditional_edge")
+        assert not dead, f"False positive on box node: {dead}"
+
+    def test_outcome_not_success_on_tool_not_flagged(self):
+        """No false-positive: outcome!=success on a parallelogram (tool) node is fine."""
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "tool": _tool("tool"),
+                "fix": _box("fix"),
+                "exit": _msquare(),
+            },
+            edges=[
+                Edge("start", "tool"),
+                Edge("tool", "exit", condition="outcome=success"),
+                Edge("tool", "fix", condition="outcome!=success"),
+                Edge("fix", "tool"),
+            ],
+        )
+        diags = lint(g)
+        dead = _diag(diags, "dead_conditional_edge")
+        assert not dead, f"False positive on tool node: {dead}"
+
+    def test_context_condition_on_diamond_not_flagged(self):
+        """No false-positive: context.* condition on a diamond is fine (evidence-routing)."""
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "gate": _diamond("gate"),
+                "done": _box("done"),
+                "retry": _box("retry"),
+                "exit": _msquare(),
+            },
+            edges=[
+                Edge("start", "gate"),
+                Edge("gate", "done", condition="context.preferred_label=done"),
+                Edge("gate", "retry", condition="context.preferred_label=retry"),
+                Edge("done", "exit"),
+                Edge("retry", "gate"),
+            ],
+        )
+        diags = lint(g)
+        dead = _diag(diags, "dead_conditional_edge")
+        assert not dead, f"False positive on context condition: {dead}"
+
+    def test_conjunction_with_outcome_not_success_flagged(self):
+        """ERROR: outcome!=success in a conjunction on a diamond is still dead."""
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "gate": _diamond("gate"),
+                "fix": _box("fix"),
+                "exit": _msquare(),
+            },
+            edges=[
+                Edge("start", "gate"),
+                Edge("gate", "exit", condition="outcome=success"),
+                Edge("gate", "fix", condition="context.x=y && outcome!=success"),
+                Edge("fix", "exit"),
+            ],
+        )
+        diags = lint(g)
+        dead = _diag(diags, "dead_conditional_edge")
+        assert dead, (
+            "Expected dead_conditional_edge for conjunction with outcome!=success"
+        )
+
+    def test_no_condition_on_diamond_not_flagged(self):
+        """No false-positive: unconditional edge out of a diamond is fine."""
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "gate": _diamond("gate"),
+                "next": _box("next"),
+                "exit": _msquare(),
+            },
+            edges=[
+                Edge("start", "gate"),
+                Edge("gate", "next"),
+                Edge("next", "exit"),
+            ],
+        )
+        diags = lint(g)
+        dead = _diag(diags, "dead_conditional_edge")
+        assert not dead, f"False positive on unconditional edge: {dead}"
+
+
+# ---------------------------------------------------------------------------
+# TOPO-002: stale_label_collision
+# ---------------------------------------------------------------------------
+
+
+class TestStaleLabelCollision:
+    """TOPO-002: tool node with last_line edge (no && outcome=success) + outcome=fail edge."""
+
+    def test_collision_flagged(self):
+        """ERROR: context.tool.last_line=X edge without && outcome=success + outcome=fail sibling."""
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "stalegate": _tool("stalegate"),
+                "fix": _tool("fix"),
+                "exit": _msquare(),
+            },
+            edges=[
+                Edge("start", "stalegate"),
+                Edge("stalegate", "exit", condition="context.tool.last_line=green"),
+                Edge("stalegate", "fix", condition="outcome=fail"),
+                Edge("fix", "stalegate"),
+            ],
+        )
+        diags = lint(g)
+        stale = _diag(diags, "stale_label_collision")
+        assert stale, "Expected stale_label_collision diagnostic"
+        assert all(d.severity == "ERROR" for d in stale)
+        assert any(d.node_id == "stalegate" for d in stale)
+
+    def test_collision_with_outcome_not_success_flagged(self):
+        """ERROR: outcome!=success sibling also triggers stale-label check."""
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "gate": _tool("gate"),
+                "fix": _box("fix"),
+                "exit": _msquare(),
+            },
+            edges=[
+                Edge("start", "gate"),
+                Edge("gate", "exit", condition="context.tool.last_line=done"),
+                Edge("gate", "fix", condition="outcome!=success"),
+                Edge("fix", "gate"),
+            ],
+        )
+        diags = lint(g)
+        stale = _diag(diags, "stale_label_collision")
+        assert stale, "Expected stale_label_collision diagnostic"
+
+    def test_conjunction_with_outcome_success_not_flagged(self):
+        """No false-positive: context.tool.last_line=X && outcome=success is safe."""
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "gate": _tool("gate"),
+                "fix": _tool("fix"),
+                "exit": _msquare(),
+            },
+            edges=[
+                Edge("start", "gate"),
+                Edge(
+                    "gate",
+                    "exit",
+                    condition="context.tool.last_line=green && outcome=success",
+                ),
+                Edge("gate", "fix", condition="outcome=fail"),
+                Edge("fix", "gate"),
+            ],
+        )
+        diags = lint(g)
+        stale = _diag(diags, "stale_label_collision")
+        assert not stale, f"False positive: {stale}"
+
+    def test_last_line_only_no_fail_sibling_not_flagged(self):
+        """No false-positive: last_line edge without outcome=fail sibling is fine."""
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "gate": _tool("gate"),
+                "done": _box("done"),
+                "exit": _msquare(),
+            },
+            edges=[
+                Edge("start", "gate"),
+                Edge("gate", "done", condition="context.tool.last_line=green"),
+                Edge("done", "exit"),
+            ],
+        )
+        diags = lint(g)
+        stale = _diag(diags, "stale_label_collision")
+        assert not stale, f"False positive (no fail sibling): {stale}"
+
+    def test_on_box_node_not_flagged(self):
+        """No false-positive: stale-label rule only applies to tool (parallelogram) nodes."""
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "gate": _box("gate"),
+                "fix": _box("fix"),
+                "exit": _msquare(),
+            },
+            edges=[
+                Edge("start", "gate"),
+                Edge("gate", "exit", condition="context.tool.last_line=green"),
+                Edge("gate", "fix", condition="outcome=fail"),
+                Edge("fix", "gate"),
+            ],
+        )
+        diags = lint(g)
+        stale = _diag(diags, "stale_label_collision")
+        assert not stale, f"False positive on box node: {stale}"
+
+    def test_clean_convergence_loop_not_flagged(self):
+        """No false-positive: the canonical clean-loop pattern passes clean."""
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "work": _tool("work"),
+                "exit": _msquare(),
+            },
+            edges=[
+                Edge("start", "work"),
+                Edge(
+                    "work",
+                    "exit",
+                    condition="context.tool.last_line=stop && outcome=success",
+                ),
+                Edge(
+                    "work",
+                    "work",
+                    condition="context.tool.last_line=go && outcome=success",
+                ),
+                Edge("work", "work", condition="outcome=fail"),
+            ],
+        )
+        diags = lint(g)
+        stale = _diag(diags, "stale_label_collision")
+        assert not stale, f"False positive on clean loop: {stale}"
+
+
+# ---------------------------------------------------------------------------
+# TOPO-003: acyclic_graph
+# ---------------------------------------------------------------------------
+
+
+class TestAcyclicGraph:
+    """TOPO-003: linear pipeline with no cycle should warn."""
+
+    def test_linear_pipeline_warns(self):
+        """WARNING: acyclic pipeline (no back-edge) should warn."""
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "a": _tool("a"),
+                "b": _tool("b"),
+                "exit": _msquare(),
+            },
+            edges=[
+                Edge("start", "a"),
+                Edge("a", "b"),
+                Edge("b", "exit"),
+            ],
+        )
+        diags = lint(g)
+        acyclic = _diag(diags, "acyclic_graph")
+        assert acyclic, "Expected acyclic_graph warning"
+        assert all(d.severity == "WARNING" for d in acyclic)
+
+    def test_graph_with_cycle_not_warned(self):
+        """No false-positive: graph with a back-edge should not warn."""
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "work": _tool("work"),
+                "exit": _msquare(),
+            },
+            edges=[
+                Edge("start", "work"),
+                Edge(
+                    "work",
+                    "exit",
+                    condition="context.tool.last_line=done && outcome=success",
+                ),
+                Edge("work", "work", condition="outcome=fail"),
+            ],
+        )
+        diags = lint(g)
+        acyclic = _diag(diags, "acyclic_graph")
+        assert not acyclic, f"False positive: {acyclic}"
+
+    def test_self_loop_is_cyclic(self):
+        """No false-positive: a self-loop counts as a cycle."""
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "work": _tool("work"),
+                "exit": _msquare(),
+            },
+            edges=[
+                Edge("start", "work"),
+                Edge(
+                    "work",
+                    "exit",
+                    condition="context.tool.last_line=stop && outcome=success",
+                ),
+                Edge("work", "work", condition="outcome=fail"),
+            ],
+        )
+        diags = lint(g)
+        acyclic = _diag(diags, "acyclic_graph")
+        assert not acyclic, f"Self-loop not recognized as cycle: {acyclic}"
+
+
+# ---------------------------------------------------------------------------
+# TOPO-004: cycle_no_conditional_exit
+# ---------------------------------------------------------------------------
+
+
+class TestCycleNoConditionalExit:
+    """TOPO-004: cycle with no conditional exit edge."""
+
+    def test_unconditional_cycle_warns(self):
+        """WARNING: a cycle where no exit edge has a condition."""
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "work": _box("work"),
+                "check": _box("check"),
+                "exit": _msquare(),
+            },
+            edges=[
+                Edge("start", "work"),
+                Edge("work", "check"),
+                Edge("check", "work"),  # back-edge (no condition)
+                Edge("check", "exit"),  # exit (no condition)
+            ],
+        )
+        diags = lint(g)
+        no_exit = _diag(diags, "cycle_no_conditional_exit")
+        assert no_exit, "Expected cycle_no_conditional_exit warning"
+        assert all(d.severity == "WARNING" for d in no_exit)
+
+    def test_conditional_exit_not_warned(self):
+        """No false-positive: cycle with a conditional exit edge is fine."""
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "work": _tool("work"),
+                "exit": _msquare(),
+            },
+            edges=[
+                Edge("start", "work"),
+                Edge(
+                    "work",
+                    "exit",
+                    condition="context.tool.last_line=done && outcome=success",
+                ),
+                Edge("work", "work", condition="outcome=fail"),
+            ],
+        )
+        diags = lint(g)
+        no_exit = _diag(diags, "cycle_no_conditional_exit")
+        assert not no_exit, f"False positive: {no_exit}"
+
+    def test_acyclic_graph_not_warned(self):
+        """No false-positive: acyclic graph should not trigger this rule."""
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "a": _box("a"),
+                "exit": _msquare(),
+            },
+            edges=[
+                Edge("start", "a"),
+                Edge("a", "exit"),
+            ],
+        )
+        diags = lint(g)
+        no_exit = _diag(diags, "cycle_no_conditional_exit")
+        assert not no_exit, f"False positive on acyclic graph: {no_exit}"
+
+
+# ---------------------------------------------------------------------------
+# TOPO-005: cycle_no_deterministic_exit
+# ---------------------------------------------------------------------------
+
+
+class TestCycleNoDeterministicExit:
+    """TOPO-005: cycle with no deterministic exit predicate (LLM-only gating)."""
+
+    def test_llm_only_cycle_warns(self):
+        """WARNING: cycle with only LLM (box) nodes and no evidence-based exit."""
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "generate": _box("generate"),
+                "assess": _box("assess"),
+                "exit": _msquare(),
+            },
+            edges=[
+                Edge("start", "generate"),
+                Edge("generate", "assess"),
+                Edge("assess", "exit", condition="outcome=success"),  # LLM-gated exit
+                Edge("assess", "generate", condition="outcome!=success"),  # back-edge
+            ],
+        )
+        diags = lint(g)
+        no_det = _diag(diags, "cycle_no_deterministic_exit")
+        assert no_det, "Expected cycle_no_deterministic_exit warning"
+        assert all(d.severity == "WARNING" for d in no_det)
+
+    def test_tool_on_cycle_not_warned(self):
+        """No false-positive: a tool node on the cycle provides deterministic evidence."""
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "work": _box("work"),
+                "validate": _tool("validate"),
+                "exit": _msquare(),
+            },
+            edges=[
+                Edge("start", "work"),
+                Edge("work", "validate"),
+                Edge(
+                    "validate",
+                    "exit",
+                    condition="context.tool.last_line=pass && outcome=success",
+                ),
+                Edge("validate", "work", condition="outcome=fail"),
+            ],
+        )
+        diags = lint(g)
+        no_det = _diag(diags, "cycle_no_deterministic_exit")
+        assert not no_det, f"False positive: {no_det}"
+
+    def test_llm_only_cycle_with_context_exit_warns(self):
+        """WARNING: cycle with only LLM (box) nodes, even with context.* exit condition.
+
+        context.preferred_label set by an LLM node via report_outcome is still
+        LLM say-so — it is not mechanically verified evidence.  A deterministic
+        evidence gate requires a tool node on the cycle whose outcome/output
+        actually gates control flow.
+        """
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "work": _box("work"),
+                "assess": _box("assess"),
+                "exit": _msquare(),
+            },
+            edges=[
+                Edge("start", "work"),
+                Edge("work", "assess"),
+                Edge("assess", "exit", condition="context.preferred_label=done"),
+                Edge("assess", "work", condition="context.preferred_label=retry"),
+            ],
+        )
+        diags = lint(g)
+        no_det = _diag(diags, "cycle_no_deterministic_exit")
+        assert no_det, (
+            "Expected cycle_no_deterministic_exit: LLM-only cycle with context.* "
+            "exit is still LLM say-so (no tool node on cycle)"
+        )
+        assert all(d.severity == "WARNING" for d in no_det)
+
+    def test_acyclic_graph_not_warned(self):
+        """No false-positive: acyclic graph does not trigger this rule."""
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "work": _box("work"),
+                "exit": _msquare(),
+            },
+            edges=[
+                Edge("start", "work"),
+                Edge("work", "exit"),
+            ],
+        )
+        diags = lint(g)
+        no_det = _diag(diags, "cycle_no_deterministic_exit")
+        assert not no_det, f"False positive on acyclic graph: {no_det}"
+
+    def test_noop_tool_on_cycle_llm_set_context_exit_warns(self):
+        """WARNING: a no-op tool on the cycle does not make an LLM-gated loop deterministic.
+
+        The tool exists on the cycle, but its own evidence (outcome / tool.*)
+        never gates routing: every outgoing edge is conditioned on
+        context.preferred_label, which is set by the LLM ``assess`` node via
+        report_outcome.  The loop's exit is still LLM say-so.  This is the
+        false-negative case a naive "tool anywhere on the SCC" check misses.
+        """
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "generate": _box("generate"),
+                "assess": _box("assess"),
+                "check": _tool("check"),  # no-op router: evidence unused
+                "exit": _msquare(),
+            },
+            edges=[
+                Edge("start", "generate"),
+                Edge("generate", "assess"),
+                Edge("assess", "check"),
+                Edge("check", "exit", condition="context.preferred_label=converged"),
+                Edge("check", "generate", condition="context.preferred_label=refine"),
+            ],
+        )
+        diags = lint(g)
+        no_det = _diag(diags, "cycle_no_deterministic_exit")
+        assert no_det, (
+            "Expected cycle_no_deterministic_exit: the only tool on the cycle "
+            "routes solely on LLM-set context keys — its own evidence gates nothing"
+        )
+        assert all(d.severity == "WARNING" for d in no_det)
+
+    def test_tool_outcome_routed_cycle_not_warned(self):
+        """No false-positive: a tool whose outcome routes the cycle is a mechanical gate.
+
+        A parallelogram's outcome is its command's exit status — mechanical
+        evidence, not LLM say-so.  Routing the exit on outcome=success and the
+        back-edge on outcome=fail is deterministic gating.
+        """
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "generate": _box("generate"),
+                "validate": _tool("validate"),
+                "exit": _msquare(),
+            },
+            edges=[
+                Edge("start", "generate"),
+                Edge("generate", "validate"),
+                Edge("validate", "exit", condition="outcome=success"),
+                Edge("validate", "generate", condition="outcome=fail"),
+            ],
+        )
+        diags = lint(g)
+        no_det = _diag(diags, "cycle_no_deterministic_exit")
+        assert not no_det, (
+            f"False positive: tool outcome routing is mechanical: {no_det}"
+        )
+
+    def test_convergence_factory_shape_not_warned(self):
+        """No false-positive: the convergence-factory pattern passes for the right reason.
+
+        The cycle contains a real validation tool with a plain out-edge: plain
+        edges only traverse on SUCCESS (FAIL is fail-fast), so a failing
+        validation mechanically halts the loop — an implicit outcome=success
+        gate.  The LLM-routed check node downstream does not undo that.
+        """
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "generate": _box("generate"),
+                "validate": _tool("validate"),  # real gate: plain edge = fail-fast
+                "assess": _box("assess"),
+                "check": _tool("check"),
+                "feedback": _box("feedback"),
+                "done": _msquare("done"),
+            },
+            edges=[
+                Edge("start", "generate"),
+                Edge("generate", "validate"),
+                Edge("validate", "assess"),  # plain edge — traverses only on SUCCESS
+                Edge("assess", "check"),
+                Edge("check", "done", condition="context.preferred_label=converged"),
+                Edge("check", "feedback", condition="context.preferred_label=refine"),
+                Edge("feedback", "generate"),
+            ],
+        )
+        diags = lint(g)
+        no_det = _diag(diags, "cycle_no_deterministic_exit")
+        assert not no_det, (
+            f"False positive on convergence-factory shape (validate's plain edge "
+            f"is an implicit outcome=success gate): {no_det}"
+        )
+
+    def test_tool_plain_edge_to_runs_on_failure_target_warns(self):
+        """WARNING: a plain edge to a runs_on=failure/always target is not a gate.
+
+        Plain edges normally traverse only on SUCCESS, but a target with
+        runs_on=always or runs_on=failure opts into FAIL routing — the tool
+        no longer halts the loop on failure, so it gates nothing.
+        """
+        sink = _box("sink")
+        sink.attrs["runs_on"] = "always"
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "generate": _box("generate"),
+                "check": _tool("check"),
+                "sink": sink,
+                "exit": _msquare(),
+            },
+            edges=[
+                Edge("start", "generate"),
+                Edge("generate", "check"),
+                Edge("check", "sink"),  # plain edge, but target opts into FAIL routing
+                Edge("sink", "exit", condition="context.preferred_label=done"),
+                Edge("sink", "generate", condition="context.preferred_label=retry"),
+            ],
+        )
+        diags = lint(g)
+        no_det = _diag(diags, "cycle_no_deterministic_exit")
+        assert no_det, (
+            "Expected cycle_no_deterministic_exit: plain edge to a runs_on=always "
+            "target traverses on FAIL too — the tool does not gate the loop"
+        )
+
+    def test_tool_on_cycle_exit_gated_on_tool_context_key_not_warned(self):
+        """No false-positive: tool on cycle AND exit gated on context key set by tool."""
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "work": _box("work"),
+                "validate": _tool("validate"),
+                "exit": _msquare(),
+            },
+            edges=[
+                Edge("start", "work"),
+                Edge("work", "validate"),
+                Edge(
+                    "validate",
+                    "exit",
+                    condition="context.tool.last_line=pass && outcome=success",
+                ),
+                Edge("validate", "work", condition="outcome=fail"),
+            ],
+        )
+        diags = lint(g)
+        no_det = _diag(diags, "cycle_no_deterministic_exit")
+        assert not no_det, (
+            f"False positive: tool on cycle with evidence-gated exit: {no_det}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TOPO-004 and TOPO-005: per-SCC analysis
+# ---------------------------------------------------------------------------
+
+
+class TestPerSCCAnalysis:
+    """TOPO-004 and TOPO-005 must check each SCC independently.
+
+    A compliant SCC must not suppress diagnostics for a separate non-compliant
+    SCC in the same graph.
+    """
+
+    def test_topo004_two_sccs_one_compliant_one_not(self):
+        """TOPO-004: two SCCs — one with conditional exit, one without.
+
+        The non-compliant SCC (no conditional exit) must still be flagged even
+        though the other SCC has a conditional exit.
+        """
+        # SCC-1: work1 <-> check1 with a conditional exit (compliant)
+        # SCC-2: work2 <-> check2 with NO conditional exit (non-compliant)
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "work1": _box("work1"),
+                "check1": _box("check1"),
+                "work2": _box("work2"),
+                "check2": _box("check2"),
+                "exit": _msquare(),
+            },
+            edges=[
+                Edge("start", "work1"),
+                Edge("work1", "check1"),
+                Edge("check1", "work1", condition="outcome=fail"),  # back-edge SCC-1
+                Edge(
+                    "check1", "work2", condition="outcome=success"
+                ),  # SCC-1 conditional exit
+                Edge("work2", "check2"),
+                Edge("check2", "work2"),  # back-edge SCC-2 (no condition)
+                Edge("check2", "exit"),  # SCC-2 exit (no condition)
+            ],
+        )
+        diags = lint(g)
+        no_exit = _diag(diags, "cycle_no_conditional_exit")
+        # SCC-2 must be flagged; SCC-1 must not be
+        assert no_exit, "Expected cycle_no_conditional_exit for non-compliant SCC-2"
+        # Only one diagnostic (for SCC-2), not two
+        assert len(no_exit) == 1, (
+            f"Expected 1 diagnostic, got {len(no_exit)}: {no_exit}"
+        )
+        # The flagged SCC should contain work2/check2
+        flagged_msg = no_exit[0].message
+        assert "work2" in flagged_msg or "check2" in flagged_msg, (
+            f"Expected SCC-2 nodes in diagnostic, got: {flagged_msg}"
+        )
+
+    def test_topo005_two_sccs_one_compliant_one_not(self):
+        """TOPO-005: two SCCs — one with deterministic exit, one without.
+
+        The non-compliant SCC (LLM-only exit) must still be flagged even
+        though the other SCC has a tool + evidence-gated exit.
+        """
+        # SCC-1: work1 -> validate1 with tool + context exit (compliant)
+        # SCC-2: work2 <-> assess2, LLM-only nodes, outcome= exit (non-compliant)
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "work1": _box("work1"),
+                "validate1": _tool("validate1"),
+                "work2": _box("work2"),
+                "assess2": _box("assess2"),
+                "exit": _msquare(),
+            },
+            edges=[
+                Edge("start", "work1"),
+                Edge("work1", "validate1"),
+                Edge(
+                    "validate1",
+                    "work2",
+                    condition="context.tool.last_line=pass && outcome=success",
+                ),
+                Edge("validate1", "work1", condition="outcome=fail"),  # SCC-1 back-edge
+                Edge("work2", "assess2"),
+                Edge(
+                    "assess2", "work2", condition="outcome!=success"
+                ),  # SCC-2 back-edge
+                Edge("assess2", "exit", condition="outcome=success"),  # LLM-gated exit
+            ],
+        )
+        diags = lint(g)
+        no_det = _diag(diags, "cycle_no_deterministic_exit")
+        # SCC-2 must be flagged; SCC-1 must not be
+        assert no_det, "Expected cycle_no_deterministic_exit for non-compliant SCC-2"
+        assert len(no_det) == 1, f"Expected 1 diagnostic, got {len(no_det)}: {no_det}"
+        flagged_msg = no_det[0].message
+        assert "work2" in flagged_msg or "assess2" in flagged_msg, (
+            f"Expected SCC-2 nodes in diagnostic, got: {flagged_msg}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# lint() API contract
+# ---------------------------------------------------------------------------
+
+
+class TestLintAPI:
+    """lint() runs structural + topological rules; validate() does not run topo rules."""
+
+    def test_lint_includes_structural_rules(self):
+        """lint() runs structural rules (e.g. missing start node)."""
+        g = _graph(
+            nodes={"exit": _msquare()},
+            edges=[],
+        )
+        diags = lint(g)
+        assert any(d.rule == "start_node" for d in diags)
+
+    def test_validate_does_not_include_topo_rules(self):
+        """validate() does NOT run topological rules — lint-only."""
+        # A graph with a dead diamond edge
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "gate": _diamond("gate"),
+                "fix": _box("fix"),
+                "exit": _msquare(),
+            },
+            edges=[
+                Edge("start", "gate"),
+                Edge("gate", "exit", condition="outcome=success"),
+                Edge("gate", "fix", condition="outcome!=success"),
+                Edge("fix", "exit"),
+            ],
+        )
+        validate_diags = validate(g)
+        lint_diags = lint(g)
+
+        validate_rules = {d.rule for d in validate_diags}
+        lint_rules = {d.rule for d in lint_diags}
+
+        assert "dead_conditional_edge" not in validate_rules, (
+            "validate() must not run topological rules"
+        )
+        assert "dead_conditional_edge" in lint_rules, (
+            "lint() must include topological rules"
+        )
+
+    def test_clean_graph_exits_clean(self):
+        """A correct convergence loop produces no diagnostics from lint()."""
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "work": _tool("work"),
+                "exit": _msquare(),
+            },
+            edges=[
+                Edge("start", "work"),
+                Edge(
+                    "work",
+                    "exit",
+                    condition="context.tool.last_line=stop && outcome=success",
+                ),
+                Edge(
+                    "work",
+                    "work",
+                    condition="context.tool.last_line=go && outcome=success",
+                ),
+                Edge("work", "work", condition="outcome=fail"),
+            ],
+        )
+        diags = lint(g)
+        topo_diags = [
+            d
+            for d in diags
+            if d.rule
+            in {
+                "dead_conditional_edge",
+                "stale_label_collision",
+                "acyclic_graph",
+                "cycle_no_conditional_exit",
+                "cycle_no_deterministic_exit",
+            }
+        ]
+        assert not topo_diags, f"False positives on clean loop: {topo_diags}"
+
+    def test_lint_returns_list_of_diagnostics(self):
+        """lint() returns a list of Diagnostic objects."""
+        g = _graph(
+            nodes={"start": _mdiamond(), "exit": _msquare()},
+            edges=[Edge("start", "exit")],
+        )
+        result = lint(g)
+        assert isinstance(result, list)
+        for d in result:
+            assert isinstance(d, Diagnostic)
+
+
+# ---------------------------------------------------------------------------
+# Regression: the 8-example dead-diamond pattern
+# ---------------------------------------------------------------------------
+
+
+class TestDeadDiamondRegressions:
+    """Regression tests for the dead-diamond bug class that shipped in 8 examples.
+
+    Each test constructs the pattern found in the affected example and asserts
+    that dead_conditional_edge fires on the diamond node.
+    """
+
+    def _make_diamond_gate_graph(self, gate_id: str) -> Graph:
+        """Minimal graph with a diamond gate routing on outcome=."""
+        return _graph(
+            nodes={
+                "start": _mdiamond(),
+                gate_id: _diamond(gate_id),
+                "work": _box("work"),
+                "fix": _box("fix"),
+                "exit": _msquare(),
+            },
+            edges=[
+                Edge("start", "work"),
+                Edge("work", gate_id),
+                Edge(gate_id, "exit", condition="outcome=success"),
+                Edge(gate_id, "fix", condition="outcome!=success"),
+                Edge("fix", "work"),
+            ],
+        )
+
+    def test_gate_pattern(self):
+        """Pattern from 03-conditional-routing and 09-manager-supervisor."""
+        g = self._make_diamond_gate_graph("gate")
+        diags = lint(g)
+        dead = _diag(diags, "dead_conditional_edge")
+        assert dead
+        assert any(d.node_id == "gate" for d in dead)
+
+    def test_test_gate_pattern(self):
+        """Pattern from 10-full-attractor, 12-graph-resume, bug-fix, feature-build, refactor, test-gen."""
+        g = self._make_diamond_gate_graph("test_gate")
+        diags = lint(g)
+        dead = _diag(diags, "dead_conditional_edge")
+        assert dead
+        assert any(d.node_id == "test_gate" for d in dead)

--- a/modules/pipeline-runner/amplifier_module_pipeline_runner/cli.py
+++ b/modules/pipeline-runner/amplifier_module_pipeline_runner/cli.py
@@ -8,6 +8,7 @@ Subcommands:
     run       <dot_file>   run a DOT pipeline
     doctor                 environment diagnostics
     trace     <run-dir>    print a human-readable iteration/descent summary
+    lint      <dot_file>   static topological lint of a .dot pipeline file
 """
 
 from __future__ import annotations
@@ -95,6 +96,18 @@ def build_parser() -> argparse.ArgumentParser:
     trace.add_argument(
         "run_dir",
         help="path to the run directory produced by 'attractor run'",
+    )
+
+    lint_p = sub.add_parser(
+        "lint",
+        help="static topological lint of a .dot pipeline file",
+    )
+    lint_p.add_argument("dot_file", help="path to a .dot file to lint")
+    lint_p.add_argument(
+        "--strict",
+        action="store_true",
+        default=False,
+        help="exit non-zero on WARNING diagnostics as well as ERRORs (default: only ERRORs cause non-zero exit)",
     )
 
     return parser
@@ -345,6 +358,78 @@ def cmd_trace(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_lint(args: argparse.Namespace) -> int:
+    """Static topological lint of a .dot pipeline file.
+
+    Parses the DOT file and runs the full basin-lint rule set:
+    structural rules (LINT-001–018) plus topological rules (TOPO-001–005).
+
+    Exit-code contract:
+        ERROR-severity diagnostics → exit 1.
+        WARNING-only (or clean) → exit 0 (unless --strict).
+        --strict: exit 1 on any diagnostic (ERROR or WARNING).
+
+    This command does not run the pipeline.  It is safe to use in CI
+    before committing a .dot file.
+    """
+    dot_path = Path(args.dot_file).expanduser()
+    if not dot_path.is_file():
+        print(f"attractor lint: DOT file not found: {dot_path}", file=sys.stderr)
+        return 1
+
+    dot_source = dot_path.read_text(encoding="utf-8")
+
+    # Import the pipeline module's parser and lint function
+    try:
+        from amplifier_module_loop_pipeline.dot_parser import parse_dot
+        from amplifier_module_loop_pipeline.validation import lint
+    except ImportError as e:
+        print(
+            f"attractor lint: cannot import lint engine: {e}",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        graph = parse_dot(dot_source)
+    except Exception as e:  # noqa: BLE001 -- fail loud with the real error, no fallback
+        print(f"attractor lint: failed to parse {dot_path}: {e}", file=sys.stderr)
+        return 1
+
+    diags = lint(graph)
+
+    if not diags:
+        print(f"attractor lint: {dot_path}: OK (no findings)")
+        return 0
+
+    errors = [d for d in diags if d.severity == "ERROR"]
+    warnings = [d for d in diags if d.severity == "WARNING"]
+    infos = [d for d in diags if d.severity not in ("ERROR", "WARNING")]
+
+    for d in diags:
+        loc = f" [{d.node_id}]" if d.node_id else ""
+        edge_loc = f" ({d.edge[0]} -> {d.edge[1]})" if d.edge else ""
+        print(f"{d.severity}: [{d.rule}]{loc}{edge_loc} {d.message}")
+        if d.fix:
+            print(f"  fix: {d.fix}")
+
+    print()
+    summary_parts = []
+    if errors:
+        summary_parts.append(f"{len(errors)} error(s)")
+    if warnings:
+        summary_parts.append(f"{len(warnings)} warning(s)")
+    if infos:
+        summary_parts.append(f"{len(infos)} info(s)")
+    print(f"attractor lint: {dot_path}: {', '.join(summary_parts)}")
+
+    if errors:
+        return 1
+    if args.strict and (warnings or infos):
+        return 1
+    return 0
+
+
 def cmd_doctor(args: argparse.Namespace) -> int:
     del args  # doctor takes no options today
 
@@ -376,6 +461,7 @@ def main(argv: list[str] | None = None) -> int:
         "run": cmd_run,
         "doctor": cmd_doctor,
         "trace": cmd_trace,
+        "lint": cmd_lint,
     }
     return dispatch[args.command](args)
 


### PR DESCRIPTION
Adds the cheapest gate in the system: `attractor lint <file.dot>` — a static, sub-second, author-time check of a pipeline's topology against the engine's actual routing semantics. Five new topological rules (TOPO-001..005) live in `loop-pipeline`'s `validation.py` behind a new importable `lint()` entry point, separate from `validate()` — run-time validation behaviour is unchanged. The CLI is a thin wrapper (exit 1 on ERRORs, 0 on warnings-only, `--strict`). Condition parsing is now a single shared grammar entry point (`conditions.parse_condition`) consumed by both the runtime evaluator and lint, so the two cannot drift.

### Why (the retrospective lesson)

Every defect class this tool catches was found the expensive way — in live runs, after shipping:

- **Dead corrective edges** (TOPO-001) shipped in 8 of 24 examples for months with a green test suite, because nothing could see topology. PR #98 fixed those examples by hand; rule 1 would have caught all 8 at author time (verified against the pre-#98 files during development), and the new examples-sweep test keeps that fix locked.
- **The stale-label collision** (TOPO-002) was discovered by empirical engine probing and cost live iterations before it was understood; it is second-visit-only — invisible to single-pass testing, statically detectable.
- **Acyclic "attractors"** (TOPO-003) — half the original example corpus was linear one-pass pipelines.
- **Unbounded/implicitly-gated loops** (TOPO-004/005) — loops whose exit criterion is invisible or rests on LLM say-so; the failure mode behind wrong-but-plausible work exiting a loop.

Lint moves the catch from runtime (minutes + API keys) to author time (static, sub-second, CI-safe).

### Rules (severities per the "honest severity" principle)

| Rule | Severity | Detects |
|---|---|---|
| TOPO-001 `dead_conditional_edge` | ERROR | `outcome!=success` / `outcome=fail` edge out of a diamond — provably dead (ConditionalHandler always returns SUCCESS; FAIL is fail-fast) |
| TOPO-002 `stale_label_collision` | ERROR | `context.tool.last_line=X` edge without `&& outcome=success` sharing a source with an `outcome=fail` edge — stale label + FAIL fan out together on the second visit |
| TOPO-003 `acyclic_graph` | WARNING | no corrective cycle — probably should be a recipe |
| TOPO-004 `cycle_no_conditional_exit` | WARNING | no explicitly-gated edge leaving the cycle (condition expression, or labeled human-gate choice) |
| TOPO-005 `cycle_no_deterministic_exit` | WARNING | no tool on the cycle whose evidence (outcome / `tool.*` keys / fail-fast plain edge) actually gates control flow, and no human gate — the loop is LLM-gated |

Every diagnostic's `fix` text teaches the evidence-routing replacement, not just the violation. Rules are per-SCC (a compliant loop does not mask a broken sibling loop).

### Verification checklist

- [x] Unit tests pass (`pytest modules/loop-pipeline/`) — **1505 passed, 1 skipped** (18.8s)
- [x] Live pipeline run — N/A per verification gradient: no `engine.py`/handler/dispatch change (lint-only tooling + behaviour-preserving parser extraction; full suite incl. spec-conformance and edge-selection tests green). The CLI itself was exercised live (red/green demo below).
- [x] AGENTS.md reviewed; repo-specific gates met (verification gradient, recurring-bug-classes doc consulted — the parser fix closes a "two parallel parsers" instance)
- [x] Backward-compat path unchanged — `validate()`/`validate_or_raise()` byte-path untouched; topo rules fire only via `lint()`; `evaluate_condition()` semantics unchanged with parity tests
- [x] PR body includes verification evidence, not just "tests pass"

### Full suites (host, documented envs)

- `cd modules/loop-pipeline && uv run --extra remote pytest -q` ⇒ **1505 passed, 1 skipped** (18.8s)
- `cd modules/pipeline-runner && uv run --with pytest pytest -q` ⇒ **45 passed, 1 skipped**
- Root subset `uv run --with pyyaml --with pytest pytest -q -x --ignore=tests/e2e` ⇒ **14 passed**
- New lint/parser tests specifically: **101 passed** (`test_topological_lint.py` + `test_conditions.py` + `test_examples_lint_clean.py`)
- Ruff: touched files format-clean and lint-clean (the only remaining findings are two pre-existing `BLE001`s already on main)

### Full examples sweep (`attractor lint` over all 25 `.dot` files on this branch)

- **0 errors. 12 files clean. 13 files warnings-only (exit 0).**
- Hits: `acyclic_graph` ×11 (deliberately linear demos/tutorials), `cycle_no_conditional_exit` ×1 + `cycle_no_deterministic_exit` ×1 (both on `04-retry-with-fallback.dot` — genuine: its implement↔validate loop has no gated exit and no evidence gate; candidate for a future example upgrade, reported here as a real finding), `goal_gate_has_retry` ×4 (pre-existing rule).
- False positives found and fixed during this sweep (per the "lint that cries wolf" rule): TOPO-005 on `conversational-gate.dot` (human gate IS a gate ⇒ hexagon suppression), TOPO-004/005 on `08-human-gate.dot`, `10-full-attractor.dot`, `feature-build.dot` (labeled human-gate exits credited).

### DTU live gate (isolated env, `attractor-evals`)

Branch fetched as `task/T1-2-polished` @ `bc9907e`; all `__pycache__` cleared (repo + tool env); `attractor` reinstalled from the branch; installed `validation.py`/`conditions.py`/`cli.py` verified **byte-identical** to the repo (the T1-1 stale-bytecode lesson, applied). `T1-2.verify.sh` (sha256-matched to the task's copy) run from the repo root:

```
entry point: 'attractor lint' exists
fixture A: dead diamond+outcome= pattern flagged
fixture B: stale-label collision flagged
fixture C: acyclic graph warned
fixture D: correct convergence loop passes clean
14 passed in 0.04s
T1-2 mechanical DoD: PASS
VERIFY_EXIT=0
```

### Notes for reviewers

- **EXTENSIONS.md verdict: no entry needed — claim re-verified post-rebase.** The topo rules run only inside `lint()`; run-time validation is unchanged. The one runtime file touched, `conditions.py`, is a behaviour-preserving parser extraction (`evaluate_condition` results identical; spec §10 conformance tests + new parity tests green). If reviewers prefer to ledger the parser-extraction refactor anyway, happy to add it.
- `validation.py`'s module docstring now states explicitly that TOPO-001..005 are lint-only additions beyond the canonical spec (the spec's Section 7 defines LINT-001..018 only). Whether the canonical spec should gain lint vocabulary is flagged as an upstream question, not assumed.
- TOPO-004's definition deliberately says "explicitly-gated exit," not "can only stop via budget cap" — with unconditional edges the engine's weight/lexical tiebreaks can still exit a loop; the smell is that the convergence criterion is invisible to a reader.
- Known conservatism, stated in the guide: lint credits topology, not command meaningfulness — a no-op `tool_command="echo ok"` with a plain edge still satisfies TOPO-005's form (ii). Not statically decidable; documented rather than papered over.
- `04-retry-with-fallback.dot`'s two loop warnings are real findings on a shipped example (reported above; fix belongs in a separate examples PR).

---

**Provenance:** Agent-built via a convergence-run attractor (the task-runner pipeline): mechanical DoD passed at 3 consecutive gate visits while dual independent critics (Anthropic + OpenAI) refused ship 3× on the residuals named above — an honest stall, operator-salvaged per the budget-as-decision-point discipline. Residuals were closed in operator fresh-eyes pass (TOPO-005 semantics fixed, parser unified, fabricated sweep record replaced by regression test, human-gate false positives found and fixed, internal references scrubbed).

Generated with [Amplifier](https://github.com/microsoft/amplifier)
