### PR TITLE
docs(contracts): replace stale line-number references with durable function anchors

### DIFF
--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -61,8 +61,8 @@ it is not consulted on per-node failure.)
 depend on missing inputs don't silently receive nothing — they don't run at all. Pipeline
 authors must explicitly opt in to any failure-routing behavior they want.
 
-**Reference:** `modules/loop-pipeline/amplifier_module_loop_pipeline/edge_selection.py`
-(lines 65–101; outcome-status guard at line 79).
+**Reference:** `modules/loop-pipeline/amplifier_module_loop_pipeline/edge_selection.py::select_edge`
+(the outcome-status guard is the `if outcome.status != StageStatus.FAIL:` check inside it).
 
 ### Explicit fail-forward opt-ins
 
@@ -79,13 +79,15 @@ Three mechanisms let pipeline authors override fail-fast for specific scenarios:
 `continue_on_fail=true` that fails has its outcome flipped FAIL→SUCCESS before edge
 selection; a downstream `runs_on=failure` node will NOT see that predecessor as failed
 (the failure was swallowed). Use `runs_on=always` on cleanup nodes that must fire after
-a `continue_on_fail` predecessor. See engine.py lines 582–596 for the canonical
+a `continue_on_fail` predecessor. See the `continue_on_fail and runs_on are NOT
+orthogonal` comment block in `engine.py::PipelineEngine.run` for the canonical
 explanation.
 
 **Reference:** `modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py`
-(lines 597–600 for the `continue_on_fail` check; lines 1332–1357 for `_get_runs_on` and
-1383–1481 for the skip-gate `_check_node_skip`). Also: `edge_selection.py` lines 65–78
-for the edge-level routing comment.
+(the `continue_on_fail` check in `engine.py::PipelineEngine.run`;
+`engine.py::PipelineEngine._get_runs_on`; and the skip-gate
+`engine.py::PipelineEngine._check_node_skip`). Also: the edge-level routing comment at
+the top of `edge_selection.py::select_edge`.
 
 ---
 
@@ -107,8 +109,8 @@ branches the engine dispatches simultaneously; any additional rate control is th
 provider module's responsibility.
 
 **Reference:**
-`modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/parallel.py` (lines 91–94,
-`ParallelHandler`). The former engine-level helper is documented in
+`modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/parallel.py::ParallelHandler.execute`
+(the `max_parallel` + semaphore setup). The former engine-level helper is documented in
 `engine.py` (T0-4 retirement comment near the old `_execute_parallel_fan_out` site).
 
 ---
@@ -160,9 +162,9 @@ event stream is a documented extension (EXTENSIONS.md §26).
 | Contract | File | Location |
 |---|---|---|
 | M5 substitution | `modules/loop-pipeline/amplifier_module_loop_pipeline/substitution.py` | Module docstring |
-| Fail-fast / edge selection | `modules/loop-pipeline/amplifier_module_loop_pipeline/edge_selection.py` | Lines 65–101 (`select_edge`) |
-| `continue_on_fail` override | `modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py` | Lines 593–596 and comment block at 578–592 |
-| `runs_on` logic | `modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py` | Lines 1299–1323 (`_get_runs_on`) and 1350–1447 (`_check_node_skip`) |
-| Structural concurrency (component) | `modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/parallel.py` | Lines 91–94 (`max_parallel` + semaphore) |
+| Fail-fast / edge selection | `modules/loop-pipeline/amplifier_module_loop_pipeline/edge_selection.py` | `select_edge` (includes the outcome-status guard) |
+| `continue_on_fail` override | `modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py` | `PipelineEngine.run` — the `continue_on_fail` check and its comment block |
+| `runs_on` logic | `modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py` | `PipelineEngine._get_runs_on` and `PipelineEngine._check_node_skip` |
+| Structural concurrency (component) | `modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/parallel.py` | `ParallelHandler.execute` (`max_parallel` + semaphore setup) |
 | Worker observability seam | `modules/loop-pipeline/amplifier_module_loop_pipeline/worker_observability.py` | Module docstring (`current_worker_sessions_dir`) |
 | Session-event persistence | `modules/hooks-pipeline-observability/amplifier_module_hooks_pipeline_observability/session_events.py` | `SessionEventPersister` |


### PR DESCRIPTION
## Summary

`docs/CONTRACTS.md` pointed at `engine.py` / `edge_selection.py` by line number, and those numbers go stale on every merge — issue #145 reports the "Fail-Fast Policy" pointers landing in unrelated code (the cited `continue_on_fail` lines are inside the timeout-handling block; the cited `edge_selection.py` guard line is blank). **The ruling (binding): fix structurally** — this PR replaces every line-number reference with durable function/section anchors in the `engine.py::function_name` style the doc already uses elsewhere (the Code Reference Index rows for worker observability and session-event persistence), not re-pinned line numbers.

Fixes #145

## Verification checklist

- [x] Unit tests pass (`pytest modules/loop-pipeline/`) — 1813 passed, 1 skipped (`uv run --extra remote pytest -q`), including `test_engine_semantics_doc_guard.py` + `test_doc_consistency.py` (11 passed)
- [x] Live pipeline run — N/A: docs-only change (AGENTS.md verification gradient: "Test fixtures, examples, docs | Unit tests sufficient.")
- [x] AGENTS.md reviewed; repo-specific gates met
- [x] Backward-compat path unchanged — N/A: no code touched
- [x] No `specs/EXTENSIONS.md` entry needed — documentation reference-style fix; no observable contract change
- [x] PR body includes verification evidence, not just "tests pass"
- [x] CI must be green before merge — this PR is NOT to be merged by its author's session; `CI Gate (all checks passed)` status reported on the PR

## Verification evidence

**Every anchor written resolves at current main (`faec8f2`), verified by grep:**
```
$ grep -n "^def select_edge" modules/loop-pipeline/amplifier_module_loop_pipeline/edge_selection.py
28:def select_edge(
$ grep -n "if outcome.status != StageStatus.FAIL:" modules/loop-pipeline/amplifier_module_loop_pipeline/edge_selection.py
94:    if outcome.status != StageStatus.FAIL:
$ grep -n "^class PipelineEngine" modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py
98:class PipelineEngine:
$ grep -n "    async def run(self" modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py
230:    async def run(self, goal: str | None = None) -> Outcome:
$ grep -n "continue_on_fail and runs_on are NOT orthogonal" modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py
669:            # NOTE — continue_on_fail and runs_on are NOT orthogonal:
$ grep -n "    def _get_runs_on" modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py
1585:    def _get_runs_on(self, node: Node) -> str:
$ grep -n "    async def _check_node_skip" modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py
1636:    async def _check_node_skip(self, node: Node) -> Outcome | None:
$ grep -n "^class ParallelHandler\|    async def execute" modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/parallel.py
35:class ParallelHandler:
58:    async def execute(
```
(`engine.py` has exactly one class, so the `PipelineEngine.*` anchors are unambiguous.)

**Zero numeric line references remain anywhere in the doc:**
```
$ grep -nEi "lines? [0-9]" docs/CONTRACTS.md
(no output, exit 1)
```
None were judged load-bearing — every one was a code pointer of exactly the class that drifts.

**Doc-guard coverage check (as requested by the directing issue triage):**
```
$ grep -rn "CONTRACTS" modules/loop-pipeline/tests/ modules/pipeline-runner/tests/ tests/
(no output)
$ uv run pytest -q tests/test_engine_semantics_doc_guard.py tests/test_doc_consistency.py
11 passed in 0.13s
```
`test_engine_semantics_doc_guard.py` guards `context/engine-semantics.md` claims; **no existing doc-guard test covers `docs/CONTRACTS.md`** — see follow-up note below.

## Notes for reviewers

- Scope note: the one `handlers/parallel.py` line-number reference (also stale: it pointed at lines 91–94; `max_parallel` + semaphore setup is now at 94–97 inside `ParallelHandler.execute`) was converted alongside the two named files — same disease, same doc, same structural remedy.
- **Follow-up candidate (not built here):** a doc-guard test asserting that every `file.py::name` anchor in `docs/CONTRACTS.md` resolves (named function/class exists in the named file) would prevent the anchor-flavored version of this drift. No current guard covers CONTRACTS.md at all.
