### PR TITLE
feat(agents): attractor-expert design-time defenses + causal retry teaching

### DIFF
--- a/agents/attractor-expert.md
+++ b/agents/attractor-expert.md
@@ -101,6 +101,65 @@ context is thin, and produces a linted `.dot` artifact. This expert is the
 consultation target the skill delegates to; `/attractorify` is the session-facing
 entry point.
 
+## Design-Time Self-Check
+
+Apply this checklist at design START, mid-build, and final review. These are
+the layers static lint cannot see — the agent is the only defense at design
+time. Full patterns and compliant examples are in the companion context file.
+
+@attractor:context/attractor-expert-defenses.md
+
+**Command-content hazards** (catch before lint runs):
+- [ ] **CMD-001 — Pipe-masked exit code:** does any tool node pipe its primary
+  command into a filter (`tail`, `head`, `grep`, `sed`, `awk`, …) without
+  `set -o pipefail`? In `/bin/sh`, the pipeline exits with the filter's code
+  (always 0). Use the redirect idiom (`cmd > out.log 2>&1`) or an honest
+  token gate (`cmd && printf ok || printf fail`) instead.
+- [ ] **CMD-002 — Always-true sentinel:** does any tool node end with
+  `&& echo TOKEN` or `&& printf TOKEN` after a pipe to a filter? The filter
+  exits 0 unconditionally, so the sentinel fires regardless of whether the
+  real command succeeded. `tool.last_line` always says yes. Remove the pipe
+  or use the honest token gate idiom.
+
+**Judge verdict contracts** (lint cannot see inside node prompts):
+- [ ] Every `goal_gate=true` LLM node has an explicit outcome instruction:
+  call `report_outcome`, emit a pure-JSON verdict, or write a verdict file
+  that a downstream deterministic `parallelogram` gate reads. Prose verdicts
+  are discarded under the fail-closed contract (engine-semantics.md §5).
+  Never leave a judge to prose.
+
+**Delta-assertion gates** (green tests on an unmodified tree prove nothing):
+- [ ] Work-completion gates anchor to a recorded base SHA and assert that
+  the expected commits or file changes exist beyond the baseline. Record
+  `git rev-parse HEAD > .ai/base-sha` in a setup node; assert
+  `git log "$base"..HEAD` is non-empty in the gate.
+
+**Deferral/observer routing power** (an observation with no routing is
+decoration):
+- [ ] Every node whose job is to NOTICE a problem (audit, health-check,
+  preflight, deferral) either (a) has conditional out-edges keyed to what it
+  observes — requiring a machine-readable evidence file and a deterministic
+  gate — or (b) is explicitly documented as advisory-only and kept off the
+  success path's certification chain.
+
+## Retry Sophistication
+
+When designing convergence pipelines, prefer causal retry routing over
+uniform retry routing:
+- **Causal per-gate `retry_target`s:** route to the node that can change the
+  cause (`run_harness` → `retry_target="fix_harness"`), not always back to a
+  single `attempt` node.
+- **Per-failure-class fix nodes:** differentiate failure edges to dedicated
+  fix nodes per failure class (build failure, test failure, security failure).
+- **Graph-level `fallback_retry_target`:** graph-level `retry_target` and
+  `fallback_retry_target` are consulted on **unsatisfied goal-gate exit**
+  (spec §3.4), in the order: node retry → node fallback → graph retry →
+  graph fallback. They are NOT consulted on per-node failure (spec §3.7) —
+  per-node failure needs a node-level `retry_target` or a conditional edge.
+  Set graph-level targets as the last step in goal-gate-exit resolution for
+  convergence pipelines. See DOT-AUTHORING-GUIDE.md §"Retry with Fallback"
+  and the Causal Retry Patterns section.
+
 ## How to Help
 
 When asked about pipeline design:
@@ -108,6 +167,7 @@ When asked about pipeline design:
 2. Provide a complete, valid DOT graph
 3. Explain attribute choices (fidelity, goal gates, retries)
 4. Point to relevant example pipelines
+5. Apply the design-time self-check above before finalizing
 
 When debugging pipeline issues:
 1. Check DOT syntax (missing start/exit nodes, invalid conditions)

--- a/context/attractor-expert-defenses.md
+++ b/context/attractor-expert-defenses.md
@@ -1,0 +1,249 @@
+# Attractor Expert — Design-Time Authoring Defenses
+
+Four defense layers that static lint cannot see. The agent self-checks every
+pipeline it designs or reviews at the command/contract layer. Each defense
+maps to a real failure mode from production incident history.
+
+---
+
+## Defense 1 — Pipe-masked exit codes (CMD-001)
+
+**The hazard:** `tool_command="cmd 2>&1 | tail -N"` — in `/bin/sh`, the
+pipeline's exit code is `tail`'s, which is always 0 when it can read input.
+The gate records SUCCESS even when `cmd` printed `No such file or directory`.
+
+**Self-check question:** Does any tool node pipe its primary command into a
+filter (`tail`, `head`, `grep`, `sed`, `awk`, etc.) without `set -o pipefail`?
+
+**Honest alternatives:**
+```sh
+# Redirect — exit code is cmd's; output in out.log for diagnostics
+cmd > out.log 2>&1
+
+# Token gate (no pipe) — both branches fire; routing on the token
+cmd && printf ok || printf fail
+```
+
+**Note:** `pipefail` is not POSIX sh — use `bash -c 'set -o pipefail; ...'`
+or prefer the redirect idiom. The lint rule CMD-001 catches this statically;
+the agent catches it at design time, before lint runs.
+
+---
+
+## Defense 2 — Always-true sentinels (CMD-002)
+
+**The hazard:** `tool_command="cmd 2>&1 | tail -N && echo SENTINEL"` — `tail`
+exits 0 unconditionally (it can always read its input), so `&& echo SENTINEL`
+fires regardless of whether `cmd` succeeded. `tool.last_line` becomes the
+sentinel string even when the command failed. The gate always says yes.
+
+**Self-check question:** Does any tool node end with `&& echo TOKEN` or
+`&& printf TOKEN` after a pipe to a filter? If so, the sentinel is always-true.
+
+**Honest token gate (no pipe):**
+```sh
+# Both branches fire — the || distinguishes success from failure
+cmd && printf green || printf red
+
+# Exit-code gate — failure is preserved
+cmd && printf green || { printf red; exit 1; }
+```
+
+**Key discriminator:** does the command's success or failure still influence
+either the exit code or the emitted token? Sentinel hazard shapes destroy that
+influence. The lint rule CMD-002 catches this statically.
+
+---
+
+## Defense 3 — Judge verdict contracts
+
+**The hazard:** A `goal_gate=true` LLM node whose prompt does not mandate a
+machine-readable verdict. Under the fail-closed contract (engine-semantics.md
+§5), a goal gate reached via plain prose returns RETRY, not SUCCESS. But a
+judge that writes "NOT CONVERGED — 2 of 7 criteria pass" as prose and never
+calls `report_outcome` or emits structured JSON will exhaust retries and
+degrade to FAIL — the replan loop never fires as intended.
+
+**Self-check question:** Does every `goal_gate=true` node have an explicit
+outcome instruction in its prompt?
+
+**Three compliant patterns:**
+
+1. **`report_outcome` tool call** (most explicit — authoritative):
+   > "You MUST report your verdict by calling the `report_outcome` tool with
+   > `status: success` or `status: fail`. Prose verdicts are discarded."
+
+2. **Pure JSON response**:
+   > "Respond with ONLY a JSON object: `{\"status\": \"success\"}` or
+   > `{\"status\": \"fail\", \"reason\": \"...\"}`. No surrounding prose."
+
+3. **Verdict file + deterministic gate** (route on evidence, not typed
+   sentinels — preferred for complex judges):
+   ```dot
+   judge [shape=box, prompt="... Write verdict to .ai/verdict.txt: first
+       line must be exactly CONVERGED or NOT_CONVERGED."]
+   verdict_gate [shape=parallelogram, max_retries=0,
+       tool_command="grep -q '^CONVERGED$' .ai/verdict.txt && printf ok || printf fail"]
+   judge -> verdict_gate
+   verdict_gate -> done  [condition="tool.last_line=ok"]
+   verdict_gate -> fix   [condition="tool.last_line=fail"]
+   ```
+
+**Cross-reference:** engine-semantics.md §5 (verdict-recovery ladder, fail-closed
+goal-gate contract, `is_explicit` field).
+
+---
+
+## Defense 4 — Delta-assertion gates (base-SHA anchor)
+
+**The hazard:** A work-completion gate that runs tests on an unmodified tree.
+`cargo test` (or `pytest`, `go test`, etc.) green on the baseline proves
+nothing about the work the pipeline was supposed to do. If the implementation
+node silently failed to write anything, the gate passes anyway.
+
+**Self-check question:** Does the pipeline's completion gate assert that the
+expected work delta actually exists — not just that tests pass?
+
+**The base-SHA pattern:**
+```sh
+# Record the baseline before any work begins (in a setup/orient node):
+git rev-parse HEAD > .ai/base-sha
+
+# In the completion gate — assert commits exist beyond the baseline:
+base=$(cat .ai/base-sha)
+new_commits=$(git log --oneline "$base"..HEAD | wc -l)
+[ "$new_commits" -gt 0 ] || { echo "No commits since baseline"; exit 1; }
+```
+
+Or assert specific files changed:
+```sh
+base=$(cat .ai/base-sha)
+git diff --name-only "$base"..HEAD | grep -q 'src/' || {
+    echo "No source changes since baseline"; exit 1; }
+```
+
+**When this matters most:** pipelines that call external build/test commands
+where a silent no-op (missing script, wrong cwd, wrong target) still exits 0.
+The delta assertion is the second check — it catches "tests passed but nothing
+changed."
+
+---
+
+## Defense 5 — Deferral/observer routing power
+
+**The hazard:** An observer or deferral node that detects a problem but has no
+conditional out-edges and no durable evidence file. Its discovery defaults to
+SUCCESS and goes nowhere. An observation that cannot route is decoration.
+
+**The archetype:** A node that checks for missing implementation work and
+writes a prose report — but all its out-edges are unconditional, so the
+pipeline continues to success regardless of what it found.
+
+**Self-check question:** For every node whose job is to NOTICE a problem
+(audit, health-check, preflight, deferral), does it either:
+- (a) have conditional out-edges keyed to what it observes (requires a
+  machine-readable observation — evidence file + tool gate), OR
+- (b) is it explicitly documented as advisory-only and kept OFF the success
+  path's certification chain?
+
+**Compliant pattern — evidence file + gate:**
+```dot
+check_impl [shape=box,
+    prompt="Check whether the implementation exists. Write .ai/impl-status.txt:
+        first line must be PRESENT or MISSING."]
+
+impl_gate [shape=parallelogram, max_retries=0,
+    tool_command="grep -q '^PRESENT$' .ai/impl-status.txt && printf ok || printf missing"]
+
+check_impl -> impl_gate
+impl_gate -> next_step  [condition="tool.last_line=ok"]
+impl_gate -> fix_impl   [condition="tool.last_line=missing"]
+```
+
+**The deferral label:** a node explicitly named or documented as a "deferral"
+(e.g., `windows_defer`) should either have routing power (pattern above) or
+carry a comment explaining why it is advisory-only and confirming it is not on
+the certification chain. Undocumented deferrals that default to success are the
+failure mode.
+
+---
+
+## Retry sophistication — patterns to teach
+
+The following patterns appear in production pipelines and exceed the
+sophistication of current exemplars. They are doctrine, not novelty.
+
+### Causal per-gate retry targets
+
+Route retry to the node that can change the cause — not always back to
+`attempt`. Different failure classes have different root causes:
+
+```dot
+build_harness [shape=parallelogram, goal_gate=true,
+    retry_target="fix_harness"]   // harness fails? fix the harness
+
+run_tests [shape=parallelogram, goal_gate=true,
+    retry_target="fix_tests"]     // tests fail? fix the tests, not the harness
+
+security_scan [shape=parallelogram, goal_gate=true,
+    retry_target="fix_security"]  // security fails? fix security issues
+```
+
+Compare to the simpler (but less causal) pattern where all retry_targets
+point to the same `attempt` node — that works for homogeneous failure classes
+but loses precision when failures have different causes.
+
+### Per-failure-class fix nodes
+
+Differentiated failure edges with dedicated fix nodes per failure class:
+
+```dot
+// Instead of one generic fix node:
+verify -> attempt [condition="outcome=fail"]
+
+// Use per-class fix nodes:
+verify -> fix_build   [condition="tool.last_line=build_failed"]
+verify -> fix_tests   [condition="tool.last_line=test_failed"]
+verify -> fix_security [condition="tool.last_line=security_failed"]
+```
+
+This is the mechanized form of differentiated failure edges (see
+DOT-AUTHORING-GUIDE.md §"Causal Retry Patterns"). The task-runner exemplar
+(`examples/patterns/task-runner.md`) uses a single triage path — per-class fix
+nodes are appropriate when failure classes are distinct and have different
+remediation strategies.
+
+### Graph-level `fallback_retry_target`
+
+Graph-level `retry_target` and `fallback_retry_target` participate in
+**unsatisfied goal-gate exit resolution** (spec §3.4) — they are the final
+steps in the order: node retry → node fallback → graph retry → graph fallback.
+They are NOT consulted on per-node failure (spec §3.7). Per-node failure with
+no matching edge and no node-level retry target terminates FAIL — it does not
+fall through to graph-level recovery. For per-node recovery, use a node-level
+`retry_target` attribute or a conditional corrective edge.
+
+In convergence pipelines, set graph-level targets as the last resort in
+goal-gate-exit resolution:
+
+```dot
+digraph ConvergencePipeline {
+    graph [
+        goal="...",
+        // These fire on unsatisfied goal-gate exit (spec §3.4),
+        // NOT on per-node failure (spec §3.7).
+        retry_target="attempt",
+        fallback_retry_target="analyze_plan"   // goal-gate exit last resort: replan
+    ]
+    // ...
+}
+```
+
+This is convergence doctrine — not just a tutorial feature. The graph-level
+fallback is the final safety net when all goal gates are unsatisfied and the
+primary retry cannot address the failure. Teach it alongside `retry_target`
+in convergence pipelines, with the understanding that it applies to goal-gate
+exit, not to ordinary per-node failure.
+
+**Cross-reference:** DOT-AUTHORING-GUIDE.md §"Retry with Fallback" and the
+Causal Retry Patterns section; examples/pipelines/04-retry-with-fallback.dot.

--- a/docs/DOT-AUTHORING-GUIDE.md
+++ b/docs/DOT-AUTHORING-GUIDE.md
@@ -189,8 +189,12 @@ should call `report_outcome(status="success", preferred_label="pass")` or
 ### Retry with Fallback
 
 Use `max_retries`, `retry_target`, and `fallback_retry_target` for resilient
-execution. When a node fails and retries are exhausted, flow jumps to the
-retry target. If that also fails, the fallback target catches it.
+execution. When a node's retries are exhausted, execution jumps to its
+`retry_target`. If the node has no `retry_target`, its `fallback_retry_target`
+is tried instead — these are two separate fallback slots on the same failing
+node, not a chain where the retry target's failure triggers the fallback.
+Graph-level `retry_target` and `fallback_retry_target` are consulted only on
+unsatisfied goal-gate exit (spec §3.4), not on per-node failure.
 
 ```dot
 digraph {
@@ -225,6 +229,122 @@ digraph {
     validate -> implement [condition="outcome=fail"]
 }
 ```
+
+### Causal Retry Patterns
+
+The basic retry pattern (`retry_target="attempt"`) works well when all failure
+classes have the same cause. For convergence pipelines with multiple
+independent gates, **causal per-gate retry targets** and **per-failure-class
+fix nodes** give the engine a more precise recovery path — routing to the node
+that can change the cause, not always back to a single generic attempt node.
+
+**Causal per-gate `retry_target`s:**
+
+```dot
+digraph ConvergencePipeline {
+    graph [
+        goal="Build, test, and security-scan a feature branch",
+        default_max_retry=2,
+        // graph-level targets fire on unsatisfied goal-gate exit (spec §3.4),
+        // NOT on per-node failure (spec §3.7). Per-node failure uses node-level
+        // retry_target or a conditional edge.
+        retry_target="implement",           // goal-gate exit: retry at the work node
+        fallback_retry_target="analyze_plan" // goal-gate exit: last resort — replan
+    ]
+
+    start [shape=Mdiamond]
+    done  [shape=Msquare]
+
+    analyze_plan [shape=box,
+        prompt="Analyze the goal and write an implementation plan."]
+
+    implement [shape=box, thread_id="work",
+        prompt="Implement the plan."]
+
+    // Each gate routes failure to the node that can change its cause:
+    build_gate [shape=parallelogram, goal_gate=true,
+        tool_command="make build > build.log 2>&1 && printf ok || { printf fail; exit 1; }"]
+
+    test_gate [shape=parallelogram, goal_gate=true,
+        retry_target="fix_tests",           // tests fail? run the test-fix node
+        tool_command="make test > test.log 2>&1 && printf ok || { printf fail; exit 1; }"]
+
+    security_gate [shape=parallelogram, goal_gate=true,
+        retry_target="fix_security",        // security fails? run the security-fix node
+        tool_command="make security-scan > sec.log 2>&1 && printf ok || { printf fail; exit 1; }"]
+
+    fix_tests    [shape=box, prompt="Read test.log and fix the failing tests."]
+    fix_security [shape=box, prompt="Read sec.log and fix the security findings."]
+
+    start -> analyze_plan -> implement -> build_gate
+
+    // Build failures route straight back to the work node — an explicit,
+    // evidence-gated corrective loop (the back-edge form of causal routing):
+    build_gate -> implement [condition="outcome=fail"]
+    build_gate -> test_gate [condition="outcome=pass"]
+
+    test_gate -> security_gate -> done
+
+    // Close every corrective loop: a fix node must route back to the gate it
+    // serves, so the gate's evidence — not the fix's optimism — decides
+    // convergence. A fix node with no outgoing edge is a dead end: the fix
+    // succeeds, no edge matches, and the run terminates FAIL.
+    fix_tests    -> test_gate
+    fix_security -> security_gate
+}
+```
+
+Two causal routing forms appear above, and both need a *complete* loop:
+
+- **Conditional corrective edge** (`build_gate -> implement
+  [condition="outcome=fail"]`): routes on failure evidence immediately.
+  This is the lint-visible back-edge — `attractor lint` sees the cycle.
+- **Node-level `retry_target`** (`test_gate`, `security_gate`): fires only
+  when no edge matches after failure (spec §3.7) — fail-fast means a FAIL
+  outcome does not traverse plain unconditional edges, so the gate dispatches
+  to its fix node. The fix node's ordinary success edge back to the gate is
+  the return half of the loop. Without it, the loop is dead: fix succeeds,
+  no edge matches, run terminates FAIL.
+
+**Per-failure-class fix nodes** (differentiated failure edges):
+
+```dot
+// Instead of one generic corrective edge:
+verify -> attempt [condition="outcome=fail"]
+
+// Use per-class routing when failures have distinct causes:
+verify -> fix_build    [condition="tool.last_line=build_failed",   weight=3]
+verify -> fix_tests    [condition="tool.last_line=test_failed",    weight=2]
+verify -> fix_security [condition="tool.last_line=security_failed", weight=1]
+```
+
+This is the mechanized form of the differentiated-failure-edges pattern. Use
+it when failure classes are distinct and have different remediation strategies.
+
+**Graph-level `fallback_retry_target` as convergence doctrine:**
+
+Graph-level `retry_target` and `fallback_retry_target` are consulted on
+**unsatisfied goal-gate exit** (spec §3.4) — they are the final steps in the
+resolution order: node retry → node fallback → graph retry → graph fallback.
+They are NOT consulted on per-node failure (spec §3.7); per-node failure with
+no matching edge and no node-level retry target terminates FAIL. For per-node
+recovery, use a node-level `retry_target` or a conditional corrective edge.
+
+In convergence pipelines, set graph-level targets as the last resort in
+goal-gate-exit resolution:
+
+```dot
+graph [
+    goal="...",
+    retry_target="implement",            // goal-gate exit: retry at the work node
+    fallback_retry_target="analyze_plan" // goal-gate exit: last resort — replan
+]
+```
+
+This is convergence doctrine — not just a tutorial feature. The graph-level
+fallback is the final safety net when all goal gates are unsatisfied and the
+primary retry cannot address the failure (e.g., a fundamentally wrong approach).
+See `examples/pipelines/04-retry-with-fallback.dot` for a minimal working example.
 
 ### Iterative Pipelines (`loop_restart`)
 


### PR DESCRIPTION
The attractor-expert agent learns the failure layers static lint cannot see, and its proven topology strengths get folded back into the authoring guide as doctrine. Agent body gains a compact **Design-Time Self-Check** (applied at design START, mid-build, and final review — the agent's existing consultation cadence); depth lives in a new companion context file; `docs/DOT-AUTHORING-GUIDE.md` gains a **Causal Retry Patterns** section with a complete, lint-clean convergence exemplar and a corrected "Retry with Fallback" narrative.

## Why

The 2026-07-28 incident pipeline (2.4 h, exit success, zero work product) was authored **by attractor-expert**. Its topology was excellent — 5 goal gates, 8 corrective fail edges — and it died anyway, at layers the agent didn't know existed: pipe-masked exit codes (every gate's exit code was `tail`'s), always-true sentinels driving `tool.last_line`, a judge that wrote prose verdicts the fail-closed contract discards, green-on-unmodified-tree completion gates, and a deferral node that noticed missing work but had no routing power. CMD-001/002 now catch the two command shapes statically (shipped in the previous commit); the other three layers live inside prompts and gate semantics where **no lint can reach — the agent is the only design-time defense**. This PR teaches the agent all five as a self-check discipline, and folds the incident graph's genuine strengths (causal per-gate retry routing, per-failure-class fix nodes, graph-level fallback scope) into the guide so authors inherit them.

## Verification

- [x] Unit tests pass — doc-guard + examples-lint suites: **32 passed**
- [x] Live pipeline run — **N/A per verification gradient**: docs + agent-file + context-file only; zero engine, handler, or dispatch bytes touched
- [x] Mechanical DoD — T4-8.verify.sh PASS; incident-graph review demo catches all four gaps + topology strengths folded back + cross-naming + instruction-budget discipline
- [x] Example lint proof: before-fix extraction → `WARNING: [acyclic_graph]` (critic B's finding reproduces); after-fix extraction → `OK (no findings)`, graphviz `dot -Tcanon` parses
- [x] AGENTS.md reviewed; repo-specific gates met

## Notes for reviewers

- **Why the exemplar shows two routing forms:** node-level `retry_target` loops are engine-real but invisible to TOPO-003's edge-walk (an attribute jump is not an edge). The exemplar therefore also carries one explicit evidence-gated corrective back-edge so the graph is structurally cyclic and lints clean — and the explainer teaches authors the distinction rather than hiding it.
- `docs/DOT-AUTHORING-GUIDE.md` is a shared file with other pending draft branches; expect section-level merges (this PR appends `### Causal Retry Patterns` after `### Retry with Fallback`).
- The corrected "Retry with Fallback" narrative was itself an in-loop critic catch (the old text described fallback-as-chain, a path the engine never takes) — verified against `_resolve_failure_retry_target` and `test_failure_routing.py`.

For full evidence, reviewer commands, and provenance see: https://github.com/microsoft/amplifier-bundle-attractor/pull/new/feat/attractor-expert-defenses