### PR TITLE
fix(capsule-implement): measured gate-diff claim + honest salvage messaging (template truth)

### DIFF
--- a/.github/workflows/capsule-implement.yml
+++ b/.github/workflows/capsule-implement.yml
@@ -342,27 +342,81 @@ jobs:
           # degraded-single-family fallback message exists any more.
           DUAL_NOTE="Both reviewers ran as independent, cross-provider critics (Anthropic + OpenAI) -- enforced by this workflow's preflight check, not merely hoped for."
 
+          # MEASURE the gate-modification claim instead of asserting it.
+          # Run 31335891096 / PR #178: the previous template asserted the
+          # gate was "unmodified" while that very PR edited the gate's
+          # verify.sh (a REPO_ROOT path line). Never assert what isn't
+          # checked -- diff the proposal dir (capsule .md, verify.sh, and
+          # sibling artifacts) against the base this run started from and
+          # state the measured result either way.
+          PROPOSAL_DIR="$(dirname "${{ steps.locate.outputs.capsule_md }}")"
+          GATE_CHANGED="$(git diff --name-only origin/main HEAD -- "$PROPOSAL_DIR")"
+          if [ -z "$GATE_CHANGED" ]; then
+            GATE_NOTE="Gate files unmodified -- measured: \`git diff --name-only origin/main HEAD -- ${PROPOSAL_DIR}\` is empty."
+          else
+            GATE_CHANGED_ONE_LINE="$(printf '%s' "$GATE_CHANGED" | tr '\n' ' ')"
+            GATE_NOTE="Gate files MODIFIED by this PR (measured): ${GATE_CHANGED_ONE_LINE} -- review the gate diff alongside the fix; a gate edit changes what \"passed\" means."
+          fi
+
+          # EXIT distinguishes the two ways this step is reached (see this
+          # step's \`if:\`): '0' = task-runner.dot genuinely converged and
+          # shipped. '' = non-convergence whose committed work-in-progress
+          # is salvaged here: the run step's script aborts before its
+          # \`echo attractor_exit=$?\` under the runner's default \`bash -e\`
+          # when the engine exits non-zero, so the output is never written,
+          # and GitHub's expression rules coerce a missing output to 0 --
+          # making this step's \`== '0'\` condition true. The PR body must
+          # say which of the two this is: run 31335891096 shipped a salvage
+          # PR (#178) wearing the converged template's claims.
+          EXIT="${{ steps.run.outputs.attractor_exit }}"
+
           BODY_FILE="$RUNNER_TEMP/capsule-implement/pr-body.md"
-          {
-            echo "## Implement-stage fix for #${ISSUE}"
-            echo
-            echo "Refs #${ISSUE}. Produced by \`task-runner.dot\` (see \`.github/capsule-pipeline/\`)"
-            echo "converging against the capsule's own definition of done and gate:"
-            echo "\`.github/capsule-pipeline/proposals/issue-${ISSUE}/${CAPSULE_ID}.md\` /"
-            echo "\`${CAPSULE_ID}.verify.sh\`."
-            echo
-            echo "The gate script (the capsule's own DoD, unmodified) passed, and this"
-            echo "change was additionally critiqued by an LLM reviewer against the"
-            echo "capsule's judgment criteria before shipping. $DUAL_NOTE"
-            echo
-            echo "This PR is opened non-draft and is NOT auto-merged -- a human reviews"
-            echo "the diff and the run evidence before merging."
-            echo
-            echo "Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          } > "$BODY_FILE"
+          if [ "$EXIT" = "0" ]; then
+            TITLE="implement: fix for #${ISSUE} (${CAPSULE_ID})"
+            {
+              echo "## Implement-stage fix for #${ISSUE}"
+              echo
+              echo "Refs #${ISSUE}. Produced by \`task-runner.dot\` (see \`.github/capsule-pipeline/\`)"
+              echo "converging against the capsule's own definition of done and gate:"
+              echo "\`.github/capsule-pipeline/proposals/issue-${ISSUE}/${CAPSULE_ID}.md\` /"
+              echo "\`${CAPSULE_ID}.verify.sh\`."
+              echo
+              echo "The gate script (the capsule's own DoD) passed, and this change was"
+              echo "additionally critiqued by an LLM reviewer against the capsule's"
+              echo "judgment criteria before shipping. $DUAL_NOTE"
+              echo
+              echo "$GATE_NOTE"
+              echo
+              echo "This PR is opened non-draft and is NOT auto-merged -- a human reviews"
+              echo "the diff and the run evidence before merging."
+              echo
+              echo "Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            } > "$BODY_FILE"
+          else
+            TITLE="implement: work-in-progress for #${ISSUE} (${CAPSULE_ID}) -- did not converge"
+            {
+              echo "## Implement-stage WORK-IN-PROGRESS for #${ISSUE} (did not converge)"
+              echo
+              echo "Refs #${ISSUE}. \`task-runner.dot\` (see \`.github/capsule-pipeline/\`) did"
+              echo "NOT converge on this capsule within its budget; this branch salvages the"
+              echo "committed work-in-progress so it is not lost. The judge's objections and"
+              echo "the postmortem (if written) are in the workflow run's uploaded artifacts."
+              echo
+              echo "Do NOT read this PR as a proven fix: the gate/critique claims a converged"
+              echo "run would carry do not apply here."
+              echo
+              echo "$GATE_NOTE"
+              echo
+              echo "This PR is opened non-draft and is NOT auto-merged -- a human reviews"
+              echo "the diff and the run evidence before deciding whether to adopt, finish,"
+              echo "or close this work."
+              echo
+              echo "Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            } > "$BODY_FILE"
+          fi
 
           url=$(gh pr create --repo "${{ github.repository }}" \
-            --title "implement: fix for #${ISSUE} (${CAPSULE_ID})" \
+            --title "$TITLE" \
             --body-file "$BODY_FILE" \
             --base main --head "$BRANCH")
           echo "url=$url" >> "$GITHUB_OUTPUT"
@@ -376,12 +430,33 @@ jobs:
           COMMENT="$RUNNER_TEMP/capsule-implement/comment.md"
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           EXIT="${{ steps.run.outputs.attractor_exit }}"
+          PR_URL="${{ steps.pr.outputs.url }}"
 
-          if [ "$EXIT" = "0" ] && [ -n "${{ steps.pr.outputs.url }}" ]; then
+          # Three real outcomes, three honest messages. Run 31335891096
+          # posted "no fix PR opened" while the SAME run's previous step had
+          # just pushed a branch and opened PR #178 (non-convergence salvage
+          # path) -- the old two-way template asserted a PR's absence it
+          # never checked. Claim "no fix PR opened" only when none was.
+          if [ "$EXIT" = "0" ] && [ -n "$PR_URL" ]; then
             {
               echo "**Implement stage: fix PR opened.**"
               echo
-              echo "${{ steps.pr.outputs.url }}"
+              echo "$PR_URL"
+              echo
+              echo "Workflow run: $RUN_URL"
+            } > "$COMMENT"
+          elif [ -n "$PR_URL" ]; then
+            {
+              echo "**Implement stage did not converge -- work-in-progress salvaged as $PR_URL.**"
+              echo
+              echo "task-runner.dot did not converge on a shipped fix within its iteration"
+              echo "budget. The committed work-in-progress was salvaged as the PR above --"
+              echo "it is NOT a proven fix; the judge's objections are in the run artifacts."
+              echo "Postmortem (if written):"
+              echo
+              echo '```'
+              cat "$GITHUB_WORKSPACE/.ai/postmortem/report.md" 2>/dev/null || echo "(no postmortem report was written)"
+              echo '```'
               echo
               echo "Workflow run: $RUN_URL"
             } > "$COMMENT"


### PR DESCRIPTION
## Summary

Fixes two false claims in `.github/workflows/capsule-implement.yml`, both observed in run [31335891096](https://github.com/microsoft/amplifier-bundle-attractor/actions/runs/31335891096) (issue #172):

1. **Issue comment claimed a PR's absence it never checked.** The run posted *"Implement stage FAILED -- no fix PR opened."* while the SAME run's "Push fix branch and open PR" step had pushed `implement/issue-172-subgraph-dead-end-silent-success` and opened PR #178. The comment template was two-way (converged / nothing); it is now three-way: converged fix PR / **did-not-converge salvage PR named by URL** (with a judge's-objections pointer and the postmortem) / genuinely no PR. "No fix PR opened" is claimed only when none was.
2. **Fix-PR body asserted the capsule gate was "unmodified" without checking.** PR #178 itself edited the gate's `verify.sh` (a REPO_ROOT path line). The claim is now **measured**: the step runs `git diff --name-only origin/main HEAD -- <proposal dir>` and states the result either way ("Gate files unmodified -- measured: ... is empty" / "Gate files MODIFIED by this PR (measured): <list> -- review the gate diff"). Fail-loud posture: never assert what isn't checked.

The salvage PR body/title also stop wearing the converged template's claims ("passed", "critiqued before shipping") when the run did not converge -- they now say plainly it is salvaged work-in-progress, not a proven fix.

## Verification checklist

- [x] Unit tests pass (`pytest modules/loop-pipeline/`) -- N/A to this diff (workflow YAML only, no Python touched); the required `CI Gate (all checks passed)` on this PR runs the full per-module matrix regardless.
- [x] Live pipeline run exercising changed code path -- N/A (no `engine.py`/handler change). The changed step scripts were extracted and dry-run against run 31335891096's real data instead; see evidence below.
- [x] AGENTS.md reviewed; repo-specific gates met
- [x] Backward-compat path unchanged (if applicable) -- converged-run messaging is unchanged in substance; the previously-unreachable-honest states get honest text.
- [x] No `specs/EXTENSIONS.md` entry needed: workflow reporting glue only -- no engine dispatch semantics, event contracts, or validation behavior change.
- [x] PR body includes verification evidence, not just "tests pass"
- [ ] **CI is green before merge** -- `CI Gate (all checks passed)` status to be confirmed via `gh pr checks` before any merge (this PR is opened for review, not merged).

## Verification evidence

Both modified step scripts extracted (with `${{ }}` interpolations substituted with the run's real values) and checked:

```
bash -n OK: /tmp/proof/comment-step.sh
bash -n OK: /tmp/proof/push-step.sh
```

**Comment logic, dry-run against run 31335891096's REAL data** (`attractor_exit` output was never written -> interpolates to empty; `steps.pr.outputs.url` = PR #178 -- both facts verified in the run's job log):

```
=== CASE 1: REAL run data (EXIT='', PR url = #178) === rc=0
**Implement stage did not converge -- work-in-progress salvaged as https://github.com/microsoft/amplifier-bundle-attractor/pull/178.**
...it is NOT a proven fix; the judge's objections are in the run artifacts.
=== CASE 2: no PR opened (EXIT='', url='') === rc=0
**Implement stage FAILED -- no fix PR opened.**
=== CASE 3: converged (EXIT='0', url set) === rc=0
**Implement stage: fix PR opened.**
```

**Gate-diff measurement, dry-run against the run's real git data** (base = the main the run started from, `3300c54`; HEAD = PR #178's `bf3f422`), both branches of the claim exercised:

```
CASE-A rc=0  (EXIT='', base=3300c54, HEAD=bf3f422)
TITLE=implement: work-in-progress for #172 (subgraph-dead-end-silent-success) -- did not converge
## Implement-stage WORK-IN-PROGRESS for #172 (did not converge)
Gate files MODIFIED by this PR (measured): .github/capsule-pipeline/proposals/issue-172/subgraph-dead-end-silent-success.verify.sh -- review the gate diff alongside the fix; a gate edit changes what "passed" means.

CASE-B rc=0  (EXIT='0', identical proposal-dir trees)
TITLE=implement: fix for #172 (subgraph-dead-end-silent-success)
## Implement-stage fix for #172
Gate files unmodified -- measured: `git diff --name-only origin/main HEAD -- .github/capsule-pipeline/proposals/issue-172` is empty.
```

`actionlint` not available on the build host; YAML parsed clean (the step-extraction itself round-trips the file through a YAML parser).

## Notes for reviewers

- **Root cause of the observed contradiction, from the run's job log**: the run step's script (`set -uo pipefail`; no `-e` reset) executes under the runner's DEFAULT `bash -e`, so the engine's exit 1 aborted the step before `echo "attractor_exit=$?"` -- the output was never written. GitHub expressions then coerce a **missing** output to `0`, so the push step's `== '0'` condition was TRUE and it pushed/opened PR #178; meanwhile the comment/fail steps read the same output as the empty **string** and took their failure branches. This PR documents that mechanism in-line and makes every message truthful in both states; it deliberately does NOT change when the salvage push happens (that is a behavior decision, not a truth fix -- flagged as a possible follow-up: capture the exit code robustly and make the salvage path an explicit condition rather than a coercion accident).
- The salvage-PR title now differs from the converged title ("work-in-progress ... -- did not converge") -- a judgment call beyond the letter of the two claims, same honesty rationale.
