### PR TITLE
fix(examples): escalated terminal fails by its own exit code (portability)

### DIFF
--- a/examples/pipelines/practical/bug-fix.dot
+++ b/examples/pipelines/practical/bug-fix.dot
@@ -47,11 +47,16 @@ digraph BugFix {
     // Escalation is a deterministic non-terminal handoff, not a second
     // successful pipeline exit. It writes a minimal fallback handoff even if
     // the postmortem LLM itself failed, so every LLM-node hard failure is
-    // absorbed before the engine returns failure.
+    // absorbed before the run reports failure. It then exits 1 DELIBERATELY:
+    // the run's failure is carried by the node's own exit code, portable
+    // under either dead-end semantics (the canonical spec treats a no-edge
+    // dead-end as SUCCESS; this engine hard-fails). max_retries=0 because
+    // the failure is the point, not a flake to retry.
     escalated [
         shape=parallelogram,
         label="Escalated",
-        tool_command="mkdir -p .ai/postmortem; if [ ! -f .ai/postmortem/report.md ]; then echo 'Postmortem could not be produced. Preserve the run logs and escalate the LLM failure to a human.' > .ai/postmortem/escalation.md; else echo 'Read .ai/postmortem/report.md and the run logs; choose change approach, split task, or human escalation.' > .ai/postmortem/escalation.md; fi; printf escalated"
+        max_retries=0,
+        tool_command="mkdir -p .ai/postmortem; if [ ! -f .ai/postmortem/report.md ]; then echo 'Postmortem could not be produced. Preserve the run logs and escalate the LLM failure to a human.' > .ai/postmortem/escalation.md; else echo 'Read .ai/postmortem/report.md and the run logs; choose change approach, split task, or human escalation.' > .ai/postmortem/escalation.md; fi; printf escalated; exit 1"
     ]
 
     // Reproduce: establish the failure before touching code.

--- a/examples/pipelines/practical/bug-fix.md
+++ b/examples/pipelines/practical/bug-fix.md
@@ -168,8 +168,11 @@ decision point for ordinary non-convergence: the postmortem node writes
 `.ai/postmortem/report.md` with what was attempted, whether the loop was
 descending or oscillating, and options for a human to decide (change approach /
 split the task / escalate). `escalated` then writes an actionable handoff.
-`escalated` has no outgoing edge, so the engine reports failure after these
-artifacts exist -- a salvageable failure, not a bare FAIL.
+`escalated` fails loudly by its own exit code (`exit 1`, after the artifacts
+are written, with `max_retries=0` so the deliberate failure is not retried),
+so the run reports failure once these artifacts exist -- a salvageable
+failure, not a bare FAIL, and portable: it does not depend on any particular
+engine dead-end semantics.
 
 To override the default budget, write a number to `.ai/budget` before running:
 ```bash


### PR DESCRIPTION
bug-fix.dot's `escalated` terminal previously exited 0 with no out-edges, so its honest-FAIL relied on the engine's no-matching-edge hard-fail — behavior that diverges from the canonical spec §3.2 (dead-end ⇒ SUCCESS), meaning under spec-canonical semantics an escalated run would report success.

The fix makes the node fail loudly by its own exit code (artifact-writing behavior unchanged). Added max_retries=0 so the deliberate failure isn't retried — attribute verified against retry.py/graph.py. Guide sentence updated to match.

**Evidence:**
- attractor lint: 0 findings
- examples lint-sweep + engine-semantics doc-guard tests: 32 passed
- root subset: 14 passed
- git diff --check: clean

No behavior change under the current engine. Identified during a spec-conformance audit of this session's merged PRs; makes the exemplar independent of dead-end semantics whichever way the engine/spec reconcile.

Generated with [Amplifier](https://github.com/microsoft/amplifier)