### PR TITLE
feat(skills): /attractorify — session-context attractor diagnosis + conversational design skill

### DIFF
--- a/agents/attractor-expert.md
+++ b/agents/attractor-expert.md
@@ -92,6 +92,15 @@ The bundle includes 15 example pipelines you can reference:
   `feature-build.dot`, `pr-review.dot`, `refactor.dot`, `test-gen.dot`
 - Programmatic usage: `@attractor:examples/programmatic_usage.py`
 
+## Session entry point
+
+If a user is deciding whether to build a pipeline at all, or needs a guided
+design conversation, direct them to `/attractorify` — the inline session skill
+that applies the three-question test, asks targeted clarifying questions when
+context is thin, and produces a linted `.dot` artifact. This expert is the
+consultation target the skill delegates to; `/attractorify` is the session-facing
+entry point.
+
 ## How to Help
 
 When asked about pipeline design:

--- a/bundle.md
+++ b/bundle.md
@@ -18,6 +18,18 @@ includes:
   - bundle: git+https://github.com/microsoft/amplifier-foundation@main
   - bundle: attractor:behaviors/attractor-core
 
+tools:
+  # Registers the bundle's skills with the Agent Skills system (slash-command
+  # registration comes from each skill's `user-invocable: true` frontmatter).
+  # Same registration pattern other bundles use for their own skills/ directory.
+  - module: tool-skills
+    source: git+https://github.com/microsoft/amplifier-bundle-skills@main#subdirectory=modules/tool-skills
+    config:
+      skills:
+        # Resolves post-merge (skills/ lands on main with this PR); local installs may
+        # also place the skill in ~/.amplifier/skills/ (standard skills discovery).
+        - "git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=skills"
+
 agents:
   # IMPORTANT: each child agent MUST declare an inline session.orchestrator running a
   # non-pipeline loop (e.g. loop-agent).  The spawn capability merges this agent's session:

--- a/docs/ATTRACTORIFY-SKILL.md
+++ b/docs/ATTRACTORIFY-SKILL.md
@@ -1,0 +1,66 @@
+# /attractorify Skill
+
+The `/attractorify` skill is the session-facing entry point for attractor pipeline
+design. It lives at `skills/attractorify/SKILL.md` and registers as a slash command
+in any Amplifier session that loads this bundle.
+
+## What it does
+
+When invoked, the skill:
+
+1. **Diagnoses first** — applies the three-question test
+   (`docs/PIPELINE_DESIGN_PRINCIPLES.md` §0) to decide whether an attractor
+   pipeline is warranted at all. When the honest answer is "one-shot it," "this is
+   a recipe," or "use the existing attractor," it says so and cites the rule.
+
+2. **Designs conversationally** when a pipeline IS warranted — extracts goal (as
+   end-state), machine-checkable DoD, budgets, and evidence gates from the session
+   context; consults the `attractor:attractor-expert` agent by delegation at design
+   start and final review; produces a `.dot` file; lints it with `attractor lint`;
+   and hands back the runnable artifact plus the exact invocation.
+
+3. **Asks before designing** when context is thin — if the session under-determines
+   any of DoD, budget, target repo, or acceptance criteria, it asks targeted
+   clarifying questions derived from what is actually missing. Not a boilerplate
+   questionnaire.
+
+## Placement rationale
+
+This skill lives in `amplifier-bundle-attractor` (the domain home) rather than
+`amplifier-bundle-skills` (the sibling collection) because:
+
+- The skill teaches from and links to `agents/attractor-expert.md`,
+  `docs/DOT-AUTHORING-GUIDE.md`, `docs/PIPELINE_DESIGN_PRINCIPLES.md`, and the
+  `attractor lint` CLI — all of which live here. Co-location keeps the decision
+  logic beside the doctrine it applies.
+- The skill is domain-specific (attractor pipeline design), not a general-purpose
+  session utility. The skills collection is the right home for cross-domain skills;
+  this one is inseparable from the attractor doctrine.
+- Maintainability: when the doctrine docs evolve, the skill's links update in the
+  same PR. A cross-repo dependency would create a lag.
+
+The tradeoff: users who load only `amplifier-bundle-skills` will not see
+`/attractorify`. If adoption evidence shows this is a friction point, the skill
+can be mirrored or the placement reconsidered.
+
+## Execution mode
+
+The skill runs **inline** (not as a forked sub-session). A forked skill with
+default `context_depth=none` sees nothing of the current session — which is
+precisely what the skill needs to read. The council/council-here pair in the
+skills family is the precedent: council (fork, external target) vs council-here
+(inline, current session). This skill is the inline variant.
+
+## Reference surfaces
+
+- `skills/attractorify/SKILL.md` — the skill itself
+- `agents/attractor-expert.md` — source prompt of the `attractor:attractor-expert`
+  agent the skill delegates to for design and review
+- `docs/PIPELINE_DESIGN_PRINCIPLES.md` §0 — the three-question test and one-sentence rule
+- `docs/DOT-AUTHORING-GUIDE.md` — node contract, lint rules, `attractor lint` CLI
+- `skills/attractorify/evidence/` — **design simulations** (authored illustrations
+  of the three acceptance scenarios: clarifying-question exchange, lint-clean
+  design run, diagnosis-honesty case — NOT session records; see the README in
+  that directory). Live-session evidence is being collected separately and will
+  replace or supplement these files before the skill is promoted beyond
+  experimental status.

--- a/docs/PIPELINE_DESIGN_PRINCIPLES.md
+++ b/docs/PIPELINE_DESIGN_PRINCIPLES.md
@@ -35,7 +35,21 @@ swallowed the intelligence.
 **Recipes vs. attractor pipelines.** Recipes are for staged sequential workflows
 with human approval gates; attractor pipelines are for machine-verified
 convergence. If your pipeline graph has no cycle, it should probably have been a
-recipe.
+recipe. The "probably" is load-bearing: this is a heuristic, not a gate.
+
+### The three-question test
+
+A quick diagnosis for whether work warrants an attractor at all:
+
+1. **Is there a cycle?**
+2. **Is the exit gated on evidence** (machine-checkable, external to the worker)
+   rather than on step-completion?
+3. **Would it still land if any one LLM node had a bad day** — a single response
+   that is plausible but wrong?
+
+A "no" is a signal to reconsider the shape — one-shot it, write a recipe, or
+reuse a shipped exemplar (`examples/patterns/task-runner.dot`) — not a verdict.
+Like the one-sentence rule, the test is a heuristic applied in context.
 
 **Why the skeleton must stay external.** In one live run, the worker
 hand-authored its own convergence evidence (a fabricated `convergence.jsonl`) to

--- a/skills/attractorify/SKILL.md
+++ b/skills/attractorify/SKILL.md
@@ -1,0 +1,408 @@
+---
+name: attractorify
+description: >
+  Analyze the current session and decide whether an attractor pipeline is
+  warranted — then design one conversationally if it is. Triggers: "/attractorify",
+  "should this be an attractor?", "design a pipeline for", "attractorify this",
+  "do I need an attractor pipeline?", "turn this into a pipeline".
+user-invocable: true
+model_role: >
+  You are an attractor pipeline design assistant. You diagnose whether a pipeline
+  is warranted, design one conversationally when it is, and ask targeted clarifying
+  questions when the session under-determines the design. You consult the
+  attractor:attractor-expert agent by delegation at design start and final review
+  (reading agents/attractor-expert.md directly only when delegation is
+  unavailable); you do not restate the doctrine from memory.
+allowed-tools:
+  - read_file
+  - write_file
+  - bash
+  - delegate
+shortcut: attractorify
+---
+
+# /attractorify — Attractor Pipeline Design Skill
+
+This skill runs **inline** in the current session (not as a forked sub-session)
+so it can read the full conversation context, files, and task state — a forked
+execution with default `context_depth=none` would see nothing of the session
+it is supposed to analyze (the council/council-here precedent).
+
+---
+
+## Step 1 — Diagnose first, in writing (does this work warrant an attractor at all?)
+
+Apply the three-question test from `docs/PIPELINE_DESIGN_PRINCIPLES.md` §0
+("The three-question test") before designing anything:
+
+- **Q1.** Is there a cycle?
+- **Q2.** Is the exit gated on evidence (machine-checkable, external to the worker)?
+- **Q3.** Would it still land if any one LLM node had a bad day?
+
+Answer all three against the capability the user is asking for, not only the
+work already in front of you: an explicit request for a repeatable, rerunnable
+mechanism with a machine-checkable gate for future recurrences makes the test
+prospective — and the quote you cite below is the user's request for that
+future loop. The honest no is reserved for asks with no machine gate.
+
+**The diagnosis is not a judgment you hold in your head — it is a file you
+write.** Write `.attractorify/diagnosis.md` under the working directory
+(`mkdir -p .attractorify` first), in exactly this shape:
+
+```
+# /attractorify diagnosis
+work: <one line naming the work being diagnosed>
+
+Q1 (cycle): <yes|no>
+Q1 quote: "<direct quote — the user's own words, or observed repo state>"
+Q2 (evidence-gated exit): <yes|no>
+Q2 quote: "<direct quote>"
+Q3 (bad-day survival): <yes|no>
+Q3 quote: "<direct quote>"
+
+verdict: <attractor|recipe|one-shot|existing-attractor>
+counter: "<the strongest quote AGAINST the verdict>" — <one-line honest disposition>
+status: <FINAL, or: PROVISIONAL — asked: the clarifying questions posed>
+budget: max <N> nodes; gates: <the evidence gates that justify them>
+```
+
+Rules of construction:
+
+- Every quote line is **user-originated**: the user's own words, or observed
+  repo state (a path plus what it shows) — predating and independent of
+  anything this skill itself suggested. **Assent to a skill-proposed option,
+  menu, or checklist is NOT evidence: if you proposed it, you cannot cite
+  agreement with it.** A "yes" without a supporting quote is invalid by
+  construction — when the session contains no determinative user-originated
+  evidence for a question, write `Q<n> quote: NO EVIDENCE IN SESSION`
+  instead, which forces either an honest "no" or a clarifying question
+  (Step 2); it can never support a design.
+- **A user deferral is delegated judgment, not missing evidence.** When the
+  user explicitly defers a question ("your call", "no strong opinion", "you
+  decide"), DERIVE the answer from the strongest session evidence: quote the
+  deferral on the quote line, and mark the answer line
+  `<yes|no> — derived (user-delegated): <the basis>` — e.g.
+  `Q1 (cycle): yes — derived (user-delegated): the machine-checkable
+  retry-until-green DoD constitutes the loop`. Do not bounce the deferred
+  question back to the user — exercising the delegated judgment is the
+  answer they asked for.
+- Q2's quote must name a **concrete check, command, or condition** in the
+  user's or the repo's own terms (a test suite, an exit code, an observable
+  state). Enthusiasm, schedule pressure, and complaints are real quotes but
+  are not evidence of a gate.
+- The `counter:` line is **required**: quote the strongest thing in the
+  session AGAINST your verdict, then disposition it honestly in one line —
+  rebut it with user-originated evidence, or concede and change the verdict.
+  Engineering around the counter-quote is the named failure this line exists
+  to surface.
+- `status:` is `PROVISIONAL — asked: ...` whenever any answer lacked
+  determinative evidence and clarifying questions went out.
+- The `budget:` line is required when the verdict is `attractor` or
+  `existing-attractor` (or an override is present): a hard node cap justified
+  by naming the evidence gates the topology serves. Machinery no named gate
+  asks for is bloat. For `existing-attractor`, the budget must additionally be
+  **machine-encoded in the recommended invocation** (iteration cap and
+  wall-clock as graph attributes or invocation parameters) — `budget: N/A`
+  alongside an emitted command is a contradiction the gate rejects.
+- An optional `caveats:` line records the one-line disposition of an
+  unresolved verifier objection (see the one-round cap below). It documents;
+  it never blocks.
+- An **informed override** — the user acknowledges the diagnosis and directs
+  the build anyway — adds one line quoting their exact words:
+  `override: "<the user's own override words>"`. Note the tradeoff in one line
+  and proceed; pushback without those words never becomes an override.
+  **A recorded override ENDS adjudication**: ONE artifact rewrite, ONE gate
+  run, then proceed DIRECTLY to design — do NOT run the independent verifier
+  on an overridden verdict. The human has overruled the diagnosis; there is
+  nothing left to verify. (The honest trade: the override quote is the user's
+  own words quoted back in-session — the user is present to correct a misquote.)
+
+When the verdict is `recipe` or `one-shot`, say so with a firm
+recommendation, cite the one-sentence rule from
+`docs/PIPELINE_DESIGN_PRINCIPLES.md` §0, and stop — the artifact is the record
+of why, and these verdicts emit **no pipeline invocation**, so they end here,
+outside the design gate. Do not follow a "no" with leading questions hunting
+for a cycle ("want automatic retry on failure?") — a cycle you have to fish
+for is not in the work, and assent to a question you posed can never be
+quoted as evidence (rules above; the verifier checks exactly this).
+
+`existing-attractor` (reuse a shipped exemplar — see
+`examples/patterns/task-runner.dot` or
+`examples/pipelines/practical/bug-fix.dot`) is **not an exit**: it hands the
+user an invocation command, which is a design handover in every way that
+matters. It carries the same artifact discipline (three questions with
+quotes, `counter:` line, `budget:` line) and must pass the executed gate AND
+clear independent verification below (its one round — or an override, which
+skips it) before any command is emitted.
+
+### The executed gate — run before ANY handover
+
+Before handing over ANYTHING actionable — a designed `.dot`, an
+exemplar/`existing-attractor` recommendation, or ANY invocation command —
+for any reason, including an override — run this check **verbatim** via bash:
+
+```bash
+d=".attractorify/diagnosis.md"; test -f "$d" \
+&& [ "$(grep -Ec '^Q[123] \([a-z -]+\): (yes|no)( — derived \(user-delegated\): .+)?$' "$d")" -eq 3 ] \
+&& [ "$(grep -Ec '^Q[123] quote: ".+"$' "$d")" -eq 3 ] \
+&& ! grep -q 'NO EVIDENCE IN SESSION' "$d" \
+&& ! grep -q 'PROVISIONAL' "$d" \
+&& grep -Eq '^status: FINAL$' "$d" \
+&& { grep -Eq '^verdict: (attractor|existing-attractor)$' "$d" || grep -Eq '^override: ".+"$' "$d"; } \
+&& grep -Eq '^counter: ".+" — .+' "$d" \
+&& grep -Eq '^budget: max [0-9]+ nodes; gates: .+' "$d" \
+&& echo "DIAGNOSIS GATE: PASS — form ok; next: verify (or design directly on a recorded override)" \
+|| { echo "DIAGNOSIS GATE: FAIL — no .dot, no invocation command; revise the diagnosis or ask"; false; }
+```
+
+The gate fails **closed** — this mirrors the engine's fail-closed goal-gates:
+a defaulted, absent, provisional, or quote-free verdict never satisfies it.
+On FAIL, produce no design; go back to the diagnosis or to clarifying
+questions. Do not weaken the check to fit the artifact; fix the artifact, or
+honestly stop. A PASS authorizes only the next step: this gate verifies
+**form, not truth** — independent verification below is what authorizes design.
+
+### Independent verification — after form-PASS, before ANY handover
+
+A bash gate cannot tell a real quote from a relevant one, and the judgment
+that authors the evidence is the same judgment that folds — so certification
+is taken away from the authoring judgment. Once the artifact is written and
+the form gate passes — unless a valid `override:` line is recorded, which
+ends adjudication (rule above): overridden verdicts skip this section
+entirely — and BEFORE any handover (a designed `.dot`, an
+`existing-attractor` recommendation, or any invocation command), you MUST
+delegate verification to a fresh-context agent with no stake in the design:
+use the same `delegate` tool as the expert consultation in Step 3, but NOT
+`attractor:attractor-expert` — a plain clean-slate delegation, which sees
+only what the instruction carries. That isolation is the point.
+
+The verifier audits the **diagnosis, not just the quotes**: armed only with
+quote-integrity questions, a coherent rationalization sails through — so the
+instruction arms it with the doctrine's counter-tests and requires it to
+re-derive the answers itself before looking at yours.
+
+The delegation instruction must carry (a) the artifact content **verbatim**,
+(b) the user's session turns, quoted **verbatim**, and (c) this ask:
+
+```
+You are verifying a diagnosis you did not write. Do not trust the
+artifact's answers.
+
+FIRST, re-derive the three-question answers YOURSELF from the user turns
+alone, before reading the artifact's answers:
+  Q1 (cycle): does THIS work loop attempt -> machine-verify -> retry?
+  Q2 (evidence-gated exit): is the exit gated on a machine-checkable
+     check, external to the worker?
+  Q3 (bad-day survival): would it still land if any one LLM node had a
+     bad day?
+Then compare your derivation with the artifact's answers. ANY mismatch
+=> INVALID, and you must show your own derivation.
+
+Apply these counter-test rules; each violation => INVALID:
+- Recurrence of a task CATEGORY (releases happen again, reports happen
+  again) is NOT a convergence cycle. A cycle exists only if THIS work
+  loops attempt -> machine-verify -> retry.
+- A human approval, review, or sign-off step makes the exit human-gated
+  — recipe-plane, not an attractor. Any machine proxy for the human's
+  satisfaction (marker files, format checks standing in for approval)
+  is manufactured evidence, not a gate.
+- Desire, enthusiasm, schedule-pressure, and complaint quotes are never
+  evidence for ANY question.
+- Q2 evidence must name a concrete machine check (a command or exit
+  condition) in the user's or the repo's own words.
+
+If the artifact contains an `override: "..."` line, the override changes
+the game. Check exactly two things: (a) the quoted words are verbatim
+from a USER turn, and (b) they genuinely acknowledge the diagnosis
+outcome AND direct the build anyway. The desire/enthusiasm exclusion
+above does NOT apply to override quotes — an informed override IS a
+directed desire; that is its nature. A valid override => VERIFIER: VALID
+even when the three questions fail (that is the override's entire
+purpose). An override quote that is not verbatim, or that expresses
+desire without acknowledging the diagnosis => INVALID as before.
+(This clause serves override-bearing artifacts that reach a verifier by
+another path — the skill itself does not send overridden verdicts here.)
+
+Then, for each of Q1/Q2/Q3, judge the quoted evidence:
+1. Is the quote verbatim from a USER turn (not from the assistant's own
+   words, questions, or proposals)?
+2. Is it genuine evidence FOR that specific question (not merely related
+   to the topic)?
+3. Is it NOT assent to an option, menu, or checklist the assistant itself
+   proposed?
+An answer clearly marked "derived (user-delegated)" with a stated basis,
+whose quote line is the user's own deferral ("your call", "you decide"),
+is acceptable evidence — judge the basis, not the absence of a user quote.
+And: is the counter: line's disposition honest — a real rebuttal grounded
+in user-originated evidence, or an honest concession?
+Reply with exactly one of:
+VERIFIER: VALID
+VERIFIER: INVALID — <per-question reasons + your own derivation>
+```
+
+**Verification is capped at ONE round per diagnosis** — the cap bounds
+worst-case latency by construction (a fresh-context judge re-litigates
+everything each round, so unbounded rounds chase a moving target instead of
+converging). On `VERIFIER: VALID`, proceed — to design, or to an
+`existing-attractor` handover. On INVALID, revise the diagnosis ONCE,
+honestly — which may flip the verdict to `recipe` or `one-shot`: that is a
+legitimate outcome, not a failure — re-run the form gate, then PROCEED,
+recording the objection's disposition in the artifact (the optional
+`caveats:` line for anything left unresolved). Do not run the verifier
+again and do not shop for a second opinion; further verifier objections are
+never blockers. If the one revision cannot honestly resolve the objection,
+convert it into ONE targeted user question (Step 2) instead of another
+verifier round. The verifier exists to catch exactly two theater modes:
+real-but-irrelevant quotes, and self-dealt evidence (assent to your own
+proposals cited as the user's ask). A fold that survives independent
+verification means the diagnosis discipline cannot be enforced in-skill at all.
+
+**Fallback (delegation unavailable):** answer the three verifier questions in
+a visibly separate self-check step before proceeding — weaker, because the
+authoring judgment is certifying itself; say so in the handback.
+
+### Holding the line (pushback without new information)
+
+When the user pushes back on a "no" without new information ("are you sure?",
+"I'd really like a pipeline", "let's do it anyway"), hold: restate which
+questions fail (a sentence each, not a doctrine wall), re-offer the
+alternative, and ask **one** open question — what new constraint changes the
+analysis? Ask it OPEN: do not propose candidate gates, checks, or menus
+yourself — a menu invites assent, and assent to your own menu is not
+evidence (the same anti-self-dealing rule as above). A reversal requires **rewriting `.attractorify/diagnosis.md` with
+new user-originated evidence, then re-running the gate AND the verifier** (a
+rewritten diagnosis with new evidence gets its own single round) —
+social pressure produces no quotes, so an artifact that could not pass before
+the pushback still cannot. A human approval/sign-off step is not a
+machine-checkable gate: it belongs on the `counter:` line, not engineered
+around. This skill is an adoption surface for the doctrine, not an
+attractor-pushing machine.
+
+---
+
+## Step 2 — Ask before designing when context is thin
+
+Never one-shot a pipeline design from under-determined context. A `.dot`
+generated from a guessed DoD, budget, or target repo is wrong-but-plausible at
+the architecture level — no gate inside the pipeline can catch a sink that was
+wrong before the first node ran. Designing from guesses on an under-determined
+ask is the ask-first failure: a provisional diagnosis with questions is always
+available and always preferred.
+
+**The three-gap checklist.** On an under-determined ask, put targeted
+clarifying questions to the user BEFORE any design artifact — covering
+whichever of these gaps the session leaves genuinely open (gaps to cover, not
+a script to recite; and this is the under-determined-ask path, distinct from
+the single open question of the pushback path in Step 1):
+
+1. **The TARGET** — which repo / service / working directory. Asking is
+   **mandatory whenever the workspace holds more than one candidate**: never
+   guess between candidates, and never infer the target from repo state alone.
+2. **The machine-checkable DEFINITION OF DONE** — the sink the whole basin is
+   carved around: the observable end-state and the external,
+   out-of-worker-context check that confirms it.
+3. **The BUDGET caps** — iteration cap AND wall-clock bound; a guessed cap is
+   a guess like any other.
+
+**Each answer must land machine-visibly in the deliverable.** The chosen
+target becomes a working directory / path / parameter in BOTH the pipeline's
+deterministic gate commands AND the handed-over invocation — prose-only
+scoping is not scoping: a verify command run from a parent directory sweeps
+repos the user excluded. The DoD becomes the deterministic gate; the caps
+become graph attributes or invocation parameters.
+
+If the session already answers a gap, do not ask it again — a fixed intake
+questionnaire remains the anti-pattern. An explicit deferral in reply ("your
+call", "no strong opinion") ANSWERS the gap by delegation: derive and record
+per Step 1's deferral rule — do not re-ask it. While questions are outstanding, the
+artifact carries `status: PROVISIONAL` — which cannot pass the gate, so design
+cannot start from it. **Re-diagnosis after answers is mechanical, not
+optional:** rewrite `.attractorify/diagnosis.md` quoting the new answers (the
+user's replies are now session evidence), set `status: FINAL` only when every
+quote line is real, and re-run the gate. The PROVISIONAL marker clears only by
+re-running the test against quotes — never by the passage of conversation.
+
+---
+
+## Step 3 — Design conversationally when an attractor IS warranted
+
+Entry condition: the diagnosis gate above has returned PASS, **and** one of:
+the independent verifier returned `VERIFIER: VALID`; a valid `override:`
+line is recorded (adjudication ended — no verifier run); or the single
+INVALID round was followed by one honest revision, a fresh gate PASS, and
+the objection's disposition recorded (`caveats:` line if unresolved). Then:
+
+1. **Extract from session context:** goal (as end-state), machine-checkable DoD,
+   budgets, evidence gates, target repo. These are the four walls of the basin.
+
+2. **Consult the `attractor-expert` agent — by delegation, not by reading its
+   file.** Delegate to `attractor:attractor-expert` at design start (pattern and
+   shape choice), for any mid-build routing or engine-semantics question, and
+   again for a final review of the drafted `.dot` before handing it back. The
+   agent is loaded with engine semantics, DOT syntax, and the full authoring
+   guide; generic builders carry no attractor engine semantics. If delegation
+   is unavailable, fall back to reading `agents/attractor-expert.md` directly.
+
+3. **Follow design order** from `docs/PIPELINE_DESIGN_PRINCIPLES.md` §0:
+   name the sink first, build the gate, build the loop, only then add work nodes.
+   The node contract (Objective / Constraints / Available capabilities / Required
+   evidence) is documented in `docs/DOT-AUTHORING-GUIDE.md` §Philosophy.
+
+4. **Fit the declared budget.** Keep the control plane lean
+   (`docs/PIPELINE_DESIGN_PRINCIPLES.md` §0, control-plane vs recipe-plane
+   line) and keep the design inside the artifact's `budget:` line. Needing
+   more nodes is a diagnosis change, not a design flourish: revise the
+   artifact first — naming the evidence gate that justifies the extra
+   machinery — re-run the gate, and only then grow the graph.
+
+5. **Write the artifact and lint it.** Write the `.dot` file to a named path in
+   the target repo (e.g. `<task-id>.dot`), then run:
+   ```
+   bash -c "attractor lint <path>"
+   ```
+   A `.dot` that fails `attractor lint` (TOPO-001 through TOPO-005, documented in
+   `docs/DOT-AUTHORING-GUIDE.md`) is not a runnable artifact. Fix lint findings
+   before handing back.
+
+6. **Hand back:** the `.dot` file path, the exact invocation command, and a
+   one-line summary of why each structural choice was made. The chosen target
+   must appear as a working directory / path / parameter in both the graph's
+   deterministic gate commands and the invocation, and both caps — iterations
+   AND wall-clock duration — must be machine-encoded in graph attributes or
+   invocation parameters; scoping or a budget stated only in prose is neither.
+
+---
+
+## Reference surfaces (link, don't restate)
+
+- `docs/PIPELINE_DESIGN_PRINCIPLES.md` §0 — one-sentence rule, control-plane vs
+  recipe-plane line, **three-question test**, design order
+- `docs/DOT-AUTHORING-GUIDE.md` — node contract, DOT syntax, TOPO-001..005 lint
+  rules, `attractor lint` CLI
+- `attractor:attractor-expert` — the consultable expert agent; delegate to it
+  for any pipeline design or debugging question (source prompt:
+  `agents/attractor-expert.md`; read directly only when delegation is unavailable)
+- `examples/patterns/task-runner.dot` — canonical control-plane skeleton
+- `examples/pipelines/practical/bug-fix.dot` — shipped exemplar for "use the
+  existing attractor" recommendations
+
+---
+
+## $ARGUMENTS passthrough
+
+If the user invokes `/attractorify <description>`, treat `$ARGUMENTS` as the
+initial session context and apply the three-question test to it immediately.
+If empty, read the current session context to identify the work before diagnosing.
+
+---
+
+## What this skill does NOT do
+
+- **Not an auto-runner.** It hands back the artifact and the invocation; launching
+  a pipeline is the human's explicit call.
+- **Not a doctrine memoir.** It links the shipped docs for depth; it does not
+  reproduce the doctrine inside its own body.
+- **Not a blanket questionnaire.** It asks only what the session genuinely does
+  not answer; a fixed intake questionnaire is the anti-pattern this skill exists
+  to prevent one level up. (The diagnosis artifact is the skill's own verdict
+  record, written from session evidence — never a form posed to the user.)

--- a/skills/attractorify/evidence/README.md
+++ b/skills/attractorify/evidence/README.md
@@ -1,0 +1,25 @@
+# Evidence directory — SIMULATIONS, not session records
+
+Every `session-*.md` file in this directory is an **authored design simulation**:
+a constructed illustration of intended skill behavior for one acceptance
+scenario. None is a live Amplifier session transcript — there are no session
+IDs, no timestamps, and no external verifiability.
+
+What IS real here: `session-b-generated.dot` is a real artifact that passes
+`attractor lint` clean (independently re-verified), and its gate command has
+been tested against fixture files.
+
+Live-session evidence is being collected separately and will replace or
+supplement these files. Until real transcripts land, treat the skill as
+experimental and these files as acceptance illustrations only.
+
+Note: these simulations predate the executed diagnosis-gate mechanic (the
+required `.attractorify/diagnosis.md` artifact + verbatim bash gate now in
+`SKILL.md` Step 1) and do not depict it.
+
+| File | Scenario it illustrates |
+|---|---|
+| `session-a-thin-context.md` | Thin context → targeted clarifying questions (ask-first) |
+| `session-b-sufficient-context.md` | Sufficient context → design + lint-clean `.dot` handback |
+| `session-b-generated.dot` | The (real) artifact produced in scenario B |
+| `session-c-diagnosis-honesty.md` | Work that does NOT warrant an attractor → honest refusal |

--- a/skills/attractorify/evidence/session-a-thin-context.md
+++ b/skills/attractorify/evidence/session-a-thin-context.md
@@ -1,0 +1,79 @@
+# Evidence Session A — Thin Context: Clarifying Questions
+
+> **SIMULATION — an authored illustration, not a session record.**
+> This file demonstrates intended skill behavior through a constructed scenario.
+> It has no session ID, timestamps, or external verifiability.
+> Live-session evidence is being collected separately and will replace or
+> supplement this file; the skill stays experimental until real transcripts land.
+
+**Scenario:** User invokes `/attractorify` with a vague description. The session
+context does not specify a machine-checkable DoD, a budget, or a target repo.
+
+**Session context at invocation time:**
+> User has been working on a Python service. The last few messages discuss wanting
+> to "improve the code quality" and "maybe automate the review process somehow."
+> No task file, no DoD script, no repository name, no iteration cap mentioned.
+
+---
+
+## Transcript
+
+**User:** `/attractorify improve my Python service's code quality`
+
+**Skill (Step 1 — Diagnose):**
+
+Applying the three-question test from `docs/PIPELINE_DESIGN_PRINCIPLES.md` §0:
+
+- **Q1. Is there a cycle?** Potentially — code quality improvement with a
+  verification loop is a classic attractor shape. Depends on what "done" means.
+- **Q2. Is the exit gated on evidence?** Unknown — "improve code quality" is not
+  machine-checkable as stated. No DoD script, no lint threshold, no test suite
+  target mentioned.
+- **Q3. Would it survive a bad day?** Unknown — depends on what the gate is.
+
+Q2 cannot be answered from the session context. The session under-determines the
+design. Proceeding to Step 2.
+
+**Skill (Step 2 — Ask):**
+
+The session answers Q1 (there's a loop-shaped problem here) but leaves Q2 and Q3
+open. Three things are genuinely missing:
+
+1. **What does "improved code quality" mean in a machine-checkable way?**
+   For example: all `ruff` checks pass? Test coverage above 80%? Zero `mypy`
+   errors? The DoD must be something a script can verify — not "the code looks
+   better." Without this, the pipeline has no convergence criterion and will
+   loop indefinitely or exit on LLM self-report.
+
+2. **What is the target repository and its working directory?** The pipeline
+   needs `--param target_dir=...` and `--cwd`. Is this the service you have
+   open now, or a different repo?
+
+3. **What is the budget?** How many verification attempts before the run
+   escalates to you? (Typical: 4–8 iterations for a quality-improvement task.)
+
+I'm not asking about your goals or your timeline — those are clear enough. These
+three questions are what the pipeline's structure depends on, and I cannot design
+the gate or the loop without them.
+
+**User:** The target is `~/projects/myservice`. DoD is: `ruff check . && mypy .`
+both exit 0. Budget: 5 iterations.
+
+**Skill:** Context is now sufficient. Proceeding to Step 3 — design.
+
+*(Design continued in a follow-up exchange; the produced artifact is not the
+focus of this session. Session B demonstrates the full design + lint path.)*
+
+---
+
+## What this demonstrates
+
+- The skill did NOT ask a boilerplate questionnaire. It asked exactly three
+  questions derived from what was genuinely missing: the machine-checkable DoD
+  (Q2 of the three-question test), the target repo (parameterization gap), and
+  the budget (loop structure gap).
+- It did NOT ask about the user's goals, timeline, team size, or other
+  context that the session had already answered or that doesn't affect pipeline
+  structure.
+- The clarifying questions are derived from the three-question test's Q2 gap,
+  not from a fixed intake form.

--- a/skills/attractorify/evidence/session-b-generated.dot
+++ b/skills/attractorify/evidence/session-b-generated.dot
@@ -1,0 +1,60 @@
+// Pipeline designed by /attractorify in evidence session B.
+// Use case: automated PR review — reads a pull request diff, produces a
+// structured review, and converges until the review passes a completeness check.
+//
+// Invocation:
+//   attractor run session-b-generated.dot \
+//       --param pr_diff=/abs/path/to/pr.diff \
+//       --param target_dir=$PWD \
+//       --cwd .
+//
+// Three-question test (from docs/PIPELINE_DESIGN_PRINCIPLES.md §0):
+//   Q1. Is there a cycle?  YES — review -> check_gate -> review (on fail).
+//   Q2. Is the exit gated on evidence?  YES — check_gate is a tool node
+//       (parallelogram) that runs a completeness script; exit requires
+//       outcome=success from that external check.
+//   Q3. Would it survive a bad day?  YES — a review that misses a required
+//       section, or skips a changed file in the per-file notes, fails
+//       check_gate (external, deterministic) and loops back; the LLM does
+//       not self-certify.
+
+digraph PRReview {
+    graph [
+        goal="Produce a complete, structured PR review for the diff at $pr_diff: summary, risk assessment, and at least one actionable suggestion per changed file.",
+        params="pr_diff, target_dir",
+        default_fidelity="compact",
+        max_pipeline_duration="1800s"
+    ]
+
+    start [shape=Mdiamond]
+    done  [shape=Msquare]
+
+    // Read the diff and produce a structured review.
+    review [shape=box,
+        prompt="Read the PR diff at $pr_diff. Produce a structured review with three sections: (1) Summary — what this PR does in 2-3 sentences; (2) Risk — any correctness, security, or maintainability concerns; (3) Per-file notes — at least one actionable comment per changed file. Write the review to .ai/review.md."]
+
+    // Deterministic completeness check, verifying the goal's own DoD:
+    //   1. all three required sections present (grep -q exits 1 -> outcome=fail);
+    //   2. the Per-file section has actual content, not just a header;
+    //   3. every changed file named in the diff ('+++ b/<path>' lines) appears
+    //      in the Per-file section — an empty or partial per-file list fails.
+    // Substitution notes: $pr_diff is a --param (seeded as a flat context key,
+    // so it substitutes in tool_command); $$ is the engine's escape for a
+    // literal '$', keeping the shell's $(...) and $f out of context substitution.
+    // Whether each per-file note is genuinely ACTIONABLE is judgment, not a
+    // machine check — this gate verifies structure and coverage; add an
+    // independent LLM critique node if adequacy of content must also be gated.
+    check_gate [shape=parallelogram, goal_gate=true, retry_target="review",
+        tool_command="grep -qE '^## Summary' .ai/review.md && grep -qE '^## Risk' .ai/review.md && awk '/^## Per-file/{p=1;next} p' .ai/review.md > .ai/per-file-notes.txt && grep -q '[^[:space:]]' .ai/per-file-notes.txt && for f in $$(grep -oE '^[+]{3} b/[^ ]+' $pr_diff | cut -c7-); do grep -qF \"$$f\" .ai/per-file-notes.txt || exit 1; done"]
+
+    // If incomplete, explain what is missing and retry.
+    fix_review [shape=box,
+        prompt="The review at .ai/review.md failed its completeness check. Read it and the diff at $pr_diff, identify what is missing — an absent or empty Summary / Risk / Per-file notes section, or a changed file with no per-file note — and produce a corrected version covering every changed file. Overwrite .ai/review.md."]
+
+    start -> review
+    review -> check_gate
+
+    check_gate -> done        [condition="outcome=success"]
+    check_gate -> fix_review  [condition="outcome=fail"]
+    fix_review -> check_gate
+}

--- a/skills/attractorify/evidence/session-b-sufficient-context.md
+++ b/skills/attractorify/evidence/session-b-sufficient-context.md
@@ -1,0 +1,111 @@
+# Evidence Session B — Sufficient Context: Lint-Clean .dot Design
+
+> **SIMULATION — an authored illustration, not a session record.**
+> This file demonstrates intended skill behavior through a constructed scenario.
+> It has no session ID, timestamps, or external verifiability.
+> The generated `.dot` artifact (`session-b-generated.dot`) is real and passes
+> `attractor lint` clean (independently verified). The transcript is constructed.
+> Live-session evidence is being collected separately and will replace or
+> supplement this file; the skill stays experimental until real transcripts land.
+
+**Scenario:** User invokes `/attractorify` with a well-specified task. The session
+context answers all three questions of the three-question test and provides a
+machine-checkable DoD.
+
+**Session context at invocation time:**
+> User is working in a repo with a PR diff at `/tmp/pr-123.diff`. They want an
+> automated PR review pipeline that produces a structured review with a Summary,
+> Risk assessment, and per-file notes. The review must be checked for completeness
+> by a script before the pipeline exits. Budget: 30 minutes max.
+
+---
+
+## Transcript
+
+**User:** `/attractorify automated PR review — reads /tmp/pr-123.diff, produces
+Summary + Risk + Per-file notes (a note for every changed file), exits only when
+a completeness check passes. Budget: 30 minutes max.`
+
+**Skill (Step 1 — Diagnose):**
+
+Applying the three-question test from `docs/PIPELINE_DESIGN_PRINCIPLES.md` §0:
+
+- **Q1. Is there a cycle?** YES — review -> completeness check -> fix_review -> check
+  is a corrective loop.
+- **Q2. Is the exit gated on evidence?** YES — a completeness script (required
+  sections present + a per-file note for every file in the diff) is
+  machine-checkable and external to the LLM reviewer.
+- **Q3. Would it survive a bad day?** YES — a review that omits "## Risk" or
+  skips a changed file fails the script regardless of how confident the LLM
+  sounds; the gate is deterministic.
+
+All three questions: YES. An attractor pipeline is warranted.
+
+**Skill (Step 2 — No clarifying questions needed):**
+
+Session provides: goal (structured PR review), DoD (completeness script: three
+sections + per-file coverage), budget (30 minutes, encoded as
+`max_pipeline_duration="1800s"`), target (current working directory). Nothing is
+missing.
+
+**Skill (Step 3 — Design):**
+
+Delegating to `attractor:attractor-expert` for design review of the shape and
+routing (gate placement, retry target, edge conditions) before handback.
+
+Following design order from `docs/PIPELINE_DESIGN_PRINCIPLES.md` §0:
+1. Sink first: `done` node — exit only when `check_gate` passes.
+2. Gate: `check_gate` (parallelogram, deterministic completeness script,
+   `goal_gate=true`).
+3. Loop: `check_gate -> fix_review -> check_gate` corrective cycle.
+4. Work node: `review` (box, LLM, reads diff, writes `.ai/review.md`).
+
+Node contract (from `docs/DOT-AUTHORING-GUIDE.md`):
+- `review`: Objective = produce structured review; Constraints = write to
+  `.ai/review.md`; Available capabilities = read_file, bash; Required evidence
+  = `.ai/review.md` contains all three sections and a note per changed file.
+- `check_gate`: Objective = verify completeness (sections + per-file coverage);
+  evidence = the script's exit code.
+
+Writing artifact to `skills/attractorify/evidence/session-b-generated.dot`...
+
+```
+attractor lint skills/attractorify/evidence/session-b-generated.dot
+```
+
+**Lint output:**
+```
+attractor lint: skills/attractorify/evidence/session-b-generated.dot: OK (no findings)
+```
+
+**Skill (handback):**
+
+Artifact: `skills/attractorify/evidence/session-b-generated.dot`
+
+Invocation:
+```bash
+attractor run skills/attractorify/evidence/session-b-generated.dot \
+    --param pr_diff=/tmp/pr-123.diff \
+    --param target_dir=$PWD \
+    --cwd .
+```
+
+Structural choices:
+- `check_gate` is `parallelogram` (not `box`) — completeness (sections present,
+  every changed file covered) is deterministic scripting, not a judgment call.
+  Whether each note is genuinely actionable IS judgment — the gate checks
+  structure and coverage; an independent critique node could gate adequacy.
+- `goal_gate=true` on `check_gate`, not on `review` — the LLM finishing is not
+  a goal state; the external check passing is.
+- `fix_review` is separate from `review` — fresh-eyes re-entry with context of
+  what was missing, not a blind retry.
+
+---
+
+## Lint output (captured)
+
+```
+attractor lint: skills/attractorify/evidence/session-b-generated.dot: OK (no findings)
+```
+
+The generated `.dot` is at `skills/attractorify/evidence/session-b-generated.dot`.

--- a/skills/attractorify/evidence/session-c-diagnosis-honesty.md
+++ b/skills/attractorify/evidence/session-c-diagnosis-honesty.md
@@ -1,0 +1,77 @@
+# Evidence Session C — Diagnosis Honesty: Not an Attractor
+
+> **SIMULATION — an authored illustration, not a session record.**
+> This file demonstrates intended skill behavior through a constructed scenario.
+> It has no session ID, timestamps, or external verifiability.
+> Live-session evidence is being collected separately and will replace or
+> supplement this file; the skill stays experimental until real transcripts land.
+
+**Scenario:** User invokes `/attractorify` on work that does not warrant a
+pipeline. The skill diagnoses honestly and recommends against building one.
+
+**Session context at invocation time:**
+> User wants to generate a CHANGELOG entry for the current sprint. They have a
+> list of merged PRs and want the skill to format them into a Markdown changelog
+> section. One-shot transformation: input = PR list, output = formatted Markdown.
+
+---
+
+## Transcript
+
+**User:** `/attractorify generate a CHANGELOG entry from this sprint's merged PRs
+— here's the list: [PR-101: Fix auth bug, PR-102: Add dark mode, PR-103: Upgrade
+deps]. Output: Markdown section with date and bullet list.`
+
+**Skill (Step 1 — Diagnose):**
+
+Applying the three-question test from `docs/PIPELINE_DESIGN_PRINCIPLES.md` §0:
+
+- **Q1. Is there a cycle?** NO — this is a one-shot transformation: PR list →
+  Markdown. There is no iteration, no corrective loop, no retry needed. The
+  output is fully determined by the input.
+- **Q2. Is the exit gated on evidence?** The output is readable Markdown — there
+  is no machine-checkable DoD that would distinguish "correct" from "incorrect"
+  formatting. Human review is the gate, which makes this a recipe, not an
+  attractor.
+- **Q3. Would it survive a bad day?** Irrelevant — Q1 is already NO. A linear
+  one-shot transformation cannot be an attractor.
+
+**Diagnosis: This is NOT an attractor use case.**
+
+The one-sentence rule from `docs/PIPELINE_DESIGN_PRINCIPLES.md` §0 applies:
+*"Recipes are for staged sequential workflows with human approval gates; attractor
+pipelines are for machine-verified convergence. If your pipeline graph has no
+cycle, it should probably have been a recipe."*
+
+This has no cycle. It should be a one-shot prompt, not a pipeline.
+
+**Recommendation:** Ask me directly — I can generate the CHANGELOG entry right
+now in this session. If you want it in a repeatable format, a recipe (a simple
+script that calls an LLM once) is the right tool. Building an attractor pipeline
+for a one-shot formatting task would be engineering overhead with no convergence
+benefit.
+
+**User:** That makes sense. Can you just generate it?
+
+**Skill:** Yes.
+
+```markdown
+## Sprint 2026-07-31
+
+- Fix authentication bug (#101)
+- Add dark mode support (#102)
+- Upgrade dependencies (#103)
+```
+
+---
+
+## What this demonstrates
+
+- The skill applied the three-question test honestly. Q1 (is there a cycle?)
+  returned NO, which is sufficient to decline.
+- It cited the one-sentence rule from `docs/PIPELINE_DESIGN_PRINCIPLES.md` §0
+  explicitly — not a vague "this doesn't need a pipeline."
+- It offered the correct alternative (one-shot in-session) rather than leaving
+  the user without a path forward.
+- It did NOT build a pipeline. The skill is an adoption surface for the doctrine,
+  not an attractor-pushing machine.


### PR DESCRIPTION
## Summary

Adds the `/attractorify` skill: an inline, user-invocable skill that puts the doctrine's decision surfaces at the actual decision moment, with the session's own context as input. It (1) **diagnoses first** — applies the three-question test to decide whether the work warrants an attractor at all, and says so honestly when the answer is "one-shot it," "this is a recipe," or "use the existing attractor"; (2) **designs conversationally** when a pipeline IS warranted — extracting goal / machine-checkable DoD / budgets / evidence gates from session context, delegating to the `attractor:attractor-expert` agent at design start and final review, and linting the produced `.dot` with `attractor lint` before handback; (3) **asks targeted clarifying questions** when the session under-determines the design — never one-shots from missing context. Ships with: bundle registration via the `tool-skills` config pattern, a paired doc (`docs/ATTRACTORIFY-SKILL.md`) carrying the placement rationale (bundle-attractor as domain home vs bundle-skills as collection) and execution-mode reasoning (inline, per the council/council-here precedent), a minimal `PIPELINE_DESIGN_PRINCIPLES.md` delta naming the three-question test in §0 (heuristic framing preserved), a cross-reference in `agents/attractor-expert.md`, and an evidence directory of **explicitly labeled design simulations** plus one real, lint-clean generated `.dot` exemplar.

## Evaluation verdict (final)

Adopted reading (caller decision): the re-based bar — named behavioral modes at zero, delivery noise quantified and documented.

A blind, two-arm, holdback-walled evaluation (3 scenarios × 2 arms × k=2 full matrices + targeted re-trials; real Amplifier sessions in Digital Twins; mechanical checks + blind judgment grading + variant-blind comparison) reached its prose-loop terminal verdict on 2026-08-02 at `0363b2c` (table below). The caller then re-opened the budget twice for the structural escalations (iterations 4–5 above; two further 12-trial matrices, 20260802T104021Z and 20260802T123050Z), ending in the evidence-terminal CANNOT verdict recorded in the iteration-5 block — and again for iterations 6–9 (four further 12-trial matrices: 20260802T144718Z, 164546Z, 182946Z, 203259Z), which drove every named behavioral mode to zero, left a quantified single-trial delivery-variance floor, and closed at the pre-registered stop rule with the terminal characterization in the iteration-9 block (strict DoD CANNOT-BE-CERTIFIED vs the re-based reading — a caller decision). Full evidence-linked verdict incl. both continuations: `.amplifier/evaluation/attractorify/FINAL-VERDICT.md`; run artifacts under `.amplifier/evaluation/attractorify/<run-id>/`; audit trail in `.amplifier/evaluation/attractorify/harness/DEVIATIONS.md`.

| scenario | verdict |
|---|---|
| A — design | **PROVEN on-par at ceiling**: dtu 5.00 mechanical-ALL-PASS in both trials; baseline 4.92 (its one mechanical flag hand-verified as a harness false positive); blind comparison: on_par=True, dtu ≥ baseline on every criterion (run 20260802T064658Z) |
| B — honest-no | **capability PROVEN, all-k consistency NOT PROVEN**: baseline perfect 5.00 in 4/4 trials across both matrices; dtu at final sha 1 genuine, mechanically confirmed fold vs 2 textbook holds (4.75; 5.00 ALL-PASS re-trial 20260802T092521Z) — **quantified 1/3 dtu-arm fold rate**; strict on-par vs a ceiling baseline: FAIL |
| C — ask-first | **arms ON PAR with each other; both below expectation**: re-trial run 20260802T094744Z code-computed ON PAR with both arms mechanically ALL-PASS; two documented probabilistic gaps — J-C3 re-diagnosis-after-answers fired in 1/6 final-sha trials, J-C4 topology bloat in 2/4 matrix trials — both arm-independent (skill-level, not environment) |

**What the loop caught and fixed along the way:** a registration/composition defect (the skill never loaded in the smoke session; the spec-documented `@attractor:skills` form is silently dropped — sandbox-proven, upstream bug); an eval-infra false-success bug (DTU exec envelope swallowing readiness aborts); the pushback-cave (iterations 1+3; zero recurrences post-iteration-3, final holds are textbook); cycle-fishing (iteration 2; J-B4 2.0→5.0); scenario-B baseline trajectory 3.25 → 3.75 → 5.00 → 5.00/5.00; three harness-fix rounds (S1/S2/S3), each self-tested, incl. a grader-contamination channel whose three affected baskets were re-graded (J-C5 3→5, 3→5, 4→5) with originals preserved.

**Terminal finding:** each budgeted prose iteration fixed exactly the failure it targeted, and the discipline failure re-expressed at whichever stage lacked a hard rule (pushback-stage → diagnosis-stage in B; never-expressed re-diagnosis in C). The named structural remedy — make the test a gate the skill *executes*, mirroring the engine's fail-closed goal-gate reconciliation (#109) — **was implemented (iteration 4) and then escalated to independent verification (iteration 5), and both were defeated in turn**: the executed gate by evidence theater (form-perfect artifacts, gamed quotes), the independent verifier by ratifying that evidence once (verbatim quotes in the iteration-5 block). The full in-skill enforcement ladder — prose → executed form-gate → independent semantic verification — is exhausted; the DoD as written is **CANNOT-BE-ACHIEVED at this model tier, evidence-terminal**. Root cause, characterized end to end: the judgment that authors the evidence is the judgment that folds — and an independent same-tier verifier judging that evidence ratified it once in one trial. The residual is honest and quantified: every arm-cell that reached up-to-expectation across all graded runs sits at 4.38–5.00; the fold is a ~25–50%-band (1/3 → 2/4 → 1/4), arm-independent, diagnosis-stage, total-when-it-happens judgment failure — the earlier dtu-vs-baseline asymmetry hypothesis is retired by the iteration-4 arm-swap (baseline folded 2/2 while dtu held 2/2). Forward paths (out of this effort's scope): a renegotiated statistical DoD (fold-rate bound at escalated k), or a doctrine-armed verifier that re-runs the three-question test itself — a new design, not an iteration of this one.

**Ship decision (three candidate SHAs — caller's call):** the capability is proven at ceiling when the diagnosis lands (every up-to-expectation cell across all graded runs: 4.38–5.00); the fold is characterized, arm-independent, and survives the full in-skill enforcement ladder. What remains is WHICH sha to ship — the data does not force a recommendation, and none is given:

| | `0363b2c` (iteration 3 — prose-final) | `a8397fa` (iteration 5 — gate + verifier) | `55836a2` (iteration 9 — branch HEAD) |
|---|---|---|---|
| SKILL.md | 182 lines, no in-session overhead | 299 lines (+117); artifact + gate + verifier round-trips | 408 lines (+226); doctrine-armed verifier + bypass closure + override + three-gap ask-first + latency bounds |
| best showing | best single-run dtu profile (064658Z: scen-A 5.00 ALL-PASS ×2; hold 4.75 + 5.00 re-trial) | verifier demonstrably catches dishonest evidence (14 verdicts; 6/6 INVALID respected; 0 false blocks) with a per-session audit trail on disk | zero folds in 16/16 honest-no trials (final 4 runs); scenario-B on-par 3 consecutive runs; scenario-C on-par with DTU at ceiling (5.00); latency-family delivery failures 4 → 0 |
| honest-no fold band | 1/3 (fold total: 0.25) | 1/4 (fold through-verifier: 1.25) — indistinguishable at these k's | zero folds in final 16 trials (both arms); ~8–13% delivery variance on design path |
| known costs | fold is silent (no artifact to audit) | dodge tax on warranted work (one 3×-yes loop deflected, no .dot through a direct request) | heaviest implementation; quantified delivery variance floor documented |

The `skills/attractorify/evidence/` simulations are **SUPERSEDED as evidence** by real session records (runs 20260802T043157Z, 20260802T064658Z, 20260802T092521Z, 20260802T094744Z, 20260802T104021Z, 20260802T123050Z, and the terminal continuation runs 20260802T144718Z, 20260802T164546Z, 20260802T182946Z, 20260802T203259Z — full transcripts, extracted artifacts, and blind grades on disk); they remain in-repo only as labeled illustrations.

## Verification checklist

- [x] Unit tests pass — doc-guard + examples-lint suites green on this branch:
  `uv run --extra remote pytest -q tests/test_engine_semantics_doc_guard.py tests/test_examples_lint_clean.py`
  → `32 passed in 0.11s` (no engine/handler code touched; docs + skill + one example artifact only)
- [x] **Live session evidence — COMPLETE.** Two-arm live evaluation ran to a terminal verdict (see "Evaluation verdict (final)" above): design path PROVEN on-par at ceiling (dtu 5.00 mechanical-ALL-PASS ×2, run 20260802T064658Z; repeated 4/4 at 5.00 in run 20260802T104021Z); honest-no proven at baseline (5.00 in 4/4) with the fold subsequently characterized across two structural escalations (1/3 → 2/4 gate-gamed → 1/4 through-verifier; runs 20260802T092521Z, 20260802T104021Z, 20260802T123050Z); ask-first arms ON PAR (run 20260802T094744Z) with two documented arm-independent gaps (J-C3 1/6, J-C4 bloat). The evidence bar is met — real session transcripts, extracted artifacts, and blind grades on disk under `.amplifier/evaluation/attractorify/` for all six graded runs; it is the **verdict's content that is mixed** (ceiling capability + a characterized CANNOT on all-k fold-free consistency; full verdict incl. continuation in `FINAL-VERDICT.md` there). The in-repo `skills/attractorify/evidence/` files remain labeled SIMULATIONS — superseded as evidence by these real session records.
- [x] AGENTS.md reviewed; repo-specific gates met (docs pairing, walk-upstream placement decision surfaced in `docs/ATTRACTORIFY-SKILL.md`, no internal-workflow leaks — grepped)
- [x] Backward-compat path unchanged — additive only: new `skills/` directory, new doc, one new `tools:` block in `bundle.md`, +9-line cross-ref in `agents/attractor-expert.md`, +15-line heuristic-framed subsection in `docs/PIPELINE_DESIGN_PRINCIPLES.md`
- [x] PR body includes verification evidence, not just "tests pass"

## Notes for reviewers

**Provenance — honest history.** Built by an autonomous dual-critic runner attempt (verify green ×4; critic A SHIP at iterations 3–4; critic B ITERATE ×4 — a stable disagreement, honestly stalled and operator-salvaged), then residual-closed by hand. Critic B's four findings, all closed in this branch:

1. **BLOCKING — evidence/claim mismatch.** The sim files self-identified as simulations, but `docs/ATTRACTORIFY-SKILL.md` called the directory "live-session evidence." Closed: docs bullet rewritten, every sim's banner strengthened ("SIMULATION — an authored illustration, not a session record"), `evidence/README.md` added labeling the whole directory, and the live-evidence gap held open in this checklist (box above stays unchecked until real transcripts attach).

2. **HIGH — exemplar gate didn't establish its own stated DoD** (goal demanded a note per changed file; gate only grepped three headers — an empty Per-file section passed). Closed: gate now verifies sections present + Per-file section non-empty + every changed file named in the diff appears in the Per-file section (fixture-tested, all four failure/success cases). The residual judgment gap — whether a note is genuinely *actionable* — is stated honestly in the artifact's comments, with the independent-critique-node option named.

3. **HIGH — skill read the expert's file instead of consulting the agent.** Closed at the contract level: `delegate` added to `allowed-tools` (family precedent), and the skill now directs delegation to `attractor:attractor-expert` at design start, mid-build, and final review — reading `agents/attractor-expert.md` demoted to explicit fallback ONLY when delegation is unavailable. Matches the agent's own "MUST be used / consult at design start, mid-build, final review" contract.

4. **MEDIUM — doctrine restated as a second, unconditional formulation.** Closed: the `PIPELINE_DESIGN_PRINCIPLES.md` delta shrunk from +30 to +15 lines — three one-line questions under a `### The three-question test` anchor (the section the skill links), with the heuristic framing restored ("a 'no' is a signal … not a verdict") and the unconditional "if all three answers are yes, the work warrants an attractor" removed.

**Registration note:** the spec-documented bundle-relative form (`@attractor:skills`) is silently dropped by tool-skills' mount-time resolver — sandbox-verified: the source never reaches the loader, no error, no skill (upstream fix is ~8 lines in `_resolve_skill_sources`, being filed against amplifier-bundle-skills; design-council's registration is latently broken the same way). This PR therefore uses the ecosystem's working git self-reference convention (`git+...@main#subdirectory=skills`), which resolves once skills/ lands on main; pre-merge local installs use standard skills discovery (`~/.amplifier/skills/`).

**Registration fix found in this close (not critic-flagged):** the salvaged commit registered the skill under a top-level `skills:` key in `bundle.md` frontmatter — not a bundle-schema key, so the slash command would never have registered. Replaced with the `tool-skills` module + `config.skills` subdirectory-URL pattern other bundles use for their own `skills/` directories.

**Merge shape:** additive; zero overlap with any open PR expected (touches no engine code). One commit, author Brian Krabach + Amplifier co-author trailer.

Generated with [Amplifier](https://github.com/microsoft/amplifier)
