### PR TITLE
fix(examples): remove pipe-masked exit code from bug-fix verdict_gate (CMD-001)

### DIFF
--- a/examples/pipelines/practical/bug-fix.dot
+++ b/examples/pipelines/practical/bug-fix.dot
@@ -130,7 +130,7 @@ digraph BugFix {
     verdict_gate [
         shape=parallelogram,
         label="Ship?",
-        tool_command="grep -E '^VERDICT:' .ai/critique.md 2>/dev/null | tail -1 | grep -q 'SHIP' && printf ship || printf iterate"
+        tool_command="awk '/^VERDICT:/ { v = $0 } END { if (v ~ /SHIP/) exit 0; exit 1 }' .ai/critique.md 2>/dev/null && printf ship || printf iterate"
     ]
 
     // Feedback: distill the highest-leverage change for the next iteration.


### PR DESCRIPTION
## Summary

`examples/pipelines/practical/bug-fix.dot`'s `verdict_gate` read the critique verdict through `grep -E '^VERDICT:' .ai/critique.md | tail -1 | grep -q 'SHIP'`: under `/bin/sh` a pipeline's exit status is the last stage's, so a wrapped read that fails after emitting a SHIP-bearing line is masked and the gate can record the ship verdict on a failed read (CMD-001) — in the pipeline that exists to verify bug fixes. This replaces the three-stage pipeline with a single awk program that finds the last `^VERDICT:` line and tests it for `SHIP` itself: no pipe seam exists to mask, and the reader's own exit code governs. Routing semantics are identical for all normal inputs (last VERDICT line contains SHIP → `ship`, otherwise → `iterate`; missing/unreadable `critique.md` → `iterate`, exactly as before). One-line diff, limited to the fixed command.

Fresh, minimal fix per the issue note — no content resurrected from the closed capsule PR #167.

Fixes #166

## Verification checklist

- [x] Unit tests pass (`pytest modules/loop-pipeline/`) — 1813 passed, 1 skipped (`uv run --extra remote pytest -q`)
- [x] Live pipeline run — N/A: example `.dot` only; no `engine.py`/handler code touched (AGENTS.md verification gradient: "Test fixtures, examples, docs | Unit tests sufficient.")
- [x] AGENTS.md reviewed; repo-specific gates met
- [x] Backward-compat path unchanged — verdict routing byte-identical for all normal inputs (equivalence matrix below)
- [x] No `specs/EXTENSIONS.md` entry needed — example command fix; no observable engine contract change
- [x] PR body includes verification evidence, not just "tests pass"
- [x] CI must be green before merge — this PR is NOT to be merged by its author's session; `CI Gate (all checks passed)` status reported on the PR

## Verification evidence

**Lint BEFORE (main @ faec8f2):**
```
$ attractor lint --strict examples/pipelines/practical/bug-fix.dot
WARNING: [CMD-001] [verdict_gate] Tool node 'verdict_gate' tool_command ends in a pipe to 'grep' without pipefail: the gate's exit code is 'grep's (always 0 on success), not the real command's. ...
attractor lint: examples/pipelines/practical/bug-fix.dot: 1 warning(s)
EXIT=1
```

**Lint AFTER (this branch):**
```
$ attractor lint --strict examples/pipelines/practical/bug-fix.dot
attractor lint: examples/pipelines/practical/bug-fix.dot: OK (no findings)
EXIT=0
```
No new findings introduced.

**Planted-failure repro (under `/bin/sh`):**
```
BEFORE shape — wrapped read emits a SHIP line but FAILS (rc=2):
  sh -c 'sh -c "printf \"VERDICT: SHIP\n\"; exit 2" | tail -1 | grep -q "SHIP" && printf ship || printf iterate'
  -> ship rc=0        (failing read MASKED into a ship verdict)
AFTER shape — the reader is a single awk whose own exit code governs; no pipe seam exists to plant into:
  missing .ai/critique.md    -> iterate rc=0
  unreadable .ai/critique.md -> iterate rc=0   (awk exits 2; failure routes to iterate, the fail-safe branch)
```

**Equivalence matrix (before | after, same file contents):**
```
last VERDICT = "VERDICT: SHIP"     -> ship    | ship
last VERDICT = "VERDICT: ITERATE"  -> iterate | iterate
no VERDICT line                    -> iterate | iterate
```

## Notes for reviewers

- Why not the `cmd | ...; rc=$?` capture idiom: `rc` there is still the last pipe stage's exit code — it silences the lint without removing the mask (a read that fails after emitting SHIP still ships). The single-command awk removes the seam itself.
- `2>/dev/null` retained: a missing critique.md stays quiet and routes to `iterate`, as before.
- awk's `$0` is safe from the engine's context substitution (`substitution.py` replaces only known context keys / `${...}` forms).
