### PR TITLE
implement: fix for #172 (subgraph-dead-end-silent-success)

### DIFF
--- a/context/engine-semantics.md
+++ b/context/engine-semantics.md
@@ -112,10 +112,17 @@ Source: `edge_selection.py`; `handlers/tool.py`; nlspec §3.3, §3.7, §10.
     (Shipped behavior since the initial engine commit `6c8bf5a`; the earlier claim here
     transcribed nlspec §3.2 step 6, which the shipped main loop has never followed — an
     unreconciled spec/engine divergence.)
-  - **Subgraph branches** (`run_subgraph`, `engine.py:917-919`): returns the last outcome on a
-    dead-end — no hard-fail. "Every LLM node needs an unconditional fallback" is an
-    authoring/lint discipline for the main loop; inside `run_subgraph` a dead-end is a
-    graceful termination. [MEDIUM]
+  - **Subgraph branches** (`run_subgraph`): behavior depends on *why* no edge was selected:
+    - **Conditional-mismatch dead end** (outgoing edges exist but none matched the current
+      outcome): returns `Outcome(status=FAIL, is_explicit=False)` with a non-empty
+      `failure_reason` naming the node and the unmatched outcome. Consistent with the
+      main loop's hard-fail posture (EXTENSIONS.md §33). A dead-ended parallel branch
+      surfaces this failure in `parallel.results` (the entry carries `status=fail` and a
+      non-empty `failure_reason`), where join policies and the fan-in can aggregate it.
+      (Resolved in issue-172; see EXTENSIONS.md §33 compatibility note update.)
+    - **No outgoing edges at all** (designed terminus): returns the last outcome unchanged —
+      graceful subgraph completion. This is the intended exit for a branch that reaches
+      the end of its designed path with no further routing required.
 
 ---
 

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py
@@ -1103,7 +1103,29 @@ class PipelineEngine:
             # Select next edge
             edge = select_edge(current_node.id, outcome, ctx, self.graph)
             if edge is None:
-                # No outgoing edge -- subgraph is complete
+                # Distinguish two cases:
+                # (a) Conditional-mismatch dead end: outgoing edges exist but
+                #     none matched the current outcome. This is a hard failure
+                #     consistent with the main loop's no-matching-edge posture
+                #     (EXTENSIONS.md §33). The engine forced this FAIL; no node
+                #     produced a verdict, so is_explicit=False.
+                # (b) No outgoing edges at all: a designed terminus. Return the
+                #     last outcome unchanged (graceful subgraph completion).
+                outgoing = self.graph.outgoing_edges(current_node.id)
+                if outgoing:
+                    return Outcome(
+                        status=StageStatus.FAIL,
+                        failure_reason=(
+                            f"Subgraph dead end at node '{current_node.id}': "
+                            f"{len(outgoing)} outgoing edge(s) exist but none "
+                            f"match the current outcome "
+                            f"(status={outcome.status.value}). "
+                            f"This is a conditional-mismatch dead end \u2014 "
+                            f"add a matching edge or a fallback route."
+                        ),
+                        is_explicit=False,
+                    )
+                # No outgoing edges at all -- subgraph reached a designed terminus.
                 return outcome
 
             current_node = self.graph.nodes[edge.to_node]

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/manager_loop.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/manager_loop.py
@@ -253,6 +253,7 @@ class ManagerLoopHandler:
                         # manager node unsatisfiable even when the child
                         # produced an explicit verdict).
                         is_explicit=child_outcome.is_explicit,
+                        failure_reason=child_outcome.failure_reason,
                         notes=f"Manager completed in {cycle} cycle(s) — stop condition satisfied",
                         context_updates={
                             "last_stage": node.id,
@@ -267,6 +268,7 @@ class ManagerLoopHandler:
                         # EXTENSIONS.md §25: propagate the child's
                         # explicitness (see stop-condition branch above).
                         is_explicit=child_outcome.is_explicit,
+                        failure_reason=child_outcome.failure_reason,
                         notes=f"Manager completed in {cycle} cycle(s)",
                         context_updates={
                             "last_stage": node.id,
@@ -279,9 +281,18 @@ class ManagerLoopHandler:
                 await asyncio.sleep(poll_interval_s)
 
         # -- Max cycles exhausted -----------------------------------------------
+        # Traceability is transitive: if the last child outcome carried a
+        # non-empty failure_reason (e.g. from a conditional-mismatch dead end),
+        # incorporate it so the causal text is not lost at the manager boundary.
+        _child_reason = last_outcome.failure_reason if last_outcome else None
+        _exhaustion_reason = (
+            f"Manager exhausted {max_cycles} cycle(s): {_child_reason}"
+            if _child_reason
+            else f"Manager exhausted {max_cycles} cycle(s)"
+        )
         return Outcome(
             status=StageStatus.FAIL,
-            failure_reason=f"Manager exhausted {max_cycles} cycle(s)",
+            failure_reason=_exhaustion_reason,
             notes=f"Last child status: {last_outcome.status.value if last_outcome else 'none'}",
             context_updates={
                 "last_stage": node.id,

--- a/modules/loop-pipeline/tests/test_engine_semantics_doc_guard.py
+++ b/modules/loop-pipeline/tests/test_engine_semantics_doc_guard.py
@@ -113,15 +113,19 @@ def test_d200_no_matching_edge_main_loop_documented():
 def test_d200_subgraph_path_distinguished():
     """D-200c (text-anchored): the doc must distinguish the subgraph path.
 
-    run_subgraph (engine.py:917-919) still returns the last outcome on a
-    dead-end — no hard-fail.  Both halves must be stated to avoid authors
-    over-trusting the hard-fail inside parallel/manager layers.
+    run_subgraph now distinguishes two dead-end cases:
+    - Conditional-mismatch (outgoing edges exist but none matched): returns FAIL
+      with a non-empty failure_reason (issue-172 fix; EXTENSIONS.md §33 update).
+    - No outgoing edges at all (designed terminus): returns last outcome unchanged.
+    Both halves must be stated to avoid authors over-trusting the hard-fail
+    inside parallel/manager layers.
     """
     doc = _doc()
     assert re.search(r"subgraph|run_subgraph|parallel branch", doc, re.IGNORECASE), (
         "engine-semantics.md documents no-matching-edge behavior but never "
-        "distinguishes the subgraph path. run_subgraph (engine.py:917-919) still "
-        "returns the last outcome on a dead-end. Both halves must be stated. (D-200c)"
+        "distinguishes the subgraph path. run_subgraph distinguishes conditional-"
+        "mismatch dead ends (FAIL with failure_reason) from designed termini "
+        "(last outcome unchanged). Both halves must be stated. (D-200c)"
     )
 
 
@@ -194,9 +198,10 @@ def test_d202a_main_loop_hard_fails_no_matching_edge(tmp_path):
     terminate_pipeline, emits PIPELINE_ERROR with error_type: no_matching_edge.'
     This test verifies that claim against the running engine.
 
-    Note: this does NOT test the subgraph path (run_subgraph returns the
-    last outcome on a dead-end — see engine.py:917-919).  The doc documents
-    both halves; this test covers the main-loop half.  (D-202a)
+    Note: this does NOT test the subgraph path (run_subgraph now distinguishes
+    conditional-mismatch dead ends from designed termini — see issue-172 and
+    EXTENSIONS.md §33).  The doc documents both halves; this test covers the
+    main-loop half.  (D-202a)
     """
     from typing import Any
 

--- a/modules/loop-pipeline/tests/test_manager_loop.py
+++ b/modules/loop-pipeline/tests/test_manager_loop.py
@@ -1023,3 +1023,149 @@ digraph parent_manager_hitl {
             "Interviewer may not have reached the child HITL gate through the "
             "manager child_dotfile pipeline."
         )
+
+
+# ---------------------------------------------------------------------------
+# Dead-end failure_reason propagation tests
+# ---------------------------------------------------------------------------
+
+
+class TestManagerDeadEndPropagation:
+    """Manager loop must propagate failure_reason from a dead-ended child subgraph.
+
+    When run_subgraph() returns FAIL with a non-empty failure_reason because
+    the child subgraph hit a conditional-mismatch dead end, the manager's
+    returned Outcome must carry that failure_reason — not silently drop it.
+    This locks down the no-lossy-reconstruction criterion from the task brief.
+    """
+
+    @pytest.mark.asyncio
+    async def test_stop_condition_child_dead_end_failure_reason_propagated(self):
+        """Stop-condition exit: failure_reason from a dead-ended child is forwarded.
+
+        Simulates: run_subgraph returns FAIL with a traceable dead-end reason.
+        The manager's stop condition matches (outcome=fail), so the manager
+        exits via the stop-condition branch.  The returned Outcome must carry
+        the same failure_reason — not None.
+        """
+        dead_end_reason = (
+            "Subgraph dead end at node 'work': 1 outgoing edge(s) exist "
+            "but none match the current outcome (status=success). "
+            "This is a conditional-mismatch dead end."
+        )
+        runner = _make_runner(
+            [
+                Outcome(
+                    status=StageStatus.FAIL,
+                    failure_reason=dead_end_reason,
+                ),
+            ]
+        )
+        handler = ManagerLoopHandler()
+        graph = _make_graph(
+            manager_attrs={
+                "manager.max_cycles": "3",
+                "manager.stop_condition": "outcome=fail",
+                "manager.poll_interval": "0s",
+            }
+        )
+        ctx = PipelineContext()
+
+        result = await handler.execute(
+            graph.nodes["manager"], ctx, graph, "/tmp", engine=runner
+        )
+
+        assert result.status == StageStatus.FAIL
+        assert result.failure_reason, (
+            "Manager must forward the child's failure_reason — got None. "
+            "A dead-ended child's traceable reason was silently dropped at "
+            "the manager boundary (lossy reconstruction)."
+        )
+        assert dead_end_reason in result.failure_reason, (
+            f"Expected dead-end reason in manager outcome, got: {result.failure_reason!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_default_guard_child_dead_end_failure_reason_propagated(self):
+        """Default-guard exit: failure_reason is forwarded even on is_success path.
+
+        Simulates: run_subgraph returns PARTIAL_SUCCESS (is_success=True) but
+        carries a failure_reason (e.g. from a partial failure with context).
+        The default guard stops on is_success; the manager must forward the
+        failure_reason rather than constructing a fresh Outcome that drops it.
+        """
+        partial_reason = "partial failure: some steps skipped"
+        runner = _make_runner(
+            [
+                Outcome(
+                    status=StageStatus.PARTIAL_SUCCESS,
+                    failure_reason=partial_reason,
+                ),
+            ]
+        )
+        handler = ManagerLoopHandler()
+        graph = _make_graph(manager_attrs={"manager.max_cycles": "3"})
+        ctx = PipelineContext()
+
+        result = await handler.execute(
+            graph.nodes["manager"], ctx, graph, "/tmp", engine=runner
+        )
+
+        assert result.is_success
+        assert result.failure_reason == partial_reason, (
+            f"Manager must forward child failure_reason on default-guard exit. "
+            f"Expected {partial_reason!r}, got {result.failure_reason!r}."
+        )
+
+    @pytest.mark.asyncio
+    async def test_exhaustion_child_dead_end_failure_reason_incorporated(self):
+        """DEFAULT-config exhaustion: child dead-end reason is incorporated transitively.
+
+        Simulates: a dead-ending child always returns FAIL (no stop_condition,
+        no is_success), so the manager exhausts its max_cycles.  The returned
+        failure_reason must incorporate the child's dead-end text, not just
+        say "Manager exhausted N cycle(s)" with the causal reason lost.
+
+        This is the binding gap identified by the scope ruling: traceability is
+        transitive — a manager that exhausts cycles because its in-graph child
+        dead-ended must surface the child's causal failure text.
+        """
+        dead_end_reason = (
+            "Subgraph dead end at node 'work': 1 outgoing edge(s) exist "
+            "but none match the current outcome (status=success). "
+            "This is a conditional-mismatch dead end."
+        )
+        # Always returns FAIL with the dead-end reason — manager never stops
+        # via stop_condition or default guard, so it exhausts max_cycles.
+        runner = _make_runner(
+            [
+                Outcome(status=StageStatus.FAIL, failure_reason=dead_end_reason),
+                Outcome(status=StageStatus.FAIL, failure_reason=dead_end_reason),
+                Outcome(status=StageStatus.FAIL, failure_reason=dead_end_reason),
+            ]
+        )
+        handler = ManagerLoopHandler()
+        # DEFAULT config: no stop_condition, manager exhausts max_cycles=3
+        graph = _make_graph(
+            manager_attrs={
+                "manager.max_cycles": "3",
+                "manager.poll_interval": "0s",
+            }
+        )
+        ctx = PipelineContext()
+
+        result = await handler.execute(
+            graph.nodes["manager"], ctx, graph, "/tmp", engine=runner
+        )
+
+        assert result.status == StageStatus.FAIL
+        assert result.failure_reason, (
+            "Manager exhaustion must carry a non-empty failure_reason — got None. "
+            "The child's dead-end reason was silently dropped (lossy reconstruction)."
+        )
+        assert dead_end_reason in result.failure_reason, (
+            f"Manager exhaustion failure_reason must incorporate the child's dead-end "
+            f"text (transitive traceability). "
+            f"Expected {dead_end_reason!r} in failure_reason, "
+            f"got: {result.failure_reason!r}"
+        )

--- a/specs/EXTENSIONS.md
+++ b/specs/EXTENSIONS.md
@@ -1737,23 +1737,39 @@ success costs an operator hours before anyone notices nothing happened.
 first commit; this entry and the corresponding `SPEC_CONFORMANCE.md` update record the decision
 that was made, not a code change.
 
-**Compatibility note — `run_subgraph` is intentionally NOT changed by this decision.**
-`run_subgraph()` (`engine.py:917-925` at time of writing) returns the last outcome unchanged on
-a dead end, matching the spec's permissive shape — this is deliberate: subgraph dead-ends are
-the *compositional* path (a folder/sub-pipeline node's internal routing choices are its own
-business), while the top-level main loop is where an unrouted graph is a run-ending authoring
-defect. Any future change to `run_subgraph`'s dead-end behavior is a separate decision, not
-implied by this entry.
+**Compatibility note — `run_subgraph` behavior updated by issue-172 (separate decision).**
+This §33 entry originally reserved any change to `run_subgraph`'s dead-end behavior as a
+separate decision. That decision has now been made (issue-172):
+
+- **Conditional-mismatch dead end** (outgoing edges exist but none matched): `run_subgraph()`
+  now returns `Outcome(status=FAIL, is_explicit=False)` with a non-empty `failure_reason`
+  naming the node and the unmatched outcome. This is consistent with the main loop's
+  hard-fail posture above. A dead-ended parallel branch surfaces this failure in
+  `parallel.results` (the entry carries `status=fail` and a non-empty `failure_reason`),
+  where join policies and the fan-in can aggregate it.
+- **No outgoing edges at all** (designed terminus): `run_subgraph()` still returns the last
+  outcome unchanged — graceful subgraph completion. The distinction between the two cases
+  is: `self.graph.outgoing_edges(current_node.id)` is non-empty (conditional mismatch) vs.
+  empty (designed terminus).
+
+The `folder`/`dot_file=` composition path is unaffected — it runs the child via a full child-engine
+`run()` call, which already hard-failed on dead ends under this §33 entry.
 
 **Implementation locations:**
 - `modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py` — main loop's no-matching-edge
   hard-fail (`terminate_pipeline()` call + `PIPELINE_ERROR` emission with
   `error_type=no_matching_edge`, around the retry-target fallback check)
+- `modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py: run_subgraph()` — the
+  conditional-mismatch dead-end detection (`outgoing_edges` check after `select_edge` returns
+  `None`); returns `Outcome(FAIL, failure_reason=...)` for mismatch, last outcome for terminus
 - `modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py: terminate_pipeline()` — the
-  sole construction path for a routing-termination outcome (see `AGENTS.md` common-pitfalls: never
-  construct a fresh `Outcome(FAIL, ...)` inline at this boundary — it drops `failure_reason`)
+  sole construction path for a routing-termination outcome in the main loop (see `AGENTS.md`
+  common-pitfalls: never construct a fresh `Outcome(FAIL, ...)` inline at this boundary —
+  it drops `failure_reason`). Note: `run_subgraph`'s dead-end path constructs its own
+  `Outcome(FAIL, ...)` directly, which is correct here because it is not a routing-termination
+  in the main-loop sense — it is a subgraph-level routing failure with its own traceable reason.
 - `context/engine-semantics.md` §3 — documents both halves (main-loop hard-fail vs.
-  `run_subgraph`'s permissive dead-end) and is guarded against drift by
+  `run_subgraph`'s two-case dead-end behavior) and is guarded against drift by
   `modules/loop-pipeline/tests/test_engine_semantics_doc_guard.py` (D-200a/b/c)
 - `examples/pipelines/practical/bug-fix.dot` (`escalated` node) — the shipped exemplar that
   depends on this hard-fail to report failure after writing handoff artifacts


### PR DESCRIPTION
## Implement-stage fix for #172

Refs #172. Produced by `task-runner.dot` (see `.github/capsule-pipeline/`)
converging against the capsule's own definition of done and gate:
`.github/capsule-pipeline/proposals/issue-172/subgraph-dead-end-silent-success.md` /
`subgraph-dead-end-silent-success.verify.sh`.

The gate script (the capsule's own DoD) passed, and this change was
additionally critiqued by an LLM reviewer against the capsule's
judgment criteria before shipping. Both reviewers ran as independent, cross-provider critics (Anthropic + OpenAI) -- enforced by this workflow's preflight check, not merely hoped for.

Gate files unmodified -- measured: `git diff --name-only origin/main HEAD -- .github/capsule-pipeline/proposals/issue-172` is empty.

This PR is opened non-draft and is NOT auto-merged -- a human reviews
the diff and the run evidence before merging.

Workflow run: https://github.com/microsoft/amplifier-bundle-attractor/actions/runs/31351382505
