### PR TITLE
fix(ci): retry transient gh API errors + harden issue_file materialization (issue #144 step-4 failure)

### DIFF
--- a/.github/workflows/capsule-specify.yml
+++ b/.github/workflows/capsule-specify.yml
@@ -94,17 +94,98 @@ jobs:
 
       - name: Materialize the issue as issue_file
         id: issue
+        # Root cause of run 31104272859 (issue #144), verified from the
+        # job's own log (`gh api .../actions/jobs/<id>/logs`, since
+        # `gh run view --log` and `--log-failed` both returned empty for
+        # this run -- the working retrieval method):
+        #
+        #   HTTP 502: 502 Bad Gateway (https://api.github.com/graphql)
+        #   ##[error]Process completed with exit code 1.
+        #
+        # That is a transient failure of GitHub's own GraphQL backend during
+        # `gh issue view` (three issues were labeled within the same
+        # ~5-second window, all hitting the API back-to-back), NOT the
+        # shell-interpolation bug that was the leading hypothesis went in
+        # verifying this. That hypothesis does not hold for this step as
+        # written: the `-q` argument is a single-quoted, fixed jq filter
+        # string -- `.title`/`.body` are jq field accessors evaluated
+        # entirely inside gh's own jq engine against JSON data, never
+        # substituted into the bash command line, so `$name`-shaped issue
+        # text was never at risk of shell re-interpretation here (reproduced
+        # against the live issue #144 content three times post-incident;
+        # rc=0 every time. Adversarial-content proof: a scratch issue whose
+        # title/body carried $VAR, backticks, $(...), single/double quotes,
+        # newlines, and unicode was created, materialized with this exact
+        # extraction logic, and diffed byte-for-byte against the source --
+        # identical. See this branch's fix commit message for the details).
+        #
+        # Fix applied for the ACTUAL root cause: retry the flaky external
+        # call with backoff so one transient 5xx doesn't sink an entire
+        # 20-40 minute pipeline run before it even starts.
+        #
+        # Fix applied as defense-in-depth (the hypothesis's underlying
+        # concern is legitimate even though it wasn't this bug): issue
+        # title/url/number are captured into shell variables and are only
+        # ever re-emitted via `printf '%s'` (bash does not re-scan an
+        # already-expanded "$var" for $-refs, backticks, or $(...) -- this
+        # is the standard safe pattern). The body -- the highest-risk,
+        # attacker-influenced, multi-line field -- never touches a bash
+        # variable at all: it is piped directly from `jq -j` into the
+        # output file, so not even command-substitution's trailing-newline
+        # trimming can alter it. Content reaches issue_file verbatim,
+        # byte-for-byte, with zero shell interpolation.
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          set -euo pipefail
+          set -uo pipefail
           mkdir -p "$RUNNER_TEMP/capsule-run"
           issue_file="$RUNNER_TEMP/capsule-run/issue.md"
-          gh issue view "$ISSUE_NUMBER" \
-            --repo "${{ github.repository }}" \
-            --json title,body,url,number \
-            -q '"# " + .title + "\n\nIssue: " + .url + " (#" + (.number|tostring) + ")\n\n" + .body' \
-            > "$issue_file"
+          err_file="$RUNNER_TEMP/capsule-run/issue-view.err"
+
+          max_attempts=5
+          attempt=1
+          issue_json=""
+          while :; do
+            issue_json="$(gh issue view "$ISSUE_NUMBER" \
+              --repo "${{ github.repository }}" \
+              --json title,body,url,number 2>"$err_file")"
+            rc=$?
+            if [ "$rc" -eq 0 ]; then
+              break
+            fi
+            if [ "$attempt" -ge "$max_attempts" ]; then
+              echo "::error::gh issue view failed after $attempt attempts (rc=$rc)"
+              cat "$err_file" >&2 || true
+              exit 1
+            fi
+            sleep_s=$(( attempt * attempt * 3 ))
+            echo "gh issue view attempt $attempt/$max_attempts failed (rc=$rc); retrying in ${sleep_s}s" >&2
+            cat "$err_file" >&2 || true
+            sleep "$sleep_s"
+            attempt=$((attempt + 1))
+          done
+          set -e
+
+          # title/url/number: single-line, low-risk fields. Safe to round
+          # -trip through a shell variable because "$VAR" expansion is not
+          # re-scanned for further substitution -- whatever bytes are in
+          # the variable are emitted as-is by printf '%s'.
+          ISSUE_TITLE_RAW="$(printf '%s' "$issue_json" | jq -r '.title')"
+          ISSUE_URL_RAW="$(printf '%s' "$issue_json" | jq -r '.url')"
+          ISSUE_NUM_RAW="$(printf '%s' "$issue_json" | jq -r '.number')"
+
+          {
+            printf '# %s\n\n' "$ISSUE_TITLE_RAW"
+            printf 'Issue: %s (#%s)\n\n' "$ISSUE_URL_RAW" "$ISSUE_NUM_RAW"
+            # body: the attacker-influenced, potentially multi-line field.
+            # Piped straight from jq to the file -- never captured into a
+            # bash variable -- so nothing (not even command-substitution's
+            # trailing-newline stripping) can alter it. -j (join/raw, no
+            # jq-added trailing newline) preserves exact bytes, including
+            # unicode, verbatim.
+            printf '%s' "$issue_json" | jq -j '.body // ""'
+          } > "$issue_file"
+
           echo "file=$issue_file" >> "$GITHUB_OUTPUT"
           echo "--- issue_file contents ---"
           cat "$issue_file"


### PR DESCRIPTION
## What

Fixes the root cause of run [31104272859](https://github.com/microsoft/amplifier-bundle-attractor/actions/runs/31104272859) (`capsule-specify.yml`'s "Materialize the issue as issue_file" step failing on issue #144), plus hardens that step as defense-in-depth.

## Root cause (verified, not assumed)

The job log (retrieved via `gh api repos/.../actions/jobs/<id>/logs` -- both `gh run view --log` and `--log-failed` returned empty for this run) shows:

```
HTTP 502: 502 Bad Gateway (https://api.github.com/graphql)
##[error]Process completed with exit code 1.
```

A transient failure of GitHub's own GraphQL backend during `gh issue view` -- issues #144/#145/#146 were all labeled within the same ~5-second window and hit the API back-to-back. This is **not** the leading hypothesis (issue #144's `$name`/backtick/`$(...)`-laden title+body getting shell-interpolated and mangled) -- that hypothesis was checked and does not hold for this step: the `-q` argument passed to `gh` is a single-quoted, fixed jq filter string, never a bash re-interpolation of issue content. Reproduced the original command against the live issue #144 content three times post-incident: rc=0 every time, byte-identical output every time.

## Fixes

1. **Actual root cause**: retry `gh issue view` with backoff (5 attempts, quadratic sleep) so one transient 5xx doesn't sink an entire 20-40 minute pipeline run before it starts.
2. **Defense in depth** (the hypothesis's underlying concern is legitimate even though it wasn't this bug): body content now flows straight from `jq -j` into the file, never through a bash variable, guaranteeing byte-for-byte verbatim delivery regardless of `$VAR`/backtick/`$(...)`/quote/newline/unicode content. This also fixes a genuine minor byte-fidelity bug in the original (it always appended one extra trailing newline regardless of the actual body's ending).

## Proof

Created and closed a scratch adversarial-content issue (#150) with `$HOME`, backticks, `$(id)`, quotes, unicode, and issue #144's own `$name`/`$name_suffix` tokens; ran the new extraction logic against it via the real `gh issue view` + `jq` path; diffed byte-for-byte against source. Identical. Full detail in the commit message.

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>
