### PR TITLE
feat(lint): command-content lint rules CMD-001/CMD-002 — pipe-masked exit codes + always-true sentinels

### DIFF
--- a/docs/DOT-AUTHORING-GUIDE.md
+++ b/docs/DOT-AUTHORING-GUIDE.md
@@ -764,6 +764,8 @@ Set these on the `graph` element:
 | Using `full` fidelity everywhere | High cost, slow execution | Use `full` only where conversation continuity matters |
 | Circular dependencies without exit | Infinite loop | Ensure every cycle has a conditional exit path |
 | `condition=\"key=value\"` (backslash delimiters) | Parser error (or, before the fail-loud fix, silent wrong routing) | Use plain quotes: `condition="key=value"` — see callout above |
+| `tool_command="cmd 2>&1 \| tail -N"` (pipe-masked exit code, CMD-001) | In `/bin/sh`, the pipeline's exit code is `tail`'s — always 0.  The gate records SUCCESS even when `cmd` failed. | Redirect instead: `cmd > out.log 2>&1`.  See CMD-001 below. |
+| `tool_command="cmd \| tail -N && echo TOKEN"` (always-true sentinel, CMD-002) | `tail` exits 0, so `&& echo TOKEN` fires unconditionally.  `tool.last_line` becomes the sentinel regardless of `cmd`'s result. | Use the honest token gate: `cmd && printf ok \|\| printf fail` (no pipe).  See CMD-002 below. |
 
 ## Complete Example: Feature Build Pipeline
 
@@ -1039,6 +1041,124 @@ loop via fail-fast before the LLM assessor ever judges the work.
 
 The check runs per SCC so that a compliant loop does not suppress diagnostics
 for a separate non-compliant loop.
+
+---
+
+### CMD-001 — Pipe-masked exit code
+
+**What it detects:** A `parallelogram` (tool) node whose `tool_command` ends
+in a pipe to a filter or pager program (`tail`, `head`, `grep`, `sed`, `awk`,
+`cut`, `sort`, `uniq`, `wc`, `xargs`) without `set -o pipefail`.
+
+**Why it matters:** In `/bin/sh` (the engine's execution environment), a
+pipeline's exit status is the **last stage's** — not the real command's.
+`false | tail -1` exits 0 whenever `tail` can read its input, which is always.
+The gate records SUCCESS even when the wrapped command failed with a fatal
+error.
+
+This was the root cause of the 2026-07-28 incident: a `run_harness` node
+printed `bash: scripts/verify-remote-access.sh: No such file or directory`
+and recorded **SUCCESS** (duration ~1 s) because its `tool_command` was
+`cmd 2>&1 | tail -N`.  The pipeline ran 2.4 h and exited success with zero
+work product.
+
+**The two honest gate idioms (not flagged):**
+
+```sh
+# Token gate — always exits 0; routing on the emitted token
+cmd && printf green || printf red
+
+# Exit-code gate — preserves failure
+cmd && printf green || { printf red; exit 1; }
+```
+
+Both idioms preserve the wrapped command's result.  The hazard shape destroys
+it.
+
+**Doctrinally-correct alternative:** redirect output to a file instead of
+piping to `tail`.  This preserves the exit code AND keeps `tool.last_line`
+clean (it becomes the routing token, not noise):
+
+```sh
+# WRONG — exit code is tail's (always 0)
+cmd 2>&1 | tail -30
+
+# CORRECT — exit code is cmd's; output in out.log for diagnostics
+cmd > out.log 2>&1
+```
+
+If you need to see the last N lines, write to a file and read it separately
+from the routing logic.
+
+**Severity:** WARNING — consistent with the TOPO rule family.  The hazard is
+real but static analysis cannot prove the command is a meaningful gate;
+conservative analysis may miss complex cases.
+
+**Suppression:** The lint rule is suppressed when `set -o pipefail` appears as
+an **executable shell statement** in the command (not inside a quoted string).
+`echo "set -o pipefail"; false | tail -1` does NOT suppress the rule — the
+`set` is inside a quoted argument to `echo`, not executed.  Only a bare
+`set -o pipefail` (or `set -eo pipefail`, `set -euo pipefail`, etc.) that
+appears outside quotes suppresses CMD-001.
+
+**Important:** `pipefail` is not POSIX sh — on Debian/Ubuntu-family systems
+`/bin/sh` is `dash`, where `set -o pipefail` exits 2 with `Illegal option`.  The engine
+runs tool commands under `/bin/sh`.  If you write `set -o pipefail` to suppress
+this warning, your tool command must explicitly invoke bash:
+`bash -c 'set -o pipefail; ...'`.  The portable alternative is the redirect
+idiom (shown above) or the honest token gate without a pipe:
+`cmd && printf ok || printf fail`.
+
+**What this rule does NOT catch:** pipes inside `$(...)` command substitutions,
+pipes inside single- or double-quoted strings (e.g. `echo 'false | tail -1'`
+is safe), `bash -o pipefail -c '...'` wrappers (pipefail not detected inside
+the quoted string argument), explicit exit-code capture (`cmd | tail; rc=$?;
+...` — use the redirect idiom or `set -o pipefail` for a suppression that lint
+detects), custom filter scripts not in the recognised set, or pipes in a
+non-final `;`-separated segment (e.g. `false | tail -1; echo done` is CLEAN —
+`echo done` determines the exit code).
+
+---
+
+### CMD-002 — Always-true sentinel
+
+**What it detects:** A `parallelogram` (tool) node whose `tool_command`
+contains a pipe to a filter/pager followed by `&& echo TOKEN` or
+`&& printf TOKEN` at the end of the command.  The sentinel fires
+unconditionally because the filter always exits 0 when it can read its input.
+
+**Why it matters:** `tool.last_line` (the primary routing channel) becomes
+the sentinel string regardless of whether the wrapped command succeeded.
+The gate always says yes.
+
+Example hazard (incident shape):
+```sh
+sh -c 'exit 1' 2>&1 | tail -5 && echo GREEN
+# tail exits 0 → && echo GREEN fires → tool.last_line = "GREEN"
+# The routing channel says success unconditionally.
+```
+
+Contrast with the honest token-gate idiom (NOT flagged):
+```sh
+# Both branches fire — the || distinguishes success from failure
+cmd && printf green || printf red
+
+# Exit-code gate — failure is preserved
+cmd && printf green || { printf red; exit 1; }
+```
+
+**The key discriminator:** does the command's success or failure still
+influence either the exit code or the emitted token?  The hazard shapes
+destroy that influence.  The honest idioms preserve it.
+
+**Severity:** WARNING — consistent with CMD-001 and the TOPO rule family.
+
+**What this rule does NOT catch:** sentinels inside `$(...)` substitutions,
+sentinels after non-pipe-masked commands (where `&& echo TOKEN` is the honest
+token-gate idiom and is safe), variable-interpolated filter names, or sentinels
+where the pipe appears in a non-final `;`-separated segment (e.g.
+`false | tail -1; echo done && echo SENTINEL` is CLEAN — the final segment
+`echo done && echo SENTINEL` has no pipe).
 
 ---
 

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/validation.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/validation.py
@@ -7,10 +7,16 @@ with severity ERROR (blocks execution) or WARNING (informational).
 Spec coverage: LINT-001–018.  TOPO-001–005 are topological basin-lint rules
 implemented here beyond the canonical spec; they are lint-only (exposed via
 ``lint()``, not ``validate()``) and do not change run-time behaviour.
+
+CMD-001–002 are command-content lint rules that inspect ``tool_command``
+strings for two specific hazard shapes: pipe-masked exit codes (CMD-001) and
+always-true trailing sentinels (CMD-002).  Both are lint-only (WARNING
+severity) and do not change run-time behaviour.
 """
 
 from __future__ import annotations
 
+import re
 from collections import deque
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -105,16 +111,17 @@ def validate(
 
 
 def lint(graph: Graph) -> list[Diagnostic]:
-    """Run topological (basin-lint) rules in addition to structural rules.
+    """Run topological (basin-lint) and command-content rules in addition to structural rules.
 
     This is the entry point for the ``attractor lint`` CLI command.  It runs
-    the full structural ``validate()`` suite plus the five new topological
-    rules (TOPO-001–005) that reason about cycle structure, handler semantics,
-    and evidence-routing patterns.
+    the full structural ``validate()`` suite plus the five topological rules
+    (TOPO-001–005) that reason about cycle structure, handler semantics, and
+    evidence-routing patterns, plus the two command-content rules (CMD-001–002)
+    that inspect ``tool_command`` strings for hazard shapes.
 
-    Topological rules are lint-only: they do not change run-time validation
-    behaviour.  Existing graphs that execute today will not start failing at
-    ``run`` time because of new WARNINGs produced here.
+    All lint-only rules do not change run-time validation behaviour.  Existing
+    graphs that execute today will not start failing at ``run`` time because of
+    new WARNINGs produced here.
 
     Exit-code contract (for CLI use):
         ERROR-severity diagnostics → non-zero exit.
@@ -128,6 +135,8 @@ def lint(graph: Graph) -> list[Diagnostic]:
     _check_acyclic_graph(graph, diags)
     _check_cycle_no_conditional_exit(graph, diags)
     _check_cycle_no_deterministic_exit(graph, diags)
+    _check_pipe_masked_exit_code(graph, diags)
+    _check_always_true_sentinel(graph, diags)
     return diags
 
 
@@ -1242,3 +1251,568 @@ def _check_cycle_no_deterministic_exit(graph: Graph, diags: list[Diagnostic]) ->
                 ),
             )
         )
+
+
+# ---------------------------------------------------------------------------
+# Command-content lint rules — CMD-001 and CMD-002
+#
+# These rules inspect ``tool_command`` attribute strings on parallelogram
+# (ToolHandler) nodes for two specific hazard shapes that cause the gate's
+# exit code to lie: pipe-masked exit codes (CMD-001) and always-true trailing
+# sentinels (CMD-002).
+#
+# Both rules are lint-only (WARNING severity) and do not change run-time
+# behaviour.  They are conservative by design: a regex/tokenizer catching the
+# two named shapes with low false positives beats an ambitious parser that
+# misfires.  Each rule's docstring states what it does NOT catch.
+#
+# Real-world incident (2026-07-28): a 20-node pipeline ran 2.4 h and exited
+# success with zero work product.  Every one of its 5 tool nodes was shaped
+# ``cmd 2>&1 | tail -N``, and 4 ended ``&& echo SENTINEL``.  The incident
+# graph linted "OK, no findings" on the pre-CMD main — these rules exist to
+# close that gap.
+#
+# Severity decision: WARNING (not ERROR).
+#   • Consistent with TOPO-002–005 (design smells, not provable defects).
+#   • Does not break existing users' lint runs or force fixing shipped examples.
+#   • The hazard is real but command content is not fully statically analysable;
+#     conservative analysis may miss complex cases.
+#   • ``test_examples_lint_clean.py`` only blocks on ERRORs, so WARNING leaves
+#     the sweep untouched.
+#
+# Engine pipefail-default recommendation: DEFER.
+#   • ``create_subprocess_shell`` targets ``/bin/sh``; ``pipefail`` is not
+#     POSIX sh and is unavailable on some platforms.
+#   • A behaviour change for every existing graph requires an EXTENSIONS.md
+#     ledger entry and a compat inventory — that is a separate ledgered change.
+#   • These lint rules are valuable either way: even under pipefail, a trailing
+#     ``&& echo SENTINEL`` still masks nothing-happened cases, and authors
+#     reading lint output learn the hazard.
+# ---------------------------------------------------------------------------
+
+# Recognised filter/pager programs whose presence as the final pipeline stage
+# masks the real command's exit code.  ``tee`` is intentionally excluded: it
+# preserves output (and is typically combined with redirection for logging).
+_PIPE_FILTER_PROGRAMS: frozenset[str] = frozenset(
+    {"tail", "head", "grep", "sed", "awk", "cut", "sort", "uniq", "wc", "xargs"}
+)
+
+# Regex for pipefail options following a standalone ``set`` builtin.  Detection
+# is deliberately limited to a top-level command statement whose first word is
+# ``set``; arbitrary text such as an ``echo`` argument or shell comment must
+# not suppress a real finding.
+_PIPEFAIL_OPTIONS_RE = re.compile(r"^set\s+-(?:[A-Za-z]*o\s+pipefail|o\s+pipefail)\b")
+
+# Regex: matches ``&& echo TOKEN`` or ``&& printf TOKEN`` (with optional
+# whitespace) at the end of a command segment.  The sentinel may be followed
+# only by whitespace or end-of-string.
+_SENTINEL_RE = re.compile(r"&&\s*(?:echo|printf)\s+\S+\s*$")
+
+
+def _strip_command_substitutions(cmd: str) -> str:
+    """Remove ``$(...)`` command substitutions from a shell command string.
+
+    This is a conservative, non-recursive strip: it removes the innermost
+    ``$(...)`` groups first (depth-1 only) so that pipes inside substitutions
+    do not confuse the top-level pipeline analysis.  Nested substitutions are
+    replaced with a placeholder that cannot match any pipe pattern.
+
+    This is NOT a full shell parser — it handles the common case of
+    ``sig=$(... | ...)`` without misidentifying the inner pipe as a top-level
+    gate pipe.
+    """
+    # Iteratively strip innermost $(...) groups (no nested $() inside)
+    # until no more are found.  Limit iterations to avoid pathological inputs.
+    placeholder = "__SUBST__"
+    for _ in range(20):
+        new_cmd, count = re.subn(r"\$\([^()]*\)", placeholder, cmd)
+        if count == 0:
+            break
+        cmd = new_cmd
+    return cmd
+
+
+def _strip_quoted_strings(cmd: str) -> str:
+    """Return the command with all quoted string contents replaced by a placeholder.
+
+    Removes the contents of single-quoted (``'...'``) and double-quoted
+    (``"..."``) strings, replacing them with ``__QUOTED__``.  Backslash
+    escapes inside double-quoted strings are respected.
+
+    Used to make ``_has_executable_pipefail`` quote-aware: ``echo "set -o pipefail"``
+    should not suppress CMD-001 because the ``set`` is inside a quoted
+    argument to ``echo``, not an executable shell statement.
+
+    This is NOT a full shell parser.  It does not handle ``$'...'`` ANSI-C
+    quoting, heredocs, or nested quoting.  Conservative: when in doubt,
+    the quoted content is stripped (reducing false suppressions).
+    """
+    result: list[str] = []
+    in_single = False
+    in_double = False
+    i = 0
+    n = len(cmd)
+    while i < n:
+        ch = cmd[i]
+        if in_single:
+            if ch == "'":
+                in_single = False
+                result.append("__QUOTED__")
+            # else: skip quoted content
+        elif in_double:
+            if ch == "\\":
+                i += 2  # skip escaped character
+                continue
+            elif ch == "\"":
+                in_double = False
+                result.append("__QUOTED__")
+            # else: skip quoted content
+        else:
+            if ch == "'":
+                in_single = True
+            elif ch == "\"":
+                in_double = True
+            else:
+                result.append(ch)
+        i += 1
+    return "".join(result)
+
+
+def _has_executable_pipefail(cmd: str) -> bool:
+    """Return whether a top-level ``set -o pipefail`` statement is present.
+
+    This is intentionally narrower than searching for the words ``pipefail``.
+    It recognizes a standalone ``set`` statement at the beginning of the
+    command or immediately after a top-level semicolon/newline.  Thus quoted
+    output, comments, and conditional text such as ``false && set -o
+    pipefail`` cannot suppress a finding when the setting may not execute.
+    This conservative scanner is not a general shell parser.
+    """
+    unquoted = _strip_quoted_strings(cmd)
+    for statement in re.split(r"[;\n]", unquoted):
+        statement = statement.strip()
+        if not statement or statement.startswith("#"):
+            continue
+        if _PIPEFAIL_OPTIONS_RE.match(statement):
+            return True
+    return False
+
+
+def _final_semicolon_segment(cmd: str) -> str:
+    """Return the final ``;``-separated segment of a shell command string.
+
+    Splits only on top-level ``;`` (not ``&&`` or ``||``) outside quotes and
+    parentheses, and returns the last segment.  This is the segment that
+    unconditionally executes last and whose exit code determines the overall
+    command's exit code when the command uses ``;`` as a separator.
+
+    Deliberately does NOT split on ``&&`` or ``||`` — those chains are
+    preserved within the final segment.  That is important for CMD-001:
+    ``cmd | tail && echo SENTINEL``
+    is a single semicolon-segment whose pipe is still the hazard, whereas
+    ``cmd | tail; echo done`` has a clean final segment (``echo done``) that
+    determines the exit code.
+
+    Conservative: does not handle here-docs, process substitution, or deeply
+    nested constructs.  Returns the whole command if no ``;`` is found.
+    """
+    segments: list[str] = []
+    depth = 0
+    in_single = False
+    in_double = False
+    current: list[str] = []
+    i = 0
+    while i < len(cmd):
+        ch = cmd[i]
+        if in_single:
+            if ch == "'":
+                in_single = False
+            current.append(ch)
+        elif in_double:
+            if ch == "\\":
+                current.append(ch)
+                i += 1
+                if i < len(cmd):
+                    current.append(cmd[i])
+            elif ch == "\"":
+                in_double = False
+                current.append(ch)
+            else:
+                current.append(ch)
+        else:
+            if ch == "'":
+                in_single = True
+                current.append(ch)
+            elif ch == "\"":
+                in_double = True
+                current.append(ch)
+            elif ch == "(":
+                depth += 1
+                current.append(ch)
+            elif ch == ")":
+                depth = max(0, depth - 1)
+                current.append(ch)
+            elif depth == 0 and ch == ";":
+                seg = "".join(current).strip()
+                if seg:
+                    segments.append(seg)
+                current = []
+            else:
+                current.append(ch)
+        i += 1
+    seg = "".join(current).strip()
+    if seg:
+        segments.append(seg)
+    return segments[-1] if segments else cmd.strip()
+
+
+def _last_pipe_stage_program(segment: str) -> str | None:
+    """Return the program name of the last pipe stage in a command segment.
+
+    Given a segment like ``cmd 2>&1 | tail -30``, returns ``"tail"``.
+    Returns ``None`` if the segment contains no pipe.
+
+    Conservative: splits on ``|`` but excludes ``||`` (logical OR).
+    Does not handle pipes inside subshells or quotes.
+    """
+    # Split on | but not ||
+    # Replace || with a placeholder to avoid splitting on it
+    safe = segment.replace("||", "\x00\x00")
+    if "|" not in safe:
+        return None
+    stages = safe.split("|")
+    if len(stages) < 2:
+        return None
+    last_stage = stages[-1].strip()
+    if not last_stage:
+        return None
+    # Extract the first word (program name), ignoring leading env vars (VAR=val)
+    # and redirections (2>&1, >/dev/null, etc.)
+    tokens = last_stage.split()
+    for token in tokens:
+        # Skip redirections and env-var assignments
+        if re.match(r"^\d*[<>]", token) or re.match(r"^[A-Za-z_][A-Za-z0-9_]*=", token):
+            continue
+        # Return the base program name (strip path prefix)
+        return token.split("/")[-1]
+    return None
+
+
+def _check_pipe_masked_exit_code(graph: Graph, diags: list[Diagnostic]) -> None:
+    """CMD-001: Tool node whose exit code is a filter's, not the real command's.
+
+    Detects parallelogram (ToolHandler) nodes whose ``tool_command`` ends in a
+    filter/pager stage (``tail``, ``head``, ``grep``, ``sed``, ``awk``,
+    ``cut``, ``sort``, ``uniq``, ``wc``, ``xargs``) without ``set -o pipefail``.
+
+    In plain ``/bin/sh`` (the engine's execution environment), a pipeline's
+    exit status is the LAST stage's.  ``false | tail -1`` exits 0 whenever
+    ``tail`` succeeds — always.  The gate records SUCCESS no matter what the
+    real command did.
+
+    What this rule does NOT catch:
+    - Pipes inside ``$(...)`` command substitutions (intentionally excluded —
+      the substitution result is captured, not used as the gate's exit code).
+    - Pipes inside ``$'...'`` ANSI-C quoting or backtick substitutions.
+    - Complex nested subshells or here-docs.
+    - Filter programs not in the recognised set (e.g. custom scripts).
+    - ``bash -o pipefail -c '...'`` wrappers (pipefail not detected inside
+      the quoted string argument — ``bash -o pipefail`` wrapping is a valid
+      but undetected suppression).
+    - Pipes inside single- or double-quoted strings ARE correctly skipped by
+      the quote-aware scanner (e.g. ``echo 'false | tail -1'`` is safe).
+    - Explicit exit-code capture (``cmd | tail; rc=$?; ...``) is not
+      recognised as a suppressor — use ``set -o pipefail`` or the redirect
+      idiom (``cmd > out.log 2>&1``) for a suppression that lint detects.
+    - Commands where the pipe appears in a non-final ``;``-separated segment
+      (e.g. ``false | tail -1; echo done``) are NOT flagged — the final
+      segment ``echo done`` determines the exit code.
+
+    Severity: WARNING — the hazard is real but static analysis cannot prove
+    the command is a meaningful gate; conservative analysis may miss cases.
+    """
+    for node in graph.nodes.values():
+        if not _is_tool(node):
+            continue
+        raw_cmd: str = str(node.attrs.get("tool_command") or "").strip()
+        if not raw_cmd:
+            continue
+
+        # If the command explicitly sets pipefail, the hazard is mitigated.
+        # _has_executable_pipefail matches only standalone ``set`` statements
+        # in quote-stripped text, so ``echo "set -o pipefail"; false | tail -1``
+        # is NOT suppressed — the ``set`` is inside a quoted argument to
+        # ``echo``, not an executable shell statement.
+        if _has_executable_pipefail(raw_cmd):
+            continue
+
+        # Strip command substitutions so inner pipes don't confuse analysis.
+        cmd = _strip_command_substitutions(raw_cmd)
+
+        # Scope the analysis to the final ``;``-separated segment.
+        # ``false | tail -1; echo done`` — the final segment is ``echo done``
+        # (exit code 0, no pipe hazard), so CMD-001 must NOT fire.
+        # ``false | tail -1 && echo SENTINEL`` — the whole command is one
+        # semicolon-segment; the pipe is still the exit-code hazard, so
+        # CMD-001 DOES fire (and CMD-002 catches the sentinel separately).
+        final_seg = _final_semicolon_segment(cmd)
+
+        # Find the last non-|| pipe position in the final segment.
+        last_pipe_pos = _find_last_bare_pipe(final_seg)
+        if last_pipe_pos is None:
+            continue
+
+        # Extract the stage after the last bare pipe.
+        after_pipe = final_seg[last_pipe_pos + 1 :]
+        program = _last_pipe_stage_program("|" + after_pipe)  # re-use helper
+        if program is None or program not in _PIPE_FILTER_PROGRAMS:
+            continue
+
+        # NOTE: a ``||`` branch after the pipe does NOT suppress CMD-001.
+        # ``false | tail -1 && printf green || printf red`` prints ``green``
+        # unconditionally — ``tail`` exits 0, so ``|| printf red`` never fires
+        # for the original failure.  The only genuinely honest ``||`` shapes
+        # are those WITHOUT a masking pipe: ``cmd && printf green || printf
+        # red`` (no pipe), which are already not flagged because
+        # ``_find_last_bare_pipe`` finds no filter in that position.
+
+        diags.append(
+            Diagnostic(
+                rule="CMD-001",
+                severity="WARNING",
+                message=(
+                    f"Tool node '{node.id}' tool_command ends in a pipe to "
+                    f"'{program}' without pipefail: the gate's "
+                    f"exit code is '{program}'s (always 0 on success), not the "
+                    f"real command's.  In /bin/sh a pipeline's exit status is "
+                    f"the last stage's — so 'false | tail -1' exits 0.  The "
+                    f"gate may record SUCCESS even when the wrapped command "
+                    f"failed.  Fix: redirect output to a file "
+                    f"('cmd > out.log 2>&1') to preserve exit code, or capture "
+                    f"exit code explicitly ('cmd; rc=$?; ... && printf ok || "
+                    f"printf fail').  See DOT-AUTHORING-GUIDE.md (CMD-001)."
+                ),
+                node_id=node.id,
+                fix=(
+                    "Replace 'cmd 2>&1 | tail -N' with 'cmd > out.log 2>&1' "
+                    "to preserve the real exit code.  Alternatively, capture "
+                    "the exit code: 'cmd; rc=$?; [ $rc -eq 0 ] && printf ok "
+                    "|| { printf fail; exit 1; }'.  If you need to see the "
+                    "last N lines, write to a file and read it separately."
+                ),
+            )
+        )
+
+
+def _find_last_bare_pipe(cmd: str) -> int | None:
+    """Return the index of the last ``|`` that is not part of ``||``.
+
+    Quote-aware: pipes inside single-quoted or double-quoted strings are
+    skipped so that ``echo 'false | tail -1'`` does not produce a false
+    positive.  Backslash escapes inside double-quoted strings are respected.
+
+    Returns ``None`` if no bare pipe is found outside of quotes.
+    """
+    in_single = False
+    in_double = False
+    last_pipe: int | None = None
+    i = 0
+    n = len(cmd)
+    while i < n:
+        ch = cmd[i]
+        if in_single:
+            if ch == "'":
+                in_single = False
+        elif in_double:
+            if ch == "\\":
+                i += 2  # skip escaped character
+                continue
+            elif ch == "\"":
+                in_double = False
+        else:
+            if ch == "'":
+                in_single = True
+            elif ch == "\"":
+                in_double = True
+            elif ch == "|":
+                # Check it's not part of ||
+                prev_is_pipe = i > 0 and cmd[i - 1] == "|"
+                next_is_pipe = i + 1 < n and cmd[i + 1] == "|"
+                if not prev_is_pipe and not next_is_pipe:
+                    last_pipe = i
+        i += 1
+    return last_pipe
+
+
+def _check_always_true_sentinel(graph: Graph, diags: list[Diagnostic]) -> None:
+    """CMD-002: Trailing ``&& echo/printf TOKEN`` after a pipe-masked command.
+
+    Detects parallelogram (ToolHandler) nodes whose ``tool_command`` contains
+    a pipe to a filter/pager followed by ``&& echo TOKEN`` or
+    ``&& printf TOKEN`` at the end of the command.  The sentinel fires
+    regardless of whether the wrapped command succeeded, making
+    ``tool.last_line`` the sentinel string rather than evidence.
+
+    Example hazard: ``sh -c 'exit 1' 2>&1 | tail -5 && echo GREEN``
+    - ``tail`` exits 0 (it read stdin fine), so ``&& echo GREEN`` fires.
+    - ``tool.last_line`` becomes ``GREEN`` regardless of the inner command.
+    - The routing channel says "success" unconditionally.
+
+    Contrast with the honest token-gate idiom (NOT flagged):
+    - ``cmd && printf green || printf red`` — no pipe; the token gate is
+      honest because ``cmd``'s exit code gates the ``&&``.
+    - ``cmd && printf green || { printf red; exit 1; }`` — exit-code gate;
+      failure is preserved.  Neither has a masking pipe before the sentinel.
+
+    NOTE: a ``||`` branch does NOT suppress CMD-002.  For example,
+    ``false | tail -1 && printf green || printf red`` is still hazardous:
+    ``tail`` exits 0 so ``printf green`` fires unconditionally.
+
+    What this rule does NOT catch:
+    - Sentinels inside ``$(...)`` substitutions.
+    - Sentinels after non-pipe-masked commands (where ``&& echo TOKEN`` is the
+      honest token-gate idiom and is safe — CMD-002 only fires when the
+      command is already pipe-masked).
+    - Multi-line or heredoc command structures.
+    - Variable-interpolated filter names (e.g. ``| $FILTER``).
+    - Commands where the sentinel is followed by ``|| ...`` at the end (those
+      end with the ``||`` branch, not the sentinel, so ``_SENTINEL_RE`` does
+      not match).
+
+    Severity: WARNING — consistent with CMD-001 and the TOPO rule family.
+    """
+    for node in graph.nodes.values():
+        if not _is_tool(node):
+            continue
+        raw_cmd: str = str(node.attrs.get("tool_command") or "").strip()
+        if not raw_cmd:
+            continue
+
+        # If the command explicitly sets pipefail, the hazard is mitigated.
+        # _has_executable_pipefail matches only standalone ``set`` statements
+        # in quote-stripped text, so ``echo "set -o pipefail"; false | tail -1
+        # && echo GREEN`` is NOT suppressed — the ``set`` is inside a quoted
+        # argument, not executed.
+        if _has_executable_pipefail(raw_cmd):
+            continue
+
+        # Strip command substitutions so inner pipes don't confuse analysis.
+        cmd = _strip_command_substitutions(raw_cmd)
+
+        # Scope the analysis to the final ``;``-separated segment.
+        # ``false | tail -1; echo done && echo SENTINEL`` — the final segment
+        # is ``echo done && echo SENTINEL`` (no pipe), so CMD-002 must NOT
+        # fire.  ``false | tail -1 && echo SENTINEL`` — the whole command is
+        # one semicolon-segment; the pipe+sentinel hazard is present.
+        final_seg = _final_semicolon_segment(cmd)
+
+        # CMD-002 pattern: a pipe to a filter FOLLOWED BY && echo/printf TOKEN
+        # at the end of the final segment.
+        #
+        # We look for: ... | <filter> [args] && (echo|printf) TOKEN [end]
+        # where [end] means end-of-string or only whitespace.
+        #
+        # NOTE: a || branch does NOT suppress this rule.  The sentinel fires
+        # unconditionally when the pipe stage is a filter that always exits 0.
+        #
+        # The sentinel must NOT be followed by || (that would be an honest
+        # token gate).
+
+        # Find positions of all bare pipes in the final segment.
+        pipe_positions = _find_all_bare_pipes(final_seg)
+        if not pipe_positions:
+            continue
+
+        for pipe_pos in pipe_positions:
+            after_pipe = final_seg[pipe_pos + 1 :]
+            program = _last_pipe_stage_program("|" + after_pipe)
+            if program is None or program not in _PIPE_FILTER_PROGRAMS:
+                continue
+
+            # There's a pipe to a filter.  Now check if the remainder of the
+            # final segment (after this pipe's stage) ends with
+            # && echo/printf TOKEN.
+            #
+            # Extract the text from this pipe to the end of the final segment.
+            remainder = final_seg[pipe_pos:]
+
+            # Does the remainder contain a sentinel?
+            sentinel_match = _SENTINEL_RE.search(remainder)
+            if not sentinel_match:
+                continue
+
+            # NOTE: a ``||`` branch does NOT suppress CMD-002.
+            # ``false | tail -1 && printf green || printf red`` is still a
+            # hazard: ``tail`` exits 0 so ``printf green`` fires unconditionally
+            # and ``|| printf red`` never fires for the original failure.
+            # The honest token-gate idiom is ``cmd && printf green || printf
+            # red`` WITHOUT a masking pipe — those are not flagged because
+            # ``_find_all_bare_pipes`` finds no filter stage in that position.
+
+            diags.append(
+                Diagnostic(
+                    rule="CMD-002",
+                    severity="WARNING",
+                    message=(
+                        f"Tool node '{node.id}' tool_command has a trailing "
+                        f"'&& echo/printf TOKEN' sentinel after a pipe-masked "
+                        f"command (pipe to '{program}').  The sentinel fires "
+                        f"unconditionally because '{program}' always exits 0 "
+                        f"when it can read its input — so tool.last_line "
+                        f"becomes the sentinel string regardless of whether the "
+                        f"wrapped command succeeded.  The gate always says yes.  "
+                        f"Fix: use the honest token-gate idiom "
+                        f"'cmd && printf ok || printf fail' (no pipe), or "
+                        f"redirect output to a file and test the exit code "
+                        f"explicitly.  See DOT-AUTHORING-GUIDE.md (CMD-002)."
+                    ),
+                    node_id=node.id,
+                    fix=(
+                        "Replace '... | tail -N && echo TOKEN' with the honest "
+                        "token-gate idiom: 'cmd && printf ok || printf fail' "
+                        "(no pipe; exit code gates the token).  Or redirect to "
+                        "a file: 'cmd > out.log 2>&1 && printf ok || printf "
+                        "fail'.  The || branch is what makes the gate honest."
+                    ),
+                )
+            )
+            break  # One CMD-002 diagnostic per node is enough
+
+
+def _find_all_bare_pipes(cmd: str) -> list[int]:
+    """Return indices of all ``|`` characters that are not part of ``||``.
+
+    Quote-aware: pipes inside single-quoted or double-quoted strings are
+    skipped so that ``printf "false | tail -1"`` does not produce a false
+    positive.  Backslash escapes inside double-quoted strings are respected.
+
+    Scans left-to-right.
+    """
+    positions: list[int] = []
+    in_single = False
+    in_double = False
+    i = 0
+    n = len(cmd)
+    while i < n:
+        ch = cmd[i]
+        if in_single:
+            if ch == "'":
+                in_single = False
+        elif in_double:
+            if ch == "\\":
+                i += 2  # skip escaped character
+                continue
+            elif ch == "\"":
+                in_double = False
+        else:
+            if ch == "'":
+                in_single = True
+            elif ch == "\"":
+                in_double = True
+            elif ch == "|":
+                prev_is_pipe = i > 0 and cmd[i - 1] == "|"
+                next_is_pipe = i + 1 < n and cmd[i + 1] == "|"
+                if not prev_is_pipe and not next_is_pipe:
+                    positions.append(i)
+        i += 1
+    return positions

--- a/modules/loop-pipeline/tests/test_command_content_lint.py
+++ b/modules/loop-pipeline/tests/test_command_content_lint.py
@@ -1,0 +1,794 @@
+"""Tests for command-content lint rules — CMD-001 and CMD-002.
+
+CMD-001: pipe-masked exit code — the final ``;``-separated segment of the
+command ends in a filter/pager stage without ``set -o pipefail`` in the
+executable command text, so the gate's exit code is the filter's (always 0),
+not the real command's.  A ``||`` branch does NOT suppress this rule.
+
+CMD-002: always-true sentinel — a trailing ``&& echo/printf TOKEN`` after a
+pipe-masked command.  The sentinel fires unconditionally, making
+``tool.last_line`` the sentinel string regardless of whether the wrapped
+command succeeded.
+
+Test pattern mirrors test_topological_lint.py: construct Graph/Node/Edge
+objects directly (no DOT parsing) for speed and isolation.
+
+False-positive discipline is the primary focus: legit pipes and honest token
+gates must NOT be flagged.  Each false-positive test case documents WHY the
+pattern is safe.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from amplifier_module_loop_pipeline.graph import Edge, Graph, Node
+from amplifier_module_loop_pipeline.validation import (
+    Diagnostic,
+    lint,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — mirrors test_topological_lint.py
+# ---------------------------------------------------------------------------
+
+
+def _mdiamond(node_id: str = "start") -> Node:
+    return Node(id=node_id, shape="Mdiamond", label="Start")
+
+
+def _msquare(node_id: str = "exit") -> Node:
+    return Node(id=node_id, shape="Msquare", label="Exit")
+
+
+def _tool(node_id: str = "tool", tool_command: str = "", **kwargs) -> Node:
+    attrs: dict = {}
+    if tool_command:
+        attrs["tool_command"] = tool_command
+    attrs.update(kwargs)
+    return Node(id=node_id, shape="parallelogram", attrs=attrs)
+
+
+def _graph(
+    nodes: dict[str, Node] | None = None,
+    edges: list[Edge] | None = None,
+) -> Graph:
+    return Graph(
+        name="test",
+        nodes=nodes or {},
+        edges=edges or [],
+    )
+
+
+def _minimal_graph_with_tool(tool_command: str, node_id: str = "gate") -> Graph:
+    """Return a minimal valid graph containing one tool node with the given command."""
+    t = _tool(node_id, tool_command=tool_command)
+    return _graph(
+        nodes={
+            "start": _mdiamond(),
+            node_id: t,
+            "done": _msquare("done"),
+        },
+        edges=[
+            Edge("start", node_id),
+            Edge(node_id, "done"),
+        ],
+    )
+
+
+def _cmd_diags(diags: list[Diagnostic], rule: str) -> list[Diagnostic]:
+    """Return diagnostics matching the given CMD rule."""
+    return [d for d in diags if d.rule == rule]
+
+
+# ---------------------------------------------------------------------------
+# CMD-001: pipe-masked exit code — positive cases (SHOULD be flagged)
+# ---------------------------------------------------------------------------
+
+
+class TestCmd001PipeMasked:
+    """CMD-001 fires when the final pipe stage is a recognised filter."""
+
+    def test_false_pipe_tail_flagged(self):
+        """Incident shape: 'false | tail -1' — exit code is tail's (0)."""
+        g = _minimal_graph_with_tool("false | tail -1")
+        diags = lint(g)
+        hits = _cmd_diags(diags, "CMD-001")
+        assert hits, "Expected CMD-001 for 'false | tail -1'"
+        assert hits[0].node_id == "gate"
+        assert hits[0].severity == "WARNING"
+
+    def test_pipe_head_flagged(self):
+        """'cmd 2>&1 | head -20' — exit code is head's."""
+        g = _minimal_graph_with_tool("some_command 2>&1 | head -20")
+        diags = lint(g)
+        assert _cmd_diags(diags, "CMD-001"), "Expected CMD-001 for pipe to head"
+
+    def test_pipe_grep_flagged(self):
+        """'cmd | grep pattern' — exit code is grep's (0 if match, 1 if not)."""
+        g = _minimal_graph_with_tool("run_tests | grep FAILED")
+        diags = lint(g)
+        assert _cmd_diags(diags, "CMD-001"), "Expected CMD-001 for pipe to grep"
+
+    def test_pipe_sed_flagged(self):
+        """'cmd 2>&1 | sed s/foo/bar/' — exit code is sed's."""
+        g = _minimal_graph_with_tool("build_cmd 2>&1 | sed 's/error/ERROR/'")
+        diags = lint(g)
+        assert _cmd_diags(diags, "CMD-001"), "Expected CMD-001 for pipe to sed"
+
+    def test_pipe_awk_flagged(self):
+        """'cmd | awk ...' — exit code is awk's."""
+        g = _minimal_graph_with_tool("run_check | awk '{print $1}'")
+        diags = lint(g)
+        assert _cmd_diags(diags, "CMD-001"), "Expected CMD-001 for pipe to awk"
+
+    def test_pipe_cut_flagged(self):
+        """'cmd | cut -d: -f1' — exit code is cut's."""
+        g = _minimal_graph_with_tool("get_status | cut -d: -f1")
+        diags = lint(g)
+        assert _cmd_diags(diags, "CMD-001"), "Expected CMD-001 for pipe to cut"
+
+    def test_pipe_wc_flagged(self):
+        """'cmd | wc -l' — exit code is wc's."""
+        g = _minimal_graph_with_tool("find . -name '*.py' | wc -l")
+        diags = lint(g)
+        assert _cmd_diags(diags, "CMD-001"), "Expected CMD-001 for pipe to wc"
+
+    def test_pipe_sort_flagged(self):
+        """'cmd | sort' — exit code is sort's."""
+        g = _minimal_graph_with_tool("list_items | sort")
+        diags = lint(g)
+        assert _cmd_diags(diags, "CMD-001"), "Expected CMD-001 for pipe to sort"
+
+    def test_pipe_uniq_flagged(self):
+        """'cmd | uniq' — exit code is uniq's."""
+        g = _minimal_graph_with_tool("get_lines | uniq")
+        diags = lint(g)
+        assert _cmd_diags(diags, "CMD-001"), "Expected CMD-001 for pipe to uniq"
+
+    def test_pipe_xargs_flagged(self):
+        """'cmd | xargs ...' — exit code is xargs's."""
+        g = _minimal_graph_with_tool("find . -name '*.txt' | xargs cat")
+        diags = lint(g)
+        assert _cmd_diags(diags, "CMD-001"), "Expected CMD-001 for pipe to xargs"
+
+    def test_incident_shape_flagged(self):
+        """Incident shape: 'sh -c exit 1 2>&1 | tail -5' — gate records SUCCESS."""
+        g = _minimal_graph_with_tool("sh -c 'exit 1' 2>&1 | tail -5")
+        diags = lint(g)
+        assert _cmd_diags(diags, "CMD-001"), "Expected CMD-001 for incident shape"
+
+    def test_node_id_in_diagnostic(self):
+        """CMD-001 diagnostic must reference the flagged node's ID."""
+        g = _minimal_graph_with_tool("false | tail -1", node_id="my_gate")
+        diags = lint(g)
+        hits = _cmd_diags(diags, "CMD-001")
+        assert hits, "Expected CMD-001"
+        assert hits[0].node_id == "my_gate"
+
+    def test_non_tool_node_not_flagged(self):
+        """CMD-001 only applies to parallelogram (tool) nodes — not box/diamond."""
+        box_node = Node(
+            id="work",
+            shape="box",
+            attrs={"tool_command": "false | tail -1"},
+        )
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "work": box_node,
+                "done": _msquare("done"),
+            },
+            edges=[Edge("start", "work"), Edge("work", "done")],
+        )
+        diags = lint(g)
+        assert not _cmd_diags(diags, "CMD-001"), (
+            "CMD-001 must not fire on non-tool nodes"
+        )
+
+    def test_tool_node_without_tool_command_not_flagged(self):
+        """Tool node with no tool_command attribute is not flagged."""
+        t = _tool("gate")  # no tool_command
+        g = _graph(
+            nodes={"start": _mdiamond(), "gate": t, "done": _msquare("done")},
+            edges=[Edge("start", "gate"), Edge("gate", "done")],
+        )
+        diags = lint(g)
+        assert not _cmd_diags(diags, "CMD-001")
+
+
+# ---------------------------------------------------------------------------
+# CMD-001: false-positive tests — legit pipes NOT flagged
+# ---------------------------------------------------------------------------
+
+
+class TestCmd001FalsePositives:
+    """Legitimate pipe patterns that must NOT trigger CMD-001."""
+
+    def test_tee_not_flagged(self):
+        """'cmd 2>&1 | tee log' — tee preserves output; not a filter gate."""
+        g = _minimal_graph_with_tool("run_tests 2>&1 | tee test.log")
+        diags = lint(g)
+        assert not _cmd_diags(diags, "CMD-001"), (
+            "tee is not a filter — it preserves output for logging"
+        )
+
+    def test_pipefail_suppresses_cmd001(self):
+        """'set -o pipefail; cmd | tail' — pipefail makes the exit code real."""
+        g = _minimal_graph_with_tool("set -o pipefail; run_tests | tail -30")
+        diags = lint(g)
+        assert not _cmd_diags(diags, "CMD-001"), (
+            "pipefail is present — CMD-001 must not fire"
+        )
+
+    def test_pipefail_euo_suppresses_cmd001(self):
+        """'set -euo pipefail; cmd | tail' — pipefail variant suppresses CMD-001."""
+        g = _minimal_graph_with_tool("set -euo pipefail; cmd 2>&1 | tail -20")
+        diags = lint(g)
+        assert not _cmd_diags(diags, "CMD-001"), (
+            "set -euo pipefail suppresses CMD-001"
+        )
+
+    def test_honest_token_gate_not_flagged(self):
+        """'cmd && printf green || printf red' — honest token gate, no pipe."""
+        g = _minimal_graph_with_tool("pytest -q > /dev/null 2>&1 && printf pass || printf fail")
+        diags = lint(g)
+        assert not _cmd_diags(diags, "CMD-001"), (
+            "Redirect + honest token gate is the safe idiom — must not be flagged"
+        )
+
+    def test_grep_as_test_not_flagged(self):
+        """'grep -q pattern file && printf match || printf nomatch' — grep IS the check."""
+        g = _minimal_graph_with_tool(
+            "grep -qE '^BLOCKED' .ai/postmortem/diagnosis.md && printf blocked || printf continue"
+        )
+        diags = lint(g)
+        assert not _cmd_diags(diags, "CMD-001"), (
+            "grep-as-test with honest || branch is the safe idiom"
+        )
+
+    def test_pipe_with_or_branch_still_flagged(self):
+        """'cmd | grep -q PASS && printf ok || printf fail' — || does NOT restore original exit code.
+
+        ``grep`` exits 0 when it can read stdin (it always can here), so
+        ``printf ok`` fires unconditionally.  ``|| printf fail`` only guards
+        against ``grep`` or ``printf`` failing — not the original command.
+        The ``||`` does not make this an honest gate.  CMD-001 must fire.
+        """
+        g = _minimal_graph_with_tool(
+            "run_check | grep -q PASS && printf ok || printf fail"
+        )
+        diags = lint(g)
+        assert _cmd_diags(diags, "CMD-001"), (
+            "|| branch after pipe-masked stage does not restore exit code — CMD-001 must fire"
+        )
+
+    def test_pipe_in_subshell_assignment_not_flagged(self):
+        """Pipe inside $(...) subshell is not a top-level gate pipe."""
+        # sig=$(tail -20 log | sed ... | md5sum | cut -f1); [ "$sig" = "$prev" ] && printf repeat || printf novel
+        cmd = (
+            "sig=$(tail -20 .ai/test.log 2>/dev/null | sed 's/[0-9]*\\.[0-9]*s//g' "
+            "| md5sum | cut -d' ' -f1); prev=$(cat .ai/last-fail-sig 2>/dev/null || echo none); "
+            "echo $sig > .ai/last-fail-sig; [ \"$sig\" = \"$prev\" ] && printf repeat || printf novel"
+        )
+        g = _minimal_graph_with_tool(cmd)
+        diags = lint(g)
+        assert not _cmd_diags(diags, "CMD-001"), (
+            "Pipe inside $(...) is not a top-level gate pipe — must not flag CMD-001"
+        )
+
+    def test_verdict_gate_pattern_flagged(self):
+        """Shipped verdict_gate pattern: grep | tail | grep -q && printf ship || printf iterate.
+
+        The final stage is ``grep -q`` (a filter in ``_PIPE_FILTER_PROGRAMS``).
+        The ``||`` branch does NOT restore the original command's exit code —
+        ``grep -q`` exits 0 when it finds a match and 1 when it does not, but
+        the pipe-masked stages before it (``grep -E | tail -1``) may hide
+        failures in the upstream command.  CMD-001 fires to alert the author.
+
+        Note: this produces a WARNING (not ERROR), so the shipped examples
+        lint sweep (``test_examples_lint_clean.py``) is unaffected.
+        """
+        cmd = (
+            "grep -E '^VERDICT:' .ai/critique.md 2>/dev/null | tail -1 | grep -q 'SHIP' "
+            "&& printf ship || printf iterate"
+        )
+        g = _minimal_graph_with_tool(cmd)
+        diags = lint(g)
+        assert _cmd_diags(diags, "CMD-001"), (
+            "Verdict gate with pipe-masked stages must flag CMD-001 (WARNING)"
+        )
+
+    def test_redirect_not_flagged(self):
+        """'cmd > out.log 2>&1' — redirect, not pipe; exit code is cmd's."""
+        g = _minimal_graph_with_tool("pytest -q > .ai/test.log 2>&1")
+        diags = lint(g)
+        assert not _cmd_diags(diags, "CMD-001"), (
+            "Redirect preserves exit code — must not flag CMD-001"
+        )
+
+    def test_exit_code_gate_not_flagged(self):
+        """'cmd && printf ok || { printf fail; exit 1; }' — exit-code gate."""
+        g = _minimal_graph_with_tool(
+            "run_tests && printf ok || { printf fail; exit 1; }"
+        )
+        diags = lint(g)
+        assert not _cmd_diags(diags, "CMD-001"), (
+            "Exit-code gate preserves failure — must not flag CMD-001"
+        )
+
+    def test_single_quoted_pipe_not_flagged(self):
+        """'echo 'false | tail -1'' — pipe is inside a single-quoted string, not a real pipe."""
+        g = _minimal_graph_with_tool("echo 'documentation: false | tail -1'")
+        diags = lint(g)
+        assert not _cmd_diags(diags, "CMD-001"), (
+            "Pipe inside single-quoted string is not a real shell pipe — must not flag CMD-001"
+        )
+
+    def test_double_quoted_pipe_not_flagged(self):
+        """'printf \"false | tail -1\"' — pipe is inside a double-quoted string."""
+        g = _minimal_graph_with_tool('printf "false | tail -1"')
+        diags = lint(g)
+        assert not _cmd_diags(diags, "CMD-001"), (
+            "Pipe inside double-quoted string is not a real shell pipe — must not flag CMD-001"
+        )
+
+    def test_command_substitution_pipe_not_flagged(self):
+        """Pipe inside $(...) is already handled by _strip_command_substitutions."""
+        g = _minimal_graph_with_tool(
+            'result=$(echo "false | tail -1"); printf "%s" "$result"'
+        )
+        diags = lint(g)
+        assert not _cmd_diags(diags, "CMD-001"), (
+            "Pipe inside $(...) is not a top-level gate pipe — must not flag CMD-001"
+        )
+
+
+# ---------------------------------------------------------------------------
+# CMD-002: always-true sentinel — positive cases (SHOULD be flagged)
+# ---------------------------------------------------------------------------
+
+
+class TestCmd002AlwaysTrueSentinel:
+    """CMD-002 fires when a pipe-masked command is followed by && echo/printf TOKEN."""
+
+    def test_incident_sentinel_shape_flagged(self):
+        """Incident shape: 'sh -c exit 1 2>&1 | tail -5 && echo GREEN'."""
+        g = _minimal_graph_with_tool("sh -c 'exit 1' 2>&1 | tail -5 && echo GREEN")
+        diags = lint(g)
+        hits = _cmd_diags(diags, "CMD-002")
+        assert hits, "Expected CMD-002 for incident sentinel shape"
+        assert hits[0].node_id == "gate"
+        assert hits[0].severity == "WARNING"
+
+    def test_pipe_tail_echo_sentinel_flagged(self):
+        """'cmd 2>&1 | tail -30 && echo DONE' — sentinel fires unconditionally."""
+        g = _minimal_graph_with_tool("run_harness 2>&1 | tail -30 && echo DONE")
+        diags = lint(g)
+        assert _cmd_diags(diags, "CMD-002"), "Expected CMD-002 for pipe+echo sentinel"
+
+    def test_pipe_tail_printf_sentinel_flagged(self):
+        """'cmd 2>&1 | tail -5 && printf GREEN' — printf sentinel fires unconditionally."""
+        g = _minimal_graph_with_tool("do_work 2>&1 | tail -5 && printf GREEN")
+        diags = lint(g)
+        assert _cmd_diags(diags, "CMD-002"), "Expected CMD-002 for pipe+printf sentinel"
+
+    def test_pipe_grep_echo_sentinel_flagged(self):
+        """'cmd | grep -v error && echo OK' — sentinel after pipe to grep."""
+        g = _minimal_graph_with_tool("run_cmd | grep -v error && echo OK")
+        diags = lint(g)
+        assert _cmd_diags(diags, "CMD-002"), "Expected CMD-002 for grep+echo sentinel"
+
+    def test_pipe_sed_echo_sentinel_flagged(self):
+        """'cmd 2>&1 | sed s/x/y/ && echo SLICE_GREEN' — incident variant."""
+        g = _minimal_graph_with_tool("run_test 2>&1 | sed 's/x/y/' && echo SLICE_GREEN")
+        diags = lint(g)
+        assert _cmd_diags(diags, "CMD-002"), "Expected CMD-002 for sed+echo sentinel"
+
+    def test_node_id_in_diagnostic(self):
+        """CMD-002 diagnostic must reference the flagged node's ID."""
+        g = _minimal_graph_with_tool(
+            "sh -c 'exit 1' 2>&1 | tail -5 && echo GREEN", node_id="sentinel_node"
+        )
+        diags = lint(g)
+        hits = _cmd_diags(diags, "CMD-002")
+        assert hits, "Expected CMD-002"
+        assert hits[0].node_id == "sentinel_node"
+
+    def test_at_most_one_cmd002_per_node(self):
+        """At most one CMD-002 diagnostic per node (don't spam)."""
+        g = _minimal_graph_with_tool("cmd | tail -1 && echo A && echo B")
+        diags = lint(g)
+        hits = _cmd_diags(diags, "CMD-002")
+        assert len(hits) <= 1, "At most one CMD-002 per node"
+
+
+# ---------------------------------------------------------------------------
+# CMD-002: false-positive tests — honest token gates NOT flagged
+# ---------------------------------------------------------------------------
+
+
+class TestCmd002FalsePositives:
+    """Legitimate patterns that must NOT trigger CMD-002."""
+
+    def test_honest_token_gate_not_flagged(self):
+        """'cmd && printf green || printf red' — both branches; no pipe."""
+        g = _minimal_graph_with_tool("pytest -q > /dev/null 2>&1 && printf pass || printf fail")
+        diags = lint(g)
+        assert not _cmd_diags(diags, "CMD-002"), (
+            "Honest token gate with || branch must not flag CMD-002"
+        )
+
+    def test_exit_code_gate_not_flagged(self):
+        """'cmd && printf ok || { printf fail; exit 1; }' — exit-code gate."""
+        g = _minimal_graph_with_tool(
+            "run_tests && printf ok || { printf fail; exit 1; }"
+        )
+        diags = lint(g)
+        assert not _cmd_diags(diags, "CMD-002"), (
+            "Exit-code gate must not flag CMD-002"
+        )
+
+    def test_pipe_with_or_branch_still_flagged(self):
+        """'cmd | grep PASS && printf ok || printf fail' — || does NOT make this honest.
+
+        The ``||`` only guards against ``grep`` or ``printf`` failing.
+        The original command's exit code is still masked by the pipe.
+        CMD-002 must fire because ``printf ok`` fires unconditionally
+        (grep exits 0 when it can read stdin).
+        """
+        g = _minimal_graph_with_tool(
+            "run_check | grep -q PASS && printf ok || printf fail"
+        )
+        diags = lint(g)
+        # CMD-001 fires (pipe-masked); CMD-002 may or may not fire depending
+        # on whether _SENTINEL_RE matches (it does not here — no sentinel at
+        # end).  At minimum CMD-001 must fire.
+        assert _cmd_diags(diags, "CMD-001"), (
+            "|| branch after pipe-masked stage does not restore exit code — CMD-001 must fire"
+        )
+
+    def test_verdict_gate_pattern_cmd002(self):
+        """Shipped verdict_gate: grep | tail | grep -q && printf ship || printf iterate.
+
+        This pattern ends with ``printf ship`` after a pipe-masked stage.
+        CMD-002 checks for ``&& echo/printf TOKEN`` at the end of the command.
+        The ``_SENTINEL_RE`` requires the sentinel at end-of-string; here the
+        command ends with ``|| printf iterate``, not a sentinel, so CMD-002
+        does NOT fire.  CMD-001 fires (pipe-masked stage).
+        """
+        cmd = (
+            "grep -E '^VERDICT:' .ai/critique.md 2>/dev/null | tail -1 | grep -q 'SHIP' "
+            "&& printf ship || printf iterate"
+        )
+        g = _minimal_graph_with_tool(cmd)
+        diags = lint(g)
+        # CMD-002 must NOT fire — the command ends with || printf iterate,
+        # not a bare sentinel.
+        assert not _cmd_diags(diags, "CMD-002"), (
+            "Verdict gate ends with || branch, not a bare sentinel — CMD-002 must not fire"
+        )
+        # CMD-001 DOES fire — pipe-masked stages are present.
+        assert _cmd_diags(diags, "CMD-001"), (
+            "Verdict gate has pipe-masked stages — CMD-001 must fire"
+        )
+
+    def test_grep_as_test_not_flagged(self):
+        """'grep -qE pattern file && printf blocked || printf continue' — grep IS the check."""
+        g = _minimal_graph_with_tool(
+            "grep -qE '^BLOCKED' .ai/postmortem/diagnosis.md && printf blocked || printf continue"
+        )
+        diags = lint(g)
+        assert not _cmd_diags(diags, "CMD-002"), (
+            "grep-as-test with honest || branch must not flag CMD-002"
+        )
+
+    def test_tee_with_echo_not_flagged(self):
+        """'cmd 2>&1 | tee log && echo done' — tee is not a filter."""
+        g = _minimal_graph_with_tool("run_tests 2>&1 | tee test.log && echo done")
+        diags = lint(g)
+        assert not _cmd_diags(diags, "CMD-002"), (
+            "tee is not in the filter set — CMD-002 must not fire"
+        )
+
+    def test_pipefail_suppresses_cmd002(self):
+        """'set -o pipefail; cmd | tail && echo done' — pipefail makes exit real."""
+        g = _minimal_graph_with_tool("set -o pipefail; run_tests | tail -30 && echo done")
+        diags = lint(g)
+        assert not _cmd_diags(diags, "CMD-002"), (
+            "pipefail suppresses CMD-002"
+        )
+
+    def test_pipe_in_subshell_assignment_not_flagged(self):
+        """Pipe inside $(...) followed by sentinel is not CMD-002."""
+        # The sentinel is after a non-pipe final segment
+        cmd = (
+            "sig=$(tail -20 .ai/test.log | md5sum | cut -d' ' -f1); "
+            "prev=$(cat .ai/last-fail-sig 2>/dev/null || echo none); "
+            "echo $sig > .ai/last-fail-sig; [ \"$sig\" = \"$prev\" ] && printf repeat || printf novel"
+        )
+        g = _minimal_graph_with_tool(cmd)
+        diags = lint(g)
+        assert not _cmd_diags(diags, "CMD-002"), (
+            "Pipe inside $(...) with honest || branch at end — must not flag CMD-002"
+        )
+
+    def test_echo_after_redirect_not_flagged(self):
+        """'cmd > out.log 2>&1 && echo done' — redirect, not pipe; exit code is cmd's."""
+        # This is NOT a pipe-masked command, so CMD-002 must not fire.
+        # (CMD-002 only fires when the && echo follows a pipe-masked segment.)
+        g = _minimal_graph_with_tool("run_tests > .ai/test.log 2>&1 && echo done")
+        diags = lint(g)
+        assert not _cmd_diags(diags, "CMD-002"), (
+            "Redirect preserves exit code — CMD-002 must not fire after redirect"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Integration: both rules together (incident graph shape)
+# ---------------------------------------------------------------------------
+
+
+class TestIncidentShape:
+    """The 2026-07-28 incident shapes produce findings from both rules."""
+
+    def test_incident_masked_node_flagged(self):
+        """'false | tail -1' must produce a CMD-001 finding."""
+        g = _minimal_graph_with_tool("false | tail -1", node_id="masked")
+        diags = lint(g)
+        hits = [d for d in diags if d.node_id == "masked" and d.rule.startswith("CMD")]
+        assert hits, "Incident masked node must produce a CMD finding"
+
+    def test_incident_sentinel_node_flagged(self):
+        """'sh -c exit 1 2>&1 | tail -5 && echo GREEN' must produce a CMD finding."""
+        g = _minimal_graph_with_tool(
+            "sh -c 'exit 1' 2>&1 | tail -5 && echo GREEN", node_id="sentinel"
+        )
+        diags = lint(g)
+        hits = [d for d in diags if d.node_id == "sentinel" and d.rule.startswith("CMD")]
+        assert hits, "Incident sentinel node must produce a CMD finding"
+
+    def test_clean_graph_no_cmd_findings(self):
+        """A graph using only safe idioms produces no CMD findings."""
+        # Uses redirect + honest token gate (the doctrinally correct pattern)
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "gate": _tool(
+                    "gate",
+                    tool_command="pytest -q > .ai/test.log 2>&1 && printf pass || printf fail",
+                ),
+                "done": _msquare("done"),
+            },
+            edges=[Edge("start", "gate"), Edge("gate", "done")],
+        )
+        diags = lint(g)
+        cmd_diags = [d for d in diags if d.rule.startswith("CMD")]
+        assert not cmd_diags, f"Safe graph must produce no CMD findings; got: {cmd_diags}"
+
+    def test_multiple_tool_nodes_flagged_independently(self):
+        """Multiple pipe-masked tool nodes each produce their own CMD-001."""
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "gate1": _tool("gate1", tool_command="cmd1 | tail -5"),
+                "gate2": _tool("gate2", tool_command="cmd2 | head -10"),
+                "done": _msquare("done"),
+            },
+            edges=[
+                Edge("start", "gate1"),
+                Edge("gate1", "gate2", condition="outcome=success"),
+                Edge("gate1", "done", condition="outcome=fail"),
+                Edge("gate2", "done"),
+            ],
+        )
+        diags = lint(g)
+        cmd001 = _cmd_diags(diags, "CMD-001")
+        node_ids = {d.node_id for d in cmd001}
+        assert "gate1" in node_ids, "gate1 must be flagged"
+        assert "gate2" in node_ids, "gate2 must be flagged"
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for iteration-3 findings (Reviewer B)
+# ---------------------------------------------------------------------------
+
+
+class TestQuotedPipefailRegression:
+    """Finding 1: pipefail inside a quoted string must NOT suppress CMD-001/002.
+
+    ``echo "set -o pipefail"; false | tail -1`` does not enable pipefail —
+    the ``set`` is inside a quoted argument to ``echo``, not executed.
+    A naive textual pipefail match on the raw command string would cause a
+    false suppression; the rule must only honour executable ``set``
+    statements.
+    """
+
+    def test_echo_quoted_pipefail_does_not_suppress_cmd001(self):
+        """'echo "set -o pipefail"; false | tail -1' → CMD-001 (not suppressed)."""
+        g = _minimal_graph_with_tool('echo "set -o pipefail"; false | tail -1')
+        diags = lint(g)
+        assert _cmd_diags(diags, "CMD-001"), (
+            "Quoted pipefail inside echo argument must not suppress CMD-001"
+        )
+
+    def test_printf_single_quoted_pipefail_does_not_suppress_cmd001(self):
+        """'printf 'set -o pipefail'; false | tail -1' → CMD-001 (not suppressed)."""
+        g = _minimal_graph_with_tool("printf 'set -o pipefail'; false | tail -1")
+        diags = lint(g)
+        assert _cmd_diags(diags, "CMD-001"), (
+            "Quoted pipefail inside printf argument must not suppress CMD-001"
+        )
+
+    def test_echo_quoted_pipefail_does_not_suppress_cmd002(self):
+        """'echo "set -o pipefail"; false | tail -1 && echo GREEN' → CMD-001+CMD-002."""
+        g = _minimal_graph_with_tool('echo "set -o pipefail"; false | tail -1 && echo GREEN')
+        diags = lint(g)
+        # The echo "set -o pipefail" is in a non-final semicolon segment,
+        # so CMD-001 fires on the final segment (false | tail -1 && echo GREEN).
+        # CMD-002 also fires for the sentinel.
+        assert _cmd_diags(diags, "CMD-001"), (
+            "Quoted pipefail in earlier segment must not suppress CMD-001"
+        )
+
+    def test_real_pipefail_still_suppresses_cmd001(self):
+        """'set -o pipefail; false | tail -1' → CLEAN (real pipefail suppresses)."""
+        g = _minimal_graph_with_tool("set -o pipefail; false | tail -1")
+        diags = lint(g)
+        assert not _cmd_diags(diags, "CMD-001"), (
+            "Real set -o pipefail must still suppress CMD-001"
+        )
+
+    def test_real_pipefail_still_suppresses_cmd002(self):
+        """'set -o pipefail; false | tail -1 && echo GREEN' → CLEAN."""
+        g = _minimal_graph_with_tool("set -o pipefail; false | tail -1 && echo GREEN")
+        diags = lint(g)
+        assert not _cmd_diags(diags, "CMD-001"), (
+            "Real set -o pipefail must still suppress CMD-001"
+        )
+        assert not _cmd_diags(diags, "CMD-002"), (
+            "Real set -o pipefail must still suppress CMD-002"
+        )
+
+
+class TestExecutablePipefailRegression:
+    """Only an executable top-level pipefail setting may suppress CMD-001."""
+
+    def test_commented_pipefail_does_not_suppress_cmd001(self):
+        """A comment mentioning pipefail does not execute it."""
+        g = _minimal_graph_with_tool("# set -o pipefail\nfalse | tail -1")
+        assert _cmd_diags(lint(g), "CMD-001")
+
+    def test_conditional_pipefail_does_not_suppress_cmd001(self):
+        """A pipefail setting after failed ``&&`` may not execute."""
+        g = _minimal_graph_with_tool("false && set -o pipefail; false | tail -1")
+        assert _cmd_diags(lint(g), "CMD-001")
+
+
+class TestNonFinalPipelineRegression:
+    """Finding 2: CMD-001 must only fire on the final ``;``-separated segment.
+
+    ``false | tail -1; echo done`` — the final command is ``echo done``
+    (exit code 0, no pipe), so CMD-001 must NOT fire.  The previous
+    implementation scanned the whole command for the last bare pipe,
+    causing false positives on compound commands.
+    """
+
+    def test_semicolon_separated_non_final_pipe_not_flagged(self):
+        """'false | tail -1; echo done' → CLEAN (echo done is the final command)."""
+        g = _minimal_graph_with_tool("false | tail -1; echo done")
+        diags = lint(g)
+        assert not _cmd_diags(diags, "CMD-001"), (
+            "Non-final pipe (before semicolon) must not flag CMD-001 — "
+            "echo done determines the exit code"
+        )
+
+    def test_semicolon_with_exit_preservation_not_flagged(self):
+        """'run_cmd | head -5; exit $?' → CLEAN (exit $? preserves the code)."""
+        g = _minimal_graph_with_tool("run_cmd | head -5; exit $?")
+        diags = lint(g)
+        assert not _cmd_diags(diags, "CMD-001"), (
+            "Non-final pipe followed by exit $? must not flag CMD-001"
+        )
+
+    def test_final_pipe_still_flagged(self):
+        """'false | tail -1' → CMD-001 (pipe is the final command)."""
+        g = _minimal_graph_with_tool("false | tail -1")
+        diags = lint(g)
+        assert _cmd_diags(diags, "CMD-001"), (
+            "Final pipe to filter must still flag CMD-001"
+        )
+
+    def test_and_chain_with_pipe_still_flagged(self):
+        """'false | tail -1 && echo SENTINEL' → CMD-001+CMD-002 (one semicolon-segment)."""
+        g = _minimal_graph_with_tool("false | tail -1 && echo SENTINEL")
+        diags = lint(g)
+        assert _cmd_diags(diags, "CMD-001"), (
+            "&& does not split semicolon segments — pipe hazard still present"
+        )
+        assert _cmd_diags(diags, "CMD-002"), (
+            "Sentinel after pipe-masked command must flag CMD-002"
+        )
+
+    def test_semicolon_non_final_pipe_cmd002_not_flagged(self):
+        """'false | tail -1; echo done && echo SENTINEL' → CLEAN for CMD-002.
+
+        The final semicolon-segment is ``echo done && echo SENTINEL``.
+        There is no pipe in that segment, so CMD-002 must NOT fire.
+        (CMD-001 also must NOT fire — echo done is the exit-code determiner.)
+        """
+        g = _minimal_graph_with_tool("false | tail -1; echo done && echo SENTINEL")
+        diags = lint(g)
+        assert not _cmd_diags(diags, "CMD-001"), (
+            "Non-final pipe before semicolon must not flag CMD-001"
+        )
+        assert not _cmd_diags(diags, "CMD-002"), (
+            "Sentinel after non-piped final segment must not flag CMD-002"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Independent-critique reproductions — THE CONTRACT
+#
+# These two reproductions were built verbatim by an independent reviewer
+# against an earlier revision of these rules.  They are preserved here under
+# their own names because they define the rule contract more precisely than
+# the surrounding suites:
+#
+#   1. executable-pipefail: only an EXECUTED `set -o pipefail` statement may
+#      suppress CMD-001/CMD-002 — quoted/printed text must not.
+#   2. final-command-boundary: CMD-001 fires only when the masked pipeline is
+#      the final exit-code-determining command; a pipe in a non-final
+#      `;`-separated segment must not be flagged.
+# ---------------------------------------------------------------------------
+
+
+class TestCriticReproductions:
+    """Verbatim reviewer reproductions — regression contract for CMD-001/002."""
+
+    def test_critic_repro_executable_pipefail(self):
+        """Reviewer repro 1 (verbatim): textual pipefail must not suppress.
+
+        ``echo "set -o pipefail"; false | tail -1``   -> must flag CMD-001
+        ``printf 'set -o pipefail'; false | tail -1`` -> must flag CMD-001
+
+        Neither command enables pipefail; each still executes the incident's
+        pipe-masked failure.  An arbitrary log message, comment, or
+        user-controlled string containing the text ``set -o pipefail`` must
+        never suppress the finding.
+        """
+        g = _minimal_graph_with_tool('echo "set -o pipefail"; false | tail -1')
+        diags = lint(g)
+        assert _cmd_diags(diags, "CMD-001"), (
+            'echo "set -o pipefail"; false | tail -1 must flag CMD-001 — '
+            "the pipefail text is printed, not executed"
+        )
+
+        g = _minimal_graph_with_tool("printf 'set -o pipefail'; false | tail -1")
+        diags = lint(g)
+        assert _cmd_diags(diags, "CMD-001"), (
+            "printf 'set -o pipefail'; false | tail -1 must flag CMD-001 — "
+            "the pipefail text is printed, not executed"
+        )
+
+    def test_critic_repro_final_command_boundary(self):
+        """Reviewer repro 2 (verbatim): non-final pipeline must not be flagged.
+
+        ``false | tail -1; echo done`` -> must NOT flag CMD-001
+
+        The ``tail`` pipeline is not the final command whose result determines
+        the tool outcome; ``echo done`` is.  Follow-on commands can
+        deliberately restore or preserve a status — flagging every earlier
+        pipe violates the rule's conservative, low-false-positive scope.
+        """
+        g = _minimal_graph_with_tool("false | tail -1; echo done")
+        diags = lint(g)
+        assert not _cmd_diags(diags, "CMD-001"), (
+            "false | tail -1; echo done must NOT flag CMD-001 — "
+            "'echo done' is the final exit-code-determining command"
+        )
+        assert not _cmd_diags(diags, "CMD-002"), (
+            "false | tail -1; echo done must NOT flag CMD-002 — "
+            "no sentinel in the final segment"
+        )

--- a/modules/pipeline-runner/amplifier_module_pipeline_runner/cli.py
+++ b/modules/pipeline-runner/amplifier_module_pipeline_runner/cli.py
@@ -362,7 +362,9 @@ def cmd_lint(args: argparse.Namespace) -> int:
     """Static topological lint of a .dot pipeline file.
 
     Parses the DOT file and runs the full basin-lint rule set:
-    structural rules (LINT-001–018) plus topological rules (TOPO-001–005).
+    structural rules (LINT-001–018), topological rules (TOPO-001–005),
+    and command-content rules (CMD-001–002, which inspect tool_command
+    strings for pipe-masked exit codes and always-true sentinels).
 
     Exit-code contract:
         ERROR-severity diagnostics → exit 1.


### PR DESCRIPTION
`attractor lint` gains a **command-content rule family** that inspects `tool_command` strings, not just graph topology. Two rules, both WARNING, both lint-only (zero run-time behaviour change): CMD-001 (pipe-masked exit code) and CMD-002 (always-true trailing sentinel). Extends the TOPO-001–005 topological lint shipped in #106, which by its own docstring "credits the topology, not the command."

## Why (the incident class)

Verified real-world incident (2026-07-28): a 20-node pipeline ran **2.4 hours and exited success with zero work product**. Every one of its 5 tool nodes was shaped `cmd 2>&1 | tail -N`; 4 ended `&& echo SENTINEL`. Tool commands run under `/bin/sh` (`create_subprocess_shell`), where a pipeline's exit status is the **last stage's** — `false | tail -1` exits 0, always. The harness gate's entire output was literally `bash: scripts/verify-remote-access.sh: No such file or directory` and the node recorded SUCCESS in ~1 s; the trailing sentinels then made `tool.last_line` (the routing channel) say "GREEN" unconditionally. The incident graph's topology was excellent (5 goal_gates, 8 corrective fail edges) and **lints "OK, no findings" on current main** — every defense died at the command-content layer no shipped rule inspects. Topological lint cannot see inside commands; these rules delete that hazard class statically instead of at 2.4h-run cost.

## What

| Rule | Severity | Detects |
|---|---|---|
| CMD-001 pipe-masked exit code | WARNING | Final `;`-segment of `tool_command` ends in a pipe to a filter/pager (`tail`, `head`, `grep`, `sed`, `awk`, `cut`, `sort`, `uniq`, `wc`, `xargs`) without an **executable** `set -o pipefail` — the gate's exit code is the filter's, not the checked command's |
| CMD-002 always-true sentinel | WARNING | Trailing `&& echo/printf TOKEN` after a pipe-masked command — the sentinel fires unconditionally and becomes `tool.last_line`; the gate always says yes |

Deliberately conservative (not shellcheck): quote-aware pipe scanning, `$(...)`-substitution stripping, executable-pipefail detection (standalone `set` statements only — printed/quoted text never suppresses), final-semicolon-segment scoping. Each rule's docstring states its known non-catches (`bash -o pipefail -c` wrappers, `$?`-capture idioms, custom filter scripts, heredocs).

**False-positive discipline (tested):** `… | tee log`, `set -o pipefail; … | tail`, token gates `cmd && printf green || printf red`, exit-code gates `… || { printf red; exit 1; }`, quoted pipes (`echo 'false | tail -1'`), redirect idiom, `$(… | …)` substitution pipes, and non-final pipelines are all unflagged. A `||` branch after a masked pipe is **not** a suppressor (`false | tail -1 && printf green || printf red` prints green unconditionally) — flagged, with tests.

**Severity decision (surfaced per task):** WARNING — consistent with TOPO-002–005 (real hazard, but static analysis can't prove a command is a meaningful gate); leaves the CLI exit-code contract (ERROR → non-zero) and existing users' lint runs unaffected. The shipped-examples sweep stays green with **zero CMD findings on all 25 examples** — no example needed fixing, so the #106-style fix-vs-overbroad judgment never triggered.

**Engine pipefail-default question (surfaced per task): DEFER**, recorded in the `validation.py` rule-family header. Reasons: `create_subprocess_shell` targets `/bin/sh` and `pipefail` is not POSIX sh (on dash it's `Illegal option`, exit 2); flipping the default is a behaviour change for every existing graph requiring an EXTENSIONS.md ledger entry + compat inventory; and the lint rules are valuable either way (even under pipefail, `&& echo SENTINEL` still masks nothing-happened cases). The guide teaches the sh-vs-bash tension directly, including that writing `set -o pipefail` to suppress the warning requires explicitly invoking bash.

**Docs:** `DOT-AUTHORING-GUIDE.md` gains two anti-patterns-table rows plus full CMD-001/CMD-002 sections: the incident, the two honest gate idioms, the key discriminator ("does the command's success still influence the exit code or the token?"), the doctrinally-correct redirect alternative (`cmd > out.log 2>&1` — preserves exit code AND keeps `tool.last_line` clean), suppression semantics, and known non-catches. `attractor lint` CLI docstring/help updated to name the CMD family.

## Provenance (honest)

Runner-built inside an isolated DTU quality loop, then operator-salvaged and polished here.

- Loop history: verify green ×3 (mechanical DoD incl. examples sweep + root subset); **critic A SHIP ×3; critic B ITERATE ×3** (budget 3/6, killed on stall).
- Critic B's iteration-1 and -2 findings were real and were fixed in-loop (removed an incorrect `||`-suppression, added quote-aware pipe scanning, executable-pipefail detection, final-segment scoping).
- Critic B's **iteration-3** critique restated the iteration-2 findings verbatim. The loop postmortem hypothesized (with evidence) that iteration-3 critique-b evaluated stale/mis-shaped reproductions — most plausibly using `shape=box` (LLM) nodes, for which the CMD rules correctly no-op.
- **Independently re-verified during this PR prep** against the salvaged tree, with `shape=parallelogram` tool nodes: all three critic-B findings are closed (transcript below). The stale-critique hypothesis also reproduced: with `shape=box`, every case returns `[]`.
- B's two reproductions are now preserved **verbatim as named contract tests** so they can never silently regress: `TestCriticReproductions::test_critic_repro_executable_pipefail` and `::test_critic_repro_final_command_boundary`.

### Critic B's reproductions (verbatim) and their closure

**Repro 1 — executable pipefail (unsafe suppression):**
```sh
echo "set -o pipefail"; false | tail -1  -> []
printf 'set -o pipefail'; false | tail -1 -> []
```
> "Neither command enables `pipefail`; each still executes the incident's pipe-masked failure. … an arbitrary log message, comment, or user-controlled text can suppress the warning."

**Closed:** `_has_executable_pipefail()` strips quoted strings, then matches only standalone `set -[e|u|o…] pipefail` statements at statement boundaries. Both repro commands now emit `CMD-001`; real `set -o pipefail; false | tail -1` still suppresses. Verified live + pinned by `test_critic_repro_executable_pipefail` (plus the pre-existing `TestQuotedPipefailRegression` suite covering commented and conditionally-executed pipefail).

**Repro 2 — final-command boundary (overbroad match):**
```sh
false | tail -1; echo done -> ['CMD-001']
```
> "The `tail` pipeline is not the final command whose result determines the tool outcome; `echo done` is. … Flagging every earlier pipe violates the explicitly conservative, low-false-positive scope."

**Closed:** both rules scope analysis to `_final_semicolon_segment()` (splits on top-level `;` only, preserving `&&`/`||` chains so `cmd | tail && echo SENTINEL` remains one hazardous segment). `false | tail -1; echo done` → `[]`; `false | tail -1` alone still fires. Verified live + pinned by `test_critic_repro_final_command_boundary` (plus `TestFinalSegment…` compound-command suite).

**Finding 3 — "pipefail OR explicit exit-code preservation" contract:** closed via the honest-narrowing path B itself offered ("document a narrowly supported preservation idiom … or state an intentionally narrower rule"). The rule's stated contract is executable-pipefail suppression only; `$?`-capture is documented as a known non-catch in the docstring and the guide, with the redirect idiom as the detected-suppression alternative. Note the common preservation shape `cmd | tail; rc=$?; …` is in fact unflagged by construction (the pipe sits in a non-final segment) — tested (`test_semicolon_with_exit_preservation_not_flagged`).

### Fresh-eyes findings fixed in this polish (delta vs the salvage, +67/−97)

1. **Stale diagnostic text:** CMD-001's message still said "without pipefail **or an || branch**" — the `||`-suppression was removed in iteration 2, so the message misstated the rule. Fixed.
2. **Dead code removed:** `_has_honest_or_branch()` (deprecated in-loop, kept "for reference") and `_final_top_level_segment()` (written for the finding-2 fix but never called — critic B explicitly noted this). ~92 lines deleted; the why-|| -doesn't-suppress rationale is preserved as comments at both use sites.
3. **Ghost-symbol references:** three comments/docstrings referenced `_PIPEFAIL_RE`, a symbol that no longer exists (renamed `_PIPEFAIL_OPTIONS_RE` inside `_has_executable_pipefail`). Fixed; the test-file docstring's reference to the never-shipped symbol rephrased.
4. **Environment leak in shipped docs:** guide said "on **this Linux environment** `/bin/sh` is `dash`" → "on Debian/Ubuntu-family systems". No other internal refs leaked (task-ID / backlog / DTU-path grep over the full diff: clean).
5. **Help-text gap:** `attractor lint`'s docstring listed only LINT-001–018 + TOPO-001–005; now names CMD-001–002 (task DoD: "lint rule docs/help updated").
6. Guide sections re-checked line-by-line against actual rule behaviour (suppression semantics, non-catches, final-segment examples) — accurate; DEFER note honest and matches the code header.

## Verification checklist

- [x] Unit tests pass — `modules/loop-pipeline`: **1589 passed, 1 skipped** (full suite, `uv run --extra remote pytest -q`); `modules/pipeline-runner`: **45 passed, 1 skipped**
- [x] Live pipeline run — **N/A per verification gradient**: validation-layer only; no `engine.py`, handler, or dispatch change (rules are exposed via `lint()` only; `validate()`/run-time path untouched). The rules were exercised live in-process against the incident fixture shapes (below).
- [x] AGENTS.md reviewed; repo-specific gates met (the fixed aspirational-contract issue — rule text claiming a suppression path the code lacks — is one of this repo's named recurring bug classes)
- [x] Backward-compat path unchanged — `validate()`/`validate_or_raise()` untouched; CMD rules fire only via `lint()`; WARNING severity keeps the CLI exit-code contract identical for existing graphs
- [x] PR body includes verification evidence, not just "tests pass"

## Verification evidence

**Mechanical DoD** — `T1-6.verify.sh` from repo root (positive control), run post-polish:
```
command-content lint check: both hazard nodes flagged (masked: ['CMD-001'], sentinel: ['CMD-001', 'CMD-002'])
25 passed   (examples lint sweep — zero CMD findings on all 25 shipped examples)
14 passed   (root tests/ subset)
T1-6 mechanical DoD: PASS
```

**Critic-repro transcript** (in-process `lint()`, parallelogram tool nodes, post-polish tree):
```
echo "set -o pipefail"; false | tail -1   -> ['CMD-001']   (was [] in the critiqued rev)
printf 'set -o pipefail'; false | tail -1 -> ['CMD-001']   (was [])
false | tail -1; echo done                -> []             (was ['CMD-001'])
set -o pipefail; false | tail -1          -> []             (real suppression intact)
false | tail -1                           -> ['CMD-001']    (incident shape)
sh -c 'exit 1' 2>&1 | tail -5 && echo GREEN -> ['CMD-001', 'CMD-002']  (incident sentinel shape)
```

**Suites:** loop-pipeline full: 1589 passed / 1 skipped. New `test_command_content_lint.py`: 61 tests (incl. the 2 named critic-repro contract tests). pipeline-runner: 45 passed / 1 skipped. `git diff --check`: clean.

## Notes for reviewers

- **Not shellcheck by design:** two named hazard shapes, conservatively matched; every non-catch is stated in the rule docstrings and the guide. The `xargs` entry in the filter set is the most debatable member — it's in the incident-adjacent class (last-stage exit code masks the producer) but reviewers may wish to weigh it.
- `docs/DOT-AUTHORING-GUIDE.md` is a shared file with other pending draft branches; expect trivial section-append merges.
- The engine pipefail-default DEFER is a recommendation recorded in code comments, not a ledger entry — implementing it later is its own EXTENSIONS.md-ledgered change.

Generated with [Amplifier](https://github.com/microsoft/amplifier)
