### PR TITLE
feat(engine): worker-session observability — durable response.md + real session-event persistence

### DIFF
--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -124,7 +124,38 @@ provider module's responsibility.
 
 ---
 
-## 5. Code Reference Index
+## 5. Worker-Session Observability Contract
+
+**Behavior:** Every codergen (`box`) node execution leaves a durable forensic record in the
+run directory (EXTENSIONS.md §26):
+
+- `<logs_root>/<node_id>/response.md` — the node's **full final response**, written on both
+  backend return shapes (string and `Outcome`). The ≤200-char `last_response` context value
+  remains truncated by design (context economy); the file is the full record.
+- `<logs_root>/<node_id>/status.json` — carries `session_id`, the join key to the worker's
+  event stream.
+- `<logs_root>/<node_id>/sessions/<session_id>/events.jsonl` — the worker session's REAL
+  event stream (session lifecycle, `prompt:submit`/`prompt:complete`, `tool:pre`/`tool:post`
+  with tool names, arguments, and results, `orchestrator:complete`), appended as it happens
+  by the session-event persister in `hooks-pipeline-observability`. Record shape:
+  `{"event": <name>, "timestamp": <utc-iso>, "data": {...}}`.
+
+**Navigation:** starting from only the run dir — read `status.json` → `session_id` → open
+`sessions/<session_id>/events.jsonl` beside it. This answers "which tools did the worker
+call?" without any external session store.
+
+**Implication for consumers:** persistence requires the `hooks-pipeline-observability`
+module in the mounted bundle (the shipped attractor-core behavior includes it; spawned
+workers inherit it through bundle composition). Custom bundles that omit the module get
+graceful no-op: pipelines run identically, but worker event streams are not persisted and
+recorded `session_id`s are dangling pointers.
+
+**Spec basis:** canonical spec §5.6 requires per-node `prompt.md`/`response.md`; the session
+event stream is a documented extension (EXTENSIONS.md §26).
+
+---
+
+## 6. Code Reference Index
 
 | Contract | File | Location |
 |---|---|---|
@@ -133,3 +164,5 @@ provider module's responsibility.
 | `continue_on_fail` override | `modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py` | Lines 593–596 and comment block at 578–592 |
 | `runs_on` logic | `modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py` | Lines 1299–1323 (`_get_runs_on`) and 1350–1447 (`_check_node_skip`) |
 | Structural concurrency (component) | `modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/parallel.py` | Lines 91–94 (`max_parallel` + semaphore) |
+| Worker observability seam | `modules/loop-pipeline/amplifier_module_loop_pipeline/worker_observability.py` | Module docstring (`current_worker_sessions_dir`) |
+| Session-event persistence | `modules/hooks-pipeline-observability/amplifier_module_hooks_pipeline_observability/session_events.py` | `SessionEventPersister` |

--- a/modules/hooks-pipeline-observability/amplifier_module_hooks_pipeline_observability/__init__.py
+++ b/modules/hooks-pipeline-observability/amplifier_module_hooks_pipeline_observability/__init__.py
@@ -6,6 +6,7 @@ import logging
 from typing import Any
 
 from .aggregator import StateAggregator
+from .session_events import register_session_event_persister
 from .status_bar import StatusBarContributor
 
 logger = logging.getLogger(__name__)
@@ -68,6 +69,8 @@ async def mount(coordinator: Any, config: dict[str, Any] | None = None) -> None:
     2. StatusBarContributor — compact system-reminder for context injection
     3. pipeline.state contribution channel — makes state queryable
     4. observability.events contribution — ensures pipeline events are discoverable
+    5. SessionEventPersister — persists worker-session event streams to the
+       run dir (EXTENSIONS.md §26; no-op outside a codergen backend call)
     """
     hooks = coordinator.get("hooks")
     aggregator = StateAggregator()
@@ -76,6 +79,15 @@ async def mount(coordinator: Any, config: dict[str, Any] | None = None) -> None:
     for event_name, handler_name in _AGGREGATOR_HANDLER_MAP.items():
         handler = getattr(aggregator, handler_name)
         hooks.register(event_name, handler, name="pipeline-observability")
+
+    # Worker-session event persistence (EXTENSIONS.md §26).  This module is
+    # composed into every spawned worker session (attractor-core mounts it on
+    # the parent bundle; PreparedBundle.spawn composes parent + child), so
+    # these handlers receive each worker's REAL event stream — session
+    # lifecycle, tool:pre/tool:post, orchestrator completion — and append it
+    # to <stage_dir>/sessions/<session_id>/events.jsonl.  Gracefully no-ops
+    # when the loop-pipeline seam is absent or unset.
+    register_session_event_persister(hooks)
 
     # Status bar contributor for context injection
     status_bar = StatusBarContributor(aggregator)

--- a/modules/hooks-pipeline-observability/amplifier_module_hooks_pipeline_observability/session_events.py
+++ b/modules/hooks-pipeline-observability/amplifier_module_hooks_pipeline_observability/session_events.py
@@ -1,0 +1,154 @@
+"""Worker-session event persistence (attractor EXTENSIONS.md Section 26).
+
+Persists the REAL event stream of pipeline worker sessions to durable
+``events.jsonl`` files under the pipeline run directory, so that a run is
+forensically traceable after the fact: which tools did the worker call, when
+did the session start and end, where did it get stuck.
+
+How it plugs in
+---------------
+This module is mounted by ``hooks-pipeline-observability`` (see
+``__init__.mount``), which the attractor-core behavior mounts into the parent
+pipeline session AND — via foundation bundle composition in
+``PreparedBundle.spawn`` — into every spawned worker (box-node) session.  The
+handlers registered here therefore receive each worker session's OWN events,
+emitted by its orchestrator and kernel as they happen (e.g. loop-agent's
+``tool:pre``/``tool:post`` emissions).
+
+Where it writes
+---------------
+The destination is task-scoped, not global: the loop-pipeline codergen
+handler sets ``current_worker_sessions_dir`` (a ``ContextVar`` in
+``amplifier_module_loop_pipeline.worker_observability``) to
+``<stage_dir>/sessions`` for the duration of each backend call.  Worker
+sessions run in-process within that same task context, so at emit time this
+persister resolves:
+
+    <stage_dir>/sessions/<session_id>/events.jsonl
+
+``session_id`` comes from the event payload itself — the amplifier-core
+kernel merges ``session_id``/``parent_id`` into every emitted event's data
+via ``hooks.set_default_fields`` at session construction.
+
+Graceful degradation (all no-ops, never errors):
+- loop-pipeline not importable (module mounted outside a pipeline context),
+- ContextVar unset (session not spawned by a codergen node),
+- event carries no ``session_id`` (bare registry without default fields).
+
+Records are standard-shaped, append-only JSONL, one event per line:
+``{"event": <name>, "timestamp": <utc-iso>, "data": {...}}`` — the same
+shape session observers write for ordinary Amplifier sessions, so existing
+session tooling can read these files unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from collections.abc import Callable
+from datetime import datetime, timezone
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+#: Events persisted per worker session.  Curated for forensic value (the
+#: questions post-mortems actually ask) rather than raw volume: session
+#: lifecycle brackets, the instruction, every tool invocation with its
+#: arguments and result, and the orchestrator's completion.  Streaming deltas
+#: (``*_delta``, ``content_block:*``) are deliberately excluded — they are
+#: UI-cadence noise; the durable response already lands in the node's
+#: ``response.md``.
+PERSISTED_SESSION_EVENTS: tuple[str, ...] = (
+    "session:start",
+    "session:resume",
+    "session:end",
+    "prompt:submit",
+    "prompt:complete",
+    "tool:pre",
+    "tool:post",
+    "orchestrator:complete",
+)
+
+
+def _default_sessions_dir_resolver() -> str | None:
+    """Resolve the current worker-sessions destination directory.
+
+    Reads loop-pipeline's ``current_worker_sessions_dir`` ContextVar.  Lazy
+    import: this hooks module must mount fine in sessions where loop-pipeline
+    is not importable (returns None -> persister no-ops).
+    """
+    try:
+        from amplifier_module_loop_pipeline.worker_observability import (
+            current_worker_sessions_dir,
+        )
+    except ImportError:
+        return None
+    return current_worker_sessions_dir.get()
+
+
+class SessionEventPersister:
+    """Appends session events to ``<sessions_dir>/<session_id>/events.jsonl``.
+
+    ``sessions_dir_resolver`` is injectable for tests; the default resolves
+    loop-pipeline's ContextVar seam (see module docstring).
+    """
+
+    def __init__(
+        self, sessions_dir_resolver: Callable[[], str | None] | None = None
+    ) -> None:
+        self._resolve_sessions_dir = (
+            sessions_dir_resolver or _default_sessions_dir_resolver
+        )
+
+    def make_handler(self, event_name: str):
+        """Build the hook handler for one event name.
+
+        The registry dispatches ``handler(event, data)`` (same signature the
+        StateAggregator handlers use); the name is also bound per-handler so
+        the persisted record never depends on the dispatch argument.
+        """
+
+        async def handler(
+            event: str | None = None, data: dict[str, Any] | None = None
+        ) -> None:
+            try:
+                self._persist(event_name, data or {})
+            except Exception:  # never break the session for observability
+                logger.debug(
+                    "session-event persistence failed for %s", event_name, exc_info=True
+                )
+
+        return handler
+
+    def _persist(self, event_name: str, data: dict[str, Any]) -> None:
+        sessions_dir = self._resolve_sessions_dir()
+        if not sessions_dir:
+            return  # not inside a worker-spawning node execution
+        session_id = data.get("session_id")
+        if not session_id:
+            return  # cannot key the stream without a session identity
+        session_dir = os.path.join(sessions_dir, str(session_id))
+        os.makedirs(session_dir, exist_ok=True)
+        record = {
+            "event": event_name,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "data": data,
+        }
+        path = os.path.join(session_dir, "events.jsonl")
+        with open(path, "a", encoding="utf-8") as f:
+            f.write(json.dumps(record, ensure_ascii=False, default=str) + "\n")
+
+
+def register_session_event_persister(
+    hooks: Any, persister: SessionEventPersister | None = None
+) -> SessionEventPersister:
+    """Register a persister handler for every event in PERSISTED_SESSION_EVENTS."""
+    persister = persister or SessionEventPersister()
+    for event_name in PERSISTED_SESSION_EVENTS:
+        hooks.register(
+            event_name,
+            persister.make_handler(event_name),
+            name="session-event-persister",
+        )
+    return persister

--- a/modules/hooks-pipeline-observability/tests/test_session_events.py
+++ b/modules/hooks-pipeline-observability/tests/test_session_events.py
@@ -1,0 +1,226 @@
+"""Tests for worker-session event persistence (EXTENSIONS.md Section 26).
+
+Covers the SessionEventPersister in isolation (injected destination
+resolver), its registration in mount(), and the real amplifier-core
+HookRegistry integration — including the kernel's default-field merge that
+supplies ``session_id`` on every emitted event.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from amplifier_core.hooks import HookRegistry
+
+from amplifier_module_hooks_pipeline_observability import mount
+from amplifier_module_hooks_pipeline_observability.session_events import (
+    PERSISTED_SESSION_EVENTS,
+    SessionEventPersister,
+    register_session_event_persister,
+)
+
+
+def _read_events(path):
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+# ---------------------------------------------------------------------------
+# Persister unit behavior (injected resolver)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_persists_tool_events_with_real_tool_names(tmp_path):
+    """tool:pre/tool:post events land in <sessions>/<id>/events.jsonl verbatim."""
+    sessions = tmp_path / "sessions"
+    persister = SessionEventPersister(lambda: str(sessions))
+
+    pre = persister.make_handler("tool:pre")
+    post = persister.make_handler("tool:post")
+    await pre(
+        "tool:pre",
+        {
+            "session_id": "sid-123",
+            "tool_name": "bash",
+            "tool_input": {"command": "pytest -q"},
+        },
+    )
+    await post(
+        "tool:post",
+        {
+            "session_id": "sid-123",
+            "tool_name": "bash",
+            "tool_input": {"command": "pytest -q"},
+            "result": "4 passed",
+            "call_id": "c1",
+        },
+    )
+
+    records = _read_events(sessions / "sid-123" / "events.jsonl")
+    assert [r["event"] for r in records] == ["tool:pre", "tool:post"]
+    assert records[0]["data"]["tool_name"] == "bash"
+    assert records[0]["data"]["tool_input"]["command"] == "pytest -q"
+    assert records[1]["data"]["result"] == "4 passed"
+    assert all("timestamp" in r for r in records)
+
+
+@pytest.mark.asyncio
+async def test_appends_across_events_and_separates_sessions(tmp_path):
+    """Events append per session; distinct session ids get distinct dirs."""
+    sessions = tmp_path / "sessions"
+    persister = SessionEventPersister(lambda: str(sessions))
+
+    start = persister.make_handler("session:start")
+    end = persister.make_handler("session:end")
+    await start("session:start", {"session_id": "sid-a"})
+    await end("session:end", {"session_id": "sid-a", "status": "completed"})
+    await start("session:start", {"session_id": "sid-b"})
+
+    a = _read_events(sessions / "sid-a" / "events.jsonl")
+    b = _read_events(sessions / "sid-b" / "events.jsonl")
+    assert [r["event"] for r in a] == ["session:start", "session:end"]
+    assert [r["event"] for r in b] == ["session:start"]
+
+
+@pytest.mark.asyncio
+async def test_noop_when_destination_unset(tmp_path):
+    """No ContextVar destination -> nothing written anywhere."""
+    persister = SessionEventPersister(lambda: None)
+    handler = persister.make_handler("tool:pre")
+    await handler("tool:pre", {"session_id": "sid-123", "tool_name": "bash"})
+    assert list(tmp_path.rglob("events.jsonl")) == []
+
+
+@pytest.mark.asyncio
+async def test_noop_without_session_id(tmp_path):
+    """Events without a session identity cannot be keyed -> skipped."""
+    sessions = tmp_path / "sessions"
+    persister = SessionEventPersister(lambda: str(sessions))
+    handler = persister.make_handler("tool:pre")
+    await handler("tool:pre", {"tool_name": "bash"})
+    await handler("tool:pre", None)
+    assert not sessions.exists()
+
+
+@pytest.mark.asyncio
+async def test_handler_never_raises(tmp_path):
+    """Persistence failures must never break the session."""
+
+    def _boom():
+        raise RuntimeError("resolver exploded")
+
+    persister = SessionEventPersister(_boom)
+    handler = persister.make_handler("tool:pre")
+    await handler("tool:pre", {"session_id": "sid-123"})  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_non_serializable_payload_falls_back_to_str(tmp_path):
+    """Arbitrary objects in event data are stringified, not fatal."""
+    sessions = tmp_path / "sessions"
+    persister = SessionEventPersister(lambda: str(sessions))
+    handler = persister.make_handler("tool:post")
+    await handler("tool:post", {"session_id": "sid-123", "result": object()})
+    records = _read_events(sessions / "sid-123" / "events.jsonl")
+    assert len(records) == 1
+    assert "object object" in records[0]["data"]["result"]
+
+
+def test_default_resolver_noop_outside_pipeline_context():
+    """Default resolver returns None when the loop-pipeline seam is unset.
+
+    (When loop-pipeline is importable, the ContextVar default is None; when
+    it is not importable, the lazy import fails -> None either way.)
+    """
+    assert SessionEventPersister()._resolve_sessions_dir() is None
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_mount_registers_session_event_persister():
+    """mount() registers a persister handler for every curated session event."""
+    hooks_mock = MagicMock()
+    coordinator = MagicMock()
+    coordinator.get.return_value = hooks_mock
+    coordinator.get_capability.return_value = []
+
+    await mount(coordinator)
+
+    registered = [
+        (c.args[0], c.kwargs.get("name"))
+        for c in hooks_mock.register.call_args_list
+        if c.kwargs.get("name") == "session-event-persister"
+    ]
+    assert {name for name, _ in registered} == set(PERSISTED_SESSION_EVENTS)
+    assert {"tool:pre", "tool:post", "session:start", "session:end"} <= {
+        name for name, _ in registered
+    }
+
+
+# ---------------------------------------------------------------------------
+# Real HookRegistry integration (the kernel default-field merge)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_real_registry_merges_session_id_default_field(tmp_path):
+    """With a real HookRegistry + set_default_fields (exactly what
+    AmplifierSession does at construction), emitted tool events carry
+    session_id and are persisted under that id — the production wiring.
+    """
+    sessions = tmp_path / "sessions"
+    hooks = HookRegistry()
+    hooks.set_default_fields(session_id="worker-xyz", parent_id="parent-1")
+    register_session_event_persister(
+        hooks, SessionEventPersister(lambda: str(sessions))
+    )
+
+    await hooks.emit("tool:pre", {"tool_name": "edit_file", "tool_input": {"p": 1}})
+    await hooks.emit(
+        "tool:post",
+        {"tool_name": "edit_file", "tool_input": {"p": 1}, "result": "ok"},
+    )
+    await hooks.emit("session:end", {"status": "completed"})
+
+    records = _read_events(sessions / "worker-xyz" / "events.jsonl")
+    assert [r["event"] for r in records] == ["tool:pre", "tool:post", "session:end"]
+    # The forensic question: which tools did the worker call?
+    tool_calls = [r["data"]["tool_name"] for r in records if r["event"] == "tool:pre"]
+    assert tool_calls == ["edit_file"]
+    assert records[0]["data"]["session_id"] == "worker-xyz"
+
+
+@pytest.mark.asyncio
+async def test_started_session_never_yields_empty_events_file(tmp_path):
+    """Empty events.jsonl != idle worker.
+
+    ``session:start`` is in the curated persist set, so every session the
+    persister observes writes at least its start record -- even a worker that
+    calls no tools. A well-formed capture therefore can NEVER produce an
+    empty events.jsonl for a session that actually started: an empty (or
+    absent) file under a recorded session id signals capture
+    failure/corruption, not an idle worker. This test pins that
+    distinguishing property.
+    """
+    sessions = tmp_path / "sessions"
+    hooks = HookRegistry()
+    hooks.set_default_fields(session_id="worker-idle")
+    register_session_event_persister(
+        hooks, SessionEventPersister(lambda: str(sessions))
+    )
+
+    # The minimal production lifecycle: the kernel emits session:start when
+    # the session begins -- this worker then does nothing at all.
+    await hooks.emit("session:start", {"parent_id": "parent-1"})
+    await hooks.emit("session:end", {"status": "completed"})
+
+    path = sessions / "worker-idle" / "events.jsonl"
+    assert path.exists() and path.stat().st_size > 0
+    records = _read_events(path)
+    assert records[0]["event"] == "session:start"

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/backend.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/backend.py
@@ -1329,6 +1329,7 @@ def _parse_outcome(output: str, *, node: object = None) -> Outcome:
                         suggested_next_ids=data.get("suggested_next_ids"),
                         context_updates=data.get("context_updates"),
                         is_explicit=True,
+                        response_text=output,  # EXTENSIONS.md §26: carry full text
                     )
         except (json.JSONDecodeError, KeyError, TypeError):
             pass
@@ -1379,6 +1380,7 @@ def _parse_outcome(output: str, *, node: object = None) -> Outcome:
                             suggested_next_ids=_embedded.get("suggested_next_ids"),
                             context_updates=_embedded.get("context_updates"),
                             is_explicit=True,
+                            response_text=output,  # EXTENSIONS.md §26: carry full text
                         )
             except (json.JSONDecodeError, KeyError, TypeError):
                 pass
@@ -1409,6 +1411,7 @@ def _parse_outcome(output: str, *, node: object = None) -> Outcome:
             notes=f"No explicit verdict from goal_gate node — plain text only: {output[:200]}",
             failure_reason="goal_gate node requires an explicit verdict (report_outcome / JSON)",
             is_explicit=False,
+            response_text=output,  # EXTENSIONS.md §26: carry full text
         )
 
     # Non-goal_gate node: plain text response — per spec Section 4.5, treat as SUCCESS.
@@ -1416,4 +1419,5 @@ def _parse_outcome(output: str, *, node: object = None) -> Outcome:
         status=StageStatus.SUCCESS,
         notes=f"Plain text response: {output[:200]}",
         is_explicit=False,
+        response_text=output,  # EXTENSIONS.md §26: carry full text
     )

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/codergen.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/codergen.py
@@ -20,6 +20,7 @@ from ..context import PipelineContext
 from ..graph import Graph, Node
 from ..outcome import Outcome, StageStatus
 from ..transforms import expand_goal_variable, expand_params
+from ..worker_observability import current_worker_sessions_dir
 
 
 @runtime_checkable
@@ -113,10 +114,35 @@ class CodergenHandler:
             # with defaults), so this unconditional call is the whole contract:
             # the production AmplifierBackend accepts them and all conforming test
             # doubles match this signature.
-            result = await self._backend.run(
-                node, prompt, context, incoming_edge=None, graph=graph
+            # EXTENSIONS.md §26: while the backend call is in flight, expose
+            # <stage_dir>/sessions as the destination for worker-session event
+            # persistence.  The spawned child session runs in-process within
+            # this same task context, so the session-event persister mounted in
+            # the child (hooks-pipeline-observability) reads this ContextVar
+            # and appends the child's REAL event stream (session lifecycle,
+            # tool:pre/tool:post, ...) to
+            # <stage_dir>/sessions/<session_id>/events.jsonl as it happens.
+            # try/finally guarantees the reset even when the backend raises.
+            sessions_token = current_worker_sessions_dir.set(
+                os.path.join(stage_dir, "sessions")
             )
+            try:
+                result = await self._backend.run(
+                    node, prompt, context, incoming_edge=None, graph=graph
+                )
+            finally:
+                current_worker_sessions_dir.reset(sessions_token)
             if isinstance(result, Outcome):
+                # EXTENSIONS.md §26: write response.md from the full text carried
+                # on the Outcome (set by _parse_outcome before any truncation).
+                # The production AmplifierBackend spawn path always returns an
+                # Outcome, so this is the only place response.md is written on
+                # that path.  If response_text is None (infrastructure failures,
+                # tool handlers) we skip the write — there is no text to save.
+                if result.response_text:
+                    _write_file(
+                        os.path.join(stage_dir, "response.md"), result.response_text
+                    )
                 _write_status(stage_dir, result)
                 return result
             response_text = str(result)
@@ -221,5 +247,11 @@ def _write_status(stage_dir: str, outcome: Outcome) -> None:
         # EXTENSIONS.md §25: is_explicit is durable audit data; the codergen
         # early-writer must carry it too, not just the engine's writers.
         "is_explicit": outcome.is_explicit,
+        # EXTENSIONS.md §26: session_id is the join key from this node's
+        # status record to the persisted worker-session event stream at
+        # <stage_dir>/sessions/<session_id>/events.jsonl — the engine's
+        # writers carry it (engine.py _write_node_status); the early-writer
+        # must too, or the Outcome path leaves a dangling trail.
+        "session_id": outcome.session_id,
     }
     _write_file(os.path.join(stage_dir, "status.json"), json.dumps(data, indent=2))

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/outcome.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/outcome.py
@@ -61,6 +61,16 @@ class Outcome:
     #: unsatisfied and the gate fails closed (RETRY / FAIL, never silent success).
     is_explicit: bool = field(default=False)
 
+    #: EXTENSIONS.md §26 — full response text from the LLM/spawn path, carried
+    #: through the Outcome so the codergen handler can write response.md even
+    #: when the backend returns an Outcome (not a raw string).  Set by
+    #: _parse_outcome() to the verbatim ``output`` text before any truncation.
+    #: The codergen handler writes this to <stage_dir>/response.md and then
+    #: discards it (it is NOT included in status.json or context_updates).
+    #: None when the Outcome was constructed by a path that did not go through
+    #: _parse_outcome (e.g. spawn infrastructure failures, tool handlers).
+    response_text: str | None = None
+
     #: Issue 10 / analog of WS-4 Sub-fix C: structured tool-invocation payload
     #: populated by ToolHandler on failure so the dashboard can display the
     #: command and output instead of the "command lost on failure" placeholder.

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/worker_observability.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/worker_observability.py
@@ -1,0 +1,35 @@
+"""Worker-session observability seam (EXTENSIONS.md Section 26).
+
+The codergen handler sets ``current_worker_sessions_dir`` to
+``<stage_dir>/sessions`` for the duration of each backend call.  Because the
+worker's child session runs in-process, within the same task context, any
+session-scoped observer (see ``hooks-pipeline-observability``'s session-event
+persister) can read this variable while the child session's events are being
+emitted and persist them under the node's stage directory:
+
+    <logs_root>/<node_id>/sessions/<session_id>/events.jsonl
+
+A ``ContextVar`` (not a global or an env var) is deliberate: parallel branches
+execute nodes in separate asyncio tasks, and context variables are task-local
+and inherited by tasks created inside the handler's await chain -- each
+worker's events land under the node that spawned it, with no cross-talk.
+
+This module owns only the seam.  The consumer side lives in
+``hooks-pipeline-observability`` (mounted into every spawned worker session via
+bundle composition -- see ``behaviors/attractor-core.yaml``), which imports
+this variable lazily and no-ops when it is unset.  The engine has no runtime
+dependency on the hooks module; the hooks module degrades gracefully when this
+module is absent.  Either side can be missing and nothing breaks.
+"""
+
+from __future__ import annotations
+
+from contextvars import ContextVar
+
+#: Destination directory for persisted worker-session event streams, set by
+#: the codergen handler around each backend call.  ``None`` (the default)
+#: means "not inside a worker-spawning node execution" -- observers must
+#: treat that as "do not persist".
+current_worker_sessions_dir: ContextVar[str | None] = ContextVar(
+    "current_worker_sessions_dir", default=None
+)

--- a/modules/loop-pipeline/tests/test_worker_session_observability.py
+++ b/modules/loop-pipeline/tests/test_worker_session_observability.py
@@ -1,0 +1,351 @@
+"""Tests for worker-session observability (EXTENSIONS.md Section 26).
+
+Two behaviors, both previously absent on the production path:
+
+1. **Full-response durability** — when the backend returns an ``Outcome``
+   (the AmplifierBackend spawn path always does), the codergen handler must
+   still write the node's full final response to ``<stage_dir>/response.md``
+   instead of letting it survive only as ~200-char scraps.
+
+2. **Session-event persistence seam** — the handler exposes
+   ``<stage_dir>/sessions`` via the ``current_worker_sessions_dir``
+   ContextVar for the duration of the backend call, so the session-event
+   persister mounted in the spawned worker session (see
+   ``hooks-pipeline-observability``) can append the worker's REAL event
+   stream to ``<stage_dir>/sessions/<session_id>/events.jsonl``.
+
+The end-to-end test loads the shipped persister from
+``modules/hooks-pipeline-observability`` by file path (the module is not an
+install-time dependency of loop-pipeline — the runtime coupling is
+deliberately lazy in BOTH directions) and drives the real engine with a
+backend that emits tool events through a real amplifier-core HookRegistry,
+exactly as a spawned loop-agent worker does.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from amplifier_core.hooks import HookRegistry
+
+from amplifier_module_loop_pipeline.backend import _parse_outcome
+from amplifier_module_loop_pipeline.context import PipelineContext
+from amplifier_module_loop_pipeline.dot_parser import parse_dot
+from amplifier_module_loop_pipeline.engine import PipelineEngine
+from amplifier_module_loop_pipeline.handlers import HandlerRegistry
+from amplifier_module_loop_pipeline.handlers.context import HandlerContext
+from amplifier_module_loop_pipeline.outcome import Outcome, StageStatus
+from amplifier_module_loop_pipeline.validation import validate_or_raise
+from amplifier_module_loop_pipeline.worker_observability import (
+    current_worker_sessions_dir,
+)
+
+TAIL_MARKER = "FULL-RESPONSE-TAIL-MARKER"
+# Marker sits ~495 chars in — beyond the 200-char truncation horizon.
+LONG_RESPONSE = ("worker analysis filler sentence. " * 15) + TAIL_MARKER
+
+SIMPLE_DOT = """
+digraph WorkerObs {
+    graph [goal="worker observability fixture"]
+    start [shape=Mdiamond]
+    work  [shape=box, prompt="produce the analysis"]
+    done  [shape=Msquare]
+    start -> work
+    work -> done
+}
+"""
+
+
+def _make_engine(backend, logs_root: str) -> PipelineEngine:
+    graph = parse_dot(SIMPLE_DOT)
+    validate_or_raise(graph)
+    return PipelineEngine(
+        graph=graph,
+        context=PipelineContext(),
+        handler_registry=HandlerRegistry(HandlerContext(backend=backend)),
+        logs_root=logs_root,
+    )
+
+
+def _load_shipped_persister_module():
+    """Load the REAL shipped session_events.py by file path."""
+    path = (
+        Path(__file__).resolve().parents[2]
+        / "hooks-pipeline-observability"
+        / "amplifier_module_hooks_pipeline_observability"
+        / "session_events.py"
+    )
+    spec = importlib.util.spec_from_file_location("_shipped_session_events", path)
+    assert spec is not None and spec.loader is not None, f"missing shipped file: {path}"
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# ---------------------------------------------------------------------------
+# 1. Full-response durability on the Outcome path
+# ---------------------------------------------------------------------------
+
+
+class ProductionShapedBackend:
+    """Returns an Outcome via _parse_outcome — like the real spawn path."""
+
+    async def run(self, node, prompt, context, incoming_edge=None, graph=None):
+        return _parse_outcome(LONG_RESPONSE)
+
+
+class OutcomeBackend:
+    """Returns a pre-built Outcome (bypasses _parse_outcome)."""
+
+    def __init__(self, outcome: Outcome) -> None:
+        self._outcome = outcome
+
+    async def run(self, node, prompt, context, incoming_edge=None, graph=None):
+        return self._outcome
+
+
+@pytest.mark.asyncio
+async def test_outcome_path_writes_full_response_md(tmp_path):
+    """The production (Outcome-returning) path writes full response.md."""
+    engine = _make_engine(ProductionShapedBackend(), str(tmp_path))
+    await engine.run()
+    response = (tmp_path / "work" / "response.md").read_text()
+    assert TAIL_MARKER in response
+    assert response == LONG_RESPONSE
+
+
+@pytest.mark.asyncio
+async def test_outcome_without_response_text_skips_response_md(tmp_path):
+    """No response_text (e.g. infrastructure outcome) -> no response.md."""
+    outcome = Outcome(status=StageStatus.SUCCESS, notes="tool-style outcome")
+    engine = _make_engine(OutcomeBackend(outcome), str(tmp_path))
+    await engine.run()
+    assert not (tmp_path / "work" / "response.md").exists()
+
+
+def test_parse_outcome_carries_full_text_on_every_path():
+    """All _parse_outcome return paths set response_text to the verbatim text."""
+    plain = _parse_outcome(LONG_RESPONSE)
+    assert plain.response_text == LONG_RESPONSE
+
+    json_verdict = json.dumps({"status": "success", "notes": "done"}) + "\ntrailing"
+    explicit = _parse_outcome(json_verdict)
+    assert explicit.response_text == json_verdict
+
+
+@pytest.mark.asyncio
+async def test_response_text_not_leaked_into_status_json(tmp_path):
+    """response_text is a file-write concern — it must not bloat status.json."""
+    engine = _make_engine(ProductionShapedBackend(), str(tmp_path))
+    await engine.run()
+    status = json.loads((tmp_path / "work" / "status.json").read_text())
+    assert TAIL_MARKER not in json.dumps(status)
+
+
+@pytest.mark.asyncio
+async def test_codergen_status_json_carries_session_id(tmp_path):
+    """The codergen early-writer records session_id (the forensic join key)."""
+    outcome = _parse_outcome(LONG_RESPONSE)
+    outcome.session_id = "sid-join-key"
+    engine = _make_engine(OutcomeBackend(outcome), str(tmp_path))
+    await engine.run()
+    status = json.loads((tmp_path / "work" / "status.json").read_text())
+    assert status["session_id"] == "sid-join-key"
+
+
+# ---------------------------------------------------------------------------
+# 2. The ContextVar seam
+# ---------------------------------------------------------------------------
+
+
+class SeamProbeBackend:
+    """Captures the ContextVar value observed during the backend call."""
+
+    def __init__(self) -> None:
+        self.observed: str | None = None
+
+    async def run(self, node, prompt, context, incoming_edge=None, graph=None):
+        self.observed = current_worker_sessions_dir.get()
+        return _parse_outcome("ok")
+
+
+class RaisingBackend:
+    async def run(self, node, prompt, context, incoming_edge=None, graph=None):
+        raise RuntimeError("backend exploded")
+
+
+@pytest.mark.asyncio
+async def test_sessions_dir_exposed_during_backend_call(tmp_path):
+    """During backend.run the seam points at <stage_dir>/sessions; after the
+    node completes it is reset to None."""
+    backend = SeamProbeBackend()
+    engine = _make_engine(backend, str(tmp_path))
+    await engine.run()
+    assert backend.observed == str(tmp_path / "work" / "sessions")
+    assert current_worker_sessions_dir.get() is None
+
+
+@pytest.mark.asyncio
+async def test_sessions_dir_reset_even_when_backend_raises(tmp_path):
+    """try/finally: the seam never leaks past a failing backend call."""
+    engine = _make_engine(RaisingBackend(), str(tmp_path))
+    await engine.run()
+    assert current_worker_sessions_dir.get() is None
+
+
+@pytest.mark.asyncio
+async def test_no_synthetic_session_record_is_fabricated(tmp_path):
+    """With no persister mounted, the handler writes NO session files — the
+    engine does not invent a session ledger after the fact (that was the
+    rejected synthetic-record design)."""
+    outcome = _parse_outcome(LONG_RESPONSE)
+    outcome.session_id = "sid-no-fabrication"
+    engine = _make_engine(OutcomeBackend(outcome), str(tmp_path))
+    await engine.run()
+    assert not (tmp_path / "work" / "sessions").exists()
+    assert list(tmp_path.rglob("events.jsonl")) == []
+
+
+# ---------------------------------------------------------------------------
+# 3. Capture-integrity invariant: empty events.jsonl != idle worker
+# ---------------------------------------------------------------------------
+
+
+def _session_capture_anomaly(stage_dir: Path) -> str | None:
+    """Distinguish "idle worker" from "capture failure/corruption".
+
+    The shipped persister's curated event set includes ``session:start``, so
+    every session it observes writes at least its start record -- even a
+    worker that called no tools. A well-formed capture therefore can NEVER
+    leave an empty (or absent) events.jsonl for a session id recorded in
+    status.json: such a file signals capture failure or corruption, not an
+    idle worker. Returns a description of the anomaly, or None when the
+    capture is well-formed. (When status.json records no session_id there is
+    nothing to cross-check -- that is the documented "no persister mounted"
+    degradation, not an anomaly.)
+    """
+    status = json.loads((stage_dir / "status.json").read_text())
+    session_id = status.get("session_id")
+    if not session_id:
+        return None
+    events_path = stage_dir / "sessions" / str(session_id) / "events.jsonl"
+    if not events_path.exists():
+        return (
+            f"session {session_id} recorded in status.json but its "
+            "events.jsonl is absent"
+        )
+    if events_path.stat().st_size == 0:
+        return f"events.jsonl for session {session_id} is empty (zero-byte)"
+    first = json.loads(events_path.read_text().splitlines()[0])
+    if first["event"] != "session:start":
+        return f"first persisted record is {first['event']!r}, not session:start"
+    return None
+
+
+@pytest.mark.asyncio
+async def test_empty_or_absent_events_file_is_detectably_abnormal(tmp_path):
+    """A zero-byte or absent events.jsonl under a recorded session id is
+    detectable as capture corruption -- it cannot be mistaken for a worker
+    that simply did nothing (an idle worker still persists session:start).
+    """
+    outcome = _parse_outcome(LONG_RESPONSE)
+    outcome.session_id = "sid-capture-lost"
+    engine = _make_engine(OutcomeBackend(outcome), str(tmp_path))
+    await engine.run()
+    work = tmp_path / "work"
+
+    # Absent file for a recorded session id -> anomaly.
+    anomaly = _session_capture_anomaly(work)
+    assert anomaly is not None and "absent" in anomaly
+
+    # Zero-byte file for a recorded session id -> anomaly.
+    events_path = work / "sessions" / "sid-capture-lost" / "events.jsonl"
+    events_path.parent.mkdir(parents=True)
+    events_path.touch()
+    anomaly = _session_capture_anomaly(work)
+    assert anomaly is not None and "zero-byte" in anomaly
+
+
+# ---------------------------------------------------------------------------
+# 4. End-to-end: real engine + shipped persister + real HookRegistry
+# ---------------------------------------------------------------------------
+
+
+class ToolCallingWorkerBackend:
+    """Simulates the spawn path: a worker session whose hook registry has the
+    shipped persister registered (as it does via bundle composition) emits
+    REAL tool events during the backend call, then the backend returns an
+    Outcome carrying the worker's session_id — exactly the production shape.
+    """
+
+    def __init__(self, hooks: HookRegistry, session_id: str) -> None:
+        self._hooks = hooks
+        self._session_id = session_id
+
+    async def run(self, node, prompt, context, incoming_edge=None, graph=None):
+        # What AmplifierSession does at construction (amplifier-core
+        # session.py): every event carries the session identity.
+        self._hooks.set_default_fields(session_id=self._session_id)
+        await self._hooks.emit("session:start", {"parent_id": None})
+        await self._hooks.emit(
+            "tool:pre",
+            {"tool_name": "bash", "tool_input": {"command": "pytest -q"}},
+        )
+        await self._hooks.emit(
+            "tool:post",
+            {
+                "tool_name": "bash",
+                "tool_input": {"command": "pytest -q"},
+                "result": "14 passed",
+                "call_id": "call-1",
+            },
+        )
+        await self._hooks.emit("session:end", {"status": "completed"})
+        outcome = _parse_outcome(LONG_RESPONSE)
+        outcome.session_id = self._session_id
+        return outcome
+
+
+@pytest.mark.asyncio
+async def test_end_to_end_real_events_persisted_and_locatable(tmp_path):
+    """The money path: engine run -> worker emits real tool events -> the
+    shipped persister writes them under <stage_dir>/sessions/<session_id>/
+    events.jsonl -> the file is locatable from the session_id recorded in
+    status.json and answers "which tools did the worker call?"."""
+    session_events = _load_shipped_persister_module()
+
+    hooks = HookRegistry()
+    session_events.register_session_event_persister(hooks)
+
+    session_id = "worker-e2e-1"
+    engine = _make_engine(ToolCallingWorkerBackend(hooks, session_id), str(tmp_path))
+    await engine.run()
+
+    # Start from ONLY the run dir: read the recorded session_id...
+    status = json.loads((tmp_path / "work" / "status.json").read_text())
+    recorded_id = status["session_id"]
+    assert recorded_id == session_id
+
+    # ...locate the session file by that id...
+    events_path = tmp_path / "work" / "sessions" / recorded_id / "events.jsonl"
+    assert events_path.exists()
+    records = [json.loads(line) for line in events_path.read_text().splitlines()]
+
+    # ...and answer the forensic question with REAL events.
+    assert [r["event"] for r in records] == [
+        "session:start",
+        "tool:pre",
+        "tool:post",
+        "session:end",
+    ]
+    tools_called = [r["data"]["tool_name"] for r in records if r["event"] == "tool:pre"]
+    assert tools_called == ["bash"]
+    assert records[2]["data"]["result"] == "14 passed"
+
+    # The full response is durable beside it.
+    assert TAIL_MARKER in (tmp_path / "work" / "response.md").read_text()

--- a/specs/EXTENSIONS.md
+++ b/specs/EXTENSIONS.md
@@ -784,6 +784,131 @@ upstream spec adopts this, this extension documents the divergence.
 
 ---
 
+## 26. Worker-Session Observability: Durable `response.md` + Real Session-Event Persistence
+
+> **This extension is additive** — it implements the canonical spec's own run-dir layout
+> contract (§5.6 requires per-node `prompt.md`/`response.md`) and adds worker-session event
+> persistence the spec does not specify. It also FIXES a spec self-contradiction; see the
+> walk-upstream note below.
+
+### Incident motivation
+
+Worker sessions inside a pipeline run were write-only compute: they thought, acted, and
+vanished. Three separate post-mortems (one on the 2026-07-28 external incident that also
+motivated §25, two on internal runs) all dead-ended on the same missing evidence:
+
+- The node's full final response survived only as a ~200-char scrap
+  (`notes="Plain text response: {output[:200]}"` / `last_response[:200]`), because the
+  codergen handler wrote `response.md` only when the backend returned a *string* — and the
+  production `AmplifierBackend` spawn path always returns an `Outcome`, early-returning past
+  the write. Diagnostic analyses produced by pipeline nodes were cut off mid-sentence.
+- The `session_id` recorded in `status.json` was a dangling pointer: no `events.jsonl` or
+  `transcript.jsonl` existed anywhere on disk for spawned worker sessions (foundation's spawn
+  path never persists; see walk-upstream note). "Which tools did the worker call?" — the
+  first question of every wrong-but-plausible audit — was unanswerable.
+
+### What this extension does
+
+**1. Full-response durability (`Outcome.response_text` → `response.md`).**
+`_parse_outcome()` (backend.py) now carries the verbatim child output on
+`Outcome.response_text` — set on every return path, *before* any truncation. The codergen
+handler writes it to `<stage_dir>/response.md` on the Outcome path, closing the early-return
+gap. The field is a file-write concern only: it is NOT serialized into `status.json`,
+`trace.jsonl`, or `context_updates`, and the ≤200-char `last_response` context truncation is
+unchanged (context economy working as designed).
+
+**2. `session_id` in the codergen early-writer.** The engine's status writers already
+serialize `session_id`; the codergen handler's own `_write_status()` now does too, so the
+Outcome path never leaves a status record without its join key.
+
+**3. Real worker-session event persistence.** The worker's actual event stream is captured
+and persisted per session:
+
+- `amplifier_module_loop_pipeline.worker_observability` exposes a `ContextVar`
+  (`current_worker_sessions_dir`); the codergen handler sets it to `<stage_dir>/sessions`
+  for the duration of each backend call (try/finally-reset, task-local so parallel branches
+  cannot cross-talk).
+- `hooks-pipeline-observability` — already mounted into the parent session by the
+  attractor-core behavior, and composed into **every spawned worker session** by
+  `PreparedBundle.spawn`'s parent+child bundle composition — registers a
+  `SessionEventPersister` that appends each received event to
+  `<stage_dir>/sessions/<session_id>/events.jsonl`. The `session_id` comes from the event
+  payload itself: the amplifier-core kernel merges it into every event via
+  `hooks.set_default_fields` at session construction.
+- Persisted events (curated for forensic value; streaming deltas excluded):
+  `session:start`, `session:resume`, `session:end`, `prompt:submit`, `prompt:complete`,
+  `tool:pre`, `tool:post`, `orchestrator:complete`. Record shape is the standard session
+  observer shape — `{"event": <name>, "timestamp": <utc-iso>, "data": {...}}` — one JSON
+  object per line, append-only.
+
+These are the events the worker's own orchestrator/kernel emit as they happen (e.g.
+loop-agent's `tool:pre`/`tool:post` at tool-execution time) — captured, not reconstructed.
+An earlier design that fabricated a 3-event ledger after the child completed was rejected in
+review: a synthetic record cannot answer "which tools did the worker call?" and amounts to a
+second, invented session store.
+
+### Forensic navigation contract
+
+Starting from ONLY the run dir:
+
+```
+<logs_root>/<node_id>/status.json        → read "session_id"
+<logs_root>/<node_id>/sessions/<session_id>/events.jsonl
+                                         → the worker's real event stream
+<logs_root>/<node_id>/response.md        → the worker's full final response
+```
+
+### Walk-upstream note: where persistence belongs
+
+Session persistence is a *session* concern owned by amplifier-foundation: ordinary sessions
+persist `events.jsonl`/`transcript.jsonl` under `~/.amplifier/projects/<project>/sessions/<id>/`
+(`amplifier_foundation/session/store.py`, `finder.py`). On this stack that idiom never fires
+for pipeline workers: `PreparedBundle.spawn()` has **zero persist call sites** —
+`DEFAULT_SESSIONS_ROOT` is never written for spawned children; they are ephemeral by
+construction. The right long-term home for worker persistence is therefore foundation's spawn
+path (an upstream change to a different repo). Until that exists, this bundle captures the
+real event stream at the seam it owns — the hooks module it already mounts into every worker
+session — and persists it in the run dir, which is (a) the canonical pipeline-scoped forensic
+record (`prompt.md`, `response.md`, `status.json` already live there) and (b) durable in
+CI/sandbox environments where `$HOME` is ephemeral. Standard file name, standard record
+shape, real events — pointers stay resolvable without inventing a parallel session store.
+
+**Spec self-contradiction (flagged upstream):** canonical spec §5.6 *requires* per-node
+`prompt.md` and `response.md` in the run-dir layout, and its conformance checklist asserts
+`artifacts_exist(logs_root, <node>, ["prompt.md", "response.md", "status.json"])` — yet the
+spec's own CodergenHandler pseudocode contains an
+`IF result is an Outcome: write_status(stage_dir, result); RETURN result` early-return that
+skips the `response.md` write for Outcome-returning backends. The shipped handler had
+faithfully transcribed that self-contradiction. This extension implements the layout
+contract; the spec's pseudocode should be corrected to match its own §5.6.
+
+### Files touched
+
+- `modules/loop-pipeline/amplifier_module_loop_pipeline/outcome.py` — `response_text` field
+- `modules/loop-pipeline/amplifier_module_loop_pipeline/backend.py` — `_parse_outcome()`
+  sets `response_text` on all return paths
+- `modules/loop-pipeline/amplifier_module_loop_pipeline/worker_observability.py` — the
+  ContextVar seam (new)
+- `modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/codergen.py` — Outcome-path
+  `response.md` write, ContextVar set/reset, `session_id` in `_write_status()`
+- `modules/hooks-pipeline-observability/amplifier_module_hooks_pipeline_observability/session_events.py`
+  — `SessionEventPersister` (new), registered in the module's `mount()`
+
+### Compatibility
+
+Fully backward-compatible and fail-safe:
+
+- Existing pipelines run unchanged; `last_response` truncation and spawn/continuity semantics
+  (thread transcripts, CR-1 invariant) are untouched.
+- Persistence degrades to a silent no-op at every missing seam: hooks module not mounted →
+  no subscriber; loop-pipeline not importable in the mounting session → resolver returns
+  `None`; ContextVar unset (session not spawned by a codergen node) → no write; event without
+  `session_id` → skipped. Persister handlers never raise into the session.
+- `response.md` is written only when `response_text` is present; infrastructure-failure
+  Outcomes (no child output) skip it.
+
+---
+
 ## Conformance Restoration Note (T0-4)
 
 **What was retired:** An unledgered dialect where non-`shape=parallel`, non-component nodes


### PR DESCRIPTION
A pipeline run's worker sessions were write-only compute: they thought, acted, and vanished. The node's full final response survived only as ~200-char scraps (`notes="Plain text response: {output[:200]}"` / `last_response[:200]`) because the codergen handler wrote `response.md` only for *string*-returning backends — and the production `AmplifierBackend` spawn path always returns an `Outcome`, early-returning past the write. The `session_id` recorded in `status.json` was a dangling pointer: no `events.jsonl`/`transcript.jsonl` existed anywhere for spawned workers (foundation's spawn path has zero persist call sites; `~/.amplifier/projects` is never written on this stack). Three separate post-mortems — including the 2026-07-28 external incident that motivated §25 — all dead-ended on exactly this missing evidence. "Which tools did the worker call?", the first question of every wrong-but-plausible audit, was unanswerable.

This PR makes the run dir a complete forensic record (EXTENSIONS.md **§26**, new):

1. **Full-response durability.** `Outcome.response_text` carries the verbatim child output — set by `_parse_outcome()` on **every** return path, before any truncation. The codergen handler writes it to `<stage_dir>/response.md` on the Outcome path. This implements canonical spec §5.6's own layout contract (the spec's CodergenHandler pseudocode contradicts its §5.6 — flagged in the ledger entry).
2. **Real worker-session event persistence.** New ContextVar seam in loop-pipeline (`worker_observability.current_worker_sessions_dir`, set to `<stage_dir>/sessions` around each backend call, try/finally-reset, task-local so parallel branches can't cross-talk) + a `SessionEventPersister` in `hooks-pipeline-observability` — a module **already composed into every spawned worker session** (attractor-core mounts it on the parent bundle; `PreparedBundle.spawn` composes parent + child). The persister appends the worker's REAL event stream — `session:start/resume/end`, `prompt:submit/complete`, `tool:pre`/`tool:post` (tool names, arguments, results), `orchestrator:complete` — to `<stage_dir>/sessions/<session_id>/events.jsonl` **as it happens** (crash-surviving, unlike post-hoc assembly). `session_id` comes from the kernel's `set_default_fields` merge on every event. Standard record shape (`{"event", "timestamp", "data"}`), standard filename, no second session store.
3. **`session_id` in the codergen early-writer's `status.json`** (the engine's writers already carry it) — the Outcome path never leaves a status record without its join key.

Forensic navigation, from the run dir alone:
`status.json → session_id → sessions/<session_id>/events.jsonl` answers "which tools did the worker call?"; `response.md` beside it holds the full final response.

**Capture-integrity invariant, pinned by test:** the persister writes `session:start` for every session it observes, so a well-formed capture can never leave an empty (or absent) `events.jsonl` under a session id recorded in `status.json` — such a file signals capture failure/corruption, never an idle worker (tested in both modules; the loop-pipeline `_session_capture_anomaly` helper encodes the forensic check).

Graceful no-op at every missing seam: hooks module not mounted → no subscriber; loop-pipeline not importable → resolver returns None; ContextVar unset → no write; no `session_id` → skipped; persister handlers never raise into the session.

## Verification checklist

- [x] Unit tests pass (`pytest modules/loop-pipeline/`) — **1636 passed, 1 skipped** (`uv run --extra remote pytest -q`); hooks-pipeline-observability **69 passed**; pipeline-runner **45 passed, 1 skipped**; root subset **14 passed**
- [x] Live pipeline run exercising changed code path — real `attractor run`, worker calls two tools, persisted events answer the forensic question (evidence below)
- [x] AGENTS.md reviewed; repo-specific gates met — doc-guard 7 passed; examples-lint + command-content + doc-guard suites 94 passed; `git diff --check` clean; ruff clean
- [x] Backward-compat path unchanged — string-backend path untouched (`test_run_directory.py` 27 passed); `last_response[:200]` truncation preserved; spawn/continuity semantics untouched
- [x] PR body includes verification evidence, not just "tests pass"

## Reviewer commands

```bash
# full suites
cd modules/loop-pipeline && uv run --extra remote pytest -q            # 1636 passed, 1 skipped
cd modules/hooks-pipeline-observability && uv run pytest -q            # 69 passed
cd modules/pipeline-runner && uv run pytest -q                         # 45 passed, 1 skipped

# the new behaviors
cd modules/loop-pipeline && uv run pytest tests/test_worker_session_observability.py -q -v
cd modules/hooks-pipeline-observability && uv run pytest tests/test_session_events.py -q -v
```

Evidence archive: `.amplifier/evaluation/attractor-uplift/2026-08-03-t14-polish-live-gate/`.