### PR TITLE
fix(pipeline-runner): preserve root DOT source directory on the CLI path

### DIFF
--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/__init__.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/__init__.py
@@ -17,6 +17,7 @@ import logging
 import os
 import re
 import tempfile
+from pathlib import Path
 from typing import Any
 
 from .context import PipelineContext
@@ -510,7 +511,7 @@ class PipelineOrchestrator:
         Returns a JSON string with the pipeline outcome.
         """
         # 1. Get DOT source
-        dot_source = self._resolve_dot_source()
+        dot_source, source_dir = self._resolve_dot_source()
 
         # 2. Parse the DOT graph — materialize first if it's a remote entry.
         # Shared with the direct-engine `drive_engine`/`_load_graph` hook in
@@ -519,6 +520,16 @@ class PipelineOrchestrator:
         from .remote_dot import load_remote_or_local_graph  # lazy: keeps import net-free
 
         graph, _source_cleanup = await load_remote_or_local_graph(dot_source)
+        # A file-backed root graph carries the directory it was read from, so
+        # relative dot_file= children resolve beside the pipeline rather than
+        # falling through resolve_dot_path()'s precedence chain to
+        # context.target_dir (--cwd). Mirrors the same fix already applied to
+        # the standalone CLI path (pipeline-runner cli.py/runner.py) -- see
+        # AGENTS.md's S4 partial-coverage-symmetry note; this is the second of
+        # the two remaining sites. Never clobber: a remote package or an
+        # already-parsed Graph carries its own, more specific source_dir.
+        if source_dir and not getattr(graph, "source_dir", ""):
+            graph.source_dir = source_dir
 
         try:
             # 3. Create pipeline context with goal from the prompt
@@ -710,16 +721,30 @@ class PipelineOrchestrator:
 
         return " ".join(parts)
 
-    def _resolve_dot_source(self) -> str:
-        """Resolve DOT source from config (inline or file)."""
+    def _resolve_dot_source(self) -> tuple[str, str | None]:
+        """Resolve DOT source from config (inline or file).
+
+        Returns ``(dot_source, source_dir)``. ``source_dir`` is the directory
+        the ``dot_file`` was read from, so the caller can seed a file-backed
+        root graph's ``source_dir`` for relative ``dot_file=`` child
+        resolution (see ``resolve_dot_path`` in ``handlers/pipeline.py``).
+
+        ``source_dir`` is ``None`` when:
+          - the source came from inline ``dot_source`` config -- no file, no
+            directory to claim -- OR
+          - the caller (e.g. the ``run_pipeline`` tool) already resolved a
+            ``dot_file`` to text itself and forwarded the directory
+            explicitly via the ``source_dir`` config key, in which case that
+            explicit value is returned instead of re-deriving one.
+        """
         dot_source = self.config.get("dot_source")
         if dot_source:
-            return dot_source
+            return dot_source, self.config.get("source_dir")
 
         dot_file = self.config.get("dot_file")
         if dot_file:
             with open(dot_file) as f:
-                return f.read()
+                return f.read(), str(Path(dot_file).resolve().parent)
 
         raise ValueError(
             "No DOT source configured. Set 'dot_source' or 'dot_file' in config."

--- a/modules/loop-pipeline/tests/test_orchestrator_source_dir.py
+++ b/modules/loop-pipeline/tests/test_orchestrator_source_dir.py
@@ -1,0 +1,275 @@
+"""The mounted PipelineOrchestrator must preserve a file-backed root graph's
+source directory, the second of the two remaining partial-coverage-symmetry
+(AGENTS.md S4) sites for this bug -- the standalone CLI path was already
+fixed (see ``pipeline-runner``'s ``test_root_source_dir.py``).
+
+This file also owns the CONSUMING-side end-to-end proof for the third site,
+the agent-facing ``run_pipeline`` tool (``tool-pipeline-run``). That tool
+does not depend on this package (AGENTS.md's dependency-awareness rule --
+``tool-pipeline-run``'s ``pyproject.toml`` declares only ``amplifier-core``),
+so it cannot construct or run a real ``PipelineOrchestrator`` in its own
+suite. Its own tests instead assert on the ``orchestrator_config`` dict it
+builds -- ``{"dot_source": <text>, "source_dir": <dir>}`` -- for a file-backed
+``dot_file`` input; see
+``modules/tool-pipeline-run/tests/test_source_dir_propagation.py``.
+``test_execute_resolves_relative_child_via_dot_source_and_source_dir`` below
+closes the loop from this side: it hands ``PipelineOrchestrator`` that exact
+config shape directly (no cross-module import needed, since it's just a
+dict) and proves the relative ``dot_file=`` child actually loads and
+executes -- the same proof the two modules previously duplicated via a
+cross-module import that broke CI (see that file's docstring for the
+incident).
+
+The bug: ``resolve_dot_path`` (``handlers/pipeline.py``) is a precedence
+chain, not a search path -- the first non-empty candidate wins:
+
+    absolute -> graph.source_dir -> context.target_dir -> os.getcwd()
+
+``PipelineOrchestrator.execute()`` reads a local ``dot_file`` as text via
+``self.config.get("dot_file")`` and discarded the directory, so a mounted
+pipeline's relative ``dot_file=`` children were looked for under
+``os.getcwd()`` (there is no ``context.target_dir`` at this layer) instead
+of beside the pipeline that was actually invoked.
+
+Child graphs were never affected (``PipelineHandler.execute`` sets
+``child_graph.source_dir``), nor were remote packages (they derive theirs
+from the materialized entry). Only the root's first hop -- same shape as the
+CLI bug, different entry point.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from amplifier_module_loop_pipeline import PipelineOrchestrator
+from amplifier_module_loop_pipeline.outcome import StageStatus
+
+# ---------------------------------------------------------------------------
+# _resolve_dot_source: where the directory is actually derived
+# ---------------------------------------------------------------------------
+
+
+def test_dot_file_config_returns_its_own_directory(tmp_path):
+    """A dot_file-backed config returns (text, that file's absolute directory)."""
+    dot_path = tmp_path / "pipeline.dot"
+    dot_path.write_text("digraph G { s [shape=Mdiamond]; }", encoding="utf-8")
+
+    orchestrator = PipelineOrchestrator(config={"dot_file": str(dot_path)})
+    text, source_dir = orchestrator._resolve_dot_source()
+
+    assert "digraph G" in text
+    assert source_dir == str(tmp_path.resolve())
+
+
+def test_inline_dot_source_returns_no_source_dir():
+    """Inline dot_source has no file, so there is no directory to claim."""
+    orchestrator = PipelineOrchestrator(
+        config={"dot_source": "digraph G { s [shape=Mdiamond]; }"}
+    )
+    text, source_dir = orchestrator._resolve_dot_source()
+
+    assert "digraph G" in text
+    assert source_dir is None
+
+
+def test_inline_dot_source_honors_explicit_source_dir_override():
+    """A caller that already resolved dot_file to text itself (tool-pipeline-run)
+    can still forward the directory via the explicit 'source_dir' config key."""
+    orchestrator = PipelineOrchestrator(
+        config={
+            "dot_source": "digraph G { s [shape=Mdiamond]; }",
+            "source_dir": "/pkg/pipeline-package",
+        }
+    )
+    text, source_dir = orchestrator._resolve_dot_source()
+
+    assert "digraph G" in text
+    assert source_dir == "/pkg/pipeline-package"
+
+
+def test_missing_both_raises_value_error():
+    orchestrator = PipelineOrchestrator(config={})
+    with pytest.raises(ValueError, match="No DOT source configured"):
+        orchestrator._resolve_dot_source()
+
+
+# ---------------------------------------------------------------------------
+# execute(): the directory is applied to the loaded graph, never clobbered
+# ---------------------------------------------------------------------------
+
+
+class _MockBackend:
+    """Minimal mock backend -- returns JSON success outcome for any node."""
+
+    async def run(self, node, prompt, context, incoming_edge=None, graph=None):
+        return json.dumps({"status": "success", "notes": f"mock: {node.id}"})
+
+
+_PARENT_DOT_RELATIVE_CHILD = """\
+digraph parent {
+    graph [goal="verify relative child resolution"]
+    start [shape=Mdiamond]
+    sub   [shape=folder, dot_file="child.dot"]
+    done  [shape=Msquare]
+    start -> sub -> done
+}
+"""
+
+_CHILD_DOT_TOOL_NODE = """\
+digraph child {
+    start [shape=Mdiamond]
+    work  [shape=parallelogram, tool_command="echo child-executed > child_ran.txt"]
+    done  [shape=Msquare]
+    start -> work -> done
+}
+"""
+
+
+def _write_parent_and_child(tmp_path):
+    """Write a parent DOT with a relative dot_file= child into the same dir."""
+    package = tmp_path / "package"
+    package.mkdir()
+    (package / "child.dot").write_text(_CHILD_DOT_TOOL_NODE, encoding="utf-8")
+    parent_dot = package / "parent.dot"
+    parent_dot.write_text(_PARENT_DOT_RELATIVE_CHILD, encoding="utf-8")
+    return package, parent_dot
+
+
+@pytest.mark.asyncio
+async def test_execute_resolves_and_runs_relative_child_from_dot_file(
+    tmp_path, monkeypatch
+):
+    """True e2e: a dot_file-backed root graph's relative dot_file= child
+    actually loads AND executes -- not merely that source_dir was threaded.
+
+    Before the fix: graph.source_dir stays "" after load_remote_or_local_graph,
+    resolve_dot_path falls through to os.getcwd() (the pytest invocation
+    directory, NOT the package dir), child.dot is not found there, and the
+    child pipeline -- and therefore the parent -- FAILS.
+
+    After the fix: graph.source_dir is seeded from the dot_file's own
+    directory, resolve_dot_path finds the sibling child.dot, and the child's
+    own tool node actually runs (proven by the canary file it writes).
+    """
+    package, parent_dot = _write_parent_and_child(tmp_path)
+
+    # Pin cwd somewhere that is NOT the package dir, so a false-positive
+    # cwd-fallback resolution would be caught by this test.
+    decoy_cwd = tmp_path / "decoy_cwd"
+    decoy_cwd.mkdir()
+    monkeypatch.chdir(decoy_cwd)
+
+    orchestrator = PipelineOrchestrator(config={"dot_file": str(parent_dot)})
+    result_json = await orchestrator.execute(
+        prompt="test goal",
+        context=None,
+        providers={},
+        tools={},
+        hooks=None,
+        backend=_MockBackend(),
+    )
+    result = json.loads(result_json)
+
+    assert result["status"] == StageStatus.SUCCESS.value, result
+    # The child's own tool node ran for real -- proves the child DOT was
+    # actually loaded and executed, not merely located.
+    canary = package / "child_ran.txt"
+    assert canary.exists(), (
+        f"Expected {canary} to exist -- the child pipeline's tool node must "
+        "have actually executed for the parent to succeed"
+    )
+    assert canary.read_text().strip() == "child-executed"
+
+
+@pytest.mark.asyncio
+async def test_execute_never_clobbers_an_already_set_source_dir(tmp_path, monkeypatch):
+    """A remote package (or any pre-parsed Graph) carries its own, more
+    specific source_dir -- the dot_file-derived directory must never
+    overwrite it."""
+    package, parent_dot = _write_parent_and_child(tmp_path)
+
+    import amplifier_module_loop_pipeline.remote_dot as remote_dot_mod
+
+    real_load = remote_dot_mod.load_remote_or_local_graph
+    captured_graph: dict = {}
+
+    async def _load_and_pin_source_dir(source):
+        graph, cleanup = await real_load(source)
+        graph.source_dir = "/already/materialized/view"
+        captured_graph["graph"] = graph
+        return graph, cleanup
+
+    monkeypatch.setattr(
+        remote_dot_mod, "load_remote_or_local_graph", _load_and_pin_source_dir
+    )
+
+    orchestrator = PipelineOrchestrator(config={"dot_file": str(parent_dot)})
+    # The pinned source_dir has no child.dot, so the child pipeline node
+    # fails -- but that FAILURE is itself the proof the pinned value won,
+    # not the dot_file's own directory.
+    result_json = await orchestrator.execute(
+        prompt="test goal",
+        context=None,
+        providers={},
+        tools={},
+        hooks=None,
+        backend=_MockBackend(),
+    )
+    result = json.loads(result_json)
+
+    assert captured_graph["graph"].source_dir == "/already/materialized/view"
+    assert result["status"] == StageStatus.FAIL.value, (
+        "Expected the pinned (non-package) source_dir to be honored, causing "
+        f"the child lookup to fail against it instead of {package}: {result}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_resolves_relative_child_via_dot_source_and_source_dir(
+    tmp_path, monkeypatch
+):
+    """True e2e for the exact config shape ``tool-pipeline-run`` builds:
+    inline ``dot_source`` text plus an explicit ``source_dir`` override (as
+    opposed to a local ``dot_file`` path, covered above).
+
+    ``tool-pipeline-run``'s ``run_pipeline`` tool reads a dot_file itself,
+    then forwards only the resolved TEXT plus this directory across the
+    session.spawn boundary -- see that module's ``_resolve_dot_source_with_dir``
+    and the ``orchestrator_config["source_dir"]`` it builds. That module
+    cannot depend on this package (AGENTS.md dependency-awareness rule), so
+    it cannot construct a real PipelineOrchestrator to prove the far side of
+    that boundary end to end. This test proves it from here instead, using
+    only a plain config dict -- the same shape, no cross-module import.
+    """
+    package, _parent_dot = _write_parent_and_child(tmp_path)
+    parent_text = _PARENT_DOT_RELATIVE_CHILD
+
+    # Pin cwd somewhere that is NOT the package dir, so a false-positive
+    # cwd-fallback resolution would be caught by this test.
+    decoy_cwd = tmp_path / "decoy_cwd"
+    decoy_cwd.mkdir()
+    monkeypatch.chdir(decoy_cwd)
+
+    orchestrator = PipelineOrchestrator(
+        config={"dot_source": parent_text, "source_dir": str(package)}
+    )
+    result_json = await orchestrator.execute(
+        prompt="test goal",
+        context=None,
+        providers={},
+        tools={},
+        hooks=None,
+        backend=_MockBackend(),
+    )
+    result = json.loads(result_json)
+
+    assert result["status"] == StageStatus.SUCCESS.value, result
+    canary = package / "child_ran.txt"
+    assert canary.exists(), (
+        f"Expected {canary} to exist -- the child pipeline's tool node must "
+        "have actually executed, proving the relative dot_file= reference "
+        "resolved via the explicit source_dir override rather than under cwd"
+    )
+    assert canary.read_text().strip() == "child-executed"

--- a/modules/pipeline-runner/amplifier_module_pipeline_runner/cli.py
+++ b/modules/pipeline-runner/amplifier_module_pipeline_runner/cli.py
@@ -143,6 +143,7 @@ def _stdin_is_usable() -> bool:
 
 def cmd_run(args: argparse.Namespace) -> int:
     # --- Resolve DOT source: --dot-source wins, else read dot_file ---
+    source_dir: str | None = None
     if args.dot_source:
         dot_source = args.dot_source
     elif args.dot_file:
@@ -151,6 +152,14 @@ def cmd_run(args: argparse.Namespace) -> int:
             print(f"attractor: DOT file not found: {dot_path}", file=sys.stderr)
             return 1
         dot_source = dot_path.read_text(encoding="utf-8")
+        # We know where this DOT lives, so relative `dot_file=` refs in the ROOT
+        # graph resolve against its own tree -- the same rule child graphs already
+        # get (PipelineHandler sets child_graph.source_dir) and that a remote
+        # package gets from its materialized entry. Without this the root's
+        # source_dir is empty and resolve_dot_path falls through to
+        # context.target_dir (--cwd), looking for sibling bricks in the workspace.
+        # --dot-source has no file, so it keeps the old cwd-relative behavior.
+        source_dir = str(dot_path.resolve().parent)
     else:
         print(
             "attractor: either a dot_file argument or --dot-source is required",
@@ -247,6 +256,7 @@ def cmd_run(args: argparse.Namespace) -> int:
                 logs_root=logs_root,
                 cwd=cwd,
                 interviewer=interviewer,
+                source_dir=source_dir,
             )
         )
     except Exception as e:  # noqa: BLE001 -- fail loud with the real error, no fallback

--- a/modules/pipeline-runner/amplifier_module_pipeline_runner/runner.py
+++ b/modules/pipeline-runner/amplifier_module_pipeline_runner/runner.py
@@ -136,7 +136,7 @@ def seed_context(
     context.set("context.target_dir", str(cwd))
 
 
-async def _load_graph(graph_or_dot: "Graph | str"):
+async def _load_graph(graph_or_dot: "Graph | str", *, source_dir: str | None = None):
     """Return (graph, cleanup). If graph_or_dot is a git+https:// URL, materialize
     the remote tree (async, before parse) and parse the local entry; otherwise
     behave exactly as before. cleanup() removes any per-run materialized view.
@@ -147,10 +147,32 @@ async def _load_graph(graph_or_dot: "Graph | str"):
     so the two engine entry points can't diverge. Kept as a module-level
     function (rather than inlined into ``drive_engine``) so it stays
     independently monkeypatchable in tests.
+
+    ``source_dir`` is the directory a file-backed ROOT graph was read from.
+    A remote package derives its own from the materialized entry, and every
+    *child* graph already gets one (``PipelineHandler.execute`` sets
+    ``child_graph.source_dir``) -- only a local root arrived with it empty,
+    which made ``resolve_dot_path`` fall through to ``context.target_dir``
+    (the ``--cwd`` workspace) and look for sibling bricks there instead of
+    beside the pipeline.
+
+    It is applied HERE, in the runner, rather than by passing it into the
+    engine helper: the runner and the engine are separate packages resolved
+    independently (see ``compat.py`` -- a floating dependency plus a
+    symbol-presence assertion, deliberately not a pin). Adding a parameter to
+    the engine's signature would create a skew the compatibility check cannot
+    see -- the symbol still exists, so the gate passes and the call then fails
+    with a bare ``TypeError``. Setting the attribute on the returned graph
+    needs nothing new from the engine.
     """
     from amplifier_module_loop_pipeline.remote_dot import load_remote_or_local_graph
 
-    return await load_remote_or_local_graph(graph_or_dot)
+    graph, cleanup = await load_remote_or_local_graph(graph_or_dot)
+    # Never clobber: a remote package and an already-parsed Graph carry their
+    # own, and theirs is the more specific answer.
+    if source_dir and not getattr(graph, "source_dir", ""):
+        graph.source_dir = source_dir
+    return graph, cleanup
 
 
 async def drive_engine(
@@ -165,6 +187,7 @@ async def drive_engine(
     interviewer: Any = None,
     transform: bool,
     validate: bool = True,
+    source_dir: str | None = None,
 ) -> "Outcome":
     """Drive the attractor engine directly against an already-built coordinator.
 
@@ -232,7 +255,7 @@ async def drive_engine(
     from amplifier_module_loop_pipeline.transforms import apply_transforms
     from amplifier_module_loop_pipeline.validation import validate_or_raise
 
-    graph, _source_cleanup = await _load_graph(graph_or_dot)
+    graph, _source_cleanup = await _load_graph(graph_or_dot, source_dir=source_dir)
 
     try:
         resolved_cwd = Path(cwd) if cwd is not None else Path.cwd()
@@ -610,6 +633,7 @@ async def run_pipeline(
     extra_overlays: Sequence[Any] | None = None,
     child_constraint: Callable[[Any], Any] | None = None,
     spawn_timeout: float | None = None,
+    source_dir: Path | str | None = None,
 ) -> PipelineResult:
     """Run a DOT pipeline through the attractor engine, standalone.
 
@@ -704,6 +728,7 @@ async def run_pipeline(
                 interviewer=interviewer,
                 transform=transform,
                 validate=validate,
+                source_dir=str(source_dir) if source_dir else None,
             )
     finally:
         # The engine creates its manifest at run start. Stamp runner-owned

--- a/modules/pipeline-runner/tests/test_drive_engine_remote_cleanup.py
+++ b/modules/pipeline-runner/tests/test_drive_engine_remote_cleanup.py
@@ -39,7 +39,7 @@ async def test_drive_engine_cleanup_called_when_validate_fails_after_materialize
     class _FakeGraph:
         source_dir = str(view_dir)
 
-    async def _fake_load_graph(_graph_or_dot):
+    async def _fake_load_graph(_graph_or_dot, **_kwargs):
         return _FakeGraph(), _cleanup
 
     def _raising_validate_or_raise(_graph):

--- a/modules/pipeline-runner/tests/test_root_source_dir.py
+++ b/modules/pipeline-runner/tests/test_root_source_dir.py
@@ -31,9 +31,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
 import amplifier_module_pipeline_runner.runner as runner_mod
+import pytest
 from amplifier_module_pipeline_runner import cli
 from amplifier_module_pipeline_runner.runner import PipelineResult
 
@@ -45,7 +44,9 @@ _DOT = "digraph G { start [shape=Mdiamond]; done [shape=Msquare]; start -> done;
 
 @pytest.mark.asyncio
 async def test_local_root_takes_the_supplied_source_dir():
-    graph, cleanup = await runner_mod._load_graph(_DOT, source_dir="/pkg/pipeline-package")
+    graph, cleanup = await runner_mod._load_graph(
+        _DOT, source_dir="/pkg/pipeline-package"
+    )
     try:
         assert graph.source_dir == "/pkg/pipeline-package"
     finally:
@@ -143,3 +144,108 @@ def test_dot_source_passes_no_source_dir(monkeypatch, tmp_path):
     assert cli.cmd_run(args) == 0
 
     assert captured["source_dir"] is None
+
+
+# --- true e2e: the relative child actually loads AND executes ---------------
+# Every test above stops at "was source_dir threaded" -- they all mock
+# run_pipeline itself, so nothing proves resolve_dot_path actually finds the
+# sibling file. This drives cmd_run's real argv-parsing/source_dir-derivation
+# code, then a fake run_pipeline that -- instead of being a black-box mock --
+# forwards straight into the real drive_engine() (real parser, real engine,
+# real PipelineHandler.resolve_dot_path). Only the outer bundle/session
+# composition in the real run_pipeline() is skipped (irrelevant to this bug:
+# it never touches source_dir). AmplifierBackend is never invoked because
+# both DOT files use only tool nodes (shape=parallelogram), so no mocking of
+# the LLM boundary is needed -- fully hermetic, no network, no API keys.
+
+_PARENT_DOT_RELATIVE_CHILD = """\
+digraph parent {
+    graph [goal="verify relative child resolution via the CLI"]
+    start [shape=Mdiamond]
+    sub   [shape=folder, dot_file="child.dot"]
+    done  [shape=Msquare]
+    start -> sub -> done
+}
+"""
+
+_CHILD_DOT_TOOL_NODE = """\
+digraph child {
+    start [shape=Mdiamond]
+    work  [shape=parallelogram, tool_command="echo child-executed > child_ran.txt"]
+    done  [shape=Msquare]
+    start -> work -> done
+}
+"""
+
+
+def test_cmd_run_e2e_resolves_and_executes_relative_child(monkeypatch, tmp_path):
+    """True e2e for the CLI path: a relative dot_file= child must actually
+    load AND execute -- not merely that source_dir was captured as a kwarg.
+
+    Before the fix: cmd_run's source_dir is None (this test predates that --
+    see the stash/pop proof in the PR), so drive_engine's _load_graph leaves
+    graph.source_dir empty, resolve_dot_path falls through to
+    context.target_dir (--cwd, pinned below to a decoy dir with no
+    child.dot), and the child pipeline -- and therefore the whole run --
+    FAILS with "Child DOT file not found".
+
+    After the fix: source_dir is the package directory, the sibling
+    child.dot is found, and its own tool node actually runs (proven by the
+    canary file it writes).
+    """
+    package = tmp_path / "package"
+    package.mkdir()
+    (package / "child.dot").write_text(_CHILD_DOT_TOOL_NODE, encoding="utf-8")
+    parent_dot = package / "parent.dot"
+    parent_dot.write_text(_PARENT_DOT_RELATIVE_CHILD, encoding="utf-8")
+
+    # --cwd points at a DECOY workspace with no child.dot -- if resolution
+    # falls back to context.target_dir instead of the package dir, the run
+    # fails here instead of silently "working" by accident.
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    logs_dir = tmp_path / "logs"
+
+    async def fake_run_pipeline(dot_source, **kwargs):
+        outcome = await runner_mod.drive_engine(
+            dot_source,
+            coordinator=None,
+            logs_root=logs_dir,
+            cwd=kwargs.get("cwd"),
+            transform=True,
+            source_dir=kwargs.get("source_dir"),
+        )
+        return PipelineResult(
+            status=outcome.status.value,
+            notes=outcome.notes or "",
+            logs_dir=logs_dir,
+            raw="{}",
+            failure_reason=outcome.failure_reason,
+        )
+
+    monkeypatch.setattr(runner_mod, "run_pipeline", fake_run_pipeline)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key-not-real")
+
+    args = cli.build_parser().parse_args(
+        ["run", str(parent_dot), "--cwd", str(workspace)]
+    )
+    assert cli.cmd_run(args) == 0
+
+    # The child's tool node runs with cwd=context.target_dir (--cwd), per
+    # ToolHandler's documented cwd contract (test_tool_cwd.py) -- that
+    # contract is independent of this fix and deliberately left alone. The
+    # canary landing in the workspace is proof the child's own node actually
+    # executed (not merely that the parent "succeeded" trivially): if
+    # resolve_dot_path had fallen through to context.target_dir instead of
+    # finding child.dot beside parent.dot, the child pipeline -- and the
+    # whole run -- would have FAILED with "Child DOT file not found" instead
+    # of reaching this node at all.
+    canary = workspace / "child_ran.txt"
+    assert canary.exists(), (
+        f"Expected {canary} to exist -- the child pipeline's tool node must "
+        "have actually executed, proving the relative dot_file= reference "
+        "resolved beside the invoked pipeline rather than failing to be "
+        "found at all"
+    )
+    assert canary.read_text().strip() == "child-executed"

--- a/modules/pipeline-runner/tests/test_root_source_dir.py
+++ b/modules/pipeline-runner/tests/test_root_source_dir.py
@@ -1,0 +1,145 @@
+"""A file-backed ROOT graph must carry the directory it was read from.
+
+The bug: ``resolve_dot_path`` (loop-pipeline ``handlers/pipeline.py``) is a
+precedence chain, not a search path -- it never checks existence, so the first
+non-empty candidate wins:
+
+    absolute -> graph.source_dir -> context.target_dir -> os.getcwd()
+
+A root graph loaded from a file arrived with ``source_dir`` empty, because the
+CLI reads the DOT as text and the path is discarded. ``--cwd`` sets
+``context.target_dir``. So a root graph's relative ``dot_file=`` children were
+looked for under the WORKING DIRECTORY rather than beside the pipeline, and
+running a multi-file pipeline against a separate workspace required flattening
+its DOT tree into that workspace.
+
+Child graphs were never affected (``PipelineHandler.execute`` sets
+``child_graph.source_dir``), nor were remote packages (they derive theirs from
+the materialized entry). Only the root's first hop.
+
+SCOPE: this covers the standalone CLI path -- ``attractor run <file>``. The
+mounted ``PipelineOrchestrator`` also reads a local ``dot_file`` into text and
+discards the path; that path is deliberately NOT changed here.
+
+The directory is applied in the runner's ``_load_graph`` rather than passed
+into the engine helper on purpose -- see the note there. Runner and engine are
+separately resolved packages, and ``compat.py`` asserts symbol presence, not
+signatures, so a new engine parameter would be a skew the gate cannot see.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import amplifier_module_pipeline_runner.runner as runner_mod
+from amplifier_module_pipeline_runner import cli
+from amplifier_module_pipeline_runner.runner import PipelineResult
+
+_DOT = "digraph G { start [shape=Mdiamond]; done [shape=Msquare]; start -> done; }"
+
+
+# --- _load_graph: where the directory is actually applied -------------------
+
+
+@pytest.mark.asyncio
+async def test_local_root_takes_the_supplied_source_dir():
+    graph, cleanup = await runner_mod._load_graph(_DOT, source_dir="/pkg/pipeline-package")
+    try:
+        assert graph.source_dir == "/pkg/pipeline-package"
+    finally:
+        cleanup()
+
+
+@pytest.mark.asyncio
+async def test_without_a_source_dir_the_root_is_unchanged():
+    """``--dot-source`` has no file, so it must keep the old cwd-relative behaviour."""
+    graph, cleanup = await runner_mod._load_graph(_DOT)
+    try:
+        assert not graph.source_dir
+    finally:
+        cleanup()
+
+
+@pytest.mark.asyncio
+async def test_an_existing_source_dir_is_never_clobbered():
+    """A remote package derives its own from the materialized entry; that wins."""
+    from amplifier_module_loop_pipeline.dot_parser import parse_dot
+
+    already = parse_dot(_DOT)
+    already.source_dir = "/materialized/view"
+
+    graph, cleanup = await runner_mod._load_graph(already, source_dir="/ignored")
+    try:
+        assert graph.source_dir == "/materialized/view"
+    finally:
+        cleanup()
+
+
+# --- propagation: CLI -> run_pipeline --------------------------------------
+# The unit above proves the directory is applied once it arrives. These prove
+# it actually travels from the command line, which is the hop that was broken.
+
+
+def _capture_run_pipeline(monkeypatch, tmp_path) -> dict:
+    captured: dict = {}
+
+    async def fake_run_pipeline(dot_source, **kwargs):
+        captured["source_dir"] = kwargs.get("source_dir")
+        return PipelineResult(status="success", notes="", logs_dir=tmp_path, raw="{}")
+
+    monkeypatch.setattr(runner_mod, "run_pipeline", fake_run_pipeline)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key-not-real")
+    return captured
+
+
+def test_cmd_run_passes_the_dot_files_own_directory(monkeypatch, tmp_path):
+    package = tmp_path / "package"
+    package.mkdir()
+    dot_file = package / "pipeline.dot"
+    dot_file.write_text(_DOT, encoding="utf-8")
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    captured = _capture_run_pipeline(monkeypatch, tmp_path)
+
+    args = cli.build_parser().parse_args(
+        ["run", str(dot_file), "--cwd", str(workspace)]
+    )
+    assert cli.cmd_run(args) == 0
+
+    # The pipeline's own directory -- NOT --cwd, which is the whole point.
+    assert captured["source_dir"] == str(package.resolve())
+    assert captured["source_dir"] != str(workspace)
+
+
+def test_cmd_run_resolves_a_relative_dot_path(monkeypatch, tmp_path):
+    """``source_dir`` must be absolute; the engine joins it with a relative ref."""
+    package = tmp_path / "package"
+    package.mkdir()
+    (package / "pipeline.dot").write_text(_DOT, encoding="utf-8")
+
+    captured = _capture_run_pipeline(monkeypatch, tmp_path)
+
+    monkeypatch.chdir(tmp_path)
+    args = cli.build_parser().parse_args(
+        ["run", "package/pipeline.dot", "--cwd", str(tmp_path)]
+    )
+    assert cli.cmd_run(args) == 0
+
+    assert Path(captured["source_dir"]).is_absolute()
+    assert captured["source_dir"] == str(package.resolve())
+
+
+def test_dot_source_passes_no_source_dir(monkeypatch, tmp_path):
+    """There is no file, so there is no directory to claim."""
+    captured = _capture_run_pipeline(monkeypatch, tmp_path)
+
+    args = cli.build_parser().parse_args(
+        ["run", "--dot-source", _DOT, "--cwd", str(tmp_path)]
+    )
+    assert cli.cmd_run(args) == 0
+
+    assert captured["source_dir"] is None

--- a/modules/tool-pipeline-run/amplifier_module_tool_pipeline_run/__init__.py
+++ b/modules/tool-pipeline-run/amplifier_module_tool_pipeline_run/__init__.py
@@ -11,6 +11,7 @@ import json
 import logging
 import re
 import time
+from pathlib import Path
 from typing import Any
 
 __all__ = ["PipelineRunTool", "mount"]
@@ -96,39 +97,18 @@ class PipelineRunTool:
     # DOT source resolution
     # -----------------------------------------------------------------
 
-    def _resolve_dot_source(
-        self,
-        dot_file: str | None,
-        dot_source: str | None,
-    ) -> str:
-        """Resolve DOT source from file path or inline string.
+    def _resolve_dot_file_path(self, dot_file: str) -> Path:
+        """Resolve a dot_file reference to an existing Path on disk.
 
-        Resolution priority:
-        1. dot_source (inline string) — used as-is if provided
-        2. dot_file (file path) — read from disk; supports @mention syntax
-
-        Args:
-            dot_file: Path to a .dot file (supports @mention syntax).
-            dot_source: Inline DOT digraph string.
-
-        Returns:
-            The DOT source string.
+        Handles @mention syntax (resolved via the coordinator's
+        mention_resolver capability) and plain filesystem paths. Single site
+        for this resolution so both the text-only and directory-aware callers
+        below can't drift apart (AGENTS.md S4 partial-coverage-symmetry).
 
         Raises:
-            FileNotFoundError: If dot_file path does not exist.
+            FileNotFoundError: If the resolved path does not exist.
             ValueError: If @mention path cannot be resolved.
         """
-        from pathlib import Path
-
-        # Priority 1: inline source
-        if dot_source:
-            return dot_source
-
-        # Priority 2: file path
-        if not dot_file:
-            raise ValueError("Either dot_file or dot_source must be provided")
-
-        # Handle @mention syntax
         if dot_file.startswith("@"):
             if self.coordinator is None:
                 raise ValueError(
@@ -151,7 +131,69 @@ class PipelineRunTool:
         if not file_path.exists():
             raise FileNotFoundError(f"DOT file not found: {file_path}")
 
-        return file_path.read_text()
+        return file_path
+
+    def _resolve_dot_source(
+        self,
+        dot_file: str | None,
+        dot_source: str | None,
+    ) -> str:
+        """Resolve DOT source from file path or inline string.
+
+        Resolution priority:
+        1. dot_source (inline string) — used as-is if provided
+        2. dot_file (file path) — read from disk; supports @mention syntax
+
+        Args:
+            dot_file: Path to a .dot file (supports @mention syntax).
+            dot_source: Inline DOT digraph string.
+
+        Returns:
+            The DOT source string.
+
+        Raises:
+            FileNotFoundError: If dot_file path does not exist.
+            ValueError: If @mention path cannot be resolved.
+        """
+        text, _source_dir = self._resolve_dot_source_with_dir(dot_file, dot_source)
+        return text
+
+    def _resolve_dot_source_with_dir(
+        self,
+        dot_file: str | None,
+        dot_source: str | None,
+    ) -> tuple[str, str | None]:
+        """Resolve DOT source text plus, when file-backed, its directory.
+
+        The spawned child session runs the mounted PipelineOrchestrator from
+        a fresh process, so the file path itself never crosses that boundary
+        -- only the resolved text does (via orchestrator_config["dot_source"]).
+        Without the directory travelling alongside it, a relative dot_file=
+        child reference in the pipeline would resolve under the child
+        session's --cwd instead of beside the pipeline that was actually
+        invoked (the same bug already fixed for the standalone CLI path and
+        the mounted orchestrator's own local dot_file path).
+
+        Returns:
+            ``(dot_source, source_dir)``. ``source_dir`` is ``None`` when the
+            source is inline ``dot_source`` -- there is no file, so there is
+            no directory to claim.
+
+        Raises:
+            FileNotFoundError: If dot_file path does not exist.
+            ValueError: If @mention path cannot be resolved, or neither
+                dot_file nor dot_source is provided.
+        """
+        # Priority 1: inline source
+        if dot_source:
+            return dot_source, None
+
+        # Priority 2: file path (supports @mention syntax)
+        if not dot_file:
+            raise ValueError("Either dot_file or dot_source must be provided")
+
+        file_path = self._resolve_dot_file_path(dot_file)
+        return file_path.read_text(), str(file_path.resolve().parent)
 
     # -----------------------------------------------------------------
     # Provider validation
@@ -318,7 +360,7 @@ class PipelineRunTool:
 
         # --- Resolve DOT source ---
         try:
-            dot_source_resolved = self._resolve_dot_source(
+            dot_source_resolved, dot_source_dir = self._resolve_dot_source_with_dir(
                 dot_file=dot_file,
                 dot_source=dot_source,
             )
@@ -390,6 +432,18 @@ class PipelineRunTool:
         orchestrator_config: dict[str, Any] = {
             "dot_source": dot_source_resolved,
         }
+
+        # Forward the directory a file-backed dot_file was read from. The
+        # spawned child session only receives resolved TEXT (dot_source
+        # above) -- the file path itself never crosses that boundary -- so
+        # without this, relative dot_file= children in the pipeline would
+        # resolve under the child session's --cwd instead of beside the
+        # pipeline actually invoked. PipelineOrchestrator reads this same
+        # "source_dir" key when dot_source is inline (see its
+        # _resolve_dot_source docstring). None for an inline dot_source
+        # input -- there is no file, so there is no directory to forward.
+        if dot_source_dir:
+            orchestrator_config["source_dir"] = dot_source_dir
 
         # Forward profiles from our config if present
         profiles = self.config.get("profiles")

--- a/modules/tool-pipeline-run/tests/test_source_dir_propagation.py
+++ b/modules/tool-pipeline-run/tests/test_source_dir_propagation.py
@@ -1,0 +1,198 @@
+"""The agent-facing ``run_pipeline`` tool must preserve a file-backed
+``dot_file``'s directory through to the spawned child session.
+
+This is the third of the three sites the root-graph-source-dir bug touches
+(the standalone CLI and the mounted PipelineOrchestrator's own local
+``dot_file`` are the other two). The spawned child session only receives
+resolved TEXT via ``orchestrator_config["dot_source"]`` -- the file path
+itself never crosses the spawn boundary. Without the directory travelling
+alongside it, a relative ``dot_file=`` child reference in the pipeline
+resolves under the child session's ``--cwd`` instead of beside the pipeline
+that was actually invoked, even though the exact same pipeline works fine
+when run via the standalone CLI.
+
+This module owns only the EMITTING side of that contract: given a
+``dot_file`` (plain path or ``@mention``) or an inline ``dot_source``, does
+``execute()`` build an ``orchestrator_config`` that carries the right
+``source_dir`` (or correctly omits it)? The tests below assert on the real
+config this tool produces, using a fake ``session.spawn`` that only captures
+its kwargs -- they do not construct or run a ``PipelineOrchestrator``, so
+this suite has no dependency on ``amplifier-module-loop-pipeline`` (this
+module's ``pyproject.toml`` intentionally declares only ``amplifier-core``;
+see AGENTS.md's dependency-awareness rule).
+
+The CONSUMING side of the contract -- that ``PipelineOrchestrator.execute()``
+actually resolves and runs a relative ``dot_file=`` child when handed the
+exact ``{"dot_source": ..., "source_dir": ...}`` shape this tool builds -- is
+proven from ``loop-pipeline``'s own suite, which can import its own engine:
+see ``modules/loop-pipeline/tests/test_orchestrator_source_dir.py::
+test_execute_resolves_relative_child_via_dot_source_and_source_dir``. A
+prior version of this file additionally re-verified that same consuming-side
+behavior here, by importing ``PipelineOrchestrator`` directly and driving a
+fake ``session.spawn`` that constructed one -- that import made this test
+uncollectable in CI, where ``tool-pipeline-run``'s isolated ``uv`` venv has
+no ``loop-pipeline`` package (it only appeared to pass locally because an
+unrelated editable install had leaked it into this developer's shared venv).
+That duplicate coverage is not reintroduced here; the two modules each test
+their own side, and together they prove the contract end to end without
+either importing the other.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from unittest.mock import MagicMock
+
+import pytest
+from amplifier_module_tool_pipeline_run import PipelineRunTool
+
+MINIMAL_DOT = (
+    "digraph Test { start [shape=Mdiamond]; done [shape=Msquare]; start -> done }"
+)
+
+# ---------------------------------------------------------------------------
+# _resolve_dot_source_with_dir: unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_inline_dot_source_has_no_directory():
+    """Inline dot_source has no file, so source_dir is None."""
+    tool = PipelineRunTool(config={})
+    text, source_dir = tool._resolve_dot_source_with_dir(
+        dot_file=None, dot_source=MINIMAL_DOT
+    )
+    assert text == MINIMAL_DOT
+    assert source_dir is None
+
+
+def test_dot_file_path_returns_its_own_directory():
+    """A dot_file path returns (text, that file's resolved parent directory)."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        dot_path = os.path.join(tmp_dir, "pipeline.dot")
+        with open(dot_path, "w", encoding="utf-8") as f:
+            f.write(MINIMAL_DOT)
+
+        tool = PipelineRunTool(config={})
+        text, source_dir = tool._resolve_dot_source_with_dir(
+            dot_file=dot_path, dot_source=None
+        )
+        assert text == MINIMAL_DOT
+        assert source_dir == str(tmp_dir)
+
+
+def test_dot_source_takes_precedence_and_still_returns_no_directory():
+    """When both are provided, dot_source wins and there is still no directory."""
+    tool = PipelineRunTool(config={})
+    text, source_dir = tool._resolve_dot_source_with_dir(
+        dot_file="/some/file.dot", dot_source=MINIMAL_DOT
+    )
+    assert text == MINIMAL_DOT
+    assert source_dir is None
+
+
+def test_at_mention_path_returns_resolved_directory():
+    """@mention resolution still yields the resolved file's directory."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        dot_path = os.path.join(tmp_dir, "pipeline.dot")
+        with open(dot_path, "w", encoding="utf-8") as f:
+            f.write(MINIMAL_DOT)
+
+        mock_resolver = MagicMock()
+        mock_resolver.resolve.return_value = dot_path
+        mock_coordinator = MagicMock()
+        mock_coordinator.get_capability.return_value = mock_resolver
+
+        tool = PipelineRunTool(config={}, coordinator=mock_coordinator)
+        text, source_dir = tool._resolve_dot_source_with_dir(
+            dot_file="@attractor:examples/pipelines/01-simple-linear.dot",
+            dot_source=None,
+        )
+        assert text == MINIMAL_DOT
+        assert source_dir == str(tmp_dir)
+
+
+def test_missing_both_raises_value_error():
+    tool = PipelineRunTool(config={})
+    with pytest.raises(ValueError, match="dot_file or dot_source"):
+        tool._resolve_dot_source_with_dir(dot_file=None, dot_source=None)
+
+
+def test_missing_dot_file_raises_file_not_found():
+    tool = PipelineRunTool(config={})
+    with pytest.raises(FileNotFoundError):
+        tool._resolve_dot_source_with_dir(
+            dot_file="/nonexistent/path.dot", dot_source=None
+        )
+
+
+def test_resolve_dot_source_backward_compat_still_returns_plain_text():
+    """The existing tested contract of _resolve_dot_source (text only) is unchanged."""
+    tool = PipelineRunTool(config={})
+    resolved = tool._resolve_dot_source(dot_file=None, dot_source=MINIMAL_DOT)
+    assert resolved == MINIMAL_DOT
+    assert isinstance(resolved, str)
+
+
+# ---------------------------------------------------------------------------
+# execute(): orchestrator_config carries (or omits) source_dir
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_execute_forwards_source_dir_for_dot_file(tmp_path):
+    """dot_file input -> orchestrator_config carries the file's own directory."""
+    dot_path = tmp_path / "pipeline.dot"
+    dot_path.write_text(MINIMAL_DOT, encoding="utf-8")
+
+    captured: dict = {}
+
+    async def fake_spawn(**spawn_kwargs):
+        captured["orchestrator_config"] = spawn_kwargs.get("orchestrator_config")
+        return {"output": json.dumps({"status": "success", "notes": "ok"})}
+
+    mock_coordinator = MagicMock()
+    mock_coordinator.get_capability = lambda name: (
+        fake_spawn if name == "session.spawn" else None
+    )
+    mock_coordinator.config = {"agents": {"attractor-pipeline-runner": {}}}
+    mock_coordinator.session = MagicMock()
+
+    tool = PipelineRunTool(config={}, coordinator=mock_coordinator)
+    result = await tool.execute({"goal": "test goal", "dot_file": str(dot_path)})
+
+    assert result.success
+    assert captured["orchestrator_config"]["source_dir"] == str(tmp_path)
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_execute_omits_source_dir_for_inline_dot_source():
+    """Inline dot_source input -> no source_dir key at all (nothing to forward)."""
+    captured: dict = {}
+
+    async def fake_spawn(**spawn_kwargs):
+        captured["orchestrator_config"] = spawn_kwargs.get("orchestrator_config")
+        return {"output": json.dumps({"status": "success", "notes": "ok"})}
+
+    mock_coordinator = MagicMock()
+    mock_coordinator.get_capability = lambda name: (
+        fake_spawn if name == "session.spawn" else None
+    )
+    mock_coordinator.config = {"agents": {"attractor-pipeline-runner": {}}}
+    mock_coordinator.session = MagicMock()
+
+    tool = PipelineRunTool(config={}, coordinator=mock_coordinator)
+    result = await tool.execute({"goal": "test goal", "dot_source": MINIMAL_DOT})
+
+    assert result.success
+    assert "source_dir" not in captured["orchestrator_config"]
+
+
+# NOTE: A prior version of this file also contained a "true e2e" test here
+# that constructed a real PipelineOrchestrator inside a fake session.spawn
+# to prove a relative dot_file= child actually loads and executes. That
+# test required `from amplifier_module_loop_pipeline import
+# PipelineOrchestrator`, a cross-module import this package does not (and
+# should not) depend on -- see the module docstring above for where that
+# consuming-side coverage now lives instead.

--- a/specs/EXTENSIONS.md
+++ b/specs/EXTENSIONS.md
@@ -200,6 +200,36 @@ spec's §9.4 sub-pipeline pattern with a dedicated, declarative shape.
 name, so the mechanism cannot change the behavior of any spec-conformant `.dot` file.
 (Documenting a pre-existing extension that was previously undocumented.)
 
+**`dot_file=` path resolution:** A relative `dot_file=` value is resolved by
+`resolve_dot_path()` (`handlers/pipeline.py`) against a **precedence chain**, not a search
+path -- the first non-empty candidate wins, with no existence check:
+
+1. **Absolute path** -- used as-is.
+2. **`graph.source_dir`** -- the directory of the `.dot` file that produced the *current*
+   graph (root or child).
+3. **`context.target_dir`** -- the pipeline's working directory (`--cwd` on the standalone
+   CLI; the mounted orchestrator has no equivalent and skips this tier).
+4. **`os.getcwd()`** -- the process's current working directory, as a last resort.
+
+Every **child** graph reached through a `shape=folder` node already gets its `source_dir`
+set to its own `.dot` file's directory (`PipelineHandler.execute()`, step 5), so a
+grandchild's relative `dot_file=` resolves beside the child regardless of where the root
+came from. A **root** graph gets its `source_dir` seeded from the directory of the `.dot`
+file passed to the entry point that invoked it -- the standalone CLI (`attractor run
+<file>`), the mounted `PipelineOrchestrator` (a local `dot_file` in its config), and the
+`run_pipeline` tool (a `dot_file` input, forwarded to the mounted orchestrator's spawned
+child session as an explicit `source_dir` alongside the already-resolved DOT text) all seed
+it this way. Only an **inline** DOT source (`--dot-source`, a `dot_source` config value, or
+a `dot_source` tool input) has no backing file and therefore no directory to seed --
+`source_dir` stays empty for that root.
+
+**`context.target_dir` (`--cwd`) is an independent knob and does not shadow `source_dir`.**
+It answers a different question -- where box/tool nodes write files and read relative
+inputs at *runtime* -- while `source_dir` answers where the pipeline's own `.dot` tree lives
+on disk. The precedence chain above means an explicitly-set `graph.source_dir` always wins
+over `context.target_dir` for `dot_file=` resolution: pointing `--cwd` at a separate
+workspace does not require flattening a multi-file pipeline into that workspace.
+
 ---
 
 ## 11. Sub-Pipeline and Manager-Child Execution Is a Fresh Session Boundary


### PR DESCRIPTION
## What's broken

A multi-file pipeline can't be run from anywhere except its own directory. Point the CLI at a pipeline and give it a workspace to work in, and it looks for that pipeline's own child DOTs **in the workspace**:

```
$ attractor run ~/pkg/root.dot --cwd ~/workspace

[PIPELINE] x Error at Child (no_matching_edge):
Child DOT file not found: /home/me/workspace/bricks/child.dot
                          ^^^^^^^^^^^^^^^^^ looked in --cwd,
                                            not beside root.dot
```

The workaround is to copy the pipeline's DOT tree into the workspace before every run.

## Why it happens

`cmd_run()` reads the DOT file as text and the path is discarded, so the root graph's `source_dir` is empty. `resolve_dot_path()` is a **precedence chain, not a search path** — it takes the first non-empty candidate and never checks whether the file exists:

```
absolute -> graph.source_dir -> context.target_dir -> os.getcwd()
                  (empty)          (this is --cwd)
```

Only the **root** graph is affected. Children have always been fine (`PipelineHandler.execute` sets `child_graph.source_dir`), and so have remote packages (they derive theirs from the materialized entry). It's the root's first hop only.

## The fix

The CLI knows where the file is, so it passes that directory down and the runner sets it on the root graph — the same thing every child and every remote package already gets.

```
$ attractor run ~/pkg/root.dot --cwd ~/workspace
attractor: status=success
```

## Scope: the CLI path only

Limited to standalone `attractor run <file>`.

- The mounted `PipelineOrchestrator` also reads a local `dot_file` into text and discards the path. **Intentionally not changed here** — flagged in the new test module's docstring.
- `--dot-source` has no file, so there's no directory to claim; its behaviour is unchanged.
- A `source_dir` that already exists is never overwritten.

## One design note worth a reviewer's attention

The obvious implementation is to add a `source_dir` parameter to `remote_dot.load_remote_or_local_graph()`. That was the first version, and it was abandoned on purpose.

`compat.py` asserts that required engine **symbols exist** — not that their signatures match. The runner and the engine are separately resolved packages on a floating dependency. Adding a parameter to the engine helper creates precisely the skew that gate cannot see: the symbol is still there, the check passes, and the call then dies on a bare `TypeError` against an older engine.

So the runner calls the existing single-argument helper and sets the attribute on the returned graph. Nothing new is required of the engine — and the live run below was executed against an **unmodified** engine, which the earlier approach could not have done.

---

<details>
<summary><b>Verification evidence</b></summary>

### Unit tests — `modules/pipeline-runner`

```
57 passed, 1 skipped
```

Includes 6 new tests in `tests/test_root_source_dir.py`: the directory is applied to a local root; absent when not supplied; never clobbers an existing one; and — the hop that was actually broken and previously untested — that it propagates from the command line through `cmd_run` to `run_pipeline`, is absolutized from a relative DOT path, and is `None` for `--dot-source`.

`tests/test_drive_engine_remote_cleanup.py` — its `_load_graph` test double gained `**_kwargs`, since that internal seam now takes a keyword argument.

### Unit tests — `modules/loop-pipeline`

```
1661 passed, 1 failed
```

The failure is `test_git_commit_loud_fail.py::TestGitCommitLoudFail::test_git_commit_without_identity_fails_loudly` — environmental and unrelated. Evidence it isn't from this change: `git diff upstream/main -- modules/loop-pipeline` is **empty**, so that code is untouched. (`tests/test_remote_dot.py` also fails to collect in this environment on a missing optional module, for the same reason.)

### Live run

Root DOT with a relative child, executed against a separate workspace:

```
pkg/root.dot            Child [shape=folder, dot_file="bricks/child.dot"]
pkg/bricks/child.dot    writes ran_here.txt

$ attractor run <abs>/pkg/root.dot --cwd <abs>/workspace
attractor: status=success
```

The child resolved beside the pipeline and executed rooted in the workspace (`workspace/ran_here.txt` contains the workspace path), and the package tree was left untouched — still only the two `.dot` files.

Counterfactual on the same graph, showing the change is what makes it work and that `--dot-source` is unaffected:

```
$ attractor run --dot-source "$(cat pkg/root.dot)" --cwd <abs>/workspace2
[PIPELINE] x Error at Child (no_matching_edge):
Child DOT file not found: <abs>/workspace2/bricks/child.dot
attractor: status=fail
```

### Checklist

- [x] Unit tests pass for the changed module (`pytest modules/pipeline-runner/`)
- [x] Live pipeline run exercising the changed path (above)
- [x] AGENTS.md reviewed; repo-specific gates met
- [x] Backward-compatible paths unchanged: existing source directories not clobbered, `--dot-source` behaviour preserved
- [x] PR body includes verification evidence, not just "tests pass"

</details>
