### PR TITLE
implement: fix for #146 (goal-gate-has-retry-loop-restart)

### DIFF
--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/validation.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/validation.py
@@ -329,13 +329,27 @@ def _check_reachability(graph: Graph, diags: list[Diagnostic]) -> None:
 
 
 def _check_goal_gate_has_retry(graph: Graph, diags: list[Diagnostic]) -> None:
-    """LINT: goal_gate_has_retry — goal gates should have retry targets."""
+    """LINT: goal_gate_has_retry — goal gates should have a retry mechanism.
+
+    A goal-gate node satisfies this rule when any of the following is true:
+
+    * The node carries a ``retry_target`` or ``fallback_retry_target``
+      attribute pointing to a node in the graph.
+    * The graph carries a top-level ``retry_target`` attribute.
+    * The node has at least one outgoing edge with ``loop_restart=true``,
+      which is the canonical retry mechanism for convergence-loop patterns.
+    """
     for node in graph.nodes.values():
         if resolve_bool_attr(node.attrs.get("goal_gate"), "goal_gate"):
+            has_loop_restart_edge = any(
+                resolve_bool_attr(e.loop_restart, "loop_restart")
+                for e in graph.outgoing_edges(node.id)
+            )
             has_retry = bool(
                 node.attrs.get("retry_target")
                 or node.attrs.get("fallback_retry_target")
                 or graph.graph_attrs.get("retry_target")
+                or has_loop_restart_edge
             )
             if not has_retry:
                 diags.append(
@@ -344,7 +358,10 @@ def _check_goal_gate_has_retry(graph: Graph, diags: list[Diagnostic]) -> None:
                         severity="WARNING",
                         message=f"Node '{node.id}' has goal_gate=true but no retry_target",
                         node_id=node.id,
-                        fix="Add retry_target or fallback_retry_target attribute",
+                        fix=(
+                            "Add retry_target or fallback_retry_target attribute, "
+                            "or add an outgoing edge with loop_restart=true"
+                        ),
                     )
                 )
 

--- a/modules/loop-pipeline/tests/test_validation.py
+++ b/modules/loop-pipeline/tests/test_validation.py
@@ -242,6 +242,31 @@ def test_goal_gate_without_retry_target():
     )
 
 
+def test_goal_gate_with_loop_restart_edge():
+    """No warning when goal_gate=true node has an outgoing loop_restart=true edge.
+
+    This is the canonical convergence-loop pattern: the gate routes back to the
+    worker via a loop_restart back-edge rather than a retry_target attribute.
+    The rule must recognise this as a valid retry mechanism and not fire.
+    """
+    g = _graph(
+        nodes={
+            "start": _mdiamond(),
+            "worker": _box("worker"),
+            "gate": _box("gate", attrs={"goal_gate": True}),
+            "exit": _msquare(),
+        },
+        edges=[
+            Edge(from_node="start", to_node="worker"),
+            Edge(from_node="worker", to_node="gate"),
+            Edge(from_node="gate", to_node="exit", attrs={"condition": "ok"}),
+            Edge(from_node="gate", to_node="worker", loop_restart=True),
+        ],
+    )
+    diags = validate(g)
+    assert not any(d.rule == "goal_gate_has_retry" for d in diags)
+
+
 def test_prompt_on_llm_nodes():
     """WARNING: codergen nodes should have prompt or label."""
     # A box node with no prompt and default label (= id) triggers warning


### PR DESCRIPTION
## Implement-stage fix for #146

Refs #146. Produced by `task-runner.dot` (see `.github/capsule-pipeline/`)
converging against the capsule's own definition of done and gate:
`.github/capsule-pipeline/proposals/issue-146/goal-gate-has-retry-loop-restart.md` /
`goal-gate-has-retry-loop-restart.verify.sh`.

The gate script (the capsule's own DoD, unmodified) passed, and this
change was additionally critiqued by an LLM reviewer against the
capsule's judgment criteria before shipping. Both reviewers ran as independent, cross-provider critics (Anthropic + OpenAI) -- enforced by this workflow's preflight check, not merely hoped for.

This PR is opened non-draft and is NOT auto-merged -- a human reviews
the diff and the run evidence before merging.

Workflow run: https://github.com/microsoft/amplifier-bundle-attractor/actions/runs/31329661804
