### PR TITLE
fix(ci): capsule-implement locate step guessed the wrong .md — select by <id>.md + <id>.verify.sh pairing

### DIFF
--- a/.github/workflows/capsule-implement.yml
+++ b/.github/workflows/capsule-implement.yml
@@ -143,12 +143,45 @@ jobs:
             CAPSULE_MD="${{ inputs.capsule_path }}"
           else
             PR_NUMBER="${{ github.event.pull_request.number }}"
-            CAPSULE_MD="$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" \
-              --json files -q '.files[].path' \
-              | grep -E '^\.github/capsule-pipeline/proposals/issue-[0-9]+/[^/]+\.md$' \
-              | head -1 || true)"
-            if [ -z "$CAPSULE_MD" ]; then
-              echo "::error::Merged PR #$PR_NUMBER touched .github/capsule-pipeline/proposals/** but no <id>.md capsule file was found among its changed files -- refusing to guess." >&2
+            # Enumerate the merged PR's changed files via the PR files API --
+            # merge-strategy-independent (identical result for rebase, squash,
+            # and merge-commit merges; no git-range arithmetic against main).
+            # --paginate clears the per-page cap so a large PR cannot silently
+            # truncate the list. Removed files are excluded: a deletion is not
+            # a capsule to implement.
+            CHANGED_FILES="$(gh api --paginate \
+              "repos/${{ github.repository }}/pulls/$PR_NUMBER/files" \
+              --jq '.[] | select(.status != "removed") | .filename')"
+
+            # A capsule PR ships supporting artifacts NEXT TO the capsule in
+            # the same proposal dir (<id>.discrimination.md, <id>.hypothesis.patch,
+            # <id>.base-sha, ...), so "any .md under proposals/" is AMBIGUOUS.
+            # The previous `... | head -1` silently guessed the alphabetically
+            # first .md and picked <id>.discrimination.md over <id>.md the very
+            # first time the production trigger fired (PR #171, run 31329562759).
+            # The capsule is structurally identifiable instead: it is the one
+            # .md whose sibling <id>.verify.sh is in the SAME changed-file set
+            # -- a pairing the specify stage's package step guarantees. Zero or
+            # multiple such pairs is refused loudly, never guessed.
+            MD_CANDIDATES="$(printf '%s\n' "$CHANGED_FILES" \
+              | grep -E '^\.github/capsule-pipeline/proposals/issue-[0-9]+/[^/]+\.md$' || true)"
+            CAPSULE_MD=""
+            PAIRED_COUNT=0
+            while IFS= read -r md; do
+              [ -n "$md" ] || continue
+              if printf '%s\n' "$CHANGED_FILES" | grep -qxF "${md%.md}.verify.sh"; then
+                CAPSULE_MD="$md"
+                PAIRED_COUNT=$((PAIRED_COUNT + 1))
+              fi
+            done <<< "$MD_CANDIDATES"
+
+            CANDIDATES_ONE_LINE="$(printf '%s' "${MD_CANDIDATES:-none}" | tr '\n' ' ')"
+            if [ "$PAIRED_COUNT" -eq 0 ]; then
+              echo "::error::Merged PR #$PR_NUMBER touched .github/capsule-pipeline/proposals/** but no capsule (<id>.md with its sibling <id>.verify.sh in the same PR) was found among its changed files -- refusing to guess. .md candidates seen: $CANDIDATES_ONE_LINE" >&2
+              exit 1
+            fi
+            if [ "$PAIRED_COUNT" -gt 1 ]; then
+              echo "::error::Merged PR #$PR_NUMBER contains $PAIRED_COUNT capsule (<id>.md + <id>.verify.sh) pairs -- one capsule per capsule PR; refusing to guess which one to implement. .md candidates seen: $CANDIDATES_ONE_LINE" >&2
               exit 1
             fi
           fi


### PR DESCRIPTION
## What

The `capsule-implement.yml` `pull_request: closed` trigger failed on its **first production firing** — the merge of capsule PR #171 (run [31329562759](https://github.com/microsoft/amplifier-bundle-attractor/actions/runs/31329562759)) died in ~1 minute at "Locate and validate the capsule". This PR fixes the root cause in the locate step.

## Root cause (evidence, not hypothesis)

**Neither of the two documented error branches fired.** The run log shows a THIRD branch:

```
##[error]Expected sibling gate script not found: .github/capsule-pipeline/proposals/issue-146/goal-gate-has-retry-loop-restart.discrimination.verify.sh
```

The enumeration itself worked. `gh pr view 171 --json files` returned all 6 changed files correctly — including BOTH `.md` files the capsule PR ships:

```
.github/capsule-pipeline/proposals/issue-146/goal-gate-has-retry-loop-restart.discrimination.md
.github/capsule-pipeline/proposals/issue-146/goal-gate-has-retry-loop-restart.md
```

The bug is the selection, not the enumeration: the script matched **any** `.md` under `proposals/issue-N/` and took `head -1`. `<id>.discrimination.md` sorts alphabetically before `<id>.md` (`.d` < `.m` after the shared stem), so the step silently picked the supporting discrimination-notes artifact as "the capsule", derived `CAPSULE_ID=goal-gate-has-retry-loop-restart.discrimination`, and then failed the sibling-`verify.sh` existence check. Reproduced verbatim against the real PR:

```console
$ gh pr view 171 --repo microsoft/amplifier-bundle-attractor --json files -q '.files[].path' \
    | grep -E '^\.github/capsule-pipeline/proposals/issue-[0-9]+/[^/]+\.md$' | head -1
.github/capsule-pipeline/proposals/issue-146/goal-gate-has-retry-loop-restart.discrimination.md
```

**Rebase-merge was NOT the cause.** PR #171 was a single-commit rebase merge (`merged: true`, `commits: 1`, `merge_commit_sha: f694d76`), and the PR files API is merge-strategy-independent — it returned the full, correct file list. The same failure would occur for a squash merge, a merge commit, or any commit count: the trigger fires deterministically for **every** capsule PR packaged by the current specify pipeline, because the pipeline always ships `<id>.discrimination.md` next to `<id>.md` (see `proposals/issue-144/` and `proposals/issue-146/` on main, and PR #143's file list).

**Why this never surfaced before:** the "successful" implement runs on 2026-08-07 (e.g. 31170066587) were `pull_request`-triggered via the repo's documented TEMPORARY pre-merge proof trigger (`types: [closed, opened, synchronize]` + widened paths — visible in the workflow file at those runs' head SHAs) running on `implement/issue-144-...` branches; they took the `workflow_dispatch`-style flow or fired on non-capsule paths, and never exercised the merged-capsule-PR enumeration against a real multi-`.md` capsule PR. Run 31261310511 (2026-08-08) was `pull_request` / **skipped** — its capsule PR #167 (issue #166) was closed **without** merging, so the `merged == true` guard correctly skipped it. PR #171 was the first true end-to-end firing of this path — and it failed immediately.

## Fix

In the `pull_request` branch of the locate step only (`workflow_dispatch` untouched):

1. **Enumerate via `gh api --paginate .../pulls/$PR/files`** — still merge-strategy-independent, now also immune to per-page truncation, and excludes `status == "removed"` files (a deletion is not a capsule to implement). Same token/permissions as the previous `gh pr view` call, which already worked live in this workflow context.
2. **Select structurally instead of alphabetically**: the capsule is the one `.md` whose sibling `<id>.verify.sh` is in the same changed-file set — the pairing the specify stage's package step guarantees.
3. **Refuse loudly on 0 or >1 pairs**, printing the `.md` candidates seen. No fallback guesses; the fail-loud posture is kept and the actual silent guess (`head -1`) is removed.

## Proof (run against real merged-PR data)

The exact shipped pairing logic, executed locally:

```console
$ /tmp/prove-locate.sh 171   # the failing merged capsule PR
CAPSULE_MD=.github/capsule-pipeline/proposals/issue-146/goal-gate-has-retry-loop-restart.md (paired_count=1)
exit=0

$ /tmp/prove-locate.sh 143   # issue-142 capsule PR: THREE .md files (.md, .discrimination.md, .single-shape.md)
CAPSULE_MD=.github/capsule-pipeline/proposals/issue-142/box-node-working-dir-forwarding.md (paired_count=1)
exit=0

$ /tmp/prove-locate.sh 156   # implement PR that touched only a proposals/ verify.sh — must refuse
REFUSED (0 pairs). .md candidates seen: none
exit=1
```

(PR #156's merge on 2026-08-08 fired this workflow and went red for exactly that reason — an implement-stage PR touching `proposals/**` with no capsule `.md`. That refusal is the existing, correct fail-loud posture and is unchanged; noted here so the red run 31232812491 isn't mistaken for this bug.)

Checks: YAML parses (`yaml.safe_load`), extracted step script passes `bash -n`, `git diff --check` clean. `actionlint` not available locally; no workflow test suite exists in this repo.

## What cannot be proven until the next live merge

The `pull_request: closed` **event payload itself** (that `github.event.pull_request.number` reaches the step and the `merged == true` guard passes) cannot be exercised locally, and this repo's own workflow-file history documents that `pull_request: closed` on main only evaluates the DEFAULT branch's workflow copy — so this fix cannot be live-proven pre-merge. The evidence that this part works is the failed run itself: run 31329562759 got past the guard, resolved `PR_NUMBER=171`, and called the files API successfully — everything upstream of the selection bug is already live-proven. **First live validation:** the next merged capsule PR should produce an implement run whose locate step outputs `capsule_md=<...>/issue-<N>/<id>.md` with the paired `verify.sh`, and proceed past step 3.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)
