### PR TITLE
fix(capsule-pipeline): resync vendored capsule.dot -- witness_gate + degenerate_gate A/B symmetry

### DIFF
--- a/.github/capsule-pipeline/README.md
+++ b/.github/capsule-pipeline/README.md
@@ -29,8 +29,9 @@ This directory wires two stages of an issue -> attractor -> PR system:
 | `attractor-pipeline-dual.yaml` | Multi-provider (Anthropic + OpenAI) base bundle for `task-runner.dot`'s dual-family critique. **Vendored but not currently wired in** — see its own provenance header and `capsule-implement.yml` for why. |
 | `vendor/backlog/check-upstream-leaks.sh` | Publication-safety gate: scans the produced `DEFINITION.md` for internal working-vocabulary leaks before it ships in a PR. |
 | `vendor/backlog/fixtures/leak-scan/*` | Self-test fixtures for the scanner above (RED/GREEN controls). |
-| `vendor/runner/check-degenerate-hack.py` | `degenerate_gate`'s checker: suspects a hypothesis-B patch that greens the gate by deleting/stubbing behavior rather than implementing a real alternate fix (THE INVERSION RULE). |
-| `vendor/runner/check-existing-tests.py` | `existing_test_gate`'s checker: derives a capsule's subject from the symbols/paths its own `DEFINITION.verify.sh` names, and blocks if the repo already ships an on-topic test the gate doesn't run (FOLD IN THE EXISTING TESTS). |
+| `vendor/runner/check-degenerate-hack.py` | `degenerate_gate`'s checker: suspects a hypothesis patch (A **and** B, checked per-patch since the A/B symmetry fix) that greens the gate by deleting/stubbing behavior rather than implementing a real alternate fix (THE INVERSION RULE). |
+| `vendor/runner/check-existing-tests.py` | `existing_test_gate`'s checker: derives a capsule's subject from the symbols/paths its own `DEFINITION.verify.sh` names, and blocks if the repo already ships an on-topic test the gate doesn't run (FOLD IN THE EXISTING TESTS). **Also a load-bearing import for `check-witness-gate.py`** (see below) — it is no longer only `existing_test_gate`'s dependency. |
+| `vendor/runner/check-witness-gate.py` | `witness_gate`'s checker: catches "vacuous by no-occasion" — a proven-greening hypothesis patch that dodges the reported defect by deleting the *occasion* to observe it (e.g. deleting a single `goal_gate=true` token) rather than fixing it. Imports `resolve_subject_symbols`/`walk_repo`/`STOPWORDS` from `check-existing-tests.py` and diff-hunk parsing from `check-degenerate-hack.py` **at runtime via `importlib`**, resolved relative to its own file location (`Path(__file__).resolve().parent`) — both sibling files must be vendored in the *same directory*, not merely somewhere under `uplift_dir`. |
 
 ## Provenance — these are VENDORED copies
 
@@ -46,7 +47,7 @@ or improvement is needed, make it in the source repository, re-copy the
 file here, and re-apply the provenance header comment.
 
 `capsule.dot` itself is **not modified** beyond the header: it references all
-three of its checker dependencies via the same `uplift_dir` **parameter**,
+of its checker dependencies via the same `uplift_dir` **parameter**,
 never a hardcoded path, so vendoring each checker at the matching relative
 location under `vendor/` and pointing
 `--param uplift_dir=.github/capsule-pipeline/vendor` at it satisfies every
@@ -56,12 +57,28 @@ logic:
 - `$uplift_dir/backlog/check-upstream-leaks.sh` (`leak_gate`) -> `vendor/backlog/check-upstream-leaks.sh`
 - `$uplift_dir/runner/check-degenerate-hack.py` (`degenerate_gate`) -> `vendor/runner/check-degenerate-hack.py`
 - `$uplift_dir/runner/check-existing-tests.py` (`existing_test_gate`) -> `vendor/runner/check-existing-tests.py`
+- `$uplift_dir/runner/check-witness-gate.py` (`witness_gate`) -> `vendor/runner/check-witness-gate.py`
 
 The `vendor/` subtree therefore mirrors the source repository's own directory
 layout (`backlog/`, `runner/`) one level down -- this is deliberate, not
 incidental: any future checker `capsule.dot` grows will resolve correctly
 under `uplift_dir` for free as long as it is vendored at the same relative
 path it lives at in the source, with no path-mapping logic to maintain here.
+
+**A fourth reference exists that is *not* a `$uplift_dir/...` shell-out and
+will not be found by grepping `capsule.dot` for `uplift_dir` at all**:
+`check-witness-gate.py` loads `check-existing-tests.py` (for
+`resolve_subject_symbols`/`walk_repo`/`STOPWORDS`) and `check-degenerate-hack.py`
+(for its diff-hunk parser) directly via `importlib`, resolved relative to
+**its own file's location** (`Path(__file__).resolve().parent`) -- not via
+`uplift_dir`, not via a `sys.path` entry, and not via the graph at all. This
+means both sibling files must be vendored in the exact same directory as
+`check-witness-gate.py` (`vendor/runner/`), or the import silently resolves
+to nothing and `witness_gate` crashes at runtime with a `FileNotFoundError`
+that no static check on `capsule.dot` itself will ever surface. See
+"Re-syncing" step 2 below -- this is precisely the class of miss that caused
+this file's own previous re-sync to ship gates whose checker scripts weren't
+vendored.
 
 `task-runner.dot` is likewise **not modified** beyond its header. It was
 authored for a slightly different invocation shape (a backlog task file with
@@ -114,8 +131,26 @@ scanner correctly) before this was wired up.
    `tool_command=` node shells out to must exist under `vendor/` at the exact
    relative path the graph resolves, or the corresponding gate breaks at
    runtime instead of at review time. As of the 2026-08-07 re-sync that means:
-   `backlog/check-upstream-leaks.sh`, `runner/check-degenerate-hack.py`, and
-   `runner/check-existing-tests.py`.
+   `backlog/check-upstream-leaks.sh`, `runner/check-degenerate-hack.py`,
+   `runner/check-existing-tests.py`, and `runner/check-witness-gate.py`.
+   **This grep is NOT sufficient by itself** -- see step 2a. (This gap is
+   exactly what let the previous re-sync ship `degenerate_gate` and
+   `existing_test_gate` referencing checkers that were never vendored: the
+   step existed, but grepping `capsule.dot` alone doesn't surface every
+   load-bearing dependency a *newly-added* checker script itself introduces.)
+2a. **Grep every newly-added or newly-vendored Python checker for its OWN
+   sibling-file dependencies** -- `importlib`-based loading of another script
+   in the same directory (e.g. `check-witness-gate.py`'s `_load(...,
+   "check-existing-tests.py")`), `sys.path` manipulation, or a plain
+   `import` of a local module. These dependencies are invisible to a grep of
+   `capsule.dot` for `uplift_dir` (the referencing script isn't shelled out
+   from the graph with a path -- it's imported from *within* another
+   checker), and an already-vendored, content-unchanged file can become
+   load-bearing for a brand-new reason: `check-existing-tests.py` didn't
+   change in this sync, but it silently became a runtime dependency of
+   `check-witness-gate.py` too. Run `grep -n "^import\|^from\|_load(\|importlib"
+   vendor/runner/*.py` and confirm every named sibling file is present in the
+   same `vendor/` subdirectory.
 3. Copy the files here verbatim (`cp`, not a manual retype), preserving the
    executable bit on any `.sh`/`.py` checker.
 4. Re-apply (or update) the provenance header comment at the top of each file
@@ -125,7 +160,13 @@ scanner correctly) before this was wired up.
    vendored checkers actually resolve** at the path the workflow sets
    `uplift_dir` to (`$GITHUB_WORKSPACE/.github/capsule-pipeline/vendor`) --
    a `workflow_dispatch` run or a local invocation with `uplift_dir` set the
-   same way, not just a file-existence check. Note any new deviations here.
+   same way, not just a file-existence check. **This must include proving any
+   cross-checker `importlib` import found in step 2a actually resolves** --
+   invoke the importing checker (not just `python3 -c "import ..."` in
+   isolation) from a scratch repo with `uplift_dir` pointed at the vendored
+   location, and run a negative control (wrong `uplift_dir`, or one sibling
+   file deliberately absent) so a pass isn't accidental. Note any new
+   deviations here.
 
 ## Re-sync log
 
@@ -145,6 +186,56 @@ scanner correctly) before this was wired up.
   Vendored their checkers (`vendor/runner/check-degenerate-hack.py`,
   `vendor/runner/check-existing-tests.py`) for the first time -- this
   `vendor/runner/` subdirectory did not exist before this sync.
+  `task-runner.dot` was checked against the same source range and found
+  **byte-identical** at its own pinned commit
+  (`f5322c24ed6fd8deaeddb519de7bfdfa861094d9`) -- no re-sync needed; see the
+  PR that performed this sync for the full proof.
+
+- **2026-08-07 (later same day)** -- `capsule.dot` re-synced
+  `d93d1e60066abdc61f082e48619569eef0816a09` ->
+  `3a53cf13cbf426bcdea7e4382fae9feb9efe977d`. Picked up two more additions:
+  - `witness_gate` (new gate, catches "vacuous by no-occasion" -- a
+    hypothesis patch that greens the gate by *deleting the observed case*
+    rather than fixing the reported cause; motivating live case: GitHub
+    issue #146, where deleting the single token `goal_gate=true` from a
+    `.dot` example greens the gate while the reported lint blind spot
+    remains untouched). Vendored its checker,
+    `vendor/runner/check-witness-gate.py`, for the first time.
+  - `degenerate_gate` A/B symmetry fix -- it previously inspected only
+    `.ai/hypothesis_b.patch`; it now runs `check-degenerate-hack.py` over
+    **both** hypothesis slots (`hypothesis.patch` and `hypothesis_b.patch`)
+    and reports which fired. No new file to vendor for this half (it reuses
+    the already-vendored `check-degenerate-hack.py` unchanged), but the
+    `.dot` body calling it changed (now invoked twice per round).
+  This sync exercised the exact trap this README's checklist step 2a now
+  names explicitly: `check-witness-gate.py` imports
+  `resolve_subject_symbols`/`walk_repo`/`STOPWORDS` from
+  `check-existing-tests.py` **and** diff-hunk parsing from
+  `check-degenerate-hack.py`, both via `importlib`, resolved relative to its
+  own file's directory -- not via `uplift_dir`, and invisible to a grep of
+  `capsule.dot` for `uplift_dir` references (that grep only finds
+  `check-witness-gate.py` itself as a new `$uplift_dir/...` shell-out; it
+  would not have flagged that the *already-vendored, content-unchanged*
+  `check-existing-tests.py` had become load-bearing for a second, different
+  consumer). `check-existing-tests.py` and `check-degenerate-hack.py` were
+  diffed against this same source range and found byte-identical to the
+  copies already vendored from the prior sync -- no re-copy was needed for
+  either, only the new `check-witness-gate.py`. Runtime resolution of all
+  three checkers, including the cross-file `importlib` import, was proven
+  from a scratch repo with `uplift_dir` set exactly as
+  `capsule-specify.yml` sets it, plus a negative control (wrong
+  `uplift_dir`) -- see the PR that performed this sync for the full
+  transcripts. `task-runner.dot` was checked against the same source range
+  and found **byte-identical** at its own separately-pinned commit
+  (`f5322c24ed6fd8deaeddb519de7bfdfa861094d9`, unchanged from the previous
+  sync) -- no re-sync needed.
+  The prior version of this README's checklist (step 2 alone: grep
+  `capsule.dot` for `uplift_dir`) would **not** have caught this sync's
+  cross-file import trap on its own -- it names only references the graph
+  itself makes. Step 2a above was added in this pass specifically to close
+  that gap: newly-vendored Python checkers must themselves be grepped for
+  sibling-file loading, and any already-vendored file they reference must be
+  re-confirmed present, even when that file's own content didn't change.
   `task-runner.dot` was checked against the same source range and found
   **byte-identical** at its own pinned commit (`f5322c24ed6fd8deaeddb519de7bfdfa861094d9`)
   -- no re-sync needed; see the PR that performed this sync for the full

--- a/.github/capsule-pipeline/capsule.dot
+++ b/.github/capsule-pipeline/capsule.dot
@@ -1,7 +1,7 @@
 // ============================================================================
 // VENDORED COPY -- see .github/capsule-pipeline/README.md for provenance,
 // scope, and re-sync instructions. Source: a private working repository
-// (not publicly reachable), pinned at its commit d93d1e60066abdc61f082e48619569eef0816a09
+// (not publicly reachable), pinned at its commit 3a53cf13cbf426bcdea7e4382fae9feb9efe977d
 // (runner/capsule.dot, 2026-08-07). This copy is otherwise byte-identical to
 // the source file below this header -- do not hand-edit the body; re-sync
 // from source and re-apply this header instead.
@@ -284,10 +284,12 @@
 //     (redgate/mutate_gate/discrimination_check's own ledger records,
 //     triage's signature comparison).
 //   - CONVERGENCE RECORD: capsule_gate, leak_gate, existing_test_gate,
-//     redgate, mutate_gate, and discrimination_check each append one line
-//     per visit to .ai/convergence.jsonl (gate keys "round"/"leak"/
-//     "existing_test"/"redgate"/"mutate_gate"/"discrimination") -- the
-//     descent record postmortem reads on non-convergence.
+//     redgate, mutate_gate, mutate_gate_b, degenerate_gate, witness_gate,
+//     and discrimination_check each append one line per visit to
+//     .ai/convergence.jsonl (gate keys "round"/"leak"/"existing_test"/
+//     "redgate"/"mutate_gate"/"mutate_gate_b"/"degenerate"/"witness"/
+//     "discrimination") -- the descent record postmortem reads on
+//     non-convergence.
 //   - PARAM NAMESPACE: `${k:-default}` is NOT engine-expanded (unknown
 //     braced key passes through); optional params (later_commit,
 //     max_iterations) are read into a shell var first (`LC=$later_commit`)
@@ -540,7 +542,7 @@ digraph CapsulePipeline {
         goal_gate=true, retry_target="author",
         tool_command="CV=.ai/capsule/DEFINITION.verify.sh; P=.ai/hypothesis_b.patch; BASE=$(cat .ai/base-sha 2>/dev/null); n=$(cat .ai/iter 2>/dev/null || echo 0); if [ -z \"$BASE\" ]; then echo 'MUTATE_GATE_B: .ai/base-sha missing -- preflight did not pin a base SHA' > .ai/gate.log; echo mutate_b > .ai/last-stage-fail; exit 1; fi; if ! git apply --check \"$P\" >/dev/null 2>&1; then printf '{\"iteration\": %s, \"gate\": \"mutate_gate_b\", \"applies\": false}\\n' \"$n\" >> .ai/convergence.jsonl; echo \"MUTATE_GATE_B: hypothesis_b.patch does not apply cleanly against pinned base $BASE\" > .ai/gate.log; echo mutate_b > .ai/last-stage-fail; exit 1; fi; git apply \"$P\"; chmod +x \"$CV\" 2>/dev/null; timeout 900 bash \"$CV\" > .ai/verify-hypothesis-b.log 2>&1; rc=$?; if [ $rc -ne 0 ]; then printf '{\"iteration\": %s, \"gate\": \"mutate_gate_b\", \"greened\": false, \"rc\": %s}\\n' \"$n\" \"$rc\" >> .ai/convergence.jsonl; { echo \"MUTATE_GATE_B: hypothesis_b.patch applied but gate rc=$rc (need 0 -- the second, differently-shaped crude patch did not turn it green -- if a real fix could only take THIS shape and not hypothesis.patch's shape, the gate may be bound to hypothesis.patch's shape, not to end-state behavior)\"; tail -30 .ai/verify-hypothesis-b.log; } > .ai/gate.log; git checkout --quiet -- .; git clean -qfd -e .ai; echo mutate_b > .ai/last-stage-fail; exit 1; fi; git checkout --quiet -- .; git clean -qfd -e .ai; if git diff --quiet -- . && [ \"$(git rev-parse HEAD)\" = \"$BASE\" ]; then printf '{\"iteration\": %s, \"gate\": \"mutate_gate_b\", \"greened\": true, \"reset_proven\": true}\\n' \"$n\" >> .ai/convergence.jsonl; printf roundtrip_b_ok; else printf '{\"iteration\": %s, \"gate\": \"mutate_gate_b\", \"greened\": true, \"reset_proven\": false}\\n' \"$n\" >> .ai/convergence.jsonl; echo \"MUTATE_GATE_B: RESET NOT PROVEN after hypothesis-B round-trip -- git diff and/or HEAD no longer matches the pinned base SHA ($BASE). Halting: an unreset tree would poison every check downstream. A human must inspect $target_dir before this pipeline (or anything else) trusts it again.\" > .ai/gate.log; printf reset_b_unproven; fi"]
 
-    // ---------- degenerate_gate: THE INVERSION RULE -- is hack B a real second shape, or a no-op? ----------
+    // ---------- degenerate_gate: THE INVERSION RULE -- is a hack a real second shape, or a no-op? ----------
     // Adversarial-review finding (real produced capsule, PR #152, a $key
     // prefix-substitution fix): DEFINITION.verify.sh asserted, for
     // substitute_context(), both "the corruption is gone" AND "real
@@ -554,12 +556,33 @@ digraph CapsulePipeline {
     // return, a deleted function, a removed guard) can be trivially
     // "different in shape" from hack A while being just as trivially wrong
     // to trust. Cheap, deterministic, POST-round-trip (this is only a
-    // problem once we know hack B actually greened -- a degenerate hack
+    // problem once we know a hack actually greened -- a degenerate hack
     // that FAILS to green is not a finding, it is the gate correctly
     // rejecting a bad hack, exactly as designed): runs
-    // check-degenerate-hack.py (this repo, runner/) against
-    // .ai/hypothesis_b.patch, which the git-clean -e .ai exclusion in
-    // mutate_gate_b left untouched on disk after the reset.
+    // check-degenerate-hack.py (this repo, runner/) against BOTH
+    // .ai/hypothesis.patch AND .ai/hypothesis_b.patch, which the git-clean
+    // -e .ai exclusion in mutate_gate / mutate_gate_b left untouched on
+    // disk after each reset -- reported PER-PATCH, never conflated.
+    //
+    // THE A/B ASYMMETRY FIX (context/NOTES-vacuous-green.md §10.1: "a bug --
+    // and a red herring"): this gate used to inspect ONLY hypothesis_b.patch,
+    // on the charter that check 3b's discrimination inference rests on hack
+    // B specifically. That charter is too narrow given what PR #152 itself
+    // teaches: a hack greening a gate by deleting a feature is a coverage
+    // hole IN THE GATE, not a property of which slot (A or B) the author
+    // happened to write the hack into. Swap hack A and hack B in PR #152's
+    // own review and the finding evaporates while the gate under test is
+    // byte-identical -- a property of the gate must not depend on which file
+    // the hack landed in. Fixed: the checker now runs over BOTH patches,
+    // per-patch, and a hit in EITHER slot is the same failure signal.
+    // NOT THE SAME FIX AS witness_gate below, and NOT a substitute for it:
+    // measured, pointed at issue #146's actual dodge (deleting
+    // goal_gate=true from a .dot example file), check-degenerate-hack.py
+    // returns RC=0 on BOTH slots -- its three signals (stub/deleted-
+    // function/removed-guard) are Python-AST-shaped and blind to a deleted
+    // attribute in a data file. Fixing this asymmetry is correct and cheap;
+    // it closes none of issue #146's hole. That is exactly why witness_gate
+    // exists as a SEPARATE gate on separate ground (see its own comment).
     //
     // THE INVERSION: a degenerate hack greening the gate is NOT evidence
     // the gate is behavior-bound (the opposite of what the two-hypothesis
@@ -572,10 +595,76 @@ digraph CapsulePipeline {
     // routes through the SAME root-cause wall (triage) every other gate
     // defect in this file uses, landing back on author with a concrete,
     // named reason to tighten DEFINITION.verify.sh -- never treated as
-    // proof hack B is invalid, never treated as proof the capsule is done.
+    // proof either hack is invalid, never treated as proof the capsule is
+    // done.
     degenerate_gate [shape=parallelogram, class="gate", max_retries=0,
         goal_gate=true, retry_target="author",
-        tool_command="P=.ai/hypothesis_b.patch; n=$(cat .ai/iter 2>/dev/null || echo 0); mkdir -p .ai/findings; python3 \"$uplift_dir/runner/check-degenerate-hack.py\" \"$P\" > .ai/degenerate-check.log 2>&1; rc=$?; if [ $rc -eq 0 ]; then printf '{\"iteration\": %s, \"gate\": \"degenerate\", \"suspected\": false}\\n' \"$n\" >> .ai/convergence.jsonl; printf b_substantive; elif [ $rc -eq 1 ]; then printf '{\"iteration\": %s, \"gate\": \"degenerate\", \"suspected\": true}\\n' \"$n\" >> .ai/convergence.jsonl; { echo \"DEGENERATE-HACK SUSPECTED (INVERSION RULE): hypothesis_b.patch greened DEFINITION.verify.sh (check 3b) but check-degenerate-hack.py suspects it deletes/stubs behavior rather than implementing a real alternate fix -- see below for which function/signal. This is NOT proof the gate is behavior-bound; it is the OPPOSITE: a hack that removes a feature and still passes means the gate is under-specified (e.g. only asserting a corrupted string is ABSENT, never that real output is still PRESENT -- exactly PR #152's expand_params() hole). Tighten DEFINITION.verify.sh: add a positive assertion for the surface hypothesis_b.patch touched, mirroring any other function whose assertion already checks both 'defect gone' AND 'real behavior still happens'.\"; cat .ai/degenerate-check.log; } > .ai/gate.log; echo degenerate > .ai/last-stage-fail; exit 1; else { echo \"DEGENERATE-HACK CHECK: check-degenerate-hack.py usage/self-test error (rc=$rc) -- infra problem, not a defect finding\"; cat .ai/degenerate-check.log; } > .ai/gate.log; echo degenerate > .ai/last-stage-fail; exit 1; fi"]
+        tool_command="PA=.ai/hypothesis.patch; PB=.ai/hypothesis_b.patch; n=$(cat .ai/iter 2>/dev/null || echo 0); mkdir -p .ai/findings; python3 \"$uplift_dir/runner/check-degenerate-hack.py\" \"$PA\" > .ai/degenerate-check-a.log 2>&1; rcA=$?; python3 \"$uplift_dir/runner/check-degenerate-hack.py\" \"$PB\" > .ai/degenerate-check-b.log 2>&1; rcB=$?; if [ $rcA -ge 2 ] || [ $rcB -ge 2 ]; then { echo \"DEGENERATE-HACK CHECK: check-degenerate-hack.py usage/self-test error (rcA=$rcA rcB=$rcB) -- infra problem, not a defect finding\"; echo '--- hypothesis.patch check ---'; cat .ai/degenerate-check-a.log; echo '--- hypothesis_b.patch check ---'; cat .ai/degenerate-check-b.log; } > .ai/gate.log; echo degenerate > .ai/last-stage-fail; exit 1; elif [ $rcA -eq 1 ] || [ $rcB -eq 1 ]; then slots=''; [ $rcA -eq 1 ] && slots=\"${slots}A\"; [ $rcB -eq 1 ] && slots=\"${slots}B\"; printf '{\"iteration\": %s, \"gate\": \"degenerate\", \"suspected\": true, \"slots\": \"%s\"}\\n' \"$n\" \"$slots\" >> .ai/convergence.jsonl; { echo \"DEGENERATE-HACK SUSPECTED (INVERSION RULE, slot(s): $slots): a hypothesis patch greened DEFINITION.verify.sh but check-degenerate-hack.py suspects it deletes/stubs behavior rather than implementing a real fix -- checked BOTH hypothesis.patch (A) and hypothesis_b.patch (B) per-patch (the A/B asymmetry fix, context/NOTES-vacuous-green.md §10.1); see below for which slot(s) and which function/signal. This is NOT proof the gate is behavior-bound; it is the OPPOSITE: a hack that removes a feature and still passes means the gate is under-specified (e.g. only asserting a corrupted string is ABSENT, never that real output is still PRESENT -- exactly PR #152's expand_params() hole). Tighten DEFINITION.verify.sh: add a positive assertion for the surface the flagged hack touched, mirroring any other function whose assertion already checks both 'defect gone' AND 'real behavior still happens'.\"; echo '--- hypothesis.patch (A) check ---'; cat .ai/degenerate-check-a.log; echo '--- hypothesis_b.patch (B) check ---'; cat .ai/degenerate-check-b.log; } > .ai/gate.log; echo degenerate > .ai/last-stage-fail; exit 1; else printf '{\"iteration\": %s, \"gate\": \"degenerate\", \"suspected\": false}\\n' \"$n\" >> .ai/convergence.jsonl; printf b_substantive; fi"]
+
+    // ---------- witness_gate: is either proven-greening hack a DELETED WITNESS, not a fix? ----------
+    // context/NOTES-vacuous-green.md, in full -- read before touching this
+    // node. THE SECOND WAY A GATE GOES VACUOUS (§4): degenerate_gate (above)
+    // closes vacuous-BY-NO-OP (the machinery still runs and does nothing --
+    // PR #152's `return text` stub). It does NOT close vacuous-BY-NO-
+    // OCCASION (the machinery's INPUT is deleted, so it never runs at all).
+    // GitHub issue #146 produced TWO capsules (PR #149, PR #159) that both
+    // bind GREEN to one repo file (examples/pipelines/00-convergence-loop.dot)
+    // instead of to the lint rule's behavior. PR #159's hypothesis.patch
+    // deletes the single token `goal_gate=true` from that file -- measured,
+    // `git apply --numstat` gives `0	1` (zero added, one removed) -- and
+    // DEFINITION.verify.sh goes fully GREEN while the reported blind spot
+    // (_check_goal_gate_has_retry ignoring edge-based retry) stands
+    // untouched. Measured against the UNCHANGED degenerate_gate machinery:
+    // check-degenerate-hack.py returns RC=0 on this exact patch (its three
+    // signals -- stub/deleted-function/removed-guard -- are Python-AST-
+    // shaped and blind to an attribute deleted from a .dot data file). This
+    // is §10.1's "correct and cheap, and it closes none of this" --
+    // the A/B asymmetry fix above is a real bug fix and a genuine red
+    // herring for issue #146 at the same time; both are true.
+    //
+    // NO NEW LLM CALL, NO NEW ROUND-TRIP (§6.C, the recommended design):
+    // reuses TWO things already shipped and already self-tested --
+    // check-existing-tests.py's own subject-symbol resolver (imported
+    // directly by check-witness-gate.py, not reimplemented) and the
+    // patches mutate_gate / mutate_gate_b have ALREADY PROVEN turn this
+    // gate GREEN. Placed POST-round-trip, immediately after degenerate_gate
+    // and before discrimination_check, for exactly degenerate_gate's own
+    // stated reason: this only matters once we know a hack actually
+    // greened.
+    //
+    // THE FOUR CONDITIONS (measured against #159, #148, and #143 -- see the
+    // design note §6.C and §11 for the false-block accounting): for each
+    // patch already proven to green the gate, FIRE only if ALL hold: (1)
+    // proven-greening -- guaranteed by placement; (2) the patch touches NO
+    // file where the gate's own declared subject (S, the same resolver
+    // existing_test_gate already runs) is DEFINED; (3) the patch is PURELY
+    // SUBTRACTIVE there (removes >=1 line, adds 0); (4) a removed line
+    // shares a non-trivial token with the capsule's declared red_signal.
+    // S EMPTY -> UNDECIDABLE -> PASS with .ai/findings/witness-undetermined.md
+    // (the no-existing-tests-run.md idiom -- what was searched, never a
+    // silent skip). CHECKER ERROR -> PASS with the SAME finding file: this
+    // is existing_test_gate's bias (a scan of an arbitrary third-party
+    // repo), deliberately NOT degenerate_gate's (a self-contained,
+    // diff-only checker where an infra failure is rare and loud) --
+    // blocking a capsule because OUR scanner tripped scanning somebody
+    // else's repo is exactly the false block that bias exists to prevent.
+    //
+    // FB-1, NAMED AND ACCEPTED (§9): an issue whose genuinely correct fix IS
+    // a deletion outside the subject surface will trip all four conditions
+    // and this gate WILL fire on a legitimate fix -- cost up to two of six
+    // iterations, worst case a human at escalate. Accepted because the
+    // root-cause wall already exists for exactly this and already
+    // terminates in a human; NOT accepted quietly, which is why this
+    // comment and the gate's own diagnostic both say so. §6.B (a void
+    // probe that SEARCHES for a dodge rather than waiting for one to be
+    // confessed in slot A or B) is specified, deliberately NOT built here,
+    // with its trigger named in the design note §7 -- build it only if (a)
+    // a capsule passes this gate and is subsequently found dodgeable, or
+    // (b) this gate fires zero times across ten capsules while a manual
+    // read finds a witness-bound gate among them.
+    witness_gate [shape=parallelogram, class="gate", max_retries=0,
+        goal_gate=true, retry_target="author",
+        tool_command="CV=.ai/capsule/DEFINITION.verify.sh; CM=.ai/capsule/DEFINITION.md; PA=.ai/hypothesis.patch; PB=.ai/hypothesis_b.patch; n=$(cat .ai/iter 2>/dev/null || echo 0); mkdir -p .ai/findings; red_signal=$(awk '/^---$/{c++;next} c==1 && /^red_signal:/{sub(/^red_signal:[[:space:]]*/,\"\"); print; exit}' \"$CM\" | sed 's/[[:space:]]*$//'); set -- --verify \"$CV\" --repo . --red-signal \"$red_signal\" --patch \"$PA\"; if [ -s \"$PB\" ] && ! head -1 \"$PB\" | grep -q '^# SINGLE-SHAPE:'; then set -- \"$@\" --patch \"$PB\"; fi; python3 \"$uplift_dir/runner/check-witness-gate.py\" \"$@\" > .ai/witness-check.log 2>&1; rc=$?; if [ $rc -eq 0 ] && head -1 .ai/witness-check.log | grep -q '^VERDICT: witness_clean'; then printf '{\"iteration\": %s, \"gate\": \"witness\", \"verdict\": \"clean\"}\\n' \"$n\" >> .ai/convergence.jsonl; printf witness_clean; elif [ $rc -eq 0 ]; then { echo '# Finding: witness_gate could not determine a subject to check'; echo; echo 'check-witness-gate.py could not resolve S (the set of repo files that DEFINE a symbol DEFINITION.verify.sh itself names) for this capsule, so it cannot tell whether a proven-greening patch dodged the witness rather than fixing it. Biased to PASS -- see context/NOTES-vacuous-green.md section 6.C. Its full report follows.'; echo; cat .ai/witness-check.log; } > .ai/findings/witness-undetermined.md; printf '{\"iteration\": %s, \"gate\": \"witness\", \"verdict\": \"undetermined\"}\\n' \"$n\" >> .ai/convergence.jsonl; printf witness_undetermined; elif [ $rc -eq 1 ]; then { echo \"WITNESS-DODGE SUSPECTED: a hypothesis patch already PROVEN to green this gate touches no file where the gate's own declared subject is defined, is purely subtractive there, and removes a line sharing a token with the declared red_signal -- see context/NOTES-vacuous-green.md (issue #146: deleting goal_gate=true greened both PR #149 and PR #159's gates while the reported lint blind spot stood untouched). This is NOT proof the fix must be additive; it is a call to bind DEFINITION.verify.sh's assertion to behavior this repo does not own (construct the input inside the gate) or to add an assertion that survives the deletion. If the reported issue's ONLY honest fix truly is this deletion (FB-1), say so explicitly when this repeats to diagnose.\"; cat .ai/witness-check.log; } > .ai/gate.log; printf '{\"iteration\": %s, \"gate\": \"witness\", \"verdict\": \"dodge_suspected\"}\\n' \"$n\" >> .ai/convergence.jsonl; echo witness > .ai/last-stage-fail; exit 1; else { echo \"WITNESS-CHECK: check-witness-gate.py usage/self-test error (rc=$rc) -- infra problem, not a defect finding. FALSE NEGATIVE bias, deliberately (existing_test_gate's divergence, not degenerate_gate's): blocking a capsule because OUR tooling tripped scanning an arbitrary third-party repo is exactly what that bias exists to prevent.\"; cat .ai/witness-check.log; } > .ai/findings/witness-undetermined.md; printf '{\"iteration\": %s, \"gate\": \"witness\", \"verdict\": \"checker_error\"}\\n' \"$n\" >> .ai/convergence.jsonl; printf witness_undetermined; fi"]
 
     // ---------- discrimination_check: RED at an unrelated later commit (skippable-with-reason) ----------
     discrimination_check [shape=parallelogram, class="gate", max_retries=0,
@@ -588,14 +677,14 @@ digraph CapsulePipeline {
     // here is a real deterministic problem (bad path, permissions), routed
     // through the SAME root-cause wall as any other gate failure.
     package [shape=parallelogram, class="gate", max_retries=0,
-        tool_command="CM=.ai/capsule/DEFINITION.md; CV=.ai/capsule/DEFINITION.verify.sh; id=$(awk '/^---$/{c++;next} c==1 && /^id:/{sub(/^id:[[:space:]]*/,\"\"); print; exit}' \"$CM\" | tr -cd 'A-Za-z0-9._-'); [ -n \"$id\" ] || id=work-definition; OUT=\"$capsule_out\"; mkdir -p \"$OUT\" && cp \"$CM\" \"$OUT/$id.md\" && cp \"$CV\" \"$OUT/$id.verify.sh\" && chmod +x \"$OUT/$id.verify.sh\"; rc=$?; [ -f .ai/base-sha ] && cp .ai/base-sha \"$OUT/$id.base-sha\"; [ -f .ai/hypothesis.patch ] && cp .ai/hypothesis.patch \"$OUT/$id.hypothesis.patch\"; [ -f .ai/hypothesis_b.patch ] && cp .ai/hypothesis_b.patch \"$OUT/$id.hypothesis-b.patch\"; [ -f .ai/findings/discrimination.md ] && cp .ai/findings/discrimination.md \"$OUT/$id.discrimination.md\"; [ -f .ai/findings/single-shape.md ] && cp .ai/findings/single-shape.md \"$OUT/$id.single-shape.md\"; [ -f .ai/findings/no-existing-tests-run.md ] && cp .ai/findings/no-existing-tests-run.md \"$OUT/$id.no-existing-tests-run.md\"; if [ $rc -eq 0 ] && [ -s \"$OUT/$id.md\" ] && [ -s \"$OUT/$id.verify.sh\" ]; then printf packaged; else echo \"PACKAGE FAILED: could not write the capsule pair to $OUT (rc=$rc)\" > .ai/gate.log; echo round > .ai/last-stage-fail; exit 1; fi"]
+        tool_command="CM=.ai/capsule/DEFINITION.md; CV=.ai/capsule/DEFINITION.verify.sh; id=$(awk '/^---$/{c++;next} c==1 && /^id:/{sub(/^id:[[:space:]]*/,\"\"); print; exit}' \"$CM\" | tr -cd 'A-Za-z0-9._-'); [ -n \"$id\" ] || id=work-definition; OUT=\"$capsule_out\"; mkdir -p \"$OUT\" && cp \"$CM\" \"$OUT/$id.md\" && cp \"$CV\" \"$OUT/$id.verify.sh\" && chmod +x \"$OUT/$id.verify.sh\"; rc=$?; [ -f .ai/base-sha ] && cp .ai/base-sha \"$OUT/$id.base-sha\"; [ -f .ai/hypothesis.patch ] && cp .ai/hypothesis.patch \"$OUT/$id.hypothesis.patch\"; [ -f .ai/hypothesis_b.patch ] && cp .ai/hypothesis_b.patch \"$OUT/$id.hypothesis-b.patch\"; [ -f .ai/findings/discrimination.md ] && cp .ai/findings/discrimination.md \"$OUT/$id.discrimination.md\"; [ -f .ai/findings/single-shape.md ] && cp .ai/findings/single-shape.md \"$OUT/$id.single-shape.md\"; [ -f .ai/findings/no-existing-tests-run.md ] && cp .ai/findings/no-existing-tests-run.md \"$OUT/$id.no-existing-tests-run.md\"; [ -f .ai/findings/witness-undetermined.md ] && cp .ai/findings/witness-undetermined.md \"$OUT/$id.witness-undetermined.md\"; if [ $rc -eq 0 ] && [ -s \"$OUT/$id.md\" ] && [ -s \"$OUT/$id.verify.sh\" ]; then printf packaged; else echo \"PACKAGE FAILED: could not write the capsule pair to $OUT (rc=$rc)\" > .ai/gate.log; echo round > .ai/last-stage-fail; exit 1; fi"]
 
     // ---------- triage: root-cause wall (task-runner.dot idiom, verbatim, on .ai/gate.log) ----------
     triage [shape=parallelogram, class="glue", max_retries=0,
         tool_command="B=$(cat .ai/budget 2>/dev/null); B=${B:-6}; n=$(cat .ai/iter 2>/dev/null || echo 0); sig=$(tail -20 .ai/gate.log 2>/dev/null | sed -E 's|/tmp/[A-Za-z0-9._-]+|TMPPATH|g; s/[0-9]+\\.[0-9]+s?//g' | md5sum | cut -d' ' -f1); prev=$(cat .ai/last-fail-sig 2>/dev/null || echo none); echo $sig > .ai/last-fail-sig; if [ \"$n\" -ge \"$B\" ]; then printf exhausted; elif [ \"$sig\" = \"$prev\" ]; then printf repeat; else printf novel; fi"]
 
     diagnose [shape=box, class="gate",
-        prompt="A capsule-round gate failed twice with the SAME failure signature (see .ai/gate.log, and .ai/last-stage-fail for which stage: round/leak/existing_test/redgate/mutate/diff_shape/mutate_b/degenerate/discrimination). Stop iterating blindly -- find the root cause. Read .ai/gate.log, .ai/brief.md, the report at $issue_file, and the relevant code in $target_dir. Determine what is actually wrong: (a) DEFINITION.verify.sh's assertion approach, (b) a misread of the reported defect, (c) an environment/tooling gap, or (d) a genuine ambiguity in the report that cannot be resolved from inside this run. Write .ai/postmortem/diagnosis.md with the root cause, the evidence, and the single change of course for the next attempt. If the blocker cannot be resolved from inside this run, include the word BLOCKED on its own line and explain."]
+        prompt="A capsule-round gate failed twice with the SAME failure signature (see .ai/gate.log, and .ai/last-stage-fail for which stage: round/leak/existing_test/redgate/mutate/diff_shape/mutate_b/degenerate/witness/discrimination). Stop iterating blindly -- find the root cause. Read .ai/gate.log, .ai/brief.md, the report at $issue_file, and the relevant code in $target_dir. Determine what is actually wrong: (a) DEFINITION.verify.sh's assertion approach, (b) a misread of the reported defect, (c) an environment/tooling gap, or (d) a genuine ambiguity in the report that cannot be resolved from inside this run. Write .ai/postmortem/diagnosis.md with the root cause, the evidence, and the single change of course for the next attempt. If the blocker cannot be resolved from inside this run, include the word BLOCKED on its own line and explain."]
 
     diagnose_gate [shape=parallelogram, class="glue", max_retries=0,
         tool_command="rm -f .ai/last-fail-sig; grep -qE '^BLOCKED' .ai/postmortem/diagnosis.md && printf blocked || printf continue"]
@@ -751,14 +840,24 @@ digraph CapsulePipeline {
 
     // degenerate_gate -> the INVERSION-RULE gate (see header, THE INVERSION
     // RULE). A green mutate_gate_b is NOT automatically discrimination
-    // proof: hack B could be a degenerate no-op (a stubbed return, a
+    // proof: either hack could be a degenerate no-op (a stubbed return, a
     // deleted function, a removed guard) that satisfies an under-specified
     // assertion rather than a genuinely different real fix. That is a
     // FAILURE signal (the gate needs tightening), never a silent pass and
     // never a hard terminal halt -- it routes through the SAME root-cause
     // wall (triage) every other gate defect uses, landing back on author.
-    degenerate_gate -> discrimination_check [condition="context.tool.last_line=b_substantive && outcome=success", label="hack B performs real, non-trivial behavior -- discrimination proof stands"]
-    degenerate_gate -> triage                [condition="outcome=fail", label="hack B greened via a stub/deletion/removed-guard -- gate under-specified, not discrimination-proof"]
+    degenerate_gate -> witness_gate [condition="context.tool.last_line=b_substantive && outcome=success", label="neither hack performs a stub/deletion/removed-guard -- proceed to the vacuous-by-no-occasion check"]
+    degenerate_gate -> triage       [condition="outcome=fail", label="a hack greened via a stub/deletion/removed-guard -- gate under-specified, not discrimination-proof"]
+
+    // witness_gate -- BESIDE degenerate_gate, same spine (see header, THE
+    // SECOND WAY A GATE GOES VACUOUS): a proven-greening hack that is
+    // mechanically substantive (degenerate_gate passed) can still be a
+    // DELETED WITNESS rather than a fix -- issue #146's `goal_gate=true`
+    // deletion is neither a stub nor a removed def/assert, so it clears
+    // degenerate_gate cleanly and needs its own, differently-shaped check.
+    witness_gate -> discrimination_check [condition="context.tool.last_line=witness_clean && outcome=success", label="no proven-greening hack touches only outside-subject files purely subtractively with a red_signal-sharing token"]
+    witness_gate -> discrimination_check [condition="context.tool.last_line=witness_undetermined && outcome=success", label="S empty, or the checker itself errored -- undecidable, finding written"]
+    witness_gate -> triage               [condition="outcome=fail", label="a proven-greening hack looks like a deleted witness, not a fix"]
 
     discrimination_check -> package [condition="context.tool.last_line=skip_recorded && outcome=success", label="no later_commit -- skipped with reason"]
     discrimination_check -> package [condition="context.tool.last_line=discrim_ok && outcome=success", label="RED confirmed at later commit"]

--- a/.github/capsule-pipeline/vendor/runner/check-witness-gate.py
+++ b/.github/capsule-pipeline/vendor/runner/check-witness-gate.py
@@ -1,0 +1,605 @@
+#!/usr/bin/env python3
+"""check-witness-gate.py -- mechanical WITNESS-DODGE tripwire for a work
+capsule's already-proven-greening hypothesis patches (capsule.dot's
+witness_gate).
+
+THE HOLE THIS CLOSES (see context/NOTES-vacuous-green.md for the full
+account -- this docstring gives the load-bearing facts, not a paraphrase):
+a capsule gate can go GREEN two ways -- because the defect was fixed, or
+because the *occasion* for observing the defect was deleted. GitHub issue
+#146 produced two capsules (PR #149, PR #159) that both bind GREEN to a
+single witness file (`examples/pipelines/00-convergence-loop.dot`) rather
+than to the rule's behavior. PR #159's hypothesis.patch deletes the single
+token `goal_gate=true` from that file -- `git apply --numstat` on it gives
+`0	1` (zero added, one removed) -- and DEFINITION.verify.sh goes GREEN while
+the reported lint blind spot (`_check_goal_gate_has_retry` in validation.py
+ignores edge-based retry) stands untouched. Neither `degenerate_gate`
+(Python-AST-shaped signals: stub/deleted-function/removed-guard; measured
+RC=0 on this exact patch) nor `diff_shape_gate` (asks only "are hack A and
+hack B mechanically different", never "is either one a candidate fix") sees
+this. This checker does.
+
+THE MECHANISM (NOTES-vacuous-green.md \u00a76.C, "run the test on the hacks you
+already have" -- no new LLM call, no new round-trip): for each hypothesis
+patch already PROVEN to green the gate (mutate_gate / mutate_gate_b already
+confirmed this before witness_gate ever runs), fire only if ALL FOUR hold:
+
+  1. the patch is one of the patches already proven to green the gate --
+     guaranteed by PLACEMENT (this checker only ever runs post-round-trip;
+     it does not re-verify this itself);
+  2. files(patch) \u2229 S = \u2205 -- S is the set of repo files that DEFINE any
+     symbol DEFINITION.verify.sh itself names, reusing
+     check-existing-tests.py's own subject-symbol resolver verbatim (see
+     `resolve_subject_symbols`, imported below, not reimplemented);
+  3. the patch is PURELY SUBTRACTIVE in that file -- removes >=1 line, adds
+     0 (same raw line-count convention as `git apply --numstat`);
+  4. at least one removed line shares a non-trivial token with the
+     capsule's declared `red_signal`.
+
+Any condition failing on a given patch -> that patch does not fire. S empty
+(no symbol in DEFINITION.verify.sh's own text resolves to a definition in
+this repo's own source) -> UNDECIDABLE -> PASS, same "absence must be
+DETERMINED, never asserted" discipline check-existing-tests.py already
+practices. An internal error -> exit 2, biased to PASS at the wiring level
+(see CONTRACT below for why this diverges from check-degenerate-hack.py's
+own rc>=2 handling).
+
+CONTRACT (mirrors check-degenerate-hack.py's and check-existing-tests.py's
+own: read before wiring):
+
+    check-witness-gate.py --verify <path/to/DEFINITION.verify.sh> \\
+        --repo <target repo root> --red-signal <declared red_signal text> \\
+        --patch <path/to/hypothesis.patch> \\
+        [--patch <path/to/hypothesis_b.patch> ...]
+    check-witness-gate.py --self-test
+
+  exit 0 -- PASS. First stdout line is one of:
+      VERDICT: witness_clean    -- no patch tripped all four conditions.
+      VERDICT: undetermined     -- S is empty; nothing to compare against.
+  exit 1 -- FIRE. At least one already-proven-greening patch tripped all
+      four conditions. STDOUT names which patch, which file(s), which
+      removed line(s), and the shared token(s) with the declared
+      red_signal.
+  exit 2 -- usage/self-test failure (infra problem, not a finding).
+
+BIAS ON exit 2 -- FALSE NEGATIVE, DELIBERATELY, and DIFFERENT FROM
+check-degenerate-hack.py's OWN rc>=2 (which capsule.dot routes to triage):
+this checker, like check-existing-tests.py, walks an ARBITRARY third-party
+repository tree and resolves symbols in it -- an internal failure here is a
+property of scanning somebody else's repo, not of the diff text alone.
+check-degenerate-hack.py takes exactly one input (a diff) and is
+self-contained; a checker-error there is rare and loud. This checker takes
+a whole repo as a second input, exactly like check-existing-tests.py, and
+inherits its bias: blocking a capsule because OUR scanner tripped is the
+false block the bias exists to prevent (capsule.dot's own wiring, not this
+script, decides to treat rc>=2 as PASS-with-a-finding).
+
+REUSE, NOT REIMPLEMENTATION (NOTES-vacuous-green.md \u00a710, "Not extend"):
+`resolve_subject_symbols` / `walk_repo` / `STOPWORDS` are imported directly
+from check-existing-tests.py (same directory), and diff-hunk parsing is
+imported directly from check-degenerate-hack.py. Both are already shipped
+and already self-tested; this script adds no independent copy of either.
+
+Self-test (proves the checker catches the known #146/#159 dodge AND does
+not flag the two things it must not):
+    python3 runner/check-witness-gate.py --self-test
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import re
+import sys
+import tempfile
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+
+
+def _load(mod_name: str, filename: str):
+    """Load a sibling script (hyphenated filename, not import-able normally)
+    as a module, so its functions can be reused verbatim rather than copied."""
+    spec = importlib.util.spec_from_file_location(mod_name, _HERE / filename)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_ET = _load("_witness_reuse_existing_tests", "check-existing-tests.py")
+_DH = _load("_witness_reuse_degenerate_hack", "check-degenerate-hack.py")
+
+# Same token shape check-existing-tests.py's candidate_identifiers() uses:
+# an identifier-looking run of >=4 characters. Deliberately reused rather
+# than invented so "non-trivial token" means the same thing in both places.
+TOKEN_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]{3,}")
+
+PLUS_PLUS_PLUS_RE = re.compile(r"^\+\+\+ (.+)$", re.MULTILINE)
+
+
+def tokenize(text: str) -> set[str]:
+    """Lowercased, stopword-filtered token set (reuses check-existing-tests.py's
+    own STOPWORDS list rather than inventing a second one)."""
+    out: set[str] = set()
+    for m in TOKEN_RE.finditer(text):
+        tok = m.group(0)
+        if tok.lower() in _ET.STOPWORDS:
+            continue
+        out.add(tok.lower())
+    return out
+
+
+def patch_files(text: str) -> set[str]:
+    """Repo-relative paths this patch's hunks touch, from '+++ ' lines (same
+    signal diff_shape_gate already uses to compare hack A and hack B)."""
+    out: set[str] = set()
+    for m in PLUS_PLUS_PLUS_RE.finditer(text):
+        raw = m.group(1).strip()
+        raw = raw.split("\t", 1)[0]
+        if raw == "/dev/null":
+            continue
+        for prefix in ("a/", "b/"):
+            if raw.startswith(prefix):
+                raw = raw[len(prefix) :]
+                break
+        out.add(raw)
+    return out
+
+
+def evaluate_patch(patch_path: Path, subject_files: set[str], red_signal: str) -> dict:
+    text = patch_path.read_text(encoding="utf-8", errors="replace")
+    files = patch_files(text)
+    hunks = _DH.parse_hunks(text)
+    added = sum(len(h["added"]) for h in hunks)
+    removed_lines = [line for h in hunks for line in h["removed"]]
+    removed = len(removed_lines)
+
+    cond2_outside_subject = not (files & subject_files)
+    cond3_purely_subtractive = removed >= 1 and added == 0
+
+    removed_tokens: set[str] = set()
+    for line in removed_lines:
+        removed_tokens |= tokenize(line)
+    sig_tokens = tokenize(red_signal)
+    shared = removed_tokens & sig_tokens
+    cond4_shared_token = bool(shared)
+
+    fired = cond2_outside_subject and cond3_purely_subtractive and cond4_shared_token
+    fire_lines = (
+        [line for line in removed_lines if tokenize(line) & shared] if shared else []
+    )
+
+    return {
+        "patch": str(patch_path),
+        "files": sorted(files),
+        "added": added,
+        "removed": removed,
+        "cond2_outside_subject": cond2_outside_subject,
+        "cond3_purely_subtractive": cond3_purely_subtractive,
+        "cond4_shared_tokens": sorted(shared),
+        "fire_lines": fire_lines[:3],
+        "fired": fired,
+    }
+
+
+def analyze(
+    verify_text: str, repo: Path, red_signal: str, patch_paths: list[Path]
+) -> tuple[int, list[str]]:
+    try:
+        tests, sources = _ET.walk_repo(repo)
+    except _ET.ScanLimit as exc:
+        return 0, [
+            "VERDICT: undetermined",
+            f"REASON: repo scan cap hit ({exc}) -- this checker will not fire on an",
+            "  incomplete scan. Biased to PASS, same discipline as check-existing-tests.py.",
+        ]
+
+    symbols, subject_paths = _ET.resolve_subject_symbols(verify_text, repo, sources)
+    subject_files: set[str] = {f for files in symbols.values() for f in files}
+    subject_files |= set(subject_paths)
+
+    if not subject_files:
+        return 0, [
+            "VERDICT: undetermined",
+            "REASON: S (the set of repo files that DEFINE a symbol DEFINITION.verify.sh",
+            "  itself names) is empty -- undecidable, biased to PASS per",
+            "  NOTES-vacuous-green.md \u00a76.C.",
+            f"SEARCHED: {len(sources)} non-test source files, {len(tests)} test files.",
+            f"SOURCE PATHS THE GATE SCRIPT NAMES: {subject_paths or '(none)'}",
+        ]
+
+    results = [evaluate_patch(p, subject_files, red_signal) for p in patch_paths]
+    fired = [r for r in results if r["fired"]]
+
+    evidence = [
+        f"SUBJECT FILES (S): {sorted(subject_files)}",
+        f"SUBJECT SYMBOLS: {sorted(symbols)}",
+        f"DECLARED red_signal: {red_signal!r}",
+        "",
+    ]
+    for r in results:
+        evidence.append(
+            f"  {r['patch']}: touches={r['files']} added={r['added']} removed={r['removed']} "
+            f"outside_S={r['cond2_outside_subject']} purely_subtractive={r['cond3_purely_subtractive']} "
+            f"shared_tokens={r['cond4_shared_tokens']}"
+        )
+
+    if fired:
+        head = ["VERDICT: witness_dodge_suspected"]
+        for r in fired:
+            head.append(
+                f"FIRE: {r['patch']} turned this gate GREEN by touching ONLY "
+                f"{r['files']} -- none of which define a symbol this gate itself names "
+                f"(S) -- purely subtractively ({r['removed']} removed / {r['added']} added), "
+                f"and removed line(s) {r['fire_lines']!r} share token(s) {r['cond4_shared_tokens']} "
+                f"with the declared red_signal."
+            )
+        return 1, head + [""] + evidence
+
+    return 0, ["VERDICT: witness_clean"] + evidence
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(add_help=True, description=__doc__)
+    parser.add_argument("--verify", help="path to the capsule's gate script")
+    parser.add_argument("--repo", help="path to the target repository root")
+    parser.add_argument(
+        "--red-signal",
+        dest="red_signal",
+        default="",
+        help="the capsule's declared red_signal",
+    )
+    parser.add_argument(
+        "--patch",
+        action="append",
+        default=[],
+        help="path to an already-proven-greening hypothesis patch (repeatable)",
+    )
+    parser.add_argument("--self-test", action="store_true", dest="self_test")
+    try:
+        args = parser.parse_args(argv[1:])
+    except SystemExit:
+        return 2
+
+    if args.self_test:
+        return self_test()
+
+    if not args.verify or not args.repo or not args.patch:
+        print(
+            "usage: check-witness-gate.py --verify <gate.sh> --repo <repo root> "
+            "--red-signal <text> --patch <patch> [--patch <patch> ...]",
+            file=sys.stderr,
+        )
+        return 2
+
+    vpath = Path(args.verify)
+    repo = Path(args.repo)
+    if not vpath.is_file():
+        print(f"usage error: gate script not found: {vpath}", file=sys.stderr)
+        return 2
+    if not repo.is_dir():
+        print(f"usage error: repo root not a directory: {repo}", file=sys.stderr)
+        return 2
+    patch_paths = [Path(p) for p in args.patch]
+    for p in patch_paths:
+        if not p.is_file():
+            print(f"usage error: patch not found: {p}", file=sys.stderr)
+            return 2
+
+    try:
+        verify_text = vpath.read_text(encoding="utf-8", errors="replace")
+        rc, report = analyze(verify_text, repo.resolve(), args.red_signal, patch_paths)
+    except Exception as exc:  # noqa: BLE001 -- an internal error must never crash the pipeline
+        print(f"internal error: {type(exc).__name__}: {exc}", file=sys.stderr)
+        return 2
+
+    print("\n".join(report))
+    return rc
+
+
+# ---------------------------------------------------------------------------
+# self-test: the real #146/#159 shape, plus the traps NOTES-vacuous-green.md
+# names by number (FB-1's #148 shape, the S-empty undetermined case, and a
+# no-false-positive control where a purely subtractive patch shares no token
+# with the red_signal).
+# ---------------------------------------------------------------------------
+
+# Reconstructs enough of amplifier_module_loop_pipeline for the resolver to
+# find _check_goal_gate_has_retry / lint / parse_dot / Node -- the exact
+# symbol list the real DEFINITION.verify.sh names (measured, NOTES-vacuous-
+# green.md \u00a78.1).
+_VALIDATION_PY = """\
+class Node:
+    pass
+
+
+def _check_goal_gate_has_retry(graph, diags):
+    pass
+
+
+def lint(graph):
+    return []
+"""
+
+_DOT_PARSER_PY = """\
+def parse_dot(text):
+    return None
+"""
+
+# The real DEFINITION.verify.sh's own text (abbreviated to the parts the
+# resolver reads): names Node, _check_goal_gate_has_retry, lint, parse_dot.
+_VERIFY_146 = """\
+set -euo pipefail
+LINT_OUTPUT=$(python3 - <<'PYEOF'
+from amplifier_module_loop_pipeline.dot_parser import parse_dot
+from amplifier_module_loop_pipeline.validation import lint, _check_goal_gate_has_retry, Node
+graph = parse_dot(open("examples/pipelines/00-convergence-loop.dot").read())
+diags = lint(graph)
+hits = [d for d in diags if d.rule == "goal_gate_has_retry" and d.node_id == "test_gate"]
+for d in hits:
+    print(d.message)
+PYEOF
+)
+if [ -n "$LINT_OUTPUT" ]; then
+    echo "Node 'test_gate' has goal_gate=true but no retry_target"
+    exit 1
+fi
+exit 0
+"""
+
+# hack A -- the EXACT #159 dodge: delete the single token goal_gate=true
+# from the .dot example. 0 added, 1 removed, measured.
+_HACK_A_DELETE_WITNESS = """\
+diff --git a/examples/pipelines/00-convergence-loop.dot b/examples/pipelines/00-convergence-loop.dot
+index b2d7582..d534cd7 100644
+--- a/examples/pipelines/00-convergence-loop.dot
++++ b/examples/pipelines/00-convergence-loop.dot
+@@ -58,7 +58,6 @@ digraph convergence_loop {
+         shape=parallelogram,
+         label="pytest",
+         tool_command="pytest -q test_word_counter.py > test_output.txt 2>&1 && echo gate_pass || echo gate_fail",
+-        goal_gate=true
+     ]
+"""
+
+# hack B -- the legitimate root-cause fix: extend the rule in validation.py
+# (a subject file, IN S). Additive, not subtractive.
+_HACK_B_ROOT_CAUSE_FIX = """\
+diff --git a/validation.py b/validation.py
+--- a/validation.py
++++ b/validation.py
+@@ -1,9 +1,12 @@
+ class Node:
+     pass
+
+
+ def _check_goal_gate_has_retry(graph, diags):
++    for edge in graph.outgoing_edges("test_gate"):
++        if edge.loop_restart:
++            return
+     pass
+
+
+ def lint(graph):
+     return []
+"""
+
+# #148's shape (FB-1's named risk, stale doc-line-refs): both hypotheses ADD
+# lines (the design's own stated fact: "both its patches add lines").
+_ENGINE_PY = """\
+def _check_node_skip(node):
+    return False
+
+
+def _get_runs_on(node):
+    return None
+
+
+class StageStatus:
+    pass
+"""
+
+_VERIFY_148 = """\
+set -euo pipefail
+python3 -c "from engine import StageStatus, _check_node_skip, _get_runs_on"
+grep -q "Reference: engine.py:42" docs/CONTRACTS.md
+"""
+
+_HACK_A_148 = """\
+diff --git a/docs/CONTRACTS.md b/docs/CONTRACTS.md
+--- a/docs/CONTRACTS.md
++++ b/docs/CONTRACTS.md
+@@ -40,3 +40,8 @@
+ See engine.py.
++
++Reference: engine.py:42
++Reference: engine.py:43
++Reference: engine.py:44
++Reference: engine.py:45
++Reference: engine.py:46
+"""
+
+_HACK_B_148 = """\
+diff --git a/docs/CONTRACTS.md b/docs/CONTRACTS.md
+--- a/docs/CONTRACTS.md
++++ b/docs/CONTRACTS.md
+@@ -40,3 +40,7 @@
+ See engine.py.
++
++See: engine.py#_check_node_skip
++See: engine.py#_get_runs_on
++See: engine.py#StageStatus
++See: engine.py#extra
+"""
+
+# No-false-positive control: purely subtractive, outside S, but the removed
+# line shares NO token with the red_signal -- condition 4 must fail.
+_HACK_UNRELATED_DELETION = """\
+diff --git a/examples/pipelines/00-convergence-loop.dot b/examples/pipelines/00-convergence-loop.dot
+--- a/examples/pipelines/00-convergence-loop.dot
++++ b/examples/pipelines/00-convergence-loop.dot
+@@ -1,4 +1,3 @@
+ digraph convergence_loop {
+-    // an unrelated stale comment line about formatting conventions
+     start [shape=Mdiamond]
+ }
+"""
+
+
+def _mk_repo(root: Path, *, with_source: bool = True) -> None:
+    if not with_source:
+        (root / "docs").mkdir(parents=True, exist_ok=True)
+        (root / "docs" / "guide.md").write_text("# Guide\n")
+        return
+    (root / "validation.py").write_text(_VALIDATION_PY)
+    (root / "dot_parser.py").write_text(_DOT_PARSER_PY)
+
+
+def self_test() -> int:
+    ok = True
+
+    def check(
+        name: str,
+        verify_text: str,
+        repo_files: dict,
+        red_signal: str,
+        patch_texts: list[str],
+        expect_rc: int,
+        must_contain: tuple[str, ...] = (),
+    ) -> None:
+        nonlocal ok
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            for rel, content in repo_files.items():
+                fp = root / rel
+                fp.parent.mkdir(parents=True, exist_ok=True)
+                fp.write_text(content)
+            patch_paths = []
+            for i, text in enumerate(patch_texts):
+                pp = root / f"hyp{i}.patch"
+                pp.write_text(text)
+                patch_paths.append(pp)
+            rc, report = analyze(verify_text, root, red_signal, patch_paths)
+        blob = "\n".join(report)
+        missing = [s for s in must_contain if s not in blob]
+        if rc == expect_rc and not missing:
+            print(f"ok:   {name} -> rc={rc} ({report[0]})")
+        else:
+            ok = False
+            print(
+                f"FAIL: {name} -> expected rc={expect_rc}, got rc={rc}; missing={missing}\n"
+                f"--- report ---\n{blob}",
+                file=sys.stderr,
+            )
+
+    # (1) THE LIVE CASE: hack A alone (the #159 dodge) -> FIRE.
+    check(
+        "#146/#159 shape: hack A deletes goal_gate=true, the ONLY hypothesis given",
+        _VERIFY_146,
+        {"validation.py": _VALIDATION_PY, "dot_parser.py": _DOT_PARSER_PY},
+        "Node 'test_gate' has goal_gate=true but no retry_target",
+        [_HACK_A_DELETE_WITNESS],
+        1,
+        ("VERDICT: witness_dodge_suspected", "goal_gate", "00-convergence-loop.dot"),
+    )
+
+    # (2) GREEN: the legitimate root-cause fix (hack B touches validation.py,
+    # a subject file -- condition 2 fails) does NOT fire, even when it is
+    # the only hypothesis given.
+    check(
+        "GREEN: legitimate root-cause fix (validation.py extension) does not fire",
+        _VERIFY_146,
+        {"validation.py": _VALIDATION_PY, "dot_parser.py": _DOT_PARSER_PY},
+        "Node 'test_gate' has goal_gate=true but no retry_target",
+        [_HACK_B_ROOT_CAUSE_FIX],
+        0,
+        ("VERDICT: witness_clean",),
+    )
+
+    # (2b) Both hypotheses present together (the real pipeline shape): A
+    # fires, B does not -- the gate must still FIRE overall (any patch firing
+    # is enough), and must name hack A specifically, not hack B.
+    check(
+        "both hypotheses present: A fires (dodge), B does not (root-cause) -> overall FIRE naming A",
+        _VERIFY_146,
+        {"validation.py": _VALIDATION_PY, "dot_parser.py": _DOT_PARSER_PY},
+        "Node 'test_gate' has goal_gate=true but no retry_target",
+        [_HACK_A_DELETE_WITNESS, _HACK_B_ROOT_CAUSE_FIX],
+        1,
+        ("VERDICT: witness_dodge_suspected", "hyp0.patch"),
+    )
+
+    # (3) NO FALSE BLOCK on FB-1's named risk / #148's shape: both patches
+    # ADD lines (condition 3 fails on both).
+    check(
+        "FB-1 / #148 shape: both hypotheses ADD lines -- not purely subtractive",
+        _VERIFY_148,
+        {"engine.py": _ENGINE_PY, "docs/guide.md": "# Guide\n"},
+        "DEFECT: stale line reference",
+        [_HACK_A_148, _HACK_B_148],
+        0,
+        ("VERDICT: witness_clean",),
+    )
+
+    # (4) S EMPTY: the gate script names no identifier resolving to a
+    # definition in this repo's own source -> undetermined, PASS.
+    check(
+        "S empty: no repo symbol resolves -- undetermined, biased to PASS",
+        'set -euo pipefail\ngrep -q "## Installation" docs/guide.md\n',
+        {},
+        "DEFECT: heading missing",
+        [_HACK_A_DELETE_WITNESS],
+        0,
+        ("VERDICT: undetermined",),
+    )
+
+    # (5) NO FALSE POSITIVE control: purely subtractive, outside S, but the
+    # removed line shares no token with the red_signal -- condition 4 must
+    # gate it out (else this checker would fire on ANY unrelated deletion).
+    check(
+        "control: purely subtractive deletion sharing NO token with red_signal -- must not fire",
+        _VERIFY_146,
+        {"validation.py": _VALIDATION_PY, "dot_parser.py": _DOT_PARSER_PY},
+        "Node 'test_gate' has goal_gate=true but no retry_target",
+        [_HACK_UNRELATED_DELETION],
+        0,
+        ("VERDICT: witness_clean",),
+    )
+
+    # usage-error self-test: nonexistent verify script -> rc 2
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        missing_verify = root / "nope.sh"
+        rc = main(
+            [
+                "check-witness-gate.py",
+                "--verify",
+                str(missing_verify),
+                "--repo",
+                str(root),
+                "--red-signal",
+                "x",
+                "--patch",
+                str(root / "nope.patch"),
+            ]
+        )
+        if rc == 2:
+            print("ok:   missing verify script -> usage error rc=2")
+        else:
+            ok = False
+            print(
+                f"FAIL: missing verify script -> expected rc=2, got {rc}",
+                file=sys.stderr,
+            )
+
+    print()
+    if ok:
+        print("check-witness-gate.py self-test: ALL PASSED")
+        return 0
+    print("check-witness-gate.py self-test: FAILURES ABOVE", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
## What

Re-syncs the vendored specify-stage pipeline (`.github/capsule-pipeline/capsule.dot`) from the source (uplift) repo, pinned commit `d93d1e6` -> `3a53cf1`. Two additions since the last vendor:

1. **`witness_gate`** (new gate) -- catches "vacuous by no-occasion": a hypothesis patch that greens the capsule's gate by *deleting the observed case* rather than fixing the reported cause. Motivating live case: GitHub issue #146, where deleting the single token `goal_gate=true` from a `.dot` example (`git apply --numstat` -> `0	1`) greens the gate while the reported lint blind spot remains untouched. Vendored its checker, `vendor/runner/check-witness-gate.py`, for the first time.
2. **`degenerate_gate` A/B symmetry fix** -- it previously inspected only `.ai/hypothesis_b.patch`; it now runs `check-degenerate-hack.py` over **both** hypothesis slots and reports which fired. No new file to vendor for this half -- reuses the already-vendored `check-degenerate-hack.py` unchanged.

## The trap this sync specifically guarded against

The last vendor of this pipeline shipped gates whose checker scripts weren't vendored. This sync's new gate has a subtler version of that same trap: `check-witness-gate.py` imports `resolve_subject_symbols`/`walk_repo`/`STOPWORDS` from `check-existing-tests.py`, and diff-hunk parsing from `check-degenerate-hack.py` -- **both via `importlib`, resolved relative to its own file's directory, not via `uplift_dir`, and invisible to a grep of `capsule.dot` for `uplift_dir` references.**

`check-existing-tests.py` and `check-degenerate-hack.py` were diffed against this same source range and found **byte-identical** to what was already vendored -- only `check-witness-gate.py` needed copying. But their continued presence in the same `vendor/runner/` directory is now load-bearing for a *second, different consumer* -- an unchanged file became newly critical for a reason no diff would show.

## Verified drift (quoted in commit + below)

- `capsule.dot`: vendored copy was missing `witness_gate` entirely and had the pre-symmetry-fix `degenerate_gate` (single-slot, `hypothesis_b.patch` only).
- `check-existing-tests.py`, `check-degenerate-hack.py`: byte-identical, no re-copy needed.
- `task-runner.dot`: checked against the same source range, **byte-identical** at its own separately-pinned commit (`f5322c24ed6fd8deaeddb519de7bfdfa861094d9`) -- no re-sync needed.

## Runtime resolution proof

From a scratch repo with `uplift_dir` set exactly as `capsule-specify.yml` sets it (`$GITHUB_WORKSPACE/.github/capsule-pipeline/vendor`), extracted the actual `tool_command` fragments for `existing_test_gate`, `degenerate_gate`, and `witness_gate` from the re-synced `.dot` and ran them directly:

- `existing_test_gate` -> resolved and ran (`VERDICT: no_on_topic_tests`, rc=0).
- `degenerate_gate` -> resolved and ran **both** slots (`rcA=0 rcB=0`, `b_substantive`), confirming the A/B symmetry fix's double-invocation.
- `witness_gate` -> resolved and ran, **correctly identifying the planted #146-shaped dodge** (`VERDICT: witness_dodge_suspected`, rc=1), naming the exact file/line/token evidence -- proving `check-witness-gate.py`'s `importlib` import of `check-existing-tests.py`'s subject-symbol resolver executed successfully (the `SUBJECT FILES (S)` / `SUBJECT SYMBOLS` output in the report is produced entirely by the imported code).

**Negative control**: pointed `uplift_dir` at a directory containing `check-witness-gate.py` and `check-degenerate-hack.py` but with `check-existing-tests.py` deliberately absent. Result: a raw, uncaught `FileNotFoundError` at Python module-load time (before `argparse` even runs) -- exactly the runtime-not-review-time breakage this vendoring guards against. Noted in the report: the crash's exit code (1) is indistinguishable from the checker's own designed "FIRE" exit code without reading the log content -- a real, if narrow, sharp edge in the pipeline's own shell wiring (not fixed here; out of scope for a vendoring sync, flagged for the source repo).

## Lint + parity

`attractor lint .github/capsule-pipeline/capsule.dot` -> OK (no findings). Node/edge/simple-cycle counts identical to source: **34 nodes / 59 edges / 69 simple cycles** (vendored == uplift, confirming the body is otherwise byte-identical below the header).

## README

Pinned SHA + re-sync log updated. **Re-sync checklist improved**: added step 2a, requiring every newly-vendored (or newly-touched) Python checker to be grepped for its own sibling-file imports (`importlib`, `sys.path`, plain local `import`) -- the exact class of miss that caused the previous re-sync to ship two gates whose checkers weren't vendored, now named explicitly so it can't repeat silently. Step 5 (runtime-resolution proof) now explicitly requires proving any such cross-checker import resolves, with a negative control.

## Not done

Not merging -- opened for review per instructions.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)