### PR TITLE
docs(doctrine): node contract, control-plane vs recipe-plane, goal_gate-on-evidence, five live-run lessons

### DIFF
--- a/context/pipeline-awareness.md
+++ b/context/pipeline-awareness.md
@@ -26,13 +26,21 @@ pipeline needed.
 
 ## Pipeline Decision Heuristic
 
+**Recipes are for staged sequential workflows with human approval gates; attractor
+pipelines are for machine-verified convergence. If your pipeline graph has no cycle,
+it should probably have been a recipe.**
+
 When the user asks you to do a complex task, decide:
 
 1. **Simple task (1-2 steps, no branching)** — Just do it directly. No pipeline.
    Example: "Add a docstring to this function" or "Fix the typo in README.md"
 
-2. **Medium task (2-4 ordered steps)** — Generate an inline pipeline with `dot_source`.
-   Example: "Refactor the auth module" becomes a plan -> implement -> test pipeline.
+2. **Medium task (2-4 ordered steps, one-pass)** — Consider whether a recipe fits
+   better than an inline pipeline. If the steps are sequential with no corrective
+   loop, it should probably have been a recipe. If you do generate an inline pipeline,
+   give it a corrective back-edge with a verification gate -- a `plan -> implement -> test`
+   linear graph (no back-edge) teaches recipe thinking, not convergence. A verification
+   gate alone does not create a cycle; the back-edge is what makes it a convergence graph.
 
 3. **Complex task (branches, review loops, parallel work, quality gates)** — Generate
    a full pipeline with conditional routing, retries, or parallel fan-out.
@@ -61,13 +69,15 @@ Run a pipeline from a file:
 }
 ```
 
-Run a simple inline pipeline:
+Run a convergence-shaped inline pipeline (worker + evidence gate + corrective back-edge):
 ```json
 {
   "goal": "Add input validation to the user registration endpoint",
-  "dot_source": "digraph { start [shape=Mdiamond]; implement [prompt=\"$goal\"]; test [prompt=\"Write tests for the changes\"]; done [shape=Msquare]; start -> implement -> test -> done }"
+  "dot_source": "digraph { start [shape=Mdiamond]; implement [prompt=\"Implement: $goal. If test_output.txt exists, read it -- it holds the latest test results.\"]; test_gate [shape=parallelogram, tool_command=\"pytest -q > test_output.txt 2>&1\", goal_gate=true]; done [shape=Msquare]; start -> implement -> test_gate; test_gate -> done [condition=\"outcome=success\"]; test_gate -> implement [condition=\"outcome=fail\"] }"
 }
 ```
+
+For a one-pass task with no corrective loop, use a recipe instead of an inline pipeline.
 
 ## Available Example Pipelines
 

--- a/docs/APP-INTEGRATION-GUIDE.md
+++ b/docs/APP-INTEGRATION-GUIDE.md
@@ -373,10 +373,18 @@ recipe loops until the code passes all scenarios.
 
 ### When to Use Each
 
+**Recipes are for staged sequential workflows with human approval gates;
+attractor pipelines are for machine-verified convergence. If your pipeline graph
+has no cycle, it should probably have been a recipe.**
+
+Note: the `@recipes:examples/attractor/` recipe *is* a recipe that implements a
+convergence loop -- it is the exception that proves the rule. The rule is about
+your graph's shape, not the recipe's name.
+
 | Approach | Best For |
 |----------|---------|
-| **DOT Pipelines** | Visual, declarative workflows with explicit control flow, conditional routing, parallel execution, human gates, multi-provider routing |
-| **Attractor Recipe** | Spec-driven code generation with convergence testing loops, where the workflow is always "generate code, test, fix, repeat until passing" |
+| **DOT Pipelines** | Machine-verified convergence loops: corrective cycles, evidence gates, stall detection, multi-provider routing, parallel fan-out |
+| **Attractor Recipe** | Spec/scenario-driven code generation with holdout validation and configurable convergence limits (machine-verified; no human approval gates) |
 
 The recipe approach is more opinionated (4 fixed stages: seed, generate,
 validate, converge) but requires less pipeline design. DOT pipelines give you

--- a/docs/DOT-AUTHORING-GUIDE.md
+++ b/docs/DOT-AUTHORING-GUIDE.md
@@ -4,14 +4,46 @@ How to design effective multi-stage AI pipelines using Graphviz DOT digraphs.
 
 ## Philosophy
 
-Attractor pipelines are **declarative workflow definitions**. You describe _what_
-should happen at each stage and _how_ stages connect -- the pipeline engine
-handles execution, retries, context passing, and backend selection.
+Attractor pipelines are **convergence graphs**: the graph encodes the
+control structure -- gates, budgets, corrective loops, feedback channels --
+and the engine walks it from `start` to `done`, executing each node and
+following edges based on outcomes.
 
-A DOT digraph is the workflow. Each node is a task (usually an LLM call). Each
-edge defines flow. Node shapes determine handler behavior (LLM call, conditional
-gate, parallel fork, human approval, etc.). The engine walks the graph from
-`start` to `done`, executing each node and following edges based on outcomes.
+**The pipeline author's job is the convergence skeleton, not the domain
+decomposition.** Keep the task-agnostic control structure: the gates, budgets,
+walls, and feedback channels that make the loop descend. Delete the domain
+decomposition -- plan/implement/test phases, backend/frontend splits -- that is
+the model's job, not the graph's. `examples/patterns/task-runner.dot` is the
+canonical example: its stages are control-plane responsibilities (orient /
+attempt / verify / critique / triage / postmortem / package), zero domain phases.
+
+**The node contract.** Every LLM node (`shape=box`) should state:
+
+1. **Objective** -- what the node is responsible for achieving
+2. **Constraints** -- what it must not do or assume
+3. **Available capabilities** -- what tools or context it has access to
+4. **Required evidence** -- what artifact or observable state proves it succeeded
+
+The prompt states the contract, not the algorithm -- never enumerate the
+procedure step-by-step unless the procedure itself is a business or safety
+requirement. A node that carries the algorithm cannot absorb a model's bad day;
+a node that carries objective + constraints + capabilities + required evidence
+lets the loop correct the *work* because "done" is defined outside the worker.
+
+**`goal_gate` belongs on evidence-bearing nodes, not implementation nodes.**
+The engine's `goal_gate` contract (spec §3.4) is: this node must succeed before
+the pipeline can exit. Attaching it to an implementation node makes "the
+implementer finished" the exit criterion -- an implementation finishing is not a
+goal state. Attach `goal_gate` to the node that *bears evidence*: a test gate,
+an acceptance check, a human approval gate, or an evidence-backed review node.
+Shipped positive example: `examples/pipelines/practical/bug-fix.dot`'s exit is
+gated on `verdict_gate` output -- implementation completing earns nothing.
+
+**Recipes vs. attractor pipelines.** Recipes are for staged sequential workflows
+with human approval gates; attractor pipelines are for machine-verified
+convergence. If your pipeline graph has no cycle, it should probably have been a
+recipe. (TOPO-003 warns on acyclic graphs for this reason; deliberate one-pass
+pipelines are legitimate -- the "probably" is load-bearing.)
 
 **Design principles:**
 
@@ -19,7 +51,7 @@ gate, parallel fork, human approval, etc.). The engine walks the graph from
 - Prompts should be self-contained -- a node should not assume context unless fidelity is `full`
 - Use `$goal` to inject the pipeline's overall objective into node prompts
 - Prefer fewer, well-prompted nodes over many thin ones
-- Use goal gates on nodes whose success is required for the pipeline to pass
+- Use `goal_gate` on evidence-bearing nodes (test gates, acceptance checks, human gates)
 - Use conditional routing to handle success/failure paths explicitly
 
 ## Pipeline Patterns
@@ -40,7 +72,8 @@ digraph {
 }
 ```
 
-A more realistic linear pipeline with planning and testing:
+A convergence-shaped pipeline -- a worker node with an evidence gate and a corrective
+back-edge. This is the recommended shape for any task where the first attempt may not succeed:
 
 ```dot
 digraph {
@@ -51,14 +84,32 @@ digraph {
     ]
 
     start     [shape=Mdiamond]
-    plan      [prompt="List 3 steps to create: $goal. Be brief."]
-    implement [prompt="Create calculator.py with add(a,b). Include type hints.", goal_gate=true]
-    test      [prompt="Write pytest tests for calculator.py and run them."]
+    implement [prompt="Create or improve calculator.py with add(a,b) and pytest tests in test_calculator.py, to satisfy: $goal. If test_output.txt exists, read it -- it holds the latest test results."]
+    test_gate [shape=parallelogram, tool_command="pytest -q test_calculator.py > test_output.txt 2>&1", goal_gate=true]
     done      [shape=Msquare]
 
-    start -> plan -> implement -> test -> done
+    start -> implement -> test_gate
+    test_gate -> done          [condition="outcome=success"]
+    test_gate -> implement     [condition="outcome=fail", label="fix and retry"]
 }
 ```
+
+The `test_gate` is a deterministic tool node (not an LLM self-report): it runs
+`pytest` and routes on the exit code. `goal_gate=true` is on the evidence-bearing node,
+not on `implement`. The corrective back-edge (`test_gate -> implement`) is what makes
+this a convergence graph rather than a recipe.
+
+Two mechanics worth copying exactly. First, test output travels through a *file*
+(`test_output.txt`), not a prompt variable: LLM-node prompts expand only `$goal`,
+`$context`, and plain (dot-free) context keys -- `tool.output` is a dotted key
+available to `tool_command` strings, not to prompts. Second, the gate uses plain
+redirection (`> test_output.txt 2>&1`) rather than a pipe: `tool_command` runs under
+`/bin/sh`, where a pipe would make the exit code `tee`'s, not pytest's (and bash-isms
+like `PIPESTATUS` are unavailable). Redirection preserves pytest's exit code, which is
+what the edges route on.
+
+The linear `start -> implement -> test -> done` shape (no back-edge) is a recipe shape
+and will trigger TOPO-003. If that is intentional -- a one-pass workflow -- use a recipe.
 
 ### Conditional Routing
 
@@ -831,6 +882,13 @@ tool -> done [condition="context.tool.last_line=green && outcome=success"]
 tool -> fix  [condition="outcome=fail"]
 ```
 
+> **Spec-reconciliation note:** This defensive rule exists because the current
+> engine selects ALL matching edges (parallel fan-out) where the canonical spec
+> prescribes deterministic single-best-edge selection; that divergence is under
+> active reconciliation.  If the engine adopts single-edge selection, the
+> `&& outcome=success` conjunction becomes unnecessary — but it is harmless, so
+> pipelines written with it stay correct either way.
+
 ---
 
 ### TOPO-003 — Acyclic graph (no corrective cycle)
@@ -968,4 +1026,4 @@ for a separate non-compliant loop.
 - [APP-INTEGRATION-GUIDE.md](APP-INTEGRATION-GUIDE.md) -- Using pipelines from Python code
 - [GETTING-STARTED.md](GETTING-STARTED.md) -- Installation and first run
 - [examples/pipelines/](../examples/pipelines/) -- 10 tutorial + 5 practical pipeline examples
-- [examples/LINT-SWEEP.md](../examples/LINT-SWEEP.md) -- Full corpus sweep results
+- [modules/loop-pipeline/tests/test_examples_lint_clean.py](../modules/loop-pipeline/tests/test_examples_lint_clean.py) -- Self-updating lint sweep (replaces the static LINT-SWEEP.md artifact; run `pytest` to re-sweep)

--- a/docs/PIPELINE_DESIGN_PRINCIPLES.md
+++ b/docs/PIPELINE_DESIGN_PRINCIPLES.md
@@ -11,6 +11,41 @@ the trade-offs so those choices are deliberate.
 
 ---
 
+## 0. The Control-Plane vs Recipe-Plane Line
+
+> Keep the convergence skeleton. Delete the domain decomposition.
+
+**The pipeline author's job** is the convergence skeleton: gates, budgets, walls,
+feedback channels -- the task-agnostic control structure that makes the loop
+descend toward a verified goal state. `examples/patterns/task-runner.dot` is the
+canonical example: orient / attempt / verify / critique / triage / postmortem /
+package -- zero domain phases, all control-plane responsibilities.
+
+**The model's job** is the domain decomposition: plan/implement/test phases,
+backend/frontend splits, the specific steps it takes to advance the work. That
+intelligence belongs in the worker node's context, not in the graph structure.
+
+When you find yourself adding `plan -> implement -> test` as graph nodes, stop:
+you are encoding the recipe plane into the control plane. The graph should encode
+*when* to verify and *how* to loop, not *which cognitive steps* the model takes.
+The shipped counter-example (at time of writing: `examples/pipelines/02-plan-implement-test.dot`)
+hardcodes cognitive phases and exact test cases in the graph -- the graph
+swallowed the intelligence.
+
+**Recipes vs. attractor pipelines.** Recipes are for staged sequential workflows
+with human approval gates; attractor pipelines are for machine-verified
+convergence. If your pipeline graph has no cycle, it should probably have been a
+recipe.
+
+**Why the skeleton must stay external.** In one live run, the worker
+hand-authored its own convergence evidence (a fabricated `convergence.jsonl`) to
+satisfy the gate; the dual critics -- outside the worker's context -- caught it
+and refused ship. One adaptive mega-node with self-assessed exit would have
+shipped the fabrication. Verification inside the context that produced the
+evidence is not verification.
+
+---
+
 ## 1. Tier Discipline: Code-Tier vs LLM-Tier Nodes
 
 > Use code-tier nodes for what code does reliably. Use LLM-tier nodes for what code
@@ -95,6 +130,18 @@ code-tier check eliminates structurally invalid outputs before they reach the LL
 check. Both nodes can route: the structural check routes back to the generator on format
 failure; the quality check routes forward or back on judgment.
 
+**Never gate on an artifact an LLM node "should" write.** If a downstream path
+requires a file, add a deterministic stub gate after the LLM node that verifies the
+file is non-empty and writes a labeled fallback if not -- never let the exit path
+depend on whether the box node actually wrote its artifact. Live catch: a `postmortem`
+node returned SUCCESS without writing its report twice in consecutive runs; a
+deterministic gate was added after the second occurrence. See
+`examples/patterns/task-runner.dot`'s `pm_gate` node for the pattern: a
+`[ -s .ai/postmortem/report.md ]` non-empty check that writes a labeled stub when the
+report is missing. (`bug-fix.dot`'s `escalated` node is the downstream half -- an
+existence check that writes an escalation handoff either way -- not the stub-gate
+pattern itself.)
+
 ---
 
 ## 3. Loop Convergence Patterns
@@ -142,6 +189,25 @@ in the environment (file exists, test passes, count reaches threshold), Pattern 
 robust — the exit is determined by evidence, not by run count. Pattern B is appropriate when
 the only terminal signal is the LLM reporting completion.
 
+**Budget the green path, not just the red path.** Every loop needs a budget or ratchet on
+*both* the corrective cycle and the quality-gate cycle. A fresh maximally-strict critic each
+iteration produces refusals on mechanically-green work -- 6 consecutive critique refusals
+occurred in a live run before a stall counter was added to the outer quality loop. Route
+stall detection to escalation, not to infinite retry; anchor critique to the DoD plus prior
+acceptances so the quality bar ratchets rather than resets.
+
+**Verify running-code identity before entering a loop.** An orient/setup node should check
+that the environment is in the expected state before the corrective loop starts -- 14 red
+iterations were burned re-flipping a coin on a stale-`.pyc` defect that no code change
+could fix. An attractor absorbs model drift, not deterministic bugs; the loop cannot
+converge on a defect that lives outside the graph's reach.
+
+**Add transient fail-routes on every ship-path node.** Ship-path LLM nodes (critique,
+feedback, package) should carry `outcome=fail` edges back to a recovery point -- an
+`overloaded_error` at a ship-path node killed a whole run after the work was already done.
+One edge addition fixed it permanently. See `examples/pipelines/practical/bug-fix.dot` for
+the pattern: every ship-path box node has an `outcome=fail` edge to `postmortem`.
+
 ---
 
 ## 4. LLM Output Protocol Patterns
@@ -162,8 +228,30 @@ is the deliverable, not the format describing it.
 **Strategy MLE — Make the Format LLM-Easy.**
 Redesign the output protocol to match what LLMs do reliably: single keywords, simple
 prose with anchored markers, minimal JSON with few required fields. Reduce precision
-requirements to reduce variance. Use `grep -qi` (keyword match) rather than exact
-string comparison.
+requirements to reduce variance.
+
+When routing on a verdict (SHIP/ITERATE, PASS/FAIL, approved/rejected), use
+**last-line anchored matching**: have the LLM write its verdict as the final line of a
+file, then check that exact line -- for example:
+
+```bash
+[ -f verdict.txt ] || exit 1
+tail -n1 verdict.txt | grep -qix 'VERDICT: SHIP'
+```
+
+Do not use bare whole-file `grep -qi` for verdict routing. A critique that quotes its
+own instructions (e.g., "write VERDICT: SHIP or VERDICT: ITERATE") contains both
+keywords -- bare `grep -qi 'SHIP'` false-SHIPs because it matches the instruction text,
+not the verdict. `tail -n1 | grep -qix` (last-line, case-insensitive exact match) is
+immune: the instruction text is never the last line, and the exact-match flag rejects
+partial matches. Always guard against a missing artifact with an explicit `[ -f ]`
+check -- a missing file should fail the gate, not silently pass it. Live catch: a
+review probe false-SHIPped a run using bare `grep -qi` when the critique quoted its
+instructions verbatim.
+
+`grep -qi` without anchoring remains appropriate for non-verdict keyword detection
+(presence checks, classification, section detection) where false-positives are not
+routing-consequential.
 
 Applicable when: routing sentinels, status indicators, binary or small-enumeration
 classification. Format simplification eliminates the variance, not the format itself.


### PR DESCRIPTION
## Summary

The authoring docs taught recipe-thinking: "each node is a task," linear plan -> implement -> test examples, goal_gate on implementation nodes. An external cold-read of the bundle and our own live-run retrospective independently converged on the same gap — the docs describe flowcharts, while the engine's value is convergence. This PR moves the doctrine INTO the existing authoring surfaces (the docs authors already read) rather than adding a new doc:

- **docs/DOT-AUTHORING-GUIDE.md** — Philosophy rewritten in place: pipelines are convergence graphs; the four-element **node contract** (Objective / Constraints / Available capabilities / Required evidence — the prompt states the contract, never the algorithm, unless the procedure is itself a business/safety requirement); **goal_gate belongs on evidence-bearing nodes**, not implementation nodes; the one-sentence recipes-vs-attractor rule (with TOPO-003 cross-reference, "probably" preserved); the first teaching example upgraded from a linear chain to a working convergence shape (worker + deterministic pytest gate + corrective back-edge), with the two engine mechanics an author must copy exactly (test evidence travels through a file, not a prompt variable; plain redirection, not a pipe). Dangling `examples/LINT-SWEEP.md` link (~:1010) replaced with the shipped self-updating lint-sweep test. A spec-reconciliation note on TOPO-002's stale-label rule marks the all-matching-edges fan-out as a divergence from the canonical spec's single-best-edge selection (under active reconciliation; the `&& outcome=success` conjunction stays harmless either way).

- **docs/PIPELINE_DESIGN_PRINCIPLES.md** — new §0 "The Control-Plane vs Recipe-Plane Line" (keep the convergence skeleton — gates, budgets, walls, feedback channels; delete the domain decomposition; verification must live OUTSIDE the worker, grounded in a live fabricated-evidence catch). Five live-run lessons woven into the existing sections as one-line war stories: deterministic must-write stub gates (§2), budget-the-green-path / stall detection (§3), running-code-identity checks (§3), transient fail-routes on ship-path nodes (§3), and last-line anchored verdict matching with a missing-artifact guard (§4: `[ -f verdict.txt ] || exit 1; tail -n1 verdict.txt | grep -qix 'VERDICT: SHIP'`).

- **docs/APP-INTEGRATION-GUIDE.md** + **context/pipeline-awareness.md** — the one-sentence recipes-vs-attractor rule at both tool-choice decision surfaces ("Recipes are for staged sequential workflows with human approval gates; attractor pipelines are for machine-verified convergence. If your pipeline graph has no cycle, it should probably have been a recipe."), with the Attractor-Recipe naming-collision note; the inline `dot_source` example upgraded from a linear chain to a convergence shape.

## Verification checklist

- [x] Unit tests pass (`pytest modules/loop-pipeline/`) — 1505 passed, 1 skipped
- [x] Live pipeline run exercising changed code path — docs-only PR, but the new convergence example was executed live end-to-end (evidence below): this exact class of doc bug (plausible-but-broken example) is what the PR fixes
- [x] AGENTS.md reviewed; repo-specific gates met
- [x] Backward-compat path unchanged — N/A, no code changes
- [x] PR body includes verification evidence, not just "tests pass"

## Verification evidence

**Every mechanical claim in the new prose was verified against the engine source** (this discipline is itself what the review loop that produced this PR kept enforcing — see Notes):

- Node-prompt variable expansion: `handlers/codergen.py` `_expand_variables` expands only `$goal`, `$context`, and plain dot-free context keys — dotted keys like `tool.output` are `tool_command`-only (`handlers/tool.py:93` + `substitution.py`). The examples therefore route test evidence through a file, matching the shipped `bug-fix.dot` pattern.
- `tool_command` executes via `asyncio.create_subprocess_shell` → `/bin/sh` (`handlers/tool.py:129`). An earlier draft used `... | tee test_output.txt; exit ${PIPESTATUS[0]}` — under dash that is "Bad substitution", **exit 2 regardless of test results** (gate always red, loop never exits). Proven live: `sh -c '... exit ${PIPESTATUS[0]}'` → `Bad substitution`, exit 2 — while the underlying pytest run was green. The shipped form uses plain redirection so the gate's exit code is pytest's own.
- Live run of the exact DOT-AUTHORING-GUIDE example (fresh dir, real engine, `attractor run example.dot --cwd .`): `status=success` — the worker wrote `calculator.py` + `test_calculator.py`, `test_gate` executed `pytest -q test_calculator.py > test_output.txt 2>&1`, 20 tests passed, exit 0 routed `outcome=success` → done. (Honest caveat: the first attempt was correct, so the corrective back-edge did not fire in this run; outcome=fail edge routing is engine behavior covered by the module suite.)
- `goal_gate` §3.4 contract: `engine.py` ("Spec Section 3.4: Goal Gate Enforcement"). TOPO-003 acyclic warning: `validation.py:977`.
- Cited exemplars verified as merged: `examples/patterns/task-runner.dot` stages orient/attempt/verify/critique/triage/postmortem/package; its `pm_gate` is the `[ -s .ai/postmortem/report.md ]` + labeled-stub pattern; `bug-fix.dot`'s exit gated on `verdict_gate`; every ship-path box node in `bug-fix.dot` carries an `outcome=fail` edge to `postmortem`.
- Link-fix target exists: `modules/loop-pipeline/tests/test_examples_lint_clean.py`.
- Recipe-table claims match the doc's own recipe section (holdout scenario validation, configurable iteration limits, no human approval gates).

Suites (all on this branch):

- Task DoD gate: PASS (all 6 concept checks + root subset 14 passed; the same script was negative-controlled RED on pre-work main @ 3178d36)
- `modules/loop-pipeline` full suite: **1505 passed, 1 skipped**
- Engine-semantics doc-drift guard (adjacent doc surface): **7 passed**
- Examples lint-clean sweep: **25 passed**
- `git diff --check`: clean

## Notes for reviewers

- **Provenance (honest):** the base content was produced by an agent convergence run whose mechanical DoD was green at every gate visit but whose two independent critics refused ship 3 consecutive times with *descending* residuals; the run was operator-salvaged at stall. All remaining critic residuals were closed in this fresh-eyes pass (details in the draft file's residual table). Fitting: the critics kept catching exactly the failure mode this PR documents — plausible-looking examples whose mechanics don't match the engine.
- One deliberate scope line: `02-plan-implement-test.dot` is *named* as the recipe-shaped counter-example ("at time of writing") but not rewritten here — example upgrades are a separate change.
- PR #100's pending review may want the conformance-levels / extensions-ledger conversation; this PR deliberately stays docs-only and touches none of #100's files.