### PR TITLE
fix(examples): stop pipe-masking git log exit code in task-runner ship_check (CMD-001)

### DIFF
--- a/examples/patterns/task-runner.dot
+++ b/examples/patterns/task-runner.dot
@@ -179,7 +179,7 @@ digraph TaskRunner {
         prompt="Both gates passed. Prepare the work for handoff in $target_dir: ensure runner artifacts (.ai/) are excluded from version control via .git/info/exclude (do NOT commit them); create or reuse a branch named task/<task-id> (the id is in the task file's frontmatter at $task_file); commit all task changes with a clear conventional commit message stating WHAT changed and WHY (draw on .ai/brief.md and .ai/critique.md; include the standard Amplifier co-authored-by attribution); and write .ai/SHIPPED.md summarizing the goal, what shipped, where the evidence lives (.ai/verify.log, .ai/convergence.jsonl, run events), and anything a reviewer should know."]
 
     ship_check [shape=parallelogram, class="gate", max_retries=0,
-        tool_command="[ -z \"$(git status --porcelain | grep -v -E '^\\?\\? \\.ai')\" ] && git log --oneline -1 | grep -q . && printf shipped || printf dirty"]
+        tool_command="[ -z \"$(git status --porcelain | grep -v -E '^\\?\\? \\.ai')\" ] && git log --oneline -1 >/dev/null 2>&1 && printf shipped || printf dirty"]
 
     // ---------- budget exhaustion: a decision point, not a fuse ----------
     postmortem [shape=box, class="gate",


### PR DESCRIPTION
## Summary

`examples/patterns/task-runner.dot`'s `ship_check` gate piped `git log --oneline -1` into `grep -q .`: under `/bin/sh` a pipeline's exit status is the last stage's, so a wrapped command that fails while emitting output is masked and the gate can record `shipped` on a real failure (CMD-001). This replaces the pipe with the redirect idiom documented in `DOT-AUTHORING-GUIDE.md` (CMD-001): `git log --oneline -1 >/dev/null 2>&1`, which preserves git log's own exit code (non-zero on no-commits or any git failure) with identical routing semantics (`shipped`/`dirty` token, node always exits 0). One-line diff, limited to the fixed command.

Fixes #165

## Verification checklist

- [x] Unit tests pass (`pytest modules/loop-pipeline/`) — 1813 passed, 1 skipped (`uv run --extra remote pytest -q`)
- [x] Live pipeline run — N/A: example `.dot` only; no `engine.py`/handler code touched (AGENTS.md verification gradient: "Test fixtures, examples, docs | Unit tests sufficient.")
- [x] AGENTS.md reviewed; repo-specific gates met
- [x] Backward-compat path unchanged — routing semantics byte-identical for all normal inputs; only the failure-masking case changes (now honestly `dirty`)
- [x] No `specs/EXTENSIONS.md` entry needed — example command fix; no observable engine contract change
- [x] PR body includes verification evidence, not just "tests pass"
- [x] CI must be green before merge — this PR is NOT to be merged by its author's session; `CI Gate (all checks passed)` status reported on the PR

## Verification evidence

**Lint BEFORE (main @ faec8f2):**
```
$ attractor lint --strict examples/patterns/task-runner.dot
WARNING: [CMD-001] [ship_check] Tool node 'ship_check' tool_command ends in a pipe to 'grep' without pipefail: the gate's exit code is 'grep's (always 0 on success), not the real command's.  In /bin/sh a pipeline's exit status is the last stage's — so 'false | tail -1' exits 0.  The gate may record SUCCESS even when the wrapped command failed. ...
attractor lint: examples/patterns/task-runner.dot: 1 warning(s)
EXIT=1
```

**Lint AFTER (this branch):**
```
$ attractor lint --strict examples/patterns/task-runner.dot
attractor lint: examples/patterns/task-runner.dot: OK (no findings)
EXIT=0
```
No new findings introduced.

**Behavioral repro (extracted tool_command run under `/bin/sh` in a fresh git repo with one commit):**
```
=== normal case (clean tree, 1 commit) ===
before: shipped rc=0
after:  shipped rc=0
=== planted failure in the wrapped command (emits output, exits 1) ===
BEFORE shape: sh -c '[ -z "" ] && sh -c "echo deadbeef; exit 1" | grep -q . && printf shipped || printf dirty'
  -> shipped rc=0        (failure MASKED: gate records shipped)
AFTER shape:  sh -c '[ -z "" ] && sh -c "echo deadbeef; exit 1" >/dev/null 2>&1 && printf shipped || printf dirty'
  -> dirty rc=0          (failure preserved: gate routes to escalate)
=== dirty tree still detected after fix ===
after: dirty rc=0
```

## Notes for reviewers

- `git log --oneline -1 | grep -q .` asserted "at least one commit exists"; `git log --oneline -1 >/dev/null 2>&1` asserts the same thing via git log's own exit code (128 in an empty repo, 0 with ≥1 commit) — equivalent for routing, minus the mask.
- The pipe inside the `$(git status --porcelain | grep -v ...)` command substitution is intentionally untouched: its exit code is genuinely not consumed (only its output is), and CMD-001 explicitly excludes substitution-internal pipes for that reason.
