### PR TITLE
fix: restore §31/32/33 ledger entries clobbered by a -Xtheirs rebase

### DIFF
--- a/modules/loop-pipeline/tests/test_extensions_ledger_integrity.py
+++ b/modules/loop-pipeline/tests/test_extensions_ledger_integrity.py
@@ -1,0 +1,166 @@
+"""Ledger-integrity guard for ``specs/EXTENSIONS.md``.
+
+Guards against a class of damage discovered in practice: a rebase conflict on
+``specs/EXTENSIONS.md`` resolved with ``git rebase -Xtheirs`` silently
+discarded three already-merged ledger entries (`## 31.`, `## 32.`, `## 33.`)
+while a fourth PR's own new entry (`## 34.`) survived, because `-Xtheirs`
+takes one side's *whole file* rather than reconciling both sides' additions.
+The numbering on either side of the gap stayed superficially plausible
+(`## 30.` immediately followed by `## 34.`), and nothing asserted that the
+sequence was supposed to be contiguous, so CI went green on a main branch
+that had quietly lost three merged entries.
+
+This test closes that gap: it asserts the numbered ``## N.`` section headings
+in ``specs/EXTENSIONS.md`` form a contiguous ``1..max`` sequence with no gaps
+and no duplicates. It does NOT check entry *content* (that a section's prose
+is correct) -- only that the heading sequence itself is not missing entries
+or double-counting one, which is exactly the invariant a silent multi-entry
+clobber violates while leaving individually well-formed headings behind.
+
+Honest limits:
+  - This is a structural (heading-sequence) check, not a content check. A
+    rebase resolution that clobbered *prose inside* a still-numbered section
+    (rather than dropping whole headings) would not be caught here.
+  - Non-numbered headings (``## Entry Format``, ``## Conformance Restoration
+    Note (T0-4)``) are deliberately excluded from the sequence -- they are
+    not ledger entries and carry no number to validate.
+"""
+
+import re
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+BUNDLE_ROOT = Path(__file__).parent.parent.parent.parent
+LEDGER_PATH = BUNDLE_ROOT / "specs" / "EXTENSIONS.md"
+
+# Matches "## 31. Title..." style numbered ledger-entry headings only.
+# Non-numbered headings ("## Entry Format", "## Conformance Restoration
+# Note (T0-4)") do not match and are correctly excluded from the sequence.
+_SECTION_HEADING_RE = re.compile(r"^## (\d+)\.", re.MULTILINE)
+
+
+def _section_numbers(text: str) -> list[int]:
+    """Extract the numbered ``## N.`` section headings, in document order."""
+    return [int(n) for n in _SECTION_HEADING_RE.findall(text)]
+
+
+def _find_ledger_gaps_and_duplicates(text: str) -> tuple[list[int], list[int]]:
+    """Return ``(gaps, duplicates)`` in the numbered section sequence.
+
+    ``gaps``: section numbers in ``1..max(observed)`` that never appear.
+    ``duplicates``: section numbers that appear more than once, in the order
+    their *second* (repeat) occurrence is seen.
+    """
+    numbers = _section_numbers(text)
+    if not numbers:
+        return [], []
+
+    seen: set[int] = set()
+    duplicates: list[int] = []
+    for n in numbers:
+        if n in seen:
+            duplicates.append(n)
+        seen.add(n)
+
+    expected = set(range(1, max(numbers) + 1))
+    gaps = sorted(expected - seen)
+    return gaps, duplicates
+
+
+# ---------------------------------------------------------------------------
+# Live-file check: the actual specs/EXTENSIONS.md must be contiguous today.
+# ---------------------------------------------------------------------------
+
+
+def test_extensions_ledger_section_numbers_contiguous_no_gaps_or_duplicates():
+    """specs/EXTENSIONS.md's numbered ``## N.`` headings must be 1..max with
+    no gaps and no duplicates.
+
+    A gap here means a merged ledger entry has gone missing (e.g. a rebase
+    conflict resolved with ``-Xtheirs`` silently dropped one side's
+    additions) even though the numbering on either side of the hole still
+    looks superficially fine. A duplicate means two entries claim the same
+    section number, which is its own form of ledger corruption (e.g. a
+    stacked-branch rebase that renumbered one entry to collide with another
+    instead of the next free number).
+    """
+    text = LEDGER_PATH.read_text()
+    gaps, duplicates = _find_ledger_gaps_and_duplicates(text)
+
+    assert not gaps, (
+        f"specs/EXTENSIONS.md is missing numbered ledger section(s): {gaps}. "
+        "The heading sequence jumps over these numbers even though entries "
+        "on both sides are present and well-formed -- this is exactly the "
+        "shape of a rebase conflict resolved with 'git rebase -Xtheirs' (or "
+        "a merge that silently took one side's whole file) discarding "
+        "already-merged entries. Restore the missing section(s) verbatim "
+        "from the commit that last had them (check git log/blame on this "
+        "file), do not re-author them from memory."
+    )
+    assert not duplicates, (
+        f"specs/EXTENSIONS.md has duplicate numbered ledger section(s): "
+        f"{duplicates}. Two entries claim the same section number -- "
+        "renumber the later entry to the next free number and fix any "
+        "'depends-on: §NN' cross-references that pointed at the collided "
+        "number."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Regression proof: synthetic content mirroring the exact incident shape.
+#
+# These do not touch the live file at all -- they prove the *checker logic*
+# itself flags gaps/duplicates, independent of whatever specs/EXTENSIONS.md
+# currently contains. See the module docstring for the real-world incident
+# these mirror (PR #135's §31/32/33 silently discarded by PR #136's
+# `-Xtheirs` rebase, leaving §30 followed directly by §34).
+# ---------------------------------------------------------------------------
+
+
+def _synthetic_ledger(numbers: list[int]) -> str:
+    """Build a minimal synthetic EXTENSIONS.md body with the given section
+    numbers, in order, each a well-formed heading + body + separator."""
+    parts = [
+        "# Attractor Extensions\n\n## Entry Format\n\nnot a numbered entry\n\n---\n"
+    ]
+    for n in numbers:
+        parts.append(f"## {n}. Synthetic Entry {n}\n\nsome body text.\n\n---\n")
+    parts.append("## Conformance Restoration Note (T0-4)\n\nnot a numbered entry\n")
+    return "\n".join(parts)
+
+
+def test_checker_flags_the_incident_shape_30_then_34():
+    """Regression proof (RED case): a synthetic doc with 1..30 present and
+    then jumping straight to 34 -- exactly the shape this repo's main branch
+    was silently reduced to -- must be flagged as missing 31, 32, and 33.
+    """
+    doc = _synthetic_ledger([*range(1, 31), 34])
+    gaps, duplicates = _find_ledger_gaps_and_duplicates(doc)
+    assert gaps == [31, 32, 33], (
+        f"expected the checker to flag exactly [31, 32, 33] as missing, got {gaps}"
+    )
+    assert duplicates == []
+
+
+def test_checker_flags_duplicate_section_numbers():
+    """Regression proof (RED case): a synthetic doc with two entries both
+    numbered 34 (e.g. a stacked-branch rebase collision) must be flagged."""
+    doc = _synthetic_ledger([*range(1, 34), 34, 34])
+    gaps, duplicates = _find_ledger_gaps_and_duplicates(doc)
+    assert gaps == []
+    assert duplicates == [34], (
+        f"expected duplicate [34] to be flagged, got {duplicates}"
+    )
+
+
+def test_checker_passes_a_contiguous_sequence():
+    """Regression proof (GREEN case): a synthetic doc with an unbroken
+    1..34 sequence -- the restored shape -- must report no gaps and no
+    duplicates."""
+    doc = _synthetic_ledger(list(range(1, 35)))
+    gaps, duplicates = _find_ledger_gaps_and_duplicates(doc)
+    assert gaps == []
+    assert duplicates == []

--- a/specs/EXTENSIONS.md
+++ b/specs/EXTENSIONS.md
@@ -1544,6 +1544,214 @@ engines.
 
 ---
 
+## 31. Ledger Entry for PR #134: Retry-Budget Validation (Conformance Restoration) and
+Tool-Command/Handler-Mismatch Rejection (Stricter-Than-Spec Admission)
+
+> **This entry is a ledger entry for already-merged work, not new work.** PR #134
+> (commit `d792807`, "fix: validate DOT retry budgets", @robotdad) shipped two `validate()`-time
+> structural checks without a corresponding entry in this file. Credit for the implementation
+> belongs to the PR's author; this entry is written after the fact to close the ledger gap and
+> to classify each half of the change honestly — they are not the same kind of change.
+>
+> **depends-on:** §2, §3 (this entry validates the exact attributes those extensions define:
+> `default_max_retries`/`default_max_retry` and node-level `max_retries` inheritance)
+>
+> **upstream action:** not applicable to the retry-parsing half (conformance restoration, see
+> below — canonical spec already requires this). Not applicable to the handler-mismatch half
+> either: it is a strictly local admission-time narrowing that refuses a subset of graphs the
+> spec would silently admit; it does not ask the spec to change, so there is nothing to propose
+> upstream.
+
+**What shipped:**
+
+1. **`retry_budget_non_negative` — a conformance restoration.** The canonical spec declares
+   both the graph-level default and the node-level override as typed `Integer` attributes:
+   `default_max_retries` (`attractor-spec.md:139`, also `:1993`) and `max_retries`
+   (`attractor-spec.md:152`, also `:2010`). Before this PR, the DOT parser silently coerced
+   malformed values (`int(val)` truncated fractions like `1.5`→`1`, accepted `True` as `1` since
+   Python's `int(True) == 1`, and raised an unhandled `ValueError`/`TypeError` on non-numeric
+   strings instead of producing a diagnostic). `_parse_non_negative_retry_count()`
+   (`retry.py`) and the new `_check_retry_budgets()` validation rule (`validation.py`) now reject
+   negative values, booleans, fractions, and unparseable strings at `validate()` time with a
+   named `ERROR` diagnostic, for both the node attribute and both graph-level aliases
+   (`default_max_retry` / `default_max_retries`). **This is a restoration, not an extension:**
+   the spec already declares these attributes as `Integer`; the implementation previously
+   accepted values the spec's own type never permitted, and silently mis-executed rather than
+   diagnosing them. No spec change is needed and no `upstream action` applies.
+
+2. **`tool_command_requires_tool_handler` — a stricter-than-spec admission rule.** Canonical
+   spec §4.5 (`CodergenHandler`, `attractor-spec.md:656-705`) never reads or references the
+   `tool_command` attribute at all; the spec is silent on it for a codergen-resolved node, which
+   means a spec-conformant `CodergenHandler` simply ignores a `tool_command` attribute sitting on
+   a node it handles — the spec permits (by omission) a graph where `tool_command` is present but
+   inert. This PR's `_check_tool_command_handler()` (`validation.py`) makes that shape a
+   validation `ERROR`: a non-empty `tool_command` on a node whose *effective* handler resolves to
+   a recognized non-tool built-in (codergen, conditional, start, exit, …) is now rejected outright,
+   not silently ignored. **This is a real narrowing, plainly stated:** we now refuse to execute a
+   graph the canonical spec would admit and run (just with the attribute quietly doing nothing).
+   Unrecognized/custom `type=`/`node_type=` values are deliberately exempted (`_effective_handler_type()`
+   returns `None` for any unknown explicit type), preserving the custom-handler extension point —
+   the rule only fires when the *resolved* handler is a recognized non-tool built-in, never for an
+   unregistered extension type the runtime hasn't seen yet.
+
+**Why this framing matters:** conflating the two would either overstate the retry-parsing fix
+as a behavior change requiring upstream sign-off (it doesn't — the spec's own `Integer` type
+already prohibited the values now rejected) or understate the handler-mismatch rule as "just
+tightening validation" without naming that it refuses spec-legal graphs. Recording both
+correctly is the point of this entry.
+
+**Compatibility:** The retry-parsing restoration is backward-compatible for every graph that
+was already supplying spec-conformant integer retry values; only malformed values that were
+previously mis-executed (truncated, coerced, or silently defaulted via an uncaught exception
+path) now produce a clear diagnostic instead. The handler-mismatch rule is a **breaking**
+narrowing for the specific, narrow case of a `tool_command` attribute present on a node
+resolving to a recognized non-tool handler — such a graph now fails `validate()` where it
+previously ran with the attribute silently inert.
+
+**Implementation locations:**
+- `modules/loop-pipeline/amplifier_module_loop_pipeline/dot_parser.py: _set_graph_attr()` —
+  preserves the raw parsed graph-level retry default instead of coercing it at parse time
+- `modules/loop-pipeline/amplifier_module_loop_pipeline/retry.py: _parse_non_negative_retry_count()` —
+  the shared non-negative-integer parser (used by both the runtime `RetryPolicy` and validation)
+- `modules/loop-pipeline/amplifier_module_loop_pipeline/validation.py: _check_retry_budgets()`,
+  `_check_tool_command_handler()`, `_effective_handler_type()`
+- `docs/DOT-AUTHORING-GUIDE.md` — documents both structural errors under "Static Lint Rules"
+- Tests: `modules/loop-pipeline/tests/test_dot_parser.py`, `test_retry.py`, `test_validation.py`
+
+---
+
+## 32. Ledger Entry for PR #106: `attractor lint` as a Separate Entry Point (§7.4)
+
+> **This entry is a ledger entry for already-merged work, not new work.** PR #106 ("attractor
+> lint — five topological basin-lint rules + CLI") shipped claiming no `specs/EXTENSIONS.md`
+> entry was needed. An independent post-merge audit judged that call "arguable, and I'd add
+> one" — the discriminator for whether an entry is owed is the **entry point** a change lands
+> on (advisory `lint()` vs. admission-gating `validate()`/`validate_or_raise()`), not the
+> severity of the findings it produces, and a separate advisory entry point is itself a fact
+> about the implementation worth recording even though it widens nothing. This entry pays that
+> down. Credit for the implementation belongs to PR #106; this entry is written after the fact.
+>
+> **depends-on:** none
+>
+> **upstream action:** not applicable — canonical spec §7.4 explicitly permits custom/additional
+> lint rules as an extension point (`extra_rules` parameter on `validate()`; see §7.3-7.4 of the
+> canonical spec), and `lint()` composes exactly that permitted mechanism. `validate_or_raise()`
+> (the admission-gating entry point) is untouched by this change. Nothing here diverges from or
+> narrows the spec, so there is no upstream ask.
+
+**What shipped:** A new `lint()` public entry point (`validation.py`) distinct from
+`validate()`/`validate_or_raise()`, plus a CLI subcommand (`attractor lint <file.dot>`) that runs
+it. `lint()` runs everything `validate()` runs (LINT-001–018, the structural rules, including the
+two admission-gating rules from §31 above) **plus** five additional topological ("basin-lint")
+rules that reason about cycle structure and handler semantics rather than per-attribute syntax:
+
+- **TOPO-001** (`ERROR`) — dead conditional edge out of a `diamond` (`ConditionalHandler`) node:
+  `outcome!=success` / `outcome=fail` conditions on an edge out of a diamond can never fire,
+  because `ConditionalHandler` always returns `SUCCESS` unconditionally and `FAIL` is fail-fast
+  (never reaches a diamond via a plain edge). This was the root cause of 8 shipped examples
+  carrying dead corrective edges for months before this rule existed.
+- **TOPO-002** (`WARNING`) — ambiguous multi-match on a tool node (stale `tool.last_line` +
+  `outcome=fail` both matching on a retry visit).
+- **TOPO-003** (`WARNING`) — acyclic graph (no corrective cycle at all); flags a candidate for
+  "this should have been a recipe, not an attractor," while explicitly allowing deliberate
+  one-pass pipelines.
+- **TOPO-004** (`WARNING`) — a cycle (SCC) with no explicitly-gated exit edge.
+- **TOPO-005** (`WARNING`) — a cycle whose continuation/exit rests solely on LLM say-so, with no
+  deterministic (tool or human-gate) evidence gate on the cycle.
+
+**Why a separate entry point, not folded into `validate()`:** the five TOPO rules are
+judgment calls about pipeline *design quality* (is this graph shaped like a converging
+attractor?), not about whether the graph is *executable*. `validate_or_raise()` — the
+admission-gating entry point that decides whether a pipeline runs at all — is untouched;
+every one of the five rules is reachable only through `lint()`, and only TOPO-001 defaults to
+`ERROR` severity within `lint()`'s own exit-code contract (errors → exit 1, warnings → exit 0
+unless `--strict`). This is exactly the kind of extension canonical §7.4 anticipates: additional
+rules layered on top of, not instead of, the spec's own validation surface.
+
+**Compatibility:** Fully additive. No existing `validate()` or `validate_or_raise()` caller is
+affected; `lint()` is a new, separately-invoked surface. A pipeline that was runnable before
+this PR remains equally runnable after it — `attractor lint` is an author-time advisory tool,
+never consulted by the engine at run time.
+
+**Implementation locations:**
+- `modules/loop-pipeline/amplifier_module_loop_pipeline/validation.py` — `lint()` entry point;
+  `_check_dead_conditional_edge()` (TOPO-001) and the four sibling TOPO-002–005 checks
+- `modules/pipeline-runner/amplifier_module_pipeline_runner/cli.py` — `attractor lint` subcommand
+- `docs/DOT-AUTHORING-GUIDE.md` — "Static Lint Rules (`attractor lint`)" section documents all
+  five rules with fix examples
+- Tests: `modules/loop-pipeline/tests/test_topological_lint.py`,
+  `modules/loop-pipeline/tests/test_examples_lint_clean.py`
+
+---
+
+## 33. Main-Loop No-Matching-Edge Hard-Fail
+
+> **This extension DIVERGES from canonical spec §3.2.** Canonical spec §3.2 step 6
+> (`attractor-spec.md:388-393`) specifies: when no next edge is selected, return the last
+> outcome unchanged if it is `FAIL`; otherwise return `Outcome(status=SUCCESS, notes="Pipeline
+> completed")` — a dead end is treated as a normal, successful pipeline completion regardless of
+> whether the graph's author intended that node to be a true exit. Our engine instead hard-fails
+> in every case: a dead end always terminates the pipeline with `status=FAIL` and a
+> `PIPELINE_ERROR` event carrying `error_type=no_matching_edge`, whether or not the last outcome
+> was `FAIL`. See `SPEC_CONFORMANCE.md` ATX-11 for the ledger entry and `PRINCIPLES.md` for the
+> walk-upstream note.
+>
+> **depends-on:** none
+>
+> **upstream action:** deferred, reason: this repo's upstream-contribution effort is currently
+> concentrated elsewhere; proposing a change to canonical §3.2's dead-end semantics is a
+> considered spec-language edit we want to bring with worked examples (including the
+> `run_subgraph` counter-case noted below) rather than a quick issue, review-by: 2026-09-05
+
+### The decision
+
+This was an unledgered divergence: the engine has hard-failed on no-matching-edge since its
+initial commit (verified against `git log` — the behavior predates and is unrelated to PR #66,
+which only removed a duplicate resume-path check). A session audit found the gap and initially
+recorded it with a pending `DECIDE` disposition (ALIGN vs. DIVERGE); that disposition was never
+committed to `SPEC_CONFORMANCE.md`, so the decision has been open, undocumented, and — because
+`examples/pipelines/practical/bug-fix.dot`'s `escalated` node relies on exactly this hard-fail
+behavior to report failure after writing its handoff artifacts (§8 backward-compat note in the
+T0-4 restoration above notwithstanding) — **load-bearing** for a shipped exemplar.
+
+**The decision: keep the hard-fail. Never a silent fallback; always a traceable failure
+reason.** Rationale: a silent `SUCCESS` on an unrouted, dead-ended graph is the exact incident
+class this engine exists to prevent. A real 2.4-hour pipeline run once exited `status=success`
+with zero work product because a downstream signal was silently treated as acceptable
+completion (see §25's incident motivation for the sibling case at the goal-gate layer). Applying
+the spec's dead-end→SUCCESS rule at the main-loop level would reintroduce that same failure
+mode one layer up: any graph with a genuinely unreachable or missing edge — an authoring
+mistake, not a designed exit — would silently report success instead of surfacing the gap. A
+loud, traceable failure (`PIPELINE_ERROR error_type=no_matching_edge`, plus
+`terminate_pipeline()`'s `failure_reason`) costs an author a debugging session; a silent false
+success costs an operator hours before anyone notices nothing happened.
+
+**No behavior change in this entry.** The engine already behaves this way and has since its
+first commit; this entry and the corresponding `SPEC_CONFORMANCE.md` update record the decision
+that was made, not a code change.
+
+**Compatibility note — `run_subgraph` is intentionally NOT changed by this decision.**
+`run_subgraph()` (`engine.py:917-925` at time of writing) returns the last outcome unchanged on
+a dead end, matching the spec's permissive shape — this is deliberate: subgraph dead-ends are
+the *compositional* path (a folder/sub-pipeline node's internal routing choices are its own
+business), while the top-level main loop is where an unrouted graph is a run-ending authoring
+defect. Any future change to `run_subgraph`'s dead-end behavior is a separate decision, not
+implied by this entry.
+
+**Implementation locations:**
+- `modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py` — main loop's no-matching-edge
+  hard-fail (`terminate_pipeline()` call + `PIPELINE_ERROR` emission with
+  `error_type=no_matching_edge`, around the retry-target fallback check)
+- `modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py: terminate_pipeline()` — the
+  sole construction path for a routing-termination outcome (see `AGENTS.md` common-pitfalls: never
+  construct a fresh `Outcome(FAIL, ...)` inline at this boundary — it drops `failure_reason`)
+- `context/engine-semantics.md` §3 — documents both halves (main-loop hard-fail vs.
+  `run_subgraph`'s permissive dead-end) and is guarded against drift by
+  `modules/loop-pipeline/tests/test_engine_semantics_doc_guard.py` (D-200a/b/c)
+- `examples/pipelines/practical/bug-fix.dot` (`escalated` node) — the shipped exemplar that
+  depends on this hard-fail to report failure after writing handoff artifacts
+
+---
 ## 34. `suggested_next_ids` Type Coercion at Edge Selection (Bug Fix)
 
 > **This is a bug fix restoring intended behavior, not a new extension.** The spec (§3.3 Step 3)


### PR DESCRIPTION
## What happened

PR #135 (`837ba56`) added `specs/EXTENSIONS.md` §31, §32, and §33. PR #136 was
then rebased onto that main using `git rebase -Xtheirs` to resolve a conflict
in `specs/EXTENSIONS.md` — which took #136's whole side of the file instead
of reconciling both sides' additions, **silently discarding #135's three
entries** while keeping #136's own new entry (which landed as §34). CI went
green on a main branch that had quietly lost three merged ledger entries,
because nothing asserted the ledger's heading sequence was supposed to be
contiguous.

## Blast radius (verified, not assumed)

Diffing `837ba56:specs/EXTENSIONS.md` against pre-fix `main`:
- §31 (PR #134 retry-budget validation ledger entry), §32 (PR #106
  `attractor lint` ledger entry), and §33 (main-loop no-matching-edge
  hard-fail) were **gone**. §30 was immediately followed by §34.
- The top-of-file "Entry Format" mandatory-fields block and the §25/§29
  backfilled fields were **intact** — the loss was confined to the three
  numbered sections, not the surrounding scaffolding.

Whole-tree diff (`git diff 837ba56 main --stat`) confirms the damage is
**confined to `specs/EXTENSIONS.md`**: the only other files that differ are
`edge_selection.py`, `engine.py`, and a new test file — all legitimate new
code from PR #136 itself (the `suggested_next_ids` type-coercion bug fix),
not overwritten #135 content. Other #135 changes called out as at-risk in
the report that flagged this (README stability section, PR template
checkbox, root `SPEC_CONFORMANCE.md` ATX-11) were verified untouched.

## Fix

Restores §31, §32, and §33 **verbatim** from `837ba56`, inserted ahead of
#136's §34, which is otherwise untouched. Result: §30 → §31 → §32 → §33 →
§34 → Conformance Restoration Note, in order, matching `837ba56`'s content
exactly for the restored sections.

Coherence verified:
- Section numbering contiguous 1–34, no duplicate headings.
- `depends-on:`/`upstream action:` fields on the restored entries intact
  (§31 depends on §2/§3, unaffected by the clobber).
- No cross-references elsewhere in the repo pointed at the wrong numbers
  (README.md's own reference to "`specs/EXTENSIONS.md` §33" already matched
  the restored section once §33 was back in place).
- `git diff --check` clean; diff against pre-fix main is a pure `+208 -0`
  (this PR only adds back what was lost — it does not touch #136's content).

## New guard

Nothing asserted the ledger's heading sequence was contiguous, so CI could
not have caught this. Adds
`modules/loop-pipeline/tests/test_extensions_ledger_integrity.py`: asserts
the numbered `## N.` section headings in `specs/EXTENSIONS.md` form a
contiguous `1..max` sequence with no gaps and no duplicates.

**RED** (run against the clobbered file, i.e. pre-fix `main`):
```
E       AssertionError: specs/EXTENSIONS.md is missing numbered ledger section(s): [31, 32, 33]. The heading sequence jumps over these numbers even though entries on both sides are present and well-formed -- this is exactly the shape of a rebase conflict resolved with 'git rebase -Xtheirs' (or a merge that silently took one side's whole file) discarding already-merged entries. Restore the missing section(s) verbatim from the commit that last had them (check git log/blame on this file), do not re-author them from memory.
E       assert not [31, 32, 33]
FAILED tests/test_extensions_ledger_integrity.py::test_extensions_ledger_section_numbers_contiguous_no_gaps_or_duplicates
1 failed in 0.03s
```

**GREEN** (run against this branch's restored file):
```
tests/test_extensions_ledger_integrity.py::test_extensions_ledger_section_numbers_contiguous_no_gaps_or_duplicates PASSED [ 25%]
tests/test_extensions_ledger_integrity.py::test_checker_flags_the_incident_shape_30_then_34 PASSED [ 50%]
tests/test_extensions_ledger_integrity.py::test_checker_flags_duplicate_section_numbers PASSED [ 75%]
tests/test_extensions_ledger_integrity.py::test_checker_passes_a_contiguous_sequence PASSED [100%]
4 passed in 0.01s
```

The synthetic regression tests (`test_checker_flags_the_incident_shape_30_then_34`,
`test_checker_flags_duplicate_section_numbers`, `test_checker_passes_a_contiguous_sequence`)
prove the checker logic itself catches gaps and duplicates independent of
whatever the live file currently contains.

## Gates

- `test_extensions_ledger_integrity.py`: 4 passed
- doc-guard suite (`test_engine_semantics_doc_guard.py`): 7 passed
- examples-lint suite (`test_examples_lint_clean.py`): 30 passed
- Full `loop-pipeline` suite: 1790 passed, 1 skipped
- `git diff --check`: clean

## Not merging

Per instructions, this PR is opened non-draft for review but **not merged** —
merge decision is the maintainer's call.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)