### PR TITLE
fix(loop-agent): make parallel-gating test deterministic, not timing-based

### DIFF
--- a/modules/loop-agent/tests/test_parallel_gating.py
+++ b/modules/loop-agent/tests/test_parallel_gating.py
@@ -9,7 +9,6 @@ Verifies that:
 """
 
 import asyncio
-import time
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock
@@ -79,6 +78,54 @@ def _make_slow_tool(name: str, delay: float = 0.1, output: str = "ok"):
         return ToolResult(success=True, output=output)
 
     tool.execute = AsyncMock(side_effect=slow_execute)
+    return tool
+
+
+class _ConcurrencyTracker:
+    """Records the high-water mark of simultaneously in-flight calls.
+
+    Deterministic substitute for wall-clock timing assertions: a serial
+    implementation can never observe more than 1 call in flight at once;
+    a concurrent (gather-based) implementation of N overlapping calls must
+    observe N in flight at some point. Immune to machine speed/contention.
+    """
+
+    def __init__(self):
+        self.in_flight = 0
+        self.max_in_flight = 0
+        self._lock = asyncio.Lock()
+
+    async def enter(self):
+        async with self._lock:
+            self.in_flight += 1
+            self.max_in_flight = max(self.max_in_flight, self.in_flight)
+
+    async def exit(self):
+        async with self._lock:
+            self.in_flight -= 1
+
+
+def _make_tracked_tool(name: str, tracker: "_ConcurrencyTracker", delay: float = 0.05):
+    """Tool that records its in-flight window on a shared concurrency tracker.
+
+    A brief `delay` widens the window in which overlapping calls would be
+    observed together, but no assertion ever depends on its magnitude or on
+    wall-clock elapsed time -- only on whether calls actually overlapped.
+    """
+    tool = MagicMock()
+    tool.name = name
+    tool.description = f"Mock {name}"
+    tool.input_schema = {"type": "object", "properties": {}}
+
+    async def tracked_execute(args):
+        await tracker.enter()
+        try:
+            await asyncio.sleep(delay)
+            return ToolResult(success=True, output="ok")
+        finally:
+            await tracker.exit()
+
+    tool.execute = AsyncMock(side_effect=tracked_execute)
     return tool
 
 
@@ -177,10 +224,16 @@ async def test_sequential_preserves_order():
 
 @pytest.mark.asyncio
 async def test_sequential_timing():
-    """Sequential execution takes longer than parallel (proves no gather)."""
-    delay = 0.05  # 50ms per tool
-    tool_a = _make_slow_tool("tool_a", delay=delay)
-    tool_b = _make_slow_tool("tool_b", delay=delay)
+    """Sequential execution never overlaps calls (proves no gather).
+
+    Deterministic (no wall-clock): with supports_parallel_tool_calls=False,
+    a shared concurrency tracker's high-water mark must stay at 1 -- each
+    tool call must fully complete (enter -> sleep -> exit) before the next
+    one starts. Immune to slow/contended CI runners, unlike a timing bound.
+    """
+    tracker = _ConcurrencyTracker()
+    tool_a = _make_tracked_tool("tool_a", tracker)
+    tool_b = _make_tracked_tool("tool_b", tracker)
 
     provider = AsyncMock()
     provider.complete = AsyncMock(
@@ -201,14 +254,11 @@ async def test_sequential_timing():
         hooks=hooks,
     )
 
-    start = time.monotonic()
     await session.process_input("do both")
-    elapsed = time.monotonic() - start
 
-    # Sequential: should take at least 2x the delay (100ms)
-    # With parallel it would take ~50ms
-    assert elapsed >= delay * 1.5, (
-        f"Expected sequential timing (>={delay * 1.5:.3f}s), got {elapsed:.3f}s"
+    assert tracker.max_in_flight == 1, (
+        f"Expected sequential execution to never overlap (max 1 in flight), "
+        f"but observed {tracker.max_in_flight} simultaneously in flight"
     )
 
 
@@ -217,10 +267,18 @@ async def test_sequential_timing():
 
 @pytest.mark.asyncio
 async def test_parallel_when_enabled_and_multiple():
-    """With supports_parallel_tool_calls=True and multiple calls, runs in parallel."""
-    delay = 0.1
-    tool_a = _make_slow_tool("tool_a", delay=delay)
-    tool_b = _make_slow_tool("tool_b", delay=delay)
+    """With supports_parallel_tool_calls=True and multiple calls, they run concurrently.
+
+    Deterministic (no wall-clock): a shared concurrency tracker records the
+    high-water mark of simultaneously in-flight tool executions. A serial
+    implementation can never exceed 1 in flight; a concurrent (gather-based)
+    implementation of two overlapping calls must reach 2. This proves actual
+    concurrency regardless of machine speed or scheduler contention -- unlike
+    a wall-clock ratio, which a busy shared CI runner can fail spuriously.
+    """
+    tracker = _ConcurrencyTracker()
+    tool_a = _make_tracked_tool("tool_a", tracker)
+    tool_b = _make_tracked_tool("tool_b", tracker)
 
     provider = AsyncMock()
     provider.complete = AsyncMock(
@@ -241,14 +299,11 @@ async def test_parallel_when_enabled_and_multiple():
         hooks=hooks,
     )
 
-    start = time.monotonic()
     await session.process_input("do both")
-    elapsed = time.monotonic() - start
 
-    # Parallel: should complete in roughly delay time, not 2x
-    # Use generous bound to avoid flaky CI
-    assert elapsed < delay * 1.8, (
-        f"Expected parallel timing (<{delay * 1.8:.3f}s), got {elapsed:.3f}s"
+    assert tracker.max_in_flight >= 2, (
+        f"Expected both tool calls to be in flight simultaneously (concurrent "
+        f"execution), but max observed concurrency was {tracker.max_in_flight}"
     )
 
 


### PR DESCRIPTION
## Problem

CI just gained an aggregate `CI Gate (all checks passed)` job that is now a **required** status check on main. Its first run went red on a flaky timing assertion:

```
modules/loop-agent/tests/test_parallel_gating.py:250 :: test_parallel_when_enabled_and_multiple
>       assert elapsed < delay * 1.8, (
E       AssertionError: Expected parallel timing (<0.180s), got 0.499s
E       assert 0.49887997499999415 < (0.1 * 1.8)
1 failed, 513 passed in 8.66s
```

- The same commit's **py3.13** cell **passed**.
- The **previous** main commit (`d1da563`) was green with the **identical** test.

This is a wall-clock ratio assertion running on a shared, contended GitHub Actions runner — a scheduling hiccup fails it. Now that the aggregate gate is required, every such hiccup blocks every PR in the repo.

Locally the test **never flakes**: 5/5 runs of `uv run pytest -q tests/test_parallel_gating.py` passed in ~0.35s total (see below). That's expected and honest — the margin problem is runner contention, not test logic on this machine. The CI evidence stands on its own.

## Why a wider threshold / retry plugin is not the fix

Widening the ratio or adding a rerun-on-failure plugin treats the symptom. The threshold will still be wrong for *some* contention level; it just moves the flake rate around. The test's actual intent — "when parallel tool execution is enabled and there are multiple calls, they run concurrently rather than serially" — has nothing to do with wall-clock time at all.

## Fix

Replaced the wall-clock assertions in both `test_parallel_when_enabled_and_multiple` and its sequential counterpart `test_sequential_timing` with a deterministic concurrency tracker:

```python
class _ConcurrencyTracker:
    """Records the high-water mark of simultaneously in-flight calls.

    Deterministic substitute for wall-clock timing assertions: a serial
    implementation can never observe more than 1 call in flight at once;
    a concurrent (gather-based) implementation of N overlapping calls must
    observe N in flight at some point. Immune to machine speed/contention.
    """

    def __init__(self):
        self.in_flight = 0
        self.max_in_flight = 0
        self._lock = asyncio.Lock()

    async def enter(self):
        async with self._lock:
            self.in_flight += 1
            self.max_in_flight = max(self.max_in_flight, self.in_flight)

    async def exit(self):
        async with self._lock:
            self.in_flight -= 1


def _make_tracked_tool(name: str, tracker: "_ConcurrencyTracker", delay: float = 0.05):
    """Tool that records its in-flight window on a shared concurrency tracker."""
    tool = MagicMock()
    tool.name = name
    tool.description = f"Mock {name}"
    tool.input_schema = {"type": "object", "properties": {}}

    async def tracked_execute(args):
        await tracker.enter()
        try:
            await asyncio.sleep(delay)
            return ToolResult(success=True, output="ok")
        finally:
            await tracker.exit()

    tool.execute = AsyncMock(side_effect=tracked_execute)
    return tool
```

`test_parallel_when_enabled_and_multiple` now asserts:

```python
assert tracker.max_in_flight >= 2, (
    f"Expected both tool calls to be in flight simultaneously (concurrent "
    f"execution), but max observed concurrency was {tracker.max_in_flight}"
)
```

`test_sequential_timing` (kept, name preserved) now asserts the opposite:

```python
assert tracker.max_in_flight == 1, (
    f"Expected sequential execution to never overlap (max 1 in flight), "
    f"but observed {tracker.max_in_flight} simultaneously in flight"
)
```

Neither assertion depends on wall-clock elapsed time or the mock delay's magnitude — only on whether calls actually overlapped in the event loop. Immune to machine speed and scheduler contention. `import time` is no longer used and was removed.

## Proof the new assertion is not vacuous (negative control)

Before committing, ran a throwaway test (not part of this PR) that monkeypatches `asyncio.gather` — as seen by `amplifier_module_loop_agent.agent_session` — to await its coroutines **sequentially** instead of concurrently, simulating what a serial ("fake parallel") implementation would do:

```python
async def _serial_gather(*coros, **kwargs):
    results = []
    for c in coros:
        results.append(await c)
    return results

monkeypatch.setattr(agent_session_module.asyncio, "gather", _serial_gather)
```

Running the exact same assertion shape against the serialized gather:

```
E       AssertionError: Expected both tool calls to be in flight simultaneously (concurrent execution), but max observed concurrency was 1
E       assert 1 >= 2
E        +  where 1 = <tests.test_negative_control_TEMP._ConcurrencyTracker object at 0xf2a8175a0c20>.max_in_flight
tests/test_negative_control_TEMP.py:130: AssertionError
FAILED tests/test_negative_control_TEMP.py::test_parallel_assertion_fails_against_serial_gather
1 failed in 0.16s
```

Restored to the real (concurrent) `asyncio.gather`, the committed test passes:

```
tests/test_parallel_gating.py .........                                  [100%]
9 passed in 0.30s
```

So a serial implementation fails this test loudly, and the concurrent implementation passes it — the assertion is load-bearing, not vacuous.

## Full suite

```
$ cd modules/loop-agent && uv run pytest -q
514 passed in 6.73s
```

(previously 513 passed + 1 flaky failure; no other regressions)

## What's in this PR

- `modules/loop-agent/tests/test_parallel_gating.py`: removed the unused `import time`; added `_ConcurrencyTracker` + `_make_tracked_tool`; rewrote `test_sequential_timing` and `test_parallel_when_enabled_and_multiple` to assert on tracked concurrency instead of elapsed time. `_make_slow_tool` is kept (it's still a reasonable general-purpose helper) though these two tests no longer use it; `ruff check` reports no issues.

No production code changed — this is test-only.

---

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>
