### PR TITLE
feat(engine): fail-closed goal-gate outcomes — explicit verdict contract (is_explicit)

### DIFF
--- a/PRINCIPLES.md
+++ b/PRINCIPLES.md
@@ -38,7 +38,29 @@ Document accepted deviations from the canonical spec here. Each delta should rec
 - **Why** — the use case that justified the deviation; what was insufficient about the upstream behavior.
 - **Link** — the PR or decision that landed it.
 
-Empty until the next change author captures theirs. If a delta exists in the codebase today and is not listed here, this is the place to add it.
+### Delta 1 — Fail-closed goal-gate outcomes (T0-5, 2026-07-31)
+
+**What we changed:** Canonical spec §4.5 `CodergenHandler` pseudocode returns
+`Outcome(status=SUCCESS, notes="Stage completed: …")` unconditionally for any non-empty string
+response. We diverge for `goal_gate=true` nodes: a plain-prose response (no `report_outcome`
+tool call, no JSON, no embedded verdict) returns `Outcome(status=RETRY)` instead of SUCCESS.
+This means a goal gate cannot be satisfied by silence or by a response that literally says the
+work is not done.
+
+**Why:** Verified real-world incident (2026-07-28): a convergence judge marked `goal_gate=true`
+wrote "NOT CONVERGED — 2 of 7 criteria pass" and was recorded `outcome=success` by the
+fail-open default. The designed replan loop never fired; the pipeline exited false success with
+zero work product after 2.4 hours. The spec's fail-open default is the upstream cause; this
+delta closes the class for goal_gate nodes without breaking the vast majority of pipelines
+whose ordinary `box` nodes end in prose.
+
+**Walk-upstream note:** The canonical spec §4.5 default should gain a `goal_gate` check. The
+recommended change: before the final SUCCESS fallback, check whether the node carries
+`goal_gate=true`; if so, return RETRY (or FAIL with a clear message) rather than SUCCESS.
+This is general enough that other consumers of the nlspec would benefit. Until the upstream
+spec adopts this, the divergence is documented in `specs/EXTENSIONS.md §25`.
+
+**Link:** `specs/EXTENSIONS.md §25`; task T0-5.
 
 ---
 

--- a/context/engine-semantics.md
+++ b/context/engine-semantics.md
@@ -129,18 +129,62 @@ Source: `substitution.py`; `node_outputs.py:68-75`; `handlers/tool.py:116-123`.
 
 ## 5. Verdict contract
 
-Source: `backend.py:604-637, 903-951`.
+Source: `backend.py:_parse_outcome, _outcome_from_spawn_result`; `outcome.py`.
 
-- A verdict status is taken from the response **only if the entire stripped response is a
-  JSON object** (`stripped.startswith("{")`) or a ` ```json ``` ` fenced block
-  (`backend.py:614-618`). Not "JSON on the last line" — the **whole** message.
-- **Prose-then-JSON recovery (FIXED):** if a response is prose with a trailing/embedded JSON
-  verdict object, the engine now extracts the LAST balanced `{...}` and, if it carries a recognized
-  `status`, HONORS it (with a logged warning) instead of coercing to SUCCESS (`backend.py:947-994`).
-  An explicit FAIL/RETRY is no longer silently dropped. Empty response → FAIL. (Still prefer pure
-  JSON / `report_outcome` — the recovery is a safety net, not a contract.)
-- **Robust path:** have the node call the **`report_outcome` tool** rather than emit
-  free-text JSON.
+**The verdict-recovery ladder** (tried in order for every LLM response):
+
+1. **`report_outcome` tool call** — authoritative; checked before any text parsing (tool-loop
+   path: `backend.py:_find_report_outcome_call`; spawn path: `metadata["report_outcome"]`).
+2. **Fenced JSON** — ` ```json … ``` ` stripped, then parsed as JSON.
+3. **Pure JSON** — entire stripped response starts with `{`, parsed, `status` field honored.
+4. **Embedded verdict recovery** — last balanced `{…}` in prose extracted; if it carries a
+   recognized `status`, honored with a warning. This catches "prose + trailing JSON" patterns.
+5. **Plain-prose fallback** — no parseable verdict found (see fail-closed rule below).
+
+Empty response → FAIL (no work was done).
+
+**Fail-closed goal-gate contract (EXTENSIONS.md §25 — diverges from canonical spec §4.5):**
+A `goal_gate=true` node MUST provide an explicit verdict (paths 1–4 above). If the response
+reaches the plain-prose fallback (path 5), the outcome is **RETRY** (not SUCCESS). RETRY
+respects `max_retries` and then degrades to FAIL; it is the correct signal for "try again
+with an explicit verdict." A goal gate cannot be satisfied by silence or by prose that says
+the work is not done.
+
+For **non-goal_gate nodes**, path 5 still returns SUCCESS per canonical spec §4.5 — backward
+compatible default for ordinary `box` nodes that end in prose.
+
+**`is_explicit` field on `Outcome`:** `outcome.is_explicit=True` means the status was asserted
+by an unambiguous mechanism: paths 1–4 above, a tool (parallelogram) node's exit code
+(0 = explicit success, nonzero = explicit fail; `handlers/tool.py`), **verdict-shaped**
+`response_schema` structured output (a captured `report_outcome` call or a `status` field
+with a recognized value — `backend._outcome_from_structured_output`), or a deterministic
+handler verdict that cannot be LLM-defaulted (human-gate selections/freeform input,
+start/exit/conditional structural SUCCESS, fan-in ranking, parallel join-policy results).
+`is_explicit=False` means the status was defaulted: plain-prose fallback, empty-response
+default, a status-only spawn result with no node-level verdict, or **non-verdict**
+structured output (format ≠ verdict — `{"name": "Alice"}` parses but asserts nothing, and
+does not satisfy a gate). Compositional handlers whose outcome IS a child's outcome
+(folder/pipeline nodes, manager-loop stop) propagate the child's `is_explicit`. The
+`"Plain text response:"` notes prefix is the legacy signal; `is_explicit` is the durable
+field, serialized into every node `status.json` (flat and iteration-scoped) and every
+`trace.jsonl` record (`engine.py:_write_node_status`, `codergen.py:_write_status`).
+
+**The gate check enforces both flags:** `_check_goal_gates()` (`engine.py`) treats a goal gate
+as satisfied only when `outcome.is_success AND outcome.is_explicit`. A SUCCESS with
+`is_explicit=False` (e.g. a spawn wrapper's clean exit with no `report_outcome`, or a schema
+node whose output carried no recognized verdict) does NOT satisfy the gate. This centralized enforcement
+closes bypass paths that never go through `_parse_outcome`. The RETRY-from-`_parse_outcome`
+rule above is the belt; the gate's `is_explicit` requirement is the suspenders.
+
+**Author guidance:** For `goal_gate=true` nodes, always call the **`report_outcome` tool** or
+emit a pure JSON response (or use a parallelogram tool node — its exit code is the verdict).
+Do not rely on prose output — even prose that says "CONVERGED" will return RETRY under the
+fail-closed contract. The recovery ladder (paths 2–4) is a safety net, not a contract.
+
+**Plain-edge hazard:** RETRY (like FAIL) does not traverse plain unconditional edges — it
+routes only via `condition="outcome=fail"`, `retry_target`, or `runs_on=always|failure` nodes.
+Goal_gate nodes should have explicit `condition="outcome=fail"` or `retry_target` edges. For
+non-goal_gate nodes, the plain-prose SUCCESS default means plain edges still work as before.
 
 ---
 

--- a/docs/DOT-AUTHORING-GUIDE.md
+++ b/docs/DOT-AUTHORING-GUIDE.md
@@ -39,6 +39,21 @@ an acceptance check, a human approval gate, or an evidence-backed review node.
 Shipped positive example: `examples/pipelines/practical/bug-fix.dot`'s exit is
 gated on `verdict_gate` output -- implementation completing earns nothing.
 
+**`goal_gate` nodes require an explicit verdict (fail-closed).** A goal gate is
+satisfied only by an explicit verdict: a `report_outcome` tool call, a pure or
+fenced JSON response with a `status` field, an embedded trailing JSON verdict,
+or -- for `shape=parallelogram` tool nodes -- the command's exit code. A
+plain-prose response ("looks good, all done") returns RETRY instead of SUCCESS,
+so the gate is never satisfied by a defaulted response; even prose that says
+"CONVERGED" does not count (`specs/EXTENSIONS.md` §25). Prompt your gate nodes
+to call `report_outcome` (or emit pure JSON), or make the gate a parallelogram
+tool node whose exit code is the verdict:
+
+```dot
+judge [shape=box, goal_gate=true, retry_target="implement",
+    prompt="Evaluate the work against the criteria. You MUST call the report_outcome tool with status=success only if all criteria pass; otherwise status=retry with what is missing."]
+```
+
 **Recipes vs. attractor pipelines.** Recipes are for staged sequential workflows
 with human approval gates; attractor pipelines are for machine-verified
 convergence. If your pipeline graph has no cycle, it should probably have been a
@@ -571,7 +586,7 @@ Every node in a DOT pipeline can have these attributes:
 | `label` | String | node ID | Display name. Used as prompt fallback if `prompt` is empty. |
 | `prompt` | String | `""` | Primary instruction for LLM nodes. Supports `$goal` expansion. |
 | `type` | String | `""` | Explicit handler type override. Takes precedence over shape. |
-| `goal_gate` | Boolean | `false` | Node must succeed before pipeline can exit. |
+| `goal_gate` | Boolean | `false` | Node must succeed **with an explicit verdict** (report_outcome / JSON / tool exit code) before pipeline can exit. Plain prose returns RETRY (fail-closed, EXTENSIONS.md §25). |
 | `max_retries` | Integer | `0` | Additional attempts beyond the first. `max_retries=3` = 4 total. |
 | `retry_target` | String | `""` | Node to jump to when retries exhausted. |
 | `fallback_retry_target` | String | `""` | Secondary retry target if primary is missing. |

--- a/docs/DOT-SYNTAX.md
+++ b/docs/DOT-SYNTAX.md
@@ -32,7 +32,7 @@ digraph {
 | Attribute | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `prompt` | string | -- | Instructions for the LLM. `$goal` and `$param` tokens are expanded. |
-| `goal_gate` | bool | false | Must succeed for pipeline to complete |
+| `goal_gate` | bool | false | Must succeed **with an explicit verdict** (report_outcome / JSON / tool exit code) for pipeline to complete; plain prose returns RETRY (fail-closed, `specs/EXTENSIONS.md` §25) |
 | `max_retries` | int | graph default | Retry count on failure |
 | `retry_target` | string | -- | Node to jump to on gate failure |
 | `fidelity` | string | "compact" | Context carryover mode |

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/__init__.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/__init__.py
@@ -80,6 +80,7 @@ class DirectProviderBackend:
         from .backend import (
             _build_unified_tools,
             _find_report_outcome_call,
+            _outcome_from_structured_output,
             _parse_outcome,
             _resolve_concrete_model,
             _resolve_model,
@@ -262,10 +263,19 @@ class DirectProviderBackend:
             }
             if parsed_obj is not None:
                 ctx_ext23[node.id] = parsed_obj
-            outcome = Outcome(
-                status=StageStatus.SUCCESS,
-                notes=raw_json,
-                context_updates=ctx_ext23,
+            # EXTENSIONS.md §25 policy (corrected in independent review round
+            # 2): format ≠ verdict. Schema output is explicit ONLY when it
+            # carries a recognized verdict (captured report_outcome, or a
+            # `status` field with a recognized value — the same verdict
+            # ladder as every other path). Generic structured output stays
+            # DERIVED (is_explicit=False) so a goal_gate schema node
+            # returning non-verdict JSON fails closed. See
+            # backend._outcome_from_structured_output.
+            outcome = _outcome_from_structured_output(
+                raw_json=raw_json,
+                parsed_obj=parsed_obj,
+                ctx_updates=ctx_ext23,
+                result=result,
             )
             self._completed_nodes[node.id] = outcome
             self._last_node_id = node.id
@@ -280,7 +290,7 @@ class DirectProviderBackend:
                 r"^```(?:json)?\s*([\s\S]*?)\s*```$", stripped, re.DOTALL
             )
             if bool(_fence_match) or stripped.startswith("{"):
-                outcome = _parse_outcome(text)
+                outcome = _parse_outcome(text, node=node)
                 outcome.context_updates = {
                     "last_stage": node.id,
                     "last_response": text[:200],
@@ -299,18 +309,34 @@ class DirectProviderBackend:
                 preferred_label=lo.get("preferred_label"),
                 suggested_next_ids=lo.get("suggested_next_ids"),
                 notes=lo.get("notes"),
+                is_explicit=True,
             )
             self._completed_nodes[node.id] = outcome
             self._last_node_id = node.id
             return outcome
 
         if text:
-            outcome = _parse_outcome(text)
+            outcome = _parse_outcome(text, node=node)
         else:
-            outcome = Outcome(
-                status=StageStatus.SUCCESS,
-                notes=f"Stage completed: {node.id}",
-            )
+            # No text and no report_outcome.
+            # EXTENSIONS.md §25 scope decision: apply fail-closed only to
+            # goal_gate nodes. Non-goal-gate nodes retain spec §4.5 SUCCESS
+            # default. goal_gate nodes require an explicit verdict.
+            _is_goal_gate = node.attrs.get("goal_gate") in (True, "true")
+            if _is_goal_gate:
+                outcome = Outcome(
+                    status=StageStatus.FAIL,
+                    notes=f"No output from DirectProviderBackend: {node.id}",
+                    failure_reason="Empty DirectProviderBackend response — goal_gate node requires explicit verdict",
+                    is_explicit=False,
+                )
+            else:
+                # Non-goal-gate: spec §4.5 SUCCESS default preserved.
+                outcome = Outcome(
+                    status=StageStatus.SUCCESS,
+                    notes=f"Stage completed: {node.id}",
+                    is_explicit=False,
+                )
 
         outcome.context_updates = {
             "last_stage": node.id,

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/backend.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/backend.py
@@ -565,7 +565,7 @@ class AmplifierBackend:
                 failure_reason="Empty spawn output",
             )
 
-        outcome = _parse_outcome(output)
+        outcome = _parse_outcome(output, node=node)
 
         # Capture session_id from spawn result for status.json observability.
         # session_id is kept on the Outcome for telemetry/debugging — it no longer
@@ -739,10 +739,21 @@ class AmplifierBackend:
             }
             if parsed_obj is not None:
                 ctx_updates[node.id] = parsed_obj
-            return Outcome(
-                status=StageStatus.SUCCESS,
-                notes=raw_json,
-                context_updates=ctx_updates,
+            # EXTENSIONS.md §25 policy (corrected in independent review round
+            # 2): FORMAT is not a VERDICT. Schema-parsed output is explicit
+            # ONLY when it carries a recognized verdict — a captured
+            # report_outcome tool call, or a `status` field with a recognized
+            # StageStatus value (the same verdict ladder every other path
+            # uses). Generic structured output (e.g. {"name": "Alice"} or
+            # {"assessment": "NOT CONVERGED"}) proves the model followed the
+            # schema, not that it asserted a verdict — it stays DERIVED
+            # (is_explicit=False), so a goal_gate schema node returning
+            # non-verdict JSON does not satisfy its gate (fail-closed).
+            return _outcome_from_structured_output(
+                raw_json=raw_json,
+                parsed_obj=parsed_obj,
+                ctx_updates=ctx_updates,
+                result=result,
             )
 
         # Map GenerateResult → Outcome
@@ -761,8 +772,11 @@ class AmplifierBackend:
         #      are cloned for parallel branches.
         #   2. No report_outcome call → result.text (JSON, fenced JSON, embedded
         #      JSON, or plain prose) → _parse_outcome handles all of these,
-        #      falling back to SUCCESS for plain prose per spec 4.5.
-        #   3. No text at all → SUCCESS.
+        #      falling back to SUCCESS for plain prose per spec 4.5 (or RETRY
+        #      for goal_gate=true nodes per EXTENSIONS.md §25).
+        #   3. No text at all → FAIL for goal_gate=true nodes (consistent with
+        #      the spawn path's empty→FAIL; EXTENSIONS.md §25); non-goal_gate
+        #      nodes keep the spec 4.5 SUCCESS default.
         lo = _find_report_outcome_call(result)
         if lo is not None:
             return Outcome(
@@ -772,13 +786,40 @@ class AmplifierBackend:
                 preferred_label=lo.get("preferred_label"),
                 suggested_next_ids=lo.get("suggested_next_ids"),
                 notes=lo.get("notes"),
+                is_explicit=True,
             )
 
         if result.text:
-            return _parse_outcome(result.text)
+            return _parse_outcome(result.text, node=node)
+        # No text and no report_outcome call.
+        # EXTENSIONS.md §25 scope decision: apply fail-closed only to goal_gate
+        # nodes. Non-goal-gate nodes retain the spec §4.5 SUCCESS default so
+        # that observer/reporter nodes with plain out-edges are not broken.
+        # goal_gate nodes require an explicit verdict; no-text is treated as
+        # FAIL (same as the spawn path's empty→FAIL).
+        is_goal_gate = node.attrs.get("goal_gate") in (True, "true")
+        if is_goal_gate:
+            logger.warning(
+                "Node %s (goal_gate=true): tool loop returned no text and no "
+                "report_outcome call. Fail-closed contract (EXTENSIONS.md §25).",
+                node.id,
+            )
+            return Outcome(
+                status=StageStatus.FAIL,
+                notes=f"No output from tool loop: {node.id}",
+                failure_reason="Empty tool-loop response — goal_gate node requires explicit verdict",
+                is_explicit=False,
+            )
+        # Non-goal-gate node: spec §4.5 SUCCESS default preserved.
+        logger.warning(
+            "Node %s: tool loop returned no text and no report_outcome call "
+            "(non-goal-gate node; SUCCESS per spec §4.5).",
+            node.id,
+        )
         return Outcome(
             status=StageStatus.SUCCESS,
             notes=f"Stage completed: {node.id}",
+            is_explicit=False,
         )
 
     # ------------------------------------------------------------------
@@ -1085,6 +1126,85 @@ def _find_report_outcome_call(result: Any) -> dict[str, Any] | None:
     return found
 
 
+def _outcome_from_structured_output(
+    raw_json: str,
+    parsed_obj: Any,
+    ctx_updates: dict[str, Any],
+    result: Any,
+) -> Outcome:
+    """Build the Outcome for a response_schema (EXT-23) structured-output node.
+
+    EXTENSIONS.md §25 policy, corrected in independent review round 2:
+    **format ≠ verdict.** Parseable schema output proves the model followed
+    the requested FORMAT; it does not prove the node asserted a VERDICT.
+    Schema-parsed output is therefore explicit ONLY when it carries a
+    recognized verdict, routed through the same verdict ladder as every
+    other outcome path:
+
+      1. a captured ``report_outcome`` tool call (authoritative, mirrors the
+         priority order of the non-schema paths), or
+      2. a ``status`` field whose value is a recognized ``StageStatus``
+         (the same rule ``_parse_outcome`` applies to JSON responses).
+
+    Generic structured output — ``{"name": "Alice"}``,
+    ``{"assessment": "NOT CONVERGED"}`` — stays DERIVED
+    (``is_explicit=False``): the node still returns SUCCESS (EXT-23
+    behavior for ordinary schema nodes is unchanged), but a
+    ``goal_gate=true`` schema node cannot satisfy its gate with it
+    (fail-closed at the gate layer).
+
+    ``ctx_updates`` (the ``last_stage``/``last_response``/``node.id`` data
+    stash) is preserved on every branch so downstream nodes keep access to
+    the structured payload regardless of verdict classification.
+    """
+    ro = _find_report_outcome_call(result)
+    if ro is not None:
+        ro_extra = ro.get("context_updates")
+        return Outcome(
+            status=_STATUS_MAP.get(ro.get("status", ""), StageStatus.FAIL),
+            notes=ro.get("notes") or raw_json,
+            failure_reason=ro.get("failure_reason"),
+            preferred_label=ro.get("preferred_label"),
+            suggested_next_ids=ro.get("suggested_next_ids"),
+            context_updates={
+                **ctx_updates,
+                **(ro_extra if isinstance(ro_extra, dict) else {}),
+            },
+            is_explicit=True,
+        )
+
+    verdict: StageStatus | None = None
+    if isinstance(parsed_obj, dict):
+        status_val = parsed_obj.get("status")
+        if isinstance(status_val, str):
+            verdict = _STATUS_MAP.get(status_val)
+    if verdict is not None:
+        assert isinstance(parsed_obj, dict)  # narrowed above
+        extra = parsed_obj.get("context_updates")
+        return Outcome(
+            status=verdict,
+            notes=parsed_obj.get("notes") or raw_json,
+            failure_reason=parsed_obj.get("failure_reason"),
+            preferred_label=parsed_obj.get("preferred_label"),
+            suggested_next_ids=parsed_obj.get("suggested_next_ids"),
+            context_updates={
+                **ctx_updates,
+                **(extra if isinstance(extra, dict) else {}),
+            },
+            is_explicit=True,
+        )
+
+    # Non-verdict structured output (including empty/unparseable): node
+    # DATA, not a verdict. SUCCESS per EXT-23 (non-gate schema nodes are
+    # unchanged) but DERIVED — a goal_gate on this node fails closed.
+    return Outcome(
+        status=StageStatus.SUCCESS,
+        notes=raw_json,
+        context_updates=ctx_updates,
+        is_explicit=False,
+    )
+
+
 # Spawn-result status strings that count as a real, non-failing completion.
 # These map 1:1 to non-FAIL StageStatus members; any other string (e.g.
 # "error", "", or a missing status) is treated as "no success signal".
@@ -1132,25 +1252,48 @@ def _outcome_from_spawn_result(result: Any) -> Outcome | None:
                 preferred_label=report_outcome.get("preferred_label"),
                 suggested_next_ids=report_outcome.get("suggested_next_ids"),
                 context_updates=report_outcome.get("context_updates"),
+                is_explicit=True,
             )
 
     if result.get("status") in _SPAWN_SUCCESS_STATUSES:
         status = _STATUS_MAP[result["status"]]
+        # The orchestrator's completion status is NOT an explicit verdict from
+        # the node itself (no report_outcome, no JSON, no embedded recovery).
+        # is_explicit=False so that a goal_gate node cannot satisfy its gate
+        # solely because the spawn wrapper reported a clean exit.
+        # EXTENSIONS.md §25: a goal_gate node requires is_explicit=True.
         return Outcome(
             status=status,
             notes="Child session completed with empty final message",
+            is_explicit=False,
         )
 
     return None
 
 
-def _parse_outcome(output: str) -> Outcome:
+def _parse_outcome(output: str, *, node: object = None) -> Outcome:
     """Parse an outcome from child session output.
 
     Tries JSON first (from tool-report-outcome). Plain text responses return
-    SUCCESS per spec Section 4.5 — the backend is only responsible for
-    producing Outcome objects when it wants non-SUCCESS status. Empty output
-    returns FAIL (no work was done).
+    SUCCESS per spec Section 4.5 for ordinary nodes — the backend is only
+    responsible for producing Outcome objects when it wants non-SUCCESS status.
+    Empty output returns FAIL (no work was done).
+
+    EXTENSIONS.md §25 — fail-closed goal-gate contract:
+    When ``node`` is provided and the node carries ``goal_gate=true``, a
+    plain-text response (no JSON, no report_outcome, no embedded verdict) is
+    NOT sufficient to satisfy the gate.  In that case the outcome is RETRY
+    (respects max_retries, then degrades to FAIL) rather than silent SUCCESS.
+    ``is_explicit=True`` is set on every outcome that came from a real verdict
+    (JSON / fenced JSON / embedded recovery); the plain-text fallback leaves
+    ``is_explicit=False`` so downstream checks and analysts can distinguish the
+    two cases without reverse-engineering the notes prefix.
+
+    Args:
+        output: The raw text output from the LLM node.
+        node: Optional graph Node object.  When supplied and the node has
+            ``goal_gate=true``, the fail-closed contract applies to the
+            plain-text fallback path.
     """
     # Empty/whitespace-only output means no work was done
     stripped = output.strip()
@@ -1159,6 +1302,7 @@ def _parse_outcome(output: str) -> Outcome:
             status=StageStatus.FAIL,
             notes="No output from LLM",
             failure_reason="Empty LLM response",
+            is_explicit=False,
         )
 
     # Strip markdown code fences (```json...``` or ```...```) that LLMs sometimes
@@ -1184,6 +1328,7 @@ def _parse_outcome(output: str) -> Outcome:
                         preferred_label=data.get("preferred_label"),
                         suggested_next_ids=data.get("suggested_next_ids"),
                         context_updates=data.get("context_updates"),
+                        is_explicit=True,
                     )
         except (json.JSONDecodeError, KeyError, TypeError):
             pass
@@ -1233,12 +1378,42 @@ def _parse_outcome(output: str) -> Outcome:
                             preferred_label=_embedded.get("preferred_label"),
                             suggested_next_ids=_embedded.get("suggested_next_ids"),
                             context_updates=_embedded.get("context_updates"),
+                            is_explicit=True,
                         )
             except (json.JSONDecodeError, KeyError, TypeError):
                 pass
 
-    # Plain text response — per spec Section 4.5, treat as SUCCESS
+    # Plain text response — no explicit verdict recovered.
+    # EXTENSIONS.md §25: for goal_gate=true nodes, a plain-text response is NOT
+    # sufficient — the gate requires an explicit verdict.  Return RETRY so the
+    # engine respects max_retries and degrades to FAIL rather than silently
+    # satisfying the gate.  For all other nodes, fall through to SUCCESS per
+    # spec Section 4.5 (backward-compatible default).
+    _is_goal_gate = (
+        node is not None
+        and hasattr(node, "attrs")
+        and node.attrs.get("goal_gate") in (True, "true")  # type: ignore[union-attr]
+    )
+    if _is_goal_gate:
+        logger.warning(
+            "Node %r (goal_gate=true) produced plain-text output with no "
+            "explicit verdict (no report_outcome, no JSON, no embedded verdict). "
+            "Fail-closed contract (EXTENSIONS.md §25): returning RETRY so the "
+            "gate is not satisfied by a defaulted plain-text response. "
+            "Node output (first 200 chars): %r",
+            getattr(node, "id", repr(node)),
+            output[:200],
+        )
+        return Outcome(
+            status=StageStatus.RETRY,
+            notes=f"No explicit verdict from goal_gate node — plain text only: {output[:200]}",
+            failure_reason="goal_gate node requires an explicit verdict (report_outcome / JSON)",
+            is_explicit=False,
+        )
+
+    # Non-goal_gate node: plain text response — per spec Section 4.5, treat as SUCCESS.
     return Outcome(
         status=StageStatus.SUCCESS,
         notes=f"Plain text response: {output[:200]}",
+        is_explicit=False,
     )

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py
@@ -1030,7 +1030,17 @@ class PipelineEngine:
             if node is None:
                 continue
             if node.attrs.get("goal_gate") in (True, "true"):
-                if outcome.is_success:
+                # EXTENSIONS.md §25 — fail-closed gate enforcement.
+                # A goal_gate node satisfies its gate ONLY when:
+                #   1. outcome.is_success is True (SUCCESS or PARTIAL_SUCCESS), AND
+                #   2. outcome.is_explicit is True (an asserted verdict: report_outcome,
+                #      JSON, fenced JSON, or recovered embedded verdict).
+                # This closes the spawn-path bypass: _outcome_from_spawn_result()
+                # returns is_explicit=False when recovering from the orchestrator's
+                # completion status alone (no report_outcome, no JSON). That outcome
+                # may be SUCCESS but it is not an explicit verdict from the node.
+                gate_satisfied = outcome.is_success and outcome.is_explicit
+                if gate_satisfied:
                     satisfied.append(node_id)
                 else:
                     unsatisfied.append((node_id, outcome))
@@ -1154,6 +1164,10 @@ class PipelineEngine:
             "notes": outcome.notes,
             "failure_reason": outcome.failure_reason,
             "session_id": outcome.session_id,
+            # EXTENSIONS.md §25: is_explicit is durable audit data — analysts
+            # must be able to distinguish asserted verdicts from defaulted
+            # ones without reverse-engineering the notes prefix.
+            "is_explicit": outcome.is_explicit,
             # Issue 10: structured tool-invocation failure payload.
             # Populated by ToolHandler on failure; None/absent on success.
             "failed_step": outcome.failed_step,
@@ -1183,6 +1197,8 @@ class PipelineEngine:
             "node_id": node_id,
             "status": outcome.status.value,
             "preferred_label": outcome.preferred_label,
+            # EXTENSIONS.md §25: durable audit field (see status.json above).
+            "is_explicit": outcome.is_explicit,
             "duration_ms": duration_ms,
             "ts": datetime.now(timezone.utc).isoformat(),
         }

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/codergen.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/codergen.py
@@ -128,15 +128,40 @@ class CodergenHandler:
         # 4. Write response to logs
         _write_file(os.path.join(stage_dir, "response.md"), response_text)
 
-        # 5. Build and write outcome
-        outcome = Outcome(
-            status=StageStatus.SUCCESS,
-            notes=f"Stage completed: {node.id}",
-            context_updates={
+        # 5. Build and write outcome.
+        #
+        # EXTENSIONS.md §25 — fail-closed goal-gate contract: when the node
+        # carries goal_gate=true, a string response from the backend must go
+        # through the verdict-recovery ladder (_parse_outcome). JSON / fenced
+        # JSON / embedded verdicts are honored (is_explicit=True); plain prose
+        # returns RETRY so the gate is never satisfied by a defaulted response.
+        # This is the exact goal_gate check that PRINCIPLES.md Delta 1
+        # recommends adding to the spec's CodergenHandler pseudocode.
+        #
+        # Non-goal_gate nodes keep the spec §4.5 unconditional-SUCCESS wrap
+        # (is_explicit defaults to False — the status is defaulted, not
+        # asserted; that is only load-bearing for goal_gate nodes).
+        if node.attrs.get("goal_gate") in (True, "true"):
+            # Deferred import: avoid a handlers <-> backend import cycle at
+            # module load time.
+            from ..backend import _parse_outcome
+
+            outcome = _parse_outcome(response_text, node=node)
+            merged_updates: dict[str, Any] = {
                 "last_stage": node.id,
                 "last_response": response_text[:200],
-            },
-        )
+            }
+            merged_updates.update(outcome.context_updates or {})
+            outcome.context_updates = merged_updates
+        else:
+            outcome = Outcome(
+                status=StageStatus.SUCCESS,
+                notes=f"Stage completed: {node.id}",
+                context_updates={
+                    "last_stage": node.id,
+                    "last_response": response_text[:200],
+                },
+            )
         _write_status(stage_dir, outcome)
         return outcome
 
@@ -193,5 +218,8 @@ def _write_status(stage_dir: str, outcome: Outcome) -> None:
         "context_updates": outcome.context_updates,
         "notes": outcome.notes,
         "failure_reason": outcome.failure_reason,
+        # EXTENSIONS.md §25: is_explicit is durable audit data; the codergen
+        # early-writer must carry it too, not just the engine's writers.
+        "is_explicit": outcome.is_explicit,
     }
     _write_file(os.path.join(stage_dir, "status.json"), json.dumps(data, indent=2))

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/conditional.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/conditional.py
@@ -45,4 +45,10 @@ class ConditionalHandler:
         engine: "PipelineEngine | None" = None,
     ) -> Outcome:
         """Return SUCCESS immediately.  Routing is handled by the engine."""
-        return Outcome(status=StageStatus.SUCCESS, notes=f"Conditional node: {node.id}")
+        # EXTENSIONS.md §25: structural no-op — deterministic SUCCESS that
+        # cannot be an LLM default, so it is an explicit verdict.
+        return Outcome(
+            status=StageStatus.SUCCESS,
+            notes=f"Conditional node: {node.id}",
+            is_explicit=True,
+        )

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/exit.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/exit.py
@@ -31,4 +31,10 @@ class ExitHandler:
         engine: "PipelineEngine | None" = None,
     ) -> Outcome:
         """Return SUCCESS immediately."""
-        return Outcome(status=StageStatus.SUCCESS, notes=f"Exit node: {node.id}")
+        # EXTENSIONS.md §25: structural no-op — deterministic SUCCESS that
+        # cannot be an LLM default, so it is an explicit verdict.
+        return Outcome(
+            status=StageStatus.SUCCESS,
+            notes=f"Exit node: {node.id}",
+            is_explicit=True,
+        )

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/fan_in.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/fan_in.py
@@ -130,12 +130,20 @@ class FanInHandler:
         if best_status == "fail":
             return Outcome(
                 status=StageStatus.FAIL,
+                # EXTENSIONS.md §25: the ranking rule over branch statuses is
+                # this node's verdict mechanism — deterministic, not an LLM
+                # default.
+                is_explicit=True,
                 failure_reason=f"All candidates failed. Best: {best_id}",
                 notes=best.get("notes"),
             )
 
         return Outcome(
             status=StageStatus.SUCCESS,
+            # EXTENSIONS.md §25: deterministic aggregation verdict (ranking
+            # over branch statuses) — cannot be an LLM default. Without this,
+            # a goal_gate=true fan-in node is unsatisfiable.
+            is_explicit=True,
             notes=f"Selected best candidate: {best_id} ({best_status})",
             context_updates={
                 "parallel.fan_in.best_id": best_id,

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/human.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/human.py
@@ -267,6 +267,9 @@ class HumanGateHandler:
         ):
             return Outcome(
                 status=StageStatus.FAIL,
+                # EXTENSIONS.md §25: a SKIP is a deterministic interviewer
+                # decision, not a defaulted LLM completion — explicit verdict.
+                is_explicit=True,
                 context_updates={
                     text_key: None,
                     "human.gate.label": node.label,
@@ -402,6 +405,10 @@ class HumanGateHandler:
 
         return Outcome(
             status=StageStatus.SUCCESS,
+            # EXTENSIONS.md §25: a human's selection is the most explicit
+            # verdict possible — deterministic, cannot be an LLM default.
+            # Without this, a goal_gate=true human gate is unsatisfiable.
+            is_explicit=True,
             suggested_next_ids=target_ids if target_ids else None,
             context_updates={
                 "human.gate.selected": selected,
@@ -515,6 +522,9 @@ class HumanGateHandler:
 
         return Outcome(
             status=StageStatus.SUCCESS,
+            # EXTENSIONS.md §25: freeform human input is a deterministic
+            # human action, not a defaulted LLM completion — explicit.
+            is_explicit=True,
             suggested_next_ids=target_ids if target_ids else None,
             context_updates={
                 "human.gate.text": answer.text,

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/manager_loop.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/manager_loop.py
@@ -241,6 +241,12 @@ class ManagerLoopHandler:
                 if evaluate_condition(stop_condition, child_outcome, context):
                     return Outcome(
                         status=child_outcome.status,
+                        # EXTENSIONS.md §25: the manager's verdict IS the
+                        # child's — propagate the child's explicitness rather
+                        # than dropping to False (which made a goal_gate=true
+                        # manager node unsatisfiable even when the child
+                        # produced an explicit verdict).
+                        is_explicit=child_outcome.is_explicit,
                         notes=f"Manager completed in {cycle} cycle(s) — stop condition satisfied",
                         context_updates={
                             "last_stage": node.id,
@@ -252,6 +258,9 @@ class ManagerLoopHandler:
                 if child_outcome.is_success:
                     return Outcome(
                         status=child_outcome.status,
+                        # EXTENSIONS.md §25: propagate the child's
+                        # explicitness (see stop-condition branch above).
+                        is_explicit=child_outcome.is_explicit,
                         notes=f"Manager completed in {cycle} cycle(s)",
                         context_updates={
                             "last_stage": node.id,

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/parallel.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/parallel.py
@@ -86,6 +86,9 @@ class ParallelHandler:
             return Outcome(
                 status=StageStatus.SUCCESS,
                 notes="Parallel node with no branches",
+                # EXTENSIONS.md §25: deterministic structural fact (no
+                # branches to run) — cannot be an LLM default.
+                is_explicit=True,
             )
 
         max_parallel = int(node.attrs.get("max_parallel", 4))
@@ -407,8 +410,15 @@ def _apply_join_policy(
     Supports: wait_all, first_success, k_of_n, quorum.
     Unknown policies fall back to wait_all behaviour.
     """
+    # EXTENSIONS.md §25: every join-policy outcome below is is_explicit=True.
+    # The join policy is a deterministic counting rule over branch statuses —
+    # the parallel node's own verdict mechanism (analogous to a tool node's
+    # exit code). It cannot be a defaulted LLM completion. Without this, a
+    # goal_gate=true parallel node would be unsatisfiable.
     if not results:
-        return Outcome(status=StageStatus.SUCCESS, notes="No branches")
+        return Outcome(
+            status=StageStatus.SUCCESS, notes="No branches", is_explicit=True
+        )
 
     attrs = node_attrs or {}
 
@@ -424,10 +434,12 @@ def _apply_join_policy(
             return Outcome(
                 status=StageStatus.SUCCESS,
                 notes=f"All {total} branches succeeded",
+                is_explicit=True,
             )
         return Outcome(
             status=StageStatus.PARTIAL_SUCCESS,
             notes=f"{success_count}/{total} branches succeeded, {fail_count} failed",
+            is_explicit=True,
         )
 
     # -- first_success ---------------------------------------------------
@@ -436,10 +448,12 @@ def _apply_join_policy(
             return Outcome(
                 status=StageStatus.SUCCESS,
                 notes=f"At least one branch succeeded ({success_count}/{total})",
+                is_explicit=True,
             )
         return Outcome(
             status=StageStatus.FAIL,
             failure_reason=f"No branches succeeded out of {total}",
+            is_explicit=True,
         )
 
     # -- k_of_n ----------------------------------------------------------
@@ -449,6 +463,7 @@ def _apply_join_policy(
             return Outcome(
                 status=StageStatus.SUCCESS,
                 notes=f"{success_count}/{total} branches succeeded (needed {k})",
+                is_explicit=True,
             )
         return Outcome(
             status=StageStatus.FAIL,
@@ -456,6 +471,7 @@ def _apply_join_policy(
                 f"Only {success_count}/{k} required branches succeeded "
                 f"(out of {total} total)"
             ),
+            is_explicit=True,
         )
 
     # -- quorum ----------------------------------------------------------
@@ -469,6 +485,7 @@ def _apply_join_policy(
                     f"{success_count}/{total} branches succeeded "
                     f"(needed {needed}, fraction={fraction})"
                 ),
+                is_explicit=True,
             )
         return Outcome(
             status=StageStatus.FAIL,
@@ -476,6 +493,7 @@ def _apply_join_policy(
                 f"Only {success_count}/{needed} required branches succeeded "
                 f"(fraction={fraction}, total={total})"
             ),
+            is_explicit=True,
         )
 
     # -- Unknown policy: fall back to wait_all ---------------------------
@@ -483,8 +501,10 @@ def _apply_join_policy(
         return Outcome(
             status=StageStatus.SUCCESS,
             notes=f"All {total} branches succeeded",
+            is_explicit=True,
         )
     return Outcome(
         status=StageStatus.PARTIAL_SUCCESS,
         notes=f"{success_count}/{total} branches succeeded",
+        is_explicit=True,
     )

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/pipeline.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/pipeline.py
@@ -326,5 +326,9 @@ class PipelineHandler:
             },
         )
 
-        # (12) Return child outcome
+        # (12) Return child outcome verbatim. EXTENSIONS.md §25: this
+        # propagates the child's is_explicit — a folder node's outcome CAN
+        # carry a defaulted LLM completion (the child's terminal outcome), so
+        # it must NOT be blanket-classified as explicit; explicitness flows
+        # from the child's own verdict mechanism.
         return outcome

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/start.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/start.py
@@ -31,4 +31,10 @@ class StartHandler:
         engine: "PipelineEngine | None" = None,
     ) -> Outcome:
         """Return SUCCESS immediately."""
-        return Outcome(status=StageStatus.SUCCESS, notes=f"Start node: {node.id}")
+        # EXTENSIONS.md §25: structural no-op — deterministic SUCCESS that
+        # cannot be an LLM default, so it is an explicit verdict.
+        return Outcome(
+            status=StageStatus.SUCCESS,
+            notes=f"Start node: {node.id}",
+            is_explicit=True,
+        )

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/tool.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/tool.py
@@ -162,6 +162,9 @@ class ToolHandler:
                 exit_code: int = proc.returncode or -1
                 return Outcome(
                     status=StageStatus.FAIL,
+                    # EXTENSIONS.md §25: a tool's exit code IS an explicit
+                    # verdict — the process asserted failure unambiguously.
+                    is_explicit=True,
                     failure_reason=(
                         f"Command exited with code {exit_code}: "
                         f"{stderr_text.strip() or stdout_text.strip()}"
@@ -222,6 +225,11 @@ class ToolHandler:
 
             return Outcome(
                 status=StageStatus.SUCCESS,
+                # EXTENSIONS.md §25: exit code 0 IS an explicit verdict — the
+                # process asserted success unambiguously. Without this, a
+                # goal_gate=true tool node could never satisfy its gate
+                # (the gate check requires is_success AND is_explicit).
+                is_explicit=True,
                 context_updates=context_updates,
                 notes=f"Tool completed: {command}",
             )

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/outcome.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/outcome.py
@@ -4,11 +4,12 @@ Defines StageStatus enum and Outcome dataclass that drive routing
 decisions and state updates after each node handler completes.
 
 Spec coverage: OUT-001–007, Section 5.2 (Outcome)
+Extension: EXTENSIONS.md §25 (fail-closed goal-gate outcomes)
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
 
@@ -34,6 +35,12 @@ class Outcome:
     context updates, and retry/failure routing.
 
     Spec Section 5.2: Outcome model.
+
+    EXTENSIONS.md §25: the ``is_explicit`` field distinguishes an asserted
+    verdict (report_outcome / JSON / embedded recovery) from a defaulted one
+    (plain-prose fallback).  A goal_gate=true node whose outcome is NOT
+    explicit cannot satisfy its own gate — the gate check treats a defaulted
+    SUCCESS as unsatisfied (fail-closed contract).
     """
 
     status: StageStatus
@@ -45,6 +52,14 @@ class Outcome:
     session_id: str | None = (
         None  # child Amplifier session ID (if executed via AmplifierBackend)
     )
+
+    #: EXTENSIONS.md §25 — True when the status was asserted by the node
+    #: (report_outcome tool call, pure JSON response, fenced JSON, or recovered
+    #: embedded {…} verdict).  False when the status is the parser's plain-text
+    #: fallback ("Plain text response: …").  A goal_gate=true node REQUIRES
+    #: is_explicit=True to satisfy its gate; a defaulted SUCCESS is treated as
+    #: unsatisfied and the gate fails closed (RETRY / FAIL, never silent success).
+    is_explicit: bool = field(default=False)
 
     #: Issue 10 / analog of WS-4 Sub-fix C: structured tool-invocation payload
     #: populated by ToolHandler on failure so the dashboard can display the

--- a/modules/loop-pipeline/tests/test_fail_closed_outcomes.py
+++ b/modules/loop-pipeline/tests/test_fail_closed_outcomes.py
@@ -1,0 +1,649 @@
+"""Fail-closed goal-gate outcome contract — EXTENSIONS.md §25.
+
+Regression tests for T0-5: no-verdict completions must not satisfy goal gates.
+
+Incident (2026-07-28): a convergence judge marked goal_gate=true wrote
+"NOT CONVERGED — 2 of 7 criteria pass" and was recorded outcome=success by
+the fail-open default in _parse_outcome. These tests lock down the fix.
+
+Coverage:
+  FC-001  goal_gate=true + plain prose → RETRY (fail-closed, not SUCCESS)
+  FC-002  non-goal_gate + plain prose → SUCCESS (spec §4.5 preserved, plain-edge safe)
+  FC-003  goal_gate=true + explicit JSON verdict → SUCCESS (ladder preserved)
+  FC-004  goal_gate=true + fenced JSON verdict → SUCCESS (ladder preserved)
+  FC-005  goal_gate=true + embedded verdict recovery → SUCCESS (ladder preserved)
+  FC-006  goal_gate=true + report_outcome-style JSON → SUCCESS (ladder preserved)
+  FC-007  is_explicit=True on explicit verdicts, False on plain-prose fallback
+  FC-008  is_explicit=False on spawn-status-only result (no node-level verdict)
+  FC-009  plain-edge safety: observer node (no goal_gate) with plain out-edge
+          still gets SUCCESS and can traverse the edge (no silent hard-stop)
+  FC-010  full-engine fixture: goal_gate + plain prose → pipeline does NOT exit success
+  FC-011  full-engine fixture: goal_gate + explicit JSON success → pipeline exits success
+  FC-012  goal_gate=true human gate is satisfiable (selection is an explicit verdict)
+  FC-013  goal_gate=true fan-in node is satisfiable (aggregation is an explicit verdict)
+  FC-014  is_explicit serialized into status.json (flat + iteration) and trace.jsonl
+  FC-015  is_explicit serialized by the codergen early-writer (_write_status)
+
+Structured-output (response_schema) verdict policy tests live in
+test_response_schema.py (they need the unified_llm mock harness).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from amplifier_module_loop_pipeline.backend import _parse_outcome, _outcome_from_spawn_result
+from amplifier_module_loop_pipeline.context import PipelineContext
+from amplifier_module_loop_pipeline.dot_parser import parse_dot
+from amplifier_module_loop_pipeline.engine import PipelineEngine
+from amplifier_module_loop_pipeline.graph import Node
+from amplifier_module_loop_pipeline.handlers import HandlerRegistry
+from amplifier_module_loop_pipeline.handlers.context import HandlerContext
+from amplifier_module_loop_pipeline.outcome import Outcome, StageStatus
+from amplifier_module_loop_pipeline.validation import validate_or_raise
+
+# ---------------------------------------------------------------------------
+# Incident prose specimen — the exact text from the 2026-07-28 incident
+# ---------------------------------------------------------------------------
+_INCIDENT_PROSE = (
+    "I reviewed the seven convergence criteria in detail. "
+    "Verdict: NOT CONVERGED - only 2 of 7 criteria pass. "
+    "The networking implementation does not work and the harness was never created. "
+    "Substantial work remains before this pipeline can be considered done."
+)
+
+# A benign observer node prose specimen
+_OBSERVER_PROSE = "Observer: pipeline health looks good, no issues detected."
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_node(goal_gate: bool = False, node_id: str = "judge") -> Node:
+    """Build a minimal Node for _parse_outcome testing."""
+    return Node(
+        id=node_id,
+        attrs={"goal_gate": "true" if goal_gate else None},
+        goal_gate=goal_gate or None,
+    )
+
+
+def _make_engine(
+    dot_source: str,
+    backend: object | None = None,
+    logs_root: str = "/tmp/test-fail-closed",
+) -> PipelineEngine:
+    graph = parse_dot(dot_source)
+    validate_or_raise(graph)
+    context = PipelineContext()
+    registry = HandlerRegistry(HandlerContext(backend=backend))
+    return PipelineEngine(
+        graph=graph,
+        context=context,
+        handler_registry=registry,
+        logs_root=logs_root,
+    )
+
+
+# ---------------------------------------------------------------------------
+# FC-001: goal_gate=true + plain prose → RETRY
+# ---------------------------------------------------------------------------
+
+
+def test_fc001_goal_gate_plain_prose_returns_retry():
+    """FC-001: goal_gate=true node with plain prose → RETRY (fail-closed).
+
+    This is the exact incident failure mode: the judge wrote "NOT CONVERGED"
+    in prose and was recorded SUCCESS. After the fix, it must return RETRY.
+    """
+    node = _make_node(goal_gate=True)
+    result = _parse_outcome(_INCIDENT_PROSE, node=node)
+
+    assert result.status == StageStatus.RETRY, (
+        f"goal_gate=true plain prose must return RETRY (fail-closed), got {result.status!r}. "
+        "EXTENSIONS.md §25 fix may not be applied."
+    )
+    assert not result.is_success, "RETRY must not be is_success"
+    assert result.is_explicit is False, "Plain-prose fallback must have is_explicit=False"
+
+
+# ---------------------------------------------------------------------------
+# FC-002: non-goal_gate + plain prose → SUCCESS (spec §4.5 preserved)
+# ---------------------------------------------------------------------------
+
+
+def test_fc002_non_goal_gate_plain_prose_returns_success():
+    """FC-002: Non-goal_gate node with plain prose → SUCCESS (spec §4.5 preserved).
+
+    The fail-closed contract is scoped to goal_gate=true nodes only.
+    Ordinary box nodes must still return SUCCESS for plain prose so that
+    existing pipelines and plain-edge routing are unaffected.
+    """
+    # No node arg — simulates a non-goal_gate call
+    result_no_node = _parse_outcome(_OBSERVER_PROSE)
+    assert result_no_node.status == StageStatus.SUCCESS, (
+        f"Non-goal_gate plain prose must return SUCCESS (spec §4.5), got {result_no_node.status!r}"
+    )
+    assert "Plain text response" in (result_no_node.notes or "")
+
+    # Explicit node with goal_gate=False
+    node = _make_node(goal_gate=False)
+    result_explicit = _parse_outcome(_OBSERVER_PROSE, node=node)
+    assert result_explicit.status == StageStatus.SUCCESS, (
+        f"goal_gate=False plain prose must return SUCCESS, got {result_explicit.status!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# FC-003: goal_gate=true + explicit JSON verdict → SUCCESS preserved
+# ---------------------------------------------------------------------------
+
+
+def test_fc003_goal_gate_explicit_json_success_preserved():
+    """FC-003: goal_gate=true + pure JSON success verdict → SUCCESS (ladder preserved).
+
+    The fail-closed rule sits BELOW the verdict-recovery ladder.
+    An explicit JSON success verdict must still satisfy the gate.
+    """
+    node = _make_node(goal_gate=True)
+    payload = json.dumps({"status": "success", "notes": "All 7 criteria pass."})
+    result = _parse_outcome(payload, node=node)
+
+    assert result.status == StageStatus.SUCCESS, (
+        f"Explicit JSON success on goal_gate node must return SUCCESS, got {result.status!r}"
+    )
+    assert result.is_explicit is True, "JSON verdict must have is_explicit=True"
+    assert result.notes == "All 7 criteria pass."
+
+
+# ---------------------------------------------------------------------------
+# FC-004: goal_gate=true + fenced JSON verdict → SUCCESS preserved
+# ---------------------------------------------------------------------------
+
+
+def test_fc004_goal_gate_fenced_json_success_preserved():
+    """FC-004: goal_gate=true + fenced JSON success verdict → SUCCESS (ladder preserved)."""
+    node = _make_node(goal_gate=True)
+    payload = "```json\n" + json.dumps({"status": "success", "notes": "Converged."}) + "\n```"
+    result = _parse_outcome(payload, node=node)
+
+    assert result.status == StageStatus.SUCCESS, (
+        f"Fenced JSON success on goal_gate node must return SUCCESS, got {result.status!r}"
+    )
+    assert result.is_explicit is True
+
+
+# ---------------------------------------------------------------------------
+# FC-005: goal_gate=true + embedded verdict recovery → SUCCESS preserved
+# ---------------------------------------------------------------------------
+
+
+def test_fc005_goal_gate_embedded_verdict_recovery_preserved():
+    """FC-005: goal_gate=true + prose-then-JSON verdict → embedded recovery preserved.
+
+    Judges that emit prose + trailing JSON verdicts must keep working via
+    the embedded verdict recovery path (step 4 of the ladder).
+    """
+    node = _make_node(goal_gate=True)
+    payload = (
+        "After reviewing all 7 criteria in detail, here is my verdict:\n"
+        + json.dumps({"status": "success", "notes": "All criteria satisfied."})
+    )
+    result = _parse_outcome(payload, node=node)
+
+    assert result.status == StageStatus.SUCCESS, (
+        f"Embedded JSON success on goal_gate node must return SUCCESS, got {result.status!r}"
+    )
+    assert result.is_explicit is True
+
+
+# ---------------------------------------------------------------------------
+# FC-006: goal_gate=true + explicit FAIL verdict → FAIL preserved
+# ---------------------------------------------------------------------------
+
+
+def test_fc006_goal_gate_explicit_fail_verdict_preserved():
+    """FC-006: goal_gate=true + explicit JSON FAIL verdict → FAIL (not RETRY).
+
+    An explicit FAIL verdict must not be changed to RETRY by the fail-closed rule.
+    The fail-closed rule only fires when there is NO parseable verdict at all.
+    """
+    node = _make_node(goal_gate=True)
+    payload = json.dumps({"status": "fail", "failure_reason": "Tests did not pass."})
+    result = _parse_outcome(payload, node=node)
+
+    assert result.status == StageStatus.FAIL, (
+        f"Explicit JSON FAIL on goal_gate node must return FAIL, got {result.status!r}"
+    )
+    assert result.is_explicit is True
+    assert result.failure_reason == "Tests did not pass."
+
+
+# ---------------------------------------------------------------------------
+# FC-007: is_explicit field semantics
+# ---------------------------------------------------------------------------
+
+
+def test_fc007_is_explicit_field_semantics():
+    """FC-007: is_explicit=True on explicit verdicts, False on plain-prose fallback.
+
+    is_explicit is the durable observability field for distinguishing asserted
+    verdicts from defaulted ones. Incident analysts should not need to
+    reverse-engineer the 'Plain text response:' notes prefix.
+    """
+    node = _make_node(goal_gate=False)  # non-goal_gate so plain prose → SUCCESS
+
+    # Plain prose → is_explicit=False
+    plain = _parse_outcome("The work looks complete.", node=node)
+    assert plain.status == StageStatus.SUCCESS
+    assert plain.is_explicit is False, "Plain-prose fallback must have is_explicit=False"
+
+    # Pure JSON → is_explicit=True
+    explicit = _parse_outcome(json.dumps({"status": "success", "notes": "done"}), node=node)
+    assert explicit.status == StageStatus.SUCCESS
+    assert explicit.is_explicit is True, "JSON verdict must have is_explicit=True"
+
+    # Fenced JSON → is_explicit=True
+    fenced = _parse_outcome(
+        "```json\n" + json.dumps({"status": "success"}) + "\n```", node=node
+    )
+    assert fenced.is_explicit is True
+
+    # Embedded recovery → is_explicit=True
+    embedded = _parse_outcome(
+        "Some prose here.\n" + json.dumps({"status": "fail", "failure_reason": "x"}),
+        node=node,
+    )
+    assert embedded.is_explicit is True
+
+    # Empty → is_explicit=False (FAIL, no verdict)
+    empty = _parse_outcome("", node=node)
+    assert empty.status == StageStatus.FAIL
+    assert empty.is_explicit is False
+
+
+# ---------------------------------------------------------------------------
+# FC-008: spawn-path consistency — status-only success is is_explicit=False
+# ---------------------------------------------------------------------------
+
+
+def test_fc008_spawn_status_only_is_not_explicit():
+    """FC-008: _outcome_from_spawn_result() status-only success → is_explicit=False.
+
+    A spawn result that has no report_outcome and no final text but has
+    status=success in the orchestrator result should NOT be is_explicit=True.
+    A goal_gate child cannot satisfy its gate via the spawn wrapper's status
+    alone — it must provide a real verdict.
+
+    EXTENSIONS.md §25: spawn-path consistency.
+    """
+    # Status-only spawn result (no metadata, no report_outcome)
+    result = {"status": "success", "output": ""}
+    outcome = _outcome_from_spawn_result(result)
+
+    assert outcome is not None, "Status-only spawn result should return an Outcome"
+    assert outcome.status == StageStatus.SUCCESS
+    assert outcome.is_explicit is False, (
+        "Spawn status-only success must have is_explicit=False — "
+        "the orchestrator's completion status is not a node-level verdict. "
+        "EXTENSIONS.md §25 fix may not be applied."
+    )
+
+    # With report_outcome in metadata → is_explicit=True (real verdict)
+    result_with_ro = {
+        "status": "success",
+        "output": "",
+        "metadata": {
+            "report_outcome": {"status": "success", "notes": "All done."}
+        },
+    }
+    outcome_with_ro = _outcome_from_spawn_result(result_with_ro)
+    assert outcome_with_ro is not None
+    assert outcome_with_ro.is_explicit is True, (
+        "Spawn result with report_outcome must have is_explicit=True"
+    )
+
+
+# ---------------------------------------------------------------------------
+# FC-009: plain-edge safety — observer node (no goal_gate) with plain out-edge
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fc009_observer_node_plain_edge_safety(tmp_path):
+    """FC-009: Observer node (no goal_gate) with only plain out-edges gets SUCCESS.
+
+    The plain-edge silent-hard-stop hazard: FAIL/RETRY do not traverse plain
+    unconditional edges. A naive global default flip would convert observer/
+    reporter nodes into hard stops. The fail-closed contract is scoped to
+    goal_gate=true nodes only, so observer nodes are unaffected.
+
+    This test demonstrates the mitigation: a non-goal_gate node whose backend
+    calls _parse_outcome with plain prose gets SUCCESS and can traverse its
+    plain out-edge to exit. The backend must return an Outcome (not a string)
+    so the codergen handler sees the _parse_outcome result directly.
+    """
+
+    class ParseOutcomeBackend:
+        """Backend that calls _parse_outcome (mimics production spawn path)."""
+
+        async def run(
+            self, node, prompt, context, incoming_edge=None, graph=None
+        ) -> Outcome:
+            return _parse_outcome(_OBSERVER_PROSE, node=node)
+
+    engine = _make_engine(
+        dot_source="""
+        digraph {
+            start [shape=Mdiamond]
+            observer [prompt="Observe the pipeline health"]
+            exit [shape=Msquare]
+            start -> observer -> exit
+        }
+        """,
+        backend=ParseOutcomeBackend(),
+        logs_root=str(tmp_path),
+    )
+    outcome = await engine.run()
+
+    # Observer node (no goal_gate) with plain prose → SUCCESS (spec §4.5 preserved)
+    # Plain out-edge start -> observer -> exit traversed normally (no silent hard-stop)
+    assert outcome.is_success, (
+        f"Observer node (no goal_gate) with plain prose must exit success via plain edge. "
+        f"Got {outcome.status!r}. The fail-closed rule must be goal_gate-scoped only."
+    )
+
+
+# ---------------------------------------------------------------------------
+# FC-010: full-engine fixture — goal_gate + plain prose → pipeline does NOT exit success
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fc010_goal_gate_plain_prose_does_not_exit_success(tmp_path):
+    """FC-010: Full-engine: goal_gate=true + plain prose → pipeline does NOT exit success.
+
+    This is the mechanical DoD fixture from T0-5.verify.sh run in-process.
+    The incident's exact prose is used. The backend calls _parse_outcome
+    directly (mimicking the production spawn path) so the fail-closed rule
+    in _parse_outcome is exercised. The pipeline must NOT exit success.
+    """
+
+    class PlainProseBackend:
+        """Mimics production spawn path: calls _parse_outcome over plain prose.
+
+        Returns an Outcome so the codergen handler sees the _parse_outcome
+        result directly (isinstance(result, Outcome) → return result).
+        """
+
+        async def run(
+            self, node, prompt, context, incoming_edge=None, graph=None
+        ) -> Outcome:
+            return _parse_outcome(_INCIDENT_PROSE, node=node)
+
+    engine = _make_engine(
+        dot_source="""
+        digraph {
+            start [shape=Mdiamond]
+            judge [prompt="Evaluate convergence", goal_gate=true, max_retries=0]
+            exit [shape=Msquare]
+            start -> judge
+            judge -> exit [condition="outcome=fail"]
+            judge -> exit [condition="outcome=success"]
+        }
+        """,
+        backend=PlainProseBackend(),
+        logs_root=str(tmp_path),
+    )
+    outcome = await engine.run()
+
+    assert not outcome.is_success, (
+        f"goal_gate=true plain prose must NOT exit success. Got {outcome.status!r}. "
+        "EXTENSIONS.md §25 fail-closed fix may not be applied."
+    )
+
+
+# ---------------------------------------------------------------------------
+# FC-011: full-engine fixture — goal_gate + explicit JSON success → pipeline exits success
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fc011_goal_gate_explicit_json_success_exits_success(tmp_path):
+    """FC-011: Full-engine: goal_gate=true + explicit JSON success → pipeline exits success.
+
+    Explicit verdicts must keep working. A goal_gate node whose backend
+    calls _parse_outcome over a JSON success verdict must allow the pipeline
+    to exit success.
+    """
+
+    class ExplicitVerdictBackend:
+        """Backend that calls _parse_outcome over an explicit JSON success verdict."""
+
+        async def run(
+            self, node, prompt, context, incoming_edge=None, graph=None
+        ) -> Outcome:
+            payload = json.dumps({
+                "status": "success",
+                "notes": "All 7 convergence criteria satisfied.",
+            })
+            return _parse_outcome(payload, node=node)
+
+    engine = _make_engine(
+        dot_source="""
+        digraph {
+            start [shape=Mdiamond]
+            judge [prompt="Evaluate convergence", goal_gate=true]
+            exit [shape=Msquare]
+            start -> judge -> exit
+        }
+        """,
+        backend=ExplicitVerdictBackend(),
+        logs_root=str(tmp_path),
+    )
+    outcome = await engine.run()
+
+    assert outcome.is_success, (
+        f"goal_gate=true explicit JSON success must exit success. Got {outcome.status!r}. "
+        "The verdict-recovery ladder must not be weakened."
+    )
+
+
+# ---------------------------------------------------------------------------
+# FC-012: goal_gate=true human gate is satisfiable (review round 2, Finding 2)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fc012_goal_gate_human_gate_satisfiable(tmp_path):
+    """FC-012: A goal_gate=true human gate must be satisfiable.
+
+    Review round 2, Finding 2 (MAJOR): the gate check requires is_explicit
+    for EVERY goal_gate node, but the human handler returned SUCCESS without
+    it — so a goal_gate=true human gate retry-stormed despite carrying the
+    most explicit verdict possible (a human's selection). The fix classifies
+    the human selection as an explicit verdict (is_explicit=True) rather
+    than scoping the gate check down: one uniform gate rule is preserved.
+    """
+    from amplifier_module_loop_pipeline.interviewer import AutoApproveInterviewer
+
+    graph = parse_dot(
+        """
+        digraph {
+            start [shape=Mdiamond]
+            gate [shape=hexagon, goal_gate=true, prompt="Approve the release?"]
+            exit [shape=Msquare]
+            start -> gate
+            gate -> exit [label="approve"]
+        }
+        """
+    )
+    validate_or_raise(graph)
+    registry = HandlerRegistry(
+        HandlerContext(backend=None, interviewer=AutoApproveInterviewer())
+    )
+    engine = PipelineEngine(
+        graph=graph,
+        context=PipelineContext(),
+        handler_registry=registry,
+        logs_root=str(tmp_path),
+    )
+    outcome = await engine.run()
+
+    gate_outcome = engine.node_outcomes["gate"]
+    assert gate_outcome.is_explicit is True, (
+        "Human gate selection must be an explicit verdict (deterministic "
+        "human action, cannot be an LLM default). EXTENSIONS.md §25."
+    )
+    assert outcome.is_success, (
+        f"goal_gate=true human gate must be satisfiable by a selection. "
+        f"Got {outcome.status!r} — the gate check is over-broad (Finding 2)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# FC-013: goal_gate=true fan-in node is satisfiable (review round 2, Finding 2)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fc013_goal_gate_fan_in_satisfiable(tmp_path):
+    """FC-013: A goal_gate=true fan-in node must be satisfiable.
+
+    The fan-in handler's verdict is a deterministic ranking rule over branch
+    statuses — a legitimate non-LLM verdict mechanism (analogous to a tool
+    exit code). It must carry is_explicit=True or a goal_gate fan-in is
+    unsatisfiable.
+    """
+    graph = parse_dot(
+        """
+        digraph {
+            start [shape=Mdiamond]
+            consolidate [shape=tripleoctagon, goal_gate=true]
+            exit [shape=Msquare]
+            start -> consolidate -> exit
+        }
+        """
+    )
+    validate_or_raise(graph)
+    context = PipelineContext()
+    # Simulate an upstream parallel node's results (the fan-in contract input).
+    context.set(
+        "parallel.results",
+        [
+            {"node_id": "branch_a", "status": "success", "notes": "A done"},
+            {"node_id": "branch_b", "status": "fail", "failure_reason": "B broke"},
+        ],
+    )
+    registry = HandlerRegistry(HandlerContext(backend=None))
+    engine = PipelineEngine(
+        graph=graph,
+        context=context,
+        handler_registry=registry,
+        logs_root=str(tmp_path),
+    )
+    outcome = await engine.run()
+
+    fan_in_outcome = engine.node_outcomes["consolidate"]
+    assert fan_in_outcome.is_explicit is True, (
+        "Fan-in aggregation verdict must be explicit (deterministic ranking "
+        "over branch statuses). EXTENSIONS.md §25."
+    )
+    assert outcome.is_success, (
+        f"goal_gate=true fan-in with a successful best candidate must be "
+        f"satisfiable. Got {outcome.status!r} — gate check over-broad (Finding 2)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# FC-014: is_explicit is serialized (status.json flat + iteration, trace.jsonl)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fc014_is_explicit_serialized_in_status_and_trace(tmp_path):
+    """FC-014: is_explicit is durable audit data — it must be serialized.
+
+    Review round 2, Finding 3 (MINOR): engine-semantics.md calls is_explicit
+    the durable field, but the status.json and trace.jsonl writers omitted
+    it. Regression: assert presence (and correct value) in the flat
+    status.json, the iteration-scoped status.json, and every trace.jsonl
+    record.
+    """
+
+    class ExplicitVerdictBackend:
+        async def run(
+            self, node, prompt, context, incoming_edge=None, graph=None
+        ) -> Outcome:
+            return _parse_outcome(
+                json.dumps({"status": "success", "notes": "done"}), node=node
+            )
+
+    engine = _make_engine(
+        dot_source="""
+        digraph {
+            start [shape=Mdiamond]
+            judge [prompt="Evaluate", goal_gate=true]
+            exit [shape=Msquare]
+            start -> judge -> exit
+        }
+        """,
+        backend=ExplicitVerdictBackend(),
+        logs_root=str(tmp_path),
+    )
+    outcome = await engine.run()
+    assert outcome.is_success
+
+    from pathlib import Path
+
+    root = Path(str(tmp_path))
+
+    # 1. Flat status.json
+    flat = json.loads((root / "judge" / "status.json").read_text())
+    assert "is_explicit" in flat, "status.json must serialize is_explicit"
+    assert flat["is_explicit"] is True
+
+    # 2. Iteration-scoped status.json (Extension #24)
+    iter_files = list(root.glob("iteration_*/judge/status.json"))
+    assert iter_files, "iteration-scoped status.json missing"
+    iter_status = json.loads(iter_files[0].read_text())
+    assert iter_status["is_explicit"] is True
+
+    # 3. trace.jsonl — every record carries the field
+    trace_lines = (root / "trace.jsonl").read_text().strip().splitlines()
+    assert trace_lines, "trace.jsonl missing or empty"
+    records = [json.loads(line) for line in trace_lines]
+    assert all("is_explicit" in r for r in records), (
+        "every trace.jsonl record must carry is_explicit"
+    )
+    judge_records = [r for r in records if r["node_id"] == "judge"]
+    assert judge_records and judge_records[-1]["is_explicit"] is True
+
+
+# ---------------------------------------------------------------------------
+# FC-015: codergen early-writer serializes is_explicit
+# ---------------------------------------------------------------------------
+
+
+def test_fc015_codergen_early_writer_serializes_is_explicit(tmp_path):
+    """FC-015: the codergen handler's own status writer carries is_explicit."""
+    from amplifier_module_loop_pipeline.handlers.codergen import _write_status
+
+    _write_status(
+        str(tmp_path),
+        Outcome(status=StageStatus.SUCCESS, notes="ok", is_explicit=True),
+    )
+    data = json.loads((tmp_path / "status.json").read_text())
+    assert data["is_explicit"] is True
+
+    _write_status(
+        str(tmp_path),
+        Outcome(status=StageStatus.SUCCESS, notes="defaulted"),
+    )
+    data = json.loads((tmp_path / "status.json").read_text())
+    assert data["is_explicit"] is False

--- a/modules/loop-pipeline/tests/test_goal_gates.py
+++ b/modules/loop-pipeline/tests/test_goal_gates.py
@@ -73,7 +73,10 @@ async def test_satisfied_goal_gates_allow_exit(tmp_path):
     """When all goal gates succeed, pipeline exits successfully."""
     backend = MockBackend(
         outcomes={
-            "critical": Outcome(status=StageStatus.SUCCESS, notes="All good"),
+            # is_explicit=True: this mock represents a backend that returned an
+            # explicit verdict (report_outcome / JSON). EXTENSIONS.md §25:
+            # goal_gate nodes require is_explicit=True to satisfy the gate.
+            "critical": Outcome(status=StageStatus.SUCCESS, notes="All good", is_explicit=True),
         }
     )
     engine = _make_engine(
@@ -97,8 +100,10 @@ async def test_partial_success_satisfies_goal_gate(tmp_path):
     """PARTIAL_SUCCESS counts as satisfying a goal gate."""
     backend = MockBackend(
         outcomes={
+            # is_explicit=True: explicit verdict (EXTENSIONS.md §25 — goal_gate
+            # requires is_explicit=True to satisfy the gate).
             "critical": Outcome(
-                status=StageStatus.PARTIAL_SUCCESS, notes="Mostly done"
+                status=StageStatus.PARTIAL_SUCCESS, notes="Mostly done", is_explicit=True
             ),
         }
     )
@@ -159,7 +164,9 @@ async def test_unsatisfied_goal_gate_jumps_to_node_retry_target(tmp_path):
         outcomes_by_call={
             "critical": [
                 Outcome(status=StageStatus.FAIL, failure_reason="broken"),
-                Outcome(status=StageStatus.SUCCESS, notes="Fixed"),
+                # is_explicit=True: second call succeeds with an explicit verdict
+                # (EXTENSIONS.md §25 — goal_gate requires is_explicit=True).
+                Outcome(status=StageStatus.SUCCESS, notes="Fixed", is_explicit=True),
             ],
         }
     )
@@ -193,7 +200,9 @@ async def test_unsatisfied_goal_gate_uses_graph_retry_target(tmp_path):
         outcomes_by_call={
             "critical": [
                 Outcome(status=StageStatus.FAIL, failure_reason="broken"),
-                Outcome(status=StageStatus.SUCCESS, notes="Fixed"),
+                # is_explicit=True: second call succeeds with an explicit verdict
+                # (EXTENSIONS.md §25 — goal_gate requires is_explicit=True).
+                Outcome(status=StageStatus.SUCCESS, notes="Fixed", is_explicit=True),
             ],
         }
     )
@@ -225,7 +234,8 @@ async def test_multiple_goal_gates_all_must_pass(tmp_path):
     """All goal gates must be satisfied, not just the first one."""
     backend = MockBackend(
         outcomes={
-            "review": Outcome(status=StageStatus.SUCCESS),
+            # is_explicit=True: explicit verdict (EXTENSIONS.md §25).
+            "review": Outcome(status=StageStatus.SUCCESS, is_explicit=True),
             "test": Outcome(status=StageStatus.FAIL, failure_reason="tests fail"),
         }
     )

--- a/modules/loop-pipeline/tests/test_pipeline_e2e.py
+++ b/modules/loop-pipeline/tests/test_pipeline_e2e.py
@@ -56,7 +56,13 @@ def _load_fixture(name: str) -> str:
 
 
 class SuccessBackend:
-    """Backend that returns SUCCESS for every node."""
+    """Backend that returns an explicit SUCCESS verdict for every node.
+
+    Returns a pure-JSON verdict string so that goal_gate=true nodes are
+    satisfied under the fail-closed contract (EXTENSIONS.md \u00a725): the JSON
+    goes through the verdict-recovery ladder and yields is_explicit=True.
+    A plain-prose string would leave goal gates unsatisfied by design.
+    """
 
     def __init__(self) -> None:
         self.calls: list[str] = []
@@ -65,7 +71,7 @@ class SuccessBackend:
     async def run(self, node: Node, prompt: str, context: PipelineContext, incoming_edge=None, graph=None) -> str:
         self.calls.append(node.id)
         self.prompts[node.id] = prompt
-        return f"Completed: {node.id}"
+        return json.dumps({"status": "success", "notes": f"Completed: {node.id}"})
 
 
 class OutcomeBackend:
@@ -116,6 +122,9 @@ class RetryThenSucceedBackend:
         return Outcome(
             status=StageStatus.SUCCESS,
             notes=f"Completed: {node.id}",
+            # This double represents "the backend produced an explicit result"
+            # — required for goal_gate satisfaction (EXTENSIONS.md §25).
+            is_explicit=True,
         )
 
 

--- a/modules/loop-pipeline/tests/test_response_schema.py
+++ b/modules/loop-pipeline/tests/test_response_schema.py
@@ -551,6 +551,9 @@ class TestBackendToolLoopWiring:
         # Parsed object stashed under node.id in context_updates
         assert outcome.context_updates is not None
         assert outcome.context_updates[node.id] == {"name": "Alice"}
+        # EXTENSIONS.md §25 (corrected): non-verdict structured output is
+        # DERIVED — format is not a verdict.
+        assert outcome.is_explicit is False
 
     @pytest.mark.asyncio
     async def test_structured_output_with_invalid_json_still_succeeds(self) -> None:
@@ -583,6 +586,8 @@ class TestBackendToolLoopWiring:
         # node.id key should NOT be present when JSON parse failed
         assert outcome.context_updates is not None
         assert node.id not in outcome.context_updates
+        # Unparseable structured output is never explicit (fail-closed at gates).
+        assert outcome.is_explicit is False
 
 
 # ---------------------------------------------------------------------------
@@ -667,6 +672,8 @@ class TestDirectProviderBackendWiring:
 
         assert outcome.status == StageStatus.SUCCESS
         assert outcome.notes == json_response
+        # {"name": "Bob"} carries no verdict — DERIVED (EXTENSIONS.md §25).
+        assert outcome.is_explicit is False
 
     @pytest.mark.asyncio
     async def test_direct_backend_no_response_format_when_no_schema(self) -> None:
@@ -687,3 +694,207 @@ class TestDirectProviderBackendWiring:
         assert len(mock_client.requests) >= 1
         req = mock_client.requests[-1]
         assert req.response_format is None
+
+
+# ---------------------------------------------------------------------------
+# 9. EXTENSIONS.md §25 corrected policy: format ≠ verdict (review round 2)
+# ---------------------------------------------------------------------------
+
+
+def _make_tool_loop_backend(text: str) -> "AmplifierBackend":
+    """AmplifierBackend wired to the tool-loop path with a canned response."""
+    return AmplifierBackend(
+        coordinator=MagicMock(
+            get_capability=lambda _: None,
+            config={"agents": {}},
+            session=MagicMock(),
+        ),
+        profiles={},
+        provider=MagicMock(),
+        unified_client=_MockUnifiedClient(text=text),
+    )
+
+
+class TestStructuredOutputVerdictPolicy:
+    """Schema-parsed output is explicit ONLY when it carries a recognized verdict.
+
+    Review round 2, Finding 1 (BLOCKER): the round-1 policy marked ANY
+    parseable JSON as is_explicit=True, so a goal_gate structured-output
+    node returning {"assessment": "NOT CONVERGED"} — or {"name": "Alice"} —
+    shipped success. Corrected policy: format ≠ verdict.
+    """
+
+    @pytest.mark.asyncio
+    async def test_non_verdict_schema_output_is_derived(self) -> None:
+        """{"name": "Alice"} parses but asserts nothing → SUCCESS, DERIVED."""
+        backend = _make_tool_loop_backend(json.dumps({"name": "Alice"}))
+        node = _make_node_with_schema(_INLINE_SCHEMA_DICT)
+        outcome = await backend._run_with_tool_loop(
+            node=node, instruction="Extract", reasoning_effort=None
+        )
+        assert outcome.status == StageStatus.SUCCESS
+        assert outcome.is_explicit is False
+
+    @pytest.mark.asyncio
+    async def test_incident_shape_not_converged_is_derived(self) -> None:
+        """{"assessment": "NOT CONVERGED"} carries no recognized verdict → DERIVED.
+
+        This is the reviewer's incident-class example: a goal_gate judge
+        emitting non-verdict structured output must not be able to satisfy
+        its gate.
+        """
+        backend = _make_tool_loop_backend(
+            json.dumps({"assessment": "NOT CONVERGED"})
+        )
+        node = _make_node_with_schema(_INLINE_SCHEMA_DICT)
+        outcome = await backend._run_with_tool_loop(
+            node=node, instruction="Judge", reasoning_effort=None
+        )
+        assert outcome.status == StageStatus.SUCCESS  # non-gate behavior unchanged
+        assert outcome.is_explicit is False, (
+            "Non-verdict structured output must be DERIVED — the round-1 "
+            "'parseable ⇒ explicit' policy was a false-success side door."
+        )
+
+    @pytest.mark.asyncio
+    async def test_verdict_shaped_schema_output_is_explicit_success(self) -> None:
+        """A `status` field with a recognized value IS an explicit verdict."""
+        backend = _make_tool_loop_backend(
+            json.dumps({"status": "success", "notes": "All criteria pass."})
+        )
+        node = _make_node_with_schema(_INLINE_SCHEMA_DICT)
+        outcome = await backend._run_with_tool_loop(
+            node=node, instruction="Judge", reasoning_effort=None
+        )
+        assert outcome.status == StageStatus.SUCCESS
+        assert outcome.is_explicit is True
+        assert outcome.notes == "All criteria pass."
+
+    @pytest.mark.asyncio
+    async def test_verdict_shaped_schema_output_fail_honored(self) -> None:
+        """An explicit FAIL verdict in schema output is honored, not wrapped."""
+        backend = _make_tool_loop_backend(
+            json.dumps({"status": "fail", "failure_reason": "2 of 7 criteria pass"})
+        )
+        node = _make_node_with_schema(_INLINE_SCHEMA_DICT)
+        outcome = await backend._run_with_tool_loop(
+            node=node, instruction="Judge", reasoning_effort=None
+        )
+        assert outcome.status == StageStatus.FAIL
+        assert outcome.is_explicit is True
+        assert outcome.failure_reason == "2 of 7 criteria pass"
+
+    @pytest.mark.asyncio
+    async def test_unrecognized_status_value_is_derived(self) -> None:
+        """{"status": "NOT CONVERGED"} — unrecognized value is NOT a verdict."""
+        backend = _make_tool_loop_backend(
+            json.dumps({"status": "NOT CONVERGED"})
+        )
+        node = _make_node_with_schema(_INLINE_SCHEMA_DICT)
+        outcome = await backend._run_with_tool_loop(
+            node=node, instruction="Judge", reasoning_effort=None
+        )
+        assert outcome.status == StageStatus.SUCCESS
+        assert outcome.is_explicit is False
+
+    @pytest.mark.asyncio
+    async def test_direct_backend_same_policy(self) -> None:
+        """DirectProviderBackend shares the classifier — same policy both paths."""
+        from amplifier_module_loop_pipeline import DirectProviderBackend
+
+        # Non-verdict → DERIVED
+        backend = DirectProviderBackend(
+            provider=MagicMock(),
+            unified_client=_MockUnifiedClient(
+                text=json.dumps({"assessment": "NOT CONVERGED"})
+            ),
+        )
+        node = _make_node_with_schema(_INLINE_SCHEMA_DICT)
+        outcome = await backend.run(node, "Judge", _make_context())
+        assert outcome.status == StageStatus.SUCCESS
+        assert outcome.is_explicit is False
+
+        # Verdict-shaped → explicit
+        backend2 = DirectProviderBackend(
+            provider=MagicMock(),
+            unified_client=_MockUnifiedClient(
+                text=json.dumps({"status": "success", "notes": "converged"})
+            ),
+        )
+        outcome2 = await backend2.run(node, "Judge", _make_context())
+        assert outcome2.status == StageStatus.SUCCESS
+        assert outcome2.is_explicit is True
+
+
+class TestGoalGateStructuredOutput:
+    """Full-engine red/green for goal_gate + response_schema nodes."""
+
+    def _engine(self, response_text: str, tmp_path: Path, goal_gate: bool):
+        from amplifier_module_loop_pipeline import DirectProviderBackend
+        from amplifier_module_loop_pipeline.engine import PipelineEngine
+        from amplifier_module_loop_pipeline.handlers import HandlerRegistry
+        from amplifier_module_loop_pipeline.handlers.context import HandlerContext
+
+        attrs: dict[str, Any] = {"goal_gate": "true"} if goal_gate else {}
+        node = _make_node_with_schema(
+            _INLINE_SCHEMA_DICT, id="judge", attrs=attrs
+        )
+        graph = _make_minimal_graph(node)
+        backend = DirectProviderBackend(
+            provider=MagicMock(),
+            unified_client=_MockUnifiedClient(text=response_text),
+        )
+        return PipelineEngine(
+            graph=graph,
+            context=_make_context(),
+            handler_registry=HandlerRegistry(HandlerContext(backend=backend)),
+            logs_root=str(tmp_path),
+        )
+
+    @pytest.mark.asyncio
+    async def test_goal_gate_schema_non_verdict_json_gate_rejects(
+        self, tmp_path: Path
+    ) -> None:
+        """RED: goal_gate schema node returning non-verdict JSON must FAIL.
+
+        The BLOCKER fix: {"assessment": "NOT CONVERGED"} is format, not
+        verdict — the gate must reject it (pipeline must not exit success).
+        """
+        engine = self._engine(
+            json.dumps({"assessment": "NOT CONVERGED"}), tmp_path, goal_gate=True
+        )
+        outcome = await engine.run()
+        assert not outcome.is_success, (
+            "goal_gate schema node with non-verdict JSON must NOT exit "
+            "success — response_schema was a false-success side door."
+        )
+        assert engine.node_outcomes["judge"].is_explicit is False
+
+    @pytest.mark.asyncio
+    async def test_goal_gate_schema_verdict_json_exits_success(
+        self, tmp_path: Path
+    ) -> None:
+        """GREEN: verdict-shaped schema output satisfies the gate."""
+        engine = self._engine(
+            json.dumps({"status": "success", "notes": "converged"}),
+            tmp_path,
+            goal_gate=True,
+        )
+        outcome = await engine.run()
+        assert outcome.is_success
+        assert engine.node_outcomes["judge"].is_explicit is True
+
+    @pytest.mark.asyncio
+    async def test_plain_schema_node_non_verdict_still_succeeds(
+        self, tmp_path: Path
+    ) -> None:
+        """Non-gate schema node returning {"name": "Alice"} succeeds as before."""
+        engine = self._engine(
+            json.dumps({"name": "Alice"}), tmp_path, goal_gate=False
+        )
+        outcome = await engine.run()
+        assert outcome.is_success, "non-gate schema node behavior must be unchanged"
+        judge_outcome = engine.node_outcomes["judge"]
+        assert judge_outcome.is_explicit is False
+        assert judge_outcome.context_updates is not None
+        assert judge_outcome.context_updates["judge"] == {"name": "Alice"}

--- a/specs/EXTENSIONS.md
+++ b/specs/EXTENSIONS.md
@@ -551,3 +551,233 @@ this extension documents the behavior here.
 - `engine.py: run() Step 6 (loop_restart)` — increments and re-seeds both keys on restart
 - `engine.py: _write_node_status()` — writes iteration-scoped path and appends to `trace.jsonl`
 - `modules/pipeline-runner/amplifier_module_pipeline_runner/cli.py: cmd_trace()` — trace subcommand
+
+---
+
+## 25. Fail-Closed Goal-Gate Outcomes
+
+> **This extension DIVERGES from canonical spec §4.5.** The canonical spec pseudocode (§4.5,
+> `CodergenHandler`) returns `Outcome(status=SUCCESS, notes="Stage completed: …")` unconditionally
+> for any non-empty string response. This extension changes that behavior for `goal_gate=true`
+> nodes. See walk-upstream note in `PRINCIPLES.md`.
+
+### Incident motivation
+
+2026-07-28: a 20-node pipeline ran 2.4 hours via the standalone attractor CLI and exited
+`status=success` with zero work product. The convergence judge node (marked `goal_gate=true`)
+wrote "NOT CONVERGED — 2 of 7 criteria pass. The networking implementation does not work and
+the harness was never created." — and was recorded `outcome=success` because `_parse_outcome`'s
+final fallback converted the plain-prose response to SUCCESS. The designed replan loop
+(`max_retries=4, retry_target=analyze_plan`) never fired. This extension closes that class of
+false success.
+
+### What the canonical spec says
+
+Canonical spec §4.5 `CodergenHandler` pseudocode:
+
+```
+any string response → write response.md → Outcome(status=SUCCESS, notes="Stage completed: …")
+```
+
+This is unconditional: even a response that literally says "NOT CONVERGED" is recorded as
+SUCCESS. The spec is fail-open by design (it assumes the node's prose is advisory and routing
+is the caller's responsibility).
+
+### What this extension does instead
+
+**Scope decision: goal_gate=true nodes only.** A global default flip to RETRY/FAIL for all
+plain-text responses would break nearly every existing pipeline (most `box` nodes in tutorials
+and examples end in prose — see backward-compat inventory below). The fail-closed contract
+applies only when the node carries `goal_gate=true`, which already signals that the node's
+outcome is load-bearing for pipeline exit.
+
+**The verdict-recovery ladder is preserved.** `_parse_outcome` already tries (in order):
+1. Fenced JSON (` ```json … ``` `) → strip fence, parse as JSON
+2. Pure JSON (`stripped.startswith("{")`) → parse, honor `status` field
+3. Embedded verdict recovery → find last balanced `{…}` in prose, parse if it carries `status`
+
+The fail-closed rule sits **below** this ladder. Only when every recovery attempt has failed
+(the output is genuinely plain prose with no parseable verdict) does the fail-closed rule fire.
+Judges that emit prose + trailing JSON verdicts keep working via path 3.
+
+**Status choice: RETRY, not FAIL.** FAIL is fail-fast — it does not traverse plain edges
+(EXTENSIONS.md §16; `edge_selection.py:79-101`). A naive FAIL default would convert observer/
+reporter nodes with only plain out-edges into hard stops. RETRY respects `max_retries` (then
+degrades to FAIL) and is the appropriate signal for "try again with an explicit verdict." When
+`max_retries=0`, RETRY degrades immediately to FAIL at the goal-gate check.
+
+**`is_explicit` field on `Outcome`.** A new `is_explicit: bool` field (default `False`)
+distinguishes an asserted verdict from a defaulted one. `is_explicit=True` is set by every
+producer with an unambiguous verdict mechanism:
+
+- `report_outcome` tool call (tool-loop, direct-provider, and spawn paths)
+- pure JSON / fenced JSON / recovered embedded JSON verdicts (`_parse_outcome`)
+- a tool (parallelogram) node's exit code — 0 is an explicit success, nonzero an explicit
+  fail (`handlers/tool.py`); the exit code IS the verdict
+- **verdict-shaped** `response_schema` structured output — a captured `report_outcome`
+  call or a `status` field with a recognized value (see policy decision below)
+- deterministic handler verdicts that cannot be LLM-defaulted: human-gate selections and
+  freeform input (`handlers/human.py`), structural no-op SUCCESS (`start`/`exit`/
+  `conditional` handlers), fan-in ranking (`handlers/fan_in.py`), and parallel join-policy
+  aggregation (`handlers/parallel.py`)
+
+`is_explicit=False` marks defaulted statuses: the plain-prose fallback, empty-response
+defaults, a spawn wrapper's status-only completion, **non-verdict** structured output
+(parseable or not — format is not a verdict), and config/environment failures (timeout,
+missing `tool_command`, handler exception) where no verdict was produced.
+
+**Enforcement is two-layer (belt and suspenders).**
+
+1. *Parser layer:* `_parse_outcome` returns RETRY (not SUCCESS) for plain-prose goal_gate
+   responses, so retry machinery fires at the node.
+2. *Gate layer (centralized):* `_check_goal_gates()` treats a gate as satisfied only when
+   `outcome.is_success AND outcome.is_explicit` (`engine.py`). This closes bypass paths that
+   never reach the parser's plain-prose rung — notably the spawn path's status-only SUCCESS
+   and unparseable structured output.
+
+`is_explicit` is therefore load-bearing at the gate check, not just observability metadata.
+Any new Outcome producer must classify itself: set `is_explicit=True` iff the status comes
+from an unambiguous verdict mechanism.
+
+**`response_schema` policy decision (corrected in independent review round 2).**
+**Format ≠ verdict.** Parseable schema output proves the model followed the requested
+FORMAT; it does not prove the node asserted a VERDICT. Schema-parsed output is explicit
+ONLY when it carries a recognized verdict, routed through the same verdict ladder as every
+other path: a captured `report_outcome` tool call (authoritative), or a `status` field
+whose value is a recognized StageStatus. Generic structured output — `{"name": "Alice"}`,
+`{"assessment": "NOT CONVERGED"}` — stays DERIVED (`is_explicit=False`): the node still
+returns SUCCESS (ordinary schema nodes are unchanged), but a `goal_gate=true` schema node
+cannot satisfy its gate with it. The original round-1 policy ("parseable schema output IS
+explicit") was a false-success side door: a goal_gate structured-output judge returning
+`{"assessment": "NOT CONVERGED"}` — or a name-extraction payload — would have shipped
+success. Both structured-output paths (`backend.py` tool-loop and
+`DirectProviderBackend.run()`) share one classifier
+(`backend._outcome_from_structured_output`); empty or unparseable schema output also
+stays `is_explicit=False`, so a goal_gate schema node fails closed in every non-verdict
+case.
+
+**CodergenHandler string path.** When a backend returns a raw string (the spec §4.5
+`CodergenHandler` path — exercised by simple/custom backends and test doubles), a
+`goal_gate=true` node's string is routed through the verdict-recovery ladder
+(`_parse_outcome`): JSON verdicts are honored, plain prose returns RETRY. This implements in
+our own handler the exact goal_gate check the walk-upstream note recommends for the spec.
+Non-goal_gate string responses keep the unconditional-SUCCESS wrap (spec §4.5 preserved).
+
+**Spawn-path consistency.** `_outcome_from_spawn_result()` returns `is_explicit=False` when
+recovering from the orchestrator's completion status alone (no `report_outcome`, no JSON). A
+goal_gate child that produces no final text and no report_outcome cannot satisfy its gate via
+the spawn wrapper's status field alone — the gate layer rejects it.
+
+### Backward-compat inventory
+
+**Producer classification (every Outcome-producing path that can reach a goal-gate check):**
+
+| Producer | Verdict mechanism | `is_explicit` |
+|---|---|---|
+| `report_outcome` tool call (tool-loop / direct-provider / spawn metadata) | asserted by node | `True` |
+| Pure / fenced / embedded JSON verdict (`_parse_outcome`) | asserted by node | `True` |
+| Tool node exit code (`handlers/tool.py`) — 0 and nonzero | process exit code | `True` |
+| `response_schema` output carrying a verdict — captured `report_outcome`, or `status` field with a recognized value (`backend._outcome_from_structured_output`) | verdict via the standard ladder | `True` |
+| `response_schema` output WITHOUT a verdict — generic data such as `{"name": "Alice"}`; also empty/unparseable | format only, no verdict | `False` (gate fails closed) |
+| Plain-prose fallback (`_parse_outcome`) | none — defaulted | `False` (+ RETRY for goal_gate) |
+| Codergen string-wrap for non-goal_gate nodes (spec §4.5) | none — defaulted | `False` (not gate-relevant) |
+| Spawn status-only completion (`_outcome_from_spawn_result`) | wrapper status, not node verdict | `False` (gate fails closed) |
+| Empty response (any path) | none | `False` (FAIL) |
+| Tool timeout / missing `tool_command` / handler exception | environment failure | `False` (FAIL — not gate-relevant) |
+| Human gate selection / freeform input (`handlers/human.py`) | deterministic human action — cannot be LLM-defaulted | `True` |
+| Human gate SKIPPED (`handlers/human.py`) | deterministic interviewer decision | `True` (FAIL) |
+| Start / Exit / Conditional structural no-ops | deterministic structural SUCCESS — no LLM in the loop | `True` |
+| Fan-in ranking verdict (`handlers/fan_in.py`) | deterministic aggregation over branch statuses | `True` |
+| Fan-in with no `parallel.results` (`handlers/fan_in.py`) | environment/wiring failure | `False` (FAIL) |
+| Parallel join-policy verdict, incl. no-branch SUCCESS (`handlers/parallel.py`) | deterministic counting rule over branch statuses | `True` |
+| Parallel branch exception / missing engine (`handlers/parallel.py`) | environment failure | `False` (FAIL) |
+| Manager-loop stop/guard completion (`handlers/manager_loop.py`) | the child's verdict | propagates child's `is_explicit` |
+| Manager-loop cycle exhaustion / config failure (`handlers/manager_loop.py`) | environment failure | `False` (FAIL) |
+| Folder / pipeline (subgraph) node (`handlers/pipeline.py`) | child pipeline's terminal outcome — CAN carry a defaulted LLM completion | propagates child's `is_explicit` (outcome returned verbatim) |
+
+**Shipped examples with `goal_gate=true` nodes (complete sweep of `examples/`):**
+
+| File | Gate node(s) | Behavior delta |
+|---|---|---|
+| `examples/patterns/task-runner.dot` | `verify`, `verdict` (parallelogram tool gates) | **None** — tool exit codes are explicit verdicts; gates satisfied on exit 0 exactly as before |
+| `examples/pipelines/practical/feature-build.dot` | `integration_test` (LLM, retry_target=self) | Plain-prose completion now RETRYs instead of silently satisfying the gate |
+| `examples/pipelines/02-plan-implement-test.dot` | `implement` (LLM) | Same — explicit verdict (report_outcome / JSON) now required |
+| `examples/pipelines/04-retry-with-fallback.dot` | `implement`, `simple_implement` (LLM) | Same |
+| `examples/pipelines/10-full-attractor.dot` | `implement_backend`, `implement_frontend` (LLM) | Same |
+| `examples/pipelines/practical/pr-review.dot` | `generate_comments` (LLM, no retry_target) | Same; with no retry_target an unsatisfied gate ends the pipeline FAIL (see hazard note) |
+| `examples/pipelines/practical/multi-lens-review.dot` | `synthesize` (LLM, no retry_target) | Same |
+| `examples/pipelines/practical/refactor.dot` | `snapshot_tests` (LLM, retry_target=self) | Same |
+| `examples/pipelines/practical/test-gen.dot` | `write_tests` (LLM, retry_target) | Same |
+
+For the LLM gate nodes above this is the intended breaking change: in the default Amplifier
+backend the child session has the `report_outcome` tool available and is prompted to use it;
+completions that end in bare prose now RETRY (then degrade to FAIL) instead of silently
+recording success — which is the incident class this extension closes.
+
+**Tests affected and updated in this change:**
+
+| Test | Why affected | Resolution |
+|---|---|---|
+| `test_goal_gate_retry_clears_failures.py` (3 tests, tool-node gates) | tool exits lacked `is_explicit` | fixed by `handlers/tool.py` (exit codes are explicit) |
+| `test_pipeline_e2e.py::TestGoalGate::test_success_with_satisfied_gate` | `SuccessBackend` returned plain prose | `SuccessBackend` now returns a pure-JSON verdict |
+| `test_pipeline_e2e.py::TestGoalGate::test_retry_on_unsatisfied_gate` | `RetryThenSucceedBackend` Outcome lacked `is_explicit` | double now sets `is_explicit=True` |
+| `test_pipeline_e2e.py::TestSpecSmokeTest::test_step3_execute` | `SuccessBackend` plain prose on `goal_gate` node | same `SuccessBackend` fix |
+| `tests/test_backend.py:576` `test_backend_plain_text_returns_success` | tests a **non**-goal_gate node | unaffected (plain prose → SUCCESS preserved) |
+| `tests/test_backend.py:1096` `test_parse_outcome_plain_text_returns_success` | `_parse_outcome` with no `node` arg | unaffected |
+| `tests/test_goal_gates.py` | MockBackend returns explicit Outcomes | updated with `is_explicit=True` on mock verdicts |
+
+**Plain-edge silent-hard-stop hazard:** Observer and reporter nodes that have only plain
+out-edges and no `goal_gate=true` are **unaffected** — they still get SUCCESS for plain prose
+(spec §4.5 preserved). For `goal_gate=true` nodes with only plain out-edges, the RETRY status
+will not traverse those edges (RETRY routes like FAIL for edge selection). Authors should
+ensure goal_gate nodes have explicit `condition="outcome=fail"` or `retry_target` edges, or
+use `report_outcome` / JSON verdicts to produce the expected routing signal. The lint sweep
+(`test_examples_lint_clean.py`) and `dot_graph validate` catch isolated nodes and missing
+fallback edges.
+
+### Walk-upstream note
+
+The canonical spec §4.5 default should change to: when a node carries `goal_gate=true`, a
+plain-prose response (no JSON, no `report_outcome`) must NOT be recorded as SUCCESS. The
+recommended upstream change is to add a `goal_gate` check in `CodergenHandler` before the
+final SUCCESS fallback, returning RETRY (or FAIL with a clear message) instead. Until the
+upstream spec adopts this, this extension documents the divergence.
+
+### Implementation locations
+
+- `backend.py: _parse_outcome()` — fail-closed rule at the final rung; `node` parameter added
+- `backend.py: _outcome_from_spawn_result()` — status-only success is `is_explicit=False`
+- `backend.py: _run_with_spawn()` — passes `node=node` to `_parse_outcome`
+- `backend.py: _run_with_tool_loop()` — passes `node=node` to `_parse_outcome`; no-text path
+  now returns FAIL for goal_gate nodes (consistent with spawn path's empty→FAIL); non-goal_gate
+  no-text keeps the spec §4.5 SUCCESS default; structured-output path delegates to
+  `_outcome_from_structured_output` (verdict-shaped → explicit; generic data → derived)
+- `backend.py: _outcome_from_structured_output()` — the single structured-output classifier
+  shared by both backends (format ≠ verdict; see policy decision above)
+- `__init__.py: DirectProviderBackend.run()` — passes `node=node` to `_parse_outcome`; same
+  no-text scoping; structured-output path delegates to the shared classifier
+- `outcome.py: Outcome` — `is_explicit: bool = False` field added
+- `handlers/tool.py: ToolHandler.execute()` — exit-code outcomes are explicit verdicts
+  (`is_explicit=True` for both exit 0 → SUCCESS and nonzero → FAIL); timeout, missing
+  `tool_command`, and handler exceptions remain non-explicit (no verdict was produced)
+- `handlers/codergen.py: CodergenHandler.execute()` — goal_gate string responses are routed
+  through `_parse_outcome` (verdict ladder + fail-closed); non-goal_gate string responses keep
+  the spec §4.5 unconditional-SUCCESS wrap
+- `handlers/human.py` — selections, freeform input, and SKIP are explicit (deterministic
+  human/interviewer actions); a `goal_gate=true` human gate is satisfiable
+- `handlers/start.py`, `handlers/exit.py`, `handlers/conditional.py` — structural no-op
+  SUCCESS is explicit (deterministic, no LLM in the loop)
+- `handlers/fan_in.py`, `handlers/parallel.py` — aggregation/join-policy verdicts are
+  explicit (deterministic rules over branch statuses); wiring/environment failures stay
+  non-explicit
+- `handlers/manager_loop.py` — stop/guard completions propagate the child's `is_explicit`;
+  exhaustion and config failures stay non-explicit
+- `handlers/pipeline.py` — returns the child outcome verbatim, so the child's `is_explicit`
+  propagates (a folder node's outcome CAN carry a defaulted LLM completion)
+- `engine.py: _check_goal_gates()` — centralized gate enforcement:
+  `gate_satisfied = outcome.is_success and outcome.is_explicit`. The gate DOES consult
+  `is_explicit` directly; this is what closes the spawn status-only bypass and any future
+  producer that forgets to classify itself
+- `engine.py: _write_node_status()` and `handlers/codergen.py: _write_status()` —
+  `is_explicit` is serialized into every `status.json` (flat + iteration-scoped) and every
+  `trace.jsonl` record, making it durable audit data rather than an in-memory-only flag


### PR DESCRIPTION

### Summary

A `goal_gate=true` node can no longer be satisfied by a defaulted outcome. This PR
introduces an explicit-verdict contract on `Outcome` (`is_explicit`) and enforces it in two
layers: `_parse_outcome` returns RETRY (not SUCCESS) for plain-prose goal-gate responses, and
`_check_goal_gates()` requires `outcome.is_success AND outcome.is_explicit`. Every Outcome
producer in the module is classified explicit/derived (table below). Docs are updated in
lockstep (`context/engine-semantics.md` §5, `specs/EXTENSIONS.md` §25, `PRINCIPLES.md`
Delta 1, `DOT-AUTHORING-GUIDE.md`, `DOT-SYNTAX.md`).

**Why (verified real-world incident, 2026-07-28):** a 20-node pipeline ran 2.4 hours via the
standalone attractor CLI and exited `status=success` with zero work product. Its convergence
judge node — marked `goal_gate=true` — wrote *"NOT CONVERGED — 2 of 7 criteria pass. The
networking implementation does not work and the harness was never created."* That plain-prose
response hit `_parse_outcome`'s final fallback, was recorded `outcome=success`, satisfied the
goal gate, and the designed replan loop (`max_retries=4, retry_target=analyze_plan`) never
fired. Cascade analysis of that incident identified the fail-open plain-text default as the
single highest-leverage fix: a goal gate that can be satisfied by silence — or by prose that
literally says the work is not done — is not a gate.

### What changed — producer-by-producer

`Outcome.is_explicit=True` means the status was asserted by an unambiguous mechanism;
`False` means it was defaulted. The gate check requires both `is_success` and `is_explicit`.

| Producer | Verdict mechanism | `is_explicit` |
|---|---|---|
| `report_outcome` tool call (tool-loop / direct-provider / spawn metadata) | asserted by node | `True` |
| Pure / fenced / embedded JSON verdict (`_parse_outcome`) | asserted by node | `True` |
| Tool node exit code (`handlers/tool.py`) — exit 0 and nonzero | process exit code | `True` |
| `response_schema` output **carrying a verdict** (captured `report_outcome`, or `status` field with recognized value — `backend._outcome_from_structured_output`) | verdict via the standard ladder | `True` |
| `response_schema` output **without a verdict** (generic data like `{"name":"Alice"}`; also empty/unparseable) | format only, no verdict | `False` → gate fails closed |
| Plain-prose fallback (`_parse_outcome`) | none — defaulted | `False`; goal_gate → **RETRY** |
| Codergen string-wrap, non-goal_gate (spec §4.5) | none — defaulted | `False` (not gate-relevant) |
| Codergen string result on a goal_gate node | routed through `_parse_outcome` ladder | JSON → `True`; prose → RETRY |
| Spawn status-only completion (`_outcome_from_spawn_result`) | wrapper status, not node verdict | `False` → gate fails closed |
| Empty response (any path) | none | `False` (FAIL) |
| Tool timeout / missing `tool_command` / handler exception | environment failure, no verdict | `False` (FAIL — not gate-relevant) |
| Human gate selection / freeform input (`handlers/human.py`) | deterministic human action | `True` |
| Human gate SKIPPED | deterministic interviewer decision | `True` (FAIL) |
| Start / Exit / Conditional structural no-ops | deterministic structural SUCCESS | `True` |
| Fan-in ranking verdict (`handlers/fan_in.py`) | deterministic aggregation over branch statuses | `True` (missing `parallel.results` stays `False`) |
| Parallel join-policy verdict (`handlers/parallel.py`) | deterministic counting rule over branch statuses | `True` (branch exception / missing engine stays `False`) |
| Manager-loop stop/guard completion | the child's verdict | propagates child's `is_explicit` |
| Folder / pipeline (subgraph) node | child pipeline's terminal outcome (can carry a defaulted LLM completion) | propagates child's `is_explicit` (returned verbatim) |

Policy decisions made and ledgered in `specs/EXTENSIONS.md` §25:

1. **Tool exit codes ARE explicit verdicts** (both directions). Without this, a
   `goal_gate=true` parallelogram gate (e.g. `examples/patterns/task-runner.dot`'s `verify`
   and `verdict`) could never satisfy its gate.
2. **`response_schema`: format ≠ verdict** (corrected in review round 2). Schema output is
   explicit ONLY when it carries a recognized verdict (captured `report_outcome`, or a
   `status` field with a recognized value — the same ladder as every other path). Generic
   structured output stays DERIVED; unparseable/empty schema output also fails closed at
   the gate. Ordinary (non-gate) schema nodes are behaviorally unchanged.
3. **The CodergenHandler string path applies the same ladder for goal_gate nodes** — this is
   the exact `goal_gate` check that our own walk-upstream note recommends adding to the
   spec's `CodergenHandler` pseudocode, implemented in our handler.
4. **Legitimate non-LLM verdicts are explicit** (review round 2): human-gate answers,
   structural no-ops, fan-in ranking, and parallel join-policy results are deterministic
   verdict mechanisms that cannot be LLM-defaulted — classifying them explicit keeps ONE
   uniform gate rule while making `goal_gate=true` on those shapes satisfiable.
   Compositional handlers whose outcome IS a child's outcome (folder, manager-loop stop)
   propagate the child's `is_explicit` instead of asserting their own.

### Spec note — deliberate letter-divergence from §4.5

Canonical spec §4.5 (`CodergenHandler` pseudocode) is fail-open: any non-empty string
response → `Outcome(SUCCESS)`. This PR diverges for `goal_gate=true` nodes only. The
divergence is letter-divergent but intent-aligned: the spec's own convergence philosophy
(§3.4 goal gates: "done" must be earned, not defaulted) is defeated by the fail-open default
in exactly the incident class above. Non-goal_gate nodes preserve the §4.5 SUCCESS default
unchanged. The divergence is ledgered as `specs/EXTENSIONS.md` §25 with a walk-upstream note
in `PRINCIPLES.md` (Delta 1) recommending the upstream spec adopt the same check.

### BREAKING CHANGE

A `goal_gate=true` node whose LLM replies with bare prose now gets RETRY (degrading to FAIL
per `max_retries`) instead of silently satisfying the gate — **that is the fix working.**
Migration for graph authors: have gate nodes call `report_outcome` or emit a pure-JSON
verdict, or make the gate a `shape=parallelogram` tool node whose exit code is the verdict.
Non-goal_gate nodes are completely unchanged (verified: plain prose → SUCCESS preserved,
`test_backend_plain_text_returns_success` et al.).

Shipped-example impact (complete `goal_gate=true` sweep of `examples/`, ledgered in §25):
`task-runner.dot`'s two tool gates — **no behavior change** (exit codes are explicit); the 12
LLM gate nodes across 8 example files (02, 04, 10, feature-build, pr-review,
multi-lens-review, refactor, test-gen) now require explicit verdicts — in the default
Amplifier backend the child session has `report_outcome` available; bare-prose completions
now RETRY instead of recording false success.

### Verification checklist (repo PR template)

- [x] Unit tests pass (`pytest modules/loop-pipeline/`) — **1529 passed, 1 skipped** (full suite, `uv run --extra remote pytest -q`)
- [x] Live pipeline run exercising changed code path — **RUN 2026-07-31 in DTU
      `attractor-evals`** on this exact commit (`7fbabe0`), via the installed `attractor` CLI
      with real Anthropic calls. Red/green pair + NEW schema-red gate below; full captures in
      `.amplifier/evaluation/attractor-uplift/2026-07-31-reconciliation-live-gates-r2/t05-live/`
      (round-1 captures at `.../2026-07-31-reconciliation-live-gates/t05-live/`).
- [x] AGENTS.md reviewed; repo-specific gates met (doc-drift guard + examples lint below)
- [x] Backward-compat path unchanged where applicable — non-goal_gate plain prose → SUCCESS
      preserved on every path (parser, tool-loop no-text, direct-provider no-text, codergen wrap)
- [x] PR body includes verification evidence, not just "tests pass"

### Verification evidence

All on the exact squashed commit `7fbabe0a`, host machine:

| Gate | Command | Result |
|---|---|---|
| Positive control (task DoD) | `T0-5.verify.sh` from repo root | **PASS, exit 0** — in-process fixture: goal_gate judge returning the incident's plain-prose "NOT CONVERGED" text does NOT yield pipeline success (`status=StageStatus.FAIL`) |
| Negative-control history | same script on pre-work main | RED (defaulted SUCCESS satisfied the gate) — this is the task's recorded negative control from before the work |
| Full loop-pipeline suite | `cd modules/loop-pipeline && uv run --extra remote pytest -q` | **1529 passed, 1 skipped** (round-1: 1516 passed; pre-residual baseline: 1510 passed, **6 failed**) |
| New contract tests | `tests/test_fail_closed_outcomes.py` (FC-001…FC-015) + schema verdict-policy tests in `tests/test_response_schema.py` | 54 passed across the two files (within suite) |
| pipeline-runner suite | `cd modules/pipeline-runner && uv run pytest -q` | **45 passed, 1 skipped** |
| Root subset | `uv run --with pyyaml --with pytest pytest -q -x --ignore=tests/e2e` | PASS (ends 14/14 doc-guard) |
| Doc-drift guard (#101) | `test_engine_semantics_doc_guard.py` | **14 passed** |
| Examples lint sweep | `test_examples_lint_clean.py` | **32 passed** |
| Whitespace | `git diff 88b4e92..HEAD --check` | clean |

### Independent cross-provider review round 2 (2026-07-31)

Two independent cross-provider reviews returned **REVISE**. Findings and dispositions
(all closed; the commit was amended and re-proven live):

1. **BLOCKER — `response_schema` was a false-success side door.** The round-1 policy
   marked ANY parseable JSON as `is_explicit=True`, so a goal_gate structured-output judge
   returning `{"assessment": "NOT CONVERGED"}` — or a name-extraction payload
   `{"name": "Alice"}` — shipped success. **Fixed: format ≠ verdict.** Schema output is
   explicit ONLY when it carries a recognized verdict (captured `report_outcome`, or a
   `status` field with a recognized value — the same verdict ladder as every other path);
   generic structured output stays DERIVED. One shared classifier
   (`backend._outcome_from_structured_output`) serves both backends. Non-gate schema nodes
   behaviorally unchanged (proved by test + live). §25 policy paragraph rewritten.
2. **MAJOR — gate check over-broad: non-LLM goal gates were unsatisfiable.** The gate
   requires `is_explicit` for EVERY goal_gate node, but the human handler returned SUCCESS
   without it → a `goal_gate=true` human gate retry-stormed despite the most explicit
   verdict possible. **Fixed by classifying legitimate non-LLM verdicts as explicit**
   (keeping one uniform gate rule): human-gate selections/freeform/skip; start/exit/
   conditional structural SUCCESS; fan-in ranking; parallel join-policy results.
   Manager-loop stop and folder (subgraph) nodes **propagate the child's** `is_explicit`
   (their outcomes can carry a defaulted LLM completion — blanket-explicit would launder
   it). All `Outcome(` constructions across `handlers/` audited; full classification table
   updated in §25 and above. Tests: goal_gate human gate satisfiable (FC-012), goal_gate
   fan-in satisfiable (FC-013).
3. **MINOR — `is_explicit` not serialized.** engine-semantics.md called it durable audit
   data but the writers omitted it. **Fixed:** serialized in node `status.json` (flat +
   iteration-scoped), every `trace.jsonl` record, and the codergen early-writer; regression
   tests FC-014/FC-015. Confirmed live: the DTU green run's `work/status.json` carries
   `"is_explicit": true`.

Re-proof: full suite 1529 passed / 1 skipped; `T0-5.verify.sh` PASS; doc-guard +
examples sweep green; live red/green re-run PLUS a NEW schema-red live gate (below) in
`.amplifier/evaluation/attractor-uplift/2026-07-31-reconciliation-live-gates-r2/`.

### Live pipeline run evidence (2026-07-31, DTU `attractor-evals`, r2 on `7fbabe0`)

Minimal live goal-gate graph (`start → work[box, goal_gate=true, max_retries=0] → done`),
real agent session writing a file, run on this exact commit via the installed CLI
(`attractor run /root/t05r2-*.dot`):

**RED — node instructed to reply plain prose only (no report_outcome, no JSON):**
```
attractor: status=fail          # exit code 1
work/status.json: "outcome": "fail", "is_explicit": false
```
The agent DID do the work (`/tmp/t05r2-live-out.txt` == `done`); only the verdict was
missing, and the gate refused it.

**GREEN — identical node, explicit pure-JSON verdict as final message:**
```
attractor: status=success       # exit code 0
notes: wrote /tmp/t05r2-pass-out.txt
work/status.json: "is_explicit": true    # Finding-3 serialization, live
```

**NEW SCHEMA-RED — goal_gate + `response_schema` node returning non-verdict JSON
(the BLOCKER fix, live):** run on the direct-LLM path (the only path that supports
`response_schema`; the spawn path fail-louds on it by design — also captured), real
Anthropic call, pinned installed venv code:
```
judge notes: {"assessment": "The convergence work ... is NOT complete. ..."}
judge status: success (node-level, EXT-23 data output unchanged)
judge is_explicit: False        # format ≠ verdict
pipeline status: fail           # the gate rejected it
```

Captures (logs, all three .dot graphs, run-dir slices, code-identity checks):
`.amplifier/evaluation/attractor-uplift/2026-07-31-reconciliation-live-gates-r2/t05-live/`
(round-1 captures preserved at `.../2026-07-31-reconciliation-live-gates/t05-live/`).

Live-gate hygiene note: a first attempt at the RED run returned `status=success` — root-caused
to the amplifier **bundle cache** (`~/.amplifier/cache/amplifier-bundle-attractor-*`) mounting
`loop-pipeline` from `git+…@main` and shadowing the installed branch code at runtime. After
pinning the cache to this commit (verified by `cmp` of engine.py/backend.py across repo, venv,
and cache), the red/green pair behaved exactly as designed. Future live gates must include the
cache in branch-switch hygiene.

**Interaction verified (2026-07-31, re-verified r2 on the amended commits):** merged with
`task/T0-4-polished` in order T0-5 → T0-4 (`integration/reconciliation-r2`, merge `7d5b70f`)
— exactly one trivial append-append conflict in `specs/EXTENSIONS.md` (T0-4's restoration
note placed after §25), same as round 1; combined tree passes the red/green pair, the new
schema-red gate, T0-4's single-edge live gate, and both branches' verify fixtures
(`T0-5.verify.sh` + `T0-4.verify.sh`, both PASS). **Merge order note unchanged: T0-5 → T0-4.**

The 6 pre-residual failures were exactly the ones the run's critics identified
(`test_goal_gate_retry_clears_failures.py` ×3 — tool gates; `TestGoalGate` ×2 +
`TestSpecSmokeTest::test_step3_execute` — plain-prose test doubles), all fixed by the
producer classification, not by weakening the gate.

### Notes for reviewers

- **The gate check consults `is_explicit` directly** (`engine.py`, `_check_goal_gates`):
  `gate_satisfied = outcome.is_success and outcome.is_explicit`. This centralized layer is
  what closes the spawn status-only bypass and any future producer that forgets to classify
  itself. The parser-level RETRY is the belt; this is the suspenders.
- **Test doubles updated deliberately**: `SuccessBackend` now returns a pure-JSON verdict
  string (exercises the production parse path), `RetryThenSucceedBackend` marks its explicit
  Outcomes `is_explicit=True`. Doubles that represent "backend produced an explicit result"
  must say so under the new contract.
- **File overlap with PR #100** (local providers): `backend.py`, `engine.py`, `__init__.py`.
  Different regions (their change is provider resolution; ours is outcome parsing/gating) —
  expect a clean or trivial rebase for whichever lands second.
- Honest caveat: the in-process fixture and suites exercise the parser, gate, tool-handler,
  codergen, and schema paths; the schema classifier is also proven LIVE on the direct path
  (r2 schema-red gate). The **spawn path's** `is_explicit=False` (status-only) behavior is
  covered by unit tests (`test_fail_closed_outcomes.py`), not by a dedicated live
  status-only spawn run; the spawn path's `response_schema` fail-loud rejection WAS
  captured live (r2, `schema-cli-spawn-path-judge-status.json`).

### Provenance (honest)

Produced by an agent convergence run (task-runner attractor) that **stalled honestly**:
verify gate green ×3 iterations while two independent critics (Anthropic + OpenAI) refused
ship ×3 with descending residuals — the recurring finding was "incomplete assembly: contract
applied to some producers but not all." The run was halted by stall detection and the work
salvaged (`task/T0-5` @ `2a28347e`). This branch is that salvage rebased onto current main
(clean cherry-pick, no conflicts — #108 touched disjoint docs) plus the residual close:

1. `handlers/tool.py` exit codes → explicit (critics' blocking finding; fixed 3 tests)
2. `response_schema` policy decided + implemented on both paths (critic B's blocker)
3. CodergenHandler goal_gate string routing (fresh-eyes finding: the failing TestGoalGate
   tests actually flowed through the handler's string-wrap, not `_parse_outcome`; routing
   goal_gate strings through the ladder makes the documented contract true on every path)
4. Test doubles updated to emit explicit verdicts (critic A's answer)
5. `specs/EXTENSIONS.md` §25 narrative fixed — it previously claimed "the gate check does NOT
   consult `is_explicit` directly," contradicting the implementation (critic B's
   docs-drift finding); inventory expanded from 6 rows to full producer classification +
   complete examples sweep + affected-tests table
6. Author-facing docs (`DOT-AUTHORING-GUIDE.md`, `DOT-SYNTAX.md`) updated (critics' finding 5)
7. `engine-semantics.md` §5: removed the incorrect "SUCCESS with is_explicit=False is a bug"
   claim; now documents the two-layer enforcement accurately

### Reviewer commands

```bash
# full suite
cd modules/loop-pipeline && uv run --extra remote pytest -q

# the contract tests alone
uv run --extra remote pytest tests/test_fail_closed_outcomes.py tests/test_goal_gates.py -q

# doc-drift guard + examples lint
uv run --extra remote pytest tests/test_engine_semantics_doc_guard.py tests/test_examples_lint_clean.py -q

# the incident fixture (from repo root, task repo checkout required)
bash ../attractor-uplift/backlog/tasks/T0-5.verify.sh
```