### PR TITLE
fix: validate DOT retry budgets

### DIFF
--- a/docs/DOT-AUTHORING-GUIDE.md
+++ b/docs/DOT-AUTHORING-GUIDE.md
@@ -1079,9 +1079,25 @@ change run-time validation behaviour.
 - Errors (ERROR severity) → exit 1 (pipeline will not execute correctly)
 - Warnings only → exit 0 (use `--strict` to treat warnings as errors)
 
-**Spec note:** These lint rules are lint-only — they do not change run-time
-behaviour and require no `specs/EXTENSIONS.md` entry.  They enforce the
-canonical attractor spec's routing semantics statically, at author time.
+Two structural errors are enforced by both run-time `validate()` and `attractor
+lint`:
+
+- **`tool_command_requires_tool_handler`** -- a non-empty `tool_command`
+  requires the effective built-in `tool` handler. Use `shape=parallelogram`,
+  `type=tool`, or `node_type=tool`; do not attach shell commands to a node
+  explicitly handled as `codergen` or another recognized built-in type.
+- **`retry_budget_non_negative`** -- node `max_retries` and graph defaults
+  must be non-negative integers. Both graph aliases,
+  `default_max_retry` and `default_max_retries`, are accepted. Valid forms
+  include `0`, `2`, and quoted integers such as `"2"`. Booleans, negative
+  values, fractions, and malformed strings are rejected, including `true`,
+  `-1`, `1.5`, and `"invalid"`.
+
+**Spec note:** The structural errors above are also run-time validation
+errors. The topology and command-content rules below are lint-only: they do
+not change run-time behaviour and require no `specs/EXTENSIONS.md` entry.
+They enforce the canonical attractor spec's routing semantics statically, at
+author time.
 
 ---
 

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/dot_parser.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/dot_parser.py
@@ -449,9 +449,10 @@ def _set_graph_attr(ctx: _ParseContext, key: str, val: Any) -> None:
     if key == "goal":
         ctx.graph_fields["goal"] = str(val)
     elif key in ("default_max_retry", "default_max_retries"):
-        ctx.graph_fields["default_max_retry"] = (
-            int(val) if not isinstance(val, int) else val
-        )
+        # Preserve the parsed value for structural validation. Coercing here
+        # truncated fractions, accepted booleans as integers, and raised before
+        # validate() could return a deterministic diagnostic for malformed text.
+        ctx.graph_fields["default_max_retry"] = val
     elif key == "model_stylesheet":
         ctx.graph_fields["model_stylesheet"] = str(val)
     elif key == "max_pipeline_duration":

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/retry.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/retry.py
@@ -176,8 +176,19 @@ class RetryPolicy:
         if max_retries is None:
             max_retries = 0
 
-        max_retries = int(max_retries)
+        max_retries = _parse_non_negative_retry_count(max_retries)
         return cls(max_attempts=max_retries + 1)
+
+
+def _parse_non_negative_retry_count(value: object) -> int:
+    """Return a validated retry count compatible with structural validation."""
+    if isinstance(value, bool):
+        raise ValueError("max_retries must be a non-negative integer, not a boolean")
+    if isinstance(value, int) and value >= 0:
+        return value
+    if isinstance(value, str) and re.fullmatch(r"[+]?\d+", value.strip()):
+        return int(value)
+    raise ValueError(f"max_retries must be a non-negative integer, got {value!r}")
 
 
 async def execute_with_retry(

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/validation.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/validation.py
@@ -102,6 +102,8 @@ def validate(
     _check_fidelity_valid(graph, diags)
     _check_retry_target_exists(graph, diags)
     _check_response_schema(graph, diags)
+    _check_tool_command_handler(graph, diags)
+    _check_retry_budgets(graph, diags)
 
     # L-19: Run user-supplied extra rules
     for rule in extra_rules or []:
@@ -377,6 +379,81 @@ def _check_prompt_on_llm_nodes(graph: Graph, diags: list[Diagnostic]) -> None:
 
 # All known handler types (values from SHAPE_TO_HANDLER mapping)
 _KNOWN_HANDLER_TYPES: frozenset[str] = frozenset(SHAPE_TO_HANDLER.values())
+
+
+def _effective_handler_type(node: Node) -> str | None:
+    """Mirror built-in runtime precedence without blocking custom handlers."""
+    explicit_types = (node.type, node.attrs.get("node_type"))
+    for explicit_type in explicit_types:
+        if explicit_type in _KNOWN_HANDLER_TYPES:
+            return explicit_type
+    if any(explicit_types):
+        return None
+    return SHAPE_TO_HANDLER.get(node.shape)
+
+
+def _check_tool_command_handler(graph: Graph, diags: list[Diagnostic]) -> None:
+    """Reject commands that a recognized non-tool handler would silently ignore."""
+    for node in graph.nodes.values():
+        command = node.attrs.get("tool_command")
+        if command is None or not str(command).strip():
+            continue
+
+        handler_type = _effective_handler_type(node)
+        if handler_type is not None and handler_type != "tool":
+            diags.append(
+                Diagnostic(
+                    rule="tool_command_requires_tool_handler",
+                    severity="ERROR",
+                    message=(
+                        f"Node '{node.id}' has tool_command but resolves to "
+                        f"recognized built-in non-tool handler '{handler_type}'"
+                    ),
+                    node_id=node.id,
+                    fix="Use shape=parallelogram or type=tool, or remove tool_command",
+                )
+            )
+
+
+def _check_retry_budgets(graph: Graph, diags: list[Diagnostic]) -> None:
+    """Reject retry values that cannot safely form an attempt count."""
+    for node in graph.nodes.values():
+        if node.max_retries is not None and _retry_value(node.max_retries) is None:
+            diags.append(
+                Diagnostic(
+                    rule="retry_budget_non_negative",
+                    severity="ERROR",
+                    message=(
+                        f"Node '{node.id}' has invalid max_retries="
+                        f"{node.max_retries!r}; expected a non-negative integer"
+                    ),
+                    node_id=node.id,
+                    fix="Set max_retries to zero or a positive integer",
+                )
+            )
+
+    if _retry_value(graph.default_max_retry) is None:
+        diags.append(
+            Diagnostic(
+                rule="retry_budget_non_negative",
+                severity="ERROR",
+                message=(
+                    "Graph default_max_retry/default_max_retries must be zero "
+                    f"or a positive integer, got {graph.default_max_retry!r}"
+                ),
+                fix="Set the graph retry default to zero or a positive integer",
+            )
+        )
+
+
+def _retry_value(value: object) -> int | None:
+    """Return a safe non-negative retry integer, accepting quoted integers."""
+    try:
+        from .retry import _parse_non_negative_retry_count
+
+        return _parse_non_negative_retry_count(value)
+    except ValueError:
+        return None
 
 
 def _check_condition_syntax(graph: Graph, diags: list[Diagnostic]) -> None:

--- a/modules/loop-pipeline/tests/test_dot_parser.py
+++ b/modules/loop-pipeline/tests/test_dot_parser.py
@@ -8,7 +8,7 @@ and graph-level attributes.
 import pytest
 
 from amplifier_module_loop_pipeline.dot_parser import parse_dot
-
+from amplifier_module_loop_pipeline.validation import validate
 
 # --- Basic parsing ---
 
@@ -232,6 +232,42 @@ def test_integer_values():
     assert graph.nodes["A"].attrs.get("max_retries") == 3
 
 
+@pytest.mark.parametrize(
+    ("raw_value", "is_valid"),
+    [
+        ("-1", False),
+        ('"-1"', False),
+        ("true", False),
+        ("1.5", False),
+        ('"1.5"', False),
+        ("invalid", False),
+        ("0", True),
+        ("2", True),
+        ('"2"', True),
+    ],
+)
+def test_parsed_node_retry_values_are_validated(raw_value: str, is_valid: bool):
+    """Raw DOT node retry syntax reaches structural validation without coercion leaks."""
+    graph = parse_dot(
+        f"""
+        digraph RetryBudget {{
+            start [shape=Mdiamond]
+            work [shape=box, prompt="work", max_retries={raw_value}]
+            exit [shape=Msquare]
+            start -> work -> exit
+        }}
+        """
+    )
+
+    errors = [
+        diagnostic
+        for diagnostic in validate(graph)
+        if diagnostic.rule == "retry_budget_non_negative"
+        and diagnostic.node_id == "work"
+    ]
+    assert bool(errors) is not is_valid
+
+
 def test_leading_dot_float_values():
     """Leading-dot floats like .5 should be parsed as 0.5 (L-1)."""
     graph = parse_dot("""
@@ -315,6 +351,60 @@ def test_graph_level_attributes_bare():
     """)
     assert graph.goal == "Build the feature"
     assert graph.default_max_retry == 5
+
+
+@pytest.mark.parametrize(
+    ("alias", "value"),
+    [
+        ("default_max_retry", '"-1"'),
+        ("default_max_retries", "true"),
+        ("default_max_retry", "1.5"),
+        ("default_max_retries", '"invalid"'),
+    ],
+)
+def test_invalid_parsed_graph_retry_aliases_reach_validation(alias: str, value: str):
+    """The parser preserves malformed defaults so validation can diagnose them."""
+    graph = parse_dot(
+        f"""
+        digraph RetryBudget {{
+            graph [{alias}={value}]
+            start [shape=Mdiamond]
+            work [shape=box, prompt="work"]
+            exit [shape=Msquare]
+            start -> work -> exit
+        }}
+        """
+    )
+
+    diagnostics = validate(graph)
+
+    assert any(
+        diagnostic.rule == "retry_budget_non_negative"
+        and diagnostic.severity == "ERROR"
+        for diagnostic in diagnostics
+    )
+
+
+@pytest.mark.parametrize("alias", ["default_max_retry", "default_max_retries"])
+def test_quoted_integer_graph_retry_aliases_are_valid(alias: str):
+    """Quoted integer defaults remain compatible for both accepted spellings."""
+    graph = parse_dot(
+        f"""
+        digraph RetryBudget {{
+            graph [{alias}="2"]
+            start [shape=Mdiamond]
+            work [shape=box, prompt="work"]
+            exit [shape=Msquare]
+            start -> work -> exit
+        }}
+        """
+    )
+
+    diagnostics = validate(graph)
+
+    assert not any(
+        diagnostic.rule == "retry_budget_non_negative" for diagnostic in diagnostics
+    )
 
 
 def test_graph_attr_block():

--- a/modules/loop-pipeline/tests/test_retry.py
+++ b/modules/loop-pipeline/tests/test_retry.py
@@ -244,6 +244,16 @@ def test_retry_policy_from_node_max_retries():
     assert policy.max_attempts == 4
 
 
+@pytest.mark.parametrize("value", [-1, "-1", True, 1.5, "1.5", "invalid"])
+def test_retry_policy_rejects_the_same_invalid_values_as_validation(value):
+    """Runtime retry coercion cannot reintroduce values structural validation rejects."""
+    node = _make_node()
+    node.max_retries = value
+
+    with pytest.raises(ValueError, match="non-negative integer"):
+        RetryPolicy.from_node(node, _make_graph())
+
+
 def test_retry_policy_from_graph_default():
     """Build policy from graph default_max_retry when node has none."""
     node = _make_node(attrs={})

--- a/modules/loop-pipeline/tests/test_validation.py
+++ b/modules/loop-pipeline/tests/test_validation.py
@@ -8,14 +8,19 @@ import re
 
 import pytest
 
+from amplifier_module_loop_pipeline.context import PipelineContext
+from amplifier_module_loop_pipeline.dot_parser import parse_dot
 from amplifier_module_loop_pipeline.graph import Edge, Graph, Node
+from amplifier_module_loop_pipeline.handlers import HandlerRegistry
+from amplifier_module_loop_pipeline.handlers.context import HandlerContext
+from amplifier_module_loop_pipeline.outcome import Outcome, StageStatus
 from amplifier_module_loop_pipeline.validation import (
     Diagnostic,
     ValidationError,
+    lint,
     validate,
     validate_or_raise,
 )
-
 
 # --- Test helpers ---
 
@@ -321,6 +326,424 @@ def test_valid_graph_no_errors():
     diags = validate(g)
     errors = [d for d in diags if d.severity == "ERROR"]
     assert len(errors) == 0
+
+
+# --- handler/tool-command and retry-budget structural errors ---
+
+
+@pytest.mark.parametrize(
+    ("node", "expected_rule"),
+    [
+        (
+            Node(
+                id="RCExhausted",
+                shape="box",
+                prompt="This is not a tool",
+                attrs={"tool_command": "exit 1"},
+            ),
+            "tool_command_requires_tool_handler",
+        ),
+        (
+            Node(
+                id="explicit_non_tool",
+                shape="parallelogram",
+                type="codergen",
+                prompt="This explicit type wins over the shape",
+                attrs={"tool_command": "exit 1"},
+            ),
+            "tool_command_requires_tool_handler",
+        ),
+    ],
+)
+def test_tool_command_on_non_tool_handler_is_error(node: Node, expected_rule: str):
+    """A command cannot silently be ignored by a non-tool handler."""
+    graph = _make_graph(
+        nodes_extra=[node],
+        edges_extra=[
+            Edge(from_node="work", to_node=node.id),
+            Edge(from_node=node.id, to_node="done"),
+        ],
+    )
+
+    diagnostics = validate(graph)
+
+    assert any(
+        diagnostic.rule == expected_rule
+        and diagnostic.severity == "ERROR"
+        and diagnostic.node_id == node.id
+        for diagnostic in diagnostics
+    )
+    with pytest.raises(ValidationError):
+        validate_or_raise(graph)
+
+
+@pytest.mark.parametrize(
+    "node",
+    [
+        Node(
+            id="tool_by_shape",
+            shape="parallelogram",
+            attrs={"tool_command": "printf ok"},
+        ),
+        Node(
+            id="tool_by_explicit_type",
+            shape="box",
+            type="tool",
+            prompt="Explicit tool handler",
+            attrs={"tool_command": "printf ok"},
+        ),
+        Node(
+            id="tool_by_node_type",
+            shape="box",
+            type="unknown.custom",
+            prompt="Recognized node_type wins after unknown explicit type",
+            attrs={"node_type": "tool", "tool_command": "printf ok"},
+        ),
+        Node(
+            id="unknown_explicit_types_preserve_custom_escape",
+            shape="box",
+            type="unknown.custom",
+            prompt="Both explicit custom names remain extensible",
+            attrs={"node_type": "also.unknown", "tool_command": "custom command"},
+        ),
+    ],
+)
+def test_tool_command_handler_check_accepts_runtime_resolved_tool_nodes(node: Node):
+    """Each runtime precedence path that resolves to tool accepts a command."""
+    graph = _make_graph(
+        nodes_extra=[node],
+        edges_extra=[
+            Edge(from_node="work", to_node=node.id),
+            Edge(from_node=node.id, to_node="done"),
+        ],
+    )
+
+    diagnostics = validate(graph)
+
+    assert not any(
+        diagnostic.rule == "tool_command_requires_tool_handler"
+        and diagnostic.node_id == node.id
+        for diagnostic in diagnostics
+    )
+
+
+def test_explicit_tool_type_wins_over_codergen_node_type():
+    """Runtime and validation both honor type before the node_type alias."""
+    node = Node(
+        id="tool_over_codergen",
+        shape="box",
+        type="tool",
+        prompt="explicit tool owns execution",
+        attrs={"node_type": "codergen", "tool_command": "printf executed"},
+    )
+    graph = _make_graph(
+        nodes_extra=[node],
+        edges_extra=[
+            Edge(from_node="work", to_node=node.id),
+            Edge(from_node=node.id, to_node="done"),
+        ],
+    )
+
+    assert type(HandlerRegistry(HandlerContext()).get(node)).__name__ == "ToolHandler"
+    assert not any(
+        diagnostic.rule == "tool_command_requires_tool_handler"
+        and diagnostic.node_id == node.id
+        for diagnostic in validate(graph)
+    )
+
+
+def test_unknown_type_known_codergen_node_type_rejects_ignored_tool_command():
+    """Validation follows runtime to codergen after an unknown custom type."""
+    node = Node(
+        id="unknown_then_codergen",
+        shape="parallelogram",
+        type="unknown.custom",
+        prompt="codergen owns execution",
+        attrs={"node_type": "codergen", "tool_command": "printf ignored"},
+    )
+    graph = _make_graph(
+        nodes_extra=[node],
+        edges_extra=[
+            Edge(from_node="work", to_node=node.id),
+            Edge(from_node=node.id, to_node="done"),
+        ],
+    )
+
+    assert (
+        type(HandlerRegistry(HandlerContext()).get(node)).__name__ == "CodergenHandler"
+    )
+    diagnostics = validate(graph)
+    assert any(
+        diagnostic.rule == "tool_command_requires_tool_handler"
+        and diagnostic.severity == "ERROR"
+        and diagnostic.node_id == node.id
+        for diagnostic in diagnostics
+    )
+
+
+def test_unknown_type_known_tool_node_type_allows_tool_command():
+    """Validation follows runtime to tool after an unknown custom type."""
+    node = Node(
+        id="unknown_then_tool",
+        shape="box",
+        type="unknown.custom",
+        prompt="tool owns execution",
+        attrs={"node_type": "tool", "tool_command": "printf executed"},
+    )
+    graph = _make_graph(
+        nodes_extra=[node],
+        edges_extra=[
+            Edge(from_node="work", to_node=node.id),
+            Edge(from_node=node.id, to_node="done"),
+        ],
+    )
+
+    assert type(HandlerRegistry(HandlerContext()).get(node)).__name__ == "ToolHandler"
+    diagnostics = validate(graph)
+    assert not any(
+        diagnostic.rule == "tool_command_requires_tool_handler"
+        and diagnostic.node_id == node.id
+        for diagnostic in diagnostics
+    )
+
+
+@pytest.mark.parametrize(
+    "node",
+    [
+        Node(
+            id="recognized_type_wins",
+            shape="parallelogram",
+            type="codergen",
+            prompt="Recognized explicit type wins",
+            attrs={"node_type": "tool", "tool_command": "printf ignored"},
+        ),
+        Node(
+            id="recognized_node_type_wins",
+            shape="parallelogram",
+            type="unknown.custom",
+            prompt="Recognized node_type wins",
+            attrs={"node_type": "codergen", "tool_command": "printf ignored"},
+        ),
+        Node(
+            id="known_conditional",
+            shape="parallelogram",
+            type="conditional",
+            prompt="Known conditional cannot execute a command",
+            attrs={"tool_command": "printf ignored"},
+        ),
+        Node(
+            id="unknown_type_known_conditional",
+            shape="parallelogram",
+            type="unknown.custom",
+            prompt="Known node_type follows unknown custom type",
+            attrs={"node_type": "conditional", "tool_command": "printf ignored"},
+        ),
+    ],
+)
+def test_tool_command_handler_check_matches_runtime_non_tool_precedence(node: Node):
+    """Definitive recognized built-in non-tool handlers reject commands."""
+    graph = _make_graph(
+        nodes_extra=[node],
+        edges_extra=[
+            Edge(from_node="work", to_node=node.id),
+            Edge(from_node=node.id, to_node="done"),
+        ],
+    )
+
+    diagnostics = validate(graph)
+
+    assert any(
+        diagnostic.rule == "tool_command_requires_tool_handler"
+        and diagnostic.severity == "ERROR"
+        and diagnostic.node_id == node.id
+        for diagnostic in diagnostics
+    )
+
+
+@pytest.mark.asyncio
+async def test_registered_custom_handler_with_tool_command_is_not_blocked(tmp_path):
+    """Unknown explicit types remain available to runtime-registered handlers."""
+
+    class CustomHandler:
+        async def execute(self, node, context, graph, logs_root, *, engine=None):
+            return Outcome(status=StageStatus.SUCCESS, notes="custom executed")
+
+    node = Node(
+        id="custom",
+        shape="box",
+        type="custom.handler",
+        prompt="custom work",
+        attrs={"tool_command": "custom handler owns this attribute"},
+    )
+    graph = _make_graph(
+        nodes_extra=[node],
+        edges_extra=[
+            Edge(from_node="work", to_node=node.id),
+            Edge(from_node=node.id, to_node="done"),
+        ],
+    )
+
+    diagnostics = validate(graph)
+    assert not any(
+        diagnostic.rule == "tool_command_requires_tool_handler"
+        and diagnostic.node_id == node.id
+        for diagnostic in diagnostics
+    )
+
+    registry = HandlerRegistry(HandlerContext())
+    handler = CustomHandler()
+    registry.register("custom.handler", handler)
+
+    assert registry.get(node) is handler
+    outcome = await registry.get(node).execute(
+        node,
+        PipelineContext(),
+        graph,
+        str(tmp_path),
+    )
+    assert outcome.status == StageStatus.SUCCESS
+
+
+@pytest.mark.parametrize(
+    ("node_retries", "graph_default"),
+    [
+        (-1, ""),
+        (
+            None,
+            "graph [default_max_retry=-1]",
+        ),
+        (
+            None,
+            "graph [default_max_retries=-1]",
+        ),
+    ],
+)
+def test_negative_effective_retry_budget_is_error(
+    node_retries: int | None,
+    graph_default: str,
+):
+    """Node and both parsed graph-default spellings reject negative retry budgets."""
+    graph = parse_dot(
+        f"""
+        digraph RetryBudget {{
+            {graph_default}
+            start [shape=Mdiamond]
+            work [shape=box, prompt="work"]
+            exit [shape=Msquare]
+            start -> work -> exit
+        }}
+        """
+    )
+    if node_retries is not None:
+        graph.nodes["work"].max_retries = -1
+
+    diagnostics = validate(graph)
+
+    assert any(
+        diagnostic.rule == "retry_budget_non_negative"
+        and diagnostic.severity == "ERROR"
+        for diagnostic in diagnostics
+    )
+    with pytest.raises(ValidationError):
+        validate_or_raise(graph)
+
+
+def test_zero_and_node_override_retry_budgets_are_valid():
+    """Zero is valid and a non-negative node override wins over a graph default."""
+    graph = _make_graph(graph_attrs={"default_max_retry": 3})
+    graph.nodes["work"].max_retries = 0
+
+    diagnostics = validate(graph)
+
+    assert not any(
+        diagnostic.rule == "retry_budget_non_negative" for diagnostic in diagnostics
+    )
+
+
+@pytest.mark.parametrize("value", [-1, "-1", True, 1.5, "1.5", "invalid"])
+def test_invalid_programmatic_node_retry_values_are_deterministic_errors(value):
+    """Validation rejects unsafe node retry values without raising Python errors."""
+    graph = _make_graph()
+    graph.nodes["work"].max_retries = value
+
+    diagnostics = validate(graph)
+
+    assert any(
+        diagnostic.rule == "retry_budget_non_negative"
+        and diagnostic.severity == "ERROR"
+        and diagnostic.node_id == "work"
+        for diagnostic in diagnostics
+    )
+
+
+@pytest.mark.parametrize("value", [-1, "-1", True, 1.5, "1.5", "invalid"])
+def test_invalid_programmatic_graph_retry_values_are_deterministic_errors(value):
+    """Validation rejects unsafe graph defaults without TypeError or truncation."""
+    graph = _make_graph()
+    graph.default_max_retry = value
+
+    diagnostics = validate(graph)
+
+    assert any(
+        diagnostic.rule == "retry_budget_non_negative"
+        and diagnostic.severity == "ERROR"
+        and not diagnostic.node_id
+        for diagnostic in diagnostics
+    )
+
+
+def test_quoted_integer_node_retry_is_valid():
+    """Programmatic quoted integer node retries remain accepted."""
+    graph = _make_graph()
+    graph.nodes["work"].max_retries = "2"
+
+    diagnostics = validate(graph)
+
+    assert not any(
+        diagnostic.rule == "retry_budget_non_negative" for diagnostic in diagnostics
+    )
+
+
+def test_lint_includes_tool_command_handler_structural_error():
+    """The public lint surface includes structural handler/command errors."""
+    graph = parse_dot(
+        """
+        digraph HandlerMismatch {
+            start [shape=Mdiamond]
+            RCExhausted [shape=box, prompt="not a tool", tool_command="exit 1"]
+            exit [shape=Msquare]
+            start -> RCExhausted -> exit
+        }
+        """
+    )
+
+    assert any(
+        diagnostic.rule == "tool_command_requires_tool_handler"
+        and diagnostic.severity == "ERROR"
+        and diagnostic.node_id == "RCExhausted"
+        for diagnostic in lint(graph)
+    )
+
+
+def test_lint_includes_retry_budget_structural_error():
+    """The public lint surface includes negative retry-budget errors."""
+    graph = parse_dot(
+        """
+        digraph RetryBudget {
+            start [shape=Mdiamond]
+            work [shape=box, prompt="work", max_retries=-1]
+            exit [shape=Msquare]
+            start -> work -> exit
+        }
+        """
+    )
+
+    assert any(
+        diagnostic.rule == "retry_budget_non_negative"
+        and diagnostic.severity == "ERROR"
+        and diagnostic.node_id == "work"
+        for diagnostic in lint(graph)
+    )
 
 
 # --- Diagnostic model ---


### PR DESCRIPTION
## Summary

Fail early and deterministically on malformed DOT retry budgets and on `tool_command` attributes that would be ignored by a recognized non-tool handler. The parser now preserves malformed retry values long enough for validation to produce actionable diagnostics, runtime retry parsing enforces the same nonnegative-integer contract, handler resolution follows runtime precedence while preserving the unknown-custom-handler extension point, and the authoring guide documents the accepted and rejected forms.

## Verification checklist

- [x] Unit tests pass (`pytest modules/loop-pipeline/`)
- [x] Live pipeline run exercising changed code path — **N/A: this PR does not change `engine.py` or any handler; the runtime strict retry parser and public validation/lint surfaces are exercised directly by tests**
- [x] AGENTS.md reviewed; repo-specific gates met
- [x] Backward-compat path unchanged (if applicable)
- [x] PR body includes verification evidence, not just "tests pass"
- [ ] **CI is green before merge — on every path** (auto-merge, manual/UI merge, or agentic/CLI merge). Confirm with `gh pr checks <n>` and look for `CI Gate (all checks passed)` reporting `pass`. `--admin` may bypass the code-owner review requirement only (see `AGENTS.md`) — it must never bypass a red or pending `CI Gate`. — **Pending until this PR exists and CI runs; `CI Gate (all checks passed)` is required before merge.**

## Verification evidence

Independent branch `fix/dot-validation-retry-budgets` at `44e1725a040fcc9f29244896b0491684146c7eae`:

```text
loop-pipeline full suite:
1784 passed, 1 skipped, 3 warnings

focused parser/retry/validation/lint suites:
PASS

git diff --check:
PASS
```

Focused coverage includes:

```text
modules/loop-pipeline/tests/test_dot_parser.py
modules/loop-pipeline/tests/test_retry.py
modules/loop-pipeline/tests/test_validation.py
modules/loop-pipeline/tests/test_topological_lint.py
modules/loop-pipeline/tests/test_command_content_lint.py
modules/loop-pipeline/tests/test_examples_lint_clean.py
```

The tests prove that:

```text
valid retry budgets:
  0, positive integers, and quoted integer strings -> accepted

invalid retry budgets:
  negatives, booleans, fractions, and malformed strings -> deterministic ERROR

handler validation:
  known non-tool handler + tool_command -> tool_command_requires_tool_handler ERROR
  recognized tool handler + tool_command -> accepted
  unknown custom handler -> not blocked by the built-in-only rule
```

The three warnings are the known DOT parser warnings for space-separated attributes.

## Notes for reviewers

- Valid nonnegative integer values and quoted integer strings keep their existing behavior.
- The parser intentionally preserves malformed values instead of truncating or raising early, allowing `validate()` and `lint()` to return stable diagnostics.
- Runtime `RetryPolicy` parsing enforces the same contract as validation, preventing booleans, fractions, malformed strings, or negative values from slipping through alternate call paths.
- Built-in handler precedence matches runtime resolution: recognized `type`, then recognized `node_type`, then shape fallback. Explicit unknown custom handlers retain their extension escape hatch.
- The new diagnostics are documented in `docs/DOT-AUTHORING-GUIDE.md` for `max_retries`, `default_max_retry`, and `default_max_retries`.
- A live pipeline run is not required for this PR because it changes neither `engine.py` nor handler dispatch; the changed runtime parser and public lint/validation paths are directly covered by the focused and full suites above.
- This branch is an independent one-commit child of `fda5e6a68fb9551c5e8dde423f96654d29e3dee0`; it does not depend on the outcome-transport PR.
- CI remains pending. Do not merge until `CI Gate (all checks passed)` reports `pass`.

---
See: [Per-Repo Conventions](https://github.com/microsoft/amplifier-foundation/blob/main/docs/PER_REPO_CONVENTIONS.md) and this repo's `AGENTS.md` for the verification discipline this checklist enforces.
