### PR TITLE
docs: going-live artifacts for the autonomous issue->fix pipeline (defect-report form + ISSUE_PIPELINE.md)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/defect-report.yml
+++ b/.github/ISSUE_TEMPLATE/defect-report.yml
@@ -1,0 +1,94 @@
+name: Defect report
+description: Report a defect in a form the autonomous issue pipeline can work with. Describe what the software DOES — not what the fix should be.
+labels: ["defect-report"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a defect report. This repo runs an autonomous pipeline that can
+        take a well-specified defect report all the way to a proposed fix
+        (see [docs/ISSUE_PIPELINE.md](https://github.com/microsoft/amplifier-bundle-attractor/blob/main/docs/ISSUE_PIPELINE.md)).
+        Whether it converges depends almost entirely on the quality of this report.
+
+        Three rules that measurably decide the outcome:
+
+        1. **Describe what the software DOES, not what the fix should be.** Do not
+           prescribe the fix — the pipeline verifies against behavior, and a prescription
+           narrows and biases its verification gate.
+        2. **Be self-contained.** Everything needed to understand the defect belongs in
+           this report, in plain English. Links-only reports don't work — the pipeline
+           reads this text, not your browser tabs.
+        3. **Quote real output.** Paste the actual bytes the commands produced. Don't
+           paraphrase or reconstruct from memory.
+  - type: textarea
+    id: what-happens
+    attributes:
+      label: What happens
+      description: >-
+        The observable behavior, in plain English. What does the software actually do?
+        Stick to observations — no diagnosis, no proposed fix.
+      placeholder: >-
+        Running the linter over the first tutorial example produces a warning even though
+        the graph does implement a retry route.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Exact reproduction
+      description: >-
+        The exact commands you ran and the ACTUAL output they produced, quoted verbatim.
+        This is the single most important field — the pipeline builds an executable
+        verification gate from observable behavior, and a reproduction it can run is the
+        strongest possible input.
+      render: shell
+      placeholder: |
+        $ attractor lint --strict examples/pipelines/00-convergence-loop.dot
+        WARNING: [goal_gate_has_retry] [test_gate] Node 'test_gate' has goal_gate=true but no retry_target
+          fix: Add retry_target or fallback_retry_target attribute
+
+        attractor lint: examples/pipelines/00-convergence-loop.dot: 1 warning(s)
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: >-
+        What you expected instead, stated plainly. Expected-vs-actual is what makes a
+        defect checkable. (Saying what SHOULD happen is not a fix prescription — saying
+        HOW to change the code is.)
+      placeholder: >-
+        Expected the first tutorial example to pass the tool's own strict lint with no
+        warnings.
+    validations:
+      required: true
+  - type: input
+    id: observed-on
+    attributes:
+      label: Commit SHA or branch observed on
+      description: >-
+        The SHA (preferred) or branch where you observed the behavior. The pipeline pins
+        its verification to a base commit, so knowing where you saw it matters.
+      placeholder: "e.g. 16cd142, or main as of 2026-08-10"
+    validations:
+      required: true
+  - type: input
+    id: affected-area
+    attributes:
+      label: Affected area or module (optional)
+      description: >-
+        If you happen to know roughly where the behavior lives (a module, a doc, an
+        example file), name it. Leave blank if unsure — a wrong guess is worse than no
+        guess.
+      placeholder: "e.g. modules/loop-pipeline validation, examples/pipelines/"
+    validations:
+      required: false
+  - type: markdown
+    attributes:
+      value: |
+        **What happens next:** a maintainer reviews this report and, if it is
+        pipeline-ready, applies the `ready:spec` label to hand it to the pipeline — that
+        label is deliberately maintainer-applied, never automatic. The full flow, its
+        human review gates, and honest expectations about what converges are described in
+        [docs/ISSUE_PIPELINE.md](https://github.com/microsoft/amplifier-bundle-attractor/blob/main/docs/ISSUE_PIPELINE.md).

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ cited as prior-art inspiration where useful.
 | [Routing Reference](docs/ROUTING-REFERENCE.md) | Edge selection algorithm, `report_outcome` tool, condition expressions, common pitfalls |
 | [App Integration Guide](docs/APP-INTEGRATION-GUIDE.md) | Using pipelines from Python applications (DirectProvider vs AmplifierSession) |
 | [Pipeline Design Principles](docs/PIPELINE_DESIGN_PRINCIPLES.md) | Six framework-agnostic design principles: tier discipline, validation patterns, loop convergence, LLM output protocols, parameterization, verdict-bearing nodes |
+| [Issue Pipeline](docs/ISSUE_PIPELINE.md) | What happens after a maintainer labels an issue `ready:spec` -- the autonomous specify/implement pipeline, its human review gates, and what makes a good defect report |
 
 ## Quick Start
 

--- a/docs/ISSUE_PIPELINE.md
+++ b/docs/ISSUE_PIPELINE.md
@@ -1,0 +1,75 @@
+# The Issue Pipeline: What Happens After You Label
+
+This repo runs an autonomous issue -> fix pipeline. A maintainer hands it a
+well-specified defect report; it hands back a machine-verified definition of done and,
+later, a proposed fix -- with a human review gate at every step. This page is what to
+expect after filing a [defect report](../.github/ISSUE_TEMPLATE/defect-report.yml).
+
+## The flow
+
+1. **A maintainer applies the `ready:spec` label.** The label is the deliberate human
+   trigger -- it is never applied automatically, because each run spends real compute.
+
+2. **The specify stage runs** (`.github/workflows/capsule-specify.yml`; measured runs
+   take roughly 20-40 minutes, budgeted up to several hours). It reads the issue,
+   investigates the pinned repository, and tries to produce a **work capsule**: a
+   definition-of-done document paired with an executable verification gate that is
+   proven RED-for-the-right-reason at the pinned base commit and proven non-vacuous
+   (crude hypothesis patches are shown to turn it green). The outcome, either way, is
+   posted as a comment on the issue:
+   - **A capsule PR** opens for human review. It contains *no implementation* --
+     merging it approves the definition of done, nothing more.
+   - **Or an honest refusal**: the gate is already green at the base commit, or no
+     non-vacuous gate could be proven within budget, or the run genuinely did not
+     converge -- each posted with its reasons (including a postmortem for
+     non-convergence), never silently.
+
+3. **A human reviews and merges the capsule PR.** The review focus, by design: read the
+   hypothesis patches -- if a deliberately crude patch would look like an acceptable
+   pass, the gate is too weak and the capsule should be tightened, not merged.
+
+4. **Merging the capsule PR auto-fires the implement stage**
+   (`.github/workflows/capsule-implement.yml`; typically 30-90+ minutes, budgeted up to
+   4 hours). A convergence-loop pipeline makes real code changes, verifies them against
+   the capsule's own gate, and subjects green work to independent LLM critique across
+   two model families. It ends in one of:
+   - **A fix PR**, opened non-draft for human review.
+   - **Or an honestly-titled work-in-progress PR** ("did not converge") salvaging the
+     committed work, with the judge's objections and the postmortem in the workflow
+     run's uploaded artifacts.
+
+## The human gates are features
+
+- Labeling is deliberate and maintainer-only -- the cost gate.
+- Capsule PRs and fix PRs are reviewed by a human. **The pipeline never merges its own
+  work** -- every PR it opens says so explicitly.
+
+## Honest expectations
+
+Issue quality determines convergence -- this is measured, not a guess. Well-specified
+defect reports (observable behavior, exact repro with real output quoted, expected vs.
+actual, pinned SHA, no fix prescriptions) converge. Vague reports, design questions,
+and feature requests produce honest non-convergence: a polite refusal with reasons,
+not a fix. Each run costs real compute, which is exactly why the label gate exists.
+
+## What makes a good report
+
+Use the [defect report form](../.github/ISSUE_TEMPLATE/defect-report.yml) -- it walks
+you through it. The measured essentials:
+
+- **Describe what the software DOES, not what the fix should be.** The pipeline
+  independently explores repair surfaces and verifies against behavior; a prescribed
+  fix biases and narrows its verification gate.
+- **Exact repro commands with the actual output quoted** -- the gate is built from
+  observable behavior, so a runnable reproduction is the strongest input.
+- **Expected vs. actual, stated plainly**, and the commit SHA you observed it on.
+- **Self-contained plain English** -- the pipeline reads the issue text, not your
+  browser tabs.
+
+## Provenance
+
+This system is measured, not aspirational: the pipeline's fixes for
+[#146](https://github.com/microsoft/amplifier-bundle-attractor/issues/146) (capsule PR
+#171 -> fix PR #175) and
+[#172](https://github.com/microsoft/amplifier-bundle-attractor/issues/172) (capsule PR
+#174 -> fix PR #182) shipped to `main` after human review.


### PR DESCRIPTION
## Summary

Going-live artifacts for the autonomous issue -> fix pipeline, ahead of opening it to people who aren't its authors. Two artifacts encoding one measured lesson — issue QUALITY determines convergence: (1) `.github/ISSUE_TEMPLATE/defect-report.yml`, an issue form that walks a non-author through filing a pipeline-ready defect report (observable behavior; exact repro with the actual output quoted; expected vs. actual; pinned SHA; explicitly NO fix prescriptions — the pipeline verifies against behavior, and a prescription narrows its verification gate), and (2) `docs/ISSUE_PIPELINE.md`, a one-page honest description of what happens after a maintainer applies `ready:spec` — the specify/implement flow, the human review gates stated as features, honest expectations (well-specified defects converge; vague reports and design questions get an honest non-convergence with reasons), and measured provenance (#146 -> capsule PR #171 -> fix PR #175; #172 -> capsule PR #174 -> fix PR #182, both merged after human review). The two artifacts reference each other: the form's closing note points at the doc; the doc points back at the form. The form auto-applies a new `defect-report` label (created); `ready:spec` stays maintainer-applied — the form says so explicitly. `config.yml` keeps blank issues enabled. README's Documentation table gains a one-line pointer.

Every behavioral claim in the doc is grounded in the two workflows (`.github/workflows/capsule-specify.yml`, `capsule-implement.yml`) and the pipeline's own comments on issues #146/#172 — timings are the workflows' own measured figures (specify ~20-40 min measured; implement 30-90+ min, 4h internal wall), outcome branches match the workflows' actual classify/comment steps, and "the pipeline never merges its own work" is quoted from the PR bodies the workflows generate.

## Verification checklist

- [x] Unit tests pass (`pytest modules/loop-pipeline/`) — full suite run exactly as CI does (`uv sync --extra remote`, provider keys unset): **1813 passed, 1 skipped**
- [x] Live pipeline run — N/A: no `engine.py`, handler, or any code change (docs + issue form + README row only)
- [x] AGENTS.md reviewed; repo-specific gates met — verification gradient row "Test fixtures, examples, docs -> Unit tests sufficient" applies
- [x] Backward-compat path unchanged — N/A: no code changed
- [x] No `specs/EXTENSIONS.md` entry needed: docs + issue-form only; no observable engine/dispatch/validation contract changes
- [x] PR body includes verification evidence, not just "tests pass"
- [x] CI is green — `gh pr checks 187` reports `CI Gate (all checks passed)  pass` (run 31441848770; all 31 checks pass). This PR is left unmerged for human review.

## Verification evidence

**Issue-form YAML parses and is schema-valid** (`yaml.safe_load` + field-type check):

```
config.yml: {'blank_issues_enabled': True}
form name: Defect report
labels: ['defect-report']
  body[0]: type=markdown
  body[1]: type=textarea id=what-happens required=True
  body[2]: type=textarea id=reproduction required=True
  body[3]: type=textarea id=expected required=True
  body[4]: type=input id=observed-on required=True
  body[5]: type=input id=affected-area required=False
  body[6]: type=markdown
ERRORS: none
```

**Leak scan** (`.github/capsule-pipeline/vendor/backlog/check-upstream-leaks.sh` over all three new files):

```
clean (no seeded pattern matched — silence proves nothing; run the membership test + human scan).
exit=0
```

**Unit tests** (`cd modules/loop-pipeline && uv sync --extra remote && env -u ANTHROPIC_API_KEY -u OPENAI_API_KEY -u GEMINI_API_KEY -u GOOGLE_API_KEY uv run pytest -q`):

```
1813 passed, 1 skipped, 3 warnings in 25.92s
```

`git diff --check` clean. `defect-report` label created:

```
defect-report	Pipeline-ready defect report (filed via the defect-report issue form)	#1D76DB
```

## Notes for reviewers

- The form deliberately does NOT auto-apply `ready:spec` — that label is the human cost gate and stays maintainer-applied; both the form's closing note and the doc say so.
- Timings in the doc come from the workflows' own header comments (measured ~20-40 min specify; 30-90+ min implement), not aspiration.
- The example output in the form's repro placeholder is issue #146's real lint output — the report that actually converged.
- GitHub only renders issue forms from the default branch, so the form is verifiable here as YAML but only becomes live UI after merge.