### PR TITLE
fix(tools): make JSON-schema enums deterministic across processes to stop prompt-cache invalidation

### DIFF
--- a/docs/designs/RECURRING-BUG-CLASSES.md
+++ b/docs/designs/RECURRING-BUG-CLASSES.md
@@ -142,6 +142,33 @@ ecosystem over the past year, and 100% of fix commits in
   S4. Will be partially closed by **T3.1 HostPath/DTUPath** (Wave 3 —
   typed paths force translation at the host/DTU boundary, with a
   runtime check in `to_host()` per refinement C3).
+- **Third incident (tool JSON-schema `enum` ordering)**: three Amplifier
+  tool modules (`tool-report-outcome`, `tool-pipeline-status`,
+  `tool-dashboard-query`) each expose a JSON-schema `enum` array and a
+  parallel error-message listing, both derived from the same validation
+  `frozenset`. `tool-report-outcome` and `tool-pipeline-status` built the
+  `enum` with `list(<frozenset>)` directly — `frozenset` iteration order
+  for strings depends on `PYTHONHASHSEED`, which is randomized per
+  interpreter start, so the serialized schema differed on every process
+  restart. Anthropic's prompt cache is hierarchical (`tools` → `system` →
+  `messages`); ANY byte change to the serialized `tools` block
+  invalidates the entire cache, so this silently nuked the whole prompt
+  cache on every restart — the failure surfaced as a cost/latency
+  regression, nowhere near the two lines that caused it (S4's usual
+  displaced-symptom signature). `tool-dashboard-query`'s two sites both
+  called `sorted(<frozenset>)` independently, which happens to be
+  deterministic already (`sorted()` imposes a total order regardless of
+  input iteration order) — not a live bug, but the same *structural*
+  S4 shape: two independent call sites deriving the same thing, one
+  edit away from drifting. All three were closed identically: one
+  module-level canonical tuple (`_STATUSES_SORTED` / `_FILTERS_SORTED` /
+  `_OPERATIONS_SORTED` — a tuple, not a list, so the shared source of
+  truth can't be mutated through a consumer) that both the schema
+  `enum` and the error-message join read from. Proven with a regression
+  test that spawns N independent subprocesses (`PYTHONHASHSEED` only
+  varies *between* interpreter starts, so a same-process test cannot
+  catch this) and asserts byte-identical serialized schemas; see each
+  module's `test_schema_serialization_is_deterministic_across_processes`.
 - **Noun-fix**: centralize normalization at the single entry point.
   Once data enters the system, it is already normalized in every
   branch of the symmetry.

--- a/modules/tool-dashboard-query/amplifier_module_tool_dashboard_query/__init__.py
+++ b/modules/tool-dashboard-query/amplifier_module_tool_dashboard_query/__init__.py
@@ -38,6 +38,17 @@ VALID_OPERATIONS = frozenset(
     }
 )
 
+# Canonical, stable ordering of VALID_OPERATIONS, read by BOTH the schema
+# `enum` and the error-message join below so they can never drift apart
+# (S4 -- partial-coverage symmetry; not a live bug here, since `sorted()`
+# over a frozenset is already deterministic -- this closes the structural
+# recurrence, not a live cache-invalidation bug). A tuple, not a list, so
+# the shared source of truth can't be mutated through a consumer. Do NOT
+# reorder and do NOT inline `sorted(VALID_OPERATIONS)` at either consumer
+# again. Full story: docs/designs/RECURRING-BUG-CLASSES.md (S4).
+# Regression guard: test_schema_serialization_is_deterministic_across_processes.
+_OPERATIONS_SORTED: tuple[str, ...] = tuple(sorted(VALID_OPERATIONS))
+
 
 class DashboardQueryTool:
     """Query and manage Attractor pipelines via the dashboard HTTP API.
@@ -87,7 +98,7 @@ class DashboardQueryTool:
             "properties": {
                 "operation": {
                     "type": "string",
-                    "enum": sorted(VALID_OPERATIONS),
+                    "enum": list(_OPERATIONS_SORTED),
                     "description": "Operation to perform",
                 },
                 "pipeline_id": {
@@ -158,7 +169,7 @@ class DashboardQueryTool:
         if operation not in VALID_OPERATIONS:
             error_msg = (
                 f"Invalid operation: {operation!r}. "
-                f"Must be one of: {', '.join(sorted(VALID_OPERATIONS))}"
+                f"Must be one of: {', '.join(_OPERATIONS_SORTED)}"
             )
             return ToolResult(
                 success=False, output=error_msg, error={"message": error_msg}

--- a/modules/tool-dashboard-query/tests/test_dashboard_query.py
+++ b/modules/tool-dashboard-query/tests/test_dashboard_query.py
@@ -1,12 +1,17 @@
 """Tests for dashboard_query tool."""
 
+import hashlib
 import json
+import os
+import subprocess
+import sys
 
 import httpx
 import pytest
-
-from amplifier_module_tool_dashboard_query import DashboardQueryTool
-
+from amplifier_module_tool_dashboard_query import (
+    _OPERATIONS_SORTED as _MODULE_OPERATIONS_SORTED,
+)
+from amplifier_module_tool_dashboard_query import VALID_OPERATIONS, DashboardQueryTool
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -286,3 +291,79 @@ async def test_close_when_no_client_is_noop():
 
     await tool.close()  # should not raise
     assert tool._client is None
+
+
+# -- Schema determinism (prompt-cache stability) ----------------------------
+#
+# Regression guard for the S4 structural pattern (two independent `enum`
+# call sites that must never drift apart). Full story:
+# docs/designs/RECURRING-BUG-CLASSES.md (S4). See
+# test_schema_serialization_is_deterministic_across_processes below for the
+# actual cross-process proof.
+
+
+def test_schema_enum_matches_canonical_order():
+    """The enum must be exactly the module's canonical sorted order."""
+    tool = DashboardQueryTool(config={})
+    assert tool.input_schema["properties"]["operation"]["enum"] == list(
+        _MODULE_OPERATIONS_SORTED
+    )
+
+
+def test_schema_enum_contains_expected_members():
+    """Regression guard: sorting must never silently drop or add a value."""
+    tool = DashboardQueryTool(config={})
+    enum = tool.input_schema["properties"]["operation"]["enum"]
+    assert set(enum) == VALID_OPERATIONS
+    assert len(enum) == 7
+
+
+_SCHEMA_PROBE = (
+    "import json\n"
+    "from amplifier_module_tool_dashboard_query import DashboardQueryTool\n"
+    "tool = DashboardQueryTool(config={})\n"
+    "print(json.dumps(tool.input_schema, sort_keys=False, separators=(',', ':')))\n"
+)
+
+
+def test_schema_serialization_is_deterministic_across_processes():
+    """The REAL eval: the serialized input_schema must be byte-identical across
+    independent interpreter starts.
+
+    A same-process test cannot catch this bug class because PYTHONHASHSEED is
+    fixed for the lifetime of one interpreter -- frozenset iteration order
+    only varies *between* process starts. This spawns N independent
+    subprocesses (matching how the real production incident manifested: a
+    fresh schema hash at every process restart) and asserts they all produce
+    the identical serialized schema.
+    """
+    n_procs = 8
+    env = dict(os.environ)
+    env.pop("PYTHONHASHSEED", None)  # let each subprocess pick its own random seed
+
+    canon_outputs: list[str] = []
+    for _ in range(n_procs):
+        result = subprocess.run(
+            [sys.executable, "-c", _SCHEMA_PROBE],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            env=env,
+            check=False,
+        )
+        assert result.returncode == 0, (
+            f"Probe subprocess failed (rc={result.returncode}): "
+            f"stdout={result.stdout!r} stderr={result.stderr!r}"
+        )
+        canon_outputs.append(result.stdout.strip())
+
+    hashes = {hashlib.sha256(c.encode()).hexdigest()[:16] for c in canon_outputs}
+    distinct_orders = sorted(set(canon_outputs))
+    assert len(hashes) == 1, (
+        f"Expected 1 distinct input_schema serialization across {n_procs} "
+        f"independent processes, got {len(hashes)}. The schema's byte "
+        "representation is not stable across interpreter restarts (a "
+        "PYTHONHASHSEED-dependent frozenset iteration order), which "
+        "invalidates the ENTIRE Anthropic prompt cache on every process "
+        f"restart.\nDistinct serializations observed:\n" + "\n".join(distinct_orders)
+    )

--- a/modules/tool-pipeline-status/amplifier_module_tool_pipeline_status/__init__.py
+++ b/modules/tool-pipeline-status/amplifier_module_tool_pipeline_status/__init__.py
@@ -17,6 +17,16 @@ logger = logging.getLogger(__name__)
 
 VALID_FILTERS = frozenset({"full", "metrics", "current"})
 
+# Canonical, stable ordering of VALID_FILTERS, read by BOTH the schema
+# `enum` and the error-message join below so they can never drift apart
+# (S4 -- partial-coverage symmetry). A tuple, not a list, so the shared
+# source of truth can't be mutated through a consumer. Do NOT reorder and
+# do NOT inline `sorted(VALID_FILTERS)` at either consumer again -- that
+# reopens the prompt-cache bug. Full story:
+# docs/designs/RECURRING-BUG-CLASSES.md (S4). Regression guard:
+# test_schema_serialization_is_deterministic_across_processes.
+_FILTERS_SORTED: tuple[str, ...] = tuple(sorted(VALID_FILTERS))
+
 # Keys returned for the "metrics" filter
 _METRICS_KEYS = frozenset(
     {
@@ -75,7 +85,7 @@ class PipelineStatusTool:
             "properties": {
                 "filter": {
                     "type": "string",
-                    "enum": list(VALID_FILTERS),
+                    "enum": list(_FILTERS_SORTED),
                     "description": (
                         "Detail level: 'full' (default) returns everything, "
                         "'metrics' returns only aggregate metrics, "
@@ -102,7 +112,7 @@ class PipelineStatusTool:
         if filter_mode not in VALID_FILTERS:
             error_msg = (
                 f"Invalid filter: {filter_mode!r}. "
-                f"Must be one of: {', '.join(sorted(VALID_FILTERS))}"
+                f"Must be one of: {', '.join(_FILTERS_SORTED)}"
             )
             return ToolResult(
                 success=False,

--- a/modules/tool-pipeline-status/tests/test_pipeline_status.py
+++ b/modules/tool-pipeline-status/tests/test_pipeline_status.py
@@ -2,12 +2,20 @@
 
 from __future__ import annotations
 
+import hashlib
+import os
+import subprocess
+import sys
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-
-from amplifier_module_tool_pipeline_status import PipelineStatusTool, mount
-
+from amplifier_module_tool_pipeline_status import (
+    _FILTERS_SORTED as _MODULE_FILTERS_SORTED,
+)
+from amplifier_module_tool_pipeline_status import (
+    PipelineStatusTool,
+    mount,
+)
 
 # -- Helpers ---------------------------------------------------------------
 
@@ -217,3 +225,79 @@ async def test_execute_without_coordinator():
 
     assert result.success
     assert "no pipeline" in result.output["message"].lower()
+
+
+# -- Schema determinism (prompt-cache stability) ----------------------------
+#
+# Regression guard for the S4 structural pattern (two independent `enum`
+# call sites that must never drift apart). Full story:
+# docs/designs/RECURRING-BUG-CLASSES.md (S4). See
+# test_schema_serialization_is_deterministic_across_processes below for the
+# actual cross-process proof.
+
+
+def test_schema_enum_matches_canonical_order():
+    """The enum must be exactly the module's canonical sorted order."""
+    tool = PipelineStatusTool(config={})
+    assert tool.input_schema["properties"]["filter"]["enum"] == list(
+        _MODULE_FILTERS_SORTED
+    )
+
+
+def test_schema_enum_contains_expected_members():
+    """Regression guard: sorting must never silently drop or add a value."""
+    tool = PipelineStatusTool(config={})
+    enum = tool.input_schema["properties"]["filter"]["enum"]
+    assert set(enum) == {"full", "metrics", "current"}
+    assert len(enum) == 3
+
+
+_SCHEMA_PROBE = (
+    "import json\n"
+    "from amplifier_module_tool_pipeline_status import PipelineStatusTool\n"
+    "tool = PipelineStatusTool(config={})\n"
+    "print(json.dumps(tool.input_schema, sort_keys=False, separators=(',', ':')))\n"
+)
+
+
+def test_schema_serialization_is_deterministic_across_processes():
+    """The REAL eval: the serialized input_schema must be byte-identical across
+    independent interpreter starts.
+
+    A same-process test cannot catch this bug class because PYTHONHASHSEED is
+    fixed for the lifetime of one interpreter -- frozenset iteration order
+    only varies *between* process starts. This spawns N independent
+    subprocesses (matching how the real production incident manifested: a
+    fresh schema hash at every process restart) and asserts they all produce
+    the identical serialized schema.
+    """
+    n_procs = 8
+    env = dict(os.environ)
+    env.pop("PYTHONHASHSEED", None)  # let each subprocess pick its own random seed
+
+    canon_outputs: list[str] = []
+    for _ in range(n_procs):
+        result = subprocess.run(
+            [sys.executable, "-c", _SCHEMA_PROBE],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            env=env,
+            check=False,
+        )
+        assert result.returncode == 0, (
+            f"Probe subprocess failed (rc={result.returncode}): "
+            f"stdout={result.stdout!r} stderr={result.stderr!r}"
+        )
+        canon_outputs.append(result.stdout.strip())
+
+    hashes = {hashlib.sha256(c.encode()).hexdigest()[:16] for c in canon_outputs}
+    distinct_orders = sorted(set(canon_outputs))
+    assert len(hashes) == 1, (
+        f"Expected 1 distinct input_schema serialization across {n_procs} "
+        f"independent processes, got {len(hashes)}. The schema's byte "
+        "representation is not stable across interpreter restarts (a "
+        "PYTHONHASHSEED-dependent frozenset iteration order), which "
+        "invalidates the ENTIRE Anthropic prompt cache on every process "
+        f"restart.\nDistinct serializations observed:\n" + "\n".join(distinct_orders)
+    )

--- a/modules/tool-report-outcome/amplifier_module_tool_report_outcome/__init__.py
+++ b/modules/tool-report-outcome/amplifier_module_tool_report_outcome/__init__.py
@@ -17,6 +17,16 @@ logger = logging.getLogger(__name__)
 
 VALID_STATUSES = frozenset({"success", "fail", "partial_success", "retry"})
 
+# Canonical, stable ordering of VALID_STATUSES, read by BOTH the schema
+# `enum` and the error-message join below so they can never drift apart
+# (S4 -- partial-coverage symmetry). A tuple, not a list, so the shared
+# source of truth can't be mutated through a consumer. Do NOT reorder and
+# do NOT inline `sorted(VALID_STATUSES)` at either consumer again -- that
+# reopens the prompt-cache bug. Full story:
+# docs/designs/RECURRING-BUG-CLASSES.md (S4). Regression guard:
+# test_schema_serialization_is_deterministic_across_processes.
+_STATUSES_SORTED: tuple[str, ...] = tuple(sorted(VALID_STATUSES))
+
 
 class ReportOutcomeTool:
     """Report structured outcome data for pipeline routing.
@@ -52,7 +62,7 @@ class ReportOutcomeTool:
             "properties": {
                 "status": {
                     "type": "string",
-                    "enum": list(VALID_STATUSES),
+                    "enum": list(_STATUSES_SORTED),
                     "description": (
                         "Outcome status: 'success', 'fail', "
                         "'partial_success', or 'retry'"
@@ -110,7 +120,7 @@ class ReportOutcomeTool:
         if status not in VALID_STATUSES:
             error_msg = (
                 f"Invalid status: {status!r}. "
-                f"Must be one of: {', '.join(sorted(VALID_STATUSES))}"
+                f"Must be one of: {', '.join(_STATUSES_SORTED)}"
             )
             return ToolResult(
                 success=False,

--- a/modules/tool-report-outcome/tests/test_report_outcome.py
+++ b/modules/tool-report-outcome/tests/test_report_outcome.py
@@ -1,9 +1,15 @@
 """Tests for report_outcome tool."""
 
+import hashlib
+import os
+import subprocess
+import sys
+
 import pytest
-
+from amplifier_module_tool_report_outcome import (
+    _STATUSES_SORTED as _MODULE_STATUSES_SORTED,
+)
 from amplifier_module_tool_report_outcome import ReportOutcomeTool
-
 
 VALID_STATUSES = ["success", "fail", "partial_success", "retry"]
 
@@ -221,3 +227,79 @@ async def test_suggested_next_ids_type_validation():
     )
     assert not result.success
     assert "message" in result.error
+
+
+# -- Schema determinism (prompt-cache stability) ----------------------------
+#
+# Regression guard for the S4 structural pattern (two independent `enum`
+# call sites that must never drift apart). Full story:
+# docs/designs/RECURRING-BUG-CLASSES.md (S4). See
+# test_schema_serialization_is_deterministic_across_processes below for the
+# actual cross-process proof.
+
+
+def test_schema_enum_matches_canonical_order():
+    """The enum must be exactly the module's canonical sorted order."""
+    tool = ReportOutcomeTool(config={})
+    assert tool.input_schema["properties"]["status"]["enum"] == list(
+        _MODULE_STATUSES_SORTED
+    )
+
+
+def test_schema_enum_contains_expected_members():
+    """Regression guard: sorting must never silently drop or add a value."""
+    tool = ReportOutcomeTool(config={})
+    enum = tool.input_schema["properties"]["status"]["enum"]
+    assert set(enum) == {"success", "fail", "partial_success", "retry"}
+    assert len(enum) == 4
+
+
+_SCHEMA_PROBE = (
+    "import json\n"
+    "from amplifier_module_tool_report_outcome import ReportOutcomeTool\n"
+    "tool = ReportOutcomeTool(config={})\n"
+    "print(json.dumps(tool.input_schema, sort_keys=False, separators=(',', ':')))\n"
+)
+
+
+def test_schema_serialization_is_deterministic_across_processes():
+    """The REAL eval: the serialized input_schema must be byte-identical across
+    independent interpreter starts.
+
+    A same-process test cannot catch this bug class because PYTHONHASHSEED is
+    fixed for the lifetime of one interpreter -- frozenset iteration order
+    only varies *between* process starts. This spawns N independent
+    subprocesses (matching how the real production incident manifested: a
+    fresh schema hash at every process restart) and asserts they all produce
+    the identical serialized schema.
+    """
+    n_procs = 8
+    env = dict(os.environ)
+    env.pop("PYTHONHASHSEED", None)  # let each subprocess pick its own random seed
+
+    canon_outputs: list[str] = []
+    for _ in range(n_procs):
+        result = subprocess.run(
+            [sys.executable, "-c", _SCHEMA_PROBE],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            env=env,
+            check=False,
+        )
+        assert result.returncode == 0, (
+            f"Probe subprocess failed (rc={result.returncode}): "
+            f"stdout={result.stdout!r} stderr={result.stderr!r}"
+        )
+        canon_outputs.append(result.stdout.strip())
+
+    hashes = {hashlib.sha256(c.encode()).hexdigest()[:16] for c in canon_outputs}
+    distinct_orders = sorted(set(canon_outputs))
+    assert len(hashes) == 1, (
+        f"Expected 1 distinct input_schema serialization across {n_procs} "
+        f"independent processes, got {len(hashes)}. The schema's byte "
+        "representation is not stable across interpreter restarts (a "
+        "PYTHONHASHSEED-dependent frozenset iteration order), which "
+        "invalidates the ENTIRE Anthropic prompt cache on every process "
+        f"restart.\nDistinct serializations observed:\n" + "\n".join(distinct_orders)
+    )


### PR DESCRIPTION
## Summary

Anthropic prompt caching is hierarchical: `tools` -> `system` -> `messages`. ANY byte change to the serialized `tools` array invalidates the ENTIRE cache.

Two tool modules built their JSON-Schema `enum` from a `frozenset` via `list(...)`. String set iteration order depends on PYTHONHASHSEED, randomized per interpreter start — so the serialized tool schema differed on every process restart, silently invalidating the whole prompt cache. The failure surfaced as a cost/latency regression nowhere near the two lines that caused it.

Measured in production session data (128 LLM requests, one session): 3 distinct `tools` hashes, changing at exactly the two process restarts, each costing a full 314k–374k token cache rewrite. Diff isolated to `report_outcome.input_schema.enum` reordering. Same tool count, identical byte length, different content.

## Verification Checklist

- [x] Unit tests pass (`pytest modules/loop-pipeline/`)
- [x] No live pipeline run required — schema changes, not engine/handler changes
- [x] AGENTS.md reviewed; repo-specific gates met
- [x] Backward-compat path unchanged
- [x] Observable contract change assessment: no specs/EXTENSIONS.md entry needed — `enum` ordering is internal schema serialization. Membership validation (`not in VALID_*`) is set-based and order-independent. No event payloads, no dispatch, no DOT semantics changed. Pipeline authors' `.dot` behavior is identical before/after.
- [x] PR body includes verification evidence

## Verification Evidence

### Pre-fix: Independent 16-process determinism harness

```
tool                    distinct hashes   verdict
tool-report-outcome     12                FAIL     ['success','partial_success','fail','retry']
                                                   ['success','retry','fail','partial_success']
                                                   ['success','fail','partial_success','retry']
tool-pipeline-status     6                FAIL     ['current','full','metrics'] / ['metrics','current','full'] ...
tool-dashboard-query     1                PASS     (control — already deterministic)
```

### Post-fix: Same harness
All three at **1 distinct hash — PASS**. The control passing both before and after confirms the harness is sound rather than merely pessimistic.

### Test suites (provider keys unset: `env -u ANTHROPIC_API_KEY -u OPENAI_API_KEY -u GEMINI_API_KEY -u GOOGLE_API_KEY uv sync && uv run pytest -q`)

```
tool-report-outcome     21 passed
tool-pipeline-status    15 passed
tool-dashboard-query    19 passed
                        -- 55 passed total
```

### Regression property proven (revert ONLY schema-site line, keep tests)

```
tool-report-outcome   -> test_schema_serialization_is_deterministic_across_processes FAILED
                         "Expected 1 distinct serialization across 8 processes, got 7"
tool-pipeline-status  -> same test FAILED, "got 5"
tool-dashboard-query  -> test PASSES on revert
```

The dashboard-query test passes on revert because `sorted()` over a frozenset was never non-deterministic — there is no live bug there for a behavioral test to catch. This confirms the structural-vs-live distinction: all three now have centralized constants, dashboard-query closes the recurrence class even though it had no live bug.

## Review Trail

Two independent reviews ran before this PR:

1. **Code review** returned SHIP WITH CHANGES, mapping the change to **Species 4 (partial-coverage symmetry)** in this repo's own `docs/designs/RECURRING-BUG-CLASSES.md`, and noting the original fix added a SECOND independent `sorted()` call site rather than centralizing — which the repo's own `CODE-REVIEW-CHECKLIST.md` explicitly names as the anti-fix. Applied.

2. **6-lens council review** returned SHIP WITH CHANGES (unanimous CONCERN, no FAIL). All six lenses independently found that `tool-dashboard-query` — cited as the "already correct control" — still carried the same two-independent-`sorted()`-sites structure. Applied (third module now centralized). The council also converged on trimming duplicated comment narratives to pointers, deleting a mutation test that covered pre-existing untouched behavior, deleting a tautological assertion, and reducing the subprocess timeout from 15s to 5s (measured actual runtime 0.017–0.036s; caps worst-case hang at 40s instead of 120s, addressing the subprocess-flake shape AGENTS.md flags from the `loop-agent` incident).

## Known Remaining Gap

All three known instances of this pattern in the repo are now closed. However, **nothing added here (no lint rule, no shared helper, no repo-wide check) prevents a fourth module authored tomorrow from writing `list(<frozenset>)` into a schema enum.** The docs entry and the per-module regression tests are the mitigation; class-level enforcement is not in this PR.

## Change Summary

Per module: one canonical ordered tuple read by BOTH order-sensitive consumers (schema `enum` + error-message join).

- `tool-report-outcome`: `_STATUSES_SORTED` 
- `tool-pipeline-status`: `_FILTERS_SORTED`
- `tool-dashboard-query`: `_OPERATIONS_SORTED`

Frozensets kept — they are membership sets (`status not in VALID_STATUSES`). Tuple not list, so the shared source of truth cannot be mutated through a consumer.

Also updated `docs/designs/RECURRING-BUG-CLASSES.md` with a third S4 incident entry (the single full explanation; all code sites carry a short warning + pointer to it).