### PR TITLE
docs: state CI-green as an explicit pre-merge gate (all paths)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,7 @@
 - [ ] AGENTS.md reviewed; repo-specific gates met
 - [ ] Backward-compat path unchanged (if applicable)
 - [ ] PR body includes verification evidence, not just "tests pass"
+- [ ] **CI is green before merge — on every path** (auto-merge, manual/UI merge, or agentic/CLI merge). Confirm with `gh pr checks <n>` and look for `CI Gate (all checks passed)` reporting `pass`. `--admin` may bypass the code-owner review requirement only (see `AGENTS.md`) — it must never bypass a red or pending `CI Gate`.
 
 ## Verification evidence
 <!-- Paste the relevant slice of events.jsonl, test-run output, or other proof here. For engine/handler changes, include enough of the event stream to demonstrate the changed path actually fired. -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,18 @@ If you need to describe *where* to run a pipeline, say "any attractor-compatible
 "any Amplifier session with the loop-pipeline module loaded" — not the name of a specific
 downstream resolver.
 
+## Merge discipline: CI Gate is required, never bypass it
+
+Branch protection on `main` requires exactly one status check: **`CI Gate (all checks passed)`** (the aggregate job in `.github/workflows/ci.yml` — fails if the unit-test matrix, live-graph gate, or type-check is failure, cancelled, or skipped). Before running `gh pr merge` — auto, manual/UI, or `--admin` — check it:
+
+    gh pr checks <n>
+
+Confirm `CI Gate (all checks passed)` reports `pass`. If it's still pending, use `--auto` (merges once it's green); if it's red, fix it — don't merge past it.
+
+**`--admin` bypasses the code-owner review requirement only.** That's a legitimate, routine use here: branch protection requires 1 code-owner approval, and a solo/sole-code-owner author cannot approve their own PR — `--admin` is how that PR still ships. **`--admin` must never be used to bypass a red or pending `CI Gate`.** GitHub does not technically stop you from doing so today (`enforce_admins` is off) — this is a discipline rule backed by a required check, not an unbypassable technical control, so it holds regardless of whether `enforce_admins` ever gets flipped on.
+
+This rule exists because this repo previously shipped a fake type-check test (`skipif`'d away on every CI runner, so it always "passed") and ran the rest of CI as advisory-only — no required status check at all. On `CI Gate`'s first run as a required check, it caught a real red on `main` (a flaky timing assertion in `loop-agent`'s parallel-gating tests). Don't reopen either gap: don't let a check go back to advisory, and don't let `--admin` become the way around it.
+
 ## PR checklist
 
 `.github/PULL_REQUEST_TEMPLATE.md` will appear automatically when you open a PR. Honor it. The boxes are not decorative.


### PR DESCRIPTION
## Summary

Docs-only change making it unambiguous, in the two places a human or an agent reads before merging, that **CI must be green before any merge — by any path** (auto-merge, manual/UI merge, or agentic/CLI merge).

## Why now

Branch protection on `main` was recently tightened to require exactly one status check: `CI Gate (all checks passed)` (the aggregate job in `.github/workflows/ci.yml` — fails if the unit-test matrix, live-graph gate, or type-check job is failure, cancelled, or skipped).

This was verified live via a throwaway probe, PR #131 (`[probe] verify required-check enforcement — DO NOT MERGE`, since closed with no merge): with checks pending, `mergeStateStatus=BLOCKED` and `gh pr merge` on the normal path is refused — GitHub's own refusal offers `--auto` (merge once requirements are met) and `--admin` (bypass immediately) as the two ways forward.

Only one of those is ever appropriate here, and the nuance is exactly what this PR documents: **`enforce_admins` is `false`**, so an admin *can* bypass the gate — and in this repo, an admin merge is *routinely legitimate for a different reason*: branch protection also requires 1 code-owner approval, and the sole code owner cannot approve their own PR. `--admin` is the correct tool for that review-requirement bypass. It must never be the tool for a red or pending `CI Gate`.

## What changed

- **`.github/PULL_REQUEST_TEMPLATE.md`**: new checklist item requiring CI-green confirmation (`gh pr checks <n>`, looking for `CI Gate (all checks passed)` = `pass`) before merge, worded to cover all three merge paths.
- **`AGENTS.md`**: new "Merge discipline: CI Gate is required, never bypass it" section — the permitted use of `--admin` (code-owner review bypass) vs. the prohibited use (CI Gate bypass), the check-first command, and why the rule exists: this repo previously shipped a fake type-check test (silently `skipif`'d on every CI runner) and ran the rest of CI as advisory-only (no required status check at all); on `CI Gate`'s first run as a required check, it caught a real red on `main` (a flaky timing assertion in `loop-agent`'s parallel-gating tests, fixed in `d9bb76e`).

No overclaiming: the PR states plainly that GitHub currently *permits* admin bypass and that this is a discipline rule backed by a required check, not an unbypassable technical control — worded so it still reads correctly if `enforce_admins` is ever flipped on.

## Discovery notes

- No root-level `PULL_REQUEST_TEMPLATE.md` exists — only `.github/PULL_REQUEST_TEMPLATE.md`. Nothing to reconcile/de-duplicate.
- `PRINCIPLES.md` is upstream-spec-linkage discipline (walk-upstream-first, intentional deltas from the `strongdm/attractor` nlspec), not merge process. Left untouched — not its natural home.

## Verification checklist

- [x] Unit tests pass (`pytest modules/loop-pipeline/`) — N/A, docs-only, no code touched.
- [x] Live pipeline run — N/A, docs-only, no `engine.py`/handler code touched.
- [x] AGENTS.md reviewed; repo-specific gates met.
- [x] Backward-compat path unchanged — N/A, docs-only.
- [x] PR body includes verification evidence, not just "tests pass" — see below.
- [x] CI is green before merge — awaiting this PR's own `CI Gate (all checks passed)` run (see below); will not be merged by me — reviewer/caller merges after confirming the gate.

## Verification evidence

Gates run locally before opening:

```
$ git diff --check
(clean, exit 0)

$ cd modules/loop-pipeline && uv run pytest tests/test_engine_semantics_doc_guard.py -q
.......                                                                  [100%]
7 passed in 0.04s

$ cd modules/loop-pipeline && uv run pytest tests/test_doc_consistency.py -q
....                                                                     [100%]
4 passed in 0.01s
```

## Notes for reviewers

Docs-only PR (2 files, +13/-0 lines). Not merging this myself — please confirm `CI Gate (all checks passed)` is green (`gh pr checks <PR#>`) before merging, which is exactly the discipline this PR asks everyone (including me) to follow going forward.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>