### PR TITLE
feat(ci): wire the "specify" stage of issue -> attractor -> PR

### DIFF
--- a/.github/capsule-pipeline/README.md
+++ b/.github/capsule-pipeline/README.md
@@ -1,0 +1,79 @@
+# Capsule pipeline — the "specify" stage
+
+This directory wires the **specify** stage of an issue -> attractor -> PR system:
+given a GitHub issue labeled `ready:spec`, an attractor pipeline reads the
+issue, investigates the pinned repository, and produces a **work capsule** —
+a definition-of-done markdown (`DEFINITION.md`) paired with an executable gate
+script (`DEFINITION.verify.sh`) that is provably red-for-the-right-reason at
+the issue's base commit and provably non-vacuous (a crude hypothesis patch
+turns it green, then the tree is hard-reset and the reset is proven — twice,
+via two independently-shaped hacks). The pipeline never implements a fix and
+never merges anything; it opens a **capsule PR** containing the proposed
+definition of done for a human to review. See
+`.github/workflows/capsule-specify.yml` for the workflow that drives it.
+
+## Files
+
+| Path | What it is |
+|---|---|
+| `capsule.dot` | The attractor pipeline itself (`digraph CapsulePipeline`). |
+| `vendor/backlog/check-upstream-leaks.sh` | Publication-safety gate: scans the produced `DEFINITION.md` for internal working-vocabulary leaks before it ships in a PR. |
+| `vendor/backlog/fixtures/leak-scan/*` | Self-test fixtures for the scanner above (RED/GREEN controls). |
+
+## Provenance — these are VENDORED copies
+
+`capsule.dot` and `vendor/backlog/check-upstream-leaks.sh` (+ its fixtures)
+were authored and evaluated in a private working repository that is **not
+publicly reachable** — GitHub Actions runners cannot clone it, so the
+pipeline cannot reference it live the way it does when run by hand from that
+repository. Both files are copied here **verbatim below their provenance
+header** (see the header comment at the top of each file for the exact
+source commit). Do not hand-edit the body of either file — if a fix or
+improvement is needed, make it in the source repository, re-copy the file
+here, and re-apply the provenance header comment.
+
+`capsule.dot` itself is **not modified** beyond the header: it references its
+leak-scanning dependency via a `uplift_dir` **parameter**, not a hardcoded
+path, so vendoring the scanner under `vendor/backlog/check-upstream-leaks.sh`
+and pointing `--param uplift_dir=.github/capsule-pipeline/vendor` at it
+satisfies the graph's existing `$uplift_dir/backlog/check-upstream-leaks.sh`
+reference with zero changes to the pipeline's logic.
+
+## Why the leak-scan gate still applies here
+
+`check-upstream-leaks.sh` exists to keep a private project's internal
+working vocabulary (task IDs, internal mechanism names, private-repo
+terminology) out of text that ships publicly. Its home repository is
+private; this repository (`amplifier-bundle-attractor`) is the **public**
+target such text ships *into* — that is the boundary the scanner was built
+to guard, and running the pipeline directly inside the public repo does not
+remove the concern: `DEFINITION.md` is a work-order artifact that lands in a
+PR any contributor to this repo may read, and it must be written in this
+repo's own vocabulary (referencing this repo's docs, conventions, and
+exemplars), not in unexplained jargon from an unrelated private project.
+Nothing about the gate's DENY list needed to change for that reason; it is
+vendored as-is.
+
+**Known, harmless deviation**: `vendor/backlog/check-upstream-leaks.sh
+--self-test` reports 2 of its 6 self-checks failing here (the GREEN controls
+that assert specific historical document text from the *source* repository
+scans clean, and that a specific historical task-ID census matches). Those
+two checks are about the source repository's own document set, not about
+this repository, and the same two checks already fail identically when run
+from the source repo's own checkout — this is a pre-existing property of the
+fixtures, not something vendoring introduced, and it does not affect the
+scanner's actual runtime behavior (scanning an arbitrary file against the
+DENY list), which is exercised directly by `leak_gate` in `capsule.dot` and
+was independently re-verified working (the 4 RED fixtures all still trip the
+scanner correctly) before this was wired up.
+
+## Re-syncing
+
+1. In the source repository, confirm the current commit of `runner/capsule.dot`
+   and `backlog/check-upstream-leaks.sh` (+ `backlog/fixtures/leak-scan/`).
+2. Copy the files here verbatim (`cp`, not a manual retype).
+3. Re-apply (or update) the provenance header comment at the top of each file
+   with the new source commit.
+4. Run `attractor lint .github/capsule-pipeline/capsule.dot` and
+   `vendor/backlog/check-upstream-leaks.sh --self-test` and note any new
+   deviations here.

--- a/.github/capsule-pipeline/capsule.dot
+++ b/.github/capsule-pipeline/capsule.dot
@@ -1,0 +1,595 @@
+// ============================================================================
+// VENDORED COPY -- see .github/capsule-pipeline/README.md for provenance,
+// scope, and re-sync instructions. Source: a private working repository
+// (not publicly reachable), pinned at its commit 67a53e531a133f44fa7bfc1afed3b6849a5a5610
+// (runner/capsule.dot, 2026-08-06). This copy is otherwise byte-identical to
+// the source file below this header -- do not hand-edit the body; re-sync
+// from source and re-apply this header instead.
+// ============================================================================
+// ============================================================================
+// Capsule Pipeline — issue-shaped report -> proven work definition
+// ============================================================================
+// Takes a GitHub-issue-shaped input and produces a WORK CAPSULE: a pair of
+// files (a work-definition doc + an executable gate script) that is
+// PROVABLY red-for-the-right-reason on a pinned base SHA and PROVABLY
+// non-vacuous. This is the "specify" stage of the issue->attractor->PR
+// system: triage happens elsewhere (a prompt, not a graph); implementation
+// happens elsewhere (the hardened task-runner.dot). This file's ONLY job is
+// to produce a definition of done a human can approve in minutes, not hours.
+//
+// NOT wired to GitHub Actions. Runs by hand:
+//   cd <target_repo> && \
+//   attractor run <runner_dir>/capsule.dot \
+//       --param issue_file=/abs/path/to/issue.md \
+//       --param target_dir=$PWD \
+//       --param base_sha=<pinned commit the issue was filed against> \
+//       --param later_commit=<optional unrelated later commit, or omit> \
+//       --param uplift_dir=/abs/path/to/attractor-uplift \
+//       --param capsule_out=/abs/path/to/somewhere/outside/target_dir \
+//       --param max_iterations=6 \
+//       --cwd $PWD
+//
+// target_dir is read-only for this run's purposes: this pipeline never
+// commits, branches, or pushes there (contrast task-runner.dot's package/
+// ship_check, which does — capsule.dot has no analog, by design). All
+// durable output is copied OUT to capsule_out; .ai/ scratch lives under
+// target_dir exactly like task-runner.dot's (untracked, never committed —
+// same convention, not a new one).
+//
+// THE SINK (three mechanical checks, cheap-before-expensive, per doctrine):
+//   1. RED with the right exit code   -- redgate:      rc==1 required.
+//      rc==0 is a FINDING (green_on_main), not a retry. rc>=2 is BROKEN
+//      (infra/prerequisite failure -- routes back to author, never treated
+//      as a valid RED).
+//   2. Diagnostic names the defect    -- redgate:      grep -qF the
+//      frontmatter's red_signal against the gate's own red-run log.
+//   3. Non-vacuity via real mutation, TWO INDEPENDENTLY-SHAPED WAYS --
+//      mutate/mutate_gate writes and proves hypothesis.patch (hack A);
+//      mutate_b/diff_shape_gate/mutate_gate_b then writes and proves a
+//      SECOND, mechanically-DIFFERENT hack (hypothesis_b.patch, hack B).
+//      Each patch is applied, the gate must go GREEN, then target_dir is
+//      hard-reset and the reset is PROVEN (git diff --quiet + HEAD ==
+//      pinned base SHA) before anything downstream trusts the tree again --
+//      for BOTH patches, independently. A reset that cannot be proven
+//      routes to reset_fail -- a LOUD, non-retryable halt (task-runner.dot's
+//      forge_fail idiom: a corrupted-state class must stop the run, not
+//      loop on it).
+//
+//      WHY TWO SHAPES (TWO-HYPOTHESIS DISCRIMINATION, see the commit report
+//      for the measured evidence this replaces): a ground-truth eval of the
+//      ONE-hypothesis design found the gate correctly RED at base in 6/6
+//      real cases, but only 2/6 went GREEN at the commit that actually
+//      fixed the bug -- the dominant cause was the gate's GREEN assertion
+//      bound to a GUESS about the shape of the fix (an argument signature,
+//      an invented rule name, a synthetic internal code path, a whole-file
+//      substring grep) rather than to end-state behavior. A single
+//      hypothesis patch only ever proves the gate greens against ONE
+//      guessed shape -- the author's own guess, greened by the author's own
+//      hack, proves almost nothing about a DIFFERENTLY-shaped real fix.
+//      Requiring a SECOND, mechanically-different hack (mutate_b) to ALSO
+//      green the SAME gate is mechanical evidence the assertion is bound to
+//      observable behavior, not to one imagined implementation -- a gate
+//      that greens on hack A but not on a genuinely different hack B is
+//      exactly the failure the eval measured, now caught at authoring time
+//      instead of six commits later. diff_shape_gate (cheap, deterministic,
+//      BEFORE the expensive mutate_gate_b round-trip -- same cheap-before-
+//      expensive discipline as capsule_gate/leak_gate before redgate)
+//      mechanically rejects a COSMETIC variant (same file(s), high changed-
+//      line overlap, same add/remove polarity as hack A) so "different in
+//      shape, identical in observable outcome" is checked, not just
+//      claimed. An author who honestly cannot construct a second shape (a
+//      real possibility -- some defects have exactly one honest fix, e.g. a
+//      literal typo or magic string) is not blocked: mutate_b may instead
+//      write a `# SINGLE-SHAPE:` explanation, which diff_shape_gate accepts
+//      as a distinct, HONESTLY-LABELED finding (.ai/findings/single-
+//      shape.md, shipped alongside the capsule pair) rather than either a
+//      forced fake variant or a silent skip -- the pipeline SAYS which
+//      case it is, it never silently degrades.
+//
+//      "## Fix-shape independence" WRITTEN-SECTION REQUIREMENT RETIRED
+//      (was: author must write, and capsule_gate must verify, a body
+//      section of DEFINITION.md answering "would this gate still go green
+//      if the real fix took a different approach?"): the SAME ground-truth
+//      eval that motivated the two-hypothesis check ALSO measured this
+//      prose lever directly -- adding it produced an IDENTICAL 2/6 result
+//      (self-attestation did not change a single outcome) and caused a
+//      real regression: case t0-5 burned its entire 8-iteration budget
+//      against the new written-section requirement and packaged ZERO
+//      artifacts (see BUDGET-EXHAUSTION MISATTRIBUTION FIX below for the
+//      compounding bug that made that failure invisible). The capsules'
+//      own prose already flagged the exact risk the four failures then
+//      fell into; asking for MORE written reasoning repeated the same
+//      failure mode instead of fixing it. A mechanical, adversarial check
+//      (a second author has to actually GREEN the gate with a genuinely
+//      different mechanism) tests the property the prose could only ever
+//      claim to have. author's prompt keeps a brief, UNGATED reminder to
+//      think about end-state behavior while writing DEFINITION.verify.sh
+//      (cheap, harmless, and it is genuinely useful authoring guidance) --
+//      but nothing reads or grades that thought anymore.
+// PLUS three-point discrimination (discrimination_check) where history
+// allows: RED@base (redgate) + GREEN@hypothesis (mutate_gate) + RED@an
+// unrelated later commit. Skippable-with-reason (never silently) when no
+// later_commit is supplied -- the skip is itself a written artifact
+// (.ai/findings/discrimination.md), copied into the capsule_out evidence.
+//
+// Checks 1+2 (redgate) are cheap and deterministic and run BEFORE check 3's
+// expensive mutation round-trip -- same discipline as task-runner.dot's
+// deterministic-verify-before-LLM-critique ordering (primer doctrine #2).
+//
+// TERMINAL STATES (four, per the design; only one is Msquare "the capsule
+// is proven" -- the other three are equally-valuable FINDINGS, each with
+// its own written artifact, not failures):
+//   done        -- the capsule is proven (checks 1-3 pass; discrimination
+//                  passes or is skipped-with-reason).
+//   green_on_main -- redgate found rc==0 at the pinned base SHA: already
+//                  fixed, or the gate doesn't capture the defect. Writes
+//                  .ai/findings/green-on-main.md.
+//   cant_gate   -- the iteration budget was exhausted specifically at the
+//                  mutation stage: no hypothesis patch, however crude,
+//                  could turn the gate green. Per the design: "if it can't
+//                  write such a patch, the gate isn't specified tightly
+//                  enough -- that's a finding." Writes
+//                  .ai/findings/cant-write-gate.md.
+//   escalate    -- generic budget exhaustion / diagnose-blocked (human
+//                  gate); postmortem writes .ai/postmortem/report.md,
+//                  including the SPECIFIC questions to send back to the
+//                  issue's reporter -- the value salvaged from non-
+//                  convergence, per doctrine #5.
+//
+// AUTHOR-NODE-ONLY CORRECTIVE EDGES: triage and diagnose_gate route back
+// to `author` only. No deterministic gate (capsule_gate/leak_gate/redgate/
+// mutate_gate/discrimination_check) is ever the TARGET of a corrective
+// back-edge -- they are re-ENTERED (fresh classification of whatever author
+// produced next), never "fixed in place."
+//
+// UPSTREAM-LEGAL AUTHORING (leak_gate) -- ARTIFACT SPLIT (fixes the
+// unsatisfiable-by-construction leak gate found live: EX evidence
+// .amplifier/evaluation/capsule-eval/20260805T184234Z -- 6/6 ground-truth
+// cases bounced forever on `LEAK-HIT [.ai/capsule/CAPSULE.md] pattern
+// '\bcapsules?\b': verify: CAPSULE.verify.sh`. Root cause: the file the
+// worker was told to PUBLISH and the file it was told to SHIP were the
+// SAME artifact, under the SAME internal name this program uses for
+// itself -- so the frontmatter's own `verify:` field could only ever be
+// satisfied by writing the forbidden word. backlog/TEMPLATE.md's own rule
+// names this exactly: "the capsule must never hand the worker an
+// obligation it can only satisfy in forbidden vocabulary.")
+//
+// THE FIX IS A NAME, not a suppression: the published pair is named
+// DEFINITION.md / DEFINITION.verify.sh -- neutral words this program's own
+// internal vocabulary never needs, so the frontmatter's `verify:` field
+// (and every other required field) is satisfiable in upstream-legal prose
+// FROM THE FIRST DRAFT, not as a post-hoc vocabulary hunt after a bounce.
+// leak_gate scans EXACTLY these two files (the ones package/ ships out of
+// target_dir) -- the thing that actually gets published, not a proxy for
+// it. Do NOT rename them back to anything containing "capsule": that
+// reintroduces this exact contradiction. .ai/brief.md (orient's output) is
+// the genuinely-internal counterpart -- "internal working material, never
+// published, no vocabulary constraints" (see orient's prompt) -- so there
+// is no need for a THIRD file; the split is DEFINITION.{md,verify.sh}
+// (published, upstream-legal from the start) vs. brief.md (internal,
+// free vocabulary), never one file trying to be both.
+//
+// check-upstream-leaks.sh (usage read first: it accepts one or more file
+// paths, or `-` for stdin; exit 0 clean / 1 blocking hit(s) / 2 usage-or-
+// self-test failure) is wired as a real gate, not advisory: a hit routes
+// back to author to rewrite in upstream-legal vocabulary. This is HONEST
+// wiring, not decoration: capsule.dot's own comments and prompts are free
+// to use uplift vocabulary (this file is never published, and prompts are
+// never written into the scanned artifact); only DEFINITION.md's authored
+// CONTENT is scanned and must pass -- the internal staging directory name
+// (.ai/capsule/) is never scanned (the scanner reads file content, not
+// paths) and stays as-is purely as our own scratch namespace.
+//
+// VERIFIED ENGINE SEMANTICS THIS FILE DEPENDS ON (inherited from
+// task-runner.dot; re-verified against the served engine before this file
+// was authored -- see the commit's own report for the identity-probe
+// evidence):
+//   - Tool-node cwd == context.target_dir == the --cwd the pipeline was
+//     invoked with (KNOWN_ISSUES: process cwd MUST equal --cwd). Every
+//     tool_command below runs FROM target_dir -- DEFINITION.verify.sh is
+//     invoked as `bash .ai/capsule/DEFINITION.verify.sh` with NO leading `cd`,
+//     because cwd is already the target repo root (the exact convention
+//     backlog/TEMPLATE.md documents for verify scripts).
+//   - STALE-LABEL RULE: a failing tool node does not refresh
+//     tool.last_line, so every parallelogram gate below that carries BOTH
+//     last_line-keyed success edges AND a single generic
+//     `condition="outcome=fail"` edge adds the defensive `&& outcome=
+//     success` conjunction to its last_line edges (task-runner.dot
+//     idiom, verbatim).
+//   - must_write= (EXTENSIONS.md §27): declared on orient (.ai/brief.md),
+//     author (.ai/capsule/DEFINITION.verify.sh -- the load-bearing machine
+//     artifact; DEFINITION.md's presence/shape is instead checked explicitly
+//     by capsule_gate, since must_write= takes exactly one path), mutate
+//     (.ai/hypothesis.patch), and postmortem (.ai/postmortem/report.md).
+//     BUDGET-BLIND-DEAD-END FIX (live evidence: EX 20260805T184234Z, 6/6
+//     cases -- run.log logged "must_write= freshness floor violated"
+//     against `author` on 5/6, and ALL 6 froze with convergence.jsonl
+//     stuck at round 1 despite a LATER author-write mtime proving a second
+//     attempt occurred): a must_write violation that exhausts retries
+//     FAILs loudly through the node's normal fail edges (this file's own
+//     contract, above) -- but FAIL never traverses a plain edge (primer.md
+//     #2). author's and orient's only edges WERE plain, so that FAIL had
+//     nowhere to go and the run dead-ended silently, budget ledger frozen,
+//     escalate never reached. Fixed: author now carries the SAME
+//     transient-recovery edge mutate already had (`-> capsule_gate
+//     [outcome=fail]`, spending budget via the ledger on re-entry); orient
+//     (pre-loop, no budget minted yet -- task-runner.dot's own orient
+//     carries no must_write= at all, "fails early, cheap to relaunch")
+//     gets a LOUD fail-fast edge to orient_fail instead of a budgeted
+//     retry, so a violation there surfaces instead of hanging silently.
+//   - LEDGER-DERIVED BUDGET (task-runner.dot idiom, verbatim): capsule_gate
+//     derives its round number n as (count of prior "gate": "round"
+//     records in .ai/convergence.jsonl)+1, ignoring any stray .ai/iter
+//     write, then mirrors n back to .ai/iter for downstream readers
+//     (redgate/mutate_gate/discrimination_check's own ledger records,
+//     triage's signature comparison).
+//   - CONVERGENCE RECORD: capsule_gate, leak_gate, redgate, mutate_gate,
+//     and discrimination_check each append one line per visit to
+//     .ai/convergence.jsonl (gate keys "round"/"leak"/"redgate"/
+//     "mutate_gate"/"discrimination") -- the descent record postmortem
+//     reads on non-convergence.
+//   - PARAM NAMESPACE: `${k:-default}` is NOT engine-expanded (unknown
+//     braced key passes through); optional params (later_commit,
+//     max_iterations) are read into a shell var first (`LC=$later_commit`)
+//     and defaulted in shell. An entirely-OMITTED param leaves the literal
+//     `$name` text for the shell to expand as its OWN (unset, empty)
+//     variable -- functionally identical to the engine substituting an
+//     empty string, so no special-casing is needed either way.
+//   - goal_gate=true + retry_target="author" on the four proof gates
+//     (capsule_gate/redgate/mutate_gate/discrimination_check) mirrors
+//     task-runner.dot's verify/verdict: belt (their own tool exit code is
+//     already `is_explicit`) and suspenders (an unclassified in-node crash
+//     still has somewhere honest to go).
+//
+// A DELIBERATE DIVERGENCE FROM task-runner.dot, NAMED HONESTLY: this file
+// does NOT use feedback_from= or loop_restart=true anywhere. task-runner
+// .dot itself does not use feedback_from= either (it predates/coexists
+// with the manual .ai/feedback/N-next.md convention, used in ITS outer
+// dual-critique loop). capsule.dot has no outer LLM-judgment loop to
+// accumulate critique across -- every one of its checks is deterministic
+// (redgate/mutate_gate/discrimination_check are shell + git + the gate
+// script, not an LLM critic) -- so the shape here is entirely
+// task-runner.dot's INNER mechanical-fix loop (session continuity via
+// thread_id, "read the log first" via .ai/gate.log), never its outer one.
+// Forcing feedback_from= onto `author` would have been decoration, not
+// inheritance; see the commit's report for the full reasoning.
+// ============================================================================
+
+digraph CapsulePipeline {
+    graph [
+        goal="Given an issue-shaped report and a pinned base SHA in target_dir, produce a work capsule (DEFINITION.md + DEFINITION.verify.sh) that is provably red-for-the-right-reason at that SHA and provably non-vacuous (a crude hypothesis patch turns it green, then the tree is hard-reset and the reset is proven), authored in upstream-legal vocabulary.",
+        params="issue_file, target_dir, base_sha, later_commit, uplift_dir, capsule_out, max_iterations",
+        default_max_retries=2,
+        default_fidelity="compact",
+        max_pipeline_duration="3600s",
+        retry_target="author"
+    ]
+
+    // ENGINE CONSTRAINT (lint rule terminal_node, M-11): exactly ONE exit
+    // node is permitted (shape=Msquare / type="exit" / id="exit"|"end").
+    // green_on_main and cant_gate are therefore NOT separate Msquare nodes
+    // -- they are OUTCOMES distinguished by their WRITTEN ARTIFACT
+    // (.ai/findings/green-on-main.md / .ai/findings/cant-write-gate.md),
+    // both of which route to the single `done` exit, exactly as the
+    // design's four terminal STATES map onto the engine's one terminal
+    // SHAPE plus the escalate hexagon (which is not a dead-end -- it has
+    // outgoing edges, so it does not compete for exit-node status).
+    start [shape=Mdiamond]
+    done  [shape=Msquare]
+
+    // ---------- setup: deterministic preflight (fail fast, cheap to relaunch) ----------
+    // REFUSE A DIRTY TREE (design requirement): the mutation round-trip
+    // (mutate_gate) proves its reset via `git diff --quiet` against the
+    // pinned base SHA -- an unclean START makes that proof meaningless (you
+    // cannot tell "we reset cleanly" from "it was already dirty before we
+    // began"). Distinct terminal (dirty_tree) from generic bad_input:
+    // this is a precondition violation, not a missing-file typo.
+    setup [shape=parallelogram, class="glue", max_retries=0,
+        tool_command="mkdir -p .ai/capsule .ai/feedback .ai/postmortem .ai/findings; B=$max_iterations; echo ${B:-6} > .ai/budget; if [ ! -d \"$target_dir/.git\" ]; then echo \"target_dir is not a git checkout: $target_dir\" > .ai/setup-error.log; printf invalid; elif [ -n \"$(git status --porcelain 2>&1)\" ]; then printf dirty; elif [ -z \"$issue_file\" ] || [ ! -f \"$issue_file\" ]; then echo \"issue_file not found: $issue_file\" > .ai/setup-error.log; printf invalid; elif [ -z \"$base_sha\" ] || ! git rev-parse --verify \"${base_sha}^{commit}\" >/dev/null 2>&1; then echo \"base_sha does not resolve to a commit in target_dir: $base_sha\" > .ai/setup-error.log; printf invalid; elif [ -z \"$uplift_dir\" ] || [ ! -f \"$uplift_dir/backlog/check-upstream-leaks.sh\" ]; then echo \"uplift_dir/backlog/check-upstream-leaks.sh not found under: $uplift_dir\" > .ai/setup-error.log; printf invalid; elif [ -z \"$capsule_out\" ]; then echo 'capsule_out param is required (absolute path OUTSIDE target_dir for the durable capsule pair)' > .ai/setup-error.log; printf invalid; elif ! git checkout --quiet \"$base_sha\"; then echo \"git checkout of base_sha failed: $base_sha\" > .ai/setup-error.log; printf invalid; else git rev-parse HEAD > .ai/base-sha; printf ok; fi"]
+
+    bad_input [shape=parallelogram, class="glue", max_retries=0,
+        tool_command="[ -s .ai/setup-error.log ] && cat .ai/setup-error.log >&2 || echo 'FATAL: capsule preflight failed and no error detail was captured' >&2; exit 1"]
+
+    dirty_tree [shape=parallelogram, class="glue", max_retries=0,
+        tool_command="echo 'FATAL: target_dir has uncommitted changes -- refusing to run. The mutation round-trip (mutate_gate) proves its hard-reset via git diff --quiet against the pinned base SHA; an unclean START makes that proof meaningless. Commit, stash, or use a fresh checkout, then re-run.' >&2; exit 1"]
+
+    // LOUD, NON-RETRYABLE HALT for orient's must_write=.ai/brief.md
+    // contract (BUDGET-BLIND-DEAD-END FIX, see header): orient runs BEFORE
+    // the round/budget loop even starts (capsule_gate has not minted a
+    // ledger entry yet), so there is no budget to spend recovering it --
+    // task-runner.dot's own orient carries no must_write= at all for
+    // exactly this reason ("fails early, cheap to relaunch"). A violation
+    // here now surfaces LOUD (bad_input/dirty_tree/reset_fail idiom: dead-
+    // end is loud since #66) instead of a silent hang with no diagnostic.
+    orient_fail [shape=parallelogram, class="glue", max_retries=0,
+        tool_command="echo 'FATAL: orient failed to write .ai/brief.md within its retry budget (must_write= contract exhausted, or another in-node crash). Fail-fast per task-runner.dot orient doctrine: this is a preflight step before the round/budget loop starts, so there is no budget to spend retrying it here. Re-run the pipeline by hand once the underlying cause (provider outage, an unreadable issue_file, etc.) is addressed.' >&2; exit 1"]
+
+    // ---------- orient: read the report, survey the pinned tree ----------
+    orient [shape=box, class="maker", must_write=".ai/brief.md",
+        prompt="You are given an issue-shaped report at $issue_file describing a defect or gap in the repository now checked out at $target_dir, pinned to commit $base_sha (see .ai/base-sha). Read the report IN FULL. Survey the pinned tree for the files, functions, and behavior it concerns -- ground everything in what the code at THIS SHA actually does, not what the report assumes. Write .ai/brief.md containing: (1) the reported problem restated in your own words as a concrete, observable behavior gap; (2) a candidate literal diagnostic substring the defect would produce if reproduced right now (a candidate red_signal -- real command output, not invented); (3) real file:line references or command transcripts grounding the above; (4) risks, ambiguities, or missing information in the report that the eventual capsule should either resolve or flag. This file is internal working material, never published -- write plainly, no vocabulary constraints here."]
+
+    // ---------- author: writes the capsule pair (the load-bearing artifact) ----------
+    // Session continuity across the inner loop (thread_id=work, fidelity=
+    // full), mirroring task-runner.dot's `attempt` node exactly -- NOT
+    // feedback_from=/loop_restart= (see header: no outer LLM-judgment loop
+    // exists here for those to attach to).
+    author [shape=box, class="maker", thread_id="work", fidelity="full",
+        must_write=".ai/capsule/DEFINITION.verify.sh",
+        prompt="Write the work capsule: two files, .ai/capsule/DEFINITION.md and .ai/capsule/DEFINITION.verify.sh. Sources of truth: .ai/brief.md, the report at $issue_file, and the ACTUAL code in $target_dir (pinned at $base_sha -- see .ai/base-sha). If .ai/gate.log exists, it holds the most recent gate's exact diagnostic; read it FIRST and fix precisely what it reports -- do not re-guess. If .ai/postmortem/diagnosis.md exists, honor its change of course.\n\nDEFINITION.verify.sh: a bash script. Its FIRST line must be exactly `set -euo pipefail`. It will be invoked as `bash .ai/capsule/DEFINITION.verify.sh` with the target repo root as its cwd (no arguments, no cd). Guard every prerequisite explicitly (missing binary, missing fixture, a cd that could fail) and exit >=2 on infrastructure problems -- ONLY an assertion failure (the reported defect genuinely reproducing) may exit exactly 1. Exit 0 means the defect is NOT present (already fixed, or this gate does not capture it -- both are valid, useful outcomes, not something to hide). On the rc=1 path, print a line containing the EXACT literal substring you will declare as red_signal below -- this is what proves the red is red for the stated reason, not an unrelated crash. The script must be idempotent: it will be re-run, unmodified, against multiple commits and after a hypothesis patch is applied and reverted. Never write an unconditional `exit 1` or any other assertion that cannot fail -- a gate that cannot fail is not a gate (checks 2 and 3 downstream exist specifically to catch this). Keep the GREEN half honest while you write it: you are guessing at how the defect will actually be fixed, and this gate can only ever exercise the fix that lands, not the one you pictured -- if the real fix took a completely different approach than the one you have in mind (a different function, a different internal name, a different code path, a fix that removes something instead of adding it), would this script still go green? Bind GREEN to the END-STATE BEHAVIOR your Goal describes -- what a user or a test can observe happening or not happening -- never to your guess about which function, argument shape, internal identifier, or code path the fix will touch: those are implementation details you cannot know in advance and do not need to know. You do not need to write this reasoning down anywhere -- a later stage (mutate_b/diff_shape_gate/mutate_gate_b) PROVES it mechanically by requiring a second, differently-shaped crude patch to ALSO turn this same script green, so there is no written self-attestation to satisfy here.\n\nDEFINITION.md: YAML frontmatter between --- lines with fields `id` (short, filename-safe), `title`, `red_signal` (the literal substring above, written PLAIN with no surrounding quotes -- it is checked with `grep -qF`), `base_sha` (copy $base_sha), `later_commit` (copy $later_commit if non-empty, else omit the field), `target_repo`, `verify: DEFINITION.verify.sh`. Body: Goal (the end state, not steps), Why this matters, Definition of done (what the script checks, plus any judgment criteria a human reviewer should still apply), Non-goals.\n\nUPSTREAM-LEGAL VOCABULARY (this file will be published into the target project): ground every claim in files, behavior, and terminology that exist in the target repo's own shipped tree. Do not use this pipeline's own internal program name, its internal documentation names, or any internal task-numbering scheme anywhere in DEFINITION.md -- write as if a contributor to the target project who has never heard of this pipeline will read it. leak_gate will scan this file and route you back here with a diagnostic if it finds vocabulary that does not belong in a published artifact."]
+
+    // ---------- capsule_gate: CHEAP deterministic gate (shape + budget wall) ----------
+    // Ledger-derived budget (task-runner.dot idiom, verbatim, key "round"):
+    // checked BEFORE the shape work, so every re-entry -- including the
+    // transient-recovery re-entries from mutate/discrimination_check/
+    // package below -- spends an iteration (same "verify walls the budget
+    // on every entry" discipline).
+    capsule_gate [shape=parallelogram, class="gate", max_retries=0,
+        goal_gate=true, retry_target="author",
+        tool_command="n=$(grep -c '\"gate\": \"round\"' .ai/convergence.jsonl 2>/dev/null); n=$((${n:-0}+1)); echo $n > .ai/iter; B=$(cat .ai/budget 2>/dev/null); B=${B:-6}; if [ \"$n\" -gt \"$B\" ]; then printf '{\"iteration\": %s, \"gate\": \"round\", \"budget\": \"exhausted\"}\\n' \"$n\" >> .ai/convergence.jsonl; printf exhausted; else CM=.ai/capsule/DEFINITION.md; CV=.ai/capsule/DEFINITION.verify.sh; ok=1; msg=''; if [ ! -s \"$CM\" ]; then msg='DEFINITION.md missing or empty'; elif [ ! -s \"$CV\" ]; then msg='DEFINITION.verify.sh missing or empty'; elif ! grep -q '^set -euo pipefail' \"$CV\"; then msg='DEFINITION.verify.sh does not start with set -euo pipefail'; elif ! grep -q '^red_signal:' \"$CM\"; then msg='DEFINITION.md frontmatter is missing red_signal:'; elif ! grep -q '^id:' \"$CM\"; then msg='DEFINITION.md frontmatter is missing id:'; elif ! grep -q '^title:' \"$CM\"; then msg='DEFINITION.md frontmatter is missing title:'; else ok=0; fi; if [ $ok -eq 0 ]; then printf '{\"iteration\": %s, \"gate\": \"round\", \"shape\": \"ok\"}\\n' \"$n\" >> .ai/convergence.jsonl; printf shape_ok; else printf '{\"iteration\": %s, \"gate\": \"round\", \"shape\": \"bad\"}\\n' \"$n\" >> .ai/convergence.jsonl; echo \"SHAPE GATE: $msg\" > .ai/gate.log; echo round > .ai/last-stage-fail; exit 1; fi; fi"]
+
+    // ---------- leak_gate: publication-safety gate (deterministic, wired honestly) ----------
+    // check-upstream-leaks.sh's own contract (read before wiring): 0 clean,
+    // 1 blocking hit(s), 2 usage/self-test failure. Both non-zero classes
+    // route to author (a hit needs a rewrite; a scanner crash still needs a
+    // human-visible reason via .ai/gate.log, surfaced through the same
+    // root-cause wall as any other repeated gate failure).
+    leak_gate [shape=parallelogram, class="gate", max_retries=0,
+        tool_command="n=$(cat .ai/iter 2>/dev/null || echo 0); sh \"$uplift_dir/backlog/check-upstream-leaks.sh\" .ai/capsule/DEFINITION.md > .ai/leak.log 2>&1; rc=$?; printf '{\"iteration\": %s, \"gate\": \"leak\", \"clean\": %s}\\n' \"$n\" \"$([ $rc -eq 0 ] && echo true || echo false)\" >> .ai/convergence.jsonl; if [ $rc -eq 0 ]; then printf leak_clean; else cp .ai/leak.log .ai/gate.log; echo round > .ai/last-stage-fail; exit 1; fi"]
+
+    // ---------- redgate: checks 1+2 -- RED with the right exit code, diagnostic names the defect ----------
+    redgate [shape=parallelogram, class="gate", max_retries=0,
+        goal_gate=true, retry_target="author",
+        tool_command="CV=.ai/capsule/DEFINITION.verify.sh; chmod +x \"$CV\" 2>/dev/null; timeout 900 bash \"$CV\" > .ai/verify-red.log 2>&1; rc=$?; [ $rc -eq 124 ] && echo 'GATE TIMEOUT after 900s' >> .ai/verify-red.log; red_signal=$(awk '/^---$/{c++;next} c==1 && /^red_signal:/{sub(/^red_signal:[[:space:]]*/,\"\"); print; exit}' .ai/capsule/DEFINITION.md | sed 's/[[:space:]]*$//'); n=$(cat .ai/iter 2>/dev/null || echo 0); printf '{\"iteration\": %s, \"gate\": \"redgate\", \"rc\": %s}\\n' \"$n\" \"$rc\" >> .ai/convergence.jsonl; if [ $rc -eq 0 ]; then printf green_on_main; elif [ $rc -eq 1 ] && [ -n \"$red_signal\" ] && grep -qF \"$red_signal\" .ai/verify-red.log; then printf red_ok; else { echo \"REDGATE FAIL: rc=$rc (need exactly 1 for a valid RED; >=2 is an infra/prerequisite problem, not a defect); red_signal='$red_signal'; signal-found=$(grep -qF \\\"$red_signal\\\" .ai/verify-red.log 2>/dev/null && echo yes || echo no)\"; tail -30 .ai/verify-red.log; } > .ai/gate.log; echo redgate > .ai/last-stage-fail; exit 1; fi"]
+
+    // ---------- write_green_finding: rc==0 at base SHA is a FINDING, not a retry ----------
+    write_green_finding [shape=parallelogram, class="glue", max_retries=0,
+        tool_command="mkdir -p .ai/findings; { echo '# Finding: gate is GREEN at the pinned base SHA'; echo; echo \"DEFINITION.verify.sh exited 0 against target_dir at base SHA $(cat .ai/base-sha 2>/dev/null) -- either the reported defect is already fixed on this SHA, or the gate does not capture it. No further capsule work is warranted without new information from the reporter.\"; echo; echo '--- gate output (.ai/verify-red.log) ---'; cat .ai/verify-red.log 2>/dev/null; } > .ai/findings/green-on-main.md; printf synthesized"]
+
+    // ---------- mutate: check 3 -- write the deliberately CRUDE hypothesis patch ----------
+    mutate [shape=box, class="maker", thread_id="mutate",
+        must_write=".ai/hypothesis.patch",
+        prompt="The gate is proven RED for the stated reason at the pinned base SHA (redgate: rc=1, diagnostic contains the declared red_signal). Now prove the gate is NOT vacuous. Write a deliberately CRUDE hypothesis patch to .ai/hypothesis.patch: a unified diff (git diff format, applicable via `git apply` from the target repo root) that hardcodes, stubs, or early-returns its way to making DEFINITION.verify.sh exit 0. This is explicitly NOT a correct fix -- a hack that only needs to turn the gate green is the entire point; a real fix is out of scope here. Ground it in the ACTUAL current file contents of $target_dir (read the real files; do not invent paths or line numbers). If .ai/gate.log exists from a prior attempt at this stage, read it and try a different hack -- do not repeat an already-failed patch. If you genuinely cannot construct ANY patch, however crude, that would satisfy the gate, that is itself important evidence that the gate is not specified tightly enough: say so explicitly as a comment header in .ai/hypothesis.patch (a short explanation of why no working stub could be found) rather than fabricating a patch that will not apply."]
+
+    // ---------- mutate_gate: applies the patch, proves GREEN, hard-resets, PROVES the reset ----------
+    // git clean excludes .ai/ explicitly -- it is our own untracked scratch
+    // state; without the exclusion `git clean -fd` would delete the very
+    // ledger/log files this run depends on.
+    mutate_gate [shape=parallelogram, class="gate", max_retries=0,
+        goal_gate=true, retry_target="author",
+        tool_command="CV=.ai/capsule/DEFINITION.verify.sh; P=.ai/hypothesis.patch; BASE=$(cat .ai/base-sha 2>/dev/null); n=$(cat .ai/iter 2>/dev/null || echo 0); if [ -z \"$BASE\" ]; then echo 'MUTATE_GATE: .ai/base-sha missing -- preflight did not pin a base SHA' > .ai/gate.log; echo mutate > .ai/last-stage-fail; exit 1; fi; if ! git apply --check \"$P\" >/dev/null 2>&1; then printf '{\"iteration\": %s, \"gate\": \"mutate_gate\", \"applies\": false}\\n' \"$n\" >> .ai/convergence.jsonl; echo \"MUTATE_GATE: hypothesis.patch does not apply cleanly against pinned base $BASE\" > .ai/gate.log; echo mutate > .ai/last-stage-fail; exit 1; fi; git apply \"$P\"; chmod +x \"$CV\" 2>/dev/null; timeout 900 bash \"$CV\" > .ai/verify-hypothesis.log 2>&1; rc=$?; if [ $rc -ne 0 ]; then printf '{\"iteration\": %s, \"gate\": \"mutate_gate\", \"greened\": false, \"rc\": %s}\\n' \"$n\" \"$rc\" >> .ai/convergence.jsonl; { echo \"MUTATE_GATE: hypothesis patch applied but gate rc=$rc (need 0 -- the crude patch did not turn it green)\"; tail -30 .ai/verify-hypothesis.log; } > .ai/gate.log; git checkout --quiet -- .; git clean -qfd -e .ai; echo mutate > .ai/last-stage-fail; exit 1; fi; git checkout --quiet -- .; git clean -qfd -e .ai; if git diff --quiet -- . && [ \"$(git rev-parse HEAD)\" = \"$BASE\" ]; then printf '{\"iteration\": %s, \"gate\": \"mutate_gate\", \"greened\": true, \"reset_proven\": true}\\n' \"$n\" >> .ai/convergence.jsonl; printf roundtrip_ok; else printf '{\"iteration\": %s, \"gate\": \"mutate_gate\", \"greened\": true, \"reset_proven\": false}\\n' \"$n\" >> .ai/convergence.jsonl; echo \"MUTATE_GATE: RESET NOT PROVEN after hard-reset attempt -- git diff and/or HEAD no longer matches the pinned base SHA ($BASE). Halting: an unreset tree would poison every check downstream. A human must inspect $target_dir before this pipeline (or anything else) trusts it again.\" > .ai/gate.log; printf reset_unproven; fi"]
+
+    // LOUD, NON-RETRYABLE HALT (task-runner.dot's forge_fail idiom): a
+    // reset that cannot be proven is a corrupted-state class, not a
+    // retryable defect. No outgoing edges -- dead-end is loud since #66.
+    // Shared by BOTH round-trip gates (mutate_gate for hypothesis.patch,
+    // mutate_gate_b for hypothesis_b.patch) -- .ai/gate.log names which one.
+    reset_fail [shape=parallelogram, class="glue", max_retries=0,
+        tool_command="echo 'RESET-PROOF FAIL: see .ai/gate.log for which round-trip (mutate_gate or mutate_gate_b) could not prove target_dir was returned to its pinned base SHA after its hypothesis-patch round-trip. Do not trust target_dir until a human has inspected and restored it.' >&2; exit 1"]
+
+    // ---------- mutate_b: check 3b -- write a SECOND, MECHANICALLY-DIFFERENT hypothesis patch ----------
+    // Session continuity of its own (thread_id="mutate_b", distinct from
+    // mutate's "mutate" thread) -- reading .ai/hypothesis.patch is enough
+    // context; it does not need mutate's own conversation.
+    mutate_b [shape=box, class="maker", thread_id="mutate_b",
+        must_write=".ai/hypothesis_b.patch",
+        prompt="Check 3 proved the gate goes GREEN against ONE guessed fix shape (.ai/hypothesis.patch). That proves the gate is non-vacuous, but a single hack, greened by its own author, proves almost nothing about a DIFFERENTLY-shaped real fix -- the gate could still be bound to that one guessed shape rather than to end-state behavior. Prove the stronger claim: write a SECOND, deliberately CRUDE hypothesis patch to .ai/hypothesis_b.patch that ALSO turns DEFINITION.verify.sh green, but through a genuinely DIFFERENT mechanism than .ai/hypothesis.patch used -- a different file, a different function or call path, an OPPOSITE operation (if A added a stub or hardcode, B should remove or short-circuit something instead, or vice versa), or a different internal name for the same concept. The explicit goal: DIFFERENT IN SHAPE, IDENTICAL IN OBSERVABLE OUTCOME (the gate goes green either way). This is still explicitly NOT a correct fix -- a second hack is the entire point. Ground it in the ACTUAL current file contents of $target_dir (the tree is reset to the pinned base SHA -- read the real files; do not invent paths or line numbers). If .ai/gate.log exists from a prior attempt at THIS stage, read it first: a prior .ai/hypothesis_b.patch may have been rejected as a cosmetic variant of hypothesis.patch (same file, near-identical changed lines, same add/remove polarity) or may have failed to green the gate -- do not repeat it. If you genuinely believe only ONE honest fix shape exists for this defect (a real possibility -- some defects are that narrow, e.g. a single typo or a single required magic string), do not fabricate a fake variant to satisfy this check: write .ai/hypothesis_b.patch containing ONLY a comment block whose FIRST LINE is exactly `# SINGLE-SHAPE:` followed by a concrete, specific explanation of why no second shape is honestly possible. That is itself valuable evidence about the gate, not a failure to hide -- diff_shape_gate accepts it as a distinct, honestly-labeled finding."]
+
+    // ---------- diff_shape_gate: CHEAP mechanical check -- is hack B a REAL second shape? ----------
+    // Cheap-before-expensive (same discipline as capsule_gate/leak_gate
+    // before redgate): reject a COSMETIC variant here, before spending the
+    // expensive apply/verify/reset round-trip on it. Mechanical, never
+    // semantic: (1) the SINGLE-SHAPE opt-out is accepted verbatim as a
+    // finding; (2) byte-identical to hypothesis.patch is rejected outright;
+    // (3) a DIFFERENT set of files touched (compares sorted `+++ ` paths)
+    // is accepted as a real shape difference; (4) same file(s) is accepted
+    // ONLY if the changed-line content overlap is <50% OR the add/remove
+    // polarity differs (additive vs subtractive vs mixed, by a 2x margin) --
+    // same file with near-identical lines and the same polarity reads as a
+    // cosmetic variant and is rejected.
+    diff_shape_gate [shape=parallelogram, class="gate", max_retries=0,
+        goal_gate=true, retry_target="author",
+        tool_command="PA=.ai/hypothesis.patch; PB=.ai/hypothesis_b.patch; n=$(cat .ai/iter 2>/dev/null || echo 0); if [ ! -s \"$PB\" ]; then echo 'DIFF-SHAPE: .ai/hypothesis_b.patch missing or empty' > .ai/gate.log; echo diff_shape > .ai/last-stage-fail; exit 1; fi; if head -1 \"$PB\" | grep -q '^# SINGLE-SHAPE:'; then mkdir -p .ai/findings; { echo '# Finding: only one hypothesis shape was validated'; echo; echo 'The author judged that no second, mechanically different crude patch honestly exists for this defect (explanation below, copied verbatim from .ai/hypothesis_b.patch). The gate is proven non-vacuous against exactly ONE guessed fix shape (.ai/hypothesis.patch) -- a human reviewer should apply extra scrutiny to whether the assertion is truly behavior-bound before trusting it as tightly as a two-shape-proven gate.'; echo; echo '--- author explanation (.ai/hypothesis_b.patch) ---'; cat \"$PB\"; } > .ai/findings/single-shape.md; printf '{\"iteration\": %s, \"gate\": \"diff_shape\", \"outcome\": \"single_shape\"}\\n' \"$n\" >> .ai/convergence.jsonl; printf single_shape; exit 0; fi; if cmp -s \"$PA\" \"$PB\"; then echo 'DIFF-SHAPE: hypothesis_b.patch is byte-identical to hypothesis.patch -- not a second shape' > .ai/gate.log; echo diff_shape > .ai/last-stage-fail; printf '{\"iteration\": %s, \"gate\": \"diff_shape\", \"outcome\": \"identical\"}\\n' \"$n\" >> .ai/convergence.jsonl; exit 1; fi; FA=$(grep '^+++ ' \"$PA\" 2>/dev/null | sed 's/^+++ //; s/[[:space:]].*$//' | sort -u); FB=$(grep '^+++ ' \"$PB\" 2>/dev/null | sed 's/^+++ //; s/[[:space:]].*$//' | sort -u); if [ \"$FA\" != \"$FB\" ]; then printf '{\"iteration\": %s, \"gate\": \"diff_shape\", \"outcome\": \"different_files\"}\\n' \"$n\" >> .ai/convergence.jsonl; printf different_files; exit 0; fi; grep '^+' \"$PA\" 2>/dev/null | grep -v '^+++' | sed 's/^+//; s/[[:space:]]//g' | sort -u > .ai/.la-add.tmp; grep '^-' \"$PA\" 2>/dev/null | grep -v '^---' | sed 's/^-//; s/[[:space:]]//g' | sort -u > .ai/.la-del.tmp; grep '^+' \"$PB\" 2>/dev/null | grep -v '^+++' | sed 's/^+//; s/[[:space:]]//g' | sort -u > .ai/.lb-add.tmp; grep '^-' \"$PB\" 2>/dev/null | grep -v '^---' | sed 's/^-//; s/[[:space:]]//g' | sort -u > .ai/.lb-del.tmp; cat .ai/.la-add.tmp .ai/.la-del.tmp | sort -u > .ai/.la-all.tmp; cat .ai/.lb-add.tmp .ai/.lb-del.tmp | sort -u > .ai/.lb-all.tmp; COMMON=$(comm -12 .ai/.la-all.tmp .ai/.lb-all.tmp | grep -c .); UNION=$(cat .ai/.la-all.tmp .ai/.lb-all.tmp | sort -u | grep -c .); ADDS_A=$(grep -c . .ai/.la-add.tmp); DELS_A=$(grep -c . .ai/.la-del.tmp); ADDS_B=$(grep -c . .ai/.lb-add.tmp); DELS_B=$(grep -c . .ai/.lb-del.tmp); pol_a=mixed; [ \"$ADDS_A\" -gt $((DELS_A*2)) ] && pol_a=additive; [ \"$DELS_A\" -gt $((ADDS_A*2)) ] && pol_a=subtractive; pol_b=mixed; [ \"$ADDS_B\" -gt $((DELS_B*2)) ] && pol_b=additive; [ \"$DELS_B\" -gt $((ADDS_B*2)) ] && pol_b=subtractive; overlap_pct=0; [ \"$UNION\" -gt 0 ] && overlap_pct=$(( COMMON * 100 / UNION )); rm -f .ai/.la-add.tmp .ai/.la-del.tmp .ai/.lb-add.tmp .ai/.lb-del.tmp .ai/.la-all.tmp .ai/.lb-all.tmp; if [ \"$pol_a\" != \"$pol_b\" ] || [ \"$overlap_pct\" -lt 50 ]; then printf '{\"iteration\": %s, \"gate\": \"diff_shape\", \"outcome\": \"different_mechanism\", \"overlap_pct\": %s, \"polarity_a\": \"%s\", \"polarity_b\": \"%s\"}\\n' \"$n\" \"$overlap_pct\" \"$pol_a\" \"$pol_b\" >> .ai/convergence.jsonl; printf different_mechanism; exit 0; fi; echo \"DIFF-SHAPE: hypothesis_b.patch touches the same file(s) as hypothesis.patch with ${overlap_pct}% changed-line overlap and the same add/remove polarity ($pol_a) -- reads as a cosmetic variant, not a mechanically different fix shape. Try a different file, a different function or call path, or an opposite operation (add vs remove).\" > .ai/gate.log; echo diff_shape > .ai/last-stage-fail; printf '{\"iteration\": %s, \"gate\": \"diff_shape\", \"outcome\": \"cosmetic_variant\", \"overlap_pct\": %s}\\n' \"$n\" \"$overlap_pct\" >> .ai/convergence.jsonl; exit 1"]
+
+    // ---------- mutate_gate_b: applies hack B, proves GREEN, hard-resets, PROVES the reset ----------
+    // Identical shape to mutate_gate (same apply/verify/reset/prove
+    // sequence, same git-clean -e .ai exclusion), operating on
+    // hypothesis_b.patch -- BOTH resets are proven independently, never
+    // just one.
+    mutate_gate_b [shape=parallelogram, class="gate", max_retries=0,
+        goal_gate=true, retry_target="author",
+        tool_command="CV=.ai/capsule/DEFINITION.verify.sh; P=.ai/hypothesis_b.patch; BASE=$(cat .ai/base-sha 2>/dev/null); n=$(cat .ai/iter 2>/dev/null || echo 0); if [ -z \"$BASE\" ]; then echo 'MUTATE_GATE_B: .ai/base-sha missing -- preflight did not pin a base SHA' > .ai/gate.log; echo mutate_b > .ai/last-stage-fail; exit 1; fi; if ! git apply --check \"$P\" >/dev/null 2>&1; then printf '{\"iteration\": %s, \"gate\": \"mutate_gate_b\", \"applies\": false}\\n' \"$n\" >> .ai/convergence.jsonl; echo \"MUTATE_GATE_B: hypothesis_b.patch does not apply cleanly against pinned base $BASE\" > .ai/gate.log; echo mutate_b > .ai/last-stage-fail; exit 1; fi; git apply \"$P\"; chmod +x \"$CV\" 2>/dev/null; timeout 900 bash \"$CV\" > .ai/verify-hypothesis-b.log 2>&1; rc=$?; if [ $rc -ne 0 ]; then printf '{\"iteration\": %s, \"gate\": \"mutate_gate_b\", \"greened\": false, \"rc\": %s}\\n' \"$n\" \"$rc\" >> .ai/convergence.jsonl; { echo \"MUTATE_GATE_B: hypothesis_b.patch applied but gate rc=$rc (need 0 -- the second, differently-shaped crude patch did not turn it green -- if a real fix could only take THIS shape and not hypothesis.patch's shape, the gate may be bound to hypothesis.patch's shape, not to end-state behavior)\"; tail -30 .ai/verify-hypothesis-b.log; } > .ai/gate.log; git checkout --quiet -- .; git clean -qfd -e .ai; echo mutate_b > .ai/last-stage-fail; exit 1; fi; git checkout --quiet -- .; git clean -qfd -e .ai; if git diff --quiet -- . && [ \"$(git rev-parse HEAD)\" = \"$BASE\" ]; then printf '{\"iteration\": %s, \"gate\": \"mutate_gate_b\", \"greened\": true, \"reset_proven\": true}\\n' \"$n\" >> .ai/convergence.jsonl; printf roundtrip_b_ok; else printf '{\"iteration\": %s, \"gate\": \"mutate_gate_b\", \"greened\": true, \"reset_proven\": false}\\n' \"$n\" >> .ai/convergence.jsonl; echo \"MUTATE_GATE_B: RESET NOT PROVEN after hypothesis-B round-trip -- git diff and/or HEAD no longer matches the pinned base SHA ($BASE). Halting: an unreset tree would poison every check downstream. A human must inspect $target_dir before this pipeline (or anything else) trusts it again.\" > .ai/gate.log; printf reset_b_unproven; fi"]
+
+    // ---------- discrimination_check: RED at an unrelated later commit (skippable-with-reason) ----------
+    discrimination_check [shape=parallelogram, class="gate", max_retries=0,
+        goal_gate=true, retry_target="author",
+        tool_command="mkdir -p .ai/findings; LC=$later_commit; CV=.ai/capsule/DEFINITION.verify.sh; n=$(cat .ai/iter 2>/dev/null || echo 0); if [ -z \"$LC\" ]; then echo 'DISCRIMINATION: skipped -- no later_commit param supplied. The three-point discrimination check (RED at an unrelated later commit, which catches an over-broad gate that passes on anything) did not run for this capsule.' > .ai/findings/discrimination.md; printf '{\"iteration\": %s, \"gate\": \"discrimination\", \"ran\": false}\\n' \"$n\" >> .ai/convergence.jsonl; printf skip_recorded; else BASE=$(cat .ai/base-sha 2>/dev/null); if ! git rev-parse --verify \"${LC}^{commit}\" >/dev/null 2>&1; then echo \"DISCRIMINATION: later_commit does not resolve to a commit: $LC\" > .ai/gate.log; echo discrimination > .ai/last-stage-fail; exit 1; fi; git checkout --quiet \"$LC\"; chmod +x \"$CV\" 2>/dev/null; timeout 900 bash \"$CV\" > .ai/verify-later.log 2>&1; rc=$?; git checkout --quiet \"$BASE\"; printf '{\"iteration\": %s, \"gate\": \"discrimination\", \"ran\": true, \"rc\": %s, \"later_commit\": \"%s\"}\\n' \"$n\" \"$rc\" \"$LC\" >> .ai/convergence.jsonl; if [ $rc -eq 1 ]; then echo \"DISCRIMINATION: RED confirmed at unrelated later commit $LC (rc=1) -- the gate does not pass on unrelated code.\" > .ai/findings/discrimination.md; printf discrim_ok; elif [ $rc -eq 0 ]; then { echo \"DISCRIMINATION FAIL: gate went GREEN at unrelated later commit $LC -- the gate is over-broad (passes on unrelated code) and needs tightening.\"; tail -20 .ai/verify-later.log; } > .ai/gate.log; echo discrimination > .ai/last-stage-fail; exit 1; else { echo \"DISCRIMINATION: infra rc=$rc at later commit $LC (expected 0 or 1)\"; tail -20 .ai/verify-later.log; } > .ai/gate.log; echo discrimination > .ai/last-stage-fail; exit 1; fi; fi"]
+
+    // ---------- package: copy the proven capsule pair OUT of target_dir ----------
+    // target_dir is read-only for this pipeline's purposes (no commit, no
+    // branch -- contrast task-runner.dot's package/ship_check). Failure
+    // here is a real deterministic problem (bad path, permissions), routed
+    // through the SAME root-cause wall as any other gate failure.
+    package [shape=parallelogram, class="gate", max_retries=0,
+        tool_command="CM=.ai/capsule/DEFINITION.md; CV=.ai/capsule/DEFINITION.verify.sh; id=$(awk '/^---$/{c++;next} c==1 && /^id:/{sub(/^id:[[:space:]]*/,\"\"); print; exit}' \"$CM\" | tr -cd 'A-Za-z0-9._-'); [ -n \"$id\" ] || id=work-definition; OUT=\"$capsule_out\"; mkdir -p \"$OUT\" && cp \"$CM\" \"$OUT/$id.md\" && cp \"$CV\" \"$OUT/$id.verify.sh\" && chmod +x \"$OUT/$id.verify.sh\"; rc=$?; [ -f .ai/base-sha ] && cp .ai/base-sha \"$OUT/$id.base-sha\"; [ -f .ai/hypothesis.patch ] && cp .ai/hypothesis.patch \"$OUT/$id.hypothesis.patch\"; [ -f .ai/hypothesis_b.patch ] && cp .ai/hypothesis_b.patch \"$OUT/$id.hypothesis-b.patch\"; [ -f .ai/findings/discrimination.md ] && cp .ai/findings/discrimination.md \"$OUT/$id.discrimination.md\"; [ -f .ai/findings/single-shape.md ] && cp .ai/findings/single-shape.md \"$OUT/$id.single-shape.md\"; if [ $rc -eq 0 ] && [ -s \"$OUT/$id.md\" ] && [ -s \"$OUT/$id.verify.sh\" ]; then printf packaged; else echo \"PACKAGE FAILED: could not write the capsule pair to $OUT (rc=$rc)\" > .ai/gate.log; echo round > .ai/last-stage-fail; exit 1; fi"]
+
+    // ---------- triage: root-cause wall (task-runner.dot idiom, verbatim, on .ai/gate.log) ----------
+    triage [shape=parallelogram, class="glue", max_retries=0,
+        tool_command="B=$(cat .ai/budget 2>/dev/null); B=${B:-6}; n=$(cat .ai/iter 2>/dev/null || echo 0); sig=$(tail -20 .ai/gate.log 2>/dev/null | sed -E 's|/tmp/[A-Za-z0-9._-]+|TMPPATH|g; s/[0-9]+\\.[0-9]+s?//g' | md5sum | cut -d' ' -f1); prev=$(cat .ai/last-fail-sig 2>/dev/null || echo none); echo $sig > .ai/last-fail-sig; if [ \"$n\" -ge \"$B\" ]; then printf exhausted; elif [ \"$sig\" = \"$prev\" ]; then printf repeat; else printf novel; fi"]
+
+    diagnose [shape=box, class="gate",
+        prompt="A capsule-round gate failed twice with the SAME failure signature (see .ai/gate.log, and .ai/last-stage-fail for which stage: round/leak/redgate/mutate/discrimination). Stop iterating blindly -- find the root cause. Read .ai/gate.log, .ai/brief.md, the report at $issue_file, and the relevant code in $target_dir. Determine what is actually wrong: (a) DEFINITION.verify.sh's assertion approach, (b) a misread of the reported defect, (c) an environment/tooling gap, or (d) a genuine ambiguity in the report that cannot be resolved from inside this run. Write .ai/postmortem/diagnosis.md with the root cause, the evidence, and the single change of course for the next attempt. If the blocker cannot be resolved from inside this run, include the word BLOCKED on its own line and explain."]
+
+    diagnose_gate [shape=parallelogram, class="glue", max_retries=0,
+        tool_command="rm -f .ai/last-fail-sig; grep -qE '^BLOCKED' .ai/postmortem/diagnosis.md && printf blocked || printf continue"]
+
+    // ---------- budget_decision: differentiate WHY the budget ran out ----------
+    // The one place the "can't write a gate" finding and generic budget
+    // exhaustion diverge: last-stage-fail=mutate (or mutate_b) means checks
+    // 1+2 (redgate) were already proven and ONLY a mutation round-trip
+    // kept failing -- exactly the design's "if it can't write such a
+    // patch, the gate isn't specified tightly enough" shape. Anything else
+    // is genuine non-convergence and gets the human postmortem path.
+    //
+    // BUDGET-EXHAUSTION MISATTRIBUTION FIX (live evidence: EX
+    // 20260806T024842Z-iter1, case t0-5-fail-closed-outcomes -- run.log
+    // shows the `mutate` box node repeatedly failing its OWN must_write=
+    // freshness floor ("Node 'mutate' must_write= freshness floor
+    // violated") across iterations 2-6; each such crash took the
+    // transient-recovery edge `mutate -> capsule_gate [outcome=fail]`
+    // straight back to the cheap gate WITHOUT ever touching
+    // .ai/last-stage-fail (that edge, like author's, deliberately bypasses
+    // triage -- see the AUTHOR-NODE-ONLY doctrine). .ai/convergence.jsonl
+    // for that run shows round/leak/redgate succeeding on iterations 2-6
+    // with NO mutate_gate record at all -- mutate_gate never got a chance
+    // to run again after iteration 1. Yet .ai/last-stage-fail was STILL
+    // "mutate" from iteration 1's one real mutate_gate failure, many
+    // rounds earlier -- a STALE flag, not fresh evidence. The old
+    // last-stage-fail=mutate check alone could not tell "the mutation
+    // round-trip genuinely could never green" (a legitimate cant_gate
+    // finding) apart from "a maker node kept crashing before the round-
+    // trip ever ran again" (an entirely different, mundane, non-finding
+    // problem) -- so it misclassified the run as cant_gate, which routes
+    // straight to write_cant_gate_finding -> done WITHOUT ever calling
+    // package: status=success, capsule_out/ empty, iteration budget
+    // burned on a misdiagnosis. A budget-exhausted run that packages
+    // nothing must not report success on a false finding.
+    //
+    // THE FIX is LEDGER-DERIVED (this file's own idiom, verbatim: "its own
+    // append-only ledger, which workers don't touch"), not a trust in a
+    // single mutable flag file: cant_gate is now legitimate ONLY when the
+    // LAST mutate_gate-family record (mutate_gate or mutate_gate_b) in
+    // .ai/convergence.jsonl was written in the round IMMEDIATELY BEFORE
+    // the exhaustion round (mg_n == n-1) -- i.e. the round-trip genuinely
+    // ran and failed right up against the wall, not many silent maker-
+    // crash rounds ago. A stale flag (mg_n < n-1) means at least one later
+    // round burned budget via the maker-crash transient-recovery path
+    // without the round-trip ever running again -- that is generic non-
+    // convergence, routed to postmortem with an explicit diagnostic
+    // (.ai/budget-exhaustion-diagnostic.md) naming exactly why the
+    // cant_gate finding was rejected, so the misattribution is SAID, never
+    // silently swallowed into a false success.
+    budget_decision [shape=parallelogram, class="glue", max_retries=0,
+        tool_command="stage=$(cat .ai/last-stage-fail 2>/dev/null || echo none); n=$(cat .ai/iter 2>/dev/null || echo 0); mg_n=$(grep -E \"gate\\\": \\\"mutate_gate(_b)?\\\"\" .ai/convergence.jsonl 2>/dev/null | grep -oE \"iteration\\\": [0-9]+\" | tail -1 | grep -oE \"[0-9]+\"); mg_n=${mg_n:-0}; if [ \"$stage\" = mutate ] || [ \"$stage\" = mutate_b ]; then if [ \"$mg_n\" -eq $((n-1)) ]; then printf cant_gate; else mkdir -p .ai/findings; { echo \"BUDGET-EXHAUSTION MISATTRIBUTION: last-stage-fail='$stage' (recorded at some earlier round) but the last real mutate_gate/mutate_gate_b attempt in .ai/convergence.jsonl ran at iteration '$mg_n', not $((n-1)) (the round immediately before exhaustion at iteration $n).\"; echo \"This means at least one later round burned budget via the maker-crash transient-recovery path (the mutate or mutate_b box node repeatedly failing its own must_write contract, re-entering via capsule_gate WITHOUT ever reaching the mutation round-trip again) -- NOT a genuine 'the gate cannot be made non-vacuous' finding. Routing to postmortem/escalate instead of the cant_gate finding path.\"; echo; echo '--- convergence ledger (tail) ---'; tail -20 .ai/convergence.jsonl 2>/dev/null; } > .ai/findings/budget-exhaustion-diagnostic.md; printf pm; fi; else printf pm; fi"]
+
+    write_cant_gate_finding [shape=parallelogram, class="glue", max_retries=0,
+        tool_command="mkdir -p .ai/findings; { echo '# Finding: the gate could not be proven non-vacuous'; echo; echo 'No hypothesis patch, however crude, turned DEFINITION.verify.sh green within the iteration budget, even though the gate was already proven RED for the stated reason at the pinned base SHA. The gate as specified may not be tight enough to admit a fix, or the reported defect may need re-scoping before a capsule can be written for it.'; echo; echo '--- last gate diagnostic (.ai/gate.log) ---'; cat .ai/gate.log 2>/dev/null; echo; echo '--- convergence ledger (tail) ---'; tail -20 .ai/convergence.jsonl 2>/dev/null; } > .ai/findings/cant-write-gate.md; printf synthesized"]
+
+    // ---------- postmortem: budget wall as a decision point, not a fuse ----------
+    postmortem [shape=box, class="gate", must_write=".ai/postmortem/report.md",
+        prompt="This capsule run has hit a decision point without convergence. Read .ai/convergence.jsonl (the descent record), .ai/gate.log, .ai/last-stage-fail, .ai/brief.md, and the report at $issue_file. Write .ai/postmortem/report.md: what was tried each round and at which stage it failed, whether the loop was DESCENDING, OSCILLATING, or WANDERING (cite the convergence record), your best hypothesis for why it has not converged, and -- the value salvaged from non-convergence -- the SPECIFIC, concrete, answerable questions this run could not resolve on its own that should go back to the person who filed the report at $issue_file. Be honest."]
+
+    pm_gate [shape=parallelogram, class="glue", max_retries=0,
+        tool_command="mkdir -p .ai/postmortem; f=.ai/postmortem/report.md; if [ -s $f ]; then { echo 'SALVAGED-PARTIAL: the postmortem node FAILED (must_write contract or node error, after engine retries), but a partial report existed; its content is preserved below.'; echo; cat $f; } > $f.tmp; mv $f.tmp $f; else { echo 'SYNTHESIZED-STUB: the postmortem node FAILED after engine retries and no report was written. Assembled from the run evidence.'; echo; echo '--- .ai/convergence.jsonl (tail) ---'; tail -20 .ai/convergence.jsonl 2>/dev/null; echo; echo '--- .ai/gate.log ---'; cat .ai/gate.log 2>/dev/null; } > $f; fi; printf synthesized"]
+
+    escalate [shape=hexagon,
+        prompt="capsule.dot could not converge within budget, or diagnose could not resolve the blocker from inside this run. Review .ai/postmortem/ and .ai/convergence.jsonl before choosing."]
+
+    bump_budget [shape=parallelogram, class="glue", max_retries=0,
+        tool_command="B=$(cat .ai/budget 2>/dev/null); B=${B:-6}; N=$((B+3)); [ $N -gt 15 ] && N=15; echo $N > .ai/budget; rm -f .ai/last-fail-sig; printf continue"]
+
+    abandon [shape=parallelogram, class="glue", max_retries=0,
+        tool_command="echo 'ABANDONED: see .ai/postmortem/report.md and .ai/convergence.jsonl' >&2; exit 1"]
+
+    // ================= edges =================
+    start -> setup
+    setup -> orient     [condition="context.tool.last_line=ok"]
+    setup -> dirty_tree [condition="context.tool.last_line=dirty"]
+    setup -> bad_input  [condition="context.tool.last_line=invalid"]
+
+    orient -> author
+    orient -> orient_fail [condition="outcome=fail", label="must_write=.ai/brief.md exhausted, or in-node crash -- fail-fast, pre-loop"]
+    // BUDGET-BLIND-DEAD-END FIX: author declares must_write=.ai/capsule/
+    // DEFINITION.verify.sh; a violation that exhausts retries FAILs
+    // loudly (this file's must_write= contract note above) but FAIL
+    // cannot traverse a plain edge (primer.md #2) -- author's ONLY edge
+    // used to be the plain one below, so that FAIL had nowhere to go and
+    // the run dead-ended silently with the budget ledger frozen (live
+    // evidence: EX 20260805T184234Z, run.log "must_write= freshness
+    // floor violated" on author, convergence.jsonl never advancing past
+    // round 1 despite a later author-write mtime). Same transient-
+    // recovery idiom mutate already uses below: re-enter via the cheap
+    // gate, which spends budget on every entry (ledger-derived, checked
+    // before shape work) regardless of how execution arrived there.
+    author -> capsule_gate [condition="outcome=fail", label="transient -- re-enter via cheap gate (also closes the must_write exhaustion dead-end)"]
+    author -> capsule_gate
+
+    // capsule_gate: budget wall + shape check. Defensive stale-label
+    // conjunctions on both last_line-keyed success tokens (this node also
+    // carries a plain outcome=fail edge to triage).
+    capsule_gate -> budget_decision [condition="context.tool.last_line=exhausted && outcome=success", label="budget exhausted"]
+    capsule_gate -> leak_gate       [condition="context.tool.last_line=shape_ok && outcome=success"]
+    capsule_gate -> triage          [condition="outcome=fail", label="shape defect"]
+
+    leak_gate -> redgate [condition="context.tool.last_line=leak_clean && outcome=success"]
+    leak_gate -> triage  [condition="outcome=fail", label="upstream-leak hit or scanner error"]
+
+    // redgate: checks 1+2. Three success-classified tokens (green_on_main
+    // is a FINDING, not a retry) plus one generic fail edge.
+    redgate -> write_green_finding [condition="context.tool.last_line=green_on_main && outcome=success", label="rc==0 at base SHA -- a finding, not a defect"]
+    redgate -> mutate               [condition="context.tool.last_line=red_ok && outcome=success", label="checks 1+2 pass"]
+    redgate -> triage                [condition="outcome=fail", label="rc!=1, or signal missing"]
+    write_green_finding -> done [label="finding: gate already green at base SHA"]
+
+    // Transient recovery (task-runner.dot idiom): a genuine box-node crash
+    // (provider error) on mutate re-enters via the cheap gate rather than
+    // losing the round.
+    mutate -> mutate_gate
+    mutate -> capsule_gate [condition="outcome=fail", label="transient -- re-enter via cheap gate"]
+
+    // Check 3 passes (hypothesis A greened + reset proven) -> proceed to
+    // check 3b (hypothesis B, the two-hypothesis discrimination proof).
+    mutate_gate -> mutate_b   [condition="context.tool.last_line=roundtrip_ok && outcome=success", label="check 3 passes -- prove a second, differently-shaped hack also greens"]
+    mutate_gate -> reset_fail [condition="context.tool.last_line=reset_unproven && outcome=success", label="reset (A) could not be proven -- LOUD halt"]
+    mutate_gate -> triage     [condition="outcome=fail", label="patch A would not apply, or would not green"]
+
+    // mutate_b: same transient-recovery idiom as mutate itself.
+    mutate_b -> diff_shape_gate
+    mutate_b -> capsule_gate [condition="outcome=fail", label="transient -- re-enter via cheap gate"]
+
+    // diff_shape_gate: cheap mechanical shape-difference check, BEFORE the
+    // expensive mutate_gate_b round-trip. single_shape is an accepted,
+    // honestly-labeled finding (skips straight to discrimination_check --
+    // there is no second patch to round-trip); different_files and
+    // different_mechanism both proceed to the expensive proof.
+    diff_shape_gate -> mutate_gate_b       [condition="context.tool.last_line=different_files && outcome=success", label="hack B touches different file(s) than hack A"]
+    diff_shape_gate -> mutate_gate_b       [condition="context.tool.last_line=different_mechanism && outcome=success", label="same file(s), but low content overlap or opposite add/remove polarity"]
+    diff_shape_gate -> discrimination_check [condition="context.tool.last_line=single_shape && outcome=success", label="author judged no second honest shape exists -- finding recorded, skip round-trip B"]
+    diff_shape_gate -> triage                [condition="outcome=fail", label="hypothesis_b missing, identical to A, or a cosmetic variant"]
+
+    mutate_gate_b -> discrimination_check [condition="context.tool.last_line=roundtrip_b_ok && outcome=success", label="check 3b passes -- second shape also greens (discrimination proven)"]
+    mutate_gate_b -> reset_fail            [condition="context.tool.last_line=reset_b_unproven && outcome=success", label="reset (B) could not be proven -- LOUD halt"]
+    mutate_gate_b -> triage                 [condition="outcome=fail", label="patch B would not apply, or would not green"]
+
+    discrimination_check -> package [condition="context.tool.last_line=skip_recorded && outcome=success", label="no later_commit -- skipped with reason"]
+    discrimination_check -> package [condition="context.tool.last_line=discrim_ok && outcome=success", label="RED confirmed at later commit"]
+    discrimination_check -> triage   [condition="outcome=fail", label="gate over-broad, or infra problem at later commit"]
+
+    package -> done   [condition="context.tool.last_line=packaged && outcome=success"]
+    package -> triage [condition="outcome=fail", label="could not write capsule_out"]
+
+    // Root-cause wall + budget wall (task-runner.dot idiom, verbatim
+    // shape). Corrective back-edges land on `author` only -- never on a
+    // deterministic gate.
+    triage -> author         [condition="context.tool.last_line=novel", label="fix"]
+    triage -> diagnose       [condition="context.tool.last_line=repeat", label="same failure twice"]
+    triage -> budget_decision [condition="context.tool.last_line=exhausted", label="budget spent"]
+
+    diagnose -> diagnose_gate
+    diagnose_gate -> author   [condition="context.tool.last_line=continue", label="change course"]
+    diagnose_gate -> escalate [condition="context.tool.last_line=blocked"]
+
+    // Budget exhaustion is a decision point with TWO possible shapes: a
+    // targeted finding (mutation stage specifically) or generic
+    // non-convergence (everything else).
+    budget_decision -> write_cant_gate_finding [condition="context.tool.last_line=cant_gate && outcome=success", label="only the mutation round-trip kept failing"]
+    budget_decision -> postmortem              [condition="context.tool.last_line=pm && outcome=success", label="generic non-convergence"]
+    write_cant_gate_finding -> done [label="finding: gate not provably non-vacuous"]
+
+    postmortem -> escalate
+    postmortem -> pm_gate [condition="outcome=fail", label="no report after engine retries -- synthesize"]
+    pm_gate -> escalate
+
+    escalate -> abandon     [label="[A] Abandon -- keep the postmortem"]
+    escalate -> bump_budget [label="[C] Continue -- raise the budget"]
+    bump_budget -> author
+}

--- a/.github/capsule-pipeline/vendor/backlog/check-upstream-leaks.sh
+++ b/.github/capsule-pipeline/vendor/backlog/check-upstream-leaks.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# ============================================================================
+# VENDORED COPY -- see .github/capsule-pipeline/README.md for provenance,
+# scope, and re-sync instructions. Source: a private working repository
+# (not publicly reachable), pinned at its commit
+# 67a53e531a133f44fa7bfc1afed3b6849a5a5610 (backlog/check-upstream-leaks.sh,
+# 2026-08-06), fixtures from the same commit. Otherwise byte-identical to the
+# source below this header -- do not hand-edit the body; re-sync from source
+# and re-apply this header instead.
+# ============================================================================
+# ============================================================================
+# check-upstream-leaks.sh — structural-leak tripwire for upstream-bound text.
+#
+# LADDER STEP 2 (pre-committed at the T4-9 checkpoint, fired by the T1-7
+# close — structural-leak instance #2, "the evals loop" in EXTENSIONS §28;
+# instance #1 was T4-9's §27 retirement inventory citing noverdict/clean_b):
+# a grep-able deny-list of internal uplift-mechanism vocabulary, run against
+# upstream-bound artifacts (PR bodies, EXTENSIONS entries, commit messages,
+# doc diffs) — INCLUDING tracked files, not just diffs.
+#
+# CONTRACT:
+#   - HIT  = exit 1 (BLOCK — a human adjudicates; a hit is a question, not
+#     automatically a leak).
+#   - SILENCE PROVES NOTHING: exit 0 means only "no seeded pattern matched."
+#     The membership test (backlog/TEMPLATE.md "Upstream citation boundary")
+#     + the close-stage human leak scan remain the CONTROL OF RECORD; this
+#     script is a mechanical tripwire beneath them, never their replacement.
+#   - Seed list per the T1-7 council; EXTENDABLE — add a line to DENY below
+#     whenever a new internal mechanism name is coined.
+#   - CLOSE-RITUAL OWNERSHIP (T2-7 council, sam): a leak adjudicated TRUE
+#     at a close EXTENDS the seed list AND commits a RED fixture
+#     reconstructing the missed text, in the SAME close. The scanner only
+#     ever knows the vocabulary its misses have taught it; the ritual is
+#     what feeds it.
+#   - DE-ESCALATION PRE-COMMITMENT (T2-7 council): after N=5 consecutive
+#     leak-free closes — counting ONLY closes that shipped upstream-bound
+#     text; the clock starts at the T2-7 close, AFTER the T2-7 seed
+#     extension — a retirement review of this tripwire is warranted
+#     (a review, not an automatic removal; the membership test + human
+#     scan remain the control of record either way).
+#
+# SEED NOTES (morphology-tolerant, with two membership-test carve-outs):
+#   - no[_-]?verdicts? matches the COMPOUND forms only (noverdict,
+#     no-verdict). The spaced phrase "no verdict" is legitimate upstream
+#     spec prose (EXTENSIONS §25 goal-gate text: "no verdict was produced")
+#     — the compound is ours, the phrase is theirs.
+#   - pm[_-]?gate is DUAL-STATUS: upstream's own exemplar
+#     examples/patterns/task-runner.dot ships a pm_gate node, so shipped
+#     upstream text may cite it legitimately. A pm_gate hit is ALLOWED only
+#     when the scanned artifact itself anchors the term to that exemplar
+#     (contains "examples/patterns/task-runner"); unanchored uses block.
+#   - TASK IDs (T2-7 close — the maiden run caught 1 of 3 leaked
+#     vocabulary classes; "T2-3 COORDINATION" scanned clean): the patterns
+#     \bT<digits>-<digits>\b and \bEX-<digits>\b are our internal task-ID
+#     vocabulary, EXCEPT the IDs upstream's own shipped tree already
+#     carries — earlier merged waves baked T0-1/T0-4/T0-5/T1-1 into
+#     upstream's AGENTS.md, PRINCIPLES.md, SPEC_CONFORMANCE.md,
+#     specs/EXTENSIONS.md ("Conformance Restoration Note (T0-4)") and
+#     docs/ (census: amplifier-bundle-attractor @ ef382c4; re-run
+#     `git grep -ohE '\bT[0-9]+-[0-9]+\b' | sort -u` there when extending
+#     TID_ALLOW). Citing an ID upstream already carries is a question
+#     already adjudicated ALLOWED; any OTHER ID blocks. Case-sensitive:
+#     canonical IDs are uppercase (lowercase t11-attempt-1 style run
+#     names are not task-ID citations).
+#   - \bprimer\b (T2-7 close — "primer §6.11" scanned clean on the maiden
+#     run): the doctrine primer is context/primer.md, internal-only;
+#     upstream's shipped tree contains zero uses of the word (same census
+#     ref). Section pointers into it are exactly the leak shape that
+#     slipped.
+#
+# Usage:
+#   backlog/check-upstream-leaks.sh <file>...     # scan files ('-' = stdin)
+#   git diff upstream-base..HEAD | backlog/check-upstream-leaks.sh -
+#   backlog/check-upstream-leaks.sh --self-test   # RED/GREEN proof (both
+#       known leak instances reconstructed as fixtures must exit 1; the
+#       current shipped EXTENSIONS §27/§28 text must exit 0)
+# Exit: 0 clean, 1 blocking hit(s), 2 usage/self-test-failure.
+# ============================================================================
+set -u
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+
+DENY='clean[_-]?b\b
+no[_-]?verdicts?\b
+evals?[-_ ](loop|harness|batter(y|ies))
+test[_-]verdict[_-]classification|verdict[-_ ]classification
+attractor[-_ ]uplift|\buplift\b
+\bbacklog\b
+\bcapsules?\b
+\bprimer\b'
+DENY_PM='pm[_-]?gate\b'
+PM_ANCHOR='examples/patterns/task-runner'
+# Task-ID census (T2-7 close; see SEED NOTES): case-SENSITIVE extraction,
+# then subtract the IDs upstream's shipped tree already carries.
+DENY_TID='\b(T[0-9]+-[0-9]+|EX-[0-9]+)\b'
+TID_ALLOW='T0-1|T0-4|T0-5|T1-1'
+
+scan_file() {  # scan_file <path-or-dash> -> sets HITS (global counter)
+    local f="$1" body tmp=""
+    if [ "$f" = "-" ]; then
+        tmp=$(mktemp); cat > "$tmp"; body="$tmp"; f="(stdin)"
+    else
+        [ -r "$1" ] || { echo "unreadable: $1" >&2; HITS=$((HITS+1)); return; }
+        body="$1"
+    fi
+    while IFS= read -r pat; do
+        [ -n "$pat" ] || continue
+        if grep -nEiq "$pat" "$body"; then
+            echo "LEAK-HIT [$f] pattern '$pat':" >&2
+            grep -nEi "$pat" "$body" | head -5 >&2
+            HITS=$((HITS+1))
+        fi
+    done <<EOF
+$DENY
+EOF
+    tids=$(grep -oE "$DENY_TID" "$body" 2>/dev/null | sort -u | grep -vE "^($TID_ALLOW)$")
+    if [ -n "$tids" ]; then
+        echo "LEAK-HIT [$f] internal task id(s) not carried by upstream's shipped tree (TID_ALLOW census): $(printf '%s' "$tids" | tr '\n' ' ')" >&2
+        grep -nE "$DENY_TID" "$body" | head -5 >&2
+        HITS=$((HITS+1))
+    fi
+    if grep -nEiq "$DENY_PM" "$body"; then
+        if grep -q "$PM_ANCHOR" "$body"; then
+            echo "note [$f]: pm_gate hit ALLOWED (anchored to upstream exemplar $PM_ANCHOR — membership-test carve-out)" >&2
+        else
+            echo "LEAK-HIT [$f] pattern '$DENY_PM' (UNANCHORED — no $PM_ANCHOR citation in artifact):" >&2
+            grep -nEi "$DENY_PM" "$body" | head -5 >&2
+            HITS=$((HITS+1))
+        fi
+    fi
+    [ -n "$tmp" ] && rm -f "$tmp"
+}
+
+if [ "${1:-}" = "--self-test" ]; then
+    FX="$HERE/fixtures/leak-scan"
+    st_fail=0
+    for red in "$FX/t4-9-prefix.RED.txt" "$FX/t1-7-prefix.RED.txt" \
+               "$FX/t2-7-coordination.RED.txt" "$FX/t2-7-primer-ref.RED.txt"; do
+        if "$0" "$red" >/dev/null 2>&1; then
+            echo "SELF-TEST FAIL: $red did NOT trip the scanner (expected exit 1)" >&2
+            st_fail=1
+        else
+            echo "self-test ok: RED fixture trips the scanner: $(basename "$red")"
+        fi
+    done
+    if "$0" "$FX/extensions-27-28.GREEN.md" >/dev/null 2>&1; then
+        echo "self-test ok: GREEN fixture (shipped EXTENSIONS §27/§28 text) passes clean"
+    else
+        echo "SELF-TEST FAIL: shipped EXTENSIONS §27/§28 text tripped the scanner (expected exit 0)" >&2
+        st_fail=1
+    fi
+    # False-positive control (T2-7 close): task IDs upstream's own shipped
+    # tree already carries must NOT block (TID_ALLOW carve-out).
+    if printf 'the fan-out retirement (T0-4) restored spec single-best-edge selection; see also T0-1, T0-5 and T1-1.\n' | "$0" - >/dev/null 2>&1; then
+        echo "self-test ok: GREEN control — upstream-carried task ids (T0-1/T0-4/T0-5/T1-1) pass the TID_ALLOW carve-out"
+    else
+        echo "SELF-TEST FAIL: upstream-carried task ids tripped the TID scan (carve-out broken)" >&2
+        st_fail=1
+    fi
+    [ $st_fail -eq 0 ] && echo "check-upstream-leaks self-test: PASS (RED x4, GREEN x2)"
+    exit $((st_fail == 0 ? 0 : 2))
+fi
+
+[ $# -ge 1 ] || { echo "usage: $0 <file>... | -  (or --self-test)" >&2; exit 2; }
+
+HITS=0
+for f in "$@"; do scan_file "$f"; done
+if [ "$HITS" -gt 0 ]; then
+    echo "BLOCKED: $HITS deny-list hit group(s) — adjudicate before shipping upstream (a hit is a question, not a verdict; the membership test is the control of record)." >&2
+    exit 1
+fi
+echo "clean (no seeded pattern matched — silence proves nothing; run the membership test + human scan)."
+exit 0

--- a/.github/capsule-pipeline/vendor/backlog/fixtures/leak-scan/extensions-27-28.GREEN.md
+++ b/.github/capsule-pipeline/vendor/backlog/fixtures/leak-scan/extensions-27-28.GREEN.md
@@ -1,0 +1,283 @@
+## 27. `must_write=` Node Attribute — Fail-Closed Artifact Contract
+
+> **This extension adds an artifact-contract enforcement check to the
+> engine** (per retry attempt, plus a final post-override backstop).
+> It does not conflict with the canonical spec; the spec is silent on
+> per-node artifact contracts.  Nodes without `must_write=` are completely
+> untouched (opt-in).
+
+### Motivation
+
+The same engine gap has been patched at the graph level repeatedly — every
+guard hand-rolled after a live failure:
+
+1. **pm_gate** (`examples/patterns/task-runner.dot`) — the postmortem node
+   was observed returning SUCCESS without writing its report; a deterministic
+   stub-guard gate now guarantees the file exists.
+2. **Verdict gates counting absence as refusal** — in live runs of this
+   pattern, a critique node silently ended on plain-text narration without
+   writing its critique file; the deterministic verdict gate downstream
+   (a grep against the missing file) counted the absence as a refusal, and
+   a stall counter killed a run whose tree was ship-quality by direct
+   re-verification.
+3. **Historical postmortem stubs** — the same "completed without writing"
+   shape observed before pm_gate existed.
+
+A box node's contract is often "this file now exists with real content."  The
+engine had no way to be told that.  `must_write=` puts the cheapest evidence
+check (the artifact exists AND is fresh AND is non-trivial) where every graph
+gets it for free, instead of every author rediscovering the trap live.
+
+### What this extension does
+
+A node may declare `must_write=<path>` as a node attribute.  After the handler
+returns a non-FAIL outcome, the engine runs a three-axis post-execution check:
+
+1. **Existence:** the file at `<path>` must exist.
+2. **Freshness floor (REQUIRED):** `artifact.mtime > node_start_wall`
+   (strictly greater than; `time.time()` snapshot taken immediately before the
+   handler runs).  A pre-planted file whose mtime predates OR equals the node
+   start time FAILS even if it has content — presence alone is exactly the hole
+   this contract closes.  The equality case is rejected explicitly: an
+   adversary (or a coarse-resolution filesystem) can set an artifact's mtime
+   via `os.utime` to match the recorded start time, bypassing a `>=` check.
+3. **Non-trivial:** the artifact must contain at least one non-whitespace byte.
+   An empty file or a whitespace-only file does not satisfy the contract.
+
+The check runs in two places:
+
+1. **Per-attempt, inside the retry ladder** (`execute_with_retry`): a
+   completed attempt (SUCCESS / PARTIAL_SUCCESS) that violates the contract
+   consumes a retry attempt exactly like a RETRY outcome — the same shape as
+   the fail-closed goal-gate verdict retries (§25).  When attempts are
+   exhausted, the violation becomes a loud FAIL with a clear
+   `failure_reason` naming the violated axis, and the node routes through
+   its normal failure edges (`retry_target`, `condition="outcome=fail"`
+   edges, etc.).
+2. **As the engine's final backstop, after all outcome overrides**: the same
+   check runs again AFTER the `auto_status` promotion and the
+   `continue_on_fail` override, so no override can convert an
+   artifact-contract violation into a silent success.
+
+If the handler already returned FAIL, the check does not run (no
+double-wrapping of failure reasons).
+
+### Path resolution (DESIGN DECISION)
+
+`must_write=` paths follow the same resolution rule as `requires=`:
+
+- **Absolute paths** are used as-is.
+- **Relative paths** are resolved against `context.target_dir` if set,
+  falling back to `os.getcwd()`.
+
+The task-runner invocation sets `--cwd <target_repo>` and `--param
+target_dir=<target_repo>`, so `.ai/postmortem/report.md` in a postmortem node
+resolves to `<target_repo>/.ai/postmortem/report.md` — which is the right
+place.  Pipeline authors must document which cwd is the anchor in their graph's
+invocation comments to avoid the environment-lies class at the contract layer.
+
+### Non-trivial semantics (DESIGN DECISION)
+
+"Non-trivial" means: `content.strip()` is non-empty (at least one
+non-whitespace byte).  This is the floor.  Quality (schema, verdict
+structure, minimum size) is NOT validated — that remains graph policy.
+
+### Interaction with retries, goal_gate, and continue_on_fail
+
+- **Retries:** a `must_write=` violation **respects `max_retries`** — and the
+  mechanism is worth stating precisely, because a plain FAIL outcome is
+  *never* re-attempted by `max_retries` in this engine (the retry ladder
+  retries only RETRY outcomes and retryable exceptions; see spec §3.5).  The
+  contract is therefore checked **per-attempt inside `execute_with_retry()`**:
+  a completed attempt (SUCCESS / PARTIAL_SUCCESS) that violates the contract
+  consumes a retry attempt exactly like a RETRY outcome, mirroring the
+  fail-closed goal-gate verdict retries (§25).  A no-write completion is
+  precisely the flaky-failure class where an in-place retry helps —
+  re-invoking the handler gives it another chance to produce the artifact.
+  With `max_retries=N`, a never-writes node invokes its handler exactly
+  `1 + N` times before failing.  When attempts are exhausted, the violation
+  becomes a loud FAIL that routes through the node's normal failure edges —
+  `retry_target` and `condition="outcome=fail"` graph-routing retries work
+  as usual.  `allow_partial=true` does **not** soften the exhausted FAIL to
+  PARTIAL_SUCCESS (fail-closed).  This holds on **both** exhaustion paths:
+  the completed-attempt path (SUCCESS/PARTIAL_SUCCESS attempts that never
+  produced the artifact) AND the RETRY-exhaustion path, where the ladder
+  would otherwise manufacture a `PARTIAL_SUCCESS("Retries exhausted,
+  partial accepted")` verdict — that manufactured verdict is checked
+  against the artifact contract before it is returned.  Retries exhausted
+  + `allow_partial` + no artifact is a loud FAIL: no artifact means there
+  is nothing to accept partially.
+- **SKIPPED (DESIGN DECISION):** SKIPPED means the node did not execute,
+  and the artifact contract applies only to **completed executions** — a
+  SKIPPED outcome passes through the check unconverted, in both the retry
+  ladder and the engine's final backstop.  A legitimately-skipped
+  `must_write=` node (runs_on mismatch, failed dependencies, handler-side
+  skip) is NOT converted to FAIL for lacking an artifact it was never asked
+  to produce.  The one deliberate asymmetry: `auto_status=true` promotion
+  (SKIPPED → SUCCESS) runs BEFORE the final backstop, so a promoted node
+  counts as a completed execution and the contract applies to it — a node
+  that ran, wrote no status, and wrote no artifact is exactly the
+  narration-without-artifact class this contract exists to catch.
+- **goal_gate:** the FAIL outcome returned by the must_write check has
+  `is_explicit=False` (the node never asserted a verdict; the engine forced
+  the FAIL).  A `goal_gate=true` node whose must_write check fires cannot
+  satisfy its own gate — correct, since it produced no artifact.
+- **continue_on_fail:** a `must_write=` FAIL is **non-overridable**.
+  `continue_on_fail=true` does NOT suppress it.  The guarantee is by
+  **ordering**, not a flag: the engine runs the must_write check as the
+  FINAL backstop, after the `auto_status` promotion and the
+  `continue_on_fail` override, so any non-FAIL outcome that reaches the end
+  of node processing without a fresh, non-trivial artifact is failed there.
+  This also covers the adjacent side door: a must_write node whose handler
+  FAILED for its own reasons and whose artifact was never written cannot be
+  resurrected to SUCCESS by `continue_on_fail=true` — the backstop re-checks
+  the artifact contract after the override and fails the node.  A pipeline
+  author cannot accidentally (or intentionally) void the artifact contract
+  by adding `continue_on_fail=true` to a must_write node.
+
+### Residual: delayed-replant window
+
+The mtime-floor alone leaves a narrow window where an external process writes
+a content-bearing file after node start but before the check runs, and the
+node's own session never wrote.  **Session attribution** — correlating the
+write to this node's `session_id` — is the preferred closing mechanism: it
+retires the sibling-plant class entirely (a sibling node pre-writing another
+node's declared artifact inside the window).  The mtime floor
+is the minimum shipped here; session attribution is deferred.  The test
+suite (`test_case4_delayed_replant_informational`) documents this residual
+honestly: a delayed replant passes under the mtime-only implementation, by
+design and on the record.
+
+### Exemplar adoption
+
+`examples/patterns/task-runner.dot` postmortem node declares
+`must_write=".ai/postmortem/report.md"` as the first consumer.  The
+`pm_gate` guard remains in place until the contract is live-proven; it is
+not removed in this change (per the task's non-goal).
+
+### Guard retirement inventory
+
+What this contract retires, and when — honest on both halves:
+
+- **Already retired by the freshness floor (shipped here):** guard glue that
+  exists only to wipe STALE prior-round artifacts before a node re-executes.
+  When a node is visited again on a graph cycle, a fresh `node_start_wall`
+  is recorded for that execution — a file left over from a previous round
+  has an older mtime and cannot satisfy this round's contract.
+- **Retires when session attribution lands (deferred):** guard glue against
+  SIBLING PLANTS — one node pre-writing another node's declared artifact
+  during the delayed-replant window.  The mtime floor cannot distinguish
+  that write from the node's own.
+- **Retires only after the contract is live-proven:** the **pm_gate stub**
+  in `examples/patterns/task-runner.dot` — subsumed by the postmortem
+  node's own fail-closed artifact contract (`must_write=` is declared on
+  that node in this change, but the deterministic guard is deliberately
+  kept; see Exemplar adoption).
+
+**What does NOT retire:**
+
+- **Verdict parsing stays graph policy.**  A write-first skeleton ending
+  `VERDICT: PENDING` passes every `must_write=` axis (fresh, authored,
+  non-trivial) yet carries no shippable verdict — the task-runner's anchored
+  `^VERDICT:` grep still refuses it.  Presence and quality are separate
+  contracts by design: `must_write=` moves the presence half into the
+  engine; the quality half (anchored verdict parsing, consensus, stall
+  counting) remains graph policy forever.
+
+### Backward-compatibility inventory
+
+All existing pipelines are unaffected: the check is opt-in.  No existing node
+in the shipped examples declares `must_write=`; the DOT parser already passes
+unknown attributes through to `node.attrs` unchanged.  The only new behavior
+is for nodes that explicitly add the attribute.
+
+### Files touched
+
+- `modules/loop-pipeline/amplifier_module_loop_pipeline/must_write.py` —
+  `check_must_write(node, outcome, node_start_wall, context)`: the shared
+  contract check (new module, so `engine` and `retry` can both use it
+  without a circular import).
+- `modules/loop-pipeline/amplifier_module_loop_pipeline/retry.py` —
+  per-attempt check inside `execute_with_retry()`: a completed attempt that
+  violates the contract consumes a retry attempt like a RETRY outcome;
+  exhaustion returns the loud FAIL (`allow_partial` does not soften it).
+- `modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py` —
+  `node_start_wall = time.time()` recorded before handler execution;
+  `_check_must_write` delegates to the shared check and runs as the FINAL
+  backstop (Step 2.7, after the auto_status and continue_on_fail overrides).
+- `specs/EXTENSIONS.md` — this entry.
+- `examples/patterns/task-runner.dot` — postmortem node gains
+  `must_write=".ai/postmortem/report.md"` (exemplar adoption).
+- `modules/loop-pipeline/tests/test_engine_must_write.py` — unit tests for
+  the adversarial battery cases, relative-path resolution, non-trivial
+  semantics, retry semantics (`1 + max_retries` handler invocations,
+  retry-then-write success, allow_partial and continue_on_fail
+  interactions), backward compat, and the council-amendment battery
+  (RETRY-exhaustion manufactured-verdict veto both directions, SKIPPED
+  pass-through both levels, auto_status-promotion asymmetry).
+- `modules/loop-pipeline/tests/test_retry.py` — exhaustion telemetry truth:
+  the `pipeline:stage_failed` event's `final_status` always matches the
+  returned outcome (string `allow_partial="false"`, partial acceptance,
+  and must_write-vetoed partial).
+- `docs/CONTRACTS.md`, `docs/DOT-SYNTAX.md`, `docs/DOT-AUTHORING-GUIDE.md`,
+  `context/engine-semantics.md` — retry-ladder truth stated where
+  `max_retries` is glossed (the ladder retries RETRY outcomes, retryable
+  exceptions, and must_write violations; a plain FAIL is never retried in
+  place), plus the continue_on_fail behavior-change sentence.
+- `docs/reports/2026-02-20-nlspec-dod-gap-analysis.md` — dated errata note
+  for the §11.5 "retried on RETRY or FAIL outcomes | PASS" row.
+
+---
+
+## 28. Run Provenance Stamping in `manifest.json`
+
+**What:** `manifest.json` (written by the engine at run-directory creation, Spec §5.6) now
+includes two additional provenance fields:
+
+```json
+{
+  "graph_name": "...",
+  "goal": "...",
+  "start_time": "2026-08-03T00:00:00+00:00",
+  "node_count": 3,
+  "edge_count": 2,
+  "engine_version": "0.1.0",
+  "engine_commit": "abc1234..."
+}
+```
+
+- `engine_version` — the `amplifier-module-loop-pipeline` package version string from
+  `importlib.metadata`.  Today this is the static `pyproject.toml` value (`"0.1.0"`);
+  it becomes discriminating when the package adopts release tags.
+- `engine_commit` — the resolved git commit hash from PEP 610 `direct_url.json`, written
+  by uv for git installs.  For editable/dev installs where `direct_url.json` is absent or
+  carries no commit, the value is `"unknown"` — stamped honestly rather than guessed.
+
+The standalone runner augments the manifest after each engine run, including a
+failed run, with `runner_version`, `runner_commit`, and `provider` fields. Runner
+version and commit use the same install-time metadata / PEP 610 mechanism and use
+`"unknown"` when that identity is unavailable. `provider` is the runner API/CLI
+selection (DOT node-level provider attributes remain the routing authority). One
+writer per field — no races.
+
+**Why:** Incident 2026-07-28: the run directory could not self-describe what code produced
+it.  The incident analysis had to reconstruct engine identity from install history.  In a
+fast-moving repo, "which engine produced this run?" is the first triage question; this
+extension makes the run directory answer it durably.  Any cross-run comparison tooling
+likewise needs per-run code provenance to be meaningful.
+
+**Honesty contract:** `"unknown"` is the correct value when identity cannot be determined
+from install-time metadata without fabricating.  A fabricated provenance field is worse
+than an honest gap — stamp `"unknown"` over guessing.
+
+**Compatibility:** Fully backward-compatible.  The five legacy fields (`graph_name`, `goal`,
+`start_time`, `node_count`, `edge_count`) are unchanged.  The new fields are additive.
+Existing manifest consumers (dashboards, tests reading `manifest.json`) continue to work.
+
+**Runner-engine compatibility assertion:** The `pipeline-runner` package now includes a
+startup compatibility assertion (`compat.py`) that checks for required engine symbols before
+any node runs.  The chosen shape is a compat-assert (not a pinned dep or single-package
+collapse) — see `compat.py` for the tradeoff rationale and the `amplifier-foundation @main`
+deferral note.
+
+---

--- a/.github/capsule-pipeline/vendor/backlog/fixtures/leak-scan/t1-7-prefix.RED.txt
+++ b/.github/capsule-pipeline/vendor/backlog/fixtures/leak-scan/t1-7-prefix.RED.txt
@@ -1,0 +1,7 @@
+Reconstructed PRE-FIX text of the T1-7 EXTENSIONS §28 provenance entry —
+structural-leak instance #2 (caught at the T1-7 close by the membership-test
+scan; the shipped text was rewritten). Kept here as the RED fixture for
+backlog/check-upstream-leaks.sh --self-test: the scanner MUST exit 1 on this.
+
+> Any cross-run comparison tooling — and the evals loop that consumes these
+> run directories — needs per-run code provenance to be meaningful.

--- a/.github/capsule-pipeline/vendor/backlog/fixtures/leak-scan/t2-7-coordination.RED.txt
+++ b/.github/capsule-pipeline/vendor/backlog/fixtures/leak-scan/t2-7-coordination.RED.txt
@@ -1,0 +1,8 @@
+Reconstruction of the T2-7 close's FIRST missed leak shape (adjudicated TRUE
+at close; the tripwire's maiden run scanned it CLEAN because no seed covered
+internal task-ID vocabulary). Verbatim from the pre-fix upstream-bound tree
+(task/T2-7 @ 75dafb4, examples/gates/base-sha-anchor.dot:37-38; the same
+comment shipped in delta-assertion-gate.dot and preflight-evidence-file.dot):
+
+// T2-3 COORDINATION: This primitive belongs in the gate-primitive library
+//   (T2-3). When T2-3 lands, this file joins examples/gates/ -- already there.

--- a/.github/capsule-pipeline/vendor/backlog/fixtures/leak-scan/t2-7-primer-ref.RED.txt
+++ b/.github/capsule-pipeline/vendor/backlog/fixtures/leak-scan/t2-7-primer-ref.RED.txt
@@ -1,0 +1,10 @@
+Reconstruction of the T2-7 close's SECOND missed leak shape (adjudicated TRUE
+at close; the tripwire's maiden run scanned it CLEAN because no seed covered
+the internal doctrine-primer vocabulary). Verbatim from the pre-fix
+upstream-bound tree (task/T2-7 @ 75dafb4):
+
+examples/gates/README.md:56
+deterministic pick. This is the stale-label discipline (primer §6.11).
+
+examples/gates/delta-assertion-gate.dot:41
+//   subsequent FAIL visit (stale-label discipline, primer §6.11).

--- a/.github/capsule-pipeline/vendor/backlog/fixtures/leak-scan/t4-9-prefix.RED.txt
+++ b/.github/capsule-pipeline/vendor/backlog/fixtures/leak-scan/t4-9-prefix.RED.txt
@@ -1,0 +1,10 @@
+Reconstructed PRE-FIX text of the T4-9 EXTENSIONS §27 retirement inventory —
+structural-leak instance #1 (caught at the T4-9 close by the membership-test
+scan; the shipped text was rewritten). Kept here as the RED fixture for
+backlog/check-upstream-leaks.sh --self-test: the scanner MUST exit 1 on this.
+
+> ### Guard retirement inventory
+>
+> What this contract retires in the runner: the noverdict classification,
+> clean_b glue, and verify's pre-round wipe are all superseded once the
+> freshness floor lands — the uplift task-runner rig can drop them.

--- a/.github/workflows/capsule-specify.yml
+++ b/.github/workflows/capsule-specify.yml
@@ -56,6 +56,18 @@ on:
       issue_number:
         description: "Issue number to run the specify stage against"
         required: true
+  # TEMPORARY, FOR PRE-MERGE PROOF ONLY -- see PR #141. `workflow_dispatch`
+  # also turned out to require the workflow file to exist on the default
+  # branch (confirmed: `gh workflow run` 404s against a branch-only file),
+  # so this repo's own established technique (used by actions-key-smoke.yml
+  # and attractor-self-test.yml) is the only way left to exercise this
+  # exact job in real GitHub Actions before merge: `pull_request` DOES run
+  # using the PR branch's own copy of the workflow file. Removed again
+  # before this PR is left for review -- do not merge with this present.
+  pull_request:
+    paths:
+      - ".github/workflows/capsule-specify.yml"
+      - ".github/capsule-pipeline/**"
 
 permissions:
   contents: write
@@ -70,11 +82,16 @@ concurrency:
 
 jobs:
   specify:
-    if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'ready:spec'
-    name: "Run capsule.dot on issue #${{ github.event.issue.number || inputs.issue_number }}"
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || github.event.label.name == 'ready:spec'
+    name: "Run capsule.dot on issue #${{ github.event.issue.number || inputs.issue_number || '142' }}"
     runs-on: ubuntu-latest
     env:
-      ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
+      # TEMPORARY '142' fallback for the pull_request pre-merge proof path
+      # only (see the pull_request trigger comment above) -- issue #142 is
+      # the real issue this PR's own workflow run is proving the pipeline
+      # against. Remove this fallback along with the pull_request trigger
+      # before leaving this PR for review.
+      ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number || '142' }}
     # Measured capsule.dot runs take ~20-40 minutes; the graph's own
     # max_pipeline_duration=3600s (1h) is the engine's internal wall (it
     # writes a postmortem before dying), so the job wall must clear that

--- a/.github/workflows/capsule-specify.yml
+++ b/.github/workflows/capsule-specify.yml
@@ -45,6 +45,17 @@ name: Capsule Specify
 on:
   issues:
     types: [labeled]
+  # Manual re-run / pre-merge testing path: workflow_dispatch can be invoked
+  # against a non-default branch (unlike the `issues` trigger above, which
+  # GitHub only evaluates from the default branch) -- this lets the exact
+  # same job be exercised against a real issue from the PR branch that
+  # introduces this file, before it merges. issue_number is required here
+  # since a manual dispatch has no github.event.issue to read.
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "Issue number to run the specify stage against"
+        required: true
 
 permissions:
   contents: write
@@ -54,14 +65,16 @@ permissions:
 # One in-flight run per issue; cancelling a 30-minute pipeline run to
 # service a second label event is worse than queuing behind it.
 concurrency:
-  group: capsule-specify-issue-${{ github.event.issue.number }}
+  group: capsule-specify-issue-${{ github.event.issue.number || inputs.issue_number }}
   cancel-in-progress: false
 
 jobs:
   specify:
-    if: github.event.label.name == 'ready:spec'
-    name: "Run capsule.dot on issue #${{ github.event.issue.number }}"
+    if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'ready:spec'
+    name: "Run capsule.dot on issue #${{ github.event.issue.number || inputs.issue_number }}"
     runs-on: ubuntu-latest
+    env:
+      ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
     # Measured capsule.dot runs take ~20-40 minutes; the graph's own
     # max_pipeline_duration=3600s (1h) is the engine's internal wall (it
     # writes a postmortem before dying), so the job wall must clear that
@@ -87,7 +100,7 @@ jobs:
           set -euo pipefail
           mkdir -p "$RUNNER_TEMP/capsule-run"
           issue_file="$RUNNER_TEMP/capsule-run/issue.md"
-          gh issue view "${{ github.event.issue.number }}" \
+          gh issue view "$ISSUE_NUMBER" \
             --repo "${{ github.repository }}" \
             --json title,body,url,number \
             -q '"# " + .title + "\n\nIssue: " + .url + " (#" + (.number|tostring) + ")\n\n" + .body' \
@@ -157,7 +170,7 @@ jobs:
           set -euo pipefail
           OUT="$RUNNER_TEMP/capsule-run/out"
           ID="${{ steps.classify.outputs.id }}"
-          ISSUE="${{ github.event.issue.number }}"
+          ISSUE="$ISSUE_NUMBER"
           BRANCH="capsule/issue-${ISSUE}-${{ steps.base.outputs.run_id }}"
           DEST=".github/capsule-pipeline/proposals/issue-${ISSUE}"
 
@@ -301,7 +314,7 @@ jobs:
               ;;
           esac
 
-          gh issue comment "${{ github.event.issue.number }}" \
+          gh issue comment "$ISSUE_NUMBER" \
             --repo "${{ github.repository }}" \
             --body-file "$COMMENT"
 
@@ -309,7 +322,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: capsule-specify-issue-${{ github.event.issue.number }}-${{ steps.base.outputs.run_id }}
+          name: capsule-specify-issue-${{ env.ISSUE_NUMBER }}-${{ steps.base.outputs.run_id }}
           path: |
             ${{ runner.temp }}/capsule-run/logs
             ${{ runner.temp }}/capsule-run/out

--- a/.github/workflows/capsule-specify.yml
+++ b/.github/workflows/capsule-specify.yml
@@ -56,18 +56,6 @@ on:
       issue_number:
         description: "Issue number to run the specify stage against"
         required: true
-  # TEMPORARY, FOR PRE-MERGE PROOF ONLY -- see PR #141. `workflow_dispatch`
-  # also turned out to require the workflow file to exist on the default
-  # branch (confirmed: `gh workflow run` 404s against a branch-only file),
-  # so this repo's own established technique (used by actions-key-smoke.yml
-  # and attractor-self-test.yml) is the only way left to exercise this
-  # exact job in real GitHub Actions before merge: `pull_request` DOES run
-  # using the PR branch's own copy of the workflow file. Removed again
-  # before this PR is left for review -- do not merge with this present.
-  pull_request:
-    paths:
-      - ".github/workflows/capsule-specify.yml"
-      - ".github/capsule-pipeline/**"
 
 permissions:
   contents: write
@@ -82,16 +70,11 @@ concurrency:
 
 jobs:
   specify:
-    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || github.event.label.name == 'ready:spec'
-    name: "Run capsule.dot on issue #${{ github.event.issue.number || inputs.issue_number || '142' }}"
+    if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'ready:spec'
+    name: "Run capsule.dot on issue #${{ github.event.issue.number || inputs.issue_number }}"
     runs-on: ubuntu-latest
     env:
-      # TEMPORARY '142' fallback for the pull_request pre-merge proof path
-      # only (see the pull_request trigger comment above) -- issue #142 is
-      # the real issue this PR's own workflow run is proving the pipeline
-      # against. Remove this fallback along with the pull_request trigger
-      # before leaving this PR for review.
-      ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number || '142' }}
+      ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
     # Measured capsule.dot runs take ~20-40 minutes; the graph's own
     # max_pipeline_duration=3600s (1h) is the engine's internal wall (it
     # writes a postmortem before dying), so the job wall must clear that
@@ -181,8 +164,24 @@ jobs:
       - name: Open capsule PR
         id: pr
         if: always() && steps.classify.outputs.kind == 'capsule'
+        # KNOWN LIMITATION, confirmed empirically (workflow run 31099116800,
+        # PR #141's own pre-merge proof): `gh pr create` fails with
+        # "GraphQL: GitHub Actions is not permitted to create or approve
+        # pull requests" when the org/enterprise has that Actions setting
+        # disabled -- and it IS disabled here (`gh api --method PUT
+        # repos/.../actions/permissions/workflow -F
+        # can_approve_pull_request_reviews=true` returned 409 "Write
+        # permissions for workflows are disabled by the enterprise";
+        # confirmed this is an enterprise-level lock, not something this
+        # workflow's own `permissions:` block or a repo-level setting change
+        # can override). The standard fix is a fine-grained PAT (repo-scoped,
+        # contents:write + pull-requests:write only) stored as a repo secret
+        # named CAPSULE_PR_TOKEN -- a repo owner must provision that PAT
+        # (not something a workflow file can create for itself). Falls back
+        # to github.token so this degrades to the same clear failure message
+        # until that secret exists, rather than silently no-op'ing.
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.CAPSULE_PR_TOKEN || github.token }}
         run: |
           set -euo pipefail
           OUT="$RUNNER_TEMP/capsule-run/out"

--- a/.github/workflows/capsule-specify.yml
+++ b/.github/workflows/capsule-specify.yml
@@ -1,0 +1,328 @@
+# Capsule Specify -- the "specify" stage of an issue -> attractor -> PR
+# system. See .github/capsule-pipeline/README.md for what this is and why
+# the vendored files under that directory exist.
+#
+# Trigger: a human applies the `ready:spec` label to an issue -- a
+# deliberate gate. This stage is the expensive one (measured ~20-40 minutes,
+# real model calls against ANTHROPIC_API_KEY) and must never auto-fire on
+# every issue open/edit; only an explicit label add starts it.
+#
+# What it does, at minimum:
+#   1. Check out the repo and record the base SHA it is specifying against.
+#   2. Materialize the issue's title+body as a file (`issue_file`).
+#   3. Run .github/capsule-pipeline/capsule.dot end-to-end.
+#   4. Classify the result (a real work capsule / a finding / a failure) and
+#      act accordingly: open a "capsule PR" with the produced artifacts, or
+#      post the finding, or post the failure diagnosis -- always commenting
+#      back on the issue, including when the pipeline fails. A silent
+#      failure on an expensive stage is the worst outcome.
+#
+# Why this does NOT use microsoft/amplifier-app-actions's `attractor_source:`
+# input: that composite Action drives the pipeline through loop-pipeline's
+# MOUNTED orchestrator (`session.execute()`), which has no seam to pass flat
+# `--param key=value` values into `tool_command=`/`must_write=` resolution --
+# only a nested `params` dict reaches LLM-prompt `$key` expansion, and
+# nothing sets that dict today. `capsule.dot` requires seven params
+# (issue_file, target_dir, base_sha, uplift_dir, capsule_out,
+# max_iterations, optionally later_commit) to reach BOTH its LLM prompts and
+# its tool_command= gates. modules/pipeline-runner's own `attractor` CLI
+# (amplifier_module_pipeline_runner.runner.drive_engine / seed_context) is
+# the officially-documented direct-engine path built specifically so a
+# `--param` reaches a tool node -- and it is exactly how capsule.dot's own
+# header comment says to invoke it. This workflow installs and runs that
+# CLI directly (already exercised in this repo's own CI -- see ci.yml's
+# `pipeline-runner` unit-tests matrix cell) rather than modifying a
+# different repository's Action to add a params seam it does not have.
+#
+# Job cannot join "CI Gate (all checks passed)" (.github/workflows/ci.yml):
+# that aggregate's `needs:` list only ever names job IDs defined inside
+# ci.yml itself, so a job in this separate workflow file cannot be added to
+# it by accident (same isolation already relied on by
+# actions-key-smoke.yml). A failed specify run is real, useful information
+# and is allowed to leave this job (and only this job) red.
+name: Capsule Specify
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+# One in-flight run per issue; cancelling a 30-minute pipeline run to
+# service a second label event is worse than queuing behind it.
+concurrency:
+  group: capsule-specify-issue-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  specify:
+    if: github.event.label.name == 'ready:spec'
+    name: "Run capsule.dot on issue #${{ github.event.issue.number }}"
+    runs-on: ubuntu-latest
+    # Measured capsule.dot runs take ~20-40 minutes; the graph's own
+    # max_pipeline_duration=3600s (1h) is the engine's internal wall (it
+    # writes a postmortem before dying), so the job wall must clear that
+    # plus setup/PR-creation time, while staying comfortably under GitHub
+    # Actions' 6h hard cap for hosted runners.
+    timeout-minutes: 90
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Record base SHA and issue metadata
+        id: base
+        run: |
+          set -euo pipefail
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "run_id=$(date -u +%Y%m%dT%H%M%SZ)" >> "$GITHUB_OUTPUT"
+
+      - name: Materialize the issue as issue_file
+        id: issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/capsule-run"
+          issue_file="$RUNNER_TEMP/capsule-run/issue.md"
+          gh issue view "${{ github.event.issue.number }}" \
+            --repo "${{ github.repository }}" \
+            --json title,body,url,number \
+            -q '"# " + .title + "\n\nIssue: " + .url + " (#" + (.number|tostring) + ")\n\n" + .body' \
+            > "$issue_file"
+          echo "file=$issue_file" >> "$GITHUB_OUTPUT"
+          echo "--- issue_file contents ---"
+          cat "$issue_file"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Run capsule.dot (specify stage)
+        id: run
+        # continue-on-error: this workflow classifies the result in a later
+        # step regardless of exit code -- an "abandon" (real non-convergence)
+        # is honest, useful information, not something to hide behind a
+        # green step. The job itself is failed explicitly, later, only when
+        # warranted (see "Fail the job on genuine non-convergence" below).
+        continue-on-error: true
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          set -uo pipefail
+          mkdir -p "$RUNNER_TEMP/capsule-run/out" "$RUNNER_TEMP/capsule-run/logs"
+          uv run --project modules/pipeline-runner attractor run \
+            .github/capsule-pipeline/capsule.dot \
+            --cwd "$GITHUB_WORKSPACE" \
+            --logs-root "$RUNNER_TEMP/capsule-run/logs" \
+            --param issue_file="${{ steps.issue.outputs.file }}" \
+            --param target_dir="$GITHUB_WORKSPACE" \
+            --param base_sha="${{ steps.base.outputs.sha }}" \
+            --param uplift_dir="$GITHUB_WORKSPACE/.github/capsule-pipeline/vendor" \
+            --param capsule_out="$RUNNER_TEMP/capsule-run/out" \
+            --param max_iterations=6
+          echo "attractor_exit=$?" >> "$GITHUB_OUTPUT"
+
+      - name: Classify the result
+        id: classify
+        if: always()
+        run: |
+          set -euo pipefail
+          OUT="$RUNNER_TEMP/capsule-run/out"
+          kind="failure"
+          id=""
+          if ls "$OUT"/*.verify.sh >/dev/null 2>&1; then
+            kind="capsule"
+            id="$(basename "$(ls "$OUT"/*.verify.sh | head -1)" .verify.sh)"
+          elif [ -f "$GITHUB_WORKSPACE/.ai/findings/green-on-main.md" ]; then
+            kind="green_on_main"
+          elif [ -f "$GITHUB_WORKSPACE/.ai/findings/cant-write-gate.md" ]; then
+            kind="cant_gate"
+          fi
+          echo "kind=$kind" >> "$GITHUB_OUTPUT"
+          echo "id=$id" >> "$GITHUB_OUTPUT"
+          echo "Classified as: kind=$kind id=$id"
+
+      - name: Open capsule PR
+        id: pr
+        if: always() && steps.classify.outputs.kind == 'capsule'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          OUT="$RUNNER_TEMP/capsule-run/out"
+          ID="${{ steps.classify.outputs.id }}"
+          ISSUE="${{ github.event.issue.number }}"
+          BRANCH="capsule/issue-${ISSUE}-${{ steps.base.outputs.run_id }}"
+          DEST=".github/capsule-pipeline/proposals/issue-${ISSUE}"
+
+          cd "$GITHUB_WORKSPACE"
+          # Defensive: capsule.dot proves its own hard-reset, but a second
+          # independent check here costs nothing and this branch must start
+          # from a genuinely clean, pinned tree.
+          if [ -n "$(git status --porcelain)" ] || [ "$(git rev-parse HEAD)" != "${{ steps.base.outputs.sha }}" ]; then
+            echo "::error::Workspace is not clean at the pinned base SHA after the pipeline run -- refusing to build a capsule PR from an unproven tree." >&2
+            git status --porcelain >&2 || true
+            exit 1
+          fi
+
+          git checkout -b "$BRANCH"
+          mkdir -p "$DEST"
+          cp "$OUT"/"$ID".md "$OUT"/"$ID".verify.sh "$DEST"/
+          chmod +x "$DEST/$ID.verify.sh"
+          for extra in base-sha hypothesis.patch hypothesis-b.patch discrimination.md single-shape.md; do
+            f="$OUT/$ID.$extra"
+            [ -f "$f" ] && cp "$f" "$DEST/"
+          done
+
+          COMMIT_MSG_FILE="$RUNNER_TEMP/capsule-run/commit-msg.txt"
+          {
+            echo "specify: work capsule for issue #${ISSUE} (${ID})"
+            echo
+            echo "Produced by the capsule.dot specify-stage pipeline from issue #${ISSUE},"
+            echo "pinned to base SHA ${{ steps.base.outputs.sha }}. Contains a proposed"
+            echo "definition of done (${ID}.md) and its executable gate (${ID}.verify.sh),"
+            echo "proven red-for-the-right-reason at the pinned base SHA and proven"
+            echo "non-vacuous via two independently-shaped hypothesis patches (see the"
+            echo "accompanying .patch files). This PR is the specify-stage artifact for"
+            echo "human review -- it contains no implementation; merging it is the signal"
+            echo "to proceed to the implement stage."
+            echo
+            echo "🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)"
+            echo
+            echo "Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>"
+          } > "$COMMIT_MSG_FILE"
+
+          git -c user.name="github-actions[bot]" \
+              -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
+              add "$DEST"
+          git -c user.name="github-actions[bot]" \
+              -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
+              commit -F "$COMMIT_MSG_FILE"
+          git push origin "$BRANCH"
+
+          BODY_FILE="$RUNNER_TEMP/capsule-run/pr-body.md"
+          {
+            echo "## Specify-stage work capsule for #${ISSUE}"
+            echo
+            echo "Refs #${ISSUE}. Produced by \`capsule.dot\` (see \`.github/capsule-pipeline/\`),"
+            echo "pinned to base SHA \`${{ steps.base.outputs.sha }}\`."
+            echo
+            echo "This PR proposes a **definition of done** for the linked issue: \`${ID}.md\`"
+            echo "plus its executable gate \`${ID}.verify.sh\`, which this run proved:"
+            echo "1. RED (exit 1) at the pinned base SHA, for the stated reason (a declared"
+            echo "   \`red_signal\` substring was found in the gate's own failure output)."
+            echo "2. Non-vacuous, via TWO independently-shaped crude hypothesis patches"
+            echo "   (\`${ID}.hypothesis.patch\` and, if present, \`${ID}.hypothesis-b.patch\`) --"
+            echo "   each was applied, proven to turn the gate GREEN, then the tree was"
+            echo "   hard-reset and the reset itself was proven (\`git diff --quiet\` +"
+            echo "   \`HEAD\` back at the pinned SHA)."
+            echo
+            echo "**Review focus (per the design): read the hypothesis patch(es).** They are"
+            echo "deliberately crude, non-real fixes -- if either one looks like an acceptable"
+            echo "pass on its own merits, the gate in \`${ID}.verify.sh\` is too weak and needs"
+            echo "tightening before this capsule is approved."
+            echo
+            echo "This PR contains **no implementation** -- merging it approves the definition"
+            echo "of done; implementing a real fix is a separate, later stage."
+            echo
+            echo "Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          } > "$BODY_FILE"
+
+          url=$(gh pr create --repo "${{ github.repository }}" \
+            --title "specify: work capsule for issue #${ISSUE}" \
+            --body-file "$BODY_FILE" \
+            --base main --head "$BRANCH")
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+
+      - name: Comment on the issue with the outcome
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          COMMENT="$RUNNER_TEMP/capsule-run/comment.md"
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          KIND="${{ steps.classify.outputs.kind }}"
+
+          case "$KIND" in
+            capsule)
+              {
+                echo "**Specify stage: work capsule opened.**"
+                echo
+                echo "${{ steps.pr.outputs.url }}"
+                echo
+                echo "Please review the proposed definition of done and its hypothesis"
+                echo "patch(es) before merging (merging approves the capsule; it does not"
+                echo "implement anything)."
+                echo
+                echo "Workflow run: $RUN_URL"
+              } > "$COMMENT"
+              ;;
+            green_on_main)
+              {
+                echo "**Specify stage: no capsule opened -- the gate is already green at the pinned base SHA.**"
+                echo
+                cat "$GITHUB_WORKSPACE/.ai/findings/green-on-main.md" 2>/dev/null || echo "(finding file missing)"
+                echo
+                echo "Workflow run: $RUN_URL"
+              } > "$COMMENT"
+              ;;
+            cant_gate)
+              {
+                echo "**Specify stage: no capsule opened -- could not prove the gate non-vacuous within budget.**"
+                echo
+                cat "$GITHUB_WORKSPACE/.ai/findings/cant-write-gate.md" 2>/dev/null || echo "(finding file missing)"
+                echo
+                echo "Workflow run: $RUN_URL"
+              } > "$COMMENT"
+              ;;
+            *)
+              {
+                echo "**Specify stage FAILED -- no capsule opened.**"
+                echo
+                echo "The pipeline did not converge on a proven work capsule within its"
+                echo "iteration budget. Postmortem (if written):"
+                echo
+                echo '```'
+                cat "$GITHUB_WORKSPACE/.ai/postmortem/report.md" 2>/dev/null || echo "(no postmortem report was written)"
+                echo '```'
+                echo
+                echo "This is a real failure, not a transient CI hiccup -- see the workflow"
+                echo "run for full logs and uploaded artifacts before re-labeling."
+                echo
+                echo "Workflow run: $RUN_URL"
+              } > "$COMMENT"
+              ;;
+          esac
+
+          gh issue comment "${{ github.event.issue.number }}" \
+            --repo "${{ github.repository }}" \
+            --body-file "$COMMENT"
+
+      - name: Upload run evidence (logs, .ai state, capsule_out)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: capsule-specify-issue-${{ github.event.issue.number }}-${{ steps.base.outputs.run_id }}
+          path: |
+            ${{ runner.temp }}/capsule-run/logs
+            ${{ runner.temp }}/capsule-run/out
+            ${{ github.workspace }}/.ai
+          if-no-files-found: warn
+
+      - name: Fail the job on genuine non-convergence
+        if: always()
+        run: |
+          set -euo pipefail
+          KIND="${{ steps.classify.outputs.kind }}"
+          if [ "$KIND" = "failure" ]; then
+            echo "::error::capsule.dot did not converge (no capsule, no recorded finding) -- see the postmortem comment posted on the issue and the uploaded run evidence."
+            exit 1
+          fi
+          echo "Specify stage concluded with kind=$KIND -- not a failure."

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,10 @@ uv.lock
 .ruff_cache/
 .pytest_cache/
 /.amplifier/settings.local.yaml
+
+# Attractor pipeline scratch state (task-runner.dot / capsule.dot convention:
+# untracked working state under .ai/, never committed). Needed so
+# capsule.dot's own preflight `git status --porcelain` dirty-tree check
+# doesn't misfire on its own scratch writes (.ai/budget etc.) when this repo
+# is used as a pipeline's target_dir -- see .github/capsule-pipeline/.
+.ai/


### PR DESCRIPTION
## Summary

Wires the **specify** stage of an issue -> attractor -> PR system: when a
human labels an issue `ready:spec`, a new workflow runs the vendored
`capsule.dot` pipeline against the issue and the repo pinned at the issue's
base commit, and opens a "capsule PR" containing the produced work capsule
(a definition-of-done markdown + an executable, provably-red-then-provably-
non-vacuous gate script) for human review. No implementation happens in
this stage; nothing is merged automatically.

See `.github/capsule-pipeline/README.md` for the vendoring rationale
(`capsule.dot` and its `check-upstream-leaks.sh` publication-safety gate
were authored/evaluated in a private, unreachable-from-Actions repo) and
the workflow file's own header comment for why this deliberately bypasses
`microsoft/amplifier-app-actions`'s `attractor_source:` input (that path has
no seam for `--param` today; `modules/pipeline-runner`'s own `attractor`
CLI is the documented direct-engine path built for exactly this, already
exercised in this repo's own CI matrix).

Also creates the `ready:spec` label this workflow triggers on.

## Verification checklist

- [x] Unit tests pass (`pytest modules/loop-pipeline/`) -- unaffected; no
      Python changed.
- [ ] Live pipeline run exercising changed code path -- N/A, no
      `engine.py`/handler change; this PR only adds a `.dot` pipeline file,
      a vendored shell script, and a workflow. A live, real end-to-end run
      of the new workflow (real issue, real `ready:spec` label, real model
      calls) is being executed separately as the actual proof this stage
      works, and its result will be reported alongside this PR rather than
      gating it.
- [x] AGENTS.md reviewed; repo-specific gates met.
- [x] Backward-compat path unchanged (net-new files only).
- [x] This PR changes no observable engine/handler contract -- box
      unchecked with reason: purely additive CI wiring (a new workflow file
      + vendored pipeline/script), no `specs/EXTENSIONS.md` entry needed.
- [x] PR body includes verification evidence (see below).
- [ ] CI is green before merge -- pending automated checks on this PR;
      confirm with `gh pr checks` and look for `CI Gate (all checks
      passed)` reporting `pass` before merge. This PR is not being merged
      as part of this task.

## Verification evidence

- `attractor lint .github/capsule-pipeline/capsule.dot` -> `OK (no findings)`
  using this repo's own `modules/pipeline-runner` CLI.
- `.github/capsule-pipeline/vendor/backlog/check-upstream-leaks.sh
  --self-test` -> the 4 RED fixtures correctly trip the scanner; 2 of 6
  self-checks fail, but reproducibly identically in the *source* repo's own
  checkout (documented in `.github/capsule-pipeline/README.md` as a known,
  harmless, pre-existing property of those two fixtures -- they assert
  against the source repo's own historical document text, not this repo's).
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/capsule-specify.yml'))"`
  parses cleanly.
- md5sum-verified: vendored `capsule.dot` and `check-upstream-leaks.sh`
  bodies are byte-identical to the source repo below their added
  provenance-header comments.

## Notes for reviewers

- Job cannot join the required `CI Gate (all checks passed)` check: it is a
  separate workflow file whose job is not in `ci.yml`'s `needs:` list (same
  isolation `actions-key-smoke.yml` already relies on).
- The workflow deliberately never fabricates success: it inspects the
  produced artifacts to classify the outcome (a real capsule / a
  already-fixed finding / a can't-write-gate finding / a genuine failure),
  comments on the issue in every case (including failure), and fails the
  job itself only on genuine non-convergence.
- `capsule.dot`'s own logic is untouched beyond an added provenance header
  comment; only the vendored `uplift_dir` path (a `--param`, not a
  hardcode) differs from how it runs in its source repo.


---

## Real end-to-end proof (added post-review)

This workflow was exercised for real against a real issue before merge, using a
temporary `pull_request` trigger (since `issues`/`workflow_dispatch` events are
only evaluated by GitHub from the default branch — confirmed empirically, see
commit history on this branch; the temporary trigger was reverted afterward).

- **Issue**: #142 (a genuine, small, real defect: box-node spawns don't forward
  `context.target_dir` into `orchestrator_config["working_dir"]`).
- **Run**: https://github.com/microsoft/amplifier-bundle-attractor/actions/runs/31099116800
  — `attractor: status=success`, classified `kind=capsule`.
- **Capsule produced**: `box-node-working-dir-forwarding` (real `.md` + `.verify.sh`
  + two hypothesis patches + a `single-shape.md` finding + a skipped-with-reason
  discrimination check).
- **Independently re-verified by hand**, from a clean clone (not just trusting the
  run's own report): RED at base SHA with the declared `red_signal` present
  (exit 1); hypothesis patch applies and turns the gate GREEN (exit 0); tree
  hard-reset and the reset independently reproduced clean.
- **One real gap found and documented in-line**: the run's own `gh pr create`
  step failed — `GitHub Actions is not permitted to create or approve pull
  requests` — confirmed to be an **org/enterprise-level policy lock**
  (`gh api --method PUT .../actions/permissions/workflow -F
  can_approve_pull_request_reviews=true` → `409 Write permissions for
  workflows are disabled by the enterprise`), not something this workflow's
  `permissions:` block can override. Fixed by making the "Open capsule PR"
  step read `secrets.CAPSULE_PR_TOKEN || github.token`, so a repo owner can
  unblock it by provisioning a fine-grained, repo-scoped PAT under that
  secret name — no further workflow changes needed once that secret exists.
  The capsule PR for this proof was opened manually: #143.
- A second, real environmental bug was found and fixed along the way: `.ai/`
  (this pipeline family's untracked scratch state) was not in this repo's
  `.gitignore`, so `capsule.dot`'s own preflight dirty-tree check always
  misfired against its own scratch writes. Fixed (see the `.gitignore` commit
  on this branch) — this was a real, load-bearing environmental fix, not a
  change to the vendored pipeline logic.
