### PR TITLE
ci: add aggregate all-green gate job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,3 +153,84 @@ jobs:
       - name: Run pyright
         working-directory: modules/unified-llm-client
         run: uv run --with pyright pyright unified_llm/
+
+  ci-gate:
+    # Aggregate "all-green" summary gate. Today CI produces 28 individual
+    # check contexts (13 modules x 2 python versions for unit-tests, plus
+    # live-graph-gate, plus type-check) -- and every one of those is purely
+    # advisory: branch protection has zero required status checks, so a
+    # fully red CI does not block a merge.
+    #
+    # The fix is NOT to require all 28 contexts by name in branch
+    # protection. That list is brittle: it changes shape every time a
+    # module is added, renamed, or dropped from the unit-tests matrix, and
+    # a renamed/removed context either silently stops being enforced or
+    # hangs every future PR waiting on a check that will never report.
+    #
+    # Instead this job is the ONE stable check to require. It depends on
+    # every other job in this workflow and fails if any of them failed,
+    # was cancelled, or was skipped -- so requiring only this one context
+    # in branch protection is equivalent to requiring the full matrix,
+    # without the matrix's brittleness. Adding, renaming, or removing a
+    # module in `unit-tests.strategy.matrix.module` never requires a
+    # branch-protection change: this job's `needs:` list only ever
+    # references the three top-level job IDs (unit-tests, live-graph-gate,
+    # type-check), not individual matrix cells.
+    #
+    # `needs:` alone is not sufficient to get fail-closed semantics. By
+    # default, if a job listed in `needs:` fails, GitHub Actions SKIPS any
+    # dependent job rather than running it -- and a job that never runs
+    # reports no failing status at all (in some branch-protection
+    # configurations a skipped required check is treated as satisfied).
+    # `if: always()` makes this job run regardless of upstream
+    # success/failure/cancellation, and the step below then explicitly
+    # inspects `needs.<job>.result` for every dependency and fails loudly
+    # (a real non-zero exit, no `continue-on-error`, no `|| true`) if any
+    # of them is not exactly `"success"`. That is what makes it
+    # IMPOSSIBLE for this job to report green while any upstream job is
+    # red, cancelled, or skipped:
+    #   - unit-tests result is "failure"   -> any matrix cell failing fails
+    #     the whole job group, which flips this to failure.
+    #   - live-graph-gate or type-check result is "failure" -> same.
+    #   - any of the three is "cancelled" (workflow run cancelled
+    #     mid-flight) -> not "success" -> this job fails.
+    #   - any of the three is "skipped" (e.g. a future workflow edit adds
+    #     an `if:` condition to one of them that doesn't fire) -> not
+    #     "success" -> this job fails. A dependency that never runs can no
+    #     longer produce a silent pass here.
+    name: CI Gate (all checks passed)
+    if: always()
+    needs:
+      - unit-tests
+      - live-graph-gate
+      - type-check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require every upstream job to have succeeded
+        run: |
+          set -euo pipefail
+
+          declare -A results=(
+            [unit-tests]="${{ needs.unit-tests.result }}"
+            [live-graph-gate]="${{ needs.live-graph-gate.result }}"
+            [type-check]="${{ needs.type-check.result }}"
+          )
+
+          overall_ok=true
+          for job_id in "${!results[@]}"; do
+            result="${results[$job_id]}"
+            echo "${job_id}: ${result}"
+            if [ "${result}" != "success" ]; then
+              echo "::error::Upstream job '${job_id}' did not succeed (result: ${result})"
+              overall_ok=false
+            fi
+          done
+
+          if [ "${overall_ok}" != "true" ]; then
+            echo ""
+            echo "One or more upstream jobs did not succeed. Failing the aggregate CI gate."
+            exit 1
+          fi
+
+          echo ""
+          echo "All upstream jobs succeeded."


### PR DESCRIPTION
## Problem: CI is real but advisory-only

CI in this repo (added by PR #123, extended by PR #125) is substantive: a matrix of 13 modules x Python 3.11/3.13 unit tests, a live-graph gate that drives a real `PipelineEngine` + handler dispatch, and a scoped `pyright` type-check job. That's 28 individual check contexts today.

None of it currently blocks a merge. Branch protection on `main` has **zero required status checks** — a PR can merge with every one of those 28 checks red.

## Why an aggregate gate instead of requiring all 28 contexts by name

Requiring the 28 existing check names directly in branch protection is brittle:

- Adding, renaming, or dropping a module in the `unit-tests` matrix changes the set of check-context names GitHub reports.
- A renamed/removed context silently stops being enforced (branch protection just never sees it again — no error, no signal).
- A newly-added required context that hasn't been configured to run on a given PR yet can hang that PR forever waiting for a check that will never report.

This PR instead adds **one** new terminal job, `ci-gate` (check name **`CI Gate (all checks passed)`**), that `needs:` the three top-level job IDs already defined in the workflow (`unit-tests`, `live-graph-gate`, `type-check`) — never the individual matrix cells. Requiring only this one context in branch protection is equivalent to requiring the full matrix, but the workflow can grow or shrink the matrix underneath it with zero branch-protection changes.

## Why `needs:` alone is not enough

By default, GitHub Actions **skips** a job if any of its `needs:` dependencies failed — it does not run the job at all, and a job that never runs produces no failing status. A plain `needs: [...]` job would therefore itself end up `skipped` whenever any upstream job was red, and a skipped required check does not reliably block a merge.

The fix: `ci-gate` sets `if: always()` so it runs regardless of upstream outcome, and its single step explicitly inspects `needs.<job>.result` for each of the three dependencies, failing (real `exit 1`, no masking) unless every one of them is exactly `"success"`.

### Exact conditions that make `ci-gate` fail

- `needs.unit-tests.result != "success"` — true if **any** cell in the 26-cell (13 modules x 2 Python versions) matrix failed. `fail-fast: false` means the matrix keeps running instead of aborting early, but the job's own overall `result` is still `"failure"` if any cell failed, so one `needs:` entry correctly covers the whole matrix.
- `needs.live-graph-gate.result != "success"` — the live-graph gate job failed.
- `needs.type-check.result != "success"` — the pyright job failed.
- Any of the above is `"cancelled"` (e.g. workflow run cancelled mid-flight) — not `"success"`, so `ci-gate` fails.
- Any of the above is `"skipped"` (e.g. a future edit adds an `if:` condition to one of them that doesn't fire) — not `"success"`, so `ci-gate` fails. This is the case a plain `needs:` (without `if: always()` + explicit result check) would silently let through.

## No masked exit codes

No `continue-on-error`, no `|| true`, no piped/filtered exit codes anywhere in the addition — this repo already lints against exactly that class of hazard in its own `.dot` graphs (CMD-001/CMD-002), and a fake test with this shape was removed in #125. The new step uses `set -euo pipefail` and an explicit `exit 1` on any non-success upstream result.

## Existing jobs unchanged

This PR is purely additive: one new job (`ci-gate`) appended to the end of `.github/workflows/ci.yml`. `unit-tests`, `live-graph-gate`, and `type-check` are byte-for-byte unchanged.

## Validation run

- `python3 -c "import yaml,sys;yaml.safe_load(open('.github/workflows/ci.yml'))"` — parses clean.
- `actionlint` was not available in this environment, so it was not run; the addition was reviewed manually against GitHub Actions' documented `needs.<job>.result` semantics (`success` / `failure` / `cancelled` / `skipped`).
- `git diff --check` — clean.
- No live-run box: this is a CI-workflow-only change with no application code touched; there is nothing for the loop-pipeline live-graph gate to exercise differently. (The next real PR to land will be the first live proof that `ci-gate` reports correctly — see follow-up below.)

## Follow-up required (not part of this PR)

This PR only makes the aggregate gate possible to require — **it does not, by itself, enforce anything.** A repo admin must add the following exact string to branch protection's required status checks for `main`:

```
CI Gate (all checks passed)
```

Until that setting is updated, `ci-gate` will run and report on every PR, but merges are not yet blocked by it.
