### PR TITLE
feat(lint): flag failure outcomes routed into the terminal success node (TOPO-006)

### DIFF
--- a/docs/DOT-AUTHORING-GUIDE.md
+++ b/docs/DOT-AUTHORING-GUIDE.md
@@ -1323,6 +1323,84 @@ for a separate non-compliant loop.
 
 ---
 
+### TOPO-006 — Failure outcome routed into the terminal success node
+
+**What it detects:** A failure-conditioned edge (`outcome=fail`,
+`outcome=error`, `outcome!=success`) routed into the exit node — directly, or
+through a silent pass-through path.  Two forms:
+
+1. **Direct:** `verify -> done [condition="outcome=fail"]`.  The failure
+   leaves through the pipeline's success door: no corrective loop, no retry,
+   no distinct failure terminal.  Always flagged — there is no intermediary
+   to mark.
+2. **Indirect:** the failure edge's receiving path reaches the exit with
+   every hop unconditional and no re-gating in between, through at least one
+   *unmarked* intermediary (default `runs_on`, only unconditional outgoing
+   edges).
+
+**Why it matters:** This is the graph-topology sibling of the CMD-001/CMD-002
+hazard class — a gate whose failure is structurally converted into a
+completed, green-looking run — and the "silent-success exit" incident class.
+The indirect form is the sharper hazard: add ONE succeeding bookkeeping step
+between the failed gate and `done` (a recorder, a notifier, a cleanup) and
+the run's final status comes from that step, not from the failed gate —
+`status: success`, exit code 0, hours of work silently lost.
+
+**What is NOT flagged** (grounded in the engine's own failure-routing
+semantics — `engine.py::_get_runs_on` and `edge_selection.py::select_edge`):
+
+- **A marked handled-failure path.**  `runs_on` normalizes to `"always"`,
+  `"failure"`, or the default `"success"` (anything else normalizes to
+  `"success"` — `_get_runs_on`).  On a FAIL outcome, plain edges are followed
+  ONLY to targets whose `runs_on` is `always` or `failure`; default targets
+  are not reached — the documented fail-fast behavior (`select_edge`).
+  `runs_on` is therefore the engine's first-class failure-routing opt-in: a
+  failure route in which **every** intermediary carries `runs_on="always"` or
+  `runs_on="failure"` is a deliberately declared handled-failure termination
+  and stays silent:
+
+  ```dot
+  verify -> record_failure [condition="outcome=fail"]
+  record_failure -> done
+  record_failure [shape=parallelogram, tool_command="echo recorded", runs_on=always]
+  ```
+
+- **A re-gating intermediary.**  A node with at least one condition-bearing
+  outgoing edge makes a fresh routing decision (retry-vs-escalate and the
+  like) — corrective routing, not a silent pass-through.
+
+- **A human-gate intermediary.**  A `hexagon` (`wait.human`) node on the
+  failure path is external human judgment — the failure cannot exit green
+  without a human seeing it (the TOPO-004/TOPO-005 human-gate precedent).
+
+**Severity:** WARNING — joins the CMD-001/CMD-002 family: the hazard is real
+but intent is not statically provable, and deliberate finish-through-`done`
+designs exist (e.g. a budget-exhaustion exit that deliberately ends at the
+single exit node with a genuine FAIL outcome, as in
+`examples/patterns/convergence-factory.dot`, which consciously carries this
+diagnostic).  ERROR would hard-fail such graphs via `validate_or_raise`.
+
+**Fix:** Route the failure to a corrective target with a back-edge to retry:
+
+```dot
+// WRONG — failure exits through the success door
+verify -> done [condition="outcome=success"]
+verify -> done [condition="outcome=fail"]
+
+// CORRECT — failure routes to a corrective loop
+verify -> done [condition="outcome=success"]
+verify -> fix  [condition="outcome=fail"]
+fix -> verify
+```
+
+Or, if finishing after a handled failure is deliberate, declare it: mark
+every intermediary on the path with `runs_on="always"` or
+`runs_on="failure"`, or re-gate the flow with a condition-bearing edge on an
+intermediary.  The diagnostic names the failure-conditioned edge, its source
+node, and (for the indirect form) the pass-through path.
+
+---
+
 ### CMD-001 — Pipe-masked exit code
 
 **What it detects:** A `parallelogram` (tool) node whose `tool_command` ends
@@ -1370,7 +1448,7 @@ If you need to see the last N lines, write to a file and read it separately
 from the routing logic.
 
 **Severity:** WARNING — consistent with the WARNING-severity TOPO rules
-(TOPO-002 through TOPO-005; note TOPO-001 is `ERROR`, not this family's
+(TOPO-002 through TOPO-006; note TOPO-001 is `ERROR`, not this family's
 default).  The hazard is real but static analysis cannot prove the command is
 a meaningful gate; conservative analysis may miss complex cases.
 
@@ -1432,7 +1510,7 @@ influence either the exit code or the emitted token?  The hazard shapes
 destroy that influence.  The honest idioms preserve it.
 
 **Severity:** WARNING — consistent with CMD-001 and the WARNING-severity TOPO
-rules (TOPO-002 through TOPO-005; TOPO-001 is `ERROR`).
+rules (TOPO-002 through TOPO-006; TOPO-001 is `ERROR`).
 
 **What this rule does NOT catch:** sentinels inside `$(...)` substitutions,
 sentinels after non-pipe-masked commands (where `&& echo TOKEN` is the honest

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/validation.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/validation.py
@@ -4,7 +4,7 @@ Validates parsed Graph models against the rules defined in
 spec Section 7 (Validation and Linting). Produces Diagnostic objects
 with severity ERROR (blocks execution) or WARNING (informational).
 
-Spec coverage: LINT-001–018.  TOPO-001–005 are topological basin-lint rules
+Spec coverage: LINT-001–018.  TOPO-001–006 are topological basin-lint rules
 implemented here beyond the canonical spec; they are lint-only (exposed via
 ``lint()``, not ``validate()``) and do not change run-time behaviour.
 
@@ -116,8 +116,8 @@ def lint(graph: Graph) -> list[Diagnostic]:
     """Run topological (basin-lint) and command-content rules in addition to structural rules.
 
     This is the entry point for the ``attractor lint`` CLI command.  It runs
-    the full structural ``validate()`` suite plus the five topological rules
-    (TOPO-001–005) that reason about cycle structure, handler semantics, and
+    the full structural ``validate()`` suite plus the six topological rules
+    (TOPO-001–006) that reason about cycle structure, handler semantics, and
     evidence-routing patterns, plus the two command-content rules (CMD-001–002)
     that inspect ``tool_command`` strings for hazard shapes.
 
@@ -137,6 +137,7 @@ def lint(graph: Graph) -> list[Diagnostic]:
     _check_acyclic_graph(graph, diags)
     _check_cycle_no_conditional_exit(graph, diags)
     _check_cycle_no_deterministic_exit(graph, diags)
+    _check_fail_routed_to_exit(graph, diags)
     _check_pipe_masked_exit_code(graph, diags)
     _check_always_true_sentinel(graph, diags)
     return diags
@@ -724,7 +725,7 @@ def _check_response_schema(graph: Graph, diags: list[Diagnostic]) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Topological (basin-lint) rules — TOPO-001 through TOPO-005
+# Topological (basin-lint) rules — TOPO-001 through TOPO-006
 #
 # These rules reason about cycle structure and handler semantics, not just
 # graph topology.  They are exposed via ``lint()`` (not ``validate()``) so
@@ -1345,6 +1346,257 @@ def _check_cycle_no_deterministic_exit(graph: Graph, diags: list[Diagnostic]) ->
                 ),
             )
         )
+
+
+def _node_runs_on(node: Node | None) -> str:
+    """Static mirror of ``engine.py::PipelineEngine._get_runs_on``.
+
+    The engine normalizes the ``runs_on`` node attribute to exactly one of
+    ``"success"`` (default), ``"always"``, or ``"failure"``; any other value
+    normalizes to the default ``"success"``.  Lint applies the identical
+    normalization so that an unrecognized marker (e.g. ``runs_on=sometimes``)
+    is treated as unmarked, exactly as the engine will treat it at run time.
+    """
+    if node is None:
+        return "success"
+    raw = node.attrs.get("runs_on", "success") or "success"
+    val = str(raw).strip().lower()
+    if val in ("always", "failure"):
+        return val
+    return "success"
+
+
+def _condition_matches_fail(cond: str) -> bool:
+    """Return True if a condition expression matches a FAIL outcome.
+
+    A clause of the form ``outcome=fail``, ``outcome=error``, or
+    ``outcome!=success`` makes the edge failure-conditioned.  Mirrors the
+    clause patterns recognized by TOPO-001 (``_check_dead_conditional_edge``).
+    """
+    for key, op, val in parse_condition(cond):
+        if key == "outcome" and (
+            (op == "=" and val in ("fail", "error"))
+            or (op == "!=" and val == "success")
+        ):
+            return True
+    return False
+
+
+def _node_regates(graph: Graph, node_id: str) -> bool:
+    """Return True if the node re-gates the flow.
+
+    A node with at least one condition-bearing outgoing edge makes a fresh
+    routing decision (retry-vs-escalate and the like) — flow through it is
+    corrective routing, not a silent pass-through.
+
+    A human-gate (hexagon / wait.human) node also re-gates: routing beyond
+    it passes through external human judgment, so a failure cannot exit the
+    pipeline green without a human seeing it.  This follows the TOPO-004/
+    TOPO-005 precedent (a labeled human-gate exit is an explicit gate; a
+    human gate on a cycle is a real gate) — warning on a failure route that
+    a human explicitly adjudicates would be a false positive that trains
+    authors to ignore the rule.
+    """
+    node = graph.nodes.get(node_id)
+    if node is not None and _is_human_gate(node):
+        return True
+    return any(
+        e.condition and e.condition.strip() for e in graph.outgoing_edges(node_id)
+    )
+
+
+def _unmarked_passthrough_path_to_exit(
+    graph: Graph, start_id: str, exit_ids: set[str]
+) -> list[str] | None:
+    """Find a silent pass-through path from ``start_id`` to an exit node.
+
+    Returns a node-ID path ``[start_id, ..., exit_id]`` such that:
+
+    - every hop is an unconditional (plain) edge,
+    - no node on the path re-gates the flow (``_node_regates``), and
+    - at least one intermediary on the path is UNMARKED — its ``runs_on``
+      normalizes to the default ``"success"`` (``_node_runs_on``).
+
+    Returns ``None`` when no such path exists: either the exit is not
+    reachable through pass-through intermediaries, or every reaching path
+    has all intermediaries marked ``runs_on="always"``/``"failure"`` (a
+    deliberately declared handled-failure termination — issue #173
+    Ruling 2).
+
+    BFS over ``(node, has_unmarked)`` states so a node may be revisited when
+    a later path reaches it with a different marked/unmarked prefix.
+    """
+    if start_id not in graph.nodes:
+        return None
+
+    start_unmarked = _node_runs_on(graph.nodes.get(start_id)) == "success"
+    queue: deque[tuple[str, bool, list[str]]] = deque(
+        [(start_id, start_unmarked, [start_id])]
+    )
+    seen: set[tuple[str, bool]] = {(start_id, start_unmarked)}
+
+    while queue:
+        node_id, has_unmarked, path = queue.popleft()
+        if _node_regates(graph, node_id):
+            # Re-gating intermediary: corrective routing — stop this branch.
+            continue
+        for edge in graph.outgoing_edges(node_id):
+            if edge.condition and edge.condition.strip():
+                continue  # unreachable given the re-gate check; kept for clarity
+            if edge.to_node in exit_ids:
+                if has_unmarked:
+                    return path + [edge.to_node]
+                continue  # all-marked path to exit: deliberate; keep searching
+            if edge.to_node not in graph.nodes:
+                continue
+            next_unmarked = (
+                has_unmarked
+                or _node_runs_on(graph.nodes.get(edge.to_node)) == "success"
+            )
+            state = (edge.to_node, next_unmarked)
+            if state not in seen:
+                seen.add(state)
+                queue.append((edge.to_node, next_unmarked, path + [edge.to_node]))
+    return None
+
+
+def _check_fail_routed_to_exit(graph: Graph, diags: list[Diagnostic]) -> None:
+    """TOPO-006: A failure outcome routed into the terminal success node.
+
+    An edge whose condition matches a FAIL outcome (``outcome=fail``,
+    ``outcome=error``, ``outcome!=success``) that targets the exit node —
+    or whose receiving path reaches the exit with every hop unconditional
+    and no re-gating in between — structurally converts a failed gate into
+    a completed, green-looking run.  This is the graph-topology sibling of
+    the CMD-001/CMD-002 hazard class (a gate whose failure is converted into
+    success) and the "silent-success exit" incident class: a pipeline runs
+    for hours, its verification gate fails, a bookkeeping step succeeds
+    afterward, and the run exits 0 reporting success.
+
+    Two forms are detected (issue #173, Ruling 1):
+
+    - **Direct:** the failure-conditioned edge targets the exit node.
+      Always flagged — there is no intermediary to mark.
+    - **Indirect:** the failure-conditioned edge's receiving path reaches
+      the exit through silent pass-through intermediaries — every hop
+      unconditional, no node re-gating the flow, and at least one
+      intermediary unmarked.
+
+    The exception (issue #173, Ruling 2), grounded in the engine's own
+    semantics:
+
+    - ``engine.py::_get_runs_on``: a node's ``runs_on`` attribute
+      normalizes to ``"always"``, ``"failure"``, or the default
+      ``"success"`` (any other value normalizes to ``"success"``).
+    - ``edge_selection.py::select_edge``: on a FAIL outcome, plain
+      (unconditional) edges are followed ONLY to targets whose ``runs_on``
+      is ``always`` or ``failure``; default ``runs_on=success`` targets are
+      not reached — the documented fail-fast behavior.  ``runs_on`` is
+      therefore the engine's first-class failure-routing opt-in.
+
+    A failure route in which EVERY intermediary between the failure edge
+    and the exit carries ``runs_on="always"`` or ``runs_on="failure"`` is a
+    deliberately declared handled-failure termination (e.g. a
+    ``runs_on=always`` recorder before ``done``) and is NOT flagged.
+    Likewise, an intermediary with at least one condition-bearing outgoing
+    edge re-gates the flow (retry-vs-escalate routing) — corrective
+    routing, not flagged.  A human-gate (hexagon / wait.human) intermediary
+    likewise re-gates — external human judgment on the failure path, per
+    the TOPO-004/TOPO-005 human-gate precedent.  An UNMARKED pass-through
+    intermediary (default
+    ``runs_on``, only unconditional outgoing edges, exit reachable) is
+    exactly the accident class this rule catches: flagged.
+
+    The rule fires regardless of the source node's shape.  On a diamond
+    source, TOPO-001 (ERROR — the edge is provably dead) additionally
+    fires and takes precedence; this rule still reports the declared
+    routing intent.
+
+    Severity: WARNING (issue #173, Ruling 3) — joins the CMD-001/CMD-002
+    family: the hazard is real but intent is not statically provable,
+    deliberate finish-through-done designs exist, and ERROR would hard-fail
+    deliberate graphs via ``validate_or_raise``.  The ``runs_on`` opt-in
+    gives authors a first-class way to declare intent and silence the
+    diagnostic entirely.
+    """
+    exit_ids = {n.id for n in graph.nodes.values() if n.is_exit_node()}
+    if not exit_ids:
+        return
+
+    for node in graph.nodes.values():
+        if node.is_exit_node():
+            continue
+        for edge in graph.outgoing_edges(node.id):
+            cond = edge.condition.strip() if edge.condition else ""
+            if not cond or not _condition_matches_fail(cond):
+                continue
+
+            if edge.to_node in exit_ids:
+                # Direct form: failure-conditioned edge targeting the exit.
+                diags.append(
+                    Diagnostic(
+                        rule="fail_routed_to_exit",
+                        severity="WARNING",
+                        message=(
+                            f"Node '{node.id}' routes a failure outcome "
+                            f"directly into the terminal success node: edge to "
+                            f"'{edge.to_node}' with condition '{cond}'. The "
+                            f"failure leaves through the pipeline's success "
+                            f"door — no corrective loop, no retry, no distinct "
+                            f"failure terminal."
+                        ),
+                        node_id=node.id,
+                        edge=(edge.from_node, edge.to_node),
+                        fix=(
+                            f"Route the failure to a corrective target instead "
+                            f"(e.g. '{node.id}' -> fix "
+                            f'[condition="outcome=fail"] with a back-edge to '
+                            f"retry), or — if finishing after a handled failure "
+                            f"is deliberate — route it through a "
+                            f"recorder/cleanup node marked "
+                            f'runs_on="always" or runs_on="failure" so the '
+                            f"intent is declared. See DOT-AUTHORING-GUIDE.md "
+                            f"(TOPO-006)."
+                        ),
+                    )
+                )
+                continue
+
+            path = _unmarked_passthrough_path_to_exit(graph, edge.to_node, exit_ids)
+            if path is not None:
+                path_str = " -> ".join(path)
+                diags.append(
+                    Diagnostic(
+                        rule="fail_routed_to_exit",
+                        severity="WARNING",
+                        message=(
+                            f"Node '{node.id}' routes a failure outcome into "
+                            f"the terminal success node via an unmarked "
+                            f"pass-through path: edge to '{edge.to_node}' with "
+                            f"condition '{cond}', then {path_str} — every hop "
+                            f"is unconditional, no node re-gates the flow, and "
+                            f"at least one intermediary lacks "
+                            f'runs_on="always"/"failure". A failed gate '
+                            f"followed by one succeeding step exits the "
+                            f"pipeline green (status success, exit code 0) — "
+                            f"the silent-success exit incident class."
+                        ),
+                        node_id=node.id,
+                        edge=(edge.from_node, edge.to_node),
+                        fix=(
+                            f"Either route the failure to a corrective target "
+                            f"with a back-edge to retry, add a "
+                            f"condition-bearing edge on an intermediary so the "
+                            f"flow is re-gated, or — if this handled-failure "
+                            f"termination is deliberate — mark every "
+                            f"intermediary on the path ({path_str}) with "
+                            f'runs_on="always" or runs_on="failure" (the '
+                            f"engine's failure-routing opt-in) so the intent "
+                            f"is declared. See DOT-AUTHORING-GUIDE.md "
+                            f"(TOPO-006)."
+                        ),
+                    )
+                )
 
 
 # ---------------------------------------------------------------------------

--- a/modules/loop-pipeline/tests/test_topological_lint.py
+++ b/modules/loop-pipeline/tests/test_topological_lint.py
@@ -1,4 +1,4 @@
-"""Tests for topological (basin-lint) rules — TOPO-001 through TOPO-005.
+"""Tests for topological (basin-lint) rules — TOPO-001 through TOPO-006.
 
 These rules reason about cycle structure and handler semantics, not just
 graph topology.  They are exposed via ``lint()`` (not ``validate()``) so
@@ -1017,3 +1017,319 @@ class TestDeadDiamondRegressions:
         dead = _diag(diags, "dead_conditional_edge")
         assert dead
         assert any(d.node_id == "test_gate" for d in dead)
+
+
+# ---------------------------------------------------------------------------
+# TOPO-006: fail_routed_to_exit
+# ---------------------------------------------------------------------------
+
+
+def _tool_with_runs_on(node_id: str, runs_on: str | None = None) -> Node:
+    attrs = {"tool_command": "echo ok"}
+    if runs_on is not None:
+        attrs["runs_on"] = runs_on
+    return Node(id=node_id, shape="parallelogram", attrs=attrs)
+
+
+class TestFailRoutedToExit:
+    """TOPO-006: a failure outcome routed into the terminal success node.
+
+    Issue #173.  The isolated-probe structure required by the maintainer
+    ruling: hazard graphs assert the diagnostic fires AND names the
+    failure-conditioned edge + source node; marked/corrective graphs assert
+    no fail_routed_to_exit diagnostic appears at all.
+    """
+
+    # -- direct form ---------------------------------------------------------
+
+    def test_direct_fail_to_done_flagged(self):
+        """Hazard probe: verify -> done [outcome=fail] fires, names edge+source."""
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "build": _tool("build"),
+                "verify": _tool("verify"),
+                "done": _msquare("done"),
+            },
+            edges=[
+                Edge("start", "build"),
+                Edge("build", "verify"),
+                Edge("verify", "done", condition="outcome=success"),
+                Edge("verify", "done", condition="outcome=fail"),
+            ],
+        )
+        diags = _diag(lint(g), "fail_routed_to_exit")
+        assert diags, "Expected fail_routed_to_exit diagnostic"
+        assert all(d.severity == "WARNING" for d in diags)
+        d = diags[0]
+        assert d.node_id == "verify"
+        assert d.edge == ("verify", "done")
+        assert "verify" in d.message and "done" in d.message
+        assert "outcome=fail" in d.message
+
+    def test_direct_fires_on_llm_source(self):
+        """Ruling 1: fires regardless of source shape — box (LLM) source."""
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "judge": _box("judge", prompt="judge it"),
+                "done": _msquare("done"),
+            },
+            edges=[
+                Edge("start", "judge"),
+                Edge("judge", "done", condition="outcome=success"),
+                Edge("judge", "done", condition="outcome=fail"),
+            ],
+        )
+        diags = _diag(lint(g), "fail_routed_to_exit")
+        assert diags and diags[0].node_id == "judge"
+
+    def test_direct_outcome_not_success_flagged(self):
+        """outcome!=success targeting the exit is a failure-conditioned edge."""
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "verify": _tool("verify"),
+                "done": _msquare("done"),
+            },
+            edges=[
+                Edge("start", "verify"),
+                Edge("verify", "done", condition="outcome=success"),
+                Edge("verify", "done", condition="outcome!=success"),
+            ],
+        )
+        assert _diag(lint(g), "fail_routed_to_exit")
+
+    def test_success_edge_to_exit_not_flagged(self):
+        """No false positive: the normal success exit edge stays silent."""
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "work": _tool("work"),
+                "verify": _tool("verify"),
+                "done": _msquare("done"),
+            },
+            edges=[
+                Edge("start", "work"),
+                Edge("work", "verify"),
+                Edge("verify", "done", condition="outcome=success"),
+                Edge("verify", "work", condition="outcome=fail"),
+            ],
+        )
+        assert not _diag(lint(g), "fail_routed_to_exit")
+
+    # -- indirect form (required, not stretch) -------------------------------
+
+    def _recorder_graph(self, recorder_runs_on: str | None) -> Graph:
+        """The issue's own runtime demonstration: fail -> recorder -> done."""
+        return _graph(
+            nodes={
+                "start": _mdiamond(),
+                "verify": _tool("verify"),
+                "record_failure": _tool_with_runs_on(
+                    "record_failure", recorder_runs_on
+                ),
+                "done": _msquare("done"),
+            },
+            edges=[
+                Edge("start", "verify"),
+                Edge("verify", "done", condition="outcome=success"),
+                Edge("verify", "record_failure", condition="outcome=fail"),
+                Edge("record_failure", "done"),
+            ],
+        )
+
+    def test_indirect_unmarked_passthrough_flagged(self):
+        """Hazard probe: unmarked recorder before done — the sharper hazard
+        (failed gate, status success, exit 0)."""
+        g = self._recorder_graph(recorder_runs_on=None)
+        diags = _diag(lint(g), "fail_routed_to_exit")
+        assert diags, "Expected fail_routed_to_exit on unmarked pass-through"
+        d = diags[0]
+        assert d.node_id == "verify"
+        assert d.edge == ("verify", "record_failure")
+        # Encouraged by the ruling: the pass-through path is named.
+        assert "record_failure" in d.message and "done" in d.message
+
+    def test_indirect_runs_on_always_not_flagged(self):
+        """Ruling 2 probe: runs_on=always recorder is a deliberately declared
+        handled-failure termination — MUST NOT be flagged."""
+        g = self._recorder_graph(recorder_runs_on="always")
+        assert not _diag(lint(g), "fail_routed_to_exit")
+
+    def test_indirect_runs_on_failure_not_flagged(self):
+        """Ruling 2 probe: runs_on=failure intermediary — MUST NOT be flagged."""
+        g = self._recorder_graph(recorder_runs_on="failure")
+        assert not _diag(lint(g), "fail_routed_to_exit")
+
+    def test_indirect_unrecognized_runs_on_flagged(self):
+        """engine.py::_get_runs_on normalizes anything but always/failure to
+        the default 'success' — an unrecognized marker is unmarked."""
+        g = self._recorder_graph(recorder_runs_on="sometimes")
+        assert _diag(lint(g), "fail_routed_to_exit")
+
+    def test_indirect_regating_intermediary_not_flagged(self):
+        """An intermediary with a condition-bearing outgoing edge re-gates the
+        flow (retry-vs-escalate routing) — corrective, not flagged."""
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "work": _box("work", prompt="do it"),
+                "verify": _tool("verify"),
+                "triage": _tool("triage"),
+                "done": _msquare("done"),
+            },
+            edges=[
+                Edge("start", "work"),
+                Edge("work", "verify"),
+                Edge("verify", "done", condition="outcome=success"),
+                Edge("verify", "triage", condition="outcome=fail"),
+                Edge("triage", "work", condition="context.tool.last_line=retry"),
+                Edge("triage", "done"),
+            ],
+        )
+        assert not _diag(lint(g), "fail_routed_to_exit")
+
+    def test_indirect_multihop_one_unmarked_flagged(self):
+        """Multi-hop path with one unmarked intermediary among marked ones
+        is still the accident class — flagged."""
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "verify": _tool("verify"),
+                "cleanup": _tool_with_runs_on("cleanup", "always"),
+                "notify": _tool_with_runs_on("notify", None),  # unmarked
+                "done": _msquare("done"),
+            },
+            edges=[
+                Edge("start", "verify"),
+                Edge("verify", "done", condition="outcome=success"),
+                Edge("verify", "cleanup", condition="outcome=fail"),
+                Edge("cleanup", "notify"),
+                Edge("notify", "done"),
+            ],
+        )
+        diags = _diag(lint(g), "fail_routed_to_exit")
+        assert diags and diags[0].edge == ("verify", "cleanup")
+
+    def test_indirect_multihop_all_marked_not_flagged(self):
+        """Every intermediary marked runs_on=always/failure — deliberate."""
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "verify": _tool("verify"),
+                "cleanup": _tool_with_runs_on("cleanup", "always"),
+                "notify": _tool_with_runs_on("notify", "failure"),
+                "done": _msquare("done"),
+            },
+            edges=[
+                Edge("start", "verify"),
+                Edge("verify", "done", condition="outcome=success"),
+                Edge("verify", "cleanup", condition="outcome=fail"),
+                Edge("cleanup", "notify"),
+                Edge("notify", "done"),
+            ],
+        )
+        assert not _diag(lint(g), "fail_routed_to_exit")
+
+    def test_indirect_no_path_to_exit_not_flagged(self):
+        """Failure routed to a corrective back-edge target (never reaches the
+        exit unconditionally) — the healthy pattern, not flagged."""
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "work": _box("work", prompt="do it"),
+                "verify": _tool("verify"),
+                "fix": _box("fix", prompt="fix it"),
+                "done": _msquare("done"),
+            },
+            edges=[
+                Edge("start", "work"),
+                Edge("work", "verify"),
+                Edge("verify", "done", condition="outcome=success"),
+                Edge("verify", "fix", condition="outcome=fail"),
+                Edge("fix", "verify"),
+            ],
+        )
+        assert not _diag(lint(g), "fail_routed_to_exit")
+
+    def test_indirect_mixed_paths_flagged(self):
+        """A marked path AND an unmarked path both exist from the receiving
+        node — the unmarked pass-through path is the hazard, flagged."""
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "verify": _tool("verify"),
+                "recorder": _tool_with_runs_on("recorder", None),  # unmarked
+                "done": _msquare("done"),
+            },
+            edges=[
+                Edge("start", "verify"),
+                Edge("verify", "done", condition="outcome=success"),
+                Edge("verify", "recorder", condition="outcome=fail"),
+                Edge("recorder", "done"),
+            ],
+        )
+        assert _diag(lint(g), "fail_routed_to_exit")
+
+    # -- DOT-text isolated probes (issue #173's own fixtures) -----------------
+
+    def test_issue_repro_dot_fires(self):
+        """The issue's fail_to_done.dot repro, via the real DOT parser."""
+        from amplifier_module_loop_pipeline.dot_parser import parse_dot
+
+        dot = """
+        digraph fail_to_done {
+            graph [goal="Implement the change and verify it"]
+            start  [shape=Mdiamond]
+            build  [shape=parallelogram, tool_command="echo built"]
+            verify [shape=parallelogram, tool_command="./run_verify.sh"]
+            done   [shape=Msquare]
+            start -> build -> verify
+            verify -> done [condition="outcome=success"]
+            verify -> done [condition="outcome=fail"]
+        }
+        """
+        diags = _diag(lint(parse_dot(dot)), "fail_routed_to_exit")
+        assert diags, "Expected fail_routed_to_exit on the issue repro"
+        assert diags[0].node_id == "verify"
+        assert diags[0].edge == ("verify", "done")
+
+    def test_issue_legit_recorder_dot_silent(self):
+        """The issue's legitimate runs_on=always recorder variant stays silent."""
+        from amplifier_module_loop_pipeline.dot_parser import parse_dot
+
+        dot = """
+        digraph handled_failure {
+            graph [goal="Implement the change and verify it"]
+            start  [shape=Mdiamond]
+            build  [shape=parallelogram, tool_command="echo built"]
+            verify [shape=parallelogram, tool_command="./run_verify.sh"]
+            record_failure [shape=parallelogram, tool_command="echo recorded the failure", runs_on=always]
+            done   [shape=Msquare]
+            start -> build -> verify
+            verify -> done [condition="outcome=success"]
+            verify -> record_failure [condition="outcome=fail"]
+            record_failure -> done
+        }
+        """
+        assert not _diag(lint(parse_dot(dot)), "fail_routed_to_exit")
+
+    def test_indirect_human_gate_intermediary_not_flagged(self):
+        """A hexagon (wait.human) intermediary re-gates via external human
+        judgment — TOPO-004/005 human-gate precedent — not flagged."""
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "verify": _tool("verify"),
+                "approve": Node(id="approve", shape="hexagon", label="Approve?"),
+                "done": _msquare("done"),
+            },
+            edges=[
+                Edge("start", "verify"),
+                Edge("verify", "done", condition="outcome=success"),
+                Edge("verify", "approve", condition="outcome=fail"),
+                Edge("approve", "done"),
+            ],
+        )
+        assert not _diag(lint(g), "fail_routed_to_exit")

--- a/modules/pipeline-runner/amplifier_module_pipeline_runner/cli.py
+++ b/modules/pipeline-runner/amplifier_module_pipeline_runner/cli.py
@@ -373,7 +373,7 @@ def cmd_lint(args: argparse.Namespace) -> int:
     """Static topological lint of a .dot pipeline file.
 
     Parses the DOT file and runs the full basin-lint rule set:
-    structural rules (LINT-001–018), topological rules (TOPO-001–005),
+    structural rules (LINT-001–018), topological rules (TOPO-001–006),
     and command-content rules (CMD-001–002, which inspect tool_command
     strings for pipe-masked exit codes and always-true sentinels).
 

--- a/skills/attractorify/SKILL.md
+++ b/skills/attractorify/SKILL.md
@@ -360,7 +360,7 @@ the objection's disposition recorded (`caveats:` line if unresolved). Then:
    ```
    bash -c "attractor lint <path>"
    ```
-   A `.dot` that fails `attractor lint` (TOPO-001 through TOPO-005, documented in
+   A `.dot` that fails `attractor lint` (TOPO-001 through TOPO-006, documented in
    `docs/DOT-AUTHORING-GUIDE.md`) is not a runnable artifact. Fix lint findings
    before handing back.
 


### PR DESCRIPTION
## Summary

Adds lint rule `fail_routed_to_exit` (**TOPO-006**): `attractor lint` now flags a failure outcome routed into the terminal success node — both the **direct** form (`verify -> done [condition="outcome=fail"]`) and the **indirect** form (a failure-conditioned edge whose receiving path reaches the exit with every hop unconditional and no re-gating, through at least one unmarked intermediary). Implements issue #173 per its binding Maintainer ruling. Fixes #173.

**Rule design** (implementer choices, within the ruling):

- **Rule ID:** `fail_routed_to_exit` (docstring-tagged TOPO-006), joining the TOPO family in `validation.py`, wired into `lint()` only — `validate()`/`validate_or_raise()` untouched.
- **Failure-conditioned edge:** condition containing a clause `outcome=fail`, `outcome=error`, or `outcome!=success` (same clause patterns TOPO-001 recognizes), via the shared `parse_condition()`.
- **Detection walk (indirect):** BFS from the receiving node over `(node, has_unmarked_intermediary)` states, following only unconditional edges through nodes that do not re-gate; flags iff an exit is reached with ≥1 unmarked intermediary on the path. The diagnostic names the failure-conditioned edge, its source node, and the pass-through path (encouraged by Ruling 1).
- **Exception semantics (Ruling 2), engine-cited in the rule's docstring and docs:**
  - `engine.py::_get_runs_on` — `runs_on` normalizes to `"always"`, `"failure"`, or default `"success"` (anything else → `"success"`); lint applies the identical normalization (`runs_on=sometimes` is unmarked).
  - `edge_selection.py::select_edge` — on FAIL, plain edges are followed **only** to `runs_on=always/failure` targets (documented fail-fast); `runs_on` is the engine's first-class failure-routing opt-in, so an all-marked path is a deliberately declared handled-failure termination: **not flagged**.
  - An intermediary with ≥1 condition-bearing outgoing edge re-gates: **not flagged**.
  - **Hexagon precedent decision:** a `hexagon`/`wait.human` intermediary is treated as re-gating, per the TOPO-004/TOPO-005 human-gate precedent — routing beyond it passes through external human judgment, so the failure cannot exit green unseen; warning there would be the false-positive class that trains authors to ignore the rule.
  - Direct form is always flagged (no intermediary to mark), per the ruling.
- **Severity:** WARNING (Ruling 3) — CMD-001/CMD-002 family; ERROR would hard-fail deliberate finish-through-`done` designs via `validate_or_raise`.

**Files:** `validation.py` (+~250: rule + 4 helpers), `test_topological_lint.py` (+16 tests), `DOT-AUTHORING-GUIDE.md` (TOPO-006 section + family-range refs), `cli.py` + `skills/attractorify/SKILL.md` (rule-range text).

## Verification checklist

- [x] Unit tests pass (`pytest modules/loop-pipeline/`) — **1829 passed, 1 skipped** (baseline at `d13fbec`: 1813 passed, 1 skipped), run as CI does (`uv sync --extra remote && uv run pytest -q`) with provider keys unset. `pipeline-runner`: 58 passed, 1 skipped.
- [x] Live pipeline run — **N/A**: no `engine.py`/handler changes; lint-only rule wired into `lint()`, not `validate()` — no run-time behavior change. (The CLI `attractor lint` entry point was exercised live on the issue's fixtures — quoted below.)
- [x] AGENTS.md reviewed; repo-specific gates met — verification gradient row "test fixtures, examples, docs / unit tests sufficient" applies (no dispatch-path change); suites run with keys unset per the shared-venv pitfall note.
- [x] Backward-compat path unchanged — `validate()`/`validate_or_raise()` emit nothing new; existing graphs cannot start failing at `run` time (WARNING severity, lint-only).
- [x] `specs/EXTENSIONS.md`: **no entry needed** — lint-only WARNING rule, no observable run-time contract change (per `DOT-AUTHORING-GUIDE.md`'s spec note: "The topology and command-content rules below are lint-only: they do not change run-time behaviour and require no `specs/EXTENSIONS.md` entry").
- [x] PR body includes verification evidence (below).
- [x] CI green before merge — will confirm `CI Gate (all checks passed)` via `gh pr checks` (this PR is **not** to be merged by the author's agent).

## Verification evidence

**Negative control (rule absent at main `d13fbec`)** — the 16 new tests were written first and run against unmodified `validation.py`; the 8 hazard probes failed (proving the gap), the exception probes were vacuously green:

```
FAILED tests/test_topological_lint.py::TestFailRoutedToExit::test_direct_fail_to_done_flagged
FAILED tests/test_topological_lint.py::TestFailRoutedToExit::test_direct_fires_on_llm_source
FAILED tests/test_topological_lint.py::TestFailRoutedToExit::test_direct_outcome_not_success_flagged
FAILED tests/test_topological_lint.py::TestFailRoutedToExit::test_indirect_unmarked_passthrough_flagged
FAILED tests/test_topological_lint.py::TestFailRoutedToExit::test_indirect_unrecognized_runs_on_flagged
FAILED tests/test_topological_lint.py::TestFailRoutedToExit::test_indirect_multihop_one_unmarked_flagged
FAILED tests/test_topological_lint.py::TestFailRoutedToExit::test_indirect_mixed_paths_flagged
FAILED tests/test_topological_lint.py::TestFailRoutedToExit::test_issue_repro_dot_fires
8 failed, 7 passed in 0.13s
```

GREEN at fix: `tests/test_topological_lint.py` → **53 passed** (whole file, incl. the 16 new).

**Isolated probes per Ruling 2** (structured so each can fail independently — no mixed-baseline subtraction). Live `attractor lint` runs through the real `cmd_lint` entry point on the checkout's own sources:

Hazard probe — the issue's own `fail_to_done.dot` repro (fires, names edge + source):

```
WARNING: [fail_routed_to_exit] [verify] (verify -> done) Node 'verify' routes a failure outcome directly into the terminal success node: edge to 'done' with condition 'outcome=fail'. The failure leaves through the pipeline's success door — no corrective loop, no retry, no distinct failure terminal.
  fix: Route the failure to a corrective target instead (e.g. 'verify' -> fix [condition="outcome=fail"] with a back-edge to retry), or — if finishing after a handled failure is deliberate — route it through a recorder/cleanup node marked runs_on="always" or runs_on="failure" so the intent is declared. See DOT-AUTHORING-GUIDE.md (TOPO-006).

attractor lint: /tmp/lint-repro/fail_to_done.dot: 2 warning(s)   [the other is the pre-existing acyclic_graph WARNING]
EXIT=0
```

Marked probe — the issue's legitimate `runs_on=always` recorder variant (silent; only the pre-existing `acyclic_graph` warning remains):

```
===== recorder_marked.dot =====
attractor lint: /tmp/lint-repro/recorder_marked.dot: 1 warning(s)
EXIT=0
```

Indirect hazard probe — same recorder **without** `runs_on` (the issue's "status: success, exit code 0" runtime demonstration; fires and names the path):

```
WARNING: [fail_routed_to_exit] [verify] (verify -> record_failure) Node 'verify' routes a failure outcome into the terminal success node via an unmarked pass-through path: edge to 'record_failure' with condition 'outcome=fail', then record_failure -> done — every hop is unconditional, no node re-gates the flow, and at least one intermediary lacks runs_on="always"/"failure". A failed gate followed by one succeeding step exits the pipeline green (status success, exit code 0) — the silent-success exit incident class.
```

The same three shapes are also locked in as unit tests (Graph-object probes plus DOT-text probes through the real parser), alongside: `outcome!=success` / `outcome=error` forms, LLM (box) source, re-gating intermediary, human-gate intermediary, multi-hop mixed marked/unmarked, all-marked multi-hop (silent), corrective back-edge (silent), and `runs_on=sometimes` normalization.

**Full suites:** loop-pipeline **1829 passed / 1 skipped** (baseline at main: **1813 passed / 1 skipped**; delta = exactly the 16 new tests), keys unset, CI-exact invocation. pipeline-runner **58 passed / 1 skipped**.

**Examples sweep adjudication** — all 33 shipped `.dot` files (examples/ + .github/capsule-pipeline/) linted; `test_examples_lint_clean.py` green (0 ERRORs). Exactly **one** new TOPO-006 warning:

| File | Finding | Adjudication |
|---|---|---|
| `examples/patterns/convergence-factory.dot` | direct: `budget_check -> done [condition="outcome=fail"]` | **Deliberate, correctly carried — not a silent-success hazard.** The example's own comment block documents this exit as load-bearing: the pipeline has exactly one exit node, and budget exhaustion deliberately ends there "with a genuine FAIL outcome, not a masked SUCCESS" so a composing parent can distinguish converged from gave-up; the run exits nonzero (`budget_check` is the last completed node). This is precisely the consciously-accepted direct-form case Ruling 2 names ("a deliberate one-pass design may consciously accept and carry the diagnostic, exactly as with the existing `acyclic_graph` warning"), and Ruling 1 forbids a direct-form exception. Example left unchanged per this issue's scope. |

No other shipped example fires the rule (in particular, `task-runner`-style corrective walls all re-gate or loop back).

## Notes for reviewers

- **Follow-up candidate (docs-only, not filed):** add a short acknowledging comment to `examples/patterns/convergence-factory.dot` noting it consciously carries the TOPO-006 WARNING (its prose already explains why the exhaustion exit is deliberate) — analogous to how deliberately-linear examples carry `acyclic_graph`.
- On a **diamond** source, an `outcome=fail` edge into the exit fires both TOPO-001 (ERROR — the edge is provably dead) and TOPO-006; TOPO-001 takes precedence semantically, and the rule's docstring says so. Firing regardless of source shape is literal Ruling 1 compliance.
- Pre-existing ruff findings in `validation.py` (2 check errors at lines ~511/556, format hunks in the CMD tokenizer region) are identical at main and untouched — verified by running ruff on both trees (same findings, same hunk count); no new findings introduced.

---
See: [Per-Repo Conventions](https://github.com/microsoft/amplifier-foundation/blob/main/docs/PER_REPO_CONVENTIONS.md) and this repo's `AGENTS.md` for the verification discipline this checklist enforces.
