### PR TITLE
fix(capsule-pipeline): resync vendored capsule.dot -- void probe (void/void_gate) for the confirmed-dodgeable witness gate

### DIFF
--- a/.github/capsule-pipeline/README.md
+++ b/.github/capsule-pipeline/README.md
@@ -31,7 +31,7 @@ This directory wires two stages of an issue -> attractor -> PR system:
 | `vendor/backlog/fixtures/leak-scan/*` | Self-test fixtures for the scanner above (RED/GREEN controls). |
 | `vendor/runner/check-degenerate-hack.py` | `degenerate_gate`'s checker: suspects a hypothesis patch (A **and** B, checked per-patch since the A/B symmetry fix) that greens the gate by deleting/stubbing behavior rather than implementing a real alternate fix (THE INVERSION RULE). |
 | `vendor/runner/check-existing-tests.py` | `existing_test_gate`'s checker: derives a capsule's subject from the symbols/paths its own `DEFINITION.verify.sh` names, and blocks if the repo already ships an on-topic test the gate doesn't run (FOLD IN THE EXISTING TESTS). **Also a load-bearing import for `check-witness-gate.py`** (see below) — it is no longer only `existing_test_gate`'s dependency. |
-| `vendor/runner/check-witness-gate.py` | `witness_gate`'s checker: catches "vacuous by no-occasion" — a proven-greening hypothesis patch that dodges the reported defect by deleting the *occasion* to observe it (e.g. deleting a single `goal_gate=true` token) rather than fixing it. Imports `resolve_subject_symbols`/`walk_repo`/`STOPWORDS` from `check-existing-tests.py` and diff-hunk parsing from `check-degenerate-hack.py` **at runtime via `importlib`**, resolved relative to its own file location (`Path(__file__).resolve().parent`) — both sibling files must be vendored in the *same directory*, not merely somewhere under `uplift_dir`. |
+| `vendor/runner/check-witness-gate.py` | Checker shared by **two gates**, `witness_gate` and `void_gate`: catches "vacuous by no-occasion" — a proven-greening (or, for `void_gate`, actively-constructed) hypothesis patch that dodges the reported defect by deleting the *occasion* to observe it (e.g. deleting a single `goal_gate=true` token) rather than fixing it. Imports `resolve_subject_symbols`/`walk_repo`/`STOPWORDS` from `check-existing-tests.py` and diff-hunk parsing from `check-degenerate-hack.py` **at runtime via `importlib`**, resolved relative to its own file location (`Path(__file__).resolve().parent`) — both sibling files must be vendored in the *same directory*, not merely somewhere under `uplift_dir`. Content is unchanged as of the void-probe sync (2026-08-07, this pass), but it gained a **second, independent graph-level caller** (`void_gate`'s own `tool_command=` shells out to it directly, exactly like `witness_gate`'s does) — see the Re-sync log entry for that sync for why an unchanged file can still need re-proving. |
 
 ## Provenance — these are VENDORED copies
 
@@ -79,6 +79,21 @@ that no static check on `capsule.dot` itself will ever surface. See
 "Re-syncing" step 2 below -- this is precisely the class of miss that caused
 this file's own previous re-sync to ship gates whose checker scripts weren't
 vendored.
+
+**A distinct-but-related trap, closed in the void-probe sync (2026-08-07, this
+pass):** a *new node* can add a **second, independent, directly-visible**
+`$uplift_dir/...` shell-out to a file that is **already vendored and whose
+content does not change** -- `void_gate` shells out to
+`$uplift_dir/runner/check-witness-gate.py` exactly like `witness_gate`
+already did, with a different (single-`--patch`) argument shape and from a
+different point in the pipeline (after `void_gate`'s own hard-reset, not
+after `mutate_gate`/`mutate_gate_b`'s). Unlike the importlib case above,
+this one *is* grep-visible via step 2's `uplift_dir` search -- but "the file
+is already vendored and its self-test still passes" is not the same claim as
+"this new call site's own invocation, with its own arguments and its own
+place in the control flow, actually resolves and behaves correctly." See
+step 5's amended wording below (the "prove **each** call site" sentence) --
+this is the reason it was added.
 
 `task-runner.dot` is likewise **not modified** beyond its header. It was
 authored for a slightly different invocation shape (a backlog task file with
@@ -151,6 +166,20 @@ scanner correctly) before this was wired up.
    `check-witness-gate.py` too. Run `grep -n "^import\|^from\|_load(\|importlib"
    vendor/runner/*.py` and confirm every named sibling file is present in the
    same `vendor/` subdirectory.
+2b. **Count the graph-level call sites of every checker named by step 2's
+   grep, not just whether the checker is present** -- an already-vendored,
+   content-unchanged file can gain a **second (or third) independent
+   `tool_command=` caller** elsewhere in the same diff (e.g. the void-probe
+   sync: `void_gate` shells out to `$uplift_dir/runner/check-witness-gate.py`
+   with its own argument shape, a single `--patch`, from a different point in
+   the control flow than `witness_gate`'s multi-`--patch` call). Step 2's
+   grep already surfaces that a second reference exists (it is not the
+   invisible import case step 2a covers) -- the trap here is stopping at
+   "the file is already vendored, and it already has a passing self-test"
+   without re-proving *that specific new call site's own invocation*. A
+   checker resolving in isolation does not prove every caller's arguments,
+   working assumptions, and place in the control flow also resolve. Note
+   every distinct node name that shells out to the same checker path.
 3. Copy the files here verbatim (`cp`, not a manual retype), preserving the
    executable bit on any `.sh`/`.py` checker.
 4. Re-apply (or update) the provenance header comment at the top of each file
@@ -165,8 +194,13 @@ scanner correctly) before this was wired up.
    invoke the importing checker (not just `python3 -c "import ..."` in
    isolation) from a scratch repo with `uplift_dir` pointed at the vendored
    location, and run a negative control (wrong `uplift_dir`, or one sibling
-   file deliberately absent) so a pass isn't accidental. Note any new
-   deviations here.
+   file deliberately absent) so a pass isn't accidental. **It must also
+   separately exercise EACH graph-level call site named by step 2b** --
+   extract that node's own `tool_command=` text verbatim from the re-synced
+   `.dot` and run it (or the checker invocation inside it) with its own exact
+   arguments, not only the checker's generic `--self-test` -- a self-test
+   proves the file loads; it does not prove a *different* caller's specific
+   arguments and calling context also work. Note any new deviations here.
 
 ## Re-sync log
 
@@ -240,3 +274,87 @@ scanner correctly) before this was wired up.
   **byte-identical** at its own pinned commit (`f5322c24ed6fd8deaeddb519de7bfdfa861094d9`)
   -- no re-sync needed; see the PR that performed this sync for the full
   proof.
+
+- **2026-08-07 (later still)** -- `capsule.dot` re-synced
+  `3a53cf13cbf426bcdea7e4382fae9feb9efe977d` ->
+  `34fff9618e9c0cba3feee8ac8b82c94798720cec`. Picked up one addition, THE
+  VOID PROBE (motivating live case: GitHub issue #146's own capsule PR #161,
+  `goal-gate-loop-restart-lint.verify.sh`, base `44428ab67a530f23aa5579104f4ff68e4e809c37`
+  -- both its hypothesis patches are legitimate, so `witness_gate` correctly
+  reported `witness_clean` on its own patches; the capsule was *still*
+  dodgeable by hand, because `witness_gate` is passive -- it only inspects
+  patches written for a different purpose, so a dodge nobody happened to
+  write into slot A or B goes undetected):
+  - `void` (new node, `class="maker"`) -- writes `.ai/hypothesis_v.patch`
+    under an INVERTED objective from `mutate`/`mutate_b`: actively search
+    for the cheapest patch that greens the gate *without* fixing the
+    reported defect, or write a `# NO-VOID:` explanation if none is
+    honestly constructible.
+  - `void_gate` (new node) -- applies that patch, proves GREEN, hard-resets,
+    proves the reset, then **re-invokes `check-witness-gate.py` a SECOND
+    time** (same four-condition analysis, reused verbatim) against only
+    `.ai/hypothesis_v.patch` as the guard: a greening patch is only treated
+    as a CONFIRMED dodge if that analysis also says so; otherwise it is
+    PASS-with-a-finding (`.ai/findings/void-inconclusive.md`), biased to
+    PASS like `witness_gate`/`existing_test_gate`.
+  - `witness_gate`'s own success edges were rewired to feed `void` (not
+    `discrimination_check`) first; `void_gate`'s three success tokens (no
+    dodge possible, dodge resisted, inconclusive) all proceed to
+    `discrimination_check`; an unproven reset is a loud halt (shared with
+    `mutate_gate`/`mutate_gate_b`); a confirmed dodge or an infra failure
+    routes to `triage` through the same root-cause wall every other gate
+    defect in this file uses.
+  **No new file to vendor**: `void_gate` reuses `check-witness-gate.py`
+  verbatim, exactly as `witness_gate` already does -- but this is precisely
+  the "recurring trap" this checklist exists to name: `check-witness-gate.py`
+  is unchanged (byte-identical diff, confirmed against the source range) yet
+  became newly load-bearing for a **second, independent graph-level caller**
+  with its own argument shape (`void_gate` passes a single `--patch`; unlike
+  `witness_gate` it also calls the checker from AFTER its own git-apply /
+  hard-reset cycle, not before one). `check-existing-tests.py` and
+  `check-degenerate-hack.py` were diffed against this same source range and
+  found byte-identical to the copies already vendored -- no re-copy needed
+  for either. `task-runner.dot` was checked against the same source range
+  and found **byte-identical** at its own separately-pinned commit
+  (`f5322c24ed6fd8deaeddb519de7bfdfa861094d9`, unchanged since the first
+  sync) -- no re-sync needed.
+
+  Runtime proof performed (see the PR that performed this sync for full
+  transcripts): (1) `check-witness-gate.py --self-test` and a direct
+  invocation with `void_gate`'s own single-`--patch` argument shape, from a
+  scratch repo with `uplift_dir` set to this repo's own
+  `.github/capsule-pipeline/vendor` (the same path `capsule-specify.yml`
+  computes); (2) a negative control vendoring `check-witness-gate.py` ALONE
+  (its two sibling files absent) reproduced the exact
+  `FileNotFoundError: check-existing-tests.py` the import trap predicts,
+  proving the positive result is not accidental; (3) a second discriminating
+  negative control -- the SAME checker invocation given a legitimate patch
+  (issue #146's own `hypothesis.patch`) instead of a dodge -- returned
+  `VERDICT: witness_clean` (rc=0), proving the mechanism discriminates
+  rather than always firing; (4) THE LIVE CASE: `void_gate`'s own
+  `tool_command=` text was extracted verbatim from the re-synced `.dot` and
+  executed against a `git worktree` of this repo pinned at base
+  `44428ab67a530f23aa5579104f4ff68e4e809c37`, seeded with issue #146's real
+  `DEFINITION.md`/`DEFINITION.verify.sh` and a reconstruction of PR #161's
+  actual dodge (`sed -i '/^ *goal_gate=true *$/d' examples/pipelines/00-convergence-loop.dot`,
+  `git diff --numstat` confirming `0	1` as the historical record states) as
+  `.ai/hypothesis_v.patch` -- the full node body ran end-to-end (git apply,
+  the real gate script via a synced `modules/loop-pipeline` venv, hard
+  reset, reset proof, and the guard) through the **vendored** checker path
+  and produced exit code 1, `.ai/gate.log` containing
+  `VOID-DODGE CONFIRMED: ...`, and `.ai/convergence.jsonl` recording
+  `{"gate": "void", "greened": true, "reset_proven": true}` followed by
+  `{"gate": "void", "verdict": "dodge_confirmed"}` -- the exact shape
+  `void_gate -> triage [condition="outcome=fail", ...]` routes on.
+
+  **Checklist hardening in this pass**: neither step 2 nor step 2a, as
+  worded before this sync, made explicit that an already-vendored,
+  content-unchanged checker can gain a **second independent graph-level
+  call site** whose own argument shape and calling context still need
+  runtime proof -- step 2's grep *does* surface the new reference here (it
+  is not the invisible-`importlib` case step 2a covers), but "the file is
+  present and its self-test passes" is not the same claim as "this specific
+  new caller's own invocation resolves." Step 2b was added to name this
+  explicitly (count call sites, not just presence), and step 5 was amended
+  to require exercising each named call site's own extracted
+  `tool_command=` text, not only the checker's generic `--self-test`.

--- a/.github/capsule-pipeline/capsule.dot
+++ b/.github/capsule-pipeline/capsule.dot
@@ -1,7 +1,7 @@
 // ============================================================================
 // VENDORED COPY -- see .github/capsule-pipeline/README.md for provenance,
 // scope, and re-sync instructions. Source: a private working repository
-// (not publicly reachable), pinned at its commit 3a53cf13cbf426bcdea7e4382fae9feb9efe977d
+// (not publicly reachable), pinned at its commit 34fff9618e9c0cba3feee8ac8b82c94798720cec
 // (runner/capsule.dot, 2026-08-07). This copy is otherwise byte-identical to
 // the source file below this header -- do not hand-edit the body; re-sync
 // from source and re-apply this header instead.
@@ -285,9 +285,9 @@
 //     triage's signature comparison).
 //   - CONVERGENCE RECORD: capsule_gate, leak_gate, existing_test_gate,
 //     redgate, mutate_gate, mutate_gate_b, degenerate_gate, witness_gate,
-//     and discrimination_check each append one line per visit to
+//     void_gate, and discrimination_check each append one line per visit to
 //     .ai/convergence.jsonl (gate keys "round"/"leak"/"existing_test"/
-//     "redgate"/"mutate_gate"/"mutate_gate_b"/"degenerate"/"witness"/
+//     "redgate"/"mutate_gate"/"mutate_gate_b"/"degenerate"/"witness"/"void"/
 //     "discrimination") -- the descent record postmortem reads on
 //     non-convergence.
 //   - PARAM NAMESPACE: `${k:-default}` is NOT engine-expanded (unknown
@@ -504,10 +504,11 @@ digraph CapsulePipeline {
     // LOUD, NON-RETRYABLE HALT (task-runner.dot's forge_fail idiom): a
     // reset that cannot be proven is a corrupted-state class, not a
     // retryable defect. No outgoing edges -- dead-end is loud since #66.
-    // Shared by BOTH round-trip gates (mutate_gate for hypothesis.patch,
-    // mutate_gate_b for hypothesis_b.patch) -- .ai/gate.log names which one.
+    // Shared by THREE round-trip gates (mutate_gate for hypothesis.patch,
+    // mutate_gate_b for hypothesis_b.patch, void_gate for the void probe's
+    // own adversarial hypothesis_v.patch) -- .ai/gate.log names which one.
     reset_fail [shape=parallelogram, class="glue", max_retries=0,
-        tool_command="echo 'RESET-PROOF FAIL: see .ai/gate.log for which round-trip (mutate_gate or mutate_gate_b) could not prove target_dir was returned to its pinned base SHA after its hypothesis-patch round-trip. Do not trust target_dir until a human has inspected and restored it.' >&2; exit 1"]
+        tool_command="echo 'RESET-PROOF FAIL: see .ai/gate.log for which round-trip (mutate_gate, mutate_gate_b, or void_gate) could not prove target_dir was returned to its pinned base SHA after its hypothesis-patch round-trip. Do not trust target_dir until a human has inspected and restored it.' >&2; exit 1"]
 
     // ---------- mutate_b: check 3b -- write a SECOND, MECHANICALLY-DIFFERENT hypothesis patch ----------
     // Session continuity of its own (thread_id="mutate_b", distinct from
@@ -666,6 +667,107 @@ digraph CapsulePipeline {
         goal_gate=true, retry_target="author",
         tool_command="CV=.ai/capsule/DEFINITION.verify.sh; CM=.ai/capsule/DEFINITION.md; PA=.ai/hypothesis.patch; PB=.ai/hypothesis_b.patch; n=$(cat .ai/iter 2>/dev/null || echo 0); mkdir -p .ai/findings; red_signal=$(awk '/^---$/{c++;next} c==1 && /^red_signal:/{sub(/^red_signal:[[:space:]]*/,\"\"); print; exit}' \"$CM\" | sed 's/[[:space:]]*$//'); set -- --verify \"$CV\" --repo . --red-signal \"$red_signal\" --patch \"$PA\"; if [ -s \"$PB\" ] && ! head -1 \"$PB\" | grep -q '^# SINGLE-SHAPE:'; then set -- \"$@\" --patch \"$PB\"; fi; python3 \"$uplift_dir/runner/check-witness-gate.py\" \"$@\" > .ai/witness-check.log 2>&1; rc=$?; if [ $rc -eq 0 ] && head -1 .ai/witness-check.log | grep -q '^VERDICT: witness_clean'; then printf '{\"iteration\": %s, \"gate\": \"witness\", \"verdict\": \"clean\"}\\n' \"$n\" >> .ai/convergence.jsonl; printf witness_clean; elif [ $rc -eq 0 ]; then { echo '# Finding: witness_gate could not determine a subject to check'; echo; echo 'check-witness-gate.py could not resolve S (the set of repo files that DEFINE a symbol DEFINITION.verify.sh itself names) for this capsule, so it cannot tell whether a proven-greening patch dodged the witness rather than fixing it. Biased to PASS -- see context/NOTES-vacuous-green.md section 6.C. Its full report follows.'; echo; cat .ai/witness-check.log; } > .ai/findings/witness-undetermined.md; printf '{\"iteration\": %s, \"gate\": \"witness\", \"verdict\": \"undetermined\"}\\n' \"$n\" >> .ai/convergence.jsonl; printf witness_undetermined; elif [ $rc -eq 1 ]; then { echo \"WITNESS-DODGE SUSPECTED: a hypothesis patch already PROVEN to green this gate touches no file where the gate's own declared subject is defined, is purely subtractive there, and removes a line sharing a token with the declared red_signal -- see context/NOTES-vacuous-green.md (issue #146: deleting goal_gate=true greened both PR #149 and PR #159's gates while the reported lint blind spot stood untouched). This is NOT proof the fix must be additive; it is a call to bind DEFINITION.verify.sh's assertion to behavior this repo does not own (construct the input inside the gate) or to add an assertion that survives the deletion. If the reported issue's ONLY honest fix truly is this deletion (FB-1), say so explicitly when this repeats to diagnose.\"; cat .ai/witness-check.log; } > .ai/gate.log; printf '{\"iteration\": %s, \"gate\": \"witness\", \"verdict\": \"dodge_suspected\"}\\n' \"$n\" >> .ai/convergence.jsonl; echo witness > .ai/last-stage-fail; exit 1; else { echo \"WITNESS-CHECK: check-witness-gate.py usage/self-test error (rc=$rc) -- infra problem, not a defect finding. FALSE NEGATIVE bias, deliberately (existing_test_gate's divergence, not degenerate_gate's): blocking a capsule because OUR tooling tripped scanning an arbitrary third-party repo is exactly what that bias exists to prevent.\"; cat .ai/witness-check.log; } > .ai/findings/witness-undetermined.md; printf '{\"iteration\": %s, \"gate\": \"witness\", \"verdict\": \"checker_error\"}\\n' \"$n\" >> .ai/convergence.jsonl; printf witness_undetermined; fi"]
 
+    // ---------- void: THE VOID PROBE -- a third adversarial hack whose GREENING is the failure ----------
+    // context/NOTES-vacuous-green.md, section 6.B, in full -- read before touching
+    // this node. BUILT NOW because trigger (a) fired (section 7): a capsule
+    // passed witness_gate and was subsequently found dodgeable by hand. LIVE
+    // EVIDENCE: issue #146's PR #161 (capsule
+    // goal-gate-loop-restart-lint.verify.sh, base 44428ab67a530f23aa5579104f4ff68e4e809c37).
+    // Both its hypothesis patches are legitimate (hypothesis.patch extends
+    // validation.py -- in S; hypothesis_b.patch adds retry_target= to the
+    // example -- additive, so condition 3 fails) -- witness_gate correctly
+    // reports witness_clean on this capsule's OWN patches. Yet the capsule is
+    // STILL dodgeable: `sed -i '/^ *goal_gate=true *$/d' examples/pipelines/
+    // 00-convergence-loop.dot` (measured: `git diff --numstat` gives `0  1`)
+    // turns the SAME DEFINITION.verify.sh fully green -- because
+    // witness_gate is PASSIVE. It only ever inspects patches mutate/mutate_b
+    // ALREADY wrote for a DIFFERENT purpose (proving non-vacuity); it can
+    // only catch a dodge that happened to be CONFESSED into one of those two
+    // slots. This is exactly section 9's named residual: "a dodge nobody
+    // happened to write into slot A or B -- witness_gate detects a
+    // CONFESSED dodge, it does not SEARCH for one."
+    //
+    // THE MOVE: void is a maker, sibling of mutate/mutate_b, writing
+    // .ai/hypothesis_v.patch under an INVERTED objective from both of them --
+    // not "the crudest hack that turns the gate green" but "green the gate
+    // WITHOUT fixing the defect, by actively searching for a way to remove,
+    // disable, or delete the thing the red_signal was observed on (or add a
+    // narrow suppression next to it)." void_gate then applies it, runs the
+    // gate, hard-resets, and proves the reset -- IDENTICAL SHAPE to
+    // mutate_gate. Placed AFTER witness_gate (both its success tokens feed
+    // here now) and BEFORE discrimination_check.
+    //
+    // THE GUARD (the design's own named weak point: "nothing mechanically
+    // distinguishes 'the model wrote a void patch' from 'the model wrote a
+    // real fix and we blamed the gate for greening.' A guard is needed --
+    // section 6.C's conditions serve"): void_gate does NOT treat "the
+    // adversarial patch greened the gate" as sufficient on its own. It
+    // re-runs check-witness-gate.py -- REUSED VERBATIM, not reimplemented,
+    // exactly as section 10's "Not extend" doctrine requires -- against
+    // ONLY .ai/hypothesis_v.patch. FIRE only when that same four-condition
+    // analysis confirms the greening patch is dodge-shaped (outside the
+    // gate's own declared subject, purely subtractive there, sharing a
+    // token with the declared red_signal). A greening patch that does NOT
+    // present that way is PASS-WITH-A-FINDING (.ai/findings/
+    // void-inconclusive.md), never silently treated as proof either way --
+    // the same false-negative bias witness_gate itself accepts.
+    //
+    // HONEST SCOPE, NAMED (not left implicit): this construction closes the
+    // SUBTRACTIVE witness-deletion class -- the exact PR #161 shape, and the
+    // concrete gap that fired trigger (a) -- by SEARCHING for it instead of
+    // waiting for it to be confessed. It does NOT reliably close an ADDITIVE
+    // suppression dodge (a `# noqa`, an added fixture exception, a
+    // retry_target=-shaped attribute insertion): reusing check-witness-gate.py's
+    // condition 3 (purely subtractive) as the guard means an additive
+    // greening patch reads as "inconclusive," not "confirmed," for the same
+    // reason condition 3 exists on witness_gate -- section 5's #148 lesson:
+    // dropping "purely subtractive" to also catch additive dodges would ALSO
+    // catch #148's own LEGITIMATE additive fix (both its real patches add
+    // lines OUTSIDE S -- see witness_gate's own comment and
+    // test_witness_gate.sh's fixture (5)), which is precisely the false
+    // block this task requires NOT happen. Closing the additive-suppression
+    // residue honestly needs a different, positive signal (not built here);
+    // the mechanism is not silent about the gap -- it is BIASED, on purpose,
+    // toward missing that shape rather than blocking #148's shape.
+    //
+    // HONEST DEGRADATION, THE "# NO-VOID:" IDIOM (the `# SINGLE-SHAPE:`
+    // idiom, verbatim): if void genuinely cannot construct ANY dodge (the
+    // gate already constructs its own input -- section 5's #143/#146
+    // framing -- or has no single deletable witness to aim at), it writes a
+    // `# NO-VOID:` header instead of fabricating one. void_gate accepts
+    // that as a distinct, honestly-labeled finding and does not spend the
+    // round-trip.
+    //
+    // BIAS ON A CHECKER ERROR -- DELIBERATE, AND WHY THIS ONE DEGRADES LIKE
+    // witness_gate/existing_test_gate, NOT LIKE degenerate_gate: the guard
+    // step scans an ARBITRARY third-party repo (the same class of risk
+    // witness_gate/existing_test_gate carry), now applied to a patch THIS
+    // PIPELINE ITSELF generated adversarially -- blocking a capsule because
+    // OUR tooling tripped scanning OUR OWN patch is exactly the false block
+    // that bias exists to prevent. degenerate_gate's rc>=2-to-triage
+    // divergence is for a SELF-CONTAINED, diff-only checker where an infra
+    // failure is rare and loud; this checker is not that shape.
+    void [shape=box, class="maker", thread_id="void",
+        must_write=".ai/hypothesis_v.patch",
+        prompt="THE VOID PROBE (context/NOTES-vacuous-green.md §6.B, built now because trigger (a) fired: a capsule passed witness_gate and was subsequently found dodgeable by hand -- issue #146's capsule for PR #161, goal-gate-loop-restart-lint.verify.sh, is provably instance-bound even though NEITHER hypothesis.patch nor hypothesis_b.patch happened to land on the dodge). witness_gate only ever inspects patches mutate/mutate_b already wrote for a DIFFERENT purpose (proving the gate is non-vacuous) -- it can only catch a dodge that happened to be CONFESSED into one of those two slots. Your job is different and adversarial: ACTIVELY SEARCH for one. Under an INVERTED objective from mutate/mutate_b -- do NOT try to fix the reported defect, and do NOT try to produce a plausible-looking fix. Instead, write the CHEAPEST possible patch to .ai/hypothesis_v.patch that turns DEFINITION.verify.sh green by REMOVING, DISABLING, or DELETING the specific thing the declared red_signal was observed on -- the witness itself (a repo file, a fixture, a data attribute, an assertion's own input) -- or by adding a narrow, purely-cosmetic suppression right next to it (a lint-disable comment, a skip marker, a narrowed match) that hides the symptom without touching the underlying behavior the Goal describes. Read .ai/capsule/DEFINITION.md (the Goal and the declared red_signal) and .ai/capsule/DEFINITION.verify.sh, and ground the patch in the ACTUAL current file contents of $target_dir (read the real files; do not invent paths or line numbers -- the tree is reset to the pinned base SHA). If .ai/gate.log exists from a prior attempt at THIS stage, read it first and try a different dodge -- do not repeat one already rejected. If you genuinely cannot find ANY way to green this gate by removing, disabling, or suppressing the observed witness rather than fixing the underlying defect -- a real possibility when the gate already constructs its own input, or has no single deletable artifact to aim at -- do not fabricate one: write .ai/hypothesis_v.patch containing ONLY a comment block whose FIRST LINE is exactly `# NO-VOID:` followed by a concrete, specific explanation of why no such dodge is honestly possible. That is itself valuable evidence the gate resists this class of attack, not a failure to hide -- void_gate accepts it as a distinct, honestly-labeled finding, exactly like mutate_b's `# SINGLE-SHAPE:` idiom."]
+
+    // Transient recovery (mutate/mutate_b idiom, verbatim): a genuine
+    // box-node crash re-enters via the cheap gate rather than losing the round.
+    void -> void_gate
+    void -> capsule_gate [condition="outcome=fail", label="transient -- re-enter via cheap gate"]
+
+    // ---------- void_gate: applies the adversarial patch, proves GREEN, hard-resets, PROVES the reset, then GUARDS ----------
+    // DELIBERATE DIVERGENCE FROM mutate_gate's polarity: mutate_gate's whole
+    // job is to prove the gate CAN be greened (non-vacuity), so failing to
+    // green IS this attempt's failure. void's whole job is the OPPOSITE --
+    // it is trying to dodge WITHOUT fixing anything, so failing to green
+    // (void_resisted) is GOOD NEWS about the gate and is NOT routed to
+    // triage; only a CONFIRMED dodge (the guard fires) or an infra failure
+    // (missing patch, non-applying patch, unproven reset) is.
+    void_gate [shape=parallelogram, class="gate", max_retries=0,
+        goal_gate=true, retry_target="author",
+        tool_command="CV=.ai/capsule/DEFINITION.verify.sh; CM=.ai/capsule/DEFINITION.md; PV=.ai/hypothesis_v.patch; BASE=$(cat .ai/base-sha 2>/dev/null); n=$(cat .ai/iter 2>/dev/null || echo 0); mkdir -p .ai/findings; if [ ! -s \"$PV\" ]; then echo \"VOID_GATE: .ai/hypothesis_v.patch missing or empty\" > .ai/gate.log; echo void > .ai/last-stage-fail; exit 1; fi; if head -1 \"$PV\" | grep -q '^# NO-VOID:'; then { echo '# Finding: no dodge could be honestly constructed'; echo; echo \"void judged that no way exists to green DEFINITION.verify.sh by removing, disabling, or deleting the thing being observed (or any other non-fix suppression) without addressing the reported defect (explanation below, copied verbatim from .ai/hypothesis_v.patch). This capsule was NOT found dodgeable by this active search -- see context/NOTES-vacuous-green.md section 6.B.\"; echo; echo '--- author explanation (.ai/hypothesis_v.patch) ---'; cat \"$PV\"; } > .ai/findings/no-void.md; printf '{\"iteration\": %s, \"gate\": \"void\", \"outcome\": \"no_void\"}\n' \"$n\" >> .ai/convergence.jsonl; printf void_no_dodge; exit 0; fi; if [ -z \"$BASE\" ]; then echo \"VOID_GATE: .ai/base-sha missing -- preflight did not pin a base SHA\" > .ai/gate.log; echo void > .ai/last-stage-fail; exit 1; fi; if ! git apply --check \"$PV\" >/dev/null 2>&1; then printf '{\"iteration\": %s, \"gate\": \"void\", \"applies\": false}\n' \"$n\" >> .ai/convergence.jsonl; echo \"VOID_GATE: hypothesis_v.patch does not apply cleanly against pinned base $BASE\" > .ai/gate.log; echo void > .ai/last-stage-fail; exit 1; fi; git apply \"$PV\"; chmod +x \"$CV\" 2>/dev/null; timeout 900 bash \"$CV\" > .ai/verify-void.log 2>&1; rc=$?; git checkout --quiet -- .; git clean -qfd -e .ai; if [ $rc -ne 0 ]; then printf '{\"iteration\": %s, \"gate\": \"void\", \"attempted\": true, \"greened\": false}\n' \"$n\" >> .ai/convergence.jsonl; printf void_resisted; exit 0; fi; if ! git diff --quiet -- . || [ \"$(git rev-parse HEAD)\" != \"$BASE\" ]; then printf '{\"iteration\": %s, \"gate\": \"void\", \"greened\": true, \"reset_proven\": false}\n' \"$n\" >> .ai/convergence.jsonl; echo \"VOID_GATE: RESET NOT PROVEN after hard-reset attempt -- git diff and/or HEAD no longer matches the pinned base SHA ($BASE). Halting: an unreset tree would poison every check downstream. A human must inspect $target_dir before this pipeline (or anything else) trusts it again.\" > .ai/gate.log; printf void_reset_unproven; exit 0; fi; printf '{\"iteration\": %s, \"gate\": \"void\", \"greened\": true, \"reset_proven\": true}\n' \"$n\" >> .ai/convergence.jsonl; red_signal=$(awk '/^---$/{c++;next} c==1 && /^red_signal:/{sub(/^red_signal:[[:space:]]*/,\"\"); print; exit}' \"$CM\" | sed 's/[[:space:]]*$//'); python3 \"$uplift_dir/runner/check-witness-gate.py\" --verify \"$CV\" --repo . --red-signal \"$red_signal\" --patch \"$PV\" > .ai/void-check.log 2>&1; rc=$?; if [ $rc -eq 1 ]; then { echo \"VOID-DODGE CONFIRMED: an ACTIVELY-CONSTRUCTED adversarial patch, explicitly instructed to green this gate WITHOUT fixing the reported defect, succeeded -- and the SAME subject/shape analysis witness_gate uses (context/NOTES-vacuous-green.md section 6.C) confirms it touches no file where this gate's own declared subject is defined, is purely subtractive there, and removes a line sharing a token with the declared red_signal. This is STRONGER evidence than witness_gate's passive check: nobody had to happen to write this dodge into hypothesis.patch or hypothesis_b.patch for it to be found. The gate is bound to one instance of the defect, in a file the implementer can edit -- construct the input inside the gate, or add an assertion that survives the deletion.\"; cat .ai/void-check.log; } > .ai/gate.log; printf '{\"iteration\": %s, \"gate\": \"void\", \"verdict\": \"dodge_confirmed\"}\n' \"$n\" >> .ai/convergence.jsonl; echo void > .ai/last-stage-fail; exit 1; elif [ $rc -eq 0 ] && head -1 .ai/void-check.log | grep -q '^VERDICT: witness_clean'; then { echo '# Finding: an adversarial dodge attempt greened the gate but does not present as a witness-deletion/suppression dodge'; echo; echo \"void was explicitly instructed to green DEFINITION.verify.sh WITHOUT addressing the reported defect. Its patch DID turn the gate green (proven, then hard-reset and the reset proven) -- but the SAME subject/shape analysis witness_gate uses found it touches a file where this gate declares its subject, or is not purely subtractive there, or shares no token with the declared red_signal. Nothing mechanically distinguishes the model having written a dodge in a shape this checker does not recognise from the model, despite instructions, having written something behaviorally real -- see context/NOTES-vacuous-green.md section 6.B own named weak point. Biased to PASS, not a silent skip: full analysis follows.\"; echo; cat .ai/void-check.log; } > .ai/findings/void-inconclusive.md; printf '{\"iteration\": %s, \"gate\": \"void\", \"verdict\": \"inconclusive_clean\"}\n' \"$n\" >> .ai/convergence.jsonl; printf void_inconclusive; exit 0; elif [ $rc -eq 0 ]; then { echo '# Finding: void_gate could not determine a subject to check against the adversarial patch'; echo; echo \"check-witness-gate.py could not resolve S (the set of repo files that DEFINE a symbol DEFINITION.verify.sh itself names) for the actively-constructed .ai/hypothesis_v.patch. Biased to PASS -- see context/NOTES-vacuous-green.md sections 6.B and 6.C.\"; echo; cat .ai/void-check.log; } > .ai/findings/void-inconclusive.md; printf '{\"iteration\": %s, \"gate\": \"void\", \"verdict\": \"inconclusive_undetermined\"}\n' \"$n\" >> .ai/convergence.jsonl; printf void_inconclusive; exit 0; else { echo \"VOID-CHECK: check-witness-gate.py usage/self-test error (rc=$rc) on the adversarial patch -- infra problem, not a defect finding. FALSE NEGATIVE bias, deliberately (same divergence witness_gate/existing_test_gate make from degenerate_gate): blocking a capsule because OUR tooling tripped scanning an arbitrary third-party repo, on a patch WE generated adversarially, is exactly what that bias exists to prevent.\"; cat .ai/void-check.log; } > .ai/findings/void-inconclusive.md; printf '{\"iteration\": %s, \"gate\": \"void\", \"verdict\": \"checker_error\"}\n' \"$n\" >> .ai/convergence.jsonl; printf void_inconclusive; exit 0; fi"]
+
     // ---------- discrimination_check: RED at an unrelated later commit (skippable-with-reason) ----------
     discrimination_check [shape=parallelogram, class="gate", max_retries=0,
         goal_gate=true, retry_target="author",
@@ -677,14 +779,14 @@ digraph CapsulePipeline {
     // here is a real deterministic problem (bad path, permissions), routed
     // through the SAME root-cause wall as any other gate failure.
     package [shape=parallelogram, class="gate", max_retries=0,
-        tool_command="CM=.ai/capsule/DEFINITION.md; CV=.ai/capsule/DEFINITION.verify.sh; id=$(awk '/^---$/{c++;next} c==1 && /^id:/{sub(/^id:[[:space:]]*/,\"\"); print; exit}' \"$CM\" | tr -cd 'A-Za-z0-9._-'); [ -n \"$id\" ] || id=work-definition; OUT=\"$capsule_out\"; mkdir -p \"$OUT\" && cp \"$CM\" \"$OUT/$id.md\" && cp \"$CV\" \"$OUT/$id.verify.sh\" && chmod +x \"$OUT/$id.verify.sh\"; rc=$?; [ -f .ai/base-sha ] && cp .ai/base-sha \"$OUT/$id.base-sha\"; [ -f .ai/hypothesis.patch ] && cp .ai/hypothesis.patch \"$OUT/$id.hypothesis.patch\"; [ -f .ai/hypothesis_b.patch ] && cp .ai/hypothesis_b.patch \"$OUT/$id.hypothesis-b.patch\"; [ -f .ai/findings/discrimination.md ] && cp .ai/findings/discrimination.md \"$OUT/$id.discrimination.md\"; [ -f .ai/findings/single-shape.md ] && cp .ai/findings/single-shape.md \"$OUT/$id.single-shape.md\"; [ -f .ai/findings/no-existing-tests-run.md ] && cp .ai/findings/no-existing-tests-run.md \"$OUT/$id.no-existing-tests-run.md\"; [ -f .ai/findings/witness-undetermined.md ] && cp .ai/findings/witness-undetermined.md \"$OUT/$id.witness-undetermined.md\"; if [ $rc -eq 0 ] && [ -s \"$OUT/$id.md\" ] && [ -s \"$OUT/$id.verify.sh\" ]; then printf packaged; else echo \"PACKAGE FAILED: could not write the capsule pair to $OUT (rc=$rc)\" > .ai/gate.log; echo round > .ai/last-stage-fail; exit 1; fi"]
+        tool_command="CM=.ai/capsule/DEFINITION.md; CV=.ai/capsule/DEFINITION.verify.sh; id=$(awk '/^---$/{c++;next} c==1 && /^id:/{sub(/^id:[[:space:]]*/,\"\"); print; exit}' \"$CM\" | tr -cd 'A-Za-z0-9._-'); [ -n \"$id\" ] || id=work-definition; OUT=\"$capsule_out\"; mkdir -p \"$OUT\" && cp \"$CM\" \"$OUT/$id.md\" && cp \"$CV\" \"$OUT/$id.verify.sh\" && chmod +x \"$OUT/$id.verify.sh\"; rc=$?; [ -f .ai/base-sha ] && cp .ai/base-sha \"$OUT/$id.base-sha\"; [ -f .ai/hypothesis.patch ] && cp .ai/hypothesis.patch \"$OUT/$id.hypothesis.patch\"; [ -f .ai/hypothesis_b.patch ] && cp .ai/hypothesis_b.patch \"$OUT/$id.hypothesis-b.patch\"; [ -f .ai/findings/discrimination.md ] && cp .ai/findings/discrimination.md \"$OUT/$id.discrimination.md\"; [ -f .ai/findings/single-shape.md ] && cp .ai/findings/single-shape.md \"$OUT/$id.single-shape.md\"; [ -f .ai/findings/no-existing-tests-run.md ] && cp .ai/findings/no-existing-tests-run.md \"$OUT/$id.no-existing-tests-run.md\"; [ -f .ai/findings/witness-undetermined.md ] && cp .ai/findings/witness-undetermined.md \"$OUT/$id.witness-undetermined.md\"; [ -f .ai/findings/no-void.md ] && cp .ai/findings/no-void.md \"$OUT/$id.no-void.md\"; [ -f .ai/findings/void-inconclusive.md ] && cp .ai/findings/void-inconclusive.md \"$OUT/$id.void-inconclusive.md\"; if [ $rc -eq 0 ] && [ -s \"$OUT/$id.md\" ] && [ -s \"$OUT/$id.verify.sh\" ]; then printf packaged; else echo \"PACKAGE FAILED: could not write the capsule pair to $OUT (rc=$rc)\" > .ai/gate.log; echo round > .ai/last-stage-fail; exit 1; fi"]
 
     // ---------- triage: root-cause wall (task-runner.dot idiom, verbatim, on .ai/gate.log) ----------
     triage [shape=parallelogram, class="glue", max_retries=0,
         tool_command="B=$(cat .ai/budget 2>/dev/null); B=${B:-6}; n=$(cat .ai/iter 2>/dev/null || echo 0); sig=$(tail -20 .ai/gate.log 2>/dev/null | sed -E 's|/tmp/[A-Za-z0-9._-]+|TMPPATH|g; s/[0-9]+\\.[0-9]+s?//g' | md5sum | cut -d' ' -f1); prev=$(cat .ai/last-fail-sig 2>/dev/null || echo none); echo $sig > .ai/last-fail-sig; if [ \"$n\" -ge \"$B\" ]; then printf exhausted; elif [ \"$sig\" = \"$prev\" ]; then printf repeat; else printf novel; fi"]
 
     diagnose [shape=box, class="gate",
-        prompt="A capsule-round gate failed twice with the SAME failure signature (see .ai/gate.log, and .ai/last-stage-fail for which stage: round/leak/existing_test/redgate/mutate/diff_shape/mutate_b/degenerate/witness/discrimination). Stop iterating blindly -- find the root cause. Read .ai/gate.log, .ai/brief.md, the report at $issue_file, and the relevant code in $target_dir. Determine what is actually wrong: (a) DEFINITION.verify.sh's assertion approach, (b) a misread of the reported defect, (c) an environment/tooling gap, or (d) a genuine ambiguity in the report that cannot be resolved from inside this run. Write .ai/postmortem/diagnosis.md with the root cause, the evidence, and the single change of course for the next attempt. If the blocker cannot be resolved from inside this run, include the word BLOCKED on its own line and explain."]
+        prompt="A capsule-round gate failed twice with the SAME failure signature (see .ai/gate.log, and .ai/last-stage-fail for which stage: round/leak/existing_test/redgate/mutate/diff_shape/mutate_b/degenerate/witness/void/discrimination). Stop iterating blindly -- find the root cause. Read .ai/gate.log, .ai/brief.md, the report at $issue_file, and the relevant code in $target_dir. Determine what is actually wrong: (a) DEFINITION.verify.sh's assertion approach, (b) a misread of the reported defect, (c) an environment/tooling gap, or (d) a genuine ambiguity in the report that cannot be resolved from inside this run. Write .ai/postmortem/diagnosis.md with the root cause, the evidence, and the single change of course for the next attempt. If the blocker cannot be resolved from inside this run, include the word BLOCKED on its own line and explain."]
 
     diagnose_gate [shape=parallelogram, class="glue", max_retries=0,
         tool_command="rm -f .ai/last-fail-sig; grep -qE '^BLOCKED' .ai/postmortem/diagnosis.md && printf blocked || printf continue"]
@@ -855,9 +957,23 @@ digraph CapsulePipeline {
     // DELETED WITNESS rather than a fix -- issue #146's `goal_gate=true`
     // deletion is neither a stub nor a removed def/assert, so it clears
     // degenerate_gate cleanly and needs its own, differently-shaped check.
-    witness_gate -> discrimination_check [condition="context.tool.last_line=witness_clean && outcome=success", label="no proven-greening hack touches only outside-subject files purely subtractively with a red_signal-sharing token"]
-    witness_gate -> discrimination_check [condition="context.tool.last_line=witness_undetermined && outcome=success", label="S empty, or the checker itself errored -- undecidable, finding written"]
+    witness_gate -> void [condition="context.tool.last_line=witness_clean && outcome=success", label="no proven-greening hack touches only outside-subject files purely subtractively with a red_signal-sharing token -- but a dodge may not have happened to land in slot A/B; SEARCH for one"]
+    witness_gate -> void [condition="context.tool.last_line=witness_undetermined && outcome=success", label="S empty, or the checker itself errored -- undecidable, finding written; still worth an active search"]
     witness_gate -> triage               [condition="outcome=fail", label="a proven-greening hack looks like a deleted witness, not a fix"]
+
+    // void_gate: THE VOID PROBE's own edges. Three success tokens all
+    // proceed to discrimination_check (the pipeline SAYS which case it is,
+    // never silently degrades one into the other -- the leak_gate/
+    // existing_test_gate idiom, verbatim); an unproven reset is a LOUD halt
+    // (shared with mutate_gate/mutate_gate_b's own reset_fail); a CONFIRMED
+    // dodge or an infra failure (missing/non-applying patch, missing
+    // base-sha) routes through the SAME root-cause wall every other gate
+    // defect in this file uses.
+    void_gate -> discrimination_check [condition="context.tool.last_line=void_no_dodge && outcome=success", label="void judged no dodge honestly constructible -- finding recorded, skip the round-trip"]
+    void_gate -> discrimination_check [condition="context.tool.last_line=void_resisted && outcome=success", label="the adversarial patch applied but did NOT green the gate -- the active search found no foothold"]
+    void_gate -> discrimination_check [condition="context.tool.last_line=void_inconclusive && outcome=success", label="the adversarial patch greened the gate, but the guard (check-witness-gate.py's own four conditions) could not confirm it is dodge-shaped -- finding recorded, biased to PASS"]
+    void_gate -> reset_fail            [condition="context.tool.last_line=void_reset_unproven && outcome=success", label="reset (void) could not be proven -- LOUD halt"]
+    void_gate -> triage                [condition="outcome=fail", label="a CONFIRMED void dodge, or hypothesis_v.patch missing/non-applying/base-sha unset"]
 
     discrimination_check -> package [condition="context.tool.last_line=skip_recorded && outcome=success", label="no later_commit -- skipped with reason"]
     discrimination_check -> package [condition="context.tool.last_line=discrim_ok && outcome=success", label="RED confirmed at later commit"]


### PR DESCRIPTION
## What

Re-syncs the vendored `.github/capsule-pipeline/capsule.dot` from the
private source repository, picking up two new nodes: **`void`** (a maker
that actively constructs an adversarial patch under the inverted objective
"green this gate WITHOUT fixing the reported defect") and **`void_gate`**
(applies it, proves GREEN, hard-resets, proves the reset, then guards the
result by re-invoking `check-witness-gate.py` against only the adversarial
patch).

Source: `runner/capsule.dot` pinned commit
`3a53cf13cbf426bcdea7e4382fae9feb9efe977d` ->
`34fff9618e9c0cba3feee8ac8b82c94798720cec`.

## Motivation, measured

Capsule PR #161 (issue #146, `goal-gate-loop-restart-lint.verify.sh`, base
`44428ab`) passed `witness_gate` -- both its hypothesis patches are
legitimate -- yet was **still dodgeable by hand**: deleting the single
`goal_gate=true` line from `examples/pipelines/00-convergence-loop.dot`
(`git diff --numstat` gives `0	1`) turns its gate fully GREEN.
`witness_gate` is *passive* -- it only inspects patches `mutate`/`mutate_b`
already wrote for a different purpose, so a dodge nobody happened to write
into slot A or B goes undetected. `void` searches for it directly.

## Verified drift (quoted)

Diffing the vendored copy's pinned commit against source `34fff96` (full
diff in the commit message / available on request), the load-bearing
change is two new nodes plus rewired edges:

```
660a662,762
>     // ---------- void: THE VOID PROBE -- a third adversarial hack whose GREENING is the failure ----------
...
>     void [shape=box, class="maker", thread_id="void",
>         must_write=".ai/hypothesis_v.patch", ...]
...
>     // ---------- void_gate: applies the adversarial patch, proves GREEN, hard-resets, PROVES the reset, then GUARDS ----------
>     void_gate [shape=parallelogram, class="gate", max_retries=0,
>         goal_gate=true, retry_target="author", ...]
850,851c952,953
<     witness_gate -> discrimination_check [condition="context.tool.last_line=witness_clean && outcome=success", ...]
<     witness_gate -> discrimination_check [condition="context.tool.last_line=witness_undetermined && outcome=success", ...]
---
>     witness_gate -> void [condition="context.tool.last_line=witness_clean && outcome=success", ...]
>     witness_gate -> void [condition="context.tool.last_line=witness_undetermined && outcome=success", ...]
852a955,968
>     void_gate -> discrimination_check [condition="context.tool.last_line=void_no_dodge && outcome=success", ...]
>     void_gate -> discrimination_check [condition="context.tool.last_line=void_resisted && outcome=success", ...]
>     void_gate -> discrimination_check [condition="context.tool.last_line=void_inconclusive && outcome=success", ...]
>     void_gate -> reset_fail            [condition="context.tool.last_line=void_reset_unproven && outcome=success", ...]
>     void_gate -> triage                [condition="outcome=fail", ...]
```

## What I vendored

**No new checker file** -- `void_gate` reuses `check-witness-gate.py`
verbatim, exactly as `witness_gate` already does. `check-witness-gate.py`,
`check-existing-tests.py`, and `check-degenerate-hack.py` are all
byte-identical to the previously-vendored copies (diffed against the
`34fff96` source range). Only `capsule.dot`'s body changed. This is exactly
the class of miss the vendoring README's checklist exists to catch: an
unchanged file with an empty diff can still be newly load-bearing --
`check-witness-gate.py` gained a **second, independent graph-level caller**
(`void_gate`'s own single-`--patch` invocation, called from a different
point in the control flow than `witness_gate`'s multi-`--patch` call).

## Runtime resolution proof, with negative control

From a scratch repo with `uplift_dir` set to this repo's own
`.github/capsule-pipeline/vendor` (the same path `capsule-specify.yml`
computes):

**Positive** -- `check-witness-gate.py`'s cross-file `importlib` imports
resolve and the mechanism fires correctly on the reconstructed dodge:
```
$ python3 "$uplift_dir/runner/check-witness-gate.py" \
    --verify goal-gate-loop-restart-lint.verify.sh --repo /tmp/scratch-repo \
    --red-signal "Node 'test_gate' has goal_gate=true but no retry_target" \
    --patch dodge.patch
VERDICT: witness_dodge_suspected
FIRE: dodge.patch turned this gate GREEN by touching ONLY [...] purely
subtractively (1 removed / 0 added), and removed line(s)
['        goal_gate=true'] share token(s) ['goal_gate'] with the
declared red_signal.
RC=1
```

**Negative control 1** -- the checker vendored ALONE (siblings absent)
reproduces the predicted resolution failure:
```
$ python3 /tmp/broken-uplift/runner/check-witness-gate.py --verify ... --patch dodge.patch
Traceback (most recent call last):
  ...
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/broken-uplift/runner/check-existing-tests.py'
```

**Negative control 2** -- a legitimate patch (issue #146's own
`hypothesis.patch`) does NOT fire, proving the mechanism discriminates
rather than always firing:
```
VERDICT: witness_clean
RC=0
```

## Live-case proof through the VENDORED path

`void_gate`'s own `tool_command=` text was extracted verbatim from the
re-synced `.dot` and executed end-to-end against a `git worktree` of this
repo pinned at base `44428ab67a530f23aa5579104f4ff68e4e809c37`, seeded
with issue #146's real `DEFINITION.md` / `DEFINITION.verify.sh` and a
reconstruction of PR #161's actual dodge as `.ai/hypothesis_v.patch`:

```
$ export uplift_dir=".../amplifier-bundle-attractor/.github/capsule-pipeline/vendor"
$ bash void_gate-tool_command.sh
=== SHELL RC=1 ===
--- .ai/gate.log ---
VOID-DODGE CONFIRMED: an ACTIVELY-CONSTRUCTED adversarial patch, explicitly
instructed to green this gate WITHOUT fixing the reported defect,
succeeded -- ...
VERDICT: witness_dodge_suspected
--- .ai/convergence.jsonl ---
{"iteration": 0, "gate": "void", "greened": true, "reset_proven": true}
{"iteration": 0, "gate": "void", "verdict": "dodge_confirmed"}
--- git status after --- (clean; HEAD == pinned base SHA)
```

This is the exact shape `void_gate -> triage [condition="outcome=fail", ...]`
routes on -- fired through the vendored `check-witness-gate.py`, not the
uplift copy.

## Lint + parity

```
$ attractor lint .github/capsule-pipeline/capsule.dot
attractor lint: .github/capsule-pipeline/capsule.dot: OK (no findings)
```
Node/edge counts: **35 nodes / 66 edges** -- matches the source file
exactly.

## Checklist hardening

Neither step 2 nor step 2a, as worded before this sync, made explicit that
an already-vendored, content-unchanged checker can gain a **second
independent graph-level call site** whose own argument shape still needs
runtime proof -- step 2's grep *does* surface the new reference here (it
is not the invisible-`importlib` case step 2a covers), but "the file is
present and its self-test passes" is not the same claim as "this specific
new caller's own invocation resolves." Added **step 2b** (count call sites,
not just presence) and amended **step 5** to require exercising each named
call site's own extracted `tool_command=` text, not only the checker's
generic `--self-test`.

## Gates

- `git diff --check`: clean.
- No `-Xtheirs`/`-Xours` used.
- `CI Gate (all checks passed)`: pending -- will report status once green.

Not merging -- opened for review.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>
