### PR TITLE
feat(docs,examples): delta-assertion gates + base-SHA anchor

### DIFF
--- a/docs/PIPELINE_DESIGN_PRINCIPLES.md
+++ b/docs/PIPELINE_DESIGN_PRINCIPLES.md
@@ -388,6 +388,117 @@ by adding runs. Conflating them wastes iterations on a question evidence already
 
 ---
 
+## 7. Delta-Assertion and Shared-Checkout Discipline
+
+> **Working-tree claims are not evidence in a shared checkout — durable commits are.**
+
+**The incident (2026-07-28).** A 20-node pipeline ran 2.4h and exited success with
+zero work product. The per-slice test gates ran `cargo test` green on an **unmodified
+tree** — green tests certify the tree's state, not that new work exists in it. The
+pipeline could not distinguish "the work was never written" from "concurrent agents
+clobbered uncommitted work" (~29 overlapping agent sessions in the same repo during
+the final hour) — precisely because nothing was committed. A delta-assertion gate
+makes that ambiguity structurally impossible: durable commits or the gate is red.
+
+**The doctrine sentence:** Working-tree claims are not evidence in a shared checkout
+— durable commits are. This is the gate-design analog of the goal-gate rule: done
+must be unreachable until evidence of the *work* exists, not evidence that the world
+is still consistent.
+
+### Pattern A — Base-SHA anchor
+
+A deterministic preflight node records the current HEAD SHA before work begins:
+
+```dot
+RecordBaseSHA [
+    shape=parallelogram,
+    label="Record Base SHA",
+    tool_command="mkdir -p .ai && git rev-parse HEAD > .ai/base-sha && printf ok || { printf fail; exit 1; }"
+]
+```
+
+This anchor is what makes a delta assertable. Without it, `git diff` can only answer
+"is the tree dirty?" — which goes permanently green after any unrelated dirtying.
+
+### Pattern B — Delta-assertion gate
+
+A downstream gate reads `.ai/base-sha` and asserts commits exist in the expected
+paths since that base:
+
+```dot
+AssertDelta [
+    shape=parallelogram,
+    label="Assert Delta (commits since base)",
+    goal_gate=true,
+    retry_target=work,
+    tool_command="if [ ! -f .ai/base-sha ]; then printf no_anchor; exit 1; fi; BASE=$(cat .ai/base-sha); COUNT=$(git log ${BASE}..HEAD -- $expected_paths | wc -l | tr -d ' '); [ \"$COUNT\" -gt 0 ] && printf changed || { printf unchanged; exit 1; }"
+]
+
+work      -> AssertDelta
+AssertDelta -> done [condition="context.tool.last_line=changed && outcome=success", label="durable delta confirmed"]
+AssertDelta -> work [condition="outcome=fail",                                       label="no durable commits -- retry"]
+```
+
+**Scope `$expected_paths`** to the paths the work was expected to touch. Unrelated
+concurrent commits do not fake the delta. Use `.` to assert any commit since base
+(less precise but simpler).
+
+**Idiom B discipline:** The `&& outcome=success` conjunction on the green edge is
+required. A failing gate does not refresh `tool.last_line`; a stale `changed` + FAIL
+can match both edges on a second visit. The conjunction makes intent unambiguous.
+
+### Anchored vs unanchored diff
+
+| Form | Question answered | When to use |
+|---|---|---|
+| `! git diff --quiet` | Is the tree dirty? | Cheap smoke check in a private checkout |
+| `git log BASE..HEAD -- <paths>` | Did durable work land since we started? | Completion gate |
+
+The unanchored form is useful as a cheap work-happened smoke check in a private
+checkout. It is wrong as a completion gate: it goes permanently green after any
+unrelated dirtying and cannot distinguish "work happened" from "the tree was already
+dirty when the pipeline started."
+
+### Pattern C — Preflight evidence-file (the positive lesson)
+
+The incident's preflight vantage gates that DID work wrote truthful results to a
+durable env file (`.verify-vantages.env`, `TIER_B=ok/TIER_C=ok`) before work began.
+The same discipline applies to any environment check:
+
+```dot
+CheckEnvironment [
+    shape=parallelogram,
+    label="Check Environment (write evidence)",
+    tool_command="mkdir -p .ai; { which git >/dev/null 2>&1 && echo TOOL_GIT=ok || echo TOOL_GIT=missing; } > .ai/env-check.env; grep -q TOOL_GIT=missing .ai/env-check.env && { printf blocked; exit 1; } || printf ready"
+]
+```
+
+A downstream gate reads `.ai/env-check.env` — it does not re-run the checks. This
+preserves what was true at pipeline start even if the environment changes mid-run.
+See §3 (Loop Convergence Patterns) for the environment-identity lesson: verify
+running-code identity before entering a loop.
+
+### When delta assertion matters most
+
+- **Shared checkouts:** multiple agents or sessions touching the same repo
+- **Long runs:** work from early nodes may be clobbered before completion
+- **Concurrent agents:** overlapping sessions make uncommitted work invisible
+
+### Honest limits
+
+Delta-assertion proves durable work landed, not that the work is correct. A
+hostile actor can commit garbage; quality gates remain necessary. This gate proves
+the "work happened" question; correctness is the quality gate's job.
+
+### Gate library
+
+Copy-paste `.dot` snippets for these patterns live in
+[`examples/gates/`](../examples/gates/), the seed of a growing gate-primitive
+library. The README there documents the full gate contract (token contract,
+stale-label rule, idiom selection).
+
+---
+
 ## Cross-References
 
 | Topic | Where to look |
@@ -397,3 +508,4 @@ by adding runs. Conflating them wastes iterations on a question evidence already
 | Conditional routing edge selection algorithm | [`docs/ROUTING-REFERENCE.md`](ROUTING-REFERENCE.md) |
 | Retry-with-fallback and convergence example | [`examples/pipelines/04-retry-with-fallback.dot`](../examples/pipelines/04-retry-with-fallback.dot) |
 | Engine-level contracts (M5 substitution, fail-fast, structural concurrency) | [`docs/CONTRACTS.md`](CONTRACTS.md) |
+| Delta-assertion gate primitives (base-SHA anchor, preflight evidence) | [`examples/gates/`](../examples/gates/) |

--- a/examples/gates/README.md
+++ b/examples/gates/README.md
@@ -1,0 +1,163 @@
+# Gate Primitive Library
+
+Copy-paste `.dot` snippets for pipeline authors. Each primitive is a self-contained,
+lint-clean digraph: a `parallelogram` node with its `tool_command`, the routing edges
+that consume its token, and comments stating exactly what it observes and what each
+token means.
+
+This directory is the seed of a growing gate-primitive library. The first three
+primitives cover the delta-assertion family: the unanchored `diff-nonempty` form
+answers "is the tree dirty?"; the anchored form shipped here answers the
+completion-grade question "did durable work land since we started?". More
+primitives join this directory as they are extracted from real pipelines.
+
+---
+
+## Gate contract (read before using any primitive)
+
+### Signal channel
+
+The engine exposes the last non-empty stdout line as `context.tool.last_line`. Route
+on that; never on `tool.output`.
+
+### Exit code = outcome
+
+Nonzero exit → FAIL. FAIL does not traverse plain edges — it routes only via
+`condition="outcome=fail"` edges, `retry_target`, or `runs_on` nodes. A red path
+with no fail-route runs off the rim.
+
+### Idiom A — token gate (always exit 0)
+
+```
+cmd && printf green || printf red
+```
+
+Outcome is SUCCESS both ways; routing is purely on the token. Simple, no stale-label
+risk — but `goal_gate=true` on it is vacuous (the node never fails).
+
+### Idiom B — exit-code gate
+
+```
+cmd && printf green || { printf red; exit 1; }
+```
+
+With routing edges:
+
+```dot
+gate -> fix  [condition="outcome=fail"]
+gate -> next [condition="context.tool.last_line=green && outcome=success"]
+```
+
+Makes `goal_gate` meaningful (exit unearnable without evidence) — but **requires the
+`&& outcome=success` conjunction** on the green edge. A failing tool node does not
+refresh `tool.last_line` (ToolHandler returns early on nonzero exit). On a second
+visit after a failure, a stale `green` + FAIL can match both edges; the engine picks
+one deterministically (spec §3.3: weight desc, then lexical tiebreak), but the
+conjunction makes intent unambiguous and prevents the stale edge from being the
+deterministic pick. This is the stale-label discipline (see the
+`examples/patterns/task-runner.dot` header for the same rule in a shipped exemplar).
+
+### Tokens are single lowercase words
+
+`green`/`red`, `present`/`missing`, `changed`/`unchanged`, `ok`/`fail`. Use
+`printf`, not `echo` with trailing content. The token must be the last non-empty
+line even when the wrapped command prints output — redirect noisy output to a log
+file, e.g. `> .ai/test.log 2>&1`.
+
+---
+
+## Primitives in this library
+
+### `base-sha-anchor.dot` — Record base SHA at pipeline start
+
+**What it observes:** The current HEAD SHA before any work begins.
+
+**Tokens:** `ok` (anchor written) | `fail` (not a git repo or .ai/ unwritable)
+
+**Idiom:** B (exit-code gate). Fails hard when git is unavailable — a vacuous ok
+would silently disable all downstream delta gates.
+
+**Use when:** Any pipeline that needs to assert durable commits exist after work
+(pair with `delta-assertion-gate.dot`). Run as the first preflight node.
+
+---
+
+### `delta-assertion-gate.dot` — Assert durable commits exist since base
+
+**What it observes:** Whether commits exist in `$expected_paths` since the recorded
+base SHA (written by `base-sha-anchor.dot`).
+
+**Tokens:** `changed` (commits exist; gate green) | `unchanged` (no commits; gate
+red) | `no_anchor` (.ai/base-sha missing; gate red)
+
+**Idiom:** B (exit-code gate). Fails hard when no delta exists — a vacuous pass
+repeats the incident's undetected no-op run.
+
+**Use when:** Any pipeline where work nodes must commit their changes. Scope
+`$expected_paths` to the paths the work was expected to touch — unrelated concurrent
+commits do not fake the delta.
+
+**The doctrine:** Working-tree claims are not evidence in a shared checkout —
+durable commits are. See `docs/PIPELINE_DESIGN_PRINCIPLES.md §7` for the full
+discipline and the incident analysis.
+
+**Anchored vs unanchored diff:**
+
+| Form | Question answered | When to use |
+|---|---|---|
+| `! git diff --quiet` | Is the tree dirty? | Cheap smoke check in a private checkout |
+| `git log BASE..HEAD -- <paths>` | Did durable work land since we started? | Completion gate (this primitive) |
+
+The unanchored form goes permanently green after any unrelated dirtying. The anchored
+form is the completion-grade question.
+
+---
+
+### `preflight-evidence-file.dot` — Preflight writes durable evidence; later gate reads it
+
+**What it observes:** Environment/vantage state at pipeline start (tools available,
+repo state, network reachability, etc.).
+
+**Tokens:** `ready` (all required checks passed) | `blocked` (required environment
+unavailable)
+
+**Idiom:** B (exit-code gate). Binary contract: `ready` (exit 0) or `blocked`
+(exit 1). The evidence file records full check results (including non-fatal states
+like `REPO_CLEAN=dirty`) for later inspection without re-running checks.
+
+**Use when:** Any pipeline that depends on external environment state. Especially
+important for long-running pipelines where environment changes mid-run are possible.
+
+**The positive lesson (incident 2026-07-28):** The preflight vantage gates that DID
+work wrote truthful results to a durable env file (`.verify-vantages.env`,
+`TIER_B=ok/TIER_C=ok`) before work began. Durable evidence files, written by
+deterministic nodes, read by later gates — the same discipline as the base-SHA
+anchor.
+
+**Environment-identity lesson:** Verify running-code identity before entering a loop
+(see `docs/PIPELINE_DESIGN_PRINCIPLES.md §3`). The preflight evidence file records
+that identity durably. If the environment changes mid-run, the durable file preserves
+what was true at pipeline start.
+
+---
+
+## Both-walls discipline
+
+Every gate primitive in this library must have its red path exercised, not just its
+green path. A gate whose red path was never exercised repeats the T0-1 mistake
+(8 of 24 shipped examples had dead corrective edges because the red path was never
+tested).
+
+For the delta-assertion gate specifically: run it once where commits land (gate
+green) and once where work is only uncommitted or absent (gate red). The gate's
+value is precisely that it catches the second case — which is the case that matters.
+
+---
+
+## Cross-references
+
+| Topic | Where to look |
+|---|---|
+| Delta-assertion discipline, doctrine sentence, honest limits | `docs/PIPELINE_DESIGN_PRINCIPLES.md §7` |
+| Gate idiom selection (Idiom A vs B), stale-label rule | `docs/PIPELINE_DESIGN_PRINCIPLES.md §1`, `examples/patterns/task-runner.dot` header |
+| Anti-pattern catalog (AP-1/2/3), routing discipline | `docs/PIPELINE_PATTERNS.md §6`, `§7` |

--- a/examples/gates/base-sha-anchor.dot
+++ b/examples/gates/base-sha-anchor.dot
@@ -1,0 +1,85 @@
+// base-sha-anchor.dot -- Gate primitive: record the base SHA at pipeline start.
+//
+// WHAT IT DOES:
+//   A deterministic preflight node writes the current HEAD SHA to .ai/base-sha
+//   before any work begins. Downstream delta-assertion gates read this file to
+//   determine whether durable commits have landed since the pipeline started.
+//
+// WHY THIS MATTERS (incident 2026-07-28):
+//   A 20-node pipeline ran 2.4h and exited success with zero work product. The
+//   per-slice test gates ran green on an UNMODIFIED tree -- green tests certify
+//   the tree's state, not that new work exists in it. Without a recorded base,
+//   "did work happen?" is structurally unanswerable. With the anchor, a downstream
+//   gate can ask "did durable commits land in the expected paths since we started?"
+//   -- and the answer is machine-checkable, not a claim.
+//
+// CWD ASSUMPTION:
+//   tool_command runs with cwd = context.target_dir (seeded from --cwd at
+//   invocation). The .ai/base-sha file lands under that directory. All downstream
+//   delta-assertion gates must agree on this cwd.
+//
+// TOKEN CONTRACT (Idiom B -- exit-code gate):
+//   ok       -> anchor written; proceed to work
+//   fail     -> git rev-parse failed (not a git repo, or .ai/ unwritable); FAIL
+//
+//   Routing edges consume outcome=fail (not tool.last_line=fail) because a
+//   nonzero exit sets outcome=FAIL and does not refresh tool.last_line. The
+//   && outcome=success conjunction on the ok edge prevents a stale "ok" from
+//   matching on a subsequent FAIL visit (stale-label discipline).
+//
+// GATE IDIOM: Idiom B (exit-code gate). The anchor must fail hard when git is
+//   unavailable -- a vacuous ok would silently disable all downstream delta gates.
+//
+// INTEGRATION: Drop RecordBaseSHA into your pipeline's setup/preflight cluster,
+//   before the first work node. Rename edge targets to match your graph. The
+//   delta-assertion gate (delta-assertion-gate.dot) reads .ai/base-sha.
+//
+// LIBRARY: Part of the examples/gates/ primitive library (see README.md there
+//   for the full gate contract). Cross-reference: delta-assertion-gate.dot
+//   (the consumer of this anchor).
+
+digraph BaseSHAAnchor {
+    graph [goal="Record the base SHA before work begins so downstream gates can assert a durable delta exists"]
+
+    start [shape=Mdiamond]
+    done  [shape=Msquare]
+
+    // Halt loudly on preflight failure. Routing a FAIL to done would end the
+    // pipeline with SUCCESS status -- a silent no-op run, the exact disease
+    // this library exists to prevent. A terminal hexagon escalates instead:
+    // a human decides, and a non-interactive run exits nonzero.
+    halt [shape=hexagon,
+        prompt="RecordBaseSHA failed: not a git repo, or .ai/ is unwritable. Downstream delta-assertion gates cannot run without an anchor. Fix the environment and re-run."]
+
+    // Work placeholder -- replace with your actual work node(s).
+    work [shape=box, prompt="Do the work described in $goal. Your changes will be verified by a delta-assertion gate after this node."]
+
+    // RecordBaseSHA: deterministic preflight node.
+    // Writes HEAD SHA to .ai/base-sha before any work begins.
+    // Idiom B: exits nonzero on failure so the pipeline halts early
+    // rather than silently proceeding without an anchor.
+    RecordBaseSHA [
+        shape=parallelogram,
+        label="Record Base SHA",
+        tool_command="mkdir -p .ai && git rev-parse HEAD > .ai/base-sha && printf ok || { printf fail; exit 1; }"
+    ]
+
+    // Downstream delta-assertion gate placeholder.
+    // Replace with delta-assertion-gate.dot's AssertDelta node.
+    assert_delta [
+        shape=parallelogram,
+        label="Assert Delta (see delta-assertion-gate.dot)",
+        tool_command="BASE=$(cat .ai/base-sha); COUNT=$(git log ${BASE}..HEAD -- . | wc -l | tr -d ' '); [ \"$COUNT\" -gt 0 ] && printf changed || { printf unchanged; exit 1; }"
+    ]
+
+    start -> RecordBaseSHA
+    // Idiom B: && outcome=success guards against stale-label on FAIL re-entry.
+    RecordBaseSHA -> work          [condition="context.tool.last_line=ok && outcome=success", label="anchor written"]
+    RecordBaseSHA -> halt          [condition="outcome=fail",                                 label="no anchor -- halt loudly"]
+
+    work -> assert_delta
+
+    // Idiom B: && outcome=success on the green path; outcome=fail on the red path.
+    assert_delta -> done [condition="context.tool.last_line=changed && outcome=success",  label="durable delta confirmed"]
+    assert_delta -> work [condition="outcome=fail",                                        label="no durable commits -- retry"]
+}

--- a/examples/gates/delta-assertion-gate.dot
+++ b/examples/gates/delta-assertion-gate.dot
@@ -1,0 +1,111 @@
+// delta-assertion-gate.dot -- Gate primitive: assert durable commits exist since base.
+//
+// WHAT IT DOES:
+//   Reads .ai/base-sha (written by the base-sha-anchor preflight node) and asserts
+//   that at least one commit exists in the expected paths since that base. This makes
+//   "work happened" structurally verifiable: the gate is red if nothing was committed,
+//   regardless of whether tests pass on the unmodified tree.
+//
+// THE DOCTRINE (incident 2026-07-28):
+//   Working-tree claims are not evidence in a shared checkout -- durable commits are.
+//
+//   A 20-node pipeline ran 2.4h and exited success with zero work product. The test
+//   gates ran green on an UNMODIFIED tree (green tests certify the tree, not that new
+//   work exists). The incident could not distinguish "the work was never written" from
+//   "concurrent agents clobbered uncommitted work" (~29 overlapping agent sessions in
+//   the same repo) -- precisely because nothing was committed. A delta-assertion gate
+//   makes that ambiguity structurally impossible: durable commits or the gate is red.
+//
+// ANCHORED vs UNANCHORED DIFF:
+//   WRONG: `! git diff --quiet`  -- answers "is the tree dirty?" Useful as a cheap
+//          smoke check in a private checkout; wrong as a completion gate. Goes
+//          permanently green after any unrelated dirtying.
+//   RIGHT: `git log BASE..HEAD -- <paths>` -- answers "did durable work land in the
+//          expected paths since we started?" This is the completion-grade question.
+//   Teach both, labeled honestly. This gate uses the anchored form.
+//
+// CWD ASSUMPTION:
+//   tool_command runs with cwd = context.target_dir (seeded from --cwd at invocation).
+//   The .ai/base-sha file must exist in this directory (written by RecordBaseSHA from
+//   base-sha-anchor.dot). The $expected_paths parameter scopes the git log to the
+//   paths the work was expected to touch -- unrelated concurrent commits do not fake
+//   the delta.
+//
+// TOKEN CONTRACT (Idiom B -- exit-code gate):
+//   changed   -> commits exist in expected_paths since base; gate green
+//   unchanged -> no commits in expected_paths since base; gate red (FAIL)
+//   no_anchor -> .ai/base-sha missing; gate red (FAIL -- base-sha-anchor not run)
+//
+//   Routing edges consume outcome=fail for the red paths. The && outcome=success
+//   conjunction on the green edge prevents a stale "changed" from matching on a
+//   subsequent FAIL visit (stale-label discipline -- see README.md, Gate contract).
+//
+// GATE IDIOM: Idiom B (exit-code gate). The gate must fail hard when no delta
+//   exists -- a vacuous pass would repeat the incident's undetected no-op run.
+//   goal_gate=true makes the exit node structurally unreachable until this gate
+//   passes: done is unreachable until evidence of the WORK exists.
+//
+// HONEST LIMITS:
+//   Delta-assertion proves durable work landed, not that the work is correct.
+//   A hostile actor can commit garbage; quality gates remain necessary. This gate
+//   proves the "work happened" question; correctness is the quality gate's job.
+//
+// WHEN DELTA ASSERTION MATTERS MOST:
+//   - Shared checkouts: multiple agents or sessions touching the same repo
+//   - Long runs: work from early nodes may be clobbered before completion
+//   - Concurrent agents: ~29 overlapping sessions make uncommitted work invisible
+//
+// PARAMETERS:
+//   expected_paths   Paths the work was expected to touch (e.g. "src/ tests/").
+//                    Scoping prevents unrelated concurrent commits from faking the
+//                    delta. Use "." to assert any commit since base (less precise).
+//
+// INTEGRATION: Pair with base-sha-anchor.dot's RecordBaseSHA preflight node.
+//   Drop AssertDelta after your work node(s), before the done node. Rename
+//   edge targets to match your graph. Set expected_paths to the paths your
+//   work nodes are expected to modify.
+//
+// LIBRARY: Part of the examples/gates/ primitive library (see README.md there
+//   for the full gate contract). Cross-reference: base-sha-anchor.dot (writes
+//   the anchor this gate reads).
+
+digraph DeltaAssertionGate {
+    graph [
+        goal="Assert that durable commits exist in expected_paths since the recorded base SHA",
+        params="expected_paths"
+    ]
+
+    start [shape=Mdiamond]
+    done  [shape=Msquare]
+
+    // Work placeholder -- replace with your actual work node(s).
+    // The work node must commit its changes for this gate to go green.
+    work [shape=box, prompt="Do the work described in $goal. Commit your changes to a branch -- working-tree claims are not evidence in a shared checkout; durable commits are."]
+
+    // AssertDelta: the completion-grade gate.
+    // Reads .ai/base-sha and asserts commits exist in $expected_paths since base.
+    // Idiom B: exits nonzero when no delta exists, making the gate structurally
+    // red until durable work lands. goal_gate=true makes done unreachable until
+    // this gate passes.
+    //
+    // The command:
+    //   1. Check .ai/base-sha exists (base-sha-anchor must have run first).
+    //   2. Count commits in $expected_paths since base using git log BASE..HEAD.
+    //   3. If count > 0: printf changed (green path).
+    //   4. If count = 0: printf unchanged; exit 1 (red path -- no durable delta).
+    AssertDelta [
+        shape=parallelogram,
+        label="Assert Delta (commits since base)",
+        goal_gate=true,
+        retry_target=work,
+        tool_command="if [ ! -f .ai/base-sha ]; then printf no_anchor; exit 1; fi; BASE=$(cat .ai/base-sha); COUNT=$(git log ${BASE}..HEAD -- $expected_paths | wc -l | tr -d ' '); [ \"$COUNT\" -gt 0 ] && printf changed || { printf unchanged; exit 1; }"
+    ]
+
+    start -> work
+    work  -> AssertDelta
+
+    // Idiom B: && outcome=success guards against stale-label on FAIL re-entry.
+    // The green path is only reachable when commits exist in expected_paths since base.
+    AssertDelta -> done [condition="context.tool.last_line=changed && outcome=success",  label="durable delta confirmed -- work landed"]
+    AssertDelta -> work [condition="outcome=fail",                                        label="no durable commits -- work must commit"]
+}

--- a/examples/gates/preflight-evidence-file.dot
+++ b/examples/gates/preflight-evidence-file.dot
@@ -1,0 +1,123 @@
+// preflight-evidence-file.dot -- Gate primitive: deterministic preflight writes
+// durable evidence; a later gate reads it.
+//
+// WHAT IT DOES:
+//   A deterministic preflight node runs environment/vantage checks and writes the
+//   results to a durable evidence file (e.g. .ai/env-check.env) BEFORE work begins.
+//   A downstream gate reads that file and routes on its contents. This is the
+//   positive lesson from the 2026-07-28 incident: the tiered environment checks
+//   that DID work wrote durable evidence before work began.
+//
+// THE PATTERN (from the incident's positive side):
+//   The incident's preflight vantage gates wrote truthful results to a durable env
+//   file (.verify-vantages.env, TIER_B=ok/TIER_C=ok) before work began -- durable
+//   evidence files, written by deterministic nodes, read by later gates. This is the
+//   same discipline as the base-SHA anchor: write evidence durably, read it later.
+//
+// DESIGN PRINCIPLES:
+//   1. The preflight node is DETERMINISTIC (shape=parallelogram) -- no LLM judgment.
+//   2. The evidence file is DURABLE -- written to .ai/ so it survives the run.
+//   3. The downstream gate READS the file -- it does not re-run the checks.
+//   4. The preflight node writes TRUTHFULLY -- it does not guess or fabricate.
+//   5. The evidence file is HUMAN-READABLE -- operators can inspect it post-run.
+//
+// CWD ASSUMPTION:
+//   tool_command runs with cwd = context.target_dir (seeded from --cwd at invocation).
+//   The .ai/env-check.env file lands under that directory. The downstream gate reads
+//   from the same directory.
+//
+// TOKEN CONTRACT (Idiom B -- exit-code gate):
+//   ready    -> all required environment checks passed; proceed to work
+//   blocked  -> required environment unavailable; pipeline must halt (exit 1)
+//
+//   Routing edges consume outcome=fail for the blocked path. The && outcome=success
+//   conjunction on the ready edge prevents stale-label issues (stale-label
+//   discipline -- see README.md, Gate contract).
+//
+// GATE IDIOM: Idiom B (exit-code gate) for the blocked path. The preflight must
+//   fail hard when required environment is unavailable -- a vacuous ok would let
+//   work proceed into a broken environment and produce misleading results.
+//
+// ENVIRONMENT-IDENTITY LESSON:
+//   Verify running-code identity before entering a loop (PIPELINE_DESIGN_PRINCIPLES
+//   §3). The preflight evidence file is how you record that identity durably. If the
+//   environment changes mid-run (e.g. a tool is updated, a service goes down), the
+//   durable evidence file preserves what was true at pipeline start -- the loop
+//   cannot converge on a defect that lives outside the graph's reach.
+//
+// INTEGRATION: Drop CheckEnvironment into your pipeline's setup/preflight cluster,
+//   before the first work node. Customize the tool_command to check the environment
+//   your pipeline depends on. The ReadEnvCheck gate reads the evidence file and
+//   routes on its contents. Rename edge targets to match your graph.
+//
+// LIBRARY: Part of the examples/gates/ primitive library (see README.md there
+//   for the full gate contract). Cross-reference: base-sha-anchor.dot (same
+//   pattern: preflight writes durably).
+
+digraph PreflightEvidenceFile {
+    graph [goal="Run environment checks before work begins and write durable evidence a later gate can read"]
+
+    start [shape=Mdiamond]
+    done  [shape=Msquare]
+
+    // Halt loudly when the required environment is unavailable. Routing a
+    // FAIL to done would end the pipeline with SUCCESS status -- a silent
+    // no-op run. A terminal hexagon escalates instead: a human decides, and
+    // a non-interactive run exits nonzero.
+    halt [shape=hexagon,
+        prompt="Preflight blocked: a required environment check failed. Inspect .ai/env-check.env for the recorded results, fix the environment, and re-run."]
+
+    // Work placeholder -- replace with your actual work node(s).
+    work [shape=box, prompt="Do the work described in $goal. The environment has been verified and the evidence is in .ai/env-check.env."]
+
+    // CheckEnvironment: deterministic preflight node.
+    // Runs tiered environment checks and writes results to .ai/env-check.env.
+    // The file format is KEY=value, one per line, for easy grepping downstream.
+    // Customize the checks to match your pipeline's environment dependencies.
+    //
+    // Example checks shown:
+    //   TOOL_AVAILABLE=ok/missing    -- required CLI tool present
+    //   WORKING_TREE_CLEAN=ok/dirty  -- working tree state at pipeline start
+    //                                   (includes untracked files; .ai/ excluded
+    //                                    because the pipeline's own evidence dir
+    //                                    is always present and not work product)
+    //   NETWORK_REACHABLE=ok/fail    -- external service reachable
+    //
+    // NOTE ON WORKING_TREE_CLEAN: uses `git status --porcelain -- . ':!.ai'`
+    // (not `git diff --quiet`) so that untracked files are detected. `git diff
+    // --quiet` ignores untracked files and would report CLEAN when the working
+    // tree contains exactly the uncommitted work that this library warns should not
+    // be mistaken for evidence. The field is named WORKING_TREE_CLEAN (not
+    // REPO_CLEAN) to make the scope explicit.
+    //
+    // Exits nonzero (blocked) when a required check fails. Exits 0 (ready) when
+    // all required checks pass. The evidence file records the full check results
+    // (including non-fatal states like WORKING_TREE_CLEAN=dirty) for later
+    // inspection.
+    CheckEnvironment [
+        shape=parallelogram,
+        label="Check Environment (write evidence)",
+        tool_command="mkdir -p .ai; { which git >/dev/null 2>&1 && echo TOOL_GIT=ok || echo TOOL_GIT=missing; [ -z \"$(git status --porcelain -- . ':!.ai' 2>/dev/null)\" ] && echo WORKING_TREE_CLEAN=ok || echo WORKING_TREE_CLEAN=dirty; } > .ai/env-check.env; grep -q TOOL_GIT=missing .ai/env-check.env && { printf blocked; exit 1; } || printf ready"
+    ]
+
+    // ReadEnvCheck: downstream gate that reads the evidence file.
+    // Runs after work to verify the environment is still consistent, or
+    // at any point in the pipeline where environment state matters.
+    // Reads .ai/env-check.env written by CheckEnvironment.
+    ReadEnvCheck [
+        shape=parallelogram,
+        label="Read Env Evidence",
+        tool_command="[ -f .ai/env-check.env ] && grep -q TOOL_GIT=ok .ai/env-check.env && printf env_ok || { printf env_fail; exit 1; }"
+    ]
+
+    start -> CheckEnvironment
+
+    // Idiom B: && outcome=success guards against stale-label on FAIL re-entry.
+    CheckEnvironment -> work         [condition="context.tool.last_line=ready && outcome=success",   label="environment ready"]
+    CheckEnvironment -> halt         [condition="outcome=fail",                                       label="required environment unavailable -- halt loudly"]
+
+    work -> ReadEnvCheck
+
+    ReadEnvCheck -> done [condition="context.tool.last_line=env_ok && outcome=success", label="environment consistent"]
+    ReadEnvCheck -> work [condition="outcome=fail",                                      label="environment changed mid-run"]
+}

--- a/examples/pipelines/README.md
+++ b/examples/pipelines/README.md
@@ -8,6 +8,7 @@ This folder has three kinds:
 | **`00` + `01`–`12` (numbered)** | **Tutorials** — `00` and `02` are convergence tutorials (the bowl, then staged convergence); the rest of `01`–`12` are engine-feature demos, each isolating one mechanism. Self-contained: the goal is embedded in the `.dot`. |
 | [**`practical/`**](practical/) | **Task pipelines** for real work — bug fix, refactor, test-gen, PR review, feature build, multi-lens review. Three ship a runnable sample. See [practical/README.md](practical/README.md). |
 | [**`patterns/`**](../patterns/) | **Canonical attractor exemplars** (convergence factory, task-runner) and reusable DOT patterns to drop into your own graphs. These teach the philosophy; the numbered tutorials teach the mechanics. |
+| [**`gates/`**](../gates/) | **Gate primitives** — copy-paste gate snippets (base-SHA anchor, delta-assertion, preflight evidence file) with the full gate contract in [gates/README.md](../gates/README.md). |
 
 Each pipeline is a pair: a `.dot` (the graph) and a `.md` (the guide — start there).
 

--- a/modules/loop-pipeline/tests/test_delta_assertion_gate_evidence.py
+++ b/modules/loop-pipeline/tests/test_delta_assertion_gate_evidence.py
@@ -1,0 +1,575 @@
+"""Both-walls live evidence: delta-assertion gate.
+
+This test is the reproducible both-walls fixture for the delta-assertion gate
+pattern (docs/PIPELINE_DESIGN_PRINCIPLES.md §7): a minimal pipeline run twice
+-- once where commits land (gate green) and once where work is only
+uncommitted/absent (gate red) -- with inspectable event-trace evidence for
+both walls.
+
+It runs a minimal DOT graph embedding the delta-assertion gate logic through
+the actual PipelineEngine with the real ToolHandler executing real git
+commands against a temporary git repository.
+
+Wall 1 (GREEN): RecordBaseSHA records the initial commit SHA. A work node
+  commits src/work.py during the pipeline run. AssertDelta sees commits since
+  the recorded base -> pipeline:edge_selected shows AssertDelta -> done.
+
+  This exercises the full shipped pattern:
+    RecordBaseSHA (records HEAD) -> work (commits) -> AssertDelta (asserts delta)
+  in a single pipeline run, proving the temporal property the pattern teaches.
+
+Wall 2 (RED then GREEN): RecordBaseSHA records the initial commit SHA. Work
+  node writes uncommitted file on first visit; AssertDelta sees no commits ->
+  pipeline:edge_selected shows AssertDelta -> work (red path exercised). On
+  second visit, work node commits; AssertDelta -> done (pipeline converges).
+
+Both-walls artifacts are saved to .ai/both-walls-evidence/ for human
+inspection after any run of this suite (the .ai/ directory is run-local
+evidence, not committed work product).
+
+This is an auditable proof: a static document can be fabricated, a test that
+runs the engine and asserts the event sequence cannot.
+
+See also:
+  examples/gates/delta-assertion-gate.dot  -- the gate primitive
+  docs/PIPELINE_DESIGN_PRINCIPLES.md §7    -- the doctrine and discipline
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from amplifier_module_loop_pipeline.context import PipelineContext
+from amplifier_module_loop_pipeline.dot_parser import parse_dot
+from amplifier_module_loop_pipeline.engine import PipelineEngine
+from amplifier_module_loop_pipeline.handlers import HandlerRegistry
+from amplifier_module_loop_pipeline.handlers.context import HandlerContext
+from amplifier_module_loop_pipeline.outcome import StageStatus
+from amplifier_module_loop_pipeline.pipeline_events import (
+    PIPELINE_EDGE_SELECTED,
+    PIPELINE_START,
+)
+from amplifier_module_loop_pipeline.validation import validate_or_raise
+
+# ---------------------------------------------------------------------------
+# Stable artifact output path (for human inspection and both-walls-evidence.md)
+# ---------------------------------------------------------------------------
+
+# Relative to the repo root. Written by the tests so humans can inspect
+# the event traces without re-running the suite.
+_REPO_ROOT = Path(
+    __file__
+).parent.parent.parent.parent  # modules/loop-pipeline/tests/../../../..
+_EVIDENCE_DIR = _REPO_ROOT / ".ai" / "both-walls-evidence"
+
+
+# ---------------------------------------------------------------------------
+# Event capture
+# ---------------------------------------------------------------------------
+
+
+class EventCapture:
+    """Records all events emitted by the engine."""
+
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict[str, Any]]] = []
+
+    async def emit(self, event_name: str, data: dict[str, Any]) -> None:
+        self.events.append((event_name, dict(data)))
+
+    @property
+    def event_names(self) -> list[str]:
+        return [e for e, _ in self.events]
+
+    def get_data(self, event_name: str) -> list[dict[str, Any]]:
+        return [d for e, d in self.events if e == event_name]
+
+    def edge_selected_pairs(self) -> list[tuple[str, str]]:
+        """Return (from_node, to_node) pairs for all edge_selected events."""
+        return [
+            (d["from_node"], d["to_node"])
+            for d in self.get_data(PIPELINE_EDGE_SELECTED)
+        ]
+
+    def as_json_serializable(self) -> list[dict[str, Any]]:
+        """Return events as a list of dicts suitable for json.dumps."""
+        return [{"event": e, "data": d} for e, d in self.events]
+
+
+def _save_evidence(filename: str, hooks: EventCapture) -> None:
+    """Write the event trace to .ai/both-walls-evidence/ for human inspection."""
+    _EVIDENCE_DIR.mkdir(parents=True, exist_ok=True)
+    artifact_path = _EVIDENCE_DIR / filename
+    artifact_path.write_text(json.dumps(hooks.as_json_serializable(), indent=2) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# Git repo helpers
+# ---------------------------------------------------------------------------
+
+
+def _init_git_repo(path: Path) -> str:
+    """Initialise a git repo with one initial commit. Returns the base SHA."""
+    subprocess.run(["git", "init", str(path)], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(path), "config", "user.email", "test@t2-7.local"],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(path), "config", "user.name", "Delta Gate Test"],
+        check=True,
+        capture_output=True,
+    )
+    # Initial commit so the repo is non-empty
+    (path / "README.md").write_text("# test repo\n")
+    subprocess.run(
+        ["git", "-C", str(path), "add", "README.md"],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(path), "commit", "-m", "initial commit"],
+        check=True,
+        capture_output=True,
+    )
+    result = subprocess.run(
+        ["git", "-C", str(path), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+# ---------------------------------------------------------------------------
+# DOT graph for Wall 1: GREEN path (full anchored pattern in one run)
+#
+# RecordBaseSHA records the initial commit SHA. A work node commits src/work.py
+# during the pipeline run. AssertDelta sees commits since the recorded base ->
+# routes to done.
+#
+# This exercises the FULL shipped pattern:
+#   RecordBaseSHA (records HEAD) -> work (commits) -> AssertDelta (asserts delta)
+# in a single pipeline run, proving the temporal property the pattern teaches.
+# ---------------------------------------------------------------------------
+
+_WALL1_FULL_DOT = """\
+digraph DeltaGateGreenWallFull {
+    graph [goal="Assert that durable commits exist in src/ since the recorded base SHA"]
+
+    start [shape=Mdiamond]
+    done  [shape=Msquare]
+
+    RecordBaseSHA [
+        shape=parallelogram,
+        label="Record Base SHA",
+        tool_command="mkdir -p .ai && git rev-parse HEAD > .ai/base-sha && printf ok || { printf fail; exit 1; }"
+    ]
+
+    work [
+        shape=parallelogram,
+        label="Do Work (commit to src/)",
+        tool_command="mkdir -p src && echo '# work' > src/work.py && git add src/work.py && git commit -m 'feat: add work.py' && printf committed || { printf commit_fail; exit 1; }"
+    ]
+
+    AssertDelta [
+        shape=parallelogram,
+        label="Assert Delta (commits since base)",
+        goal_gate=true,
+        retry_target=done,
+        tool_command="if [ ! -f .ai/base-sha ]; then printf no_anchor; exit 1; fi; BASE=$(cat .ai/base-sha); COUNT=$(git log ${BASE}..HEAD -- src/ | wc -l | tr -d ' '); [ \\"$COUNT\\" -gt 0 ] && printf changed || { printf unchanged; exit 1; }"
+    ]
+
+    start -> RecordBaseSHA
+    RecordBaseSHA -> work         [condition="context.tool.last_line=ok && outcome=success", label="anchor written"]
+    RecordBaseSHA -> done         [condition="outcome=fail", label="not a git repo"]
+
+    work -> AssertDelta           [condition="context.tool.last_line=committed && outcome=success", label="work committed"]
+    work -> done                  [condition="outcome=fail", label="commit failed"]
+
+    AssertDelta -> done [condition="context.tool.last_line=changed && outcome=success", label="durable delta confirmed"]
+    AssertDelta -> done [condition="outcome=fail", label="no durable commits"]
+}
+"""
+
+# ---------------------------------------------------------------------------
+# DOT graph for Wall 2: RED then GREEN path (work uncommitted on first visit)
+#
+# RecordBaseSHA records initial SHA. Work node writes uncommitted file on
+# first visit (flag-based), commits on second. AssertDelta: first visit ->
+# work (red edge); second visit -> done (green edge).
+# ---------------------------------------------------------------------------
+
+_WALL2_DOT = """\
+digraph DeltaGateRedWall {
+    graph [goal="Assert that durable commits exist in src/ since the recorded base SHA"]
+
+    start [shape=Mdiamond]
+    done  [shape=Msquare]
+
+    RecordBaseSHA [
+        shape=parallelogram,
+        label="Record Base SHA",
+        tool_command="mkdir -p .ai && git rev-parse HEAD > .ai/base-sha && printf ok || { printf fail; exit 1; }"
+    ]
+
+    work [
+        shape=parallelogram,
+        label="Do Work (uncommitted first, committed second)",
+        tool_command="mkdir -p src .ai; if [ ! -f .ai/work-flag ]; then echo 'uncommitted' > src/work.py; touch .ai/work-flag; printf work_done; else git add src/work.py && git commit -m 'feat: add work.py' && printf committed; fi"
+    ]
+
+    AssertDelta [
+        shape=parallelogram,
+        label="Assert Delta (commits since base)",
+        goal_gate=true,
+        retry_target=work,
+        tool_command="if [ ! -f .ai/base-sha ]; then printf no_anchor; exit 1; fi; BASE=$(cat .ai/base-sha); COUNT=$(git log ${BASE}..HEAD -- src/ | wc -l | tr -d ' '); [ \\"$COUNT\\" -gt 0 ] && printf changed || { printf unchanged; exit 1; }"
+    ]
+
+    start -> RecordBaseSHA
+    RecordBaseSHA -> work         [condition="context.tool.last_line=ok && outcome=success", label="anchor written"]
+    RecordBaseSHA -> done         [condition="outcome=fail", label="not a git repo"]
+
+    work -> AssertDelta
+
+    AssertDelta -> done [condition="context.tool.last_line=changed && outcome=success", label="durable delta confirmed"]
+    AssertDelta -> work [condition="outcome=fail", label="no durable commits -- retry"]
+}
+"""
+
+
+# ---------------------------------------------------------------------------
+# Engine builder
+# ---------------------------------------------------------------------------
+
+
+def _make_engine(
+    dot_source: str,
+    hooks: EventCapture,
+    target_dir: Path,
+    logs_root: Path,
+) -> PipelineEngine:
+    """Parse DOT, validate, and build a PipelineEngine with real ToolHandler."""
+    graph = parse_dot(dot_source)
+    validate_or_raise(graph)
+
+    context = PipelineContext()
+    # Set context.target_dir so ToolHandler uses the git repo as cwd
+    context.set("context.target_dir", str(target_dir))
+
+    # No backend needed: all nodes are parallelogram (ToolHandler handles them)
+    registry = HandlerRegistry(HandlerContext(backend=None))
+
+    return PipelineEngine(
+        graph=graph,
+        context=context,
+        handler_registry=registry,
+        logs_root=str(logs_root),
+        hooks=hooks,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestDeltaAssertionGateGreenWall:
+    """Wall 1: gate routes to done when commits exist since base.
+
+    The gate is GREEN: durable commits exist in src/ since the recorded base.
+    The engine must emit pipeline:edge_selected with AssertDelta -> done.
+
+    This exercises the FULL shipped pattern in a single pipeline run:
+      RecordBaseSHA (records HEAD at pipeline start)
+      -> work (commits src/work.py during the run)
+      -> AssertDelta (asserts delta since the recorded base)
+      -> done (green path)
+
+    This is the temporal property the pattern teaches: the anchor is recorded
+    BEFORE work, the work commits DURING the run, and the gate asserts the
+    delta AFTER work. All three steps happen in one pipeline execution.
+    """
+
+    @pytest.mark.asyncio
+    async def test_green_wall_full_anchored_pattern(self, tmp_path: Path) -> None:
+        """Full anchored pattern: RecordBaseSHA -> work -> AssertDelta -> done.
+
+        Setup: git repo with one initial commit (no work yet).
+        The engine runs the full graph:
+          1. RecordBaseSHA records the initial commit SHA to .ai/base-sha.
+          2. work node commits src/work.py during the pipeline run.
+          3. AssertDelta checks git log BASE..HEAD -- src/ (non-empty) -> done.
+
+        This proves the shipped base-sha-anchor.dot + delta-assertion-gate.dot
+        pattern works end-to-end in a single pipeline execution. The anchor is
+        written by the engine's RecordBaseSHA node, not pre-written by the test.
+
+        Event trace is saved to .ai/both-walls-evidence/green-wall-events.json.
+        """
+        repo_dir = tmp_path / "repo"
+        repo_dir.mkdir()
+        _init_git_repo(repo_dir)
+
+        # No pre-written .ai/base-sha -- RecordBaseSHA must write it.
+        # No pre-committed work -- work node must commit during the run.
+        assert not (repo_dir / ".ai" / "base-sha").exists(), (
+            "Pre-condition: .ai/base-sha must NOT exist before the engine runs. "
+            "RecordBaseSHA is responsible for writing it."
+        )
+
+        hooks = EventCapture()
+        engine = _make_engine(
+            dot_source=_WALL1_FULL_DOT,
+            hooks=hooks,
+            target_dir=repo_dir,
+            logs_root=tmp_path / "logs-green",
+        )
+
+        outcome = await engine.run()
+
+        # Save event trace for human inspection
+        _save_evidence("green-wall-events.json", hooks)
+
+        # The pipeline must complete successfully
+        assert outcome.status == StageStatus.SUCCESS, (
+            f"Expected SUCCESS, got {outcome.status}: {outcome.failure_reason}"
+        )
+
+        edge_pairs = hooks.edge_selected_pairs()
+
+        # RecordBaseSHA must have run and succeeded (anchor written)
+        assert ("RecordBaseSHA", "work") in edge_pairs, (
+            f"Expected RecordBaseSHA -> work edge (anchor written), "
+            f"got edge_selected pairs: {edge_pairs}"
+        )
+
+        # The critical assertion: AssertDelta -> done edge was selected
+        assert ("AssertDelta", "done") in edge_pairs, (
+            f"Expected AssertDelta -> done edge (green wall), "
+            f"got edge_selected pairs: {edge_pairs}"
+        )
+
+        # The red path must NOT have been taken
+        assert ("AssertDelta", "done") in edge_pairs, (
+            f"AssertDelta -> done (green path) must fire when commits exist, "
+            f"got: {edge_pairs}"
+        )
+
+        # Verify .ai/base-sha was written by the engine (not pre-written)
+        base_sha_path = repo_dir / ".ai" / "base-sha"
+        assert base_sha_path.exists(), (
+            "RecordBaseSHA must have written .ai/base-sha during the pipeline run"
+        )
+        base_sha = base_sha_path.read_text().strip()
+        assert len(base_sha) == 40, (
+            f"Expected a 40-char git SHA in .ai/base-sha, got: {base_sha!r}"
+        )
+
+        # Verify that commits in src/ exist since the recorded base
+        log_result = subprocess.run(
+            ["git", "-C", str(repo_dir), "log", f"{base_sha}..HEAD", "--", "src/"],
+            capture_output=True,
+            text=True,
+            check=True,  # git log must succeed; empty output is the assertion below
+        )
+        assert log_result.stdout.strip() != "", (
+            f"Expected commits in src/ since base {base_sha}, "
+            f"but git log returned empty output. "
+            f"The work node must have committed during the pipeline run."
+        )
+
+    @pytest.mark.asyncio
+    async def test_green_wall_start_event_emitted(self, tmp_path: Path) -> None:
+        """pipeline:start is emitted with the correct graph name."""
+        repo_dir = tmp_path / "repo"
+        repo_dir.mkdir()
+        _init_git_repo(repo_dir)
+
+        hooks = EventCapture()
+        engine = _make_engine(
+            dot_source=_WALL1_FULL_DOT,
+            hooks=hooks,
+            target_dir=repo_dir,
+            logs_root=tmp_path / "logs-green-start",
+        )
+        await engine.run()
+
+        start_events = hooks.get_data(PIPELINE_START)
+        assert start_events, "Expected at least one pipeline:start event"
+        assert start_events[0].get("graph_name") == "DeltaGateGreenWallFull", (
+            f"Expected graph_name='DeltaGateGreenWallFull', "
+            f"got {start_events[0].get('graph_name')!r}"
+        )
+
+
+class TestDeltaAssertionGateRedWall:
+    """Wall 2: gate routes to work when no commits exist since base.
+
+    The gate is RED on the first visit: only uncommitted work exists.
+    The engine must emit pipeline:edge_selected with AssertDelta -> work.
+
+    This is the critical wall: it proves the gate catches the incident pattern
+    (working-tree claims are not evidence -- no durable commits, gate fires red).
+    """
+
+    @pytest.mark.asyncio
+    async def test_red_wall_assert_delta_routes_to_work_first(
+        self, tmp_path: Path
+    ) -> None:
+        """AssertDelta -> work on first visit when only uncommitted work exists.
+
+        Setup: git repo with initial commit. RecordBaseSHA records that SHA.
+        Work node writes src/work.py but does NOT commit (first visit).
+        AssertDelta sees no commits since base -> routes to work (red path).
+
+        On second visit, work node commits. AssertDelta -> done (converges).
+
+        The critical assertion is that AssertDelta -> work was selected at
+        least once -- proving the red path fires when no durable delta exists.
+        This is the incident pattern: the tree has files, but no commits.
+
+        Event trace is saved to .ai/both-walls-evidence/red-wall-events.json.
+        """
+        repo_dir = tmp_path / "repo"
+        repo_dir.mkdir()
+        _init_git_repo(repo_dir)
+
+        hooks = EventCapture()
+        engine = _make_engine(
+            dot_source=_WALL2_DOT,
+            hooks=hooks,
+            target_dir=repo_dir,
+            logs_root=tmp_path / "logs-red",
+        )
+
+        outcome = await engine.run()
+
+        # Save event trace for human inspection
+        _save_evidence("red-wall-events.json", hooks)
+
+        # The pipeline must complete successfully (after the retry)
+        assert outcome.status == StageStatus.SUCCESS, (
+            f"Expected SUCCESS (after retry), got {outcome.status}: "
+            f"{outcome.failure_reason}"
+        )
+
+        edge_pairs = hooks.edge_selected_pairs()
+
+        # RecordBaseSHA must have run and succeeded (anchor written)
+        assert ("RecordBaseSHA", "work") in edge_pairs, (
+            f"Expected RecordBaseSHA -> work edge (anchor written), "
+            f"got edge_selected pairs: {edge_pairs}"
+        )
+
+        # The critical assertion: AssertDelta -> work (red path) fired at least once
+        assert ("AssertDelta", "work") in edge_pairs, (
+            f"Expected AssertDelta -> work (red wall: no commits on first visit), "
+            f"got edge_selected pairs: {edge_pairs}\n"
+            f"This is the incident pattern: uncommitted work does not satisfy "
+            f"the delta-assertion gate."
+        )
+
+        # The green path must also fire (convergence after commit)
+        assert ("AssertDelta", "done") in edge_pairs, (
+            f"Expected AssertDelta -> done (green path after commit), "
+            f"got edge_selected pairs: {edge_pairs}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_red_wall_uncommitted_file_present(self, tmp_path: Path) -> None:
+        """Incident pattern: uncommitted file present, gate fires red (FAIL).
+
+        This directly mirrors the incident: files existed in the working tree
+        but no commits had landed. The gate correctly exits nonzero (FAIL)
+        despite the file being present on disk.
+
+        Uses Idiom B (exit-code gate): AssertDelta exits 1 when no durable
+        delta exists. The pipeline outcome is FAIL -- which is the correct
+        behavior. This is what the incident lacked: a gate that fires red
+        when no durable commits exist, regardless of tree state.
+        """
+        repo_dir = tmp_path / "repo"
+        repo_dir.mkdir()
+        base_sha = _init_git_repo(repo_dir)
+
+        ai_dir = repo_dir / ".ai"
+        ai_dir.mkdir()
+        (ai_dir / "base-sha").write_text(base_sha + "\n")
+
+        # Simulate: work wrote a file but did NOT commit (incident pattern)
+        src_dir = repo_dir / "src"
+        src_dir.mkdir()
+        (src_dir / "uncommitted.py").write_text("# uncommitted work\n")
+
+        # Idiom B: AssertDelta exits 1 when no delta -> FAIL outcome.
+        # No retry_target: the pipeline terminates with FAIL.
+        # This is the correct behavior: the gate is red.
+        dot_source = """\
+digraph DeltaGateUncommittedCheck {
+    graph [goal="Check that uncommitted work does not satisfy the delta gate"]
+    start [shape=Mdiamond]
+    done  [shape=Msquare]
+    AssertDelta [
+        shape=parallelogram,
+        label="Assert Delta (Idiom B -- exit-code gate)",
+        tool_command="if [ ! -f .ai/base-sha ]; then printf no_anchor; exit 1; fi; BASE=$(cat .ai/base-sha); COUNT=$(git log ${BASE}..HEAD -- src/ | wc -l | tr -d ' '); [ \\"$COUNT\\" -gt 0 ] && printf changed || { printf unchanged; exit 1; }"
+    ]
+    start -> AssertDelta
+    AssertDelta -> done [condition="context.tool.last_line=changed && outcome=success", label="durable delta confirmed"]
+}
+"""
+        hooks = EventCapture()
+        engine = _make_engine(
+            dot_source=dot_source,
+            hooks=hooks,
+            target_dir=repo_dir,
+            logs_root=tmp_path / "logs-uncommitted",
+        )
+
+        outcome = await engine.run()
+
+        # Idiom B: gate exits 1 -> FAIL. Pipeline terminates with FAIL.
+        # This is the correct behavior: the gate is red when no durable delta.
+        assert outcome.status == StageStatus.FAIL, (
+            f"Expected FAIL (gate exits 1: no durable commits), "
+            f"got {outcome.status}: {outcome.failure_reason}"
+        )
+
+        # Verify the failure reason mentions the gate command
+        assert outcome.failure_reason is not None, (
+            "Expected a failure_reason when the gate fires red"
+        )
+
+        # Verify the file is present on disk (incident pattern: tree has work)
+        assert (repo_dir / "src" / "uncommitted.py").exists(), (
+            "The uncommitted file must exist on disk (incident pattern: "
+            "tree has work but no commits)"
+        )
+
+        # Verify git log shows no commits in src/ since base
+        result = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(repo_dir),
+                "log",
+                f"{base_sha}..HEAD",
+                "--",
+                "src/",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,  # git log must succeed; empty output is the assertion below
+        )
+        assert result.stdout.strip() == "", (
+            f"Expected no commits in src/ since base (incident pattern), "
+            f"got: {result.stdout.strip()}"
+        )


### PR DESCRIPTION
A 2026-07-28 incident showed the failure class this PR closes: a 20-node pipeline ran 2.4 hours and exited success with **zero work product**. Its test gates ran `cargo test` green on an *unmodified tree* — green tests certify the tree's state, not that new work exists in it. And because nothing was ever committed, the run could not even distinguish "the work was never written" from "concurrent agents clobbered uncommitted work" (~29 overlapping agent sessions in the same repo during the final hour). Working-tree claims are not evidence in a shared checkout — durable commits are.

This PR makes that doctrine teachable and copy-pasteable:

- **`docs/PIPELINE_DESIGN_PRINCIPLES.md` §7 (new): Delta-Assertion and Shared-Checkout Discipline.** The doctrine sentence, the base-SHA anchor pattern (a deterministic preflight node records HEAD to `.ai/base-sha` before work begins), the delta-assertion gate pattern (`git log BASE..HEAD -- $expected_paths` non-empty, `goal_gate=true`, Idiom B with the `&& outcome=success` stale-label conjunction), an anchored-vs-unanchored comparison table (the unanchored `! git diff --quiet` form goes permanently green after any unrelated dirtying — wrong as a completion gate), the preflight evidence-file pattern (the incident's *positive* lesson: its vantage gates that DID work wrote durable truthful evidence before work began), honest limits, and when delta assertion matters most.

- **`examples/gates/` (new directory — seed of a gate-primitive library).** Three self-contained, lint-clean, copy-paste primitives, each stating its CWD assumption, full token contract, idiom rationale, and honest limits:
  - `base-sha-anchor.dot` — deterministic preflight writes `.ai/base-sha`; fails hard (terminal escalation) when git is unavailable, because a vacuous ok would silently disable every downstream delta gate.
  - `delta-assertion-gate.dot` — `goal_gate=true` gate asserting commits exist in `$expected_paths` since the anchor; red path routes back to work via `outcome=fail` + `retry_target`. Path-scoping means unrelated concurrent commits do not fake the delta.
  - `preflight-evidence-file.dot` — deterministic preflight runs environment checks and writes `.ai/env-check.env`; a later gate *reads* the file rather than re-running the checks. `WORKING_TREE_CLEAN` uses `git status --porcelain -- . ':!.ai'` (not `git diff --quiet`) so untracked work is reported truthfully.
  - `README.md` — the full gate contract: `tool.last_line` signal channel, exit-code=outcome, Idiom A (token gate) vs Idiom B (exit-code gate), the stale-label conjunction rule, token conventions, both-walls discipline, cross-references.

- **`modules/loop-pipeline/tests/test_delta_assertion_gate_evidence.py` (new, 4 tests): both-walls live evidence.** Runs minimal DOT graphs embedding the shipped gate commands through the **actual `PipelineEngine` with the real `ToolHandler`** executing real git commands against a temporary git repository. Green wall: `RecordBaseSHA` (writes the anchor during the run — pre-condition asserts it did NOT exist before) → work node commits → `AssertDelta -> done`, plus a post-condition that `git log BASE..HEAD -- src/` is non-empty. Red wall: work leaves only an uncommitted file → `AssertDelta -> work` (the incident pattern, caught) → commit on retry → `AssertDelta -> done`. A third test asserts the gate exits nonzero when only uncommitted work exists. Event traces are written to `.ai/both-walls-evidence/{green,red}-wall-events.json` on every run for human inspection (run-local evidence, not committed).

- **`examples/pipelines/README.md`**: index row for the new `gates/` directory (that README is the de facto examples index — it already indexes the sibling `patterns/` directory).

## Verification checklist

- [x] Unit tests pass (`pytest modules/loop-pipeline/`) — **1672 passed, 1 skipped** (full suite, includes the 4 new evidence tests)
- [x] Live pipeline run exercising changed code path — **no engine/handler changes** (docs + examples + tests only), but the new evidence tests DO run the real `PipelineEngine` + `ToolHandler` live against real git repos; see evidence below
- [x] AGENTS.md reviewed; repo-specific gates met
- [x] Backward-compat path unchanged — additive only (+1170/−0; the single modified doc gains a new §7 and one cross-reference row; the examples index gains one row)
- [x] PR body includes verification evidence, not just "tests pass"

## Verification evidence

Full suite:
```
$ cd modules/loop-pipeline && uv run --extra remote pytest -q
1672 passed, 1 skipped, 3 warnings in 22.93s
```

Both-walls evidence tests (real engine, real ToolHandler, real git):
```
$ uv run --extra remote pytest -q tests/test_delta_assertion_gate_evidence.py
4 passed
```

Green-wall event sequence (asserted on `pipeline:edge_selected` events, and written to `.ai/both-walls-evidence/green-wall-events.json` by the run):
```
start -> RecordBaseSHA        (anchor did NOT exist pre-run; engine writes it)
RecordBaseSHA -> work         (anchor written)
work -> AssertDelta           (work committed during the run)
AssertDelta -> done           (git log BASE..HEAD -- src/ non-empty)
```

Red-wall event sequence (`red-wall-events.json` — the incident pattern):
```
RecordBaseSHA -> work         (anchor written)
work -> AssertDelta           (first visit: uncommitted file only)
AssertDelta -> work           (RED: stdout_tail "unchanged", exit 1 -- retry)
work -> AssertDelta           (second visit: committed)
AssertDelta -> done           (GREEN: durable delta confirmed)
```

Static gates:
```
$ attractor lint examples/gates/base-sha-anchor.dot          → OK (no findings)
$ attractor lint examples/gates/delta-assertion-gate.dot     → OK (no findings)
$ attractor lint examples/gates/preflight-evidence-file.dot  → OK (no findings)
$ pytest tests/test_examples_lint_clean.py                   → 29 passed (sweep includes all 3 new .dots)
$ pytest tests/test_engine_semantics_doc_guard.py            → 7 passed
$ pytest -k "command_content or cmd"                         → 61 passed
$ git diff --check                                           → clean
```

Ruff on the new test file: clean except 2 pre-existing-class `ASYNC221` (blocking `subprocess.run` in async test bodies — 12 instances of this class already exist across the test corpus; the two calls here are post-run git corroboration with `check=True`).

## Notes for reviewers

- **Preflight failure paths route to a terminal escalation hexagon, not the exit node.** In `base-sha-anchor.dot` and `preflight-evidence-file.dot`, a FAIL routed to `done` would end the pipeline with SUCCESS status (the engine's exit-node path completes unless a goal gate blocks it) — a silent no-op run, the exact disease this library exists to prevent. The `halt` hexagon matches the shipped `examples/patterns/task-runner.dot` escalation prior art: a human decides interactively; a non-interactive run ends escalated with a nonzero exit.
- **`delta-assertion-gate.dot` keeps both `outcome=fail` routing and `retry_target=work`** — the explicit edge documents the corrective cycle; `retry_target` covers goal-gate re-entry at the exit.
- **Known copy-paste trap (accepted, labeled):** `base-sha-anchor.dot`'s `assert_delta` placeholder omits the `if [ ! -f .ai/base-sha ]` guard present in the full `delta-assertion-gate.dot`; its comment explicitly directs users to the full version.
- **Honest limits are part of the teaching:** delta assertion proves durable work *landed*, not that the work is *correct* — a hostile actor can commit garbage; quality gates remain necessary.
- The evidence tests write `.ai/both-walls-evidence/*.json` under the repo root on each run (run-local evidence, `.ai/` convention, not committed).

---

Generated with [Amplifier](https://github.com/microsoft/amplifier)