### PR TITLE
feat(engine): must_write= node attribute — fail-closed artifact contract

### DIFF
--- a/context/engine-semantics.md
+++ b/context/engine-semantics.md
@@ -161,6 +161,13 @@ the work is not done.
 For **non-goal_gate nodes**, path 5 still returns SUCCESS per canonical spec §4.5 — backward
 compatible default for ordinary `box` nodes that end in prose.
 
+**What `max_retries` actually retries (the retry ladder):** the ladder retries RETRY
+outcomes, retryable-classified exceptions (classified by exception type and message
+content — timeouts, connection errors, HTTP 429/5xx), and `must_write=` artifact-contract
+violations (EXTENSIONS.md §27); a plain FAIL is returned immediately, never retried.
+Graph-level retries of a FAIL are a separate mechanism: `retry_target` and
+`condition="outcome=fail"` edges.
+
 **`is_explicit` field on `Outcome`:** `outcome.is_explicit=True` means the status was asserted
 by an unambiguous mechanism: paths 1–4 above, a tool (parallelogram) node's exit code
 (0 = explicit success, nonzero = explicit fail; `handlers/tool.py`), **verdict-shaped**

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -70,7 +70,7 @@ Three mechanisms let pipeline authors override fail-fast for specific scenarios:
 
 | Attribute / pattern | Applied to | Effect |
 |---|---|---|
-| `continue_on_fail="true"` | Source node | Engine converts FAIL→SUCCESS before edge selection. Downstream nodes see a success outcome and follow unconditional edges normally. Use for optional/informational nodes whose failure must not block the main flow. |
+| `continue_on_fail="true"` | Source node | Engine converts FAIL→SUCCESS before edge selection. Downstream nodes see a success outcome and follow unconditional edges normally. Use for optional/informational nodes whose failure must not block the main flow. Exception: a `must_write=` artifact-contract violation is non-overridable — the engine re-checks the contract after this override and fails the node (EXTENSIONS.md §27). Behavior change with §27: a `continue_on_fail=true` node that declares `must_write=` and fails without writing its artifact now ends FAIL where it previously flipped to silent SUCCESS. |
 | `runs_on=always` | Downstream node | Node executes even if predecessors failed. Use for cleanup nodes (teardown, notifications) that must run regardless of upstream outcome. |
 | `runs_on=failure` | Downstream node | Node executes ONLY if predecessors failed. Use for error-handling or recovery nodes. |
 | `condition="outcome=fail"` edge | Outgoing edge | Matched in Step 1 of edge selection; explicit failure-routing edge. Most semantically clear when paired with a `condition="outcome=success"` edge on the same source node. |
@@ -79,12 +79,12 @@ Three mechanisms let pipeline authors override fail-fast for specific scenarios:
 `continue_on_fail=true` that fails has its outcome flipped FAIL→SUCCESS before edge
 selection; a downstream `runs_on=failure` node will NOT see that predecessor as failed
 (the failure was swallowed). Use `runs_on=always` on cleanup nodes that must fire after
-a `continue_on_fail` predecessor. See engine.py lines 578–592 for the canonical
+a `continue_on_fail` predecessor. See engine.py lines 582–596 for the canonical
 explanation.
 
 **Reference:** `modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py`
-(lines 593–596 for the `continue_on_fail` check; lines 1299–1323 for `_get_runs_on` and
-1350–1447 for the skip-gate `_check_node_skip`). Also: `edge_selection.py` lines 65–78
+(lines 597–600 for the `continue_on_fail` check; lines 1332–1357 for `_get_runs_on` and
+1383–1481 for the skip-gate `_check_node_skip`). Also: `edge_selection.py` lines 65–78
 for the edge-level routing comment.
 
 ---

--- a/docs/DOT-AUTHORING-GUIDE.md
+++ b/docs/DOT-AUTHORING-GUIDE.md
@@ -429,8 +429,12 @@ attractor trace <run-dir>
 This prints a human-readable summary of iterations, nodes, statuses, and
 durations — the empirical form of the convergence claim.
 
-**Difference from `max_retries`:** `max_retries` retries a single node on
-failure; `loop_restart` resets the entire pipeline pass for intentional
+**Difference from `max_retries`:** `max_retries` re-attempts a single node
+in place — and only for RETRY-class outcomes, retryable exceptions
+(timeouts, connection errors, HTTP 429/5xx), and `must_write=`
+artifact-contract violations; a plain FAIL is returned immediately, never
+retried (route FAILs with `retry_target` or `outcome=fail` edges instead).
+`loop_restart` resets the entire pipeline pass for intentional
 multi-iteration refinement. Use `max_retries` for transient failures, use
 `loop_restart` for structured convergence loops.
 

--- a/docs/DOT-SYNTAX.md
+++ b/docs/DOT-SYNTAX.md
@@ -33,7 +33,7 @@ digraph {
 |-----------|------|---------|-------------|
 | `prompt` | string | -- | Instructions for the LLM. `$goal` and `$param` tokens are expanded. |
 | `goal_gate` | bool | false | Must succeed **with an explicit verdict** (report_outcome / JSON / tool exit code) for pipeline to complete; plain prose returns RETRY (fail-closed, `specs/EXTENSIONS.md` §25) |
-| `max_retries` | int | graph default | Retry count on failure |
+| `max_retries` | int | graph default | In-place re-attempts for RETRY-class outcomes, retryable exceptions, and `must_write=` violations. A plain FAIL is returned immediately, never retried (use `retry_target` / `outcome=fail` edges for that) |
 | `retry_target` | string | -- | Node to jump to on gate failure |
 | `fidelity` | string | "compact" | Context carryover mode |
 | `llm_provider` | string | -- | Override provider (anthropic/openai/gemini) |

--- a/docs/reports/2026-02-20-nlspec-dod-gap-analysis.md
+++ b/docs/reports/2026-02-20-nlspec-dod-gap-analysis.md
@@ -589,3 +589,17 @@ One additional item warranting note (counted as PASS with interpretation):
 | Spec | Section | DoD Item | Note |
 |---|---|---|---|
 | Attractor | 11.8 | Question type names: SINGLE_SELECT, MULTI_SELECT, FREE_TEXT, CONFIRM | Implementation uses YES_NO, MULTIPLE_CHOICE, FREEFORM, CONFIRMATION. Functionally equivalent naming convention difference — all four question types are supported with identical behavior. |
+
+---
+
+## Errata
+
+**2026-08-03 — §11.5 Retry Logic, row 1.** The row "Nodes with `max_retries > 0` are
+retried on RETRY or FAIL outcomes | PASS" misstates the implemented behavior: the retry
+ladder (`execute_with_retry()`) retries RETRY outcomes, retryable-classified exceptions
+(classified by exception type and message content), and — since EXTENSIONS.md §27 —
+`must_write=` artifact-contract violations. A plain FAIL outcome is returned
+immediately and is never retried in place (`test_fail_not_retried`; the fail-fast
+choice is deliberate). Graph-level `retry_target` and `condition="outcome=fail"` edges
+are the mechanism for re-attempting failures. The DoD line's "or FAIL" does not hold in
+this engine, and the PASS verdict should have flagged the divergence.

--- a/examples/patterns/task-runner.dot
+++ b/examples/patterns/task-runner.dot
@@ -183,6 +183,7 @@ digraph TaskRunner {
 
     // ---------- budget exhaustion: a decision point, not a fuse ----------
     postmortem [shape=box, class="gate",
+        must_write=".ai/postmortem/report.md",
         prompt="The run has hit a decision point without convergence: either the iteration budget is exhausted (repeated verification failures) or the quality loop has stalled (repeated critique refusals on mechanically-green work). Read .ai/convergence.jsonl (the descent record), .ai/critique.md, .ai/verify.log, and .ai/feedback/. Write .ai/postmortem/report.md: what each iteration attempted, whether the loop was DESCENDING, OSCILLATING, or WANDERING (cite the convergence record), your best hypothesis for why it has not converged, and the options (continue with more budget / change approach / split the task / abandon). Be honest — this report is the value salvaged from a non-converging run."]
 
     // Deterministic guard: the postmortem node has been observed returning

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py
@@ -29,6 +29,7 @@ from .context import PipelineContext
 from .edge_selection import select_edge
 from .graph import Graph, Node
 from .handlers import HandlerRegistry
+from .must_write import check_must_write
 from .node_outputs import SUBSTITUTABLE_ATTRS, build_output_table
 from .outcome import Outcome, StageStatus
 from .pipeline_events import (
@@ -467,6 +468,9 @@ class PipelineEngine:
             )
 
             node_start_time = time.monotonic()
+            node_start_wall = (
+                time.time()
+            )  # wall-clock epoch for must_write= mtime comparison
             retry_policy = RetryPolicy.from_node(current_node, self.graph)
 
             if _requires_fail is not None:
@@ -579,8 +583,8 @@ class PipelineEngine:
             #
             # NOTE — continue_on_fail and runs_on are NOT orthogonal:
             # - continue_on_fail (per-predecessor-node override) flips FAIL→SUCCESS
-            #   BEFORE _populate_failed_outputs runs (see the FAIL check at
-            #   engine.py:512 which tests the already-overridden outcome).
+            #   BEFORE _populate_failed_outputs runs (see the M2/R12 FAIL check
+            #   below, which tests the already-overridden outcome).
             # - runs_on=failure (per-cleanup-node gate) checks the failed_outputs
             #   table populated by _populate_failed_outputs.
             # - A predecessor with continue_on_fail=true that "fails" will appear
@@ -610,6 +614,19 @@ class PipelineEngine:
                     preferred_label=outcome.preferred_label,
                     suggested_next_ids=outcome.suggested_next_ids,
                 )
+
+            # Step 2.7: must_write= final backstop (EXTENSIONS.md §27).
+            # The per-attempt check inside execute_with_retry() already consumed
+            # max_retries attempts for violations on completed attempts; this
+            # backstop runs AFTER the auto_status and continue_on_fail overrides
+            # so that NO override can convert an artifact-contract violation into
+            # a silent success.  Running last — not a flag on the override blocks —
+            # is what makes the must_write FAIL non-overridable by construction.
+            must_write_fail = self._check_must_write(
+                current_node, outcome, node_start_wall
+            )
+            if must_write_fail is not None:
+                outcome = must_write_fail
 
             # Step 3: Record completion
             self.completed_nodes.append(current_node.id)
@@ -1607,6 +1624,24 @@ class PipelineEngine:
                 f"node runs. Set requires= to declare file preconditions."
             ),
         )
+
+    def _check_must_write(
+        self, node: Node, outcome: Outcome, node_start_wall: float
+    ) -> Outcome | None:
+        """Artifact contract for the ``must_write=`` attribute (EXTENSIONS.md §27).
+
+        Thin delegate to :func:`must_write.check_must_write` (shared with the
+        retry ladder, which runs the same check per-attempt so that violations
+        consume ``max_retries`` attempts — see ``retry.execute_with_retry``).
+        The engine calls this as the FINAL backstop, after the ``auto_status``
+        and ``continue_on_fail`` overrides, so no override can convert an
+        artifact-contract violation into a silent success.
+
+        Returns:
+            A FAIL ``Outcome`` if the contract is violated, ``None`` if the
+            contract is satisfied or the node has no ``must_write=`` attribute.
+        """
+        return check_must_write(node, outcome, node_start_wall, self.context)
 
     # -- Event helpers -------------------------------------------------------
 

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/must_write.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/must_write.py
@@ -1,0 +1,219 @@
+"""``must_write=`` fail-closed artifact contract (EXTENSIONS.md §27).
+
+A node may declare ``must_write=<path>``: completing normally then requires a
+fresh, non-trivial artifact at ``<path>``.  The check runs in two places:
+
+1. **Per-attempt, inside the retry ladder** (``retry.execute_with_retry``): a
+   completed attempt (SUCCESS / PARTIAL_SUCCESS) that violates the contract
+   consumes a retry attempt exactly like a RETRY outcome — the same shape as
+   the fail-closed goal-gate verdict retries (EXTENSIONS.md §25).  A no-write
+   completion is precisely the flaky-failure class where an in-place retry
+   helps: re-invoking the handler gives it another chance to produce the
+   artifact.
+2. **As the engine's final backstop, after all outcome overrides**
+   (``PipelineEngine._check_must_write`` call site): the check runs AFTER
+   ``auto_status`` promotion and the ``continue_on_fail`` override, so no
+   override can convert a contract violation into a silent success.  This is
+   the non-overridable, fail-closed guarantee.
+
+Shared here so both ``engine`` and ``retry`` can use it without a circular
+import (``engine`` imports ``retry``).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+from .context import PipelineContext
+from .graph import Node
+from .outcome import Outcome, StageStatus
+
+logger = logging.getLogger(__name__)
+
+
+def check_must_write(
+    node: Node,
+    outcome: Outcome,
+    node_start_wall: float,
+    context: PipelineContext,
+) -> Outcome | None:
+    """Artifact contract check for the ``must_write=`` attribute (EXTENSIONS.md §27).
+
+    If the node declares ``must_write=<path>`` and ``outcome`` is a completed
+    result (SUCCESS / PARTIAL_SUCCESS) produced without a fresh, non-trivial
+    artifact at ``<path>``, this returns a FAIL ``Outcome`` that overrides the
+    handler's result.  Nodes without ``must_write=`` are completely untouched.
+    FAIL outcomes pass through (no double-wrapping); SKIPPED outcomes pass
+    through because the node did not execute — the contract applies only to
+    completed executions (EXTENSIONS.md §27).
+
+    **Freshness floor (REQUIRED):** the artifact's mtime must be strictly
+    greater than ``node_start_wall`` (a ``time.time()`` wall-clock snapshot
+    taken immediately before the node's first attempt ran).  A pre-planted
+    file whose mtime predates OR equals the node start time FAILS even if it
+    has content.  The equality case is rejected explicitly: an adversary (or a
+    coarse-resolution filesystem) could set an artifact's mtime via
+    ``os.utime`` to match the recorded start time, bypassing a ``>=`` check.
+    Strictly-greater-than closes that boundary.
+
+    **Non-trivial:** the artifact must contain at least one non-whitespace
+    byte.  An empty file or a whitespace-only file does not satisfy the
+    contract.
+
+    **Path resolution:** the path is interpreted as-is when absolute.
+    Relative paths are resolved against ``context.target_dir`` if set,
+    falling back to ``os.getcwd()``.  This mirrors the ``requires=``
+    convention (see ``PipelineEngine._check_requires``).  Document the
+    resolution base in the graph's comments or pipeline invocation so
+    consumers know which cwd is the anchor.
+
+    **Interaction with retries / goal_gate / continue_on_fail:**
+    - A violation on a completed attempt consumes ``max_retries`` attempts
+      in-place (see ``retry.execute_with_retry``); when attempts are
+      exhausted, the FAIL routes through the node's failure edges
+      (``retry_target``, ``condition="outcome=fail"`` edges, etc.) exactly
+      like any other FAIL.  ``allow_partial`` does not soften it.
+    - ``is_explicit`` is ``False``: the node never asserted a verdict; the
+      engine is forcing a FAIL.  A goal_gate=true node whose must_write
+      check fires cannot satisfy its own gate (correct — it produced no
+      artifact).
+    - ``continue_on_fail=true`` cannot suppress the FAIL: the engine's final
+      check runs after the override.
+
+    **Residual (delayed-replant window):** mtime-after-start alone leaves
+    a narrow window where an external process writes a content-bearing file
+    after node start but before the check runs, and the node's own session
+    never wrote.  Session attribution (correlating the write to this node's
+    session via ``session_id``) is the preferred closing mechanism but is
+    not yet implemented; this residual is documented honestly in the
+    EXTENSIONS.md entry.
+
+    Returns:
+        A FAIL ``Outcome`` if the contract is violated, ``None`` if the
+        contract is satisfied or the node has no ``must_write=`` attribute.
+    """
+    raw_path = node.attrs.get("must_write") if node.attrs else None
+    if not raw_path:
+        return None  # opt-in only; nodes without must_write= are untouched
+
+    # Only intercept non-FAIL outcomes — if the handler already failed,
+    # leave its failure reason intact (no double-wrapping).
+    if outcome.status == StageStatus.FAIL:
+        return None
+
+    # SKIPPED — the node did not execute; the artifact contract applies only
+    # to completed executions (EXTENSIONS.md §27).  A legitimately-skipped
+    # node (runs_on mismatch, failed dependencies, handler-side skip) passes
+    # through unconverted.  Note: auto_status=true promotion (SKIPPED →
+    # SUCCESS) runs BEFORE the engine's final backstop, so a promoted node
+    # IS treated as a completed execution and the contract applies to it —
+    # that is exactly the narration-without-artifact class this contract
+    # exists to catch.
+    if outcome.status == StageStatus.SKIPPED:
+        return None
+
+    # Resolve path: absolute paths pass through; relative paths are
+    # anchored to context.target_dir (falling back to os.getcwd()).
+    raw_path = str(raw_path).strip()
+    artifact = Path(raw_path)
+    if not artifact.is_absolute():
+        base_dir_raw = context.get("context.target_dir")
+        base_dir = Path(str(base_dir_raw)) if base_dir_raw else Path(os.getcwd())
+        artifact = base_dir / raw_path
+
+    # --- Freshness floor: artifact must exist AND have mtime > node start ---
+    try:
+        stat = artifact.stat()
+    except FileNotFoundError:
+        # No artifact at all — the most common failure shape
+        logger.warning(
+            "Node '%s' must_write= contract violated: artifact absent (%s)",
+            node.id,
+            artifact,
+        )
+        return Outcome(
+            status=StageStatus.FAIL,
+            failure_reason=(
+                f"Node '{node.id}' declared must_write={raw_path!r} but "
+                f"no artifact was written (path: {artifact})"
+            ),
+            notes=(
+                f"must_write= contract: the artifact at '{artifact}' does not "
+                f"exist. The node must write a non-trivial file at this path "
+                f"during its own execution."
+            ),
+        )
+
+    if stat.st_mtime <= node_start_wall:
+        # File exists but was not written strictly after this node started —
+        # either planted before node start OR written at the exact same
+        # clock tick (equality bypass).  Both are rejected: the contract
+        # requires mtime STRICTLY GREATER THAN node_start_wall.
+        logger.warning(
+            "Node '%s' must_write= freshness floor violated: artifact mtime "
+            "%.3f predates node start %.3f (%s)",
+            node.id,
+            stat.st_mtime,
+            node_start_wall,
+            artifact,
+        )
+        return Outcome(
+            status=StageStatus.FAIL,
+            failure_reason=(
+                f"Node '{node.id}' declared must_write={raw_path!r} but the "
+                f"artifact was not written by this execution (mtime "
+                f"{stat.st_mtime:.3f} <= node_start {node_start_wall:.3f}; "
+                f"planted before or at node start)"
+            ),
+            notes=(
+                f"must_write= freshness floor: the artifact at '{artifact}' "
+                f"exists but its mtime does not strictly post-date this node's "
+                f"start (mtime must be strictly greater than node_start_wall). "
+                f"A pre-planted file — including one whose mtime equals the "
+                f"recorded start time — does not satisfy the contract."
+            ),
+        )
+
+    # --- Non-trivial: artifact must contain at least one non-whitespace byte ---
+    try:
+        content = artifact.read_bytes()
+    except OSError as exc:
+        logger.warning(
+            "Node '%s' must_write= read error for '%s': %s",
+            node.id,
+            artifact,
+            exc,
+        )
+        return Outcome(
+            status=StageStatus.FAIL,
+            failure_reason=(
+                f"Node '{node.id}' declared must_write={raw_path!r} but the "
+                f"artifact could not be read: {exc}"
+            ),
+            notes=f"must_write= contract: unreadable artifact at '{artifact}'.",
+        )
+
+    if not content.strip():
+        logger.warning(
+            "Node '%s' must_write= non-trivial check failed: artifact is "
+            "empty or whitespace-only (%s)",
+            node.id,
+            artifact,
+        )
+        return Outcome(
+            status=StageStatus.FAIL,
+            failure_reason=(
+                f"Node '{node.id}' declared must_write={raw_path!r} but the "
+                f"artifact is empty or whitespace-only (non-trivial content required)"
+            ),
+            notes=(
+                f"must_write= non-trivial check: the artifact at '{artifact}' "
+                f"contains no non-whitespace bytes. "
+                f"The node must write substantive content."
+            ),
+        )
+
+    # Contract satisfied: fresh, non-trivial artifact exists
+    return None

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/retry.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/retry.py
@@ -13,11 +13,13 @@ import asyncio
 import logging
 import random
 import re
+import time
 from dataclasses import dataclass, field
 from typing import Any
 
 from .context import PipelineContext
 from .graph import Graph, Node
+from .must_write import check_must_write
 from .outcome import Outcome, StageStatus
 
 logger = logging.getLogger(__name__)
@@ -193,9 +195,21 @@ async def execute_with_retry(
     Retries on RETRY outcomes and exceptions. Returns immediately on
     SUCCESS, PARTIAL_SUCCESS, FAIL, and SKIPPED.
 
+    ``must_write=`` (EXTENSIONS.md §27): a completed attempt (SUCCESS or
+    PARTIAL_SUCCESS) that violates the node's declared artifact contract
+    consumes a retry attempt exactly like a RETRY outcome — the same shape
+    as the fail-closed goal-gate verdict retries (EXTENSIONS.md §25).  When
+    attempts are exhausted, the violation is returned as a loud FAIL;
+    ``allow_partial`` does not soften it (fail-closed).
+
     Spec Section 3.5: execute_with_retry algorithm.
     """
     last_outcome: Outcome | None = None
+    # Wall-clock epoch for the must_write= freshness floor: the artifact must
+    # be written strictly after the node's execution began (all attempts
+    # belong to this node's execution, so the floor is ladder entry — an
+    # artifact written by an earlier attempt still satisfies a later one).
+    node_start_wall = time.time()
 
     for attempt in range(1, policy.max_attempts + 1):
         # Execute the handler
@@ -230,16 +244,60 @@ async def execute_with_retry(
                 failure_reason=str(e),
             )
 
-        # SUCCESS or PARTIAL_SUCCESS — return immediately
+        # SUCCESS or PARTIAL_SUCCESS — check the must_write= artifact contract
+        # (EXTENSIONS.md §27) before accepting the completion.  A violation
+        # consumes a retry attempt exactly like a RETRY outcome (the same
+        # shape as the fail-closed goal-gate verdict retries, EXTENSIONS.md
+        # §25): a no-write completion is the flaky-failure class where an
+        # in-place re-invocation helps.  When attempts are exhausted the
+        # violation is returned as a loud FAIL; allow_partial does not
+        # soften it (fail-closed — see the engine's final backstop too).
         if outcome.status in (StageStatus.SUCCESS, StageStatus.PARTIAL_SUCCESS):
-            return outcome
+            must_write_fail = check_must_write(node, outcome, node_start_wall, context)
+            if must_write_fail is None:
+                return outcome
+            last_outcome = must_write_fail
+            if attempt < policy.max_attempts:
+                logger.info(
+                    "Node %s attempt %d/%d completed without satisfying its "
+                    "must_write= contract, retrying... (%s)",
+                    node.id,
+                    attempt,
+                    policy.max_attempts,
+                    must_write_fail.failure_reason,
+                )
+                if hooks is not None:
+                    from .pipeline_events import PIPELINE_STAGE_RETRYING
+
+                    await hooks.emit(
+                        PIPELINE_STAGE_RETRYING,
+                        {
+                            "node_id": node.id,
+                            "attempt": attempt,
+                            "max_attempts": policy.max_attempts,
+                            "delay_ms": policy.backoff.delay_for_attempt(attempt),
+                            "reason": "must_write_violation",
+                        },
+                    )
+                await _sleep_backoff(policy.backoff, attempt)
+                continue
+            # Attempts exhausted: the artifact contract is still violated.
+            # Return the FAIL directly — allow_partial does NOT soften a
+            # must_write violation (fail-closed).
+            return must_write_fail
 
         # FAIL — return immediately, no retries
         if outcome.status == StageStatus.FAIL:
             return outcome
 
-        # SKIPPED — return immediately; the engine's auto_status check may
-        # promote this to SUCCESS when auto_status=true (spec §2.6 / Appendix C).
+        # SKIPPED — return immediately.  Decision (EXTENSIONS.md §27): SKIPPED
+        # means the node did not execute; the must_write= artifact contract
+        # applies only to completed executions, so a SKIPPED outcome passes
+        # through unconverted (check_must_write exempts it explicitly).  If
+        # auto_status=true later promotes this SKIPPED to SUCCESS (spec §2.6 /
+        # Appendix C), the promotion happens BEFORE the engine's final
+        # backstop — a promoted node counts as a completed execution and the
+        # contract applies to it there.
         # Do not retry a SKIPPED outcome — retrying would not produce a status.
         if outcome.status == StageStatus.SKIPPED:
             return outcome
@@ -268,7 +326,38 @@ async def execute_with_retry(
             await _sleep_backoff(policy.backoff, attempt)
             continue
 
-    # All retries exhausted
+    # All retries exhausted (the final attempt returned RETRY).  Decide the
+    # final outcome FIRST so the failure event below reports the truth
+    # (event final_status must always match the returned outcome; a raw
+    # truthiness check here once made allow_partial="false" emit
+    # "partial_success" while returning FAIL).
+    _ap = node.attrs.get("allow_partial")
+    _allow_partial = _ap is True or str(_ap).lower() == "true"
+
+    if _allow_partial:
+        final_outcome = Outcome(
+            status=StageStatus.PARTIAL_SUCCESS,
+            notes="Retries exhausted, partial accepted",
+            failure_reason=last_outcome.failure_reason if last_outcome else None,
+        )
+        # The must_write= artifact contract (EXTENSIONS.md §27) holds on the
+        # manufactured verdict too: retries exhausted + allow_partial + NO
+        # artifact must NOT become a partial acceptance — no artifact means
+        # there is nothing to accept partially.  Fail loudly instead.  (The
+        # engine's final backstop would also catch this; checking here keeps
+        # the ladder self-consistent with its in-loop exhaustion path and
+        # keeps the failure event truthful.)
+        must_write_fail = check_must_write(
+            node, final_outcome, node_start_wall, context
+        )
+        if must_write_fail is not None:
+            final_outcome = must_write_fail
+    else:
+        final_outcome = Outcome(
+            status=StageStatus.FAIL,
+            failure_reason="Max retries exceeded",
+        )
+
     if hooks is not None:
         from .pipeline_events import PIPELINE_STAGE_FAILED
 
@@ -278,23 +367,14 @@ async def execute_with_retry(
                 "node_id": node.id,
                 "attempts": policy.max_attempts,
                 "final_status": (
-                    "partial_success" if node.attrs.get("allow_partial") else "fail"
+                    "partial_success"
+                    if final_outcome.status == StageStatus.PARTIAL_SUCCESS
+                    else "fail"
                 ),
             },
         )
 
-    _ap = node.attrs.get("allow_partial")
-    if _ap is True or str(_ap).lower() == "true":
-        return Outcome(
-            status=StageStatus.PARTIAL_SUCCESS,
-            notes="Retries exhausted, partial accepted",
-            failure_reason=last_outcome.failure_reason if last_outcome else None,
-        )
-
-    return Outcome(
-        status=StageStatus.FAIL,
-        failure_reason="Max retries exceeded",
-    )
+    return final_outcome
 
 
 async def _sleep_backoff(backoff: BackoffConfig, attempt: int) -> None:

--- a/modules/loop-pipeline/tests/test_engine_must_write.py
+++ b/modules/loop-pipeline/tests/test_engine_must_write.py
@@ -1,0 +1,900 @@
+"""Unit tests for the must_write= node attribute (EXTENSIONS.md §27).
+
+Adversarial battery covering:
+  1. Narration-ending no-write       -> node FAIL
+  2. Empty-final-message completion  -> node FAIL
+  3. PLANTED content-bearing file    -> node FAIL (freshness floor)
+  4. DELAYED-REPLANT (informational) -> FAIL under session attribution;
+     under mtime-floor-only: informational PASS (documented residual)
+  5. Write-first skeleton VERDICT: PENDING -> node PASSES
+  6. No-attribute node, no-write     -> still SUCCEEDS (backward compat)
+
+Plus:
+  - Relative-path resolution (context.target_dir anchor)
+  - Whitespace-only artifact is non-trivial-fail
+  - Empty artifact is non-trivial-fail
+  - Handler already-FAIL is not double-wrapped
+  - Retry semantics: violations consume max_retries in-place
+    (1 + max_retries handler calls), retry-then-write succeeds,
+    allow_partial and continue_on_fail cannot soften the FAIL
+"""
+
+from __future__ import annotations
+
+import asyncio
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+from amplifier_module_loop_pipeline.backend import _parse_outcome
+from amplifier_module_loop_pipeline.context import PipelineContext
+from amplifier_module_loop_pipeline.dot_parser import parse_dot
+from amplifier_module_loop_pipeline.engine import PipelineEngine
+from amplifier_module_loop_pipeline.handlers import HandlerRegistry
+from amplifier_module_loop_pipeline.handlers.context import HandlerContext
+from amplifier_module_loop_pipeline.outcome import Outcome, StageStatus
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+NARRATION = (
+    "Now let me do a final comprehensive check of the report before "
+    "writing it out. The analysis looks complete and well-structured."
+)
+
+
+def _outcome_from(text: str) -> Outcome:
+    try:
+        return _parse_outcome(text)
+    except Exception:
+        return _parse_outcome(" ")
+
+
+class NoWriteBackend:
+    """Live shape 1: session ends on plain-text narration, no artifact."""
+
+    def __init__(self):
+        self.calls = 0
+
+    async def run(self, node, prompt, context, incoming_edge=None, graph=None):
+        self.calls += 1
+        return _outcome_from(NARRATION)
+
+
+class EmptyFinalBackend:
+    """Live shape 2 (observed live): the session ends with an EMPTY final message."""
+
+    async def run(self, node, prompt, context, incoming_edge=None, graph=None):
+        return _outcome_from("")
+
+
+class WriterBackend:
+    """The honest maker: a fresh, content-bearing write by this execution."""
+
+    def __init__(self, path: Path, content: str):
+        self.path = path
+        self.content = content
+
+    async def run(self, node, prompt, context, incoming_edge=None, graph=None):
+        Path(self.path).write_text(self.content)
+        return _outcome_from("Report written as required.")
+
+
+class ReplantBackend:
+    """DELAYED-REPLANT: content-bearing write by external process after node
+    start; the node itself never writes."""
+
+    def __init__(self, path: Path):
+        self.path = path
+
+    async def run(self, node, prompt, context, incoming_edge=None, graph=None):
+        subprocess.run(
+            ["sh", "-c", f"printf 'replanted by external process\\n' > '{self.path}'"],
+            check=True,
+        )
+        return _outcome_from(NARRATION)
+
+
+class AlreadyFailBackend:
+    """Backend that returns an explicit FAIL outcome (must_write should not
+    double-wrap it)."""
+
+    async def run(self, node, prompt, context, incoming_edge=None, graph=None):
+        return Outcome(
+            status=StageStatus.FAIL,
+            failure_reason="handler-level failure: upstream data missing",
+        )
+
+
+def _dot_for(artifact: str, declare: bool = True) -> str:
+    attr = f'must_write="{artifact}", ' if declare else ""
+    return f"""
+digraph MustWriteTest {{
+    graph [goal="must_write fixture"]
+    start [shape=Mdiamond]
+    done  [shape=Msquare]
+    maker [shape=box, {attr}max_retries=0,
+           prompt="Produce the declared artifact."]
+    start -> maker
+    maker -> done
+}}
+"""
+
+
+def _run(
+    backend,
+    artifact: Path,
+    declare: bool = True,
+    plant: str | None = None,
+    context: PipelineContext | None = None,
+) -> Outcome:
+    if plant is not None:
+        artifact.write_text(plant)
+    graph = parse_dot(_dot_for(str(artifact), declare))
+    logs = tempfile.mkdtemp(prefix="must-write-unit-logs-")
+    engine = PipelineEngine(
+        graph=graph,
+        context=context or PipelineContext(),
+        handler_registry=HandlerRegistry(HandlerContext(backend=backend)),
+        logs_root=logs,
+    )
+    return asyncio.run(engine.run())
+
+
+# ---------------------------------------------------------------------------
+# Battery cases
+# ---------------------------------------------------------------------------
+
+
+def test_case1_narration_no_write_fails(tmp_path):
+    """Case 1: session ends on narration without writing the artifact -> FAIL."""
+    a = tmp_path / "case1.md"
+    outcome = _run(NoWriteBackend(), a)
+    assert outcome.status == StageStatus.FAIL, (
+        "must_write node that completes on narration without its artifact must FAIL "
+        "(the narration-ending critic shape observed live; silent success is the incident class under repair)"
+    )
+    assert (
+        "must_write" in (outcome.failure_reason or "").lower()
+        or "must_write" in (outcome.notes or "").lower()
+    ), "failure_reason or notes should mention must_write"
+
+
+def test_case2_empty_final_message_fails(tmp_path):
+    """Case 2: empty final message must not satisfy an artifact contract -> FAIL."""
+    a = tmp_path / "case2.md"
+    outcome = _run(EmptyFinalBackend(), a)
+    assert outcome.status == StageStatus.FAIL, (
+        "empty final message must not satisfy must_write contract "
+        "(5th live instance: 'Child session completed with empty final message' accepted as success)"
+    )
+
+
+def test_case3_planted_file_fails(tmp_path):
+    """Case 3: pre-existing artifact (planted before node start) -> FAIL (freshness floor)."""
+    a = tmp_path / "case3.md"
+    outcome = _run(
+        NoWriteBackend(),
+        a,
+        plant="planted before node start\nVERDICT: SHIP\n",
+    )
+    assert outcome.status == StageStatus.FAIL, (
+        "a pre-existing artifact must NOT pass: presence alone is the hole the contract closes "
+        "(freshness floor: mtime after node start is REQUIRED)"
+    )
+    assert (
+        "freshness" in (outcome.failure_reason or "").lower()
+        or "predates" in (outcome.failure_reason or "").lower()
+        or "planted" in (outcome.failure_reason or "").lower()
+        or "mtime" in (outcome.failure_reason or "").lower()
+    ), "failure_reason should mention freshness/mtime for planted-file case"
+
+
+def test_case3b_equality_boundary_fails(tmp_path):
+    """Case 3b: artifact mtime set to exactly node_start_wall -> FAIL.
+
+    The freshness floor uses strictly-greater-than (mtime > node_start_wall).
+    An artifact whose mtime equals node_start_wall must be rejected — the
+    equality boundary is an adversarial bypass vector (set via os.utime or
+    a coarse-resolution filesystem).
+
+    This pins the boundary so a future ``<`` -> ``<=`` regression is caught
+    immediately.
+    """
+    import os
+
+    a = tmp_path / "case3b.md"
+
+    # Capture the wall-clock time we'll use as the fake node_start_wall.
+    fake_start = time.time()
+
+    # Write a content-bearing artifact and force its mtime to exactly fake_start.
+    a.write_text("content planted at exact start time\n")
+    os.utime(a, (fake_start, fake_start))
+
+    # Call _check_must_write directly with the equality-boundary start time.
+    from amplifier_module_loop_pipeline.graph import Node
+    from amplifier_module_loop_pipeline.outcome import Outcome, StageStatus
+
+    node = Node(id="maker", attrs={"must_write": str(a)})
+    success_outcome = Outcome(status=StageStatus.SUCCESS)
+
+    # We need a minimal engine instance to call _check_must_write.
+    import tempfile
+    from amplifier_module_loop_pipeline.context import PipelineContext
+    from amplifier_module_loop_pipeline.engine import PipelineEngine
+    from amplifier_module_loop_pipeline.dot_parser import parse_dot
+    from amplifier_module_loop_pipeline.handlers import HandlerRegistry
+    from amplifier_module_loop_pipeline.handlers.context import HandlerContext
+    from amplifier_module_loop_pipeline.backend import _parse_outcome
+
+    dot = f"""
+digraph EqualityTest {{
+    graph [goal="equality boundary test"]
+    start [shape=Mdiamond]
+    done  [shape=Msquare]
+    maker [shape=box, must_write="{a}", max_retries=0, prompt="test"]
+    start -> maker
+    maker -> done
+}}
+"""
+    graph = parse_dot(dot)
+    logs = tempfile.mkdtemp(prefix="must-write-eq-logs-")
+
+    class NoOpBackend:
+        async def run(self, node, prompt, context, incoming_edge=None, graph=None):
+            return _parse_outcome("done")
+
+    engine = PipelineEngine(
+        graph=graph,
+        context=PipelineContext(),
+        handler_registry=HandlerRegistry(HandlerContext(backend=NoOpBackend())),
+        logs_root=logs,
+    )
+
+    # Call _check_must_write directly with the equality-boundary timestamp.
+    result = engine._check_must_write(node, success_outcome, fake_start)
+
+    assert result is not None and result.status == StageStatus.FAIL, (
+        "artifact mtime == node_start_wall must FAIL the freshness floor "
+        "(equality is an adversarial bypass vector; strictly-greater-than is required). "
+        f"Got: {result}"
+    )
+    # The failure reason should mention the mtime boundary
+    reason = (result.failure_reason or "") + (result.notes or "")
+    assert any(
+        kw in reason.lower() for kw in ("mtime", "freshness", "planted", "node_start")
+    ), f"failure_reason/notes should mention the freshness violation; got: {reason!r}"
+
+
+def test_case4_delayed_replant_informational(tmp_path):
+    """Case 4: delayed-replant is informational.
+
+    Under mtime-floor-only: the external write happens after node_start_wall,
+    so mtime >= start — this is the documented accepted residual.  Under
+    session attribution (future) it would FAIL.  We do not gate on this case.
+    """
+    a = tmp_path / "case4.md"
+    outcome = _run(ReplantBackend(a), a)
+    # Informational: either result is acceptable; just print the result
+    # so the test log captures the residual honestly.
+    print(
+        f"case4 delayed-replant: {'PASS (mtime-floor residual)' if outcome.is_success else 'FAIL (session attribution active)'}"
+    )
+
+
+def test_case5_write_first_skeleton_passes(tmp_path):
+    """Case 5: fresh, authored, non-trivial skeleton -> PASSES must_write.
+
+    Presence and quality are separate contracts — a VERDICT: PENDING skeleton
+    satisfies every must_write= axis but carries no verdict.  This is why the
+    3-way verdict classification does NOT retire.
+    """
+    a = tmp_path / "case5.md"
+    outcome = _run(
+        WriterBackend(a, "# Critique skeleton\nVERDICT: PENDING\n"),
+        a,
+    )
+    assert outcome.is_success, (
+        "a fresh, authored, non-trivial skeleton must PASS must_write= "
+        "(presence != quality; the 3-way verdict classification does not retire)"
+    )
+
+
+def test_case6_no_attribute_control(tmp_path):
+    """Case 6: node without must_write= is untouched — backward compat."""
+    a = tmp_path / "case6.md"
+    outcome = _run(NoWriteBackend(), a, declare=False)
+    assert outcome.is_success, (
+        "nodes without must_write= must be completely untouched — the contract is opt-in"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Non-trivial semantics
+# ---------------------------------------------------------------------------
+
+
+def test_empty_artifact_fails(tmp_path):
+    """An artifact that is written but empty fails the non-trivial check."""
+    a = tmp_path / "empty.md"
+
+    class EmptyWriterBackend:
+        async def run(self, node, prompt, context, incoming_edge=None, graph=None):
+            Path(a).write_text("")
+            return _outcome_from("wrote empty file")
+
+    outcome = _run(EmptyWriterBackend(), a)
+    assert outcome.status == StageStatus.FAIL, (
+        "an empty artifact must not satisfy the non-trivial requirement"
+    )
+
+
+def test_whitespace_only_artifact_fails(tmp_path):
+    """An artifact with only whitespace fails the non-trivial check."""
+    a = tmp_path / "whitespace.md"
+
+    class WhitespaceWriterBackend:
+        async def run(self, node, prompt, context, incoming_edge=None, graph=None):
+            Path(a).write_text("   \n\t\n   \n")
+            return _outcome_from("wrote whitespace file")
+
+    outcome = _run(WhitespaceWriterBackend(), a)
+    assert outcome.status == StageStatus.FAIL, (
+        "a whitespace-only artifact must not satisfy the non-trivial requirement"
+    )
+
+
+def test_minimal_content_passes(tmp_path):
+    """A single non-whitespace byte satisfies the non-trivial requirement."""
+    a = tmp_path / "minimal.md"
+
+    class MinimalWriterBackend:
+        async def run(self, node, prompt, context, incoming_edge=None, graph=None):
+            Path(a).write_text("x")
+            return _outcome_from("wrote minimal content")
+
+    outcome = _run(MinimalWriterBackend(), a)
+    assert outcome.is_success, (
+        "a single non-whitespace byte must satisfy the non-trivial requirement"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Path resolution: relative paths anchored to context.target_dir
+# ---------------------------------------------------------------------------
+
+
+def test_relative_path_resolves_against_target_dir(tmp_path):
+    """Relative must_write= paths resolve against context.target_dir."""
+    target_dir = tmp_path / "repo"
+    target_dir.mkdir()
+    artifact_rel = ".ai/postmortem/report.md"
+    artifact_abs = target_dir / artifact_rel
+
+    class RelativeWriterBackend:
+        async def run(self, node, prompt, context, incoming_edge=None, graph=None):
+            artifact_abs.parent.mkdir(parents=True, exist_ok=True)
+            artifact_abs.write_text("postmortem content\n")
+            return _outcome_from("wrote report")
+
+    # Use relative path in DOT, set context.target_dir
+    dot = f"""
+digraph RelPathTest {{
+    graph [goal="relative path test"]
+    start [shape=Mdiamond]
+    done  [shape=Msquare]
+    maker [shape=box, must_write="{artifact_rel}", max_retries=0,
+           prompt="Write the postmortem report."]
+    start -> maker
+    maker -> done
+}}
+"""
+    graph = parse_dot(dot)
+    context = PipelineContext()
+    context.set("context.target_dir", str(target_dir))
+    logs = tempfile.mkdtemp(prefix="must-write-relpath-logs-")
+    engine = PipelineEngine(
+        graph=graph,
+        context=context,
+        handler_registry=HandlerRegistry(
+            HandlerContext(backend=RelativeWriterBackend())
+        ),
+        logs_root=logs,
+    )
+    outcome = asyncio.run(engine.run())
+    assert outcome.is_success, (
+        f"relative must_write= path should resolve against context.target_dir "
+        f"({target_dir}); outcome={outcome.status}, reason={outcome.failure_reason}"
+    )
+
+
+def test_relative_path_no_target_dir_uses_cwd(tmp_path, monkeypatch):
+    """Relative must_write= paths fall back to os.getcwd() when target_dir unset."""
+    monkeypatch.chdir(tmp_path)
+    artifact_rel = "output.md"
+    artifact_abs = tmp_path / artifact_rel
+
+    class CwdWriterBackend:
+        async def run(self, node, prompt, context, incoming_edge=None, graph=None):
+            artifact_abs.write_text("output content\n")
+            return _outcome_from("wrote output")
+
+    dot = f"""
+digraph CwdPathTest {{
+    graph [goal="cwd fallback test"]
+    start [shape=Mdiamond]
+    done  [shape=Msquare]
+    maker [shape=box, must_write="{artifact_rel}", max_retries=0,
+           prompt="Write the output."]
+    start -> maker
+    maker -> done
+}}
+"""
+    graph = parse_dot(dot)
+    context = PipelineContext()  # no target_dir set
+    logs = tempfile.mkdtemp(prefix="must-write-cwd-logs-")
+    engine = PipelineEngine(
+        graph=graph,
+        context=context,
+        handler_registry=HandlerRegistry(HandlerContext(backend=CwdWriterBackend())),
+        logs_root=logs,
+    )
+    outcome = asyncio.run(engine.run())
+    assert outcome.is_success, (
+        f"relative must_write= should fall back to cwd when target_dir unset; "
+        f"outcome={outcome.status}, reason={outcome.failure_reason}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Handler already-FAIL is not double-wrapped
+# ---------------------------------------------------------------------------
+
+
+def test_handler_fail_not_double_wrapped(tmp_path):
+    """If the handler already returns FAIL, must_write= does not double-wrap it."""
+    a = tmp_path / "never_written.md"
+    outcome = _run(AlreadyFailBackend(), a)
+    assert outcome.status == StageStatus.FAIL
+    # The original failure_reason must be preserved, not replaced by must_write logic
+    assert "handler-level failure" in (outcome.failure_reason or ""), (
+        "must_write= must not overwrite an existing FAIL outcome's failure_reason"
+    )
+
+
+# ---------------------------------------------------------------------------
+# must_write= does not fire on already-FAIL outcome (skip check)
+# ---------------------------------------------------------------------------
+
+
+def test_must_write_skipped_when_handler_already_fails(tmp_path):
+    """must_write= check is skipped when handler already returned FAIL.
+
+    The check only intercepts non-FAIL outcomes — it must not run when the
+    handler itself produced a FAIL (would double-wrap and lose the original
+    failure_reason).
+    """
+    a = tmp_path / "skip_check.md"
+    # AlreadyFailBackend returns FAIL without writing the file
+    outcome = _run(AlreadyFailBackend(), a)
+    # Confirm it failed (the handler's reason), and the must_write check did
+    # not fire (which would produce a different failure_reason)
+    assert "handler-level failure" in (outcome.failure_reason or ""), (
+        "must_write= check must be skipped when handler already returned FAIL"
+    )
+
+
+# ---------------------------------------------------------------------------
+# continue_on_fail must NOT suppress a must_write= FAIL (regression test)
+# ---------------------------------------------------------------------------
+
+
+def _dot_for_continue_on_fail(artifact: str) -> str:
+    """Graph with a must_write node that also sets continue_on_fail=true."""
+    return f"""
+digraph ContinueOnFailTest {{
+    graph [goal="continue_on_fail bypass regression"]
+    start [shape=Mdiamond]
+    done  [shape=Msquare]
+    maker [shape=box, must_write="{artifact}", continue_on_fail="true",
+           max_retries=0, prompt="Produce the declared artifact."]
+    start -> maker
+    maker -> done
+}}
+"""
+
+
+def test_continue_on_fail_does_not_suppress_must_write_fail(tmp_path):
+    """continue_on_fail=true must NOT override a must_write= FAIL.
+
+    Regression: the continue_on_fail block originally ran unconditionally
+    after the must_write check injected a FAIL, silently voiding the artifact
+    contract.  The guarantee is now by ORDERING: the engine runs the
+    must_write check as the final backstop, after the continue_on_fail
+    override, so any non-FAIL outcome without a fresh artifact is failed.
+
+    A node that declares must_write=<path>, produces no artifact, AND sets
+    continue_on_fail=true must still record FAIL — the fail-closed guarantee
+    is non-overridable by pipeline-level attributes.
+    """
+    a = tmp_path / "case7.md"
+    # NoWriteBackend returns SUCCESS-like outcome without writing the artifact
+    graph = parse_dot(_dot_for_continue_on_fail(str(a)))
+    logs = tempfile.mkdtemp(prefix="must-write-cof-logs-")
+    engine = PipelineEngine(
+        graph=graph,
+        context=PipelineContext(),
+        handler_registry=HandlerRegistry(HandlerContext(backend=NoWriteBackend())),
+        logs_root=logs,
+    )
+    outcome = asyncio.run(engine.run())
+    assert outcome.status == StageStatus.FAIL, (
+        "must_write= FAIL must not be suppressed by continue_on_fail=true. "
+        "The fail-closed artifact contract is non-overridable. "
+        f"Got status={outcome.status}, failure_reason={outcome.failure_reason!r}"
+    )
+    assert (
+        "must_write" in (outcome.failure_reason or "").lower()
+        or "must_write" in (outcome.notes or "").lower()
+    ), (
+        "failure_reason or notes should mention must_write "
+        f"(got: failure_reason={outcome.failure_reason!r}, notes={outcome.notes!r})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# max_retries retries must_write violations IN-PLACE (EXTENSIONS.md §27)
+# ---------------------------------------------------------------------------
+
+
+def _dot_for_max_retries(
+    artifact: str, max_retries: int = 2, extra_attrs: str = ""
+) -> str:
+    """Graph with must_write and max_retries > 0 to verify retry semantics."""
+    return f"""
+digraph MaxRetriesTest {{
+    graph [goal="max_retries must_write regression"]
+    start [shape=Mdiamond]
+    done  [shape=Msquare]
+    maker [shape=box, must_write="{artifact}", max_retries={max_retries},
+           {extra_attrs}prompt="Produce the declared artifact."]
+    start -> maker
+    maker -> done
+}}
+"""
+
+
+class WriteOnNthCallBackend:
+    """Flaky maker: completes without writing until the Nth invocation."""
+
+    def __init__(self, path: Path, content: str, write_on_call: int):
+        self.path = path
+        self.content = content
+        self.write_on_call = write_on_call
+        self.calls = 0
+
+    async def run(self, node, prompt, context, incoming_edge=None, graph=None):
+        self.calls += 1
+        if self.calls >= self.write_on_call:
+            Path(self.path).write_text(self.content)
+        return _outcome_from("Report written as required.")
+
+
+def _run_max_retries_graph(backend, dot: str) -> Outcome:
+    graph = parse_dot(dot)
+    logs = tempfile.mkdtemp(prefix="must-write-maxretries-logs-")
+    engine = PipelineEngine(
+        graph=graph,
+        context=PipelineContext(),
+        handler_registry=HandlerRegistry(HandlerContext(backend=backend)),
+        logs_root=logs,
+    )
+    return asyncio.run(engine.run())
+
+
+def test_max_retries_retries_must_write_violation_in_place(tmp_path):
+    """max_retries DOES re-invoke the handler for a must_write= violation.
+
+    The contract is checked per-attempt inside execute_with_retry(): a
+    completed attempt without the declared artifact consumes a retry attempt
+    exactly like a RETRY outcome (the fail-closed goal-gate verdict shape,
+    EXTENSIONS.md §25).  max_retries=2 on a never-writes node must therefore
+    produce exactly 1 + 2 = 3 backend calls before the loud FAIL.
+
+    This pins the documented behavior in EXTENSIONS.md §27 "Retries" — the
+    reviewer-requested integration test (BACKEND_CALLS == 1 + max_retries).
+    """
+    artifact = tmp_path / "case_max_retries.md"
+    backend = NoWriteBackend()
+    outcome = _run_max_retries_graph(
+        backend, _dot_for_max_retries(str(artifact), max_retries=2)
+    )
+    assert outcome.status == StageStatus.FAIL, (
+        "A must_write= node that never produces its artifact must FAIL even "
+        f"with max_retries=2. Got status={outcome.status}"
+    )
+    assert backend.calls == 3, (
+        "max_retries must re-invoke the handler for a must_write= violation "
+        "(per-attempt check inside the retry ladder). Expected 1 + max_retries "
+        f"= 3 backend calls, got {backend.calls}."
+    )
+
+
+def test_must_write_retry_then_write_succeeds(tmp_path):
+    """An in-place retry that DOES produce the artifact converts to SUCCESS.
+
+    The point of checking within the retry-attempt boundary: a no-write
+    completion is a flaky-failure class where re-invoking the handler helps.
+    Attempt 1 completes without writing; attempt 2 writes — the node succeeds
+    with exactly 2 backend calls and no graph-level failure routing.
+    """
+    artifact = tmp_path / "flaky_write.md"
+    backend = WriteOnNthCallBackend(
+        artifact, "# Report\nreal content\n", write_on_call=2
+    )
+    outcome = _run_max_retries_graph(
+        backend, _dot_for_max_retries(str(artifact), max_retries=2)
+    )
+    assert outcome.status == StageStatus.SUCCESS, (
+        "A retry attempt that satisfies the must_write= contract must let the "
+        f"node succeed. Got status={outcome.status}, "
+        f"failure_reason={outcome.failure_reason!r}"
+    )
+    assert backend.calls == 2, (
+        f"Expected the node to succeed on the 2nd attempt, got {backend.calls} calls."
+    )
+
+
+def test_allow_partial_does_not_soften_must_write_failure(tmp_path):
+    """allow_partial=true must NOT downgrade a must_write= FAIL to PARTIAL.
+
+    The retry ladder's exhaustion path converts RETRY exhaustion to
+    PARTIAL_SUCCESS under allow_partial — but a must_write= violation is
+    fail-closed: exhaustion returns the loud FAIL directly.
+    """
+    artifact = tmp_path / "allow_partial.md"
+    backend = NoWriteBackend()
+    outcome = _run_max_retries_graph(
+        backend,
+        _dot_for_max_retries(
+            str(artifact), max_retries=1, extra_attrs='allow_partial="true", '
+        ),
+    )
+    assert outcome.status == StageStatus.FAIL, (
+        "allow_partial must not soften a must_write= violation "
+        f"(fail-closed). Got status={outcome.status}"
+    )
+    assert backend.calls == 2, (
+        f"Expected 1 + max_retries = 2 backend calls, got {backend.calls}."
+    )
+
+
+def test_continue_on_fail_handler_fail_without_artifact_still_fails(tmp_path):
+    """continue_on_fail=true cannot resurrect a must_write node whose handler
+    FAILED and whose artifact was never written.
+
+    The engine's final backstop runs AFTER the continue_on_fail override:
+    handler FAIL → continue_on_fail flips it to SUCCESS → the backstop
+    re-checks the artifact contract → no fresh artifact → FAIL.  Without the
+    backstop ordering, this combination completed as a silent success without
+    the declared artifact (the exact hole the contract exists to close).
+    """
+    artifact = tmp_path / "cof_handler_fail.md"
+    graph = parse_dot(f"""
+digraph ContinueOnFailHandlerFail {{
+    graph [goal="continue_on_fail + handler FAIL + must_write"]
+    start [shape=Mdiamond]
+    done  [shape=Msquare]
+    maker [shape=box, must_write="{artifact}", continue_on_fail="true",
+           max_retries=0, prompt="Produce the declared artifact."]
+    start -> maker
+    maker -> done
+}}
+""")
+    logs = tempfile.mkdtemp(prefix="must-write-cof-hf-logs-")
+    engine = PipelineEngine(
+        graph=graph,
+        context=PipelineContext(),
+        handler_registry=HandlerRegistry(HandlerContext(backend=AlreadyFailBackend())),
+        logs_root=logs,
+    )
+    outcome = asyncio.run(engine.run())
+    assert outcome.status == StageStatus.FAIL, (
+        "A must_write node whose handler failed and whose artifact was never "
+        "written must stay FAILED even under continue_on_fail=true. "
+        f"Got status={outcome.status}, failure_reason={outcome.failure_reason!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Council amendment battery: RETRY-exhaustion path, SKIPPED semantics,
+# manufactured-verdict backstop
+# ---------------------------------------------------------------------------
+
+
+class AlwaysRetryBackend:
+    """Backend that always returns RETRY (drives the ladder to exhaustion).
+
+    Optionally writes the artifact on every call — models a worker that DID
+    produce its artifact but kept asking for another attempt.
+    """
+
+    def __init__(self, write_path: Path | None = None, content: str = ""):
+        self.write_path = write_path
+        self.content = content
+        self.calls = 0
+
+    async def run(self, node, prompt, context, incoming_edge=None, graph=None):
+        self.calls += 1
+        if self.write_path is not None:
+            Path(self.write_path).write_text(self.content)
+        return Outcome(status=StageStatus.RETRY, failure_reason="not ready yet")
+
+
+class SkipBackend:
+    """Backend that returns SKIPPED (handler-side skip; node did not execute)."""
+
+    async def run(self, node, prompt, context, incoming_edge=None, graph=None):
+        return Outcome(status=StageStatus.SKIPPED, notes="nothing to do")
+
+
+def _run_graph_with_engine(backend, dot: str):
+    graph = parse_dot(dot)
+    logs = tempfile.mkdtemp(prefix="must-write-council-logs-")
+    engine = PipelineEngine(
+        graph=graph,
+        context=PipelineContext(),
+        handler_registry=HandlerRegistry(HandlerContext(backend=backend)),
+        logs_root=logs,
+    )
+    outcome = asyncio.run(engine.run())
+    return outcome, engine
+
+
+def test_retry_exhaustion_allow_partial_no_artifact_fails(tmp_path):
+    """RETRY exhaustion + allow_partial + NO artifact must NOT become partial.
+
+    The exhaustion tail manufactures PARTIAL_SUCCESS("Retries exhausted,
+    partial accepted") under allow_partial — before this amendment that
+    manufactured verdict bypassed the ladder's must_write check entirely.
+    No artifact means there is nothing to accept partially: loud FAIL.
+    """
+    artifact = tmp_path / "exhausted_no_artifact.md"
+    backend = AlwaysRetryBackend()  # never writes
+    _outcome, engine = _run_graph_with_engine(
+        backend,
+        _dot_for_max_retries(
+            str(artifact), max_retries=1, extra_attrs='allow_partial="true", '
+        ),
+    )
+    maker = engine.node_outcomes["maker"]
+    assert maker.status == StageStatus.FAIL, (
+        "Retries exhausted + allow_partial + no artifact must be a loud FAIL, "
+        f"not partial acceptance. Got {maker.status}, notes={maker.notes!r}"
+    )
+    assert "must_write" in (maker.failure_reason or ""), (
+        f"FAIL should name the violated artifact contract, got "
+        f"failure_reason={maker.failure_reason!r}"
+    )
+    assert backend.calls == 2, (
+        f"Expected 1 + max_retries = 2 backend calls, got {backend.calls}."
+    )
+
+
+def test_retry_exhaustion_allow_partial_with_artifact_partial_accepted(tmp_path):
+    """Positive case: artifact present + exhausted + allow_partial → partial.
+
+    When the exhausted node DID write a fresh, non-trivial artifact, the
+    manufactured PARTIAL_SUCCESS passes the artifact contract and partial
+    acceptance stands (both in the ladder and at the engine's backstop).
+    """
+    artifact = tmp_path / "exhausted_with_artifact.md"
+    backend = AlwaysRetryBackend(write_path=artifact, content="# Real report\n")
+    _outcome, engine = _run_graph_with_engine(
+        backend,
+        _dot_for_max_retries(
+            str(artifact), max_retries=1, extra_attrs='allow_partial="true", '
+        ),
+    )
+    maker = engine.node_outcomes["maker"]
+    assert maker.status == StageStatus.PARTIAL_SUCCESS, (
+        "Artifact present + exhausted + allow_partial should accept partial. "
+        f"Got {maker.status}, failure_reason={maker.failure_reason!r}"
+    )
+    assert "partial accepted" in (maker.notes or ""), (
+        f"Expected the manufactured partial-acceptance notes, got {maker.notes!r}"
+    )
+
+
+def test_backstop_rejects_manufactured_partial_without_artifact(tmp_path):
+    """The shared backstop check rejects the exact manufactured verdict shape.
+
+    Feeds the ladder's manufactured PARTIAL_SUCCESS("Retries exhausted,
+    partial accepted") directly to check_must_write (the same function the
+    engine's final backstop delegates to): no artifact → FAIL; fresh
+    artifact → contract satisfied (None).
+    """
+    from amplifier_module_loop_pipeline.graph import Node
+    from amplifier_module_loop_pipeline.must_write import check_must_write
+
+    artifact = tmp_path / "manufactured.md"
+    node = Node(id="maker", attrs={"must_write": str(artifact)})
+    manufactured = Outcome(
+        status=StageStatus.PARTIAL_SUCCESS,
+        notes="Retries exhausted, partial accepted",
+    )
+    start = time.time()
+
+    fail = check_must_write(node, manufactured, start, PipelineContext())
+    assert fail is not None and fail.status == StageStatus.FAIL, (
+        "Manufactured partial without an artifact must fail the backstop."
+    )
+
+    artifact.write_text("# Real content\n")  # mtime strictly after `start`
+    import os as _os
+
+    _os.utime(artifact, (start + 5, start + 5))
+    ok = check_must_write(node, manufactured, start, PipelineContext())
+    assert ok is None, (
+        f"Fresh, non-trivial artifact must satisfy the backstop, got {ok!r}"
+    )
+
+
+def test_skipped_outcome_passes_through_unconverted(tmp_path):
+    """DECISION (EXTENSIONS.md §27): SKIPPED means the node did not execute.
+
+    A handler-side SKIPPED on a must_write= node passes through unconverted
+    — the artifact contract applies only to completed executions.  (The
+    executed-without-artifact direction is pinned by
+    test_case1_narration_no_write_fails and the exhaustion tests above.)
+    """
+    artifact = tmp_path / "skipped_node.md"
+    _outcome, engine = _run_graph_with_engine(SkipBackend(), _dot_for(str(artifact)))
+    maker = engine.node_outcomes["maker"]
+    assert maker.status == StageStatus.SKIPPED, (
+        "A legitimately-SKIPPED must_write node must stay SKIPPED, not be "
+        f"converted to FAIL for an artifact it was never asked to produce. "
+        f"Got {maker.status}, failure_reason={maker.failure_reason!r}"
+    )
+
+
+def test_skipped_unit_check_returns_none(tmp_path):
+    """Unit direction of the SKIPPED decision: check_must_write exempts SKIPPED."""
+    from amplifier_module_loop_pipeline.graph import Node
+    from amplifier_module_loop_pipeline.must_write import check_must_write
+
+    artifact = tmp_path / "never_written.md"  # deliberately absent
+    node = Node(id="maker", attrs={"must_write": str(artifact)})
+    skipped = Outcome(status=StageStatus.SKIPPED, notes="nothing to do")
+    assert check_must_write(node, skipped, time.time(), PipelineContext()) is None
+
+
+def test_auto_status_promoted_skip_is_a_completed_execution(tmp_path):
+    """The deliberate asymmetry: auto_status=true promotion runs BEFORE the
+    engine's final backstop, so a promoted SKIPPED→SUCCESS node counts as a
+    completed execution and the artifact contract applies — a node that ran,
+    wrote no status, and wrote no artifact is exactly the
+    narration-without-artifact class this contract exists to catch.
+    """
+    artifact = tmp_path / "auto_status_promoted.md"
+    dot = f"""
+digraph AutoStatusPromotion {{
+    graph [goal="auto_status + must_write asymmetry"]
+    start [shape=Mdiamond]
+    done  [shape=Msquare]
+    maker [shape=box, must_write="{artifact}", auto_status=true,
+           max_retries=0, prompt="Produce the declared artifact."]
+    start -> maker
+    maker -> done
+}}
+"""
+    _outcome, engine = _run_graph_with_engine(SkipBackend(), dot)
+    maker = engine.node_outcomes["maker"]
+    assert maker.status == StageStatus.FAIL, (
+        "auto_status-promoted SKIPPED counts as a completed execution: "
+        "no artifact must FAIL at the backstop. "
+        f"Got {maker.status}, notes={maker.notes!r}"
+    )

--- a/modules/loop-pipeline/tests/test_retry.py
+++ b/modules/loop-pipeline/tests/test_retry.py
@@ -500,3 +500,109 @@ async def test_retryable_exception_is_retried():
     # TimeoutError is retryable — should retry and eventually succeed
     assert result.status == StageStatus.SUCCESS
     assert handler.call_count == 2
+
+
+# --- Exhaustion telemetry truth (council amendment) ---
+
+
+class _EventCollector:
+    """Minimal hooks stand-in: collects emitted (event, payload) pairs."""
+
+    def __init__(self):
+        self.events: list[tuple[str, dict]] = []
+
+    async def emit(self, event: str, payload: dict) -> None:
+        self.events.append((event, payload))
+
+
+def _failed_events(collector: _EventCollector) -> list[dict]:
+    from amplifier_module_loop_pipeline.pipeline_events import (
+        PIPELINE_STAGE_FAILED,
+    )
+
+    return [p for (e, p) in collector.events if e == PIPELINE_STAGE_FAILED]
+
+
+@pytest.mark.asyncio
+async def test_exhaustion_event_matches_return_for_string_false():
+    """allow_partial="false" (string, as DOT attrs are) must NOT emit a
+    partial_success failure event while returning FAIL.
+
+    Regression: the event once used raw truthiness of the attr while the
+    return path used a strict check — event and return disagreed.
+    """
+    handler = MockHandler(
+        [Outcome(status=StageStatus.RETRY), Outcome(status=StageStatus.RETRY)]
+    )
+    policy = RetryPolicy(max_attempts=2, backoff=BackoffConfig(initial_delay_ms=0))
+    collector = _EventCollector()
+    result = await execute_with_retry(
+        handler,
+        _make_node(attrs={"allow_partial": "false"}),
+        PipelineContext(),
+        _make_graph(),
+        "/tmp",
+        policy,
+        hooks=collector,
+    )
+    assert result.status == StageStatus.FAIL
+    failed = _failed_events(collector)
+    assert len(failed) == 1
+    assert failed[0]["final_status"] == "fail", (
+        "Event must match the returned outcome: allow_partial='false' returns "
+        f"FAIL, but the event claimed {failed[0]['final_status']!r}."
+    )
+
+
+@pytest.mark.asyncio
+async def test_exhaustion_event_partial_success_when_partial_returned():
+    """allow_partial="true": event says partial_success AND partial is returned."""
+    handler = MockHandler(
+        [Outcome(status=StageStatus.RETRY), Outcome(status=StageStatus.RETRY)]
+    )
+    policy = RetryPolicy(max_attempts=2, backoff=BackoffConfig(initial_delay_ms=0))
+    collector = _EventCollector()
+    result = await execute_with_retry(
+        handler,
+        _make_node(attrs={"allow_partial": "true"}),
+        PipelineContext(),
+        _make_graph(),
+        "/tmp",
+        policy,
+        hooks=collector,
+    )
+    assert result.status == StageStatus.PARTIAL_SUCCESS
+    failed = _failed_events(collector)
+    assert len(failed) == 1
+    assert failed[0]["final_status"] == "partial_success"
+
+
+@pytest.mark.asyncio
+async def test_exhaustion_event_fail_when_must_write_vetoes_partial(tmp_path):
+    """allow_partial="true" + must_write= violated at exhaustion: the
+    manufactured partial is vetoed by the artifact contract (EXTENSIONS §27)
+    and the failure event reports the actual final status: fail.
+    """
+    artifact = tmp_path / "never_written.md"
+    handler = MockHandler(
+        [Outcome(status=StageStatus.RETRY), Outcome(status=StageStatus.RETRY)]
+    )
+    policy = RetryPolicy(max_attempts=2, backoff=BackoffConfig(initial_delay_ms=0))
+    collector = _EventCollector()
+    result = await execute_with_retry(
+        handler,
+        _make_node(attrs={"allow_partial": "true", "must_write": str(artifact)}),
+        PipelineContext(),
+        _make_graph(),
+        "/tmp",
+        policy,
+        hooks=collector,
+    )
+    assert result.status == StageStatus.FAIL
+    assert "must_write" in (result.failure_reason or "")
+    failed = _failed_events(collector)
+    assert len(failed) == 1
+    assert failed[0]["final_status"] == "fail", (
+        "must_write vetoed the manufactured partial; the event must say fail, "
+        f"got {failed[0]['final_status']!r}."
+    )

--- a/specs/EXTENSIONS.md
+++ b/specs/EXTENSIONS.md
@@ -909,6 +909,237 @@ Fully backward-compatible and fail-safe:
 
 ---
 
+## 27. `must_write=` Node Attribute — Fail-Closed Artifact Contract
+
+> **This extension adds an artifact-contract enforcement check to the
+> engine** (per retry attempt, plus a final post-override backstop).
+> It does not conflict with the canonical spec; the spec is silent on
+> per-node artifact contracts.  Nodes without `must_write=` are completely
+> untouched (opt-in).
+
+### Motivation
+
+The same engine gap has been patched at the graph level repeatedly — every
+guard hand-rolled after a live failure:
+
+1. **pm_gate** (`examples/patterns/task-runner.dot`) — the postmortem node
+   was observed returning SUCCESS without writing its report; a deterministic
+   stub-guard gate now guarantees the file exists.
+2. **Verdict gates counting absence as refusal** — in live runs of this
+   pattern, a critique node silently ended on plain-text narration without
+   writing its critique file; the deterministic verdict gate downstream
+   (a grep against the missing file) counted the absence as a refusal, and
+   a stall counter killed a run whose tree was ship-quality by direct
+   re-verification.
+3. **Historical postmortem stubs** — the same "completed without writing"
+   shape observed before pm_gate existed.
+
+A box node's contract is often "this file now exists with real content."  The
+engine had no way to be told that.  `must_write=` puts the cheapest evidence
+check (the artifact exists AND is fresh AND is non-trivial) where every graph
+gets it for free, instead of every author rediscovering the trap live.
+
+### What this extension does
+
+A node may declare `must_write=<path>` as a node attribute.  After the handler
+returns a non-FAIL outcome, the engine runs a three-axis post-execution check:
+
+1. **Existence:** the file at `<path>` must exist.
+2. **Freshness floor (REQUIRED):** `artifact.mtime > node_start_wall`
+   (strictly greater than; `time.time()` snapshot taken immediately before the
+   handler runs).  A pre-planted file whose mtime predates OR equals the node
+   start time FAILS even if it has content — presence alone is exactly the hole
+   this contract closes.  The equality case is rejected explicitly: an
+   adversary (or a coarse-resolution filesystem) can set an artifact's mtime
+   via `os.utime` to match the recorded start time, bypassing a `>=` check.
+3. **Non-trivial:** the artifact must contain at least one non-whitespace byte.
+   An empty file or a whitespace-only file does not satisfy the contract.
+
+The check runs in two places:
+
+1. **Per-attempt, inside the retry ladder** (`execute_with_retry`): a
+   completed attempt (SUCCESS / PARTIAL_SUCCESS) that violates the contract
+   consumes a retry attempt exactly like a RETRY outcome — the same shape as
+   the fail-closed goal-gate verdict retries (§25).  When attempts are
+   exhausted, the violation becomes a loud FAIL with a clear
+   `failure_reason` naming the violated axis, and the node routes through
+   its normal failure edges (`retry_target`, `condition="outcome=fail"`
+   edges, etc.).
+2. **As the engine's final backstop, after all outcome overrides**: the same
+   check runs again AFTER the `auto_status` promotion and the
+   `continue_on_fail` override, so no override can convert an
+   artifact-contract violation into a silent success.
+
+If the handler already returned FAIL, the check does not run (no
+double-wrapping of failure reasons).
+
+### Path resolution (DESIGN DECISION)
+
+`must_write=` paths follow the same resolution rule as `requires=`:
+
+- **Absolute paths** are used as-is.
+- **Relative paths** are resolved against `context.target_dir` if set,
+  falling back to `os.getcwd()`.
+
+The task-runner invocation sets `--cwd <target_repo>` and `--param
+target_dir=<target_repo>`, so `.ai/postmortem/report.md` in a postmortem node
+resolves to `<target_repo>/.ai/postmortem/report.md` — which is the right
+place.  Pipeline authors must document which cwd is the anchor in their graph's
+invocation comments to avoid the environment-lies class at the contract layer.
+
+### Non-trivial semantics (DESIGN DECISION)
+
+"Non-trivial" means: `content.strip()` is non-empty (at least one
+non-whitespace byte).  This is the floor.  Quality (schema, verdict
+structure, minimum size) is NOT validated — that remains graph policy.
+
+### Interaction with retries, goal_gate, and continue_on_fail
+
+- **Retries:** a `must_write=` violation **respects `max_retries`** — and the
+  mechanism is worth stating precisely, because a plain FAIL outcome is
+  *never* re-attempted by `max_retries` in this engine (the retry ladder
+  retries only RETRY outcomes and retryable exceptions; see spec §3.5).  The
+  contract is therefore checked **per-attempt inside `execute_with_retry()`**:
+  a completed attempt (SUCCESS / PARTIAL_SUCCESS) that violates the contract
+  consumes a retry attempt exactly like a RETRY outcome, mirroring the
+  fail-closed goal-gate verdict retries (§25).  A no-write completion is
+  precisely the flaky-failure class where an in-place retry helps —
+  re-invoking the handler gives it another chance to produce the artifact.
+  With `max_retries=N`, a never-writes node invokes its handler exactly
+  `1 + N` times before failing.  When attempts are exhausted, the violation
+  becomes a loud FAIL that routes through the node's normal failure edges —
+  `retry_target` and `condition="outcome=fail"` graph-routing retries work
+  as usual.  `allow_partial=true` does **not** soften the exhausted FAIL to
+  PARTIAL_SUCCESS (fail-closed).  This holds on **both** exhaustion paths:
+  the completed-attempt path (SUCCESS/PARTIAL_SUCCESS attempts that never
+  produced the artifact) AND the RETRY-exhaustion path, where the ladder
+  would otherwise manufacture a `PARTIAL_SUCCESS("Retries exhausted,
+  partial accepted")` verdict — that manufactured verdict is checked
+  against the artifact contract before it is returned.  Retries exhausted
+  + `allow_partial` + no artifact is a loud FAIL: no artifact means there
+  is nothing to accept partially.
+- **SKIPPED (DESIGN DECISION):** SKIPPED means the node did not execute,
+  and the artifact contract applies only to **completed executions** — a
+  SKIPPED outcome passes through the check unconverted, in both the retry
+  ladder and the engine's final backstop.  A legitimately-skipped
+  `must_write=` node (runs_on mismatch, failed dependencies, handler-side
+  skip) is NOT converted to FAIL for lacking an artifact it was never asked
+  to produce.  The one deliberate asymmetry: `auto_status=true` promotion
+  (SKIPPED → SUCCESS) runs BEFORE the final backstop, so a promoted node
+  counts as a completed execution and the contract applies to it — a node
+  that ran, wrote no status, and wrote no artifact is exactly the
+  narration-without-artifact class this contract exists to catch.
+- **goal_gate:** the FAIL outcome returned by the must_write check has
+  `is_explicit=False` (the node never asserted a verdict; the engine forced
+  the FAIL).  A `goal_gate=true` node whose must_write check fires cannot
+  satisfy its own gate — correct, since it produced no artifact.
+- **continue_on_fail:** a `must_write=` FAIL is **non-overridable**.
+  `continue_on_fail=true` does NOT suppress it.  The guarantee is by
+  **ordering**, not a flag: the engine runs the must_write check as the
+  FINAL backstop, after the `auto_status` promotion and the
+  `continue_on_fail` override, so any non-FAIL outcome that reaches the end
+  of node processing without a fresh, non-trivial artifact is failed there.
+  This also covers the adjacent side door: a must_write node whose handler
+  FAILED for its own reasons and whose artifact was never written cannot be
+  resurrected to SUCCESS by `continue_on_fail=true` — the backstop re-checks
+  the artifact contract after the override and fails the node.  A pipeline
+  author cannot accidentally (or intentionally) void the artifact contract
+  by adding `continue_on_fail=true` to a must_write node.
+
+### Residual: delayed-replant window
+
+The mtime-floor alone leaves a narrow window where an external process writes
+a content-bearing file after node start but before the check runs, and the
+node's own session never wrote.  **Session attribution** — correlating the
+write to this node's `session_id` — is the preferred closing mechanism: it
+retires the sibling-plant class entirely (a sibling node pre-writing another
+node's declared artifact inside the window).  The mtime floor
+is the minimum shipped here; session attribution is deferred.  The test
+suite (`test_case4_delayed_replant_informational`) documents this residual
+honestly: a delayed replant passes under the mtime-only implementation, by
+design and on the record.
+
+### Exemplar adoption
+
+`examples/patterns/task-runner.dot` postmortem node declares
+`must_write=".ai/postmortem/report.md"` as the first consumer.  The
+`pm_gate` guard remains in place until the contract is live-proven; it is
+not removed in this change (per the task's non-goal).
+
+### Guard retirement inventory
+
+What this contract retires, and when — honest on both halves:
+
+- **Already retired by the freshness floor (shipped here):** guard glue that
+  exists only to wipe STALE prior-round artifacts before a node re-executes.
+  When a node is visited again on a graph cycle, a fresh `node_start_wall`
+  is recorded for that execution — a file left over from a previous round
+  has an older mtime and cannot satisfy this round's contract.
+- **Retires when session attribution lands (deferred):** guard glue against
+  SIBLING PLANTS — one node pre-writing another node's declared artifact
+  during the delayed-replant window.  The mtime floor cannot distinguish
+  that write from the node's own.
+- **Retires only after the contract is live-proven:** the **pm_gate stub**
+  in `examples/patterns/task-runner.dot` — subsumed by the postmortem
+  node's own fail-closed artifact contract (`must_write=` is declared on
+  that node in this change, but the deterministic guard is deliberately
+  kept; see Exemplar adoption).
+
+**What does NOT retire:**
+
+- **Verdict parsing stays graph policy.**  A write-first skeleton ending
+  `VERDICT: PENDING` passes every `must_write=` axis (fresh, authored,
+  non-trivial) yet carries no shippable verdict — the task-runner's anchored
+  `^VERDICT:` grep still refuses it.  Presence and quality are separate
+  contracts by design: `must_write=` moves the presence half into the
+  engine; the quality half (anchored verdict parsing, consensus, stall
+  counting) remains graph policy forever.
+
+### Backward-compatibility inventory
+
+All existing pipelines are unaffected: the check is opt-in.  No existing node
+in the shipped examples declares `must_write=`; the DOT parser already passes
+unknown attributes through to `node.attrs` unchanged.  The only new behavior
+is for nodes that explicitly add the attribute.
+
+### Files touched
+
+- `modules/loop-pipeline/amplifier_module_loop_pipeline/must_write.py` —
+  `check_must_write(node, outcome, node_start_wall, context)`: the shared
+  contract check (new module, so `engine` and `retry` can both use it
+  without a circular import).
+- `modules/loop-pipeline/amplifier_module_loop_pipeline/retry.py` —
+  per-attempt check inside `execute_with_retry()`: a completed attempt that
+  violates the contract consumes a retry attempt like a RETRY outcome;
+  exhaustion returns the loud FAIL (`allow_partial` does not soften it).
+- `modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py` —
+  `node_start_wall = time.time()` recorded before handler execution;
+  `_check_must_write` delegates to the shared check and runs as the FINAL
+  backstop (Step 2.7, after the auto_status and continue_on_fail overrides).
+- `specs/EXTENSIONS.md` — this entry.
+- `examples/patterns/task-runner.dot` — postmortem node gains
+  `must_write=".ai/postmortem/report.md"` (exemplar adoption).
+- `modules/loop-pipeline/tests/test_engine_must_write.py` — unit tests for
+  the adversarial battery cases, relative-path resolution, non-trivial
+  semantics, retry semantics (`1 + max_retries` handler invocations,
+  retry-then-write success, allow_partial and continue_on_fail
+  interactions), backward compat, and the council-amendment battery
+  (RETRY-exhaustion manufactured-verdict veto both directions, SKIPPED
+  pass-through both levels, auto_status-promotion asymmetry).
+- `modules/loop-pipeline/tests/test_retry.py` — exhaustion telemetry truth:
+  the `pipeline:stage_failed` event's `final_status` always matches the
+  returned outcome (string `allow_partial="false"`, partial acceptance,
+  and must_write-vetoed partial).
+- `docs/CONTRACTS.md`, `docs/DOT-SYNTAX.md`, `docs/DOT-AUTHORING-GUIDE.md`,
+  `context/engine-semantics.md` — retry-ladder truth stated where
+  `max_retries` is glossed (the ladder retries RETRY outcomes, retryable
+  exceptions, and must_write violations; a plain FAIL is never retried in
+  place), plus the continue_on_fail behavior-change sentence.
+- `docs/reports/2026-02-20-nlspec-dod-gap-analysis.md` — dated errata note
+  for the §11.5 "retried on RETRY or FAIL outcomes | PASS" row.
+
+---
+
 ## Conformance Restoration Note (T0-4)
 
 **What was retired:** An unledgered dialect where non-`shape=parallel`, non-component nodes


### PR DESCRIPTION
## Summary

A node can now DECLARE the artifact it exists to produce — `must_write=<path>`
— and the engine enforces it: completing normally requires a **fresh** (mtime
strictly after node start), **non-trivial** (non-whitespace content) artifact
at that path, else the node fails loudly and routes through its normal
failure edges. This is the sibling of #109's fail-closed goal-gate verdict
contract: #109 made "no explicit verdict" fail-closed at goal gates; this
makes "no written artifact" fail-closed at any node that declares one.

**Why now (the live evidence):** five separate live instances of the same
wrong-but-plausible shape — a box node "completing" without writing the file
it exists to produce — accumulated across operational runs of the shipped
task-runner pattern:

1. A postmortem node returned SUCCESS without writing its report (this is
   why `pm_gate` exists in `examples/patterns/task-runner.dot`).
2. A critique node ended on plain-text narration ("Now let me do a final
   comprehensive check...") without writing its critique file — three times
   in one run; the downstream verdict gate counted the absence as a refusal
   and a stall counter killed a run whose tree was ship-quality by direct
   re-verification.
3. Historical postmortem stubs — the same shape observed before pm_gate
   existed.
4. A second postmortem no-write, caught only by pm_gate's stub.
5. "Child session completed with empty final message" — accepted as node
   success. Not even narration: a fully EMPTY completion satisfied the
   handler.

Each graph-level guard is correct, and each is a symptom: the engine could
not be told "this node's contract is that this file exists with real
content." This puts the cheapest evidence check where every graph gets it
for free — the same fail-open outcome class the incident analysis
identified, closed at the artifact layer.

## What changed

- **`modules/loop-pipeline/amplifier_module_loop_pipeline/must_write.py`
  (NEW):** `check_must_write(node, outcome, node_start_wall, context)` — the
  shared three-axis check (existence, freshness floor with strict `>` on
  mtime, non-trivial content). New module so `engine` and `retry` can both
  use it without a circular import.
- **`retry.py`:** the check runs **per-attempt inside
  `execute_with_retry()`** — a completed attempt (SUCCESS/PARTIAL_SUCCESS)
  that violates the contract consumes a retry attempt exactly like a RETRY
  outcome (the §25 fail-closed-verdict shape). Exhaustion returns a loud
  FAIL; `allow_partial` does not soften it.
- **`engine.py`:** `node_start_wall` wall-clock capture; the check also runs
  as the **final backstop AFTER the `auto_status` and `continue_on_fail`
  overrides** (Step 2.7) — non-overridable by construction, not by flag.
  `_check_must_write` is now a thin delegate to the shared module.
- **`specs/EXTENSIONS.md` §27 (NEW entry):** motivation, the three-axis
  check, path resolution (relative → `context.target_dir`, falling back to
  `os.getcwd()` — the `requires=` convention) and non-trivial semantics
  (`content.strip()` non-empty) as recorded design decisions, the
  retries/goal_gate/continue_on_fail interactions, the delayed-replant
  residual stated honestly (session attribution named as the preferred
  closing mechanism, deferred), and the guard retirement inventory including
  the negative half.
- **`examples/patterns/task-runner.dot`:** the postmortem node declares
  `must_write=".ai/postmortem/report.md"` — the first consumer, exactly
  where the hand-rolled guard lives today. `pm_gate` is deliberately
  retained until the contract is live-proven.
- **`docs/CONTRACTS.md`:** the fail-forward table's `continue_on_fail` row
  gains the must_write exception; stale engine.py line citations in that
  section refreshed to current anchors.
- **`tests/test_engine_must_write.py` (NEW, 25 tests):** adversarial battery
  (narration no-write, empty final message, planted file, mtime-equality
  boundary, delayed replant informational, write-first `VERDICT: PENDING`
  skeleton passes, no-attribute control), path resolution both ways,
  non-trivial semantics, no-double-wrap of handler FAILs, and the retry
  semantics: `1 + max_retries` handler invocations on a never-writes node,
  retry-then-write success, `allow_partial` and `continue_on_fail` unable to
  soften the FAIL (both directions — handler-success-no-write AND
  handler-fail-no-artifact-resurrected-by-continue_on_fail), plus the
  council-amendment battery below.

## Council amendment (pre-PR 6-lens review of this branch — 3 code items + doc package)

A council review of the prepared branch surfaced three blocking code items
and a doc-contradiction package; all verified against the branch and closed
here (same squashed commit):

1. **RETRY-exhaustion path no longer bypasses the artifact contract.** The
   ladder's exhaustion tail manufactures
   `PARTIAL_SUCCESS("Retries exhausted, partial accepted")` under
   `allow_partial` — that manufactured verdict previously skipped the
   ladder's must_write check entirely (reachable when every attempt returns
   RETRY, so the per-attempt check never ran). Decision: **retries exhausted
   + `allow_partial` + no artifact is a loud FAIL** — no artifact means
   there is nothing to accept partially. The manufactured verdict now passes
   through `check_must_write` before it is returned; artifact present →
   partial acceptance stands. Both directions tested
   (`test_retry_exhaustion_allow_partial_no_artifact_fails`,
   `test_retry_exhaustion_allow_partial_with_artifact_partial_accepted`),
   plus the manufactured-verdict shape fed directly to the shared backstop
   check (`test_backstop_rejects_manufactured_partial_without_artifact`).
2. **SKIPPED × must_write decided:** SKIPPED means the node did not execute;
   the artifact contract applies only to **completed executions**. A
   legitimately-SKIPPED must_write node passes through unconverted at both
   the ladder and the engine backstop (`check_must_write` exempts SKIPPED
   explicitly). Deliberate asymmetry, documented in §27: `auto_status=true`
   promotion (SKIPPED→SUCCESS) runs BEFORE the backstop, so a promoted node
   counts as a completed execution and the contract applies — a node that
   ran, wrote no status, and wrote no artifact is exactly the
   narration-without-artifact class this contract catches. Tested in both
   directions plus the promotion asymmetry
   (`test_skipped_outcome_passes_through_unconverted`,
   `test_skipped_unit_check_returns_none`,
   `test_auto_status_promoted_skip_is_a_completed_execution`).
3. **Exhaustion telemetry truthiness fixed:** the `pipeline:stage_failed`
   event's `final_status` used raw truthiness of `allow_partial` while the
   return path used a strict check — a node with `allow_partial="false"`
   (string, as DOT attrs are) emitted an event claiming `partial_success`
   while returning FAIL. The final outcome is now decided first and the
   event derives from it, so event and return can never disagree — including
   when the must_write veto converts the manufactured partial to FAIL.
   Pinned by 3 tests in `tests/test_retry.py`.

**Doc package (council found shipped docs contradicting the retry-ladder
fact):** `context/engine-semantics.md` now states what `max_retries`
actually retries (RETRY outcomes, retryable-classified exceptions by type
and message content, and must_write violations; a plain FAIL is returned
immediately, never retried); `docs/DOT-SYNTAX.md` ("Retry count on failure")
and `docs/DOT-AUTHORING-GUIDE.md` ("retries a single node on failure")
glosses corrected to the same truth; dated errata appended to
`docs/reports/2026-02-20-nlspec-dod-gap-analysis.md` for its §11.5 "retried
on RETRY or FAIL outcomes | PASS" row; `docs/CONTRACTS.md` continue_on_fail
row gains the explicit behavior-change sentence (continue_on_fail +
must_write + no-artifact: previously silent SUCCESS, now FAIL).

## The design decision: `must_write` violations respect `max_retries` (in-place retries)

The independent review round produced an executable finding: the salvaged
implementation checked the contract only after `execute_with_retry()`
returned, so a violation could never consume `max_retries` — a no-write node
with `max_retries=2` invoked its handler exactly once:

```
$ uv run python <reviewer repro>   # on the salvaged tree
OUTCOME=fail BACKEND_CALLS=1
```

Two honest resolutions existed: (a) move the check inside the retry-attempt
boundary so violations genuinely consume `max_retries`, or (b) keep
post-handler semantics and document that `max_retries` does not apply.

**This PR ships (a),** for three reasons:

1. **It is what the ladder already does for the sibling contract.** A plain
   FAIL outcome is *never* re-attempted by `max_retries` in this engine (the
   ladder retries only RETRY outcomes and retryable exceptions, spec §3.5).
   The §25 fail-closed goal-gate contract already solves this exact problem
   by returning RETRY so the ladder re-engages. The must_write check now
   does the same thing in the same place — no new retry machinery.
2. **A no-write completion is precisely the flaky class where an in-place
   retry helps.** The live instances above are transient LLM behaviors
   (narration endings, empty final messages); re-invoking the handler gives
   it another chance to produce the artifact. The live RED run below shows
   the retry firing and the model still not writing — then the loud FAIL.
3. **"Respects max_retries" is what an author expects the attribute to do**,
   and now it is true rather than documented-away.

After the fix, the same repro:

```
OUTCOME=fail BACKEND_CALLS=3     # 1 + max_retries=2, then loud FAIL
```

pinned by `test_max_retries_retries_must_write_violation_in_place`, plus
`test_must_write_retry_then_write_succeeds` (attempt 2 writes → SUCCESS,
exactly 2 calls) proving the retry is useful, not just counted.

**Non-overridability is by ordering, not flag:** the engine backstop runs
after `auto_status` and `continue_on_fail`. This also closes an adjacent
side door found in fresh-eyes: a must_write node whose handler FAILED for
its own reasons and whose artifact was never written could previously be
resurrected to SUCCESS by `continue_on_fail=true`. Now the backstop
re-checks after the override and fails the node (tested).

## Guard retirement inventory (honest, both halves)

- **Already retired by the freshness floor (shipped here):** wipe-glue for
  STALE prior-round artifacts — a re-executed node records a fresh
  `node_start_wall`, so a file left over from a previous round cannot
  satisfy this round's contract.
- **Retires when session attribution lands (deferred):** guards against
  SIBLING PLANTS during the delayed-replant window. The mtime floor cannot
  attribute the write; this residual is documented in §27 and reported
  informationally by the test suite — **accepted residual**, acknowledged as
  such by both reviewers.
- **Retires only after live-proving:** `pm_gate` in `task-runner.dot` —
  must_write is declared on the postmortem node in this change, but the
  deterministic stub-guard is deliberately kept (non-goal to remove it now).
- **Does NOT retire:** verdict parsing stays graph policy. A write-first
  skeleton ending `VERDICT: PENDING` passes every must_write axis yet
  carries no shippable verdict — the task-runner's anchored `^VERDICT:` grep
  still refuses it. Presence and quality are separate contracts by design.

## Verification checklist

- [x] Unit tests pass (`pytest modules/loop-pipeline/`) — **1664 passed, 1
  skipped** (full suite on the branch; base was 1651/1 — net-new: 4
  retry-semantics tests + 9 council-amendment tests)
- [x] Live pipeline run exercising changed code path — required when
  touching `engine.py` or any handler; see Verification evidence
- [x] AGENTS.md reviewed; repo-specific gates met
- [x] Backward-compat path unchanged — the attribute is opt-in; no shipped
  example declared `must_write=` before this change; nodes without it are
  untouched (`test_case6_no_attribute_control`)
- [x] PR body includes verification evidence, not just "tests pass"

## Verification evidence

**Live RED run (fail-closed firing, clean sandbox, branch code
identity-verified via the symlinked module path):** a one-node graph with
`must_write="/root/t49-live/red-report.md"`, `max_retries=1`, prompt
explicitly forbidding file writes. The in-place retry fired (two contract
warnings = two handler attempts), then the loud FAIL:

```
Node 'reporter' must_write= contract violated: artifact absent (/root/t49-live/red-report.md)
Node 'reporter' must_write= contract violated: artifact absent (/root/t49-live/red-report.md)
[PIPELINE] ✗ Error at reporter (no_matching_edge): Node 'reporter' declared must_write='/root/t49-live/red-report.md' but no artifact was written (path: /root/t49-live/red-report.md)
attractor: status=fail
{"status": "fail", "notes": "No matching edge from node 'reporter'", "logs_dir": "/tmp/attractor-run-jpztlf04"}
$ ls red-report.md → No such file or directory   # exit code 1
```

**Live GREEN run (contract satisfied):** same shape, prompt instructs
writing the file. `status=success`, exit 0, 393-byte artifact with real
content on disk. Notably the session's final message was EMPTY
("Child session completed with empty final message") — the run passed
because the ARTIFACT existed, which is precisely the contract: evidence on
disk, not chat text.

**Reviewer-repro flip (the max_retries finding):** on the salvaged tree
`OUTCOME=fail BACKEND_CALLS=1`; on this branch `OUTCOME=fail
BACKEND_CALLS=3` (repro script in the test as
`test_max_retries_retries_must_write_violation_in_place`).

**Suites on `9bb7941` (post-council-amendment):**

- loop-pipeline full: `1664 passed, 1 skipped`
- pipeline-runner: `45 passed, 1 skipped`
- doc-guard + examples-lint + command-content: `94 passed` (`131 passed`
  including topological lint)
- root subset (`--ignore=tests/e2e`): `14 passed` (the 3 gemini e2e
  failures are pre-existing on main — no GEMINI_API_KEY on this host)
- focused: `test_engine_must_write.py` 25 passed; `test_retry.py` 34 passed
- `git diff --check`: clean; touched files `ruff format` clean;
  `ruff check` clean on `must_write.py` + `test_retry.py`; `retry.py` +
  `test_engine_must_write.py` carry only the 5 findings pre-existing on the
  branch before this amendment (verified identical via stash comparison)
- DTU re-gate (`attractor-evals`, branch checked out @ `9bb7941`, pycache
  cleared): `T4-9.verify.sh` → `PASS` exit 0 (engine-identity probes,
  6-case adversarial battery, EXTENSIONS entry check, 14 root tests)

**Equality boundary observed live in the battery:**
`artifact mtime 1785775816.783 predates node start 1785775816.784` — and a
planted file whose mtime *equals* node start is likewise rejected
(strict `>`; `test_case3b_equality_boundary_fails`).

## Notes for reviewers

- **Where the check does NOT run:** if the handler itself returned FAIL, the
  check does not replace its failure reason (no double-wrapping). SKIPPED
  outcomes are exempt at both levels — the node did not execute (council
  decision, §27). `auto_status`-promoted SKIPPED→SUCCESS and timeout-path
  PARTIALs are covered by the final backstop rather than the ladder.
- **Exemplar behavior change (intended, visible):** `task-runner.dot`'s
  postmortem node inherits `default_max_retries=2`, so a no-write postmortem
  now gets two in-place retries; if it still never writes, the node FAILS
  loudly (fail-fast on its plain edge) instead of silently reaching
  pm_gate's stub. That is the fail-closed philosophy — the absence becomes
  visible instead of papered over; pm_gate stays as the transition guard and
  still fires for its original purpose if the node succeeds with the file
  later removed.
- **Delayed-replant residual (accepted):** an external process writing a
  content-bearing file after node start but before the check runs satisfies
  the mtime floor. Session attribution (correlating the write to the node's
  `session_id`, now feasible on top of #117's session-event persistence) is
  the preferred closing mechanism and is deferred; §27 says so explicitly
  and the suite reports the case informationally rather than pretending.
- **`PIPELINE_STAGE_RETRYING` events** gain `"reason": "must_write_violation"`
  on this path (additive field).
- **`docs/CONTRACTS.md` line-citation refresh:** the continue_on_fail
  section's engine.py line anchors had drifted (pre-existing); this change
  moves those lines again, so the citations were re-verified against the
  final tree.

## Reviewer commands

```bash
# The battery, through the real engine:
cd modules/loop-pipeline && uv run pytest tests/test_engine_must_write.py -v

# The max_retries contract specifically (1 + N handler calls, then FAIL):
uv run pytest tests/test_engine_must_write.py -k max_retries -v

# Non-overridability (both directions):
uv run pytest tests/test_engine_must_write.py -k continue_on_fail -v

# Full regression:
uv run pytest . -q          # 1664 passed, 1 skipped

# Live, with any provider configured — a no-write node fails loudly:
printf 'digraph R { graph [goal="demo"] start [shape=Mdiamond] done [shape=Msquare]
  n [shape=box, must_write="/tmp/r.md", max_retries=1,
     prompt="Reply with one sentence. Do NOT create or modify any files."]
  start -> n  n -> done }' > /tmp/red.dot && attractor run /tmp/red.dot; echo "exit=$?"
```