### PR TITLE
feat(runner): close the runner-engine version-skew window + stamp run provenance

### DIFF
--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py
@@ -50,6 +50,50 @@ from .substitution import extract_refs
 logger = logging.getLogger(__name__)
 
 
+def _get_engine_provenance() -> dict:
+    """Return engine version/commit provenance for manifest stamping.
+
+    Reads install-time metadata only — no shell-out to git at runtime.
+    Strategy (in order of discriminating power):
+
+    1. PEP 610 ``direct_url.json``: for git installs uv records the resolved
+       commit hash here.  Editable installs (``uv sync`` in-tree) may omit the
+       ``requested_revision`` / ``commit_id`` fields — we stamp ``"unknown"``
+       rather than guessing.
+    2. ``importlib.metadata.version()``: the static ``pyproject.toml`` version
+       string (``"0.1.0"`` today).  Low-information but honest.
+
+    Returns a dict with keys ``engine_version`` and ``engine_commit``.
+    Values are ``"unknown"`` when identity cannot be determined without
+    fabricating — a fabricated provenance field is worse than an honest gap.
+    """
+    import importlib.metadata as _meta
+
+    engine_version: str = "unknown"
+    engine_commit: str = "unknown"
+
+    try:
+        engine_version = _meta.version("amplifier-module-loop-pipeline")
+    except _meta.PackageNotFoundError:
+        pass
+
+    try:
+        # PEP 610: uv writes direct_url.json for git/url installs.
+        # Path: <site-packages>/amplifier_module_loop_pipeline-*.dist-info/direct_url.json
+        dist = _meta.distribution("amplifier-module-loop-pipeline")
+        direct_url_text = dist.read_text("direct_url.json")
+        if direct_url_text:
+            direct_url = json.loads(direct_url_text)
+            vcs_info = direct_url.get("vcs_info", {})
+            commit_id = vcs_info.get("commit_id", "")
+            if commit_id:
+                engine_commit = commit_id
+    except Exception as exc:  # noqa: BLE001 — provenance is best-effort; never crash
+        logger.debug("engine commit provenance unavailable: %s", exc)
+
+    return {"engine_version": engine_version, "engine_commit": engine_commit}
+
+
 class PipelineEngine:
     """Graph-walking execution engine.
 
@@ -1106,16 +1150,33 @@ class PipelineEngine:
         """Write manifest.json and create the artifacts/ directory.
 
         Spec Section 5.6: Run Directory Structure.
+
+        Extension #28: Run provenance stamping.  The manifest includes
+        ``engine_version`` and ``engine_commit`` so an incident analyst can
+        tell from the run directory alone what code produced the run.  Values
+        are ``"unknown"`` for editable/dev installs where commit identity is
+        not available from install-time metadata (PEP 610 direct_url.json).
+        The runner layer may augment the manifest with ``runner_version``,
+        ``runner_commit``, and ``provider`` fields after this call — one
+        writer per field, no races.  Existing fields are additive-only;
+        ``graph_name``, ``goal``, ``start_time``, ``node_count``,
+        ``edge_count`` are unchanged for backward compatibility.
         """
         os.makedirs(self.logs_root, exist_ok=True)
         os.makedirs(os.path.join(self.logs_root, "artifacts"), exist_ok=True)
 
+        provenance = _get_engine_provenance()
         manifest = {
             "graph_name": self.graph.name,
             "goal": self.graph.goal or goal or "",
             "start_time": datetime.now(timezone.utc).isoformat(),
             "node_count": len(self.graph.nodes),
             "edge_count": len(self.graph.edges),
+            # Provenance fields (Extension #28): additive, backward-compatible.
+            # Values are "unknown" when identity cannot be determined without
+            # fabricating — stamp honestly, never guess.
+            "engine_version": provenance["engine_version"],
+            "engine_commit": provenance["engine_commit"],
         }
         manifest_path = os.path.join(self.logs_root, "manifest.json")
         with open(manifest_path, "w") as f:

--- a/modules/loop-pipeline/tests/test_run_directory.py
+++ b/modules/loop-pipeline/tests/test_run_directory.py
@@ -169,6 +169,22 @@ class TestManifest:
         assert data["goal"] == "build auth"
 
     @pytest.mark.asyncio
+    async def test_manifest_has_honest_engine_provenance(self, tmp_path):
+        """Engine identity is additive and never omitted from a run manifest."""
+        engine = _make_engine(
+            dot_source="""
+            digraph { start [shape=Mdiamond]; exit [shape=Msquare]; start -> exit }
+            """,
+            backend=MockBackend(),
+            logs_root=str(tmp_path),
+        )
+        await engine.run()
+        with open(tmp_path / "manifest.json") as f:
+            data = json.load(f)
+        assert {"engine_version", "engine_commit"} <= data.keys()
+        assert all(isinstance(data[key], str) and data[key] for key in ("engine_version", "engine_commit"))
+
+    @pytest.mark.asyncio
     async def test_manifest_has_node_and_edge_counts(self, tmp_path):
         """manifest.json includes node_count and edge_count."""
         engine = _make_engine(

--- a/modules/pipeline-runner/amplifier_module_pipeline_runner/cli.py
+++ b/modules/pipeline-runner/amplifier_module_pipeline_runner/cli.py
@@ -22,6 +22,7 @@ import tempfile
 from pathlib import Path
 
 from . import runner
+from .compat import IncompatibleEngineError, check_engine_compatibility
 from .params import parse_params
 
 
@@ -456,6 +457,15 @@ def cmd_doctor(args: argparse.Namespace) -> int:
 
 
 def main(argv: list[str] | None = None) -> int:
+    # Fail loud at startup if the installed engine is incompatible with this
+    # runner.  This catches version-skew before any node runs (incident
+    # 2026-07-28: remote_dot absent in cached engine caused mid-run crash).
+    try:
+        check_engine_compatibility()
+    except IncompatibleEngineError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
     parser = build_parser()
     args = parser.parse_args(argv)
 

--- a/modules/pipeline-runner/amplifier_module_pipeline_runner/compat.py
+++ b/modules/pipeline-runner/amplifier_module_pipeline_runner/compat.py
@@ -1,0 +1,114 @@
+"""Runner-engine compatibility assertion.
+
+Chosen shape: startup compatibility assertion (compat-assert).
+
+Tradeoff rationale
+------------------
+Three shapes were available to close the version-skew window:
+
+1. **Pin the dep to a commit/tag** — closes the window structurally but
+   requires a manual bump every time the engine changes.  Release-flow cost:
+   whoever merges an engine PR must also bump the runner's pinned commit in
+   ``pipeline-runner/pyproject.toml`` and cut a new release.  In a fast-moving
+   repo with a single maintainer this is a constant friction tax and a known
+   source of forgotten bumps.
+
+2. **Collapse to a single package** — eliminates the skew problem entirely but
+   is a larger refactor that changes the module boundary and the install story
+   (users who want only the engine can no longer install it without the runner).
+   Deferred: the boundary is intentional (engine is usable standalone).
+
+3. **Startup compatibility assertion (chosen)** — keeps the floating dep but
+   adds a check at runner startup that probes for a known-new symbol and fails
+   loudly with an actionable message before any node runs.  The skew window
+   still exists in theory (a stale cache could still be resolved), but it is
+   detected immediately rather than mid-run, and the error message names both
+   the required version and the resolution command.  This is the lowest
+   friction shape for a single-repo, actively-developed package.
+
+``amplifier-foundation @main`` float
+-------------------------------------
+The ``amplifier-foundation`` dep in ``pipeline-runner/pyproject.toml`` also
+floats on ``@main``.  It is a separate package from a different repository;
+pinning it requires coordinating with that repo's release cadence.  Explicit
+deferral: the foundation symbols the runner uses (``Bundle``, ``load_bundle``
+-- imported lazily inside functions, never at module level) are long-stable
+core API, unlike the recently-added engine module that caused the incident,
+so there is currently no discriminating symbol to probe.  Apply the same
+compat-assert pattern here the moment the runner starts depending on a
+recently-added foundation symbol.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+# Minimum required engine features — each entry is a (module, symbol) pair.
+# Add a new entry here when the runner imports a symbol that was absent in an
+# older engine snapshot (the incident: remote_dot absent <= bc6cbec, #96).
+_REQUIRED_ENGINE_SYMBOLS: list[tuple[str, str]] = [
+    ("amplifier_module_loop_pipeline.remote_dot", "load_remote_or_local_graph"),
+]
+
+# Human-readable minimum description for the actionable error message.
+_ENGINE_MIN_DESCRIPTION = "engine with remote_dot support (commit bc6cbec or later, PR #96)"
+
+
+class IncompatibleEngineError(RuntimeError):
+    """Raised when the installed engine is missing symbols required by this runner.
+
+    Carries the full actionable message so callers (CLI or API) can surface it
+    appropriately: the CLI catches this and calls sys.exit(1); the API path
+    lets it propagate as a RuntimeError so the caller can handle it.
+    """
+
+
+def check_engine_compatibility() -> None:
+    """Assert that the installed engine is compatible with this runner.
+
+    Called at CLI startup and at the top of ``drive_engine()`` (before any
+    engine imports execute) so a version-skew crash surfaces immediately with
+    an actionable message rather than mid-pipeline with an opaque ImportError.
+
+    Raises ``IncompatibleEngineError`` with an actionable message if the engine
+    is incompatible.  Does nothing if the engine is compatible.  Idempotent:
+    cheap repeated calls are safe (symbol probe only, no I/O).
+
+    The CLI entry point (``cli.main``) catches ``IncompatibleEngineError`` and
+    converts it to ``sys.exit(1)`` so the shell sees a non-zero exit code.
+    The API path (``drive_engine``) lets the exception propagate as a
+    ``RuntimeError`` subclass.
+    """
+    missing: list[str] = []
+    for module_name, symbol_name in _REQUIRED_ENGINE_SYMBOLS:
+        try:
+            mod = importlib.import_module(module_name)
+            if not hasattr(mod, symbol_name):
+                missing.append(f"{module_name}.{symbol_name}")
+        except (ImportError, ModuleNotFoundError):
+            missing.append(f"{module_name} (module not found)")
+
+    if not missing:
+        return
+
+    # Build actionable message — names the missing symbols, the required
+    # engine description, and the reinstall command.
+    missing_str = "\n  ".join(missing)
+    message = (
+        f"attractor: INCOMPATIBLE ENGINE — runner requires {_ENGINE_MIN_DESCRIPTION}\n"
+        f"  but the installed engine is missing:\n"
+        f"  {missing_str}\n"
+        f"\n"
+        f"  This is a version-skew problem: the runner was installed with a newer\n"
+        f"  engine dependency than uv resolved from its cache.\n"
+        f"\n"
+        f"  Fix: reinstall the runner, forcing a fresh engine resolution:\n"
+        f"    uv tool install --reinstall \\\n"
+        f"      'amplifier-module-pipeline-runner @ "
+        f"git+https://github.com/microsoft/amplifier-bundle-attractor"
+        f"@main#subdirectory=modules/pipeline-runner'\n"
+        f"\n"
+        f"  Or, if running from the repo tree:\n"
+        f"    cd modules/pipeline-runner && uv sync --reinstall"
+    )
+    raise IncompatibleEngineError(message)

--- a/modules/pipeline-runner/amplifier_module_pipeline_runner/runner.py
+++ b/modules/pipeline-runner/amplifier_module_pipeline_runner/runner.py
@@ -168,6 +168,12 @@ async def drive_engine(
 ) -> "Outcome":
     """Drive the attractor engine directly against an already-built coordinator.
 
+    Compatibility gate: ``check_engine_compatibility()`` is called first
+    (before any engine imports execute) so a version-skew crash surfaces as
+    an actionable ``IncompatibleEngineError`` rather than a bare
+    ``ModuleNotFoundError`` mid-pipeline.  This covers both the CLI path and
+    any consumer using this function as a library seam (incident 2026-07-28).
+
     Low-level API: the caller is responsible for building the session and
     registering ``session.spawn`` on ``coordinator`` before calling this
     (see ``run_pipeline`` for the high-level convenience that does this).
@@ -212,6 +218,13 @@ async def drive_engine(
     Returns:
         The engine's ``Outcome`` (``outcome.status.value``, ``outcome.notes``).
     """
+    # Compat gate: probe required engine symbols before any engine import
+    # executes.  Raises IncompatibleEngineError with an actionable message on
+    # skew; idempotent (symbol probe only, no I/O).
+    from .compat import check_engine_compatibility
+
+    check_engine_compatibility()
+
     from amplifier_module_loop_pipeline.backend import AmplifierBackend
     from amplifier_module_loop_pipeline.context import PipelineContext
     from amplifier_module_loop_pipeline.engine import PipelineEngine
@@ -536,6 +549,52 @@ async def _build_prepared(
     return prepared
 
 
+def _get_runner_provenance() -> dict[str, str]:
+    """Return runner package identity from install-time metadata.
+
+    PEP 610 records a resolved VCS commit for git installs.  Editable installs
+    may not have that identity, so provenance deliberately says ``"unknown"``
+    rather than inferring a commit from a checkout that may not be the code
+    being executed.
+    """
+    import contextlib
+    from importlib import metadata
+
+    runner_version = "unknown"
+    runner_commit = "unknown"
+    with contextlib.suppress(metadata.PackageNotFoundError):
+        runner_version = metadata.version("amplifier-module-pipeline-runner")
+
+    # Provenance must never break a completed run -- suppress broadly.
+    with contextlib.suppress(Exception):
+        direct_url_text = metadata.distribution(
+            "amplifier-module-pipeline-runner"
+        ).read_text("direct_url.json")
+        if direct_url_text:
+            commit_id = json.loads(direct_url_text).get("vcs_info", {}).get("commit_id")
+            if commit_id:
+                runner_commit = commit_id
+
+    return {"runner_version": runner_version, "runner_commit": runner_commit}
+
+
+def _augment_manifest_provenance(logs_dir: Path, provider: str) -> None:
+    """Add runner-owned provenance fields after the engine writes its manifest.
+
+    The engine owns ``engine_*`` fields.  This sequential post-run update owns
+    only runner identity and the CLI/API provider selection, avoiding two
+    writers for the same field while preserving all engine-owned legacy fields.
+    """
+    manifest_path = logs_dir / "manifest.json"
+    if not manifest_path.exists():
+        return
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest.update(_get_runner_provenance())
+    manifest["provider"] = provider
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+
+
 async def run_pipeline(
     dot_source: str,
     *,
@@ -566,9 +625,9 @@ async def run_pipeline(
             absent). Defaults to ``Path.cwd()`` if not given.
         logs_root: Directory for this run's logs (created if absent).
             Defaults to a fresh tempdir if not given.
-        provider: Recorded for parity with the CLI's own preflight checks
-            (e.g. the fail-loud API-key check). Not currently used to alter
-            engine behavior -- the DOT's own llm_provider node attributes
+        provider: Stamped into ``manifest.json`` as runner-owned provenance
+            and used for the CLI's own preflight checks. It does not alter
+            engine routing -- the DOT's own ``llm_provider`` node attributes
             and the profiles map determine routing.
         profiles: llm_provider -> agent-name routing map. Defaults to
             ``DEFAULT_PROFILES`` if not given.
@@ -598,8 +657,6 @@ async def run_pipeline(
     Returns:
         A ``PipelineResult`` with status, notes, logs_dir, and raw JSON.
     """
-    del provider  # not yet used inside the engine call; see docstring.
-
     if logs_root is not None:
         logs_dir = Path(logs_root).expanduser().resolve()
     else:
@@ -634,19 +691,25 @@ async def run_pipeline(
         ),
     )
 
-    async with session:
-        outcome = await drive_engine(
-            dot_source,
-            session.coordinator,
-            params=params,
-            cwd=cwd_path,
-            logs_root=logs_dir,
-            hooks=hooks,
-            profiles=resolved_profiles,
-            interviewer=interviewer,
-            transform=transform,
-            validate=validate,
-        )
+    try:
+        async with session:
+            outcome = await drive_engine(
+                dot_source,
+                session.coordinator,
+                params=params,
+                cwd=cwd_path,
+                logs_root=logs_dir,
+                hooks=hooks,
+                profiles=resolved_profiles,
+                interviewer=interviewer,
+                transform=transform,
+                validate=validate,
+            )
+    finally:
+        # The engine creates its manifest at run start. Stamp runner-owned
+        # fields even when later execution raises, so failed run directories
+        # remain self-describing for incident analysis.
+        _augment_manifest_provenance(logs_dir, provider)
 
     failure_reason = getattr(outcome, "failure_reason", None)
     data = {

--- a/modules/pipeline-runner/tests/test_compat.py
+++ b/modules/pipeline-runner/tests/test_compat.py
@@ -1,0 +1,104 @@
+"""Tests for the runner's fail-loud engine compatibility gate."""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+from amplifier_module_pipeline_runner import compat
+from amplifier_module_pipeline_runner.compat import IncompatibleEngineError
+
+
+def test_compatibility_gate_passes_for_available_required_symbol(monkeypatch):
+    monkeypatch.setattr(
+        compat,
+        "_REQUIRED_ENGINE_SYMBOLS",
+        [("amplifier_module_loop_pipeline.remote_dot", "load_remote_or_local_graph")],
+    )
+
+    compat.check_engine_compatibility()
+
+
+def test_compatibility_gate_fails_loud_with_reinstall_instruction(monkeypatch):
+    def missing_module(_name: str):
+        raise ImportError("simulated stale engine")
+
+    monkeypatch.setattr(importlib, "import_module", missing_module)
+    monkeypatch.setattr(compat, "_REQUIRED_ENGINE_SYMBOLS", [("missing_engine_module", "feature")])
+
+    with pytest.raises(IncompatibleEngineError) as exc_info:
+        compat.check_engine_compatibility()
+
+    error = str(exc_info.value)
+    assert "INCOMPATIBLE ENGINE" in error
+    assert "missing_engine_module (module not found)" in error
+    assert "uv tool install --reinstall" in error
+
+
+def test_cli_converts_incompatible_engine_error_to_exit_1(monkeypatch):
+    """CLI must convert IncompatibleEngineError to sys.exit(1) for the shell."""
+    import sys
+    from io import StringIO
+
+    from amplifier_module_pipeline_runner import compat as compat_mod
+    from amplifier_module_pipeline_runner.cli import main
+
+    def missing_module(_name: str):
+        raise ImportError("simulated stale engine")
+
+    monkeypatch.setattr(importlib, "import_module", missing_module)
+    monkeypatch.setattr(
+        compat_mod, "_REQUIRED_ENGINE_SYMBOLS", [("missing_engine_module", "feature")]
+    )
+
+    captured_err = StringIO()
+    monkeypatch.setattr(sys, "stderr", captured_err)
+
+    result = main([])
+    assert result == 1
+    assert "INCOMPATIBLE ENGINE" in captured_err.getvalue()
+
+
+def test_drive_engine_api_path_raises_incompatible_engine_error_not_bare_import_error(
+    monkeypatch,
+):
+    """drive_engine() must raise IncompatibleEngineError, not a bare ModuleNotFoundError.
+
+    Regression test for the incident-class failure: a consumer using drive_engine()
+    as a library seam against a stale cached engine must receive an actionable
+    IncompatibleEngineError (with INCOMPATIBLE ENGINE diagnostic and reinstall
+    instruction) rather than a bare ModuleNotFoundError mid-pipeline.
+
+    Simulates the incident: patches _REQUIRED_ENGINE_SYMBOLS so the compat gate
+    sees a missing symbol, then calls drive_engine() directly (not via CLI).
+    """
+    import asyncio
+
+    from amplifier_module_pipeline_runner import compat as compat_mod
+    from amplifier_module_pipeline_runner.runner import drive_engine
+
+    def missing_module(_name: str):
+        raise ImportError("simulated stale engine — remote_dot absent")
+
+    monkeypatch.setattr(importlib, "import_module", missing_module)
+    monkeypatch.setattr(
+        compat_mod,
+        "_REQUIRED_ENGINE_SYMBOLS",
+        [("amplifier_module_loop_pipeline.remote_dot", "load_remote_or_local_graph")],
+    )
+
+    with pytest.raises(IncompatibleEngineError) as exc_info:
+        asyncio.run(
+            drive_engine(
+                "digraph { start [shape=Mdiamond]; end [shape=Msquare]; start -> end; }",
+                object(),  # fake coordinator — never reached
+                logs_root="/tmp/test-drive-engine-compat",
+                transform=False,
+                validate=False,
+            )
+        )
+
+    error = str(exc_info.value)
+    assert "INCOMPATIBLE ENGINE" in error
+    assert "uv tool install --reinstall" in error

--- a/modules/pipeline-runner/tests/test_provenance.py
+++ b/modules/pipeline-runner/tests/test_provenance.py
@@ -1,0 +1,34 @@
+"""Tests for runner-owned manifest provenance stamping."""
+
+from __future__ import annotations
+
+import json
+
+from amplifier_module_pipeline_runner import runner
+
+
+def test_augment_manifest_adds_runner_owned_provenance(tmp_path, monkeypatch):
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text('{"graph_name": "existing", "engine_commit": "unknown"}')
+    monkeypatch.setattr(
+        runner,
+        "_get_runner_provenance",
+        lambda: {"runner_version": "1.2.3", "runner_commit": "abc"},
+    )
+
+    runner._augment_manifest_provenance(tmp_path, "openai")
+
+    manifest = json.loads(manifest_path.read_text())
+    assert manifest == {
+        "graph_name": "existing",
+        "engine_commit": "unknown",
+        "runner_version": "1.2.3",
+        "runner_commit": "abc",
+        "provider": "openai",
+    }
+
+
+def test_augment_manifest_is_a_noop_when_manifest_missing(tmp_path):
+    runner._augment_manifest_provenance(tmp_path, "anthropic")
+
+    assert not (tmp_path / "manifest.json").exists()

--- a/specs/EXTENSIONS.md
+++ b/specs/EXTENSIONS.md
@@ -1140,6 +1140,59 @@ is for nodes that explicitly add the attribute.
 
 ---
 
+## 28. Run Provenance Stamping in `manifest.json`
+
+**What:** `manifest.json` (written by the engine at run-directory creation, Spec §5.6) now
+includes two additional provenance fields:
+
+```json
+{
+  "graph_name": "...",
+  "goal": "...",
+  "start_time": "2026-08-03T00:00:00+00:00",
+  "node_count": 3,
+  "edge_count": 2,
+  "engine_version": "0.1.0",
+  "engine_commit": "abc1234..."
+}
+```
+
+- `engine_version` — the `amplifier-module-loop-pipeline` package version string from
+  `importlib.metadata`.  Today this is the static `pyproject.toml` value (`"0.1.0"`);
+  it becomes discriminating when the package adopts release tags.
+- `engine_commit` — the resolved git commit hash from PEP 610 `direct_url.json`, written
+  by uv for git installs.  For editable/dev installs where `direct_url.json` is absent or
+  carries no commit, the value is `"unknown"` — stamped honestly rather than guessed.
+
+The standalone runner augments the manifest after each engine run, including a
+failed run, with `runner_version`, `runner_commit`, and `provider` fields. Runner
+version and commit use the same install-time metadata / PEP 610 mechanism and use
+`"unknown"` when that identity is unavailable. `provider` is the runner API/CLI
+selection (DOT node-level provider attributes remain the routing authority). One
+writer per field — no races.
+
+**Why:** Incident 2026-07-28: the run directory could not self-describe what code produced
+it.  The incident analysis had to reconstruct engine identity from install history.  In a
+fast-moving repo, "which engine produced this run?" is the first triage question; this
+extension makes the run directory answer it durably.  Any cross-run comparison tooling
+likewise needs per-run code provenance to be meaningful.
+
+**Honesty contract:** `"unknown"` is the correct value when identity cannot be determined
+from install-time metadata without fabricating.  A fabricated provenance field is worse
+than an honest gap — stamp `"unknown"` over guessing.
+
+**Compatibility:** Fully backward-compatible.  The five legacy fields (`graph_name`, `goal`,
+`start_time`, `node_count`, `edge_count`) are unchanged.  The new fields are additive.
+Existing manifest consumers (dashboards, tests reading `manifest.json`) continue to work.
+
+**Runner-engine compatibility assertion:** The `pipeline-runner` package now includes a
+startup compatibility assertion (`compat.py`) that checks for required engine symbols before
+any node runs.  The chosen shape is a compat-assert (not a pinned dep or single-package
+collapse) — see `compat.py` for the tradeoff rationale and the `amplifier-foundation @main`
+deferral note.
+
+---
+
 ## Conformance Restoration Note (T0-4)
 
 **What was retired:** An unledgered dialect where non-`shape=parallel`, non-component nodes


### PR DESCRIPTION
## Summary

"Merged" and "served" are different words. A real first-launch incident
(2026-07-28) proved it: a user ran
`uv tool install "…amplifier-bundle-attractor@main#subdirectory=modules/pipeline-runner"`
and got `ModuleNotFoundError: No module named
'amplifier_module_loop_pipeline.remote_dot'` before any node ran — the runner
resolved from HEAD while uv's cache satisfied the *floating* `@main` engine
dependency with a stale pre-#96 snapshot. The ad-hoc workaround (pin to an old
commit) then silently decided which engine bugs a 2.4-hour run was exposed to,
and the run directory couldn't say so: `manifest.json` records only
`{graph_name, goal, start_time, node_count, edge_count}` — the incident
analysis had to reconstruct engine identity from install history. This PR
ships two defenses:

1. **Startup compatibility assertion** (`compat.py`, NEW): the runner probes
   required engine symbols at BOTH entry seams — CLI `main()` (converts to
   exit 1) and the `drive_engine()` library API (raises
   `IncompatibleEngineError`) — before any engine import executes. On skew the
   user gets a loud `INCOMPATIBLE ENGINE` message naming the missing symbol,
   the required engine, and the exact `uv tool install --reinstall`
   remediation, instead of a bare `ModuleNotFoundError` mid-run. The
   packaging-shape decision (compat-assert vs pinned dep vs single-package
   collapse) is recorded with release-flow tradeoffs in the module docstring,
   including an explicit reasoned deferral for the `amplifier-foundation
   @main` float (its consumed symbols are long-stable core API; no
   discriminating symbol exists to probe today).
2. **Run provenance stamping** (Extension #28): the engine stamps
   `engine_version` + `engine_commit` into `manifest.json` (from
   `importlib.metadata` + PEP 610 `direct_url.json` — no shell-out to git);
   the runner appends `runner_version`, `runner_commit`, and `provider` after
   every run **including failed runs** (`finally` block), so failed run dirs
   stay self-describing for incident analysis. One writer per field. Values
   are `"unknown"` when identity cannot be determined honestly (editable
   installs) — a fabricated provenance field is worse than an honest gap.
   The five legacy manifest fields are unchanged; new fields are additive.

## What changed

| File | Change |
|---|---|
| `modules/pipeline-runner/amplifier_module_pipeline_runner/compat.py` | **NEW** — `check_engine_compatibility()` + `IncompatibleEngineError`; packaging-shape decision record + foundation-float deferral in docstring |
| `modules/pipeline-runner/amplifier_module_pipeline_runner/cli.py` | Compat gate at `main()` startup; `IncompatibleEngineError` → stderr + exit 1 |
| `modules/pipeline-runner/amplifier_module_pipeline_runner/runner.py` | Compat gate at top of `drive_engine()` (covers the library seam); `_get_runner_provenance()` + `_augment_manifest_provenance()`; `provider` now stamped (was `del`eted); augment runs in `finally` so failed runs are stamped too |
| `modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py` | `_get_engine_provenance()` (PEP 610 / importlib.metadata, `"unknown"` fallback); `_write_manifest` stamps `engine_version`/`engine_commit` |
| `modules/pipeline-runner/tests/test_compat.py` | **NEW** — gate passes on healthy engine; fails loud with reinstall instruction; CLI converts to exit 1; API path raises `IncompatibleEngineError`, not bare `ModuleNotFoundError` |
| `modules/pipeline-runner/tests/test_provenance.py` | **NEW** — runner-owned augment preserves engine fields + adds runner fields; no-op when manifest absent |
| `modules/loop-pipeline/tests/test_run_directory.py` | New manifest test: provenance fields present and non-empty |
| `specs/EXTENSIONS.md` | **NEW §28** — field names, sources, `"unknown"` semantics, per-field ownership, additive compatibility, compat-assert decision pointer |

## Verification checklist

- [x] Unit tests pass — `cd modules/loop-pipeline && uv run pytest -q` → **1665 passed, 1 skipped**; `cd modules/pipeline-runner && uv run pytest -q` → **51 passed, 1 skipped**; focused doc-guard/examples-lint/command-content suites → **94 passed**
- [x] Live pipeline run exercising changed code path — `engine.py` is touched (manifest write at run start). Evidence below: a real `PipelineEngine` run through a **fresh git install of this branch** stamps the actual branch commit into `manifest.json`; plus the live skew reproduction and healthy `attractor doctor` in an isolated fresh-install environment.
- [x] AGENTS.md reviewed; repo-specific gates met (real install demonstration per the verification gradient, not just unit tests)
- [x] Backward-compat path unchanged — five legacy manifest fields untouched (guarded by existing manifest tests, all green); new fields additive; `run_pipeline(provider=…)` signature unchanged (the arg is now used instead of discarded)
- [x] PR body includes verification evidence, not just "tests pass"

## Verification evidence

### 1. Live skew reproduction — the incident scenario, now refused loudly

Fresh isolated tool install **from this branch** (DTU, isolated
`UV_TOOL_DIR`/`UV_CACHE_DIR`), then the installed engine's `remote_dot.py`
hidden to reproduce the stale-engine state:

```
$ uv tool install --force --reinstall "git+file:///…/amplifier-bundle-attractor@task/T1-7-polished#subdirectory=modules/pipeline-runner"
Installed 1 executable: attractor

$ attractor doctor          # healthy engine
attractor doctor: OK -- amplifier_module_loop_pipeline importable
…
DOCTOR-EXIT=0

$ mv …/site-packages/amplifier_module_loop_pipeline/remote_dot.py{,.hidden}   # simulate stale engine
$ attractor doctor
attractor: INCOMPATIBLE ENGINE — runner requires engine with remote_dot support (commit bc6cbec or later, PR #96)
  but the installed engine is missing:
  amplifier_module_loop_pipeline.remote_dot (module not found)

  This is a version-skew problem: the runner was installed with a newer
  engine dependency than uv resolved from its cache.

  Fix: reinstall the runner, forcing a fresh engine resolution:
    uv tool install --reinstall \
      'amplifier-module-pipeline-runner @ git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/pipeline-runner'

  Or, if running from the repo tree:
    cd modules/pipeline-runner && uv sync --reinstall
SKEW-EXIT=1

$ mv …/remote_dot.py.hidden …/remote_dot.py && attractor doctor; echo $?   # restored
0
```

(On unfixed main the same state produces a bare `ModuleNotFoundError`
traceback mid-startup — the incident's exact failure.)

### 2. Provenance: a real engine run through the fresh git install stamps the real commit

Real `PipelineEngine` run (tool-only node, no LLM in path) executed inside
the branch's freshly-installed tool venv:

```json
{
  "graph_name": "M",
  "goal": "manifest demo",
  "start_time": "2026-08-03T19:00:27.564078+00:00",
  "node_count": 3,
  "edge_count": 2,
  "engine_version": "0.1.0",
  "engine_commit": "3b68e5d7de5cde2764864f6a95763268e326d747"
}
```

`engine_commit` is the exact branch HEAD — PEP 610 identity, no fabrication.
The same fixture on an **editable** (in-tree) install stamps
`"engine_commit": "unknown"` — the honesty contract working — and after the
runner augment the same manifest gains:

```json
  "runner_version": "unknown",
  "runner_commit": "unknown",
  "provider": "anthropic"
```

### 3. Full suites + focused guards

```
$ cd modules/pipeline-runner && uv run pytest -q
51 passed, 1 skipped in 0.51s
$ cd modules/loop-pipeline && uv run pytest -q
1665 passed, 1 skipped, 3 warnings in 22.36s
$ uv run pytest -q tests/test_engine_semantics_doc_guard.py tests/test_examples_lint_clean.py tests/test_command_content_lint.py
94 passed in 0.08s
```

`git diff --check` clean. No new ruff findings on touched files vs the main
baseline (three pre-existing-class violations our diff would have added were
fixed during polish: import-block placement in `engine.py`,
`try/except/pass`, `importlib.metadata` aliasing).

### 4. Both entry seams are gated (regression tests)

`test_compat.py` covers: healthy pass-through; loud failure with reinstall
instruction; CLI → exit 1; and the library-seam regression —
`drive_engine()` raises `IncompatibleEngineError`, **not** a bare
`ModuleNotFoundError` (the incident-class failure a library consumer would
otherwise still get).

## Notes for reviewers

- **Why compat-assert and not a pinned dep:** a pin closes the window
  structurally but taxes every engine merge with a manual runner bump (who
  bumps it, when?). The assert keeps the low-friction floating dep and turns
  the residual window from a mid-run crash into an immediate, actionable
  refusal. Rationale recorded in `compat.py`'s docstring; adding a newly
  required engine symbol = one entry in `_REQUIRED_ENGINE_SYMBOLS`.
- The compat gate runs at CLI `main()` before argument parsing — even
  `attractor doctor` refuses on a skewed engine (the message IS the
  diagnosis). This is deliberate: no command can produce trustworthy output
  against an engine the runner wasn't written for.
- `manifest.json` field ownership: engine writes `engine_*` at run start;
  runner appends `runner_*`/`provider` post-run (including on failure). One
  writer per field — no races, no lies.
- `provider` records the runner API/CLI selection; DOT node-level
  `llm_provider` attributes remain the routing authority (docstring updated
  to match — the old text said the arg was unused, and the old code
  `del`eted it).

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)