### PR TITLE
docs: correct false upstream-filing commitments to honest declining status

### DIFF
--- a/modules/loop-pipeline/tests/test_extensions_ledger_integrity.py
+++ b/modules/loop-pipeline/tests/test_extensions_ledger_integrity.py
@@ -164,3 +164,140 @@ def test_checker_passes_a_contiguous_sequence():
     gaps, duplicates = _find_ledger_gaps_and_duplicates(doc)
     assert gaps == []
     assert duplicates == []
+
+
+# ---------------------------------------------------------------------------
+# `upstream action:` value-format guard.
+#
+# Discovered in practice alongside the heading-sequence damage above: a
+# ledger entry can carry a well-formed, contiguous heading and still commit
+# to something dishonest in its *value* -- e.g. `deferred, ...,
+# review-by: <date>` written against an upstream repo already known to be
+# dormant, with issues disabled, where filing would not land. The Entry
+# Format section (above, in this same file) defines exactly which values are
+# legal; this check is the mechanical half of that promise: every
+# `upstream action:` value in the live ledger must start with one of them.
+#
+# This does NOT validate that a `deferred` reason or `declining` reason is
+# *true* -- that is a judgment call no regex can make. It only catches the
+# cheap, structural mistake of a value that isn't in one of the legal forms
+# at all (e.g. a bare vague promise with no link, no date, and no
+# `declining` framing), which is the shape the incident behind this task
+# took: a `review-by` date can be well-formed as a *string* while still
+# encoding a plan that the evidence already rules out -- that half is a
+# human judgment this test cannot make, and does not try to.
+# ---------------------------------------------------------------------------
+
+# The first line of an `upstream action:` value establishes which of the
+# three legal forms (link / deferred-with-date / declining-with-reason) —
+# plus the pre-existing `not applicable` disposition — the entry is using.
+# Longer reasons wrap onto further blockquote lines, which this check does
+# not need to read: the category is fixed by how the value opens.
+_UPSTREAM_ACTION_VALUE_RE = re.compile(
+    r"^>\s*\*\*upstream action:\*\*\s*(.+)$", re.MULTILINE
+)
+
+_LEGAL_UPSTREAM_ACTION_PREFIXES = (
+    "https://github.com/",  # a real upstream PR/issue link
+    "deferred, reason:",  # deferred, with a review-by date (checked below)
+    "declining, reason:",  # honest non-filing, no date required
+    "not applicable",  # no upstream action applies (spec-silent / additive)
+)
+
+_REVIEW_BY_DATE_RE = re.compile(r"review-by:\s*\d{4}-\d{2}-\d{2}\b")
+
+
+def _upstream_action_first_lines(text: str) -> list[str]:
+    """Extract the first line of every `upstream action:` value, in document
+    order (multi-line reasons continue past this point but the legal-form
+    prefix always appears on this first line)."""
+    return [m.strip() for m in _UPSTREAM_ACTION_VALUE_RE.findall(text)]
+
+
+def _illegal_upstream_action_values(first_lines: list[str]) -> list[str]:
+    """Return the subset of `upstream action:` first-lines that do not open
+    with one of the legal forms."""
+    return [
+        line
+        for line in first_lines
+        if not line.startswith(_LEGAL_UPSTREAM_ACTION_PREFIXES)
+    ]
+
+
+def test_extensions_ledger_upstream_action_values_are_legal_forms():
+    """Every `upstream action:` value in the live ledger must open with one
+    of the forms the Entry Format section declares legal: a real upstream
+    link, `deferred, reason: ..., review-by: <date>`, `declining, reason:
+    ...`, or `not applicable ...`.
+
+    This is a structural check only -- it cannot judge whether a `deferred`
+    or `declining` reason is factually true (that takes verifying the
+    upstream repo's actual state, as this task did for §25/§29/§33). It
+    exists to catch the cheaper mistake: a value that isn't shaped like any
+    of the legal forms at all.
+    """
+    text = LEDGER_PATH.read_text()
+    first_lines = _upstream_action_first_lines(text)
+    assert first_lines, (
+        "expected at least one `upstream action:` entry in the live ledger"
+    )
+
+    illegal = _illegal_upstream_action_values(first_lines)
+    assert not illegal, (
+        f"specs/EXTENSIONS.md has `upstream action:` value(s) not shaped like any "
+        f"legal form (a real link, `deferred, reason: ..., review-by: <date>`, "
+        f"`declining, reason: ...`, or `not applicable ...`): {illegal!r}. See the "
+        "Entry Format section at the top of specs/EXTENSIONS.md."
+    )
+
+
+def test_extensions_ledger_deferred_upstream_actions_carry_a_review_by_date():
+    """Every `deferred, reason: ...` value must carry a `review-by:
+    YYYY-MM-DD` date somewhere in its (possibly multi-line) reason -- a
+    non-date placeholder ("eventually", "TBD", "soon") is exactly the
+    failure mode the Entry Format section forbids.
+
+    Checked against the full multi-line banner block per entry (not just
+    the first line), since the date may trail the reason across a wrapped
+    blockquote line -- unlike the legal-form check above, which only needs
+    the opening word.
+    """
+    text = LEDGER_PATH.read_text()
+    # Each blockquote banner is a contiguous run of `>`-prefixed lines; grab
+    # every such run and inspect the ones that open an `upstream action:`
+    # value with `deferred, reason:`.
+    banners = re.findall(r"(?:^>.*\n)+", text, re.MULTILINE)
+    deferred_banners = [
+        b for b in banners if "**upstream action:** deferred, reason:" in b
+    ]
+    for banner in deferred_banners:
+        assert _REVIEW_BY_DATE_RE.search(banner), (
+            f"a `deferred` upstream action is missing a `review-by: YYYY-MM-DD` date: "
+            f"{banner!r}"
+        )
+
+
+def test_checker_flags_an_illegal_upstream_action_value():
+    """Regression proof (RED case): a vague, undated promise with no link
+    and no `declining` framing must be flagged -- this is the shape the
+    §25/§29/§33 incident would have taken if written as free prose instead
+    of one of the ledger's legal forms."""
+    doc = "> **upstream action:** we should probably raise this with upstream at some point\n"
+    first_lines = _upstream_action_first_lines(doc)
+    assert first_lines == ["we should probably raise this with upstream at some point"]
+    illegal = _illegal_upstream_action_values(first_lines)
+    assert illegal == first_lines
+
+
+def test_checker_accepts_all_four_legal_upstream_action_forms():
+    """Regression proof (GREEN case): one example of each legal form must
+    pass, including the `declining` form this task added."""
+    doc = (
+        "> **upstream action:** https://github.com/strongdm/attractor/pull/42\n"
+        "> **upstream action:** deferred, reason: needs one more release, review-by: 2026-12-01\n"
+        "> **upstream action:** declining, reason: upstream repo is dormant\n"
+        "> **upstream action:** not applicable -- spec-silent area\n"
+    )
+    first_lines = _upstream_action_first_lines(doc)
+    assert len(first_lines) == 4
+    assert _illegal_upstream_action_values(first_lines) == []

--- a/specs/EXTENSIONS.md
+++ b/specs/EXTENSIONS.md
@@ -32,13 +32,22 @@ entry with no banner):
     `strongdm/attractor` (e.g. `https://github.com/strongdm/attractor/pull/NN` or
     `.../issues/NN`), or
   - `deferred, reason: <one-line reason>, review-by: <YYYY-MM-DD>` — a concrete calendar
-    date the deferral will be revisited, not a placeholder.
+    date the deferral will be revisited, not a placeholder, or
+  - `declining, reason: <one-line reason>` — an honest statement that no upstream filing
+    is planned, because the evidence says one would not land (e.g. the upstream repo is
+    dormant, has issues disabled, or its own open community PRs of this kind sit unmerged).
+    Declining does not mean the divergence goes unrecorded: it stays exactly here, in this
+    ledger, which is what actually informs consumers of this engine. Unlike `deferred`,
+    `declining` carries no `review-by` date because there is no pending action to revisit
+    on a calendar — only new upstream conditions (the repo becoming active again, issues
+    reopening, a maintained fork appearing) would warrant reopening the entry.
 
   **A non-date value for `review-by` ("eventually", "TBD", "soon", "when we get to it") is
   not a permitted value.** Prose promising an upstream proposal with no date and no link is
   how a divergence sits unreviewed for months; a date makes it someone's job on a specific
   day. When a `review-by` date passes without the proposal being filed, the entry must be
-  revisited: either file it, or replace the date with a fresh one and a fresh reason.
+  revisited: either file it, replace the date with a fresh one and a fresh reason, or — if
+  the honest conclusion is that filing was never going to land — switch to `declining`.
 
 ---
 
@@ -623,11 +632,10 @@ this extension documents the behavior here.
 >
 > **depends-on:** none
 >
-> **upstream action:** deferred, reason: the recommended upstream change (a `goal_gate` check
-> in §4.5's `CodergenHandler` before the unconditional SUCCESS fallback) is straightforward to
-> state, but we want the backward-compat inventory below to stay settled across at least one
-> more consuming release before asking upstream to adopt a fail-closed default that every
-> nlspec implementation would then inherit, review-by: 2026-09-05
+> **upstream action:** declining, reason: `strongdm/attractor` has had no commits since
+> 2026-03-17, has issues disabled, and its own open community spec-correction PRs (#9, #10)
+> have sat unmerged for 4+ months — filing there would not land. The divergence is tracked
+> here instead.
 
 ### Incident motivation
 
@@ -1270,11 +1278,10 @@ deferral note.
 >
 > **depends-on:** none
 >
-> **upstream action:** deferred, reason: this is additive to a spec-silent area rather than a
-> divergence, but it is exactly the kind of shipped-ahead-of-upstream mechanism this repo commits
-> to proposing back; we want at least one more consuming pipeline generation beyond
-> `convergence-factory.dot` before writing spec language, so the proposal reflects a proven shape
-> rather than a speculative one, review-by: 2026-09-05
+> **upstream action:** declining, reason: `strongdm/attractor` has had no commits since
+> 2026-03-17, has issues disabled, and its own open community spec-correction PRs (#9, #10)
+> have sat unmerged for 4+ months — filing there would not land. The divergence is tracked
+> here instead.
 
 **What:** A node may declare `feedback_from="<critic_node_id>"` to establish an engine-enforced
 feedback accumulation contract. On every `loop_restart` edge traversal, the engine:
@@ -1698,10 +1705,10 @@ never consulted by the engine at run time.
 >
 > **depends-on:** none
 >
-> **upstream action:** deferred, reason: this repo's upstream-contribution effort is currently
-> concentrated elsewhere; proposing a change to canonical §3.2's dead-end semantics is a
-> considered spec-language edit we want to bring with worked examples (including the
-> `run_subgraph` counter-case noted below) rather than a quick issue, review-by: 2026-09-05
+> **upstream action:** declining, reason: `strongdm/attractor` has had no commits since
+> 2026-03-17, has issues disabled, and its own open community spec-correction PRs (#9, #10)
+> have sat unmerged for 4+ months — filing there would not land. The divergence is tracked
+> here instead.
 
 ### The decision
 


### PR DESCRIPTION
## What

`specs/EXTENSIONS.md` §25, §29, and §33 each carried `upstream action: deferred,
reason: ..., review-by: 2026-09-05` — a commitment to file spec-correction
PRs against `strongdm/attractor`. That commitment was written into a shipped
public ledger even though the principal had already explicitly declined this
action weeks earlier ("skip #2"). This PR corrects it.

## Why the previous value was false

Re-verified independently rather than taking the prior claim on faith:

- `strongdm/attractor` has had **no commits since 2026-03-17** (~5 months
  quiet as of this PR).
- The repo has **issues disabled** and no `CONTRIBUTING` guide.
- Two open community spec-correction PRs there have sat **unmerged for 4+
  months**: [#9 "Correct Attractor spec inconsistencies"](https://github.com/strongdm/attractor/pull/9)
  (opened 2026-03-26) and [#10 "8 spec improvements from building a
  PHP/Laravel implementation"](https://github.com/strongdm/attractor/pull/10)
  (opened 2026-03-29).
- Our own maintainer's earlier attempt there, [#6](https://github.com/strongdm/attractor/pull/6),
  was **closed, not merged**.
- The one PR of this shape that *did* merge, [#8](https://github.com/strongdm/attractor/pull/8)
  (2026-03-17), is the same day the repo went quiet.

Filing another spec-correction PR there would not land. `declining` is the
honest value; `deferred, ..., review-by: <date>` was not.

## What changed

1. **§25, §29, §33**: `upstream action:` changed from `deferred, reason: ...,
   review-by: 2026-09-05` to `declining, reason: <one-line, evidence-based>`,
   stating plainly that the divergence stays tracked in this ledger instead —
   which is what actually serves consumers of this engine, filing or no
   filing.
2. **Entry Format section**: the format block only documented two legal
   `upstream action:` values (a real link, or deferred-with-date). Extended
   it to explicitly permit `declining, reason: <one-line reason>` as a third
   legal form — otherwise the three corrected entries above would violate
   the very format they sit under. The existing "no non-date `review-by`
   values" rule is unchanged.
3. **Sweep**: checked `SPEC_CONFORMANCE.md`, `README.md`, `PRINCIPLES.md`,
   `docs/`, and the rest of `specs/EXTENSIONS.md` for any other undated
   promise of an upstream spec-correction PR. Found none carrying the same
   false commitment. `PRINCIPLES.md`'s two walk-upstream notes (§25, §33) and
   `feedback.py`'s docstring (§29) describe the recommended upstream change
   and point readers to the ledger entry for current disposition, but make
   no dated or otherwise falsifiable promise of their own — left unchanged.
4. **Guard test**: extended
   `modules/loop-pipeline/tests/test_extensions_ledger_integrity.py` with a
   structural check that every `upstream action:` value in the live ledger
   opens with one of the legal forms (link / deferred-with-date / declining
   / not applicable), and that every `deferred` value carries a real
   `review-by: YYYY-MM-DD` date. Proven RED against a synthetic vague-promise
   value and GREEN against one example of each legal form plus the live
   file. This cannot (and does not try to) judge whether a given reason is
   *true* — only that the value is shaped like a legal form at all.

## Gates

- `test_extensions_ledger_integrity.py`: 8/8 passed (4 pre-existing + 4 new).
- `test_engine_semantics_doc_guard.py` + `test_topological_lint.py` +
  `test_command_content_lint.py` + `test_examples_lint_clean.py`: 135/135
  passed.
- Full `loop-pipeline` suite: 1794 passed, 1 skipped (pre-existing skip,
  unrelated).
- `git diff --check`: clean.
- Ledger section-heading contiguity (§1–§35, no gaps/duplicates): verified
  by the existing guard test, still green after this change (no headings
  touched, only body/value text).

## Not in scope

This PR does not re-litigate *whether* §25/§29/§33 are the right
engineering decisions — only that their `upstream action:` field states the
true plan rather than a plan already known to be false.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>
