### PR TITLE
fix(capsule-pipeline): resync vendored capsule.dot -- two gates were missing

### DIFF
--- a/.github/capsule-pipeline/README.md
+++ b/.github/capsule-pipeline/README.md
@@ -29,6 +29,8 @@ This directory wires two stages of an issue -> attractor -> PR system:
 | `attractor-pipeline-dual.yaml` | Multi-provider (Anthropic + OpenAI) base bundle for `task-runner.dot`'s dual-family critique. **Vendored but not currently wired in** — see its own provenance header and `capsule-implement.yml` for why. |
 | `vendor/backlog/check-upstream-leaks.sh` | Publication-safety gate: scans the produced `DEFINITION.md` for internal working-vocabulary leaks before it ships in a PR. |
 | `vendor/backlog/fixtures/leak-scan/*` | Self-test fixtures for the scanner above (RED/GREEN controls). |
+| `vendor/runner/check-degenerate-hack.py` | `degenerate_gate`'s checker: suspects a hypothesis-B patch that greens the gate by deleting/stubbing behavior rather than implementing a real alternate fix (THE INVERSION RULE). |
+| `vendor/runner/check-existing-tests.py` | `existing_test_gate`'s checker: derives a capsule's subject from the symbols/paths its own `DEFINITION.verify.sh` names, and blocks if the repo already ships an on-topic test the gate doesn't run (FOLD IN THE EXISTING TESTS). |
 
 ## Provenance — these are VENDORED copies
 
@@ -43,12 +45,23 @@ source commit). Do not hand-edit the body of any of these files — if a fix
 or improvement is needed, make it in the source repository, re-copy the
 file here, and re-apply the provenance header comment.
 
-`capsule.dot` itself is **not modified** beyond the header: it references its
-leak-scanning dependency via a `uplift_dir` **parameter**, not a hardcoded
-path, so vendoring the scanner under `vendor/backlog/check-upstream-leaks.sh`
-and pointing `--param uplift_dir=.github/capsule-pipeline/vendor` at it
-satisfies the graph's existing `$uplift_dir/backlog/check-upstream-leaks.sh`
-reference with zero changes to the pipeline's logic.
+`capsule.dot` itself is **not modified** beyond the header: it references all
+three of its checker dependencies via the same `uplift_dir` **parameter**,
+never a hardcoded path, so vendoring each checker at the matching relative
+location under `vendor/` and pointing
+`--param uplift_dir=.github/capsule-pipeline/vendor` at it satisfies every
+one of the graph's existing references with zero changes to the pipeline's
+logic:
+
+- `$uplift_dir/backlog/check-upstream-leaks.sh` (`leak_gate`) -> `vendor/backlog/check-upstream-leaks.sh`
+- `$uplift_dir/runner/check-degenerate-hack.py` (`degenerate_gate`) -> `vendor/runner/check-degenerate-hack.py`
+- `$uplift_dir/runner/check-existing-tests.py` (`existing_test_gate`) -> `vendor/runner/check-existing-tests.py`
+
+The `vendor/` subtree therefore mirrors the source repository's own directory
+layout (`backlog/`, `runner/`) one level down -- this is deliberate, not
+incidental: any future checker `capsule.dot` grows will resolve correctly
+under `uplift_dir` for free as long as it is vendored at the same relative
+path it lives at in the source, with no path-mapping logic to maintain here.
 
 `task-runner.dot` is likewise **not modified** beyond its header. It was
 authored for a slightly different invocation shape (a backlog task file with
@@ -92,10 +105,47 @@ scanner correctly) before this was wired up.
 ## Re-syncing
 
 1. In the source repository, confirm the current commit of `runner/capsule.dot`
-   and `backlog/check-upstream-leaks.sh` (+ `backlog/fixtures/leak-scan/`).
-2. Copy the files here verbatim (`cp`, not a manual retype).
-3. Re-apply (or update) the provenance header comment at the top of each file
-   with the new source commit.
-4. Run `attractor lint .github/capsule-pipeline/capsule.dot` and
-   `vendor/backlog/check-upstream-leaks.sh --self-test` and note any new
-   deviations here.
+   and diff it against the vendored copy's pinned commit (its header names the
+   commit) to see exactly what's missing -- don't assume; quote the diff.
+   Do the same for `runner/task-runner.dot` against its own separately-pinned
+   commit (the two files are not necessarily in sync with each other).
+2. Check whether the diff added, removed, or renamed any `$uplift_dir/...`
+   references (grep the new source for `uplift_dir`) -- every checker a
+   `tool_command=` node shells out to must exist under `vendor/` at the exact
+   relative path the graph resolves, or the corresponding gate breaks at
+   runtime instead of at review time. As of the 2026-08-07 re-sync that means:
+   `backlog/check-upstream-leaks.sh`, `runner/check-degenerate-hack.py`, and
+   `runner/check-existing-tests.py`.
+3. Copy the files here verbatim (`cp`, not a manual retype), preserving the
+   executable bit on any `.sh`/`.py` checker.
+4. Re-apply (or update) the provenance header comment at the top of each file
+   with the new source commit and date.
+5. Run `attractor lint .github/capsule-pipeline/capsule.dot` and
+   `vendor/backlog/check-upstream-leaks.sh --self-test`, and **prove the
+   vendored checkers actually resolve** at the path the workflow sets
+   `uplift_dir` to (`$GITHUB_WORKSPACE/.github/capsule-pipeline/vendor`) --
+   a `workflow_dispatch` run or a local invocation with `uplift_dir` set the
+   same way, not just a file-existence check. Note any new deviations here.
+
+## Re-sync log
+
+- **2026-08-07** -- `capsule.dot` re-synced `67a53e531a1` (content-identical
+  to `73e75e7`, the commit actually last touching `runner/capsule.dot`) ->
+  `d93d1e60066abdc61f082e48619569eef0816a09`. Picked up two gates that did
+  not exist in the vendored copy before this sync, and were therefore never
+  exercised by any specify-stage run this repository's Actions had produced
+  up to this point:
+  - `degenerate_gate` (source commit `0afb874`, THE INVERSION RULE) --
+    routes a hypothesis-B patch that greens the gate by deleting/stubbing
+    behavior to `triage` instead of treating it as proof the gate is
+    behavior-bound.
+  - `existing_test_gate` (source commit `d93d1e6`, FOLD IN THE EXISTING
+    TESTS) -- blocks a capsule whose gate declares a subject the target
+    repo already ships an on-topic test for, and doesn't run it.
+  Vendored their checkers (`vendor/runner/check-degenerate-hack.py`,
+  `vendor/runner/check-existing-tests.py`) for the first time -- this
+  `vendor/runner/` subdirectory did not exist before this sync.
+  `task-runner.dot` was checked against the same source range and found
+  **byte-identical** at its own pinned commit (`f5322c24ed6fd8deaeddb519de7bfdfa861094d9`)
+  -- no re-sync needed; see the PR that performed this sync for the full
+  proof.

--- a/.github/capsule-pipeline/capsule.dot
+++ b/.github/capsule-pipeline/capsule.dot
@@ -1,8 +1,8 @@
 // ============================================================================
 // VENDORED COPY -- see .github/capsule-pipeline/README.md for provenance,
 // scope, and re-sync instructions. Source: a private working repository
-// (not publicly reachable), pinned at its commit 67a53e531a133f44fa7bfc1afed3b6849a5a5610
-// (runner/capsule.dot, 2026-08-06). This copy is otherwise byte-identical to
+// (not publicly reachable), pinned at its commit d93d1e60066abdc61f082e48619569eef0816a09
+// (runner/capsule.dot, 2026-08-07). This copy is otherwise byte-identical to
 // the source file below this header -- do not hand-edit the body; re-sync
 // from source and re-apply this header instead.
 // ============================================================================
@@ -54,6 +54,65 @@
 //      routes to reset_fail -- a LOUD, non-retryable halt (task-runner.dot's
 //      forge_fail idiom: a corrupted-state class must stop the run, not
 //      loop on it).
+//
+//      THE INVERSION RULE (degenerate_gate, adversarial review of a real
+//      produced capsule, PR #152): hack B greening the gate is only
+//      discrimination proof if hack B still does something. A degenerate
+//      hack B -- a stubbed return, a deleted function, a removed guard --
+//      can green an under-specified gate (PR #152's own DEFINITION.verify.sh
+//      asserted a corrupted string was ABSENT for expand_params() but never
+//      that real substitution was PRESENT; hypothesis-b.patch stubbed
+//      expand_params() to `return text` -- the parameter, unchanged -- and
+//      the gate went fully GREEN, EXIT=0, 12 passed; the patch's OWN comments
+//      said "the entire feature is silently disabled"). That is a FAILURE
+//      signal (the gate is too weak), not proof of strength -- degenerate_gate
+//      runs check-degenerate-hack.py against hypothesis_b.patch AFTER
+//      mutate_gate_b confirms roundtrip_b_ok, and a hit routes to triage (the
+//      SAME root-cause wall every other gate defect uses) rather than either
+//      a silent pass or a hard terminal halt -- this checker can only ever
+//      SUSPECT from diff text alone (see its own docstring for the
+//      irreducible ambiguity: "the correct fix is now an identity return"
+//      and "the feature was silently deleted" can be textually identical),
+//      so the honest move is a human-reachable decision point, never an
+//      automatic verdict either way.
+//
+//      FOLD IN THE EXISTING TESTS (existing_test_gate, BLOCKING as of this
+//      revision -- promoted from capsule_gate's non-blocking observation
+//      after the habit proved systemic across FOUR reviewed capsules). A
+//      gate that already runs the EXISTING tests touching the code it's
+//      about is free coverage and would have closed the PR #152 hole
+//      outright -- tests/test_param_expansion.py shipped in that same repo
+//      and failed the expand_params() stub immediately, but the authored
+//      gate only ran tests/test_unified_substitution.py. #143 never invoked
+//      pytest at all; #149 ignored both a unit test of the exact rule and a
+//      sweep over every example; #148's target was a docs file, genuinely
+//      n/a. ALL FOUR relegated running the existing tests to a "Human
+//      reviewer criteria (not automated)" section -- for a human who does
+//      not exist under the autonomous-implementer model these capsules
+//      feed. That is the whole argument for promotion: the criterion was
+//      not merely unenforced, it was addressed to nobody.
+//
+//      WHY THIS ISN'T THE MISTAKE THE RETIRED PROSE LEVER MADE. The
+//      RETIRED "## Fix-shape independence" written-section requirement
+//      (below) proved that a written SELF-ATTESTATION changes nothing
+//      measurable while burning budget on false blocks, and the earlier,
+//      deliberately non-blocking version of this check reasoned from that
+//      finding: asking the author to "prove you searched for existing
+//      tests" would repeat the same error. That reasoning was right about
+//      ATTESTATIONS and it left a third option unexplored. n=4 says the
+//      prose alone doesn't bind (primer foot-gun #13: prose rules are
+//      advisory; executed gates change behavior), so take the third
+//      option: DON'T ASK THE AUTHOR TO ATTEST ANYTHING -- MECHANICALLY
+//      INSPECT THE ARTIFACT. existing_test_gate runs
+//      check-existing-tests.py, which derives the capsule's subject from
+//      the symbols and source paths DEFINITION.verify.sh ITSELF names,
+//      finds test files in target_dir referencing those symbols, and asks
+//      whether the gate script invokes any of them. Both halves are
+//      properties of files on disk, not a self-report, so there is nothing
+//      to game by writing a better paragraph -- the attestation trap is
+//      dodged rather than re-entered. See the node's own comment for the
+//      "none exist" determination, the false-negative bias, and the
+//      measured NO answer on whether this would have caught #156.
 //
 //      WHY TWO SHAPES (TWO-HYPOTHESIS DISCRIMINATION, see the commit report
 //      for the measured evidence this replaces): a ground-truth eval of the
@@ -137,8 +196,9 @@
 //                  convergence, per doctrine #5.
 //
 // AUTHOR-NODE-ONLY CORRECTIVE EDGES: triage and diagnose_gate route back
-// to `author` only. No deterministic gate (capsule_gate/leak_gate/redgate/
-// mutate_gate/discrimination_check) is ever the TARGET of a corrective
+// to `author` only. No deterministic gate (capsule_gate/leak_gate/
+// existing_test_gate/redgate/mutate_gate/discrimination_check) is ever the
+// TARGET of a corrective
 // back-edge -- they are re-ENTERED (fresh classification of whatever author
 // produced next), never "fixed in place."
 //
@@ -223,11 +283,11 @@
 //     write, then mirrors n back to .ai/iter for downstream readers
 //     (redgate/mutate_gate/discrimination_check's own ledger records,
 //     triage's signature comparison).
-//   - CONVERGENCE RECORD: capsule_gate, leak_gate, redgate, mutate_gate,
-//     and discrimination_check each append one line per visit to
-//     .ai/convergence.jsonl (gate keys "round"/"leak"/"redgate"/
-//     "mutate_gate"/"discrimination") -- the descent record postmortem
-//     reads on non-convergence.
+//   - CONVERGENCE RECORD: capsule_gate, leak_gate, existing_test_gate,
+//     redgate, mutate_gate, and discrimination_check each append one line
+//     per visit to .ai/convergence.jsonl (gate keys "round"/"leak"/
+//     "existing_test"/"redgate"/"mutate_gate"/"discrimination") -- the
+//     descent record postmortem reads on non-convergence.
 //   - PARAM NAMESPACE: `${k:-default}` is NOT engine-expanded (unknown
 //     braced key passes through); optional params (later_commit,
 //     max_iterations) are read into a shell var first (`LC=$later_commit`)
@@ -235,8 +295,9 @@
 //     `$name` text for the shell to expand as its OWN (unset, empty)
 //     variable -- functionally identical to the engine substituting an
 //     empty string, so no special-casing is needed either way.
-//   - goal_gate=true + retry_target="author" on the four proof gates
-//     (capsule_gate/redgate/mutate_gate/discrimination_check) mirrors
+//   - goal_gate=true + retry_target="author" on the proof gates
+//     (capsule_gate/existing_test_gate/redgate/mutate_gate/
+//     discrimination_check) mirrors
 //     task-runner.dot's verify/verdict: belt (their own tool exit code is
 //     already `is_explicit`) and suspenders (an unclassified in-node crash
 //     still has somewhere honest to go).
@@ -315,7 +376,7 @@ digraph CapsulePipeline {
     // exists here for those to attach to).
     author [shape=box, class="maker", thread_id="work", fidelity="full",
         must_write=".ai/capsule/DEFINITION.verify.sh",
-        prompt="Write the work capsule: two files, .ai/capsule/DEFINITION.md and .ai/capsule/DEFINITION.verify.sh. Sources of truth: .ai/brief.md, the report at $issue_file, and the ACTUAL code in $target_dir (pinned at $base_sha -- see .ai/base-sha). If .ai/gate.log exists, it holds the most recent gate's exact diagnostic; read it FIRST and fix precisely what it reports -- do not re-guess. If .ai/postmortem/diagnosis.md exists, honor its change of course.\n\nDEFINITION.verify.sh: a bash script. Its FIRST line must be exactly `set -euo pipefail`. It will be invoked as `bash .ai/capsule/DEFINITION.verify.sh` with the target repo root as its cwd (no arguments, no cd). Guard every prerequisite explicitly (missing binary, missing fixture, a cd that could fail) and exit >=2 on infrastructure problems -- ONLY an assertion failure (the reported defect genuinely reproducing) may exit exactly 1. Exit 0 means the defect is NOT present (already fixed, or this gate does not capture it -- both are valid, useful outcomes, not something to hide). On the rc=1 path, print a line containing the EXACT literal substring you will declare as red_signal below -- this is what proves the red is red for the stated reason, not an unrelated crash. The script must be idempotent: it will be re-run, unmodified, against multiple commits and after a hypothesis patch is applied and reverted. Never write an unconditional `exit 1` or any other assertion that cannot fail -- a gate that cannot fail is not a gate (checks 2 and 3 downstream exist specifically to catch this). Keep the GREEN half honest while you write it: you are guessing at how the defect will actually be fixed, and this gate can only ever exercise the fix that lands, not the one you pictured -- if the real fix took a completely different approach than the one you have in mind (a different function, a different internal name, a different code path, a fix that removes something instead of adding it), would this script still go green? Bind GREEN to the END-STATE BEHAVIOR your Goal describes -- what a user or a test can observe happening or not happening -- never to your guess about which function, argument shape, internal identifier, or code path the fix will touch: those are implementation details you cannot know in advance and do not need to know. You do not need to write this reasoning down anywhere -- a later stage (mutate_b/diff_shape_gate/mutate_gate_b) PROVES it mechanically by requiring a second, differently-shaped crude patch to ALSO turn this same script green, so there is no written self-attestation to satisfy here.\n\nDEFINITION.md: YAML frontmatter between --- lines with fields `id` (short, filename-safe), `title`, `red_signal` (the literal substring above, written PLAIN with no surrounding quotes -- it is checked with `grep -qF`), `base_sha` (copy $base_sha), `later_commit` (copy $later_commit if non-empty, else omit the field), `target_repo`, `verify: DEFINITION.verify.sh`. Body: Goal (the end state, not steps), Why this matters, Definition of done (what the script checks, plus any judgment criteria a human reviewer should still apply), Non-goals.\n\nUPSTREAM-LEGAL VOCABULARY (this file will be published into the target project): ground every claim in files, behavior, and terminology that exist in the target repo's own shipped tree. Do not use this pipeline's own internal program name, its internal documentation names, or any internal task-numbering scheme anywhere in DEFINITION.md -- write as if a contributor to the target project who has never heard of this pipeline will read it. leak_gate will scan this file and route you back here with a diagnostic if it finds vocabulary that does not belong in a published artifact."]
+        prompt="Write the work capsule: two files, .ai/capsule/DEFINITION.md and .ai/capsule/DEFINITION.verify.sh. Sources of truth: .ai/brief.md, the report at $issue_file, and the ACTUAL code in $target_dir (pinned at $base_sha -- see .ai/base-sha). If .ai/gate.log exists, it holds the most recent gate's exact diagnostic; read it FIRST and fix precisely what it reports -- do not re-guess. If .ai/postmortem/diagnosis.md exists, honor its change of course.\n\nDEFINITION.verify.sh: a bash script. Its FIRST line must be exactly `set -euo pipefail`. It will be invoked as `bash .ai/capsule/DEFINITION.verify.sh` with the target repo root as its cwd (no arguments, no cd). Guard every prerequisite explicitly (missing binary, missing fixture, a cd that could fail) and exit >=2 on infrastructure problems -- ONLY an assertion failure (the reported defect genuinely reproducing) may exit exactly 1. Exit 0 means the defect is NOT present (already fixed, or this gate does not capture it -- both are valid, useful outcomes, not something to hide). On the rc=1 path, print a line containing the EXACT literal substring you will declare as red_signal below -- this is what proves the red is red for the stated reason, not an unrelated crash. The script must be idempotent: it will be re-run, unmodified, against multiple commits and after a hypothesis patch is applied and reverted. Never write an unconditional `exit 1` or any other assertion that cannot fail -- a gate that cannot fail is not a gate (checks 2 and 3 downstream exist specifically to catch this). Keep the GREEN half honest while you write it: you are guessing at how the defect will actually be fixed, and this gate can only ever exercise the fix that lands, not the one you pictured -- if the real fix took a completely different approach than the one you have in mind (a different function, a different internal name, a different code path, a fix that removes something instead of adding it), would this script still go green? Bind GREEN to the END-STATE BEHAVIOR your Goal describes -- what a user or a test can observe happening or not happening -- never to your guess about which function, argument shape, internal identifier, or code path the fix will touch: those are implementation details you cannot know in advance and do not need to know. You do not need to write this reasoning down anywhere -- a later stage (mutate_b/diff_shape_gate/mutate_gate_b) PROVES it mechanically by requiring a second, differently-shaped crude patch to ALSO turn this same script green, so there is no written self-attestation to satisfy here. Before you write DEFINITION.verify.sh, search target_dir's own test tree (tests/, test/, spec/ -- whatever this repo uses) for existing tests that ALREADY exercise the function(s) or module(s) the report concerns. If one exists, FOLD IT IN: have DEFINITION.verify.sh actually run that existing test (or the specific case(s) within it), not just a new bespoke assertion you invented -- an existing test is free coverage and it already encodes real expectations about the code, which is exactly the kind of positive, end-state-behavior assertion this gate needs. This is the same defect class as PR #152's capsule: it shipped with an existing tests/test_param_expansion.py in the same repo that would have caught a later degenerate hack outright, but the authored gate only ran tests/test_unified_substitution.py and never discovered or ran the other one. THIS IS NOW MECHANICALLY CHECKED, so know exactly what is checked and you will never be surprised by it: existing_test_gate reads DEFINITION.verify.sh, collects the identifiers in it that resolve to a function/class definition in the target repo's own non-test source (that is the subject YOUR script declares -- you are not asked to state it anywhere), finds test files that reference those identifiers, and requires your script to invoke at least one such file per identifier. Invoking the whole suite satisfies it. It never asks you to claim you searched; it reads what you shipped. If the checker searches and finds nothing on-topic, that passes and is written up as a finding -- so a target with genuinely no tests (a docs file, a new module) is never blocked. If it does block you, .ai/gate.log names the exact symbol and the exact file to run.\n\nDEFINITION.md: YAML frontmatter between --- lines with fields `id` (short, filename-safe), `title`, `red_signal` (the literal substring above, written PLAIN with no surrounding quotes -- it is checked with `grep -qF`), `base_sha` (copy $base_sha), `later_commit` (copy $later_commit if non-empty, else omit the field), `target_repo`, `verify: DEFINITION.verify.sh`. Body: Goal (the end state, not steps), Why this matters, Definition of done (what the script checks; you may also list judgment criteria for a human reviewer, but understand who reads this capsule -- an AUTONOMOUS IMPLEMENTER optimizing against DEFINITION.verify.sh, with no human in that loop. Anything a machine CAN check belongs in the script, never in a 'human reviewer criteria (not automated)' section: four reviewed capsules put 'run the existing tests' there, and nobody ever ran them), Non-goals.\n\nUPSTREAM-LEGAL VOCABULARY (this file will be published into the target project): ground every claim in files, behavior, and terminology that exist in the target repo's own shipped tree. Do not use this pipeline's own internal program name, its internal documentation names, or any internal task-numbering scheme anywhere in DEFINITION.md -- write as if a contributor to the target project who has never heard of this pipeline will read it. leak_gate will scan this file and route you back here with a diagnostic if it finds vocabulary that does not belong in a published artifact."]
 
     // ---------- capsule_gate: CHEAP deterministic gate (shape + budget wall) ----------
     // Ledger-derived budget (task-runner.dot idiom, verbatim, key "round"):
@@ -335,6 +396,86 @@ digraph CapsulePipeline {
     // root-cause wall as any other repeated gate failure).
     leak_gate [shape=parallelogram, class="gate", max_retries=0,
         tool_command="n=$(cat .ai/iter 2>/dev/null || echo 0); sh \"$uplift_dir/backlog/check-upstream-leaks.sh\" .ai/capsule/DEFINITION.md > .ai/leak.log 2>&1; rc=$?; printf '{\"iteration\": %s, \"gate\": \"leak\", \"clean\": %s}\\n' \"$n\" \"$([ $rc -eq 0 ] && echo true || echo false)\" >> .ai/convergence.jsonl; if [ $rc -eq 0 ]; then printf leak_clean; else cp .ai/leak.log .ai/gate.log; echo round > .ai/last-stage-fail; exit 1; fi"]
+
+    // ---------- existing_test_gate: does the gate script RUN the tests that already exist? ----------
+    // THE DEFECT CLASS (n=4 reviewed capsules, all four the same habit):
+    // DEFINITION.verify.sh does not run the tests ALREADY SHIPPING in the
+    // target repo that already exercise the code the capsule concerns --
+    // #152 ran only tests/test_unified_substitution.py while
+    // tests/test_param_expansion.py sat beside it (and later failed the
+    // degenerate expand_params() stub outright, 6 failed); #143 never
+    // invoked pytest at all though test_backend.py and
+    // test_attribute_passthrough.py already exercise the exact idiom its
+    // gate uses; #149 ignored both test_validation.py (which unit-tests
+    // the exact rule) and test_examples_lint_clean.py (which sweeps every
+    // example). All four relegated running them to a "Human reviewer
+    // criteria (not automated)" section -- for a human who DOES NOT EXIST
+    // under the autonomous-implementer model these capsules feed. Two of
+    // the four were additionally gameable by a zero-effort deletion.
+    //
+    // WHY THIS IS A GATE AND NOT MORE PROSE: author's prompt ALREADY says
+    // to search the test tree and "If one exists, FOLD IT IN," and it
+    // already cites #152 as the cautionary case. The prose is good. n=4
+    // says it does not bind. Primer foot-gun #13: prose rules are
+    // advisory; executed gates change behavior.
+    //
+    // WHY THIS IS NOT THE ATTESTATION TRAP (the third option the prior
+    // non-blocking decision left unexplored): the RETIRED "## Fix-shape
+    // independence" written-section requirement measured that demanding a
+    // written SELF-ATTESTATION changes nothing (identical 2/6) while
+    // burning budget on false blocks -- so "prove you searched for
+    // existing tests" would repeat that error exactly. This gate demands
+    // NO attestation. It MECHANICALLY INSPECTS THE SHIPPED ARTIFACT:
+    // check-existing-tests.py derives the subject from the symbols and
+    // source paths DEFINITION.verify.sh ITSELF names, finds test files in
+    // target_dir that reference those symbols, and asks whether the gate
+    // script invokes any of them. Both halves are properties of files on
+    // disk -- there is nothing to game by writing a better paragraph.
+    //
+    // THE "NONE EXIST" CASE IS DETERMINED, NEVER ASSERTED (#148's target
+    // was a docs file with no tests -- a legitimate n/a): the checker
+    // walks the tree itself and, when it finds nothing on-topic, writes
+    // .ai/findings/no-existing-tests-run.md containing WHAT IT SEARCHED
+    // (test-file count, subject symbols, source-file count) and passes.
+    // A silent skip would be the same failure wearing a different hat.
+    //
+    // BIASED TO FALSE NEGATIVE, DELIBERATELY: a gate that blocks
+    // legitimate capsules teaches authors to route around it, which is
+    // strictly worse than not having it. Every ambiguity resolves toward
+    // PASS-with-a-finding: no test tree, no symbol resolving to a
+    // definition in the repo's own source, no test referencing one, a
+    // runner invoked with no file argument (already running everything),
+    // a scan cap hit, or the CHECKER ITSELF failing (rc>=2). That last
+    // one is a deliberate divergence from degenerate_gate, which routes
+    // its own rc>=2 to triage: an infra failure there is rare and loud,
+    // whereas this gate runs a filesystem scan in an arbitrary third-party
+    // repo, and blocking a capsule because OUR scanner tripped is exactly
+    // the false block the bias exists to prevent. It is recorded in the
+    // ledger ("verdict": "checker_error") and in the finding, never
+    // swallowed.
+    //
+    // CHEAP-BEFORE-EXPENSIVE placement (this file's own discipline): after
+    // capsule_gate (budget wall + shape) and leak_gate (a single-file text
+    // scan), before redgate (which actually EXECUTES the gate script under
+    // a 900s timeout) and long before the two mutation round-trips.
+    //
+    // WOULD THIS HAVE CAUGHT THE #156 REGRESSION? NO -- measured, not
+    // assumed. The implementer's fix for issue #144 broke
+    // substitute_context("cat $name.txt", {"name":"report"}) (it stopped
+    // substituting). Checked out that regressed commit in a scratch
+    // worktree and ran the PRE-EXISTING test tree (as of the commit
+    // immediately before it) against it: the four on-topic substitution
+    // files gave 41 passed, and the FULL pre-existing suite gave 1796
+    // passed / 1 skipped -- byte-identical to the same suite against the
+    // pre-regression parent. No pre-existing test encoded the "$key
+    // followed by an ordinary period" expectation, so folding them in
+    // would NOT have caught it. Recorded here because the tempting
+    // justification ("existing tests encode neighbouring expectations, so
+    // this also closes blast-radius blindness") is NOT supported by this
+    // case. The change stands on the n=4 gameable-gate evidence alone.
+    existing_test_gate [shape=parallelogram, class="gate", max_retries=0,
+        goal_gate=true, retry_target="author",
+        tool_command="CV=.ai/capsule/DEFINITION.verify.sh; n=$(cat .ai/iter 2>/dev/null || echo 0); mkdir -p .ai/findings; python3 \"$uplift_dir/runner/check-existing-tests.py\" --verify \"$CV\" --repo . > .ai/existing-tests-check.log 2>&1; rc=$?; if [ $rc -eq 0 ] && head -1 .ai/existing-tests-check.log | grep -q \"^VERDICT: folded_in\"; then printf '{\\\"iteration\\\": %s, \\\"gate\\\": \\\"existing_test\\\", \\\"verdict\\\": \\\"folded_in\\\"}\\n' \"$n\" >> .ai/convergence.jsonl; printf folded_in; elif [ $rc -eq 0 ]; then { echo \"# Finding: no existing on-topic test was found to fold in\"; echo; echo \"DEFINITION.verify.sh was mechanically inspected against the target repo's own test tree. check-existing-tests.py derived the subject from the symbols and source paths the gate script ITSELF names, then read every test file looking for them. Its full report follows: the absence it reports was DETERMINED by that search, never asserted by the author, and a reviewer can re-run the checker to reproduce it.\"; echo; cat .ai/existing-tests-check.log; } > .ai/findings/no-existing-tests-run.md; printf '{\\\"iteration\\\": %s, \\\"gate\\\": \\\"existing_test\\\", \\\"verdict\\\": \\\"none_exist\\\"}\\n' \"$n\" >> .ai/convergence.jsonl; printf no_on_topic_tests; elif [ $rc -eq 1 ]; then { echo \"EXISTING-TEST FOLD-IN FAIL: DEFINITION.verify.sh declares a subject (by naming those symbols in its own text) that this repo ALREADY ships tests for, and it does not run them. An existing test is free coverage and it already encodes real expectations about the code -- which is exactly what catches a degenerate hack that satisfies a narrow new assertion (PR #152: the repo's own tests/test_param_expansion.py failed the expand_params() no-op stub outright, but the authored gate ran only tests/test_unified_substitution.py). FIX: have DEFINITION.verify.sh RUN the file(s) named below -- running the whole suite also satisfies this check -- and treat their failure as the gate's own RED, not as an infrastructure error. Do NOT relegate this to a human-reviewer section of DEFINITION.md: an autonomous implementer consumes this capsule and there is no human in that loop.\"; cat .ai/existing-tests-check.log; } > .ai/gate.log; printf '{\\\"iteration\\\": %s, \\\"gate\\\": \\\"existing_test\\\", \\\"verdict\\\": \\\"unrun\\\"}\\n' \"$n\" >> .ai/convergence.jsonl; echo existing_test > .ai/last-stage-fail; exit 1; else { echo \"# Finding: the existing-test fold-in check could not run\"; echo; echo \"check-existing-tests.py exited $rc (a usage or infra error, not a defect finding). BIASED TO FALSE NEGATIVE BY DESIGN: this gate passes rather than block a capsule on its own tooling failure, because a gate that blocks legitimate work teaches authors to route around it. The failure is recorded here and in the convergence ledger instead of being swallowed.\"; echo; cat .ai/existing-tests-check.log; } > .ai/findings/no-existing-tests-run.md; printf '{\\\"iteration\\\": %s, \\\"gate\\\": \\\"existing_test\\\", \\\"verdict\\\": \\\"checker_error\\\", \\\"rc\\\": %s}\\n' \"$n\" \"$rc\" >> .ai/convergence.jsonl; printf no_on_topic_tests; fi"]
 
     // ---------- redgate: checks 1+2 -- RED with the right exit code, diagnostic names the defect ----------
     redgate [shape=parallelogram, class="gate", max_retries=0,
@@ -372,7 +513,7 @@ digraph CapsulePipeline {
     // context; it does not need mutate's own conversation.
     mutate_b [shape=box, class="maker", thread_id="mutate_b",
         must_write=".ai/hypothesis_b.patch",
-        prompt="Check 3 proved the gate goes GREEN against ONE guessed fix shape (.ai/hypothesis.patch). That proves the gate is non-vacuous, but a single hack, greened by its own author, proves almost nothing about a DIFFERENTLY-shaped real fix -- the gate could still be bound to that one guessed shape rather than to end-state behavior. Prove the stronger claim: write a SECOND, deliberately CRUDE hypothesis patch to .ai/hypothesis_b.patch that ALSO turns DEFINITION.verify.sh green, but through a genuinely DIFFERENT mechanism than .ai/hypothesis.patch used -- a different file, a different function or call path, an OPPOSITE operation (if A added a stub or hardcode, B should remove or short-circuit something instead, or vice versa), or a different internal name for the same concept. The explicit goal: DIFFERENT IN SHAPE, IDENTICAL IN OBSERVABLE OUTCOME (the gate goes green either way). This is still explicitly NOT a correct fix -- a second hack is the entire point. Ground it in the ACTUAL current file contents of $target_dir (the tree is reset to the pinned base SHA -- read the real files; do not invent paths or line numbers). If .ai/gate.log exists from a prior attempt at THIS stage, read it first: a prior .ai/hypothesis_b.patch may have been rejected as a cosmetic variant of hypothesis.patch (same file, near-identical changed lines, same add/remove polarity) or may have failed to green the gate -- do not repeat it. If you genuinely believe only ONE honest fix shape exists for this defect (a real possibility -- some defects are that narrow, e.g. a single typo or a single required magic string), do not fabricate a fake variant to satisfy this check: write .ai/hypothesis_b.patch containing ONLY a comment block whose FIRST LINE is exactly `# SINGLE-SHAPE:` followed by a concrete, specific explanation of why no second shape is honestly possible. That is itself valuable evidence about the gate, not a failure to hide -- diff_shape_gate accepts it as a distinct, honestly-labeled finding."]
+        prompt="Check 3 proved the gate goes GREEN against ONE guessed fix shape (.ai/hypothesis.patch). That proves the gate is non-vacuous, but a single hack, greened by its own author, proves almost nothing about a DIFFERENTLY-shaped real fix -- the gate could still be bound to that one guessed shape rather than to end-state behavior. Prove the stronger claim: write a SECOND, deliberately CRUDE hypothesis patch to .ai/hypothesis_b.patch that ALSO turns DEFINITION.verify.sh green, but through a genuinely DIFFERENT mechanism than .ai/hypothesis.patch used -- a different file, a different function or call path, an OPPOSITE operation (if A added a stub or hardcode, B should remove or short-circuit something instead, or vice versa), or a different internal name for the same concept. The explicit goal: DIFFERENT IN SHAPE, IDENTICAL IN OBSERVABLE OUTCOME (the gate goes green either way). This is still explicitly NOT a correct fix -- a second hack is the entire point. Ground it in the ACTUAL current file contents of $target_dir (the tree is reset to the pinned base SHA -- read the real files; do not invent paths or line numbers). If .ai/gate.log exists from a prior attempt at THIS stage, read it first: a prior .ai/hypothesis_b.patch may have been rejected as a cosmetic variant of hypothesis.patch (same file, near-identical changed lines, same add/remove polarity) or may have failed to green the gate -- do not repeat it. If you genuinely believe only ONE honest fix shape exists for this defect (a real possibility -- some defects are that narrow, e.g. a single typo or a single required magic string), do not fabricate a fake variant to satisfy this check: write .ai/hypothesis_b.patch containing ONLY a comment block whose FIRST LINE is exactly `# SINGLE-SHAPE:` followed by a concrete, specific explanation of why no second shape is honestly possible. That is itself valuable evidence about the gate, not a failure to hide -- diff_shape_gate accepts it as a distinct, honestly-labeled finding. ONE CAVEAT on the opposite-operation strategy above: 'remove or short-circuit something' must still make the code DO something observably different -- a stub that deletes the feature entirely and returns its input verbatim unchanged (a bare no-op passthrough) is a DEGENERATE hack, not a real second shape, even though it is mechanically distinct from hack A. A later mechanical gate (degenerate_gate) checks for exactly this; a genuinely different real fix, even a crude hardcoded one, passes it, a no-op does not."]
 
     // ---------- diff_shape_gate: CHEAP mechanical check -- is hack B a REAL second shape? ----------
     // Cheap-before-expensive (same discipline as capsule_gate/leak_gate
@@ -399,6 +540,43 @@ digraph CapsulePipeline {
         goal_gate=true, retry_target="author",
         tool_command="CV=.ai/capsule/DEFINITION.verify.sh; P=.ai/hypothesis_b.patch; BASE=$(cat .ai/base-sha 2>/dev/null); n=$(cat .ai/iter 2>/dev/null || echo 0); if [ -z \"$BASE\" ]; then echo 'MUTATE_GATE_B: .ai/base-sha missing -- preflight did not pin a base SHA' > .ai/gate.log; echo mutate_b > .ai/last-stage-fail; exit 1; fi; if ! git apply --check \"$P\" >/dev/null 2>&1; then printf '{\"iteration\": %s, \"gate\": \"mutate_gate_b\", \"applies\": false}\\n' \"$n\" >> .ai/convergence.jsonl; echo \"MUTATE_GATE_B: hypothesis_b.patch does not apply cleanly against pinned base $BASE\" > .ai/gate.log; echo mutate_b > .ai/last-stage-fail; exit 1; fi; git apply \"$P\"; chmod +x \"$CV\" 2>/dev/null; timeout 900 bash \"$CV\" > .ai/verify-hypothesis-b.log 2>&1; rc=$?; if [ $rc -ne 0 ]; then printf '{\"iteration\": %s, \"gate\": \"mutate_gate_b\", \"greened\": false, \"rc\": %s}\\n' \"$n\" \"$rc\" >> .ai/convergence.jsonl; { echo \"MUTATE_GATE_B: hypothesis_b.patch applied but gate rc=$rc (need 0 -- the second, differently-shaped crude patch did not turn it green -- if a real fix could only take THIS shape and not hypothesis.patch's shape, the gate may be bound to hypothesis.patch's shape, not to end-state behavior)\"; tail -30 .ai/verify-hypothesis-b.log; } > .ai/gate.log; git checkout --quiet -- .; git clean -qfd -e .ai; echo mutate_b > .ai/last-stage-fail; exit 1; fi; git checkout --quiet -- .; git clean -qfd -e .ai; if git diff --quiet -- . && [ \"$(git rev-parse HEAD)\" = \"$BASE\" ]; then printf '{\"iteration\": %s, \"gate\": \"mutate_gate_b\", \"greened\": true, \"reset_proven\": true}\\n' \"$n\" >> .ai/convergence.jsonl; printf roundtrip_b_ok; else printf '{\"iteration\": %s, \"gate\": \"mutate_gate_b\", \"greened\": true, \"reset_proven\": false}\\n' \"$n\" >> .ai/convergence.jsonl; echo \"MUTATE_GATE_B: RESET NOT PROVEN after hypothesis-B round-trip -- git diff and/or HEAD no longer matches the pinned base SHA ($BASE). Halting: an unreset tree would poison every check downstream. A human must inspect $target_dir before this pipeline (or anything else) trusts it again.\" > .ai/gate.log; printf reset_b_unproven; fi"]
 
+    // ---------- degenerate_gate: THE INVERSION RULE -- is hack B a real second shape, or a no-op? ----------
+    // Adversarial-review finding (real produced capsule, PR #152, a $key
+    // prefix-substitution fix): DEFINITION.verify.sh asserted, for
+    // substitute_context(), both "the corruption is gone" AND "real
+    // substitution still happens" -- but for expand_params() it asserted
+    // ONLY "the corrupted string does not appear." hypothesis-b.patch
+    // stubbed expand_params() to `return text` (the parameter, unchanged)
+    // and the gate went fully GREEN: EXIT=0, 12 passed. The patch's OWN
+    // comments said "the entire feature is silently disabled." diff_shape_gate
+    // (above) proves hack B is MECHANICALLY DIFFERENT from hack A; it does
+    // NOT prove hack B still does anything -- a degenerate hack (a stubbed
+    // return, a deleted function, a removed guard) can be trivially
+    // "different in shape" from hack A while being just as trivially wrong
+    // to trust. Cheap, deterministic, POST-round-trip (this is only a
+    // problem once we know hack B actually greened -- a degenerate hack
+    // that FAILS to green is not a finding, it is the gate correctly
+    // rejecting a bad hack, exactly as designed): runs
+    // check-degenerate-hack.py (this repo, runner/) against
+    // .ai/hypothesis_b.patch, which the git-clean -e .ai exclusion in
+    // mutate_gate_b left untouched on disk after the reset.
+    //
+    // THE INVERSION: a degenerate hack greening the gate is NOT evidence
+    // the gate is behavior-bound (the opposite of what the two-hypothesis
+    // check exists to prove) -- it is evidence the gate is UNDER-specified,
+    // and that is a FAILURE signal. It is deliberately NOT a hard,
+    // non-retryable halt (this checker can only ever SUSPECT from diff text
+    // alone -- "the correct fix is now an identity return" and "the feature
+    // was silently deleted" can be textually identical; see the script's own
+    // docstring) and it is deliberately NOT a silent pass either: a hit
+    // routes through the SAME root-cause wall (triage) every other gate
+    // defect in this file uses, landing back on author with a concrete,
+    // named reason to tighten DEFINITION.verify.sh -- never treated as
+    // proof hack B is invalid, never treated as proof the capsule is done.
+    degenerate_gate [shape=parallelogram, class="gate", max_retries=0,
+        goal_gate=true, retry_target="author",
+        tool_command="P=.ai/hypothesis_b.patch; n=$(cat .ai/iter 2>/dev/null || echo 0); mkdir -p .ai/findings; python3 \"$uplift_dir/runner/check-degenerate-hack.py\" \"$P\" > .ai/degenerate-check.log 2>&1; rc=$?; if [ $rc -eq 0 ]; then printf '{\"iteration\": %s, \"gate\": \"degenerate\", \"suspected\": false}\\n' \"$n\" >> .ai/convergence.jsonl; printf b_substantive; elif [ $rc -eq 1 ]; then printf '{\"iteration\": %s, \"gate\": \"degenerate\", \"suspected\": true}\\n' \"$n\" >> .ai/convergence.jsonl; { echo \"DEGENERATE-HACK SUSPECTED (INVERSION RULE): hypothesis_b.patch greened DEFINITION.verify.sh (check 3b) but check-degenerate-hack.py suspects it deletes/stubs behavior rather than implementing a real alternate fix -- see below for which function/signal. This is NOT proof the gate is behavior-bound; it is the OPPOSITE: a hack that removes a feature and still passes means the gate is under-specified (e.g. only asserting a corrupted string is ABSENT, never that real output is still PRESENT -- exactly PR #152's expand_params() hole). Tighten DEFINITION.verify.sh: add a positive assertion for the surface hypothesis_b.patch touched, mirroring any other function whose assertion already checks both 'defect gone' AND 'real behavior still happens'.\"; cat .ai/degenerate-check.log; } > .ai/gate.log; echo degenerate > .ai/last-stage-fail; exit 1; else { echo \"DEGENERATE-HACK CHECK: check-degenerate-hack.py usage/self-test error (rc=$rc) -- infra problem, not a defect finding\"; cat .ai/degenerate-check.log; } > .ai/gate.log; echo degenerate > .ai/last-stage-fail; exit 1; fi"]
+
     // ---------- discrimination_check: RED at an unrelated later commit (skippable-with-reason) ----------
     discrimination_check [shape=parallelogram, class="gate", max_retries=0,
         goal_gate=true, retry_target="author",
@@ -410,14 +588,14 @@ digraph CapsulePipeline {
     // here is a real deterministic problem (bad path, permissions), routed
     // through the SAME root-cause wall as any other gate failure.
     package [shape=parallelogram, class="gate", max_retries=0,
-        tool_command="CM=.ai/capsule/DEFINITION.md; CV=.ai/capsule/DEFINITION.verify.sh; id=$(awk '/^---$/{c++;next} c==1 && /^id:/{sub(/^id:[[:space:]]*/,\"\"); print; exit}' \"$CM\" | tr -cd 'A-Za-z0-9._-'); [ -n \"$id\" ] || id=work-definition; OUT=\"$capsule_out\"; mkdir -p \"$OUT\" && cp \"$CM\" \"$OUT/$id.md\" && cp \"$CV\" \"$OUT/$id.verify.sh\" && chmod +x \"$OUT/$id.verify.sh\"; rc=$?; [ -f .ai/base-sha ] && cp .ai/base-sha \"$OUT/$id.base-sha\"; [ -f .ai/hypothesis.patch ] && cp .ai/hypothesis.patch \"$OUT/$id.hypothesis.patch\"; [ -f .ai/hypothesis_b.patch ] && cp .ai/hypothesis_b.patch \"$OUT/$id.hypothesis-b.patch\"; [ -f .ai/findings/discrimination.md ] && cp .ai/findings/discrimination.md \"$OUT/$id.discrimination.md\"; [ -f .ai/findings/single-shape.md ] && cp .ai/findings/single-shape.md \"$OUT/$id.single-shape.md\"; if [ $rc -eq 0 ] && [ -s \"$OUT/$id.md\" ] && [ -s \"$OUT/$id.verify.sh\" ]; then printf packaged; else echo \"PACKAGE FAILED: could not write the capsule pair to $OUT (rc=$rc)\" > .ai/gate.log; echo round > .ai/last-stage-fail; exit 1; fi"]
+        tool_command="CM=.ai/capsule/DEFINITION.md; CV=.ai/capsule/DEFINITION.verify.sh; id=$(awk '/^---$/{c++;next} c==1 && /^id:/{sub(/^id:[[:space:]]*/,\"\"); print; exit}' \"$CM\" | tr -cd 'A-Za-z0-9._-'); [ -n \"$id\" ] || id=work-definition; OUT=\"$capsule_out\"; mkdir -p \"$OUT\" && cp \"$CM\" \"$OUT/$id.md\" && cp \"$CV\" \"$OUT/$id.verify.sh\" && chmod +x \"$OUT/$id.verify.sh\"; rc=$?; [ -f .ai/base-sha ] && cp .ai/base-sha \"$OUT/$id.base-sha\"; [ -f .ai/hypothesis.patch ] && cp .ai/hypothesis.patch \"$OUT/$id.hypothesis.patch\"; [ -f .ai/hypothesis_b.patch ] && cp .ai/hypothesis_b.patch \"$OUT/$id.hypothesis-b.patch\"; [ -f .ai/findings/discrimination.md ] && cp .ai/findings/discrimination.md \"$OUT/$id.discrimination.md\"; [ -f .ai/findings/single-shape.md ] && cp .ai/findings/single-shape.md \"$OUT/$id.single-shape.md\"; [ -f .ai/findings/no-existing-tests-run.md ] && cp .ai/findings/no-existing-tests-run.md \"$OUT/$id.no-existing-tests-run.md\"; if [ $rc -eq 0 ] && [ -s \"$OUT/$id.md\" ] && [ -s \"$OUT/$id.verify.sh\" ]; then printf packaged; else echo \"PACKAGE FAILED: could not write the capsule pair to $OUT (rc=$rc)\" > .ai/gate.log; echo round > .ai/last-stage-fail; exit 1; fi"]
 
     // ---------- triage: root-cause wall (task-runner.dot idiom, verbatim, on .ai/gate.log) ----------
     triage [shape=parallelogram, class="glue", max_retries=0,
         tool_command="B=$(cat .ai/budget 2>/dev/null); B=${B:-6}; n=$(cat .ai/iter 2>/dev/null || echo 0); sig=$(tail -20 .ai/gate.log 2>/dev/null | sed -E 's|/tmp/[A-Za-z0-9._-]+|TMPPATH|g; s/[0-9]+\\.[0-9]+s?//g' | md5sum | cut -d' ' -f1); prev=$(cat .ai/last-fail-sig 2>/dev/null || echo none); echo $sig > .ai/last-fail-sig; if [ \"$n\" -ge \"$B\" ]; then printf exhausted; elif [ \"$sig\" = \"$prev\" ]; then printf repeat; else printf novel; fi"]
 
     diagnose [shape=box, class="gate",
-        prompt="A capsule-round gate failed twice with the SAME failure signature (see .ai/gate.log, and .ai/last-stage-fail for which stage: round/leak/redgate/mutate/discrimination). Stop iterating blindly -- find the root cause. Read .ai/gate.log, .ai/brief.md, the report at $issue_file, and the relevant code in $target_dir. Determine what is actually wrong: (a) DEFINITION.verify.sh's assertion approach, (b) a misread of the reported defect, (c) an environment/tooling gap, or (d) a genuine ambiguity in the report that cannot be resolved from inside this run. Write .ai/postmortem/diagnosis.md with the root cause, the evidence, and the single change of course for the next attempt. If the blocker cannot be resolved from inside this run, include the word BLOCKED on its own line and explain."]
+        prompt="A capsule-round gate failed twice with the SAME failure signature (see .ai/gate.log, and .ai/last-stage-fail for which stage: round/leak/existing_test/redgate/mutate/diff_shape/mutate_b/degenerate/discrimination). Stop iterating blindly -- find the root cause. Read .ai/gate.log, .ai/brief.md, the report at $issue_file, and the relevant code in $target_dir. Determine what is actually wrong: (a) DEFINITION.verify.sh's assertion approach, (b) a misread of the reported defect, (c) an environment/tooling gap, or (d) a genuine ambiguity in the report that cannot be resolved from inside this run. Write .ai/postmortem/diagnosis.md with the root cause, the evidence, and the single change of course for the next attempt. If the blocker cannot be resolved from inside this run, include the word BLOCKED on its own line and explain."]
 
     diagnose_gate [shape=parallelogram, class="glue", max_retries=0,
         tool_command="rm -f .ai/last-fail-sig; grep -qE '^BLOCKED' .ai/postmortem/diagnosis.md && printf blocked || printf continue"]
@@ -520,8 +698,19 @@ digraph CapsulePipeline {
     capsule_gate -> leak_gate       [condition="context.tool.last_line=shape_ok && outcome=success"]
     capsule_gate -> triage          [condition="outcome=fail", label="shape defect"]
 
-    leak_gate -> redgate [condition="context.tool.last_line=leak_clean && outcome=success"]
-    leak_gate -> triage  [condition="outcome=fail", label="upstream-leak hit or scanner error"]
+    leak_gate -> existing_test_gate [condition="context.tool.last_line=leak_clean && outcome=success"]
+    leak_gate -> triage             [condition="outcome=fail", label="upstream-leak hit or scanner error"]
+
+    // existing_test_gate: TWO success tokens, both proceeding to redgate --
+    // the pipeline SAYS which case it is (an on-topic existing test is
+    // folded in, vs. the checker searched and found none), it never
+    // silently degrades one into the other. The fail edge routes through
+    // the SAME root-cause wall (triage) every other gate defect in this
+    // file uses, landing back on author -- leak_gate/redgate idiom,
+    // verbatim; never a hard halt, never a silent pass.
+    existing_test_gate -> redgate [condition="context.tool.last_line=folded_in && outcome=success", label="an existing on-topic test is actually run by the gate"]
+    existing_test_gate -> redgate [condition="context.tool.last_line=no_on_topic_tests && outcome=success", label="checker searched and found none -- finding written"]
+    existing_test_gate -> triage  [condition="outcome=fail", label="an existing on-topic test exists and the gate does not run it"]
 
     // redgate: checks 1+2. Three success-classified tokens (green_on_main
     // is a FINDING, not a retry) plus one generic fail edge.
@@ -556,9 +745,20 @@ digraph CapsulePipeline {
     diff_shape_gate -> discrimination_check [condition="context.tool.last_line=single_shape && outcome=success", label="author judged no second honest shape exists -- finding recorded, skip round-trip B"]
     diff_shape_gate -> triage                [condition="outcome=fail", label="hypothesis_b missing, identical to A, or a cosmetic variant"]
 
-    mutate_gate_b -> discrimination_check [condition="context.tool.last_line=roundtrip_b_ok && outcome=success", label="check 3b passes -- second shape also greens (discrimination proven)"]
+    mutate_gate_b -> degenerate_gate        [condition="context.tool.last_line=roundtrip_b_ok && outcome=success", label="check 3b passes mechanically -- before trusting it as discrimination proof, rule out a degenerate no-op"]
     mutate_gate_b -> reset_fail            [condition="context.tool.last_line=reset_b_unproven && outcome=success", label="reset (B) could not be proven -- LOUD halt"]
     mutate_gate_b -> triage                 [condition="outcome=fail", label="patch B would not apply, or would not green"]
+
+    // degenerate_gate -> the INVERSION-RULE gate (see header, THE INVERSION
+    // RULE). A green mutate_gate_b is NOT automatically discrimination
+    // proof: hack B could be a degenerate no-op (a stubbed return, a
+    // deleted function, a removed guard) that satisfies an under-specified
+    // assertion rather than a genuinely different real fix. That is a
+    // FAILURE signal (the gate needs tightening), never a silent pass and
+    // never a hard terminal halt -- it routes through the SAME root-cause
+    // wall (triage) every other gate defect uses, landing back on author.
+    degenerate_gate -> discrimination_check [condition="context.tool.last_line=b_substantive && outcome=success", label="hack B performs real, non-trivial behavior -- discrimination proof stands"]
+    degenerate_gate -> triage                [condition="outcome=fail", label="hack B greened via a stub/deletion/removed-guard -- gate under-specified, not discrimination-proof"]
 
     discrimination_check -> package [condition="context.tool.last_line=skip_recorded && outcome=success", label="no later_commit -- skipped with reason"]
     discrimination_check -> package [condition="context.tool.last_line=discrim_ok && outcome=success", label="RED confirmed at later commit"]

--- a/.github/capsule-pipeline/vendor/runner/check-degenerate-hack.py
+++ b/.github/capsule-pipeline/vendor/runner/check-degenerate-hack.py
@@ -1,0 +1,375 @@
+#!/usr/bin/env python3
+"""check-degenerate-hack.py -- mechanical DEGENERACY tripwire for a hypothesis
+patch (capsule.dot's mutate_gate_b / degenerate_gate).
+
+THE FINDING THIS CLOSES (adversarial review of PR #152, a `$key`
+prefix-substitution capsule): DEFINITION.verify.sh asserted, for
+substitute_context(), both "the corruption is gone" AND "real substitution
+still happens" -- a real functionality/regression pair. For expand_params()
+it asserted ONLY "the corrupted string does not appear." hypothesis-b.patch
+stubbed expand_params() to `return text` (the parameter, unchanged, doing
+nothing) and the gate went fully GREEN: EXIT=0, 12 passed. The patch's OWN
+comments said "the entire feature is silently disabled." Two independently-
+shaped hacks both greening a gate is supposed to be mechanical evidence the
+gate is bound to BEHAVIOR, not to one guessed implementation (capsule.dot's
+own two-hypothesis check) -- but that inference only holds if both hacks
+still DO something. A hack that deletes the feature and still passes proves
+the opposite: the gate has a coverage hole a no-op walks straight through.
+
+CONTRACT (mirrors backlog/check-upstream-leaks.sh's own: read before
+wiring): takes exactly one argument, a path to a unified diff (`git diff`
+format, the shape mutate/mutate_b already write). Exit 0 = no degenerate
+signal found (treat hack B as substantive -- proceed to discrimination_check).
+Exit 1 = a degenerate signal was found (STDOUT names it; capsule.dot routes
+this to triage as a FAILURE, never a silent pass, never a hard terminal
+halt -- the honest read is "the gate under test is not specified tightly
+enough," which is a call for the AUTHOR to tighten DEFINITION.verify.sh, not
+proof hack B is invalid). Exit 2 = usage/self-test failure (infra problem,
+not a finding).
+
+WHAT COUNTS AS DEGENERATE (mechanical, three signals, deliberately narrow --
+biased toward FALSE NEGATIVE over false positive; see the docstring on
+`--self-test` for why):
+
+  1. STUB: a hunk's added lines collapse to a trivial no-op (`pass`, `...`,
+     bare `return`, `return None`, `return ''`/`""`/`[]`/`{}`, or a bare
+     `return <name>` where `<name>` is one of the enclosing function's own
+     PARAMETERS -- i.e. a verbatim passthrough of the input, indistinguishable
+     from the function never having run) AND that trivial body is REPLACING
+     at least one real removed line. A hardcoded literal return (`return 42`,
+     `return "FIXED"`) does NOT match this -- that is the ordinary crude-hack
+     style mutate/mutate_b already explicitly invite, and it still requires
+     the patch to have produced SOME specific value, not nothing.
+
+  2. DELETED: a function whose `def NAME(` line is itself removed in a hunk,
+     and `NAME` never reappears in any ADDED `def` line anywhere else in the
+     whole patch -- the function is simply gone, not replaced.
+
+  3. GUARD-REMOVED: a removed line matching a bare `assert` or `raise
+     ...Error` with no compensating assert/raise added in the same hunk --
+     a safety check silently dropped, not tightened or relocated.
+
+WHAT IS DELIBERATELY *NOT* FLAGGED (the false-positive trap named in the
+task): a hunk that REMOVES lines and adds NOTHING (a broken special case
+simply deleted, the surrounding real logic left intact) never reaches signal
+1 (it requires added lines to judge trivial) and won't match 2 or 3 unless
+the removed lines are literally a `def` line or an assert/raise -- so
+"delete a broken branch, keep the real computation" reads as ordinary
+simplification, not degeneracy. This is a real, acknowledged limit: from
+diff text alone, "the correct fix is now an identity return" and "the
+feature was deleted and the gate never noticed" can be textually
+IDENTICAL. This script can only ever SUSPECT, never adjudicate -- which is
+exactly why capsule.dot routes a hit back through triage/diagnose to a
+human decision point rather than silently trusting or silently rejecting it.
+
+Self-test (proves the checker catches the known defect AND does not flag
+the two things it must not):
+    python3 runner/check-degenerate-hack.py --self-test
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import tempfile
+from pathlib import Path
+
+HUNK_RE = re.compile(r"^@@ -\d+(?:,\d+)? \+\d+(?:,\d+)? @@ ?(.*)$")
+DEF_RE = re.compile(r"\bdef\s+(\w+)\s*\(([^)]*)\)")
+ASSERT_RE = re.compile(r"^(assert\b|raise\s+\w*Error\b)")
+UNCONDITIONAL_TRIVIAL_RE = re.compile(
+    r"^(pass|\.\.\.|return|return\s+none|return\s+''|return\s+\"\"|return\s+\[\]|return\s+\{\})$",
+    re.IGNORECASE,
+)
+BARE_RETURN_RE = re.compile(r"^return\s+(\w+)$", re.IGNORECASE)
+
+
+def parse_hunks(text: str) -> list[dict]:
+    """Split a unified diff into hunks. Keeps an ORDERED tagged line list
+    (each line's diff marker + content) alongside the removed/added/context
+    convenience buckets, so callers can reconstruct "what the new file's
+    body actually reads as post-patch" (context + added, in original
+    order) -- not just "what got added", which misses the common case
+    where a trivial line (e.g. a bare `return text`) was ALREADY present
+    unchanged and everything else around it was simply deleted.
+    """
+    hunks: list[dict] = []
+    cur: dict | None = None
+    for line in text.splitlines():
+        m = HUNK_RE.match(line)
+        if m:
+            if cur is not None:
+                hunks.append(cur)
+            cur = {
+                "header": m.group(1),
+                "removed": [],
+                "added": [],
+                "context": [],
+                "ordered": [],
+            }
+            continue
+        if cur is None:
+            continue
+        if line.startswith(("+++", "---")):
+            continue
+        if line.startswith("+"):
+            cur["added"].append(line[1:])
+            cur["ordered"].append(("+", line[1:]))
+        elif line.startswith("-"):
+            cur["removed"].append(line[1:])
+            cur["ordered"].append(("-", line[1:]))
+        elif line.startswith(" "):
+            cur["context"].append(line[1:])
+            cur["ordered"].append((" ", line[1:]))
+        # lines with no marker (rare, e.g. "\ No newline at end of file") ignored
+    if cur is not None:
+        hunks.append(cur)
+    return hunks
+
+
+def body_lines(ordered: list[tuple[str, str]], tags: str) -> list[str]:
+    """Non-blank, non-def-line lines whose diff tag is in `tags`, in order."""
+    out = []
+    for tag, content in ordered:
+        if tag not in tags:
+            continue
+        stripped = content.strip()
+        if not stripped or DEF_RE.search(content):
+            continue
+        out.append(stripped)
+    return out
+
+
+def nonblank(lines: list[str]) -> list[str]:
+    return [l.strip() for l in lines if l.strip()]
+
+
+def find_def(*line_groups: list[str]) -> tuple[str | None, list[str]]:
+    """Find the first `def NAME(params)` across the given line groups, in order."""
+    for lines in line_groups:
+        for l in lines:
+            m = DEF_RE.search(l)
+            if m:
+                params = [
+                    p.split("=", 1)[0].split(":", 1)[0].strip()
+                    for p in m.group(2).split(",")
+                    if p.strip() and p.strip() != "self"
+                ]
+                return m.group(1), params
+    return None, []
+
+
+def is_trivial_added_line(line: str, params: list[str]) -> bool:
+    ll = line.strip()
+    if UNCONDITIONAL_TRIVIAL_RE.match(ll):
+        return True
+    m = BARE_RETURN_RE.match(ll)
+    return bool(m and m.group(1) in params)
+
+
+def analyze(text: str) -> list[str]:
+    """Return a list of human-readable degeneracy findings (empty = clean)."""
+    hunks = parse_hunks(text)
+    findings: list[str] = []
+    all_added_text = "\n".join(l for h in hunks for l in h["added"])
+
+    for h in hunks:
+        name, params = find_def([h["header"]], h["context"], h["removed"], h["added"])
+        removed_nb = nonblank(h["removed"])
+        added_nb = nonblank(h["added"])
+
+        # Signal 1: STUB -- the hunk's POST-PATCH body (context + added, in
+        # order, i.e. what the function actually reads as after applying
+        # this hunk) collapses to a trivial no-op, and the PRE-PATCH body
+        # (context + removed) had strictly more real content. This catches
+        # both shapes: a NEW trivial line replacing removed content, AND the
+        # common realistic case where the trivial line (e.g. a bare `return
+        # text`) was ALREADY present unchanged and everything else was
+        # simply deleted around it (nothing "added" at all in that case --
+        # a pure deletion that exposes a passthrough that was always there).
+        new_body = body_lines(h["ordered"], "+ ")
+        old_body = body_lines(h["ordered"], "- ")
+        if (
+            new_body
+            and len(new_body) <= 2
+            and all(is_trivial_added_line(l, params) for l in new_body)
+            and len(old_body) > len(new_body)
+            and removed_nb
+        ):
+            label = f"function '{name}'" if name else "this hunk"
+            findings.append(
+                f"STUB: {label}'s body after this patch is a trivial no-op "
+                f"{new_body!r}, down from {len(old_body)} real line(s) "
+                f"before it {old_body!r}"
+            )
+
+        # Signal 2: DELETED -- def line itself removed, name never re-added anywhere.
+        if name:
+            removed_def_here = any(
+                re.search(rf"\bdef\s+{re.escape(name)}\s*\(", l) for l in h["removed"]
+            )
+            if (
+                removed_def_here
+                and f"def {name}(" not in all_added_text
+                and not re.search(rf"\bdef\s+{re.escape(name)}\s*\(", all_added_text)
+            ):
+                findings.append(
+                    f"DELETED: function '{name}' removed in this hunk and never "
+                    f"reappears (as a def) anywhere added in the patch"
+                )
+
+        # Signal 3: GUARD-REMOVED -- assert/raise dropped, nothing compensating added.
+        removed_guards = [l for l in removed_nb if ASSERT_RE.match(l)]
+        added_guards = [l for l in added_nb if ASSERT_RE.match(l)]
+        if removed_guards and not added_guards:
+            findings.append(
+                f"GUARD-REMOVED: assertion/guard removed with no compensating "
+                f"guard added: {removed_guards!r}"
+            )
+
+    return findings
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) == 2 and argv[1] == "--self-test":
+        return self_test()
+    if len(argv) != 2:
+        print(
+            "usage: check-degenerate-hack.py <patch-file> | --self-test",
+            file=sys.stderr,
+        )
+        return 2
+    path = Path(argv[1])
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError as e:
+        print(f"cannot read patch file '{path}': {e}", file=sys.stderr)
+        return 2
+    if not text.strip():
+        print(f"patch file '{path}' is empty", file=sys.stderr)
+        return 2
+    if not HUNK_RE.search(text.replace("@@ -", "@@ -")) and "@@ " not in text:
+        print(
+            f"no '@@' diff hunks found in '{path}' -- not a unified diff?",
+            file=sys.stderr,
+        )
+        return 2
+
+    findings = analyze(text)
+    if findings:
+        print("DEGENERATE HACK SUSPECTED:")
+        for f in findings:
+            print(f" - {f}")
+        return 1
+    print(
+        "no degenerate-hack signal found (stub / deleted function / removed guard) -- treated as substantive"
+    )
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# self-test: proves the checker catches the known defect (PR #152 shape) and
+# does NOT flag the two things it must not (the false-positive trap).
+# ---------------------------------------------------------------------------
+PASSTHROUGH_STUB_PATCH = """\
+diff --git a/lib.py b/lib.py
+--- a/lib.py
++++ b/lib.py
+@@ -10,6 +10,3 @@ def expand_params(text, params):
+-    for k, v in params.items():
+-        text = text.replace('$' + k, v)
+-    return text
++    return text
+"""
+
+LEGIT_BROKEN_SPECIAL_CASE_PATCH = """\
+diff --git a/lib.py b/lib.py
+--- a/lib.py
++++ b/lib.py
+@@ -1,7 +1,5 @@ def compute(x):
+ def compute(x):
+-    if x == 42:
+-        return -1
+     if x < 0:
+         return 0
+     return x * 2
+"""
+
+LEGIT_HARDCODE_HACK_PATCH = """\
+diff --git a/lib.py b/lib.py
+--- a/lib.py
++++ b/lib.py
+@@ -1,3 +1,3 @@ def compute(x):
+ def compute(x):
+-    return broken(x)
++    return 42
+"""
+
+DELETED_FUNCTION_PATCH = """\
+diff --git a/lib.py b/lib.py
+--- a/lib.py
++++ b/lib.py
+@@ -5,6 +5,3 @@
+-def expand_params(text, params):
+-    for k, v in params.items():
+-        text = text.replace('$' + k, v)
+-    return text
+"""
+
+
+def self_test() -> int:
+    ok = True
+
+    def check(name: str, patch: str, expect_degenerate: bool) -> None:
+        nonlocal ok
+        findings = analyze(patch)
+        got = bool(findings)
+        if got == expect_degenerate:
+            print(f"ok:   {name} -> {'flagged' if got else 'clean'} as expected")
+        else:
+            ok = False
+            print(
+                f"FAIL: {name} -> expected {'flagged' if expect_degenerate else 'clean'}, "
+                f"got {'flagged' if got else 'clean'} ({findings})",
+                file=sys.stderr,
+            )
+
+    check(
+        "PR #152 shape: expand_params stubbed to bare passthrough",
+        PASSTHROUGH_STUB_PATCH,
+        True,
+    )
+    check("function deleted outright, never re-added", DELETED_FUNCTION_PATCH, True)
+    check(
+        "TRAP: legit fix removes a broken special case, real logic intact",
+        LEGIT_BROKEN_SPECIAL_CASE_PATCH,
+        False,
+    )
+    check(
+        "legit crude hack: hardcoded literal return (expected hack style)",
+        LEGIT_HARDCODE_HACK_PATCH,
+        False,
+    )
+
+    # usage-error self-test: nonexistent file -> rc 2
+    with tempfile.TemporaryDirectory() as td:
+        missing = Path(td) / "nope.patch"
+        rc = main(["check-degenerate-hack.py", str(missing)])
+        if rc == 2:
+            print("ok:   missing patch file -> usage error rc=2")
+        else:
+            ok = False
+            print(
+                f"FAIL: missing patch file -> expected rc=2, got {rc}", file=sys.stderr
+            )
+
+    print()
+    if ok:
+        print("check-degenerate-hack.py self-test: ALL PASSED")
+        return 0
+    print("check-degenerate-hack.py self-test: FAILURES ABOVE", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.github/capsule-pipeline/vendor/runner/check-existing-tests.py
+++ b/.github/capsule-pipeline/vendor/runner/check-existing-tests.py
@@ -1,0 +1,792 @@
+#!/usr/bin/env python3
+"""check-existing-tests.py -- mechanical FOLD-IN tripwire for a work capsule's
+gate script (capsule.dot's existing_test_gate).
+
+THE DEFECT CLASS THIS CLOSES (four reviewed capsules, n=4, all four sharing
+one habit): the authored DEFINITION.verify.sh does not run the tests that
+ALREADY exist in the target repo and already exercise the exact code the
+capsule concerns -- and every one of the four relegated running them to a
+"Human reviewer criteria (not automated)" section of DEFINITION.md, for a
+human who does not exist under the autonomous-implementer model these
+capsules feed.
+
+  #152 (issue #144): tests/test_param_expansion.py shipped in the same repo
+       and caught the degenerate expand_params() stub outright (6 failed) --
+       the authored gate ran only tests/test_unified_substitution.py.
+  #143 (issue #142): test_backend.py / test_attribute_passthrough.py already
+       exercise the exact idiom the gate uses -- verify.sh never invoked
+       pytest at all.
+  #149 (issue #146): test_validation.py unit-tests the exact rule and
+       test_examples_lint_clean.py sweeps every example -- neither was run.
+  #148 (issue #145): a docs file; no tests exist. Genuinely n/a -- and this
+       checker must be able to say so ON ITS OWN EVIDENCE.
+
+WHY A CHECKER AND NOT A PROMPT: capsule.dot's author prompt ALREADY says to
+search the target's test tree and "If one exists, FOLD IT IN." The prose is
+good and it did not bind (n=4). Primer foot-gun #13: prose rules are
+advisory; executed gates change behavior. The trap to avoid is the one
+capsule.dot's own header names -- the RETIRED "## Fix-shape independence"
+written-section requirement proved that demanding a written SELF-ATTESTATION
+("prove you searched") changes nothing measurable while burning budget on
+false blocks. So this checker asks the author to attest to NOTHING. It reads
+the shipped artifact and the target repo and answers a question about
+observable facts:
+
+    Given the subject THE GATE SCRIPT ITSELF DECLARES (the source symbols and
+    source paths its own text names), does a test file exist in this repo
+    that references that subject -- and if so, does the gate script invoke it?
+
+Both halves are properties of files on disk. Nothing is self-reported, so
+there is nothing to game by writing a better paragraph.
+
+CONTRACT (mirrors check-degenerate-hack.py's and
+backlog/check-upstream-leaks.sh's own: read before wiring):
+
+    check-existing-tests.py --verify <path/to/DEFINITION.verify.sh> \
+                            --repo <target repo root>
+    check-existing-tests.py --self-test
+
+  exit 0 -- PASS. The FIRST stdout line is `VERDICT: folded_in` (an on-topic
+            existing test IS invoked, or the script runs the whole suite) or
+            `VERDICT: no_on_topic_tests` (this checker SEARCHED and found
+            none -- the report says what it searched, so the absence is
+            evidence, not an assertion). The rest of stdout is the evidence.
+  exit 1 -- BLOCK. At least one existing test file references a subject
+            symbol the gate script itself names, and NO invoked test covers
+            that symbol. STDOUT names the symbol, the file, and the line to
+            add. capsule.dot routes this to triage -> author.
+  exit 2 -- usage/self-test failure (infra problem, not a finding).
+            capsule.dot deliberately treats this as PASS-with-a-finding, NOT
+            as a block -- see BIAS below.
+
+BIAS: FALSE NEGATIVE, DELIBERATELY. A checker that blocks legitimate capsules
+teaches authors to route around it, which is strictly worse than not having
+it. Every ambiguity resolves toward PASS, and every PASS that was not a
+positive confirmation writes a finding saying why:
+
+  - no test tree, or no test files              -> PASS (no_on_topic_tests)
+  - gate script names no symbol that resolves
+    to a definition in this repo's own source   -> PASS (no_on_topic_tests)
+  - no test file references any such symbol     -> PASS (no_on_topic_tests)
+  - the gate script invokes a test runner with
+    no specific file argument (`pytest -q`,
+    `make test`, `cargo test`)                  -> PASS (folded_in): it is
+    already running everything, including the on-topic tests
+  - a subject symbol has SOME invoked on-topic
+    test                                        -> that symbol is satisfied;
+    the checker never demands you run a second file for the same symbol
+  - repo too large to scan within the caps      -> PASS (no_on_topic_tests,
+    reason recorded)
+  - anything unexpected                         -> exit 2, which the gate
+    treats as PASS-with-a-finding
+
+RELEVANCE IS SYMBOL-DRIVEN, AND THAT IS A REAL LIMIT: a test that exercises
+the subject surface without ever naming a symbol the gate script also names
+is invisible to this checker. That is the deliberate false-negative side of
+the trade. Broadening relevance (module stems, import graphs, path heuristics)
+would find more tests and would also start blocking capsules for tests that
+are not actually on-topic -- the exact failure mode that makes a gate get
+routed around. Narrow and trusted beats broad and gamed.
+
+Self-test (proves it catches the known defect AND does not flag the three
+things it must not):
+    python3 runner/check-existing-tests.py --self-test
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+import tempfile
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Scan caps. A capsule run happens inside somebody else's repo; this gate sits
+# in the cheap-before-expensive chain and must stay cheap. Exceeding a cap is
+# never a block -- it is a PASS with the reason recorded.
+# ---------------------------------------------------------------------------
+MAX_FILES_SCANNED = 20000
+MAX_TEST_FILES = 3000
+MAX_SOURCE_FILES = 8000
+MAX_FILE_BYTES = 512 * 1024
+MAX_SUBJECT_SYMBOLS = 25
+# A symbol defined in more than this many source files is a common name
+# (`main`, `run`, `handler`), not this capsule's subject.
+MAX_DEFINING_FILES = 3
+
+SKIP_DIRS = {
+    ".git",
+    ".ai",
+    ".venv",
+    "venv",
+    "env",
+    "node_modules",
+    "__pycache__",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".tox",
+    ".nox",
+    ".eggs",
+    "site-packages",
+    "build",
+    "dist",
+    "target",
+    ".gradle",
+    ".idea",
+    ".vscode",
+    ".next",
+    ".cache",
+    "coverage",
+    "htmlcov",
+    "vendor",
+}
+
+TEST_DIR_NAMES = {"tests", "test", "spec", "specs", "__tests__", "testing"}
+
+SOURCE_SUFFIXES = {
+    ".py",
+    ".js",
+    ".jsx",
+    ".ts",
+    ".tsx",
+    ".go",
+    ".rb",
+    ".rs",
+    ".java",
+    ".kt",
+    ".scala",
+    ".c",
+    ".h",
+    ".cc",
+    ".cpp",
+    ".hpp",
+    ".cs",
+    ".php",
+    ".swift",
+    ".sh",
+    ".bash",
+    ".lua",
+    ".pl",
+    ".ex",
+    ".exs",
+}
+
+# Test-runner invocations. If one of these appears with NO specific test file
+# argument, the script is running the whole suite and there is nothing to fold
+# in -- it already folded everything in.
+RUNNER_RE = re.compile(
+    r"\b("
+    r"pytest|py\.test|unittest|tox|nox|"
+    r"go\s+test|cargo\s+test|dotnet\s+test|"
+    r"npm\s+(?:run\s+)?test|yarn\s+test|pnpm\s+(?:run\s+)?test|"
+    r"make\s+\S*test|"
+    r"rspec|jest|vitest|mocha|ava|phpunit|ctest|"
+    r"gradle\s+\S*test|mvn\s+\S*test"
+    r")\b"
+)
+
+# Definition forms, across the languages above. NAME is substituted in.
+DEF_TEMPLATES = (
+    r"\bdef\s+{n}\s*\(",
+    r"\bclass\s+{n}\s*[:(\s]",
+    r"\bfunction\s+{n}\s*\(",
+    r"\bfunc\s+(?:\([^)]*\)\s*)?{n}\s*\(",
+    r"\bfn\s+{n}\s*[<(]",
+    r"\bsub\s+{n}\s*[{{(]",
+    r"\b(?:const|let|var)\s+{n}\s*=\s*(?:async\s*)?(?:function|\()",
+    r"^\s*{n}\s*\(\s*\)\s*\{{",  # POSIX shell function
+)
+
+# Identifiers a gate script mentions for reasons that have nothing to do with
+# the subject under test. Kept small on purpose: the real filter is "does this
+# identifier resolve to a definition in the repo's own non-test source?".
+STOPWORDS = {
+    "bash",
+    "echo",
+    "exit",
+    "else",
+    "elif",
+    "then",
+    "fail",
+    "true",
+    "false",
+    "null",
+    "none",
+    "self",
+    "test",
+    "tests",
+    "main",
+    "print",
+    "python",
+    "python3",
+    "pipefail",
+    "euo",
+    "set",
+    "grep",
+    "sed",
+    "awk",
+    "cat",
+    "head",
+    "tail",
+    "sort",
+    "uniq",
+    "find",
+    "mkdir",
+    "rmdir",
+    "chmod",
+    "command",
+    "return",
+    "import",
+    "from",
+    "assert",
+    "raise",
+    "sys",
+    "argv",
+    "stderr",
+    "stdout",
+    "usr",
+    "env",
+    "local",
+    "readonly",
+    "export",
+    "unset",
+    "while",
+    "done",
+    "case",
+    "esac",
+    "function",
+    "verify",
+    "definition",
+    "repo",
+    "root",
+    "infra",
+    "defect",
+    "signal",
+    "value",
+    "result",
+    "output",
+    "input",
+    "failures",
+    "append",
+    "format",
+    "string",
+    "bytes",
+    "path",
+    "file",
+    "dir",
+    "temp",
+    "tmp",
+}
+
+
+# Every no_on_topic_tests report carries this line. #148's target was a docs
+# file with genuinely no tests -- that case must PASS, but "no tests exist"
+# must be a conclusion this checker reached by looking, never a claim the
+# author made. A silent skip is the same failure wearing a different hat.
+DETERMINED = (
+    "DETERMINATION: this absence was established by THIS CHECKER reading the tree "
+    "above, not asserted by the capsule's author."
+)
+
+
+class ScanLimit(Exception):
+    """A cap was hit. Never a block -- resolves to PASS with the reason said."""
+
+
+def _read(path: Path) -> str:
+    try:
+        if path.stat().st_size > MAX_FILE_BYTES:
+            return ""
+        return path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
+
+
+def is_test_path(rel: str) -> bool:
+    """True if this repo-relative path looks like a test artifact.
+
+    Two independent signals, either is enough: it lives under a directory
+    conventionally named for tests, or its own filename is conventionally
+    named for tests.
+    """
+    parts = rel.split("/")
+    if any(p.lower() in TEST_DIR_NAMES for p in parts[:-1]):
+        return True
+    stem = parts[-1].rsplit(".", 1)[0].lower()
+    return stem.startswith(("test_", "test-")) or stem.endswith(
+        ("_test", "-test", ".test", "_spec", "-spec", ".spec")
+    )
+
+
+def walk_repo(repo: Path) -> tuple[list[str], list[str]]:
+    """Return (test_files, source_files) as repo-relative POSIX paths."""
+    tests: list[str] = []
+    sources: list[str] = []
+    seen = 0
+    for dirpath, dirnames, filenames in os.walk(repo):
+        dirnames[:] = sorted(d for d in dirnames if d not in SKIP_DIRS and not d.startswith(".git"))
+        for fn in sorted(filenames):
+            seen += 1
+            if seen > MAX_FILES_SCANNED:
+                raise ScanLimit(f"more than {MAX_FILES_SCANNED} files under the repo root")
+            full = Path(dirpath) / fn
+            try:
+                rel = full.relative_to(repo).as_posix()
+            except ValueError:
+                continue
+            if full.suffix.lower() not in SOURCE_SUFFIXES:
+                continue
+            if is_test_path(rel):
+                tests.append(rel)
+            else:
+                sources.append(rel)
+    if len(tests) > MAX_TEST_FILES:
+        raise ScanLimit(f"more than {MAX_TEST_FILES} test files")
+    if len(sources) > MAX_SOURCE_FILES:
+        raise ScanLimit(f"more than {MAX_SOURCE_FILES} non-test source files")
+    return tests, sources
+
+
+def path_named_by(verify_text: str, rel: str) -> bool:
+    """Does the gate script name this repo file?
+
+    Suffix match on path-component boundaries, NOT an exact repo-relative
+    match: a real gate script routinely `cd`s into a subproject first and then
+    refers to `tests/test_x.py` (PR #152's own does exactly that), so the
+    literal repo-relative prefix never appears in its text.
+    """
+    parts = rel.split("/")
+    for i in range(len(parts)):
+        suffix = "/".join(parts[i:])
+        if suffix in verify_text:
+            return True
+    return False
+
+
+def candidate_identifiers(verify_text: str) -> list[str]:
+    out: list[str] = []
+    seen: set[str] = set()
+    for m in re.finditer(r"[A-Za-z_][A-Za-z0-9_]{3,}", verify_text):
+        tok = m.group(0)
+        low = tok.lower()
+        if low in STOPWORDS or tok in seen:
+            continue
+        seen.add(tok)
+        out.append(tok)
+    return out
+
+
+def resolve_subject_symbols(
+    verify_text: str, repo: Path, sources: list[str]
+) -> tuple[dict[str, list[str]], list[str]]:
+    """Symbols the GATE SCRIPT ITSELF names that are DEFINED in this repo's
+    own non-test source. This is the capsule's declared subject, read off the
+    shipped artifact -- never self-reported.
+
+    Returns (symbol -> defining source files, subject source paths named).
+    """
+    subject_paths = [rel for rel in sources if path_named_by(verify_text, rel)]
+    cands = candidate_identifiers(verify_text)
+    if not cands:
+        return {}, subject_paths
+
+    cand_set = set(cands)
+    alternation = "|".join(re.escape(c) for c in sorted(cand_set, key=len, reverse=True))
+    patterns = [
+        re.compile(tpl.format(n=f"(?P<name>{alternation})"), re.MULTILINE)
+        for tpl in DEF_TEMPLATES
+    ]
+
+    defined: dict[str, set[str]] = {}
+    # Files the script named directly are the strongest evidence of subject;
+    # scan them first so they always survive the MAX_SUBJECT_SYMBOLS cut.
+    ordered = subject_paths + [s for s in sources if s not in set(subject_paths)]
+    for rel in ordered:
+        text = _read(repo / rel)
+        if not text:
+            continue
+        for pat in patterns:
+            for m in pat.finditer(text):
+                name = m.group("name")
+                if name in cand_set:
+                    defined.setdefault(name, set()).add(rel)
+
+    subject_files = set(subject_paths)
+
+    def rank(item: tuple[str, set[str]]) -> tuple[int, int, str]:
+        name, files = item
+        # Prefer symbols defined in a file the gate script itself named, then
+        # the most specific (fewest defining files), then stable by name.
+        return (0 if files & subject_files else 1, len(files), name)
+
+    kept: dict[str, list[str]] = {}
+    for name, files in sorted(defined.items(), key=rank):
+        if len(files) > MAX_DEFINING_FILES:
+            continue
+        kept[name] = sorted(files)
+        if len(kept) >= MAX_SUBJECT_SYMBOLS:
+            break
+    return kept, subject_paths
+
+
+def invoked_tests(verify_text: str, tests: list[str]) -> tuple[set[str], bool, bool]:
+    """Which test files does the gate script actually run?
+
+    Returns (named test files, whole_suite, has_runner).
+    """
+    has_runner = bool(RUNNER_RE.search(verify_text))
+    named = {rel for rel in tests if path_named_by(verify_text, rel)}
+
+    # A test DIRECTORY named as a runner argument sweeps everything under it.
+    dir_swept: set[str] = set()
+    if has_runner:
+        for rel in tests:
+            parts = rel.split("/")
+            for i in range(len(parts) - 1):
+                for j in range(i + 1, len(parts)):
+                    d = "/".join(parts[i:j])
+                    if not d:
+                        continue
+                    if re.search(rf"(?<![\w/]){re.escape(d)}/?(?=[\s'\"]|$)", verify_text):
+                        dir_swept.add(rel)
+    named |= dir_swept
+
+    # A runner with no specific test file argument runs the whole suite.
+    whole_suite = has_runner and not named
+    return named, whole_suite, has_runner
+
+
+def analyze(verify_text: str, repo: Path) -> tuple[int, list[str]]:
+    """Return (exit_code, report_lines). report_lines[0] is the VERDICT line."""
+    try:
+        tests, sources = walk_repo(repo)
+    except ScanLimit as exc:
+        return 0, [
+            "VERDICT: no_on_topic_tests",
+            f"REASON: repo scan cap hit ({exc}) -- this checker will not block on an",
+            "  incomplete scan. Biased to false-negative by design; recorded, not enforced.",
+        ]
+
+    if not tests:
+        return 0, [
+            "VERDICT: no_on_topic_tests",
+            "REASON: no test files exist in this repo.",
+            f"SEARCHED: {len(sources)} non-test source files under the repo root;",
+            f"  directories named {sorted(TEST_DIR_NAMES)} and files named test_*/*_test/*_spec.",
+            DETERMINED,
+        ]
+
+    symbols, subject_paths = resolve_subject_symbols(verify_text, repo, sources)
+
+    if not symbols:
+        return 0, [
+            "VERDICT: no_on_topic_tests",
+            "REASON: the gate script names no identifier that resolves to a function/class",
+            "  definition in this repo's own non-test source, so this checker cannot",
+            "  determine a subject to look for tests about.",
+            f"SEARCHED: {len(tests)} test files, {len(sources)} non-test source files.",
+            f"SOURCE PATHS THE GATE SCRIPT NAMES: {subject_paths or '(none)'}",
+            "  Biased to false-negative: undetermined relevance passes and is recorded.",
+            DETERMINED,
+        ]
+
+    on_topic: dict[str, list[str]] = {}
+    test_text: dict[str, str] = {}
+    for rel in tests:
+        test_text[rel] = _read(repo / rel)
+    for sym in symbols:
+        word = re.compile(rf"\b{re.escape(sym)}\b")
+        hits = [rel for rel in tests if word.search(test_text[rel])]
+        if hits:
+            on_topic[sym] = hits
+
+    searched = (
+        f"SEARCHED: {len(tests)} test files for {len(symbols)} subject symbol(s) "
+        f"the gate script itself names: {sorted(symbols)}"
+    )
+
+    if not on_topic:
+        return 0, [
+            "VERDICT: no_on_topic_tests",
+            "REASON: no existing test file references any subject symbol the gate script",
+            "  names -- there is genuinely nothing on-topic to fold in.",
+            searched,
+            DETERMINED,
+        ]
+
+    named, whole_suite, has_runner = invoked_tests(verify_text, tests)
+
+    if whole_suite:
+        return 0, [
+            "VERDICT: folded_in",
+            "REASON: the gate script invokes a test runner with no specific test-file",
+            "  argument -- it already runs the whole suite, which includes every",
+            "  on-topic test below.",
+            searched,
+            f"ON-TOPIC TESTS COVERED: {sorted({f for v in on_topic.values() for f in v})}",
+        ]
+
+    unrun: list[tuple[str, list[str]]] = []
+    covered: list[tuple[str, str]] = []
+    for sym, files in sorted(on_topic.items()):
+        hit = sorted(set(files) & named)
+        if hit:
+            covered.append((sym, hit[0]))
+        else:
+            unrun.append((sym, sorted(files)))
+
+    if not unrun:
+        return 0, [
+            "VERDICT: folded_in",
+            "REASON: every subject symbol with existing on-topic test coverage has at",
+            "  least one of those tests invoked by the gate script.",
+            searched,
+            *[f"  {sym}: covered by {rel} (invoked)" for sym, rel in covered],
+        ]
+
+    lines = [
+        "VERDICT: unrun_on_topic_tests",
+        "The gate script declares a subject (by naming these symbols in its own text)",
+        "for which this repo ALREADY ships tests -- and the gate script does not run",
+        "them. Existing tests encode the neighbouring expectations a fresh bespoke",
+        "assertion does not know about; they are free coverage and they are exactly",
+        "what catches a degenerate hack that satisfies a narrow new assertion.",
+        "",
+        searched,
+        "",
+        "UNRUN ON-TOPIC TESTS:",
+    ]
+    for sym, files in unrun:
+        lines.append(f"  symbol '{sym}' (defined in {', '.join(symbols[sym])})")
+        for rel in files:
+            lines.append(f"      -> {rel}   NOT invoked by DEFINITION.verify.sh")
+    lines += [
+        "",
+        "FIX: have DEFINITION.verify.sh actually run at least one of the files above",
+        "for each symbol listed (running the whole suite also satisfies this check).",
+        "Treat their failure as the gate's own RED, not as an infrastructure error --",
+        "an existing test that fails is the defect reproducing, which is the point.",
+    ]
+    if covered:
+        lines += ["", "ALREADY COVERED (no action needed):"]
+        lines += [f"  {sym}: {rel}" for sym, rel in covered]
+    if not has_runner:
+        lines += [
+            "",
+            "NOTE: the gate script invokes no recognized test runner at all.",
+        ]
+    return 1, lines
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(add_help=True, description=__doc__)
+    parser.add_argument("--verify", help="path to the capsule's gate script")
+    parser.add_argument("--repo", help="path to the target repository root")
+    parser.add_argument("--self-test", action="store_true", dest="self_test")
+    try:
+        args = parser.parse_args(argv[1:])
+    except SystemExit:
+        return 2
+
+    if args.self_test:
+        return self_test()
+
+    if not args.verify or not args.repo:
+        print("usage: check-existing-tests.py --verify <gate.sh> --repo <repo root>", file=sys.stderr)
+        return 2
+
+    vpath = Path(args.verify)
+    repo = Path(args.repo)
+    if not vpath.is_file():
+        print(f"usage error: gate script not found: {vpath}", file=sys.stderr)
+        return 2
+    if not repo.is_dir():
+        print(f"usage error: repo root not a directory: {repo}", file=sys.stderr)
+        return 2
+
+    try:
+        verify_text = vpath.read_text(encoding="utf-8", errors="replace")
+        rc, report = analyze(verify_text, repo.resolve())
+    except Exception as exc:  # noqa: BLE001 -- an internal error must never block
+        print(f"internal error: {type(exc).__name__}: {exc}", file=sys.stderr)
+        return 2
+
+    print("\n".join(report))
+    return rc
+
+
+# ---------------------------------------------------------------------------
+# self-test fixtures -- the real shapes, reconstructed
+# ---------------------------------------------------------------------------
+
+_SUBSTITUTION_PY = '''\
+def substitute_context(text, snapshot):
+    for k, v in snapshot.items():
+        text = text.replace("$" + k, str(v))
+    return text
+'''
+
+_TRANSFORMS_PY = '''\
+def expand_params(text, params):
+    for k, v in params.items():
+        text = text.replace(k, v)
+    return text
+'''
+
+_TEST_UNIFIED = '''\
+from substitution import substitute_context
+
+
+def test_substitute_context_basic():
+    assert substitute_context("$a", {"a": "1"}) == "1"
+'''
+
+_TEST_PARAM_EXPANSION = '''\
+from transforms import expand_params
+
+
+def test_expand_params_basic():
+    assert expand_params("$framework app", {"$framework": "FastAPI"}) == "FastAPI app"
+'''
+
+# PR #152's own shape: a bespoke assertion block plus ONE existing test file,
+# while a second existing test file covering the other named symbol is ignored.
+_VERIFY_152 = '''\
+set -euo pipefail
+python3 - <<'EOF'
+from substitution import substitute_context
+from transforms import expand_params
+assert "$name_suffix" in substitute_context("$name $name_suffix", {"name": "A"})
+assert "Alice_suffix" not in expand_params("$name_suffix", {"name": "Alice"})
+EOF
+pytest tests/test_unified_substitution.py -q
+'''
+
+_VERIFY_152_FOLDED = _VERIFY_152 + "pytest tests/test_param_expansion.py -q\n"
+
+# The whole-suite shape: a runner with no specific file argument.
+_VERIFY_WHOLE_SUITE = '''\
+set -euo pipefail
+python3 -c "from substitution import substitute_context; from transforms import expand_params"
+pytest -q
+'''
+
+# The #143 shape: never invokes a test runner at all.
+_VERIFY_NO_RUNNER = '''\
+set -euo pipefail
+python3 - <<'EOF'
+from transforms import expand_params
+assert expand_params("x", {}) == "x"
+EOF
+'''
+
+# The #148 shape: the subject is a docs file; no code symbols, no tests.
+_VERIFY_DOCS = '''\
+set -euo pipefail
+grep -q "## Installation" docs/guide.md || { echo "DEFECT: heading missing"; exit 1; }
+'''
+
+
+def _mk_repo(root: Path, *, with_tests: bool = True, docs_only: bool = False) -> None:
+    if docs_only:
+        (root / "docs").mkdir(parents=True, exist_ok=True)
+        (root / "docs" / "guide.md").write_text("# Guide\n\nno install section\n")
+        return
+    (root / "substitution.py").write_text(_SUBSTITUTION_PY)
+    (root / "transforms.py").write_text(_TRANSFORMS_PY)
+    if with_tests:
+        (root / "tests").mkdir(parents=True, exist_ok=True)
+        (root / "tests" / "test_unified_substitution.py").write_text(_TEST_UNIFIED)
+        (root / "tests" / "test_param_expansion.py").write_text(_TEST_PARAM_EXPANSION)
+
+
+def self_test() -> int:
+    ok = True
+
+    def check(name: str, verify_text: str, expect_rc: int, must_contain: tuple[str, ...] = (), **mk) -> None:
+        nonlocal ok
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            _mk_repo(root, **mk)
+            rc, report = analyze(verify_text, root)
+        blob = "\n".join(report)
+        missing = [s for s in must_contain if s not in blob]
+        if rc == expect_rc and not missing:
+            print(f"ok:   {name} -> rc={rc} ({report[0]})")
+            return
+        ok = False
+        print(
+            f"FAIL: {name} -> expected rc={expect_rc}, got rc={rc}; "
+            f"missing={missing}\n--- report ---\n{blob}",
+            file=sys.stderr,
+        )
+
+    check(
+        "PR #152 shape: existing tests/test_param_expansion.py never invoked",
+        _VERIFY_152,
+        1,
+        ("VERDICT: unrun_on_topic_tests", "expand_params", "tests/test_param_expansion.py"),
+    )
+    check(
+        "PR #152 shape, folded in: both on-topic test files invoked",
+        _VERIFY_152_FOLDED,
+        0,
+        ("VERDICT: folded_in",),
+    )
+    check(
+        "TRAP: whole-suite runner (`pytest -q`, no file arg) already covers everything",
+        _VERIFY_WHOLE_SUITE,
+        0,
+        ("VERDICT: folded_in", "whole suite"),
+    )
+    check(
+        "#143 shape: no test runner invoked at all, on-topic tests exist",
+        _VERIFY_NO_RUNNER,
+        1,
+        ("VERDICT: unrun_on_topic_tests", "no recognized test runner"),
+    )
+    check(
+        "#148 shape: docs-file subject in a repo that DOES have tests -- no code symbol "
+        "resolves, so nothing on-topic exists and the checker says so",
+        _VERIFY_DOCS,
+        0,
+        ("VERDICT: no_on_topic_tests", "SEARCHED: 2 test files", DETERMINED),
+    )
+    check(
+        "TRAP: repo with no test tree at all -> pass, absence determined by walking",
+        _VERIFY_152,
+        0,
+        ("VERDICT: no_on_topic_tests", "no test files exist", DETERMINED),
+        with_tests=False,
+    )
+    check(
+        "TRAP: docs-only repo (no source, no tests) -> pass, absence determined",
+        _VERIFY_DOCS,
+        0,
+        ("VERDICT: no_on_topic_tests", "no test files exist", DETERMINED),
+        docs_only=True,
+    )
+
+    # usage-error self-test: nonexistent gate script -> rc 2
+    with tempfile.TemporaryDirectory() as td:
+        missing = Path(td) / "nope.sh"
+        rc = main(["check-existing-tests.py", "--verify", str(missing), "--repo", td])
+        if rc == 2:
+            print("ok:   missing gate script -> usage error rc=2")
+        else:
+            ok = False
+            print(f"FAIL: missing gate script -> expected rc=2, got {rc}", file=sys.stderr)
+
+    print()
+    if ok:
+        print("check-existing-tests.py self-test: ALL PASSED")
+        return 0
+    print("check-existing-tests.py self-test: FAILURES ABOVE", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
## Verified drift

The vendored `.github/capsule-pipeline/capsule.dot` header cited pinned commit
`67a53e531a1` (`runner/capsule.dot`, 2026-08-06). That commit's own diff shows
it did not touch `runner/capsule.dot` at all (it only added held-out eval
fixtures under `runner/tests/`) — its `runner/capsule.dot` blob is
byte-identical to `73e75e7`, the commit the issue actually named. Diffing
`67a53e5:runner/capsule.dot` against `d93d1e6:runner/capsule.dot` (uplift's
current main) confirms two gates were missing from the vendored copy,
+216/−16 lines:

```
runner/capsule.dot | 232 +++++++++++++++++++++++++++++++++++++++++++++++++----
1 file changed, 216 insertions(+), 16 deletions(-)
```

- **`degenerate_gate`** (uplift `0afb874`, THE INVERSION RULE): a hypothesis-B
  patch that greens `DEFINITION.verify.sh` by deleting/stubbing behavior
  (the PR #152 `expand_params()` stub-return hole) is not proof the gate is
  behavior-bound — it's the opposite. This gate runs `check-degenerate-hack.py`
  against `hypothesis_b.patch` and routes a suspected hit to `triage`.
- **`existing_test_gate`** (uplift `d93d1e6`, FOLD IN THE EXISTING TESTS):
  blocks a capsule whose gate script names a subject (by symbol/source-path)
  the target repo already ships an on-topic test for, and doesn't run it —
  promoted to blocking after four reviewed capsules all relegated this to a
  "Human reviewer criteria" section addressed to a human that doesn't exist
  under autonomous operation.

**Consequence, confirmed**: every `capsule-specify.yml` run this repo's
Actions had produced (issue #142 → PR #143, issue #144 → the PR #152 episode
that motivated both new gates) ran without either hardening — the fixes exist
in the source and had never executed in the pipeline that actually runs.

`runner/task-runner.dot` (the *implement*-stage vendored copy) was checked
against the same source range and found **byte-identical** at its own
separately-pinned commit (`f5322c24ed6fd8deaeddb519de7bfdfa861094d9`):

```
$ git diff f5322c24ed6fd8deaeddb519de7bfdfa861094d9..d93d1e6 -- runner/task-runner.dot
(empty)
```

No drift, so it is **not** included in this PR — a separate re-sync would
have nothing to do. Called out here per the task, not filed separately.

## What changed

- `.github/capsule-pipeline/capsule.dot` re-synced to uplift `d93d1e6`
  (body verified byte-identical to the source via diff after re-applying
  only the provenance header).
- Vendored both new checkers, for the first time, under a new
  `vendor/runner/` subdirectory (mirrors the source's own `runner/` layout,
  same convention `vendor/backlog/` already used):
  - `.github/capsule-pipeline/vendor/runner/check-degenerate-hack.py`
  - `.github/capsule-pipeline/vendor/runner/check-existing-tests.py`
- `.github/capsule-pipeline/README.md`: Files table, Provenance section
  (generalized the "not modified beyond header" paragraph to cover all
  three `uplift_dir`-resolved checkers), Re-syncing steps (now says *diff
  and quote*, not just "confirm current commit"; says to grep the source
  for new `uplift_dir` references so a newly-added checker isn't missed
  next time), and a new **Re-sync log** section recording this event.

## Proof the checkers resolve at the vendored path

Extracted the exact `tool_command=` shell fragments for `existing_test_gate`
and `degenerate_gate` straight out of the re-synced `.dot` (DOT-string
unescaped programmatically, not retyped), and ran them in a scratch git
repo with `uplift_dir` set exactly the way `capsule-specify.yml` sets it:
`$GITHUB_WORKSPACE/.github/capsule-pipeline/vendor` (i.e., the real
absolute path to this repo's checked-out vendor dir).

**Positive path — both gates ran the real vendored scripts and produced
sensible, log-and-ledger-recorded verdicts:**

```
=== existing_test_gate ===
EXIT=0
.ai/existing-tests-check.log:
VERDICT: no_on_topic_tests
REASON: no test files exist in this repo.
...
.ai/convergence.jsonl: {"iteration": 0, "gate": "existing_test", "verdict": "none_exist"}

=== degenerate_gate ===
EXIT=0
.ai/degenerate-check.log:
no degenerate-hack signal found (stub / deleted function / removed guard) -- treated as substantive
.ai/convergence.jsonl: {"iteration": 0, "gate": "degenerate", "suspected": false}
```

**Negative control — proves the positive result isn't a false pass.** Same
scripts, `uplift_dir` pointed at a directory that doesn't exist:

```
=== existing_test_gate (uplift_dir=/tmp/definitely-does-not-exist) ===
EXIT=1
python3: can't open file '/tmp/definitely-does-not-exist/runner/check-existing-tests.py': [Errno 2] No such file or directory

=== degenerate_gate (uplift_dir=/tmp/definitely-does-not-exist) ===
EXIT=1
python3: can't open file '/tmp/definitely-does-not-exist/runner/check-degenerate-hack.py': [Errno 2] No such file or directory
```

Then re-ran with the correct `uplift_dir` one more time to confirm it flips
straight back to `EXIT=0` — the resolution genuinely depends on the vendored
path being right, not an accident of the test harness.

## Lint + parity with source

```
$ attractor lint .github/capsule-pipeline/capsule.dot
attractor lint: .github/capsule-pipeline/capsule.dot: OK (no findings)
```

Node/edge/cycle counts, vendored copy vs. `d93d1e6:runner/capsule.dot`
(body-diff-verified byte-identical, so this is expected, but computed
independently both ways):

| | vendored | source (d93d1e6) |
|---|---|---|
| node definitions (`name [...]`) | 33 | 33 |
| edges (`a -> b`) | 56 | 56 |
| distinct nodes appearing in an edge | 32 | 32 |
| simple cycles (networkx) | 64 | 64 |

## On the `$uplift_dir` indirection itself

It held up here and I'd keep it: `capsule.dot`'s body needed **zero**
changes to pick up two brand-new gates and their checkers — only new files
under `vendor/` and a `--param uplift_dir=` value the workflow already
passes. The trap named in the task (a `.dot`-only sync shipping gates whose
checkers don't exist) is real, but it's a **process gap** in the re-sync
procedure, not a design flaw in the parameterization: nothing about
`uplift_dir` being a parameter caused it, and nothing about hardcoding the
path would have prevented it either — a hardcoded path just moves the same
"did you copy the new file too" failure from a param value to a literal in
the graph body (and makes the *next* legitimate re-sync a body edit,
which the provenance convention explicitly forbids). The actual fix
belongs in the re-sync **checklist**, which is what this PR's README changes
add: grep the source diff for `uplift_dir` references before calling a
re-sync done, and — as demonstrated above — prove resolution with a real
invocation rather than an `ls`. I'd resist hardcoding paths into the vendored
`.dot` for the same reason the original vendoring chose not to: it would be
a body edit on every re-sync, which is exactly the hand-editing the
provenance convention exists to prevent.

## Gates

- Required check: `CI Gate (all checks passed)` — reported below once green.
- `git diff --check`: clean.
- No `-Xtheirs`/`-Xours` used; `attractor-uplift` was read-only throughout.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>
