### PR TITLE
fix(engine): refuse at startup when a node declares an unserviceable llm_provider (fail-loud provider preflight)

### DIFF
--- a/docs/DOT-AUTHORING-GUIDE.md
+++ b/docs/DOT-AUTHORING-GUIDE.md
@@ -640,6 +640,16 @@ digraph {
 Explicit node attributes (`llm_model="..."` on the node) always override
 stylesheet values.
 
+**Startup provider preflight (fail-loud):** every provider a node declares --
+explicitly or via the stylesheet -- must be serviceable by the run (a mounted
+provider/profile with its credential env var set). The engine cross-checks
+this BEFORE the walk begins and refuses to start, naming each failing node,
+its provider, and the missing credential, instead of letting one
+unserviceable node crash on every visit and drain the whole iteration budget
+(issue #155, `specs/EXTENSIONS.md` §36). There is deliberately no silent
+fallback to another provider: a multi-provider graph (e.g. dual-family
+critique) that cannot be honored is an error, not a quiet downgrade.
+
 ### Model selection: globs and evergreen forms
 
 A node's `llm_model` -- whether set directly on the node or via

--- a/docs/DOT-SYNTAX.md
+++ b/docs/DOT-SYNTAX.md
@@ -36,7 +36,7 @@ digraph {
 | `max_retries` | int | graph default | In-place re-attempts for RETRY-class outcomes, retryable exceptions, and `must_write=` violations. A plain FAIL is returned immediately, never retried (use `retry_target` / `outcome=fail` edges for that) |
 | `retry_target` | string | -- | Node to jump to on gate failure |
 | `fidelity` | string | "compact" | Context carryover mode |
-| `llm_provider` | string | -- | Override provider (anthropic/openai/gemini) |
+| `llm_provider` | string | -- | Override provider (anthropic/openai/gemini). A declared provider must be serviceable by the run -- the engine cross-checks every declared provider at startup and refuses to start otherwise, naming the node, provider, and missing credential (fail-loud, `specs/EXTENSIONS.md` §36) |
 | `llm_model` | string | -- | Override model name |
 | `reasoning_effort` | string | -- | low/medium/high (provider-dependent) |
 | `auto_status` | bool | false | Force SUCCESS regardless of outcome |

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/__init__.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/__init__.py
@@ -28,6 +28,7 @@ from .handlers.context import HandlerContext
 from .hook_bridge import _current_node_context, set_node_context
 from .outcome import Outcome, StageStatus
 from .pipeline_events import PROVIDER_ERROR, PROVIDER_REQUEST, PROVIDER_RESPONSE
+from .preflight import check_provider_preflight
 from .transforms import apply_transforms
 from .validation import validate_or_raise
 
@@ -547,6 +548,29 @@ class PipelineOrchestrator:
 
             # 5. Validate the (transformed) graph
             validate_or_raise(graph)
+
+            # 5b. Provider preflight (issue #155, EXTENSIONS.md section 36):
+            # before the walk begins, cross-check every node's DECLARED
+            # llm_provider against what this run can serve and refuse to
+            # start -- naming each failing node, its provider, and the
+            # missing credential.  An unserviceable provider used to crash
+            # on every visit and drain the entire iteration budget in a
+            # crash loop.  Skipped when the caller injects an explicit
+            # backend (kwargs["backend"]): an injected backend's
+            # serviceability is the injector's responsibility and is not
+            # described by `providers`/`profiles` (this is also what keeps
+            # mock-backend tests honest -- they are not making provider
+            # claims).  The auto-constructed backend path (production) is
+            # always checked.
+            if kwargs.get("backend") is None:
+                explicit_profiles = self.config.get("profiles")
+                check_provider_preflight(
+                    graph,
+                    mounted_providers=tuple(providers) if providers else (),
+                    profiles=explicit_profiles
+                    if isinstance(explicit_profiles, dict)
+                    else None,
+                )
 
             # 6. Set up logs directory
             logs_root = self.config.get(

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/backend.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/backend.py
@@ -241,9 +241,15 @@ class AmplifierBackend:
         max_agent_turns = (
             int(max_agent_turns_raw) if max_agent_turns_raw is not None else None
         )
-        profile_name = self._profiles.get(
-            provider, next(iter(self._profiles.values()), "")
-        )
+        # Profile lookup is exact-or-nothing (issue #155 R3): the former
+        # `next(iter(self._profiles.values()), "")` default silently routed a
+        # node whose declared provider had no profile onto SOME OTHER
+        # provider's profile -- the "silent single-provider fallback" that
+        # defeats dual-family critique (a run reporting a dual-critic quorum
+        # while both critics ran on the same model family). A missing profile
+        # now fails loud on the spawn path (see step 6 below); the tool-loop
+        # path never consumes a profile.
+        profile_name = self._profiles.get(provider)
 
         # 3. Resolve fidelity mode (spec FID-001–010)
         if graph is not None:
@@ -300,6 +306,29 @@ class AmplifierBackend:
 
         # 6. Route to Path A (spawn) or Path B (direct tool loop)
         if self._spawn_fn is not None:
+            # Fail-loud guard (issue #155 R3, defense-in-depth under the
+            # startup preflight in preflight.py): the spawn path consumes a
+            # provider->agent profile, and there is NO fallback when the
+            # node's provider has none.  Silently substituting another
+            # provider's profile is how a run reports a dual-critic quorum
+            # while both critics ran on the same model family.  ValueError is
+            # terminal in the retry ladder (retry.should_retry), so this
+            # surfaces once, loudly -- never as a budget-draining crash loop.
+            if profile_name is None:
+                from .preflight import PROVIDER_KEY_ENV
+
+                raise ValueError(
+                    f"Node '{node.id}' resolved llm_provider={provider!r} but no "
+                    f"profile is mounted for that provider (mounted profiles: "
+                    f"{sorted(self._profiles) or 'none'}). Refusing to fall back "
+                    f"to another provider's profile -- silent single-provider "
+                    f"fallback defeats dual-family critique (issue #155, "
+                    f"EXTENSIONS.md section 36). Fix: add "
+                    f"'{provider}: <agent-name>' to the orchestrator 'profiles' "
+                    f"config and ensure its credential "
+                    f"({PROVIDER_KEY_ENV.get(provider, '<PROVIDER>_API_KEY')}) "
+                    f"is set, or change the node's llm_provider."
+                )
             outcome = await self._run_with_spawn(
                 node,
                 instruction,

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/preflight.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/preflight.py
@@ -1,0 +1,181 @@
+"""Startup provider preflight (issue #155, EXTENSIONS.md section 36).
+
+Before the walk begins, cross-check every node's *declared* ``llm_provider``
+against what the run can actually serve, and refuse to start -- naming each
+failing node, its provider, and the missing credential -- instead of letting
+the first unserviceable node crash every round and drain the entire iteration
+budget (Mode A of issue #155), or letting the backend silently substitute a
+different provider (Mode B; see the fail-loud guard in ``backend.py``).
+
+"Unserviceable" is the maintainer ruling's static definition: no provider
+adapter/profile is mounted for the declared provider.  The check is purely
+static -- environment and config inspection only, never a live API call.
+
+Scope decisions (deliberate, documented):
+
+- **Declared providers only.**  A node with no ``llm_provider`` uses the
+  engine default (``"anthropic"``, see ``backend.py``).  The implicit default
+  is NOT policed here: policing it would make simulation mode (no providers
+  mounted at all -- a documented degraded mode used heavily by tests) and
+  mock-provider harnesses unreachable.  The CLI separately preflights the
+  default provider's credential before any run (``pipeline-runner cli.py``).
+- **Root graph only.**  Nested ``dot_file`` child pipelines are loaded
+  mid-walk by the pipeline handler; their nodes are not visible at startup.
+  A child graph's unserviceable declaration fails loud at its first
+  execution via the backend's no-fallback guard rather than at startup.
+- **LLM-consuming node types only.**  Only handler types that reach the LLM
+  backend (``codergen``, ``stack.manager_loop``) are checked; an
+  ``llm_provider`` attribute on e.g. a tool node is inert and ignored.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Collection, Mapping
+
+from .graph import Graph, Node
+
+# Env var name per provider.  Mirrors (deliberately, with a cross-reference)
+# ``amplifier_module_pipeline_runner.runner.PROVIDER_KEY_ENV`` -- the runner
+# cannot import this module at its own module import time (its compat gate
+# requires engine imports to stay deferred), so the two small maps are kept
+# in sync by convention.  Used to NAME the likely-missing credential in
+# refusal messages and to statically check profile serviceability.
+PROVIDER_KEY_ENV: dict[str, str] = {
+    "anthropic": "ANTHROPIC_API_KEY",
+    "openai": "OPENAI_API_KEY",
+    "gemini": "GEMINI_API_KEY",
+}
+
+# Handler types that consume the LLM backend (and therefore a provider).
+_LLM_HANDLER_TYPES = frozenset({"codergen", "stack.manager_loop"})
+
+
+class ProviderPreflightError(Exception):
+    """Raised before the walk begins when nodes declare unserviceable providers.
+
+    One instance carries EVERY failing node (issue #155 R1: the refusal names
+    each failing node, its provider, and the missing credential) so a
+    misconfiguration costs one clear error, not a per-node discovery loop.
+    """
+
+
+def _effective_handler_type(node: Node) -> str:
+    """Resolve the node's handler type the way the engine does (type > shape)."""
+    from .validation import SHAPE_TO_HANDLER  # local: avoid import cycle
+
+    if node.type:
+        return node.type
+    return SHAPE_TO_HANDLER.get(node.shape, "codergen")
+
+
+def _declared_provider(node: Node) -> str | None:
+    """The node's declared llm_provider (promoted field first, attrs fallback).
+
+    Stylesheet-assigned providers are visible here too: ``apply_transforms``
+    materializes stylesheet properties onto node attrs before validation, and
+    the preflight runs after transforms.
+    """
+    if getattr(node, "llm_provider", None):
+        return str(node.llm_provider)
+    attr = node.attrs.get("llm_provider")
+    return str(attr) if attr else None
+
+
+def collect_declared_llm_providers(graph: Graph) -> dict[str, list[str]]:
+    """Map declared provider -> sorted list of LLM-node ids declaring it.
+
+    Tolerates graph stand-ins without a ``nodes`` mapping (some callers'
+    tests drive the engine seams with bare stubs and ``validate=False``):
+    no visible nodes means nothing to check -- same posture as
+    ``validate_or_raise`` being opt-out on those paths.
+    """
+    declared: dict[str, list[str]] = {}
+    nodes = getattr(graph, "nodes", None) or {}
+    for node in nodes.values():
+        if _effective_handler_type(node) not in _LLM_HANDLER_TYPES:
+            continue
+        provider = _declared_provider(node)
+        if provider:
+            declared.setdefault(provider, []).append(node.id)
+    for node_ids in declared.values():
+        node_ids.sort()
+    return declared
+
+
+def check_provider_preflight(
+    graph: Graph,
+    *,
+    mounted_providers: Collection[str] = (),
+    profiles: Mapping[str, str] | None = None,
+    env: Mapping[str, str] | None = None,
+) -> None:
+    """Refuse to start when a declared ``llm_provider`` is unserviceable.
+
+    Serviceability (static, no live API call):
+
+    - a provider MODULE mounted under that name serves it
+      (``mounted_providers`` -- the orchestrator's ``providers`` dict keys);
+    - a PROFILE mapped for that name serves it *if* its credential can be
+      presumed present: for providers with a known credential env var
+      (``PROVIDER_KEY_ENV``) the var must be set -- a profile whose agent can
+      never construct its provider is exactly the issue-#155 crash loop; for
+      unknown providers the profile gets the benefit of the doubt (nothing
+      to check statically).
+
+    When NOTHING is mounted (no providers, no profiles) the check is skipped
+    entirely: that is simulation mode, a documented degraded mode with its
+    own loud warning, and refusing would make it unreachable.
+
+    Raises:
+        ProviderPreflightError: naming every failing node, its provider, and
+        the missing credential.  Zero nodes have executed; zero budget spent.
+    """
+    profiles = profiles or {}
+    env = env if env is not None else os.environ
+    if not mounted_providers and not profiles:
+        return  # simulation mode -- nothing will consume a real provider
+
+    declared = collect_declared_llm_providers(graph)
+    if not declared:
+        return
+
+    mounted = set(mounted_providers)
+    failures: list[str] = []  # one line per failing node
+    for provider, node_ids in sorted(declared.items()):
+        if provider in mounted:
+            continue
+        key_env = PROVIDER_KEY_ENV.get(provider)
+        if provider in profiles:
+            if key_env is None or env.get(key_env):
+                continue  # profile mounted and credential present/unknowable
+            reason = (
+                f"profile '{profiles[provider]}' is mounted for it, but its "
+                f"credential {key_env} is not set"
+            )
+        else:
+            cred = f" (credential: {key_env})" if key_env else ""
+            reason = f"no provider module or profile is mounted for it{cred}"
+        for node_id in node_ids:
+            failures.append(
+                f"  - node '{node_id}' declares llm_provider=\"{provider}\": {reason}"
+            )
+
+    if not failures:
+        return
+
+    raise ProviderPreflightError(
+        "PROVIDER PREFLIGHT FAILED -- refusing to start the pipeline "
+        "(issue #155, EXTENSIONS.md section 36). The following nodes declare "
+        "an llm_provider this run cannot serve:\n"
+        + "\n".join(failures)
+        + "\nAn unserviceable provider would otherwise crash on every visit "
+        "and can drain the entire iteration budget in a crash loop, or "
+        "silently degrade to a different provider -- both are the failure "
+        "class this preflight exists to prevent (e.g. dual-family critique "
+        "silently collapsing to one model family). "
+        "Fix: mount a provider/profile for each provider named above and set "
+        "its credential env var, or change the node's llm_provider. "
+        "Degrading to fewer providers must be an explicit graph/bundle "
+        "change, never a silent fallback."
+    )

--- a/modules/loop-pipeline/tests/test_provider_preflight.py
+++ b/modules/loop-pipeline/tests/test_provider_preflight.py
@@ -1,0 +1,377 @@
+"""Startup provider preflight + no-fallback profile resolution (issue #155).
+
+Covers the maintainer ruling's acceptance spec:
+
+- R1: STARTUP PREFLIGHT -- before the walk begins, the engine cross-checks
+  every node's declared ``llm_provider`` against the mounted providers and
+  REFUSES TO START, naming each failing node, its provider, and the missing
+  credential.  Static check only -- no live API call, zero nodes executed,
+  zero budget consumed.
+- R3: the silent profile fallback in ``backend.py``
+  (``self._profiles.get(provider, next(iter(self._profiles.values()), ""))``)
+  must not survive -- a declared provider with no profile fails loud naming
+  the provider, never falls back to another provider's profile.
+- R5: the provider-not-in-profiles regression class is a shipped test.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from amplifier_module_loop_pipeline import PipelineOrchestrator
+from amplifier_module_loop_pipeline.backend import AmplifierBackend
+from amplifier_module_loop_pipeline.context import PipelineContext
+from amplifier_module_loop_pipeline.dot_parser import parse_dot
+from amplifier_module_loop_pipeline.outcome import StageStatus
+from amplifier_module_loop_pipeline.preflight import (
+    ProviderPreflightError,
+    check_provider_preflight,
+    collect_declared_llm_providers,
+)
+from amplifier_module_loop_pipeline.transforms import apply_transforms
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+_DOT_DECLARED_OPENAI = """\
+digraph declared_openai {
+    graph [goal="preflight fixture"]
+    start [shape=Mdiamond]
+    critique_b [shape=box, llm_provider="openai", prompt="review"]
+    done [shape=Msquare]
+    start -> critique_b -> done
+}
+"""
+
+_DOT_MULTI_UNSERVICEABLE = """\
+digraph multi {
+    start [shape=Mdiamond]
+    a [shape=box, llm_provider="openai", prompt="x"]
+    b [shape=box, llm_provider="openai", prompt="y"]
+    c [shape=box, llm_provider="gemini", prompt="z"]
+    done [shape=Msquare]
+    start -> a -> b -> c -> done
+}
+"""
+
+
+class _SpyBackend:
+    """Injected backend spy -- proves the walk did/did not start."""
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    async def run(self, node, prompt, context, incoming_edge=None, graph=None):
+        self.calls.append(node.id)
+        return json.dumps({"status": "success", "notes": f"mock: {node.id}"})
+
+
+class _SpySpawnCoordinator:
+    """Minimal coordinator with a session.spawn capability that records calls."""
+
+    def __init__(self) -> None:
+        self.spawn_called = False
+        self.session = None
+        self.config: dict[str, Any] = {
+            "agents": {
+                "attractor-anthropic": {
+                    "session": {"orchestrator": {"module": "loop-agent"}},
+                },
+            }
+        }
+
+    def get_capability(self, name: str):
+        if name == "session.spawn":
+            return self._spawn_fn
+        return None
+
+    async def _spawn_fn(self, **kwargs):
+        self.spawn_called = True
+        return {"output": json.dumps({"status": "success"}), "session_id": "c-1"}
+
+
+# ---------------------------------------------------------------------------
+# check_provider_preflight unit behavior (R1)
+# ---------------------------------------------------------------------------
+
+
+def test_refusal_names_node_provider_and_credential():
+    graph = parse_dot(_DOT_DECLARED_OPENAI)
+    with pytest.raises(ProviderPreflightError) as exc_info:
+        check_provider_preflight(
+            graph, profiles={"anthropic": "attractor-agent-anthropic"}, env={}
+        )
+    msg = str(exc_info.value)
+    assert "critique_b" in msg  # the failing node
+    assert 'llm_provider="openai"' in msg  # its provider
+    assert "OPENAI_API_KEY" in msg  # the missing credential
+    assert "refusing to start" in msg.lower()
+
+
+def test_refusal_lists_every_failing_node_in_one_error():
+    graph = parse_dot(_DOT_MULTI_UNSERVICEABLE)
+    with pytest.raises(ProviderPreflightError) as exc_info:
+        check_provider_preflight(
+            graph, profiles={"anthropic": "attractor-agent-anthropic"}, env={}
+        )
+    msg = str(exc_info.value)
+    for node_id in ("'a'", "'b'", "'c'"):
+        assert node_id in msg, f"expected {node_id} in refusal:\n{msg}"
+    assert "OPENAI_API_KEY" in msg
+    assert "GEMINI_API_KEY" in msg
+
+
+def test_profile_with_missing_credential_is_unserviceable():
+    """The incident config: an 'openai' PROFILE is mounted (DEFAULT_PROFILES
+    always maps it) but OPENAI_API_KEY is absent -- exactly the crash-loop
+    configuration.  Must refuse, naming the profile AND the credential."""
+    graph = parse_dot(_DOT_DECLARED_OPENAI)
+    with pytest.raises(ProviderPreflightError) as exc_info:
+        check_provider_preflight(
+            graph,
+            profiles={
+                "anthropic": "attractor-agent-anthropic",
+                "openai": "attractor-agent-openai",
+            },
+            env={"ANTHROPIC_API_KEY": "sk-x"},
+        )
+    msg = str(exc_info.value)
+    assert "attractor-agent-openai" in msg
+    assert "OPENAI_API_KEY is not set" in msg
+
+
+def test_profile_with_credential_present_is_serviceable():
+    graph = parse_dot(_DOT_DECLARED_OPENAI)
+    check_provider_preflight(
+        graph,
+        profiles={"openai": "attractor-agent-openai"},
+        env={"OPENAI_API_KEY": "sk-x"},
+    )  # must not raise
+
+
+def test_mounted_provider_module_is_serviceable():
+    graph = parse_dot(_DOT_DECLARED_OPENAI)
+    check_provider_preflight(graph, mounted_providers=["openai"], env={})
+
+
+def test_unknown_provider_with_profile_gets_benefit_of_the_doubt():
+    """A provider outside PROVIDER_KEY_ENV has no statically checkable
+    credential -- a mounted profile is accepted as serviceable."""
+    dot = _DOT_DECLARED_OPENAI.replace('"openai"', '"local-llama"')
+    graph = parse_dot(dot)
+    check_provider_preflight(graph, profiles={"local-llama": "agent-local"}, env={})
+
+
+def test_unknown_provider_without_profile_is_refused():
+    dot = _DOT_DECLARED_OPENAI.replace('"openai"', '"local-llama"')
+    graph = parse_dot(dot)
+    with pytest.raises(ProviderPreflightError) as exc_info:
+        check_provider_preflight(graph, profiles={"anthropic": "a"}, env={})
+    assert "local-llama" in str(exc_info.value)
+
+
+def test_simulation_mode_is_skipped():
+    """Nothing mounted at all -> simulation mode -- preflight must not make
+    it unreachable."""
+    graph = parse_dot(_DOT_DECLARED_OPENAI)
+    check_provider_preflight(graph, mounted_providers=(), profiles=None, env={})
+
+
+def test_undeclared_default_provider_is_not_policed():
+    """A node with NO declared llm_provider uses the engine default; the
+    preflight deliberately does not police the implicit default (documented
+    scope decision -- see preflight.py)."""
+    dot = """\
+digraph undeclared {
+    start [shape=Mdiamond]
+    work [shape=box, prompt="x"]
+    done [shape=Msquare]
+    start -> work -> done
+}
+"""
+    graph = parse_dot(dot)
+    check_provider_preflight(graph, profiles={"openai": "agent-o"}, env={})
+
+
+def test_non_llm_nodes_are_ignored():
+    """llm_provider on a tool node is inert -- never triggers a refusal."""
+    dot = """\
+digraph toolonly {
+    start [shape=Mdiamond]
+    t [shape=parallelogram, tool_command="true", llm_provider="openai"]
+    done [shape=Msquare]
+    start -> t -> done
+}
+"""
+    graph = parse_dot(dot)
+    check_provider_preflight(graph, profiles={"anthropic": "a"}, env={})
+
+
+def test_stylesheet_assigned_provider_is_visible_to_preflight():
+    """apply_transforms materializes stylesheet properties before the
+    preflight runs -- a stylesheet-routed provider is checked too."""
+    dot = """\
+digraph styled {
+    graph [model_stylesheet="#work { llm_provider: openai }"]
+    start [shape=Mdiamond]
+    work [shape=box, prompt="x"]
+    done [shape=Msquare]
+    start -> work -> done
+}
+"""
+    graph = parse_dot(dot)
+    apply_transforms(graph, PipelineContext())
+    declared = collect_declared_llm_providers(graph)
+    assert declared == {"openai": ["work"]}
+    with pytest.raises(ProviderPreflightError):
+        check_provider_preflight(graph, profiles={"anthropic": "a"}, env={})
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator startup refusal (R1: refuses to start, zero nodes executed)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_execute_refuses_at_startup_before_any_node():
+    """The mounted-orchestrator entry point refuses BEFORE the walk begins:
+    the error is raised out of execute() and no engine/backend was built."""
+    orchestrator = PipelineOrchestrator(
+        config={
+            "dot_source": _DOT_DECLARED_OPENAI,
+            # The shipped bundle's shape: profiles for all three providers.
+            # 'openai' has a profile but (in this test env) no credential.
+            "profiles": {
+                "anthropic": "attractor-agent-anthropic",
+                "openai": "attractor-agent-openai",
+            },
+        }
+    )
+    import os
+
+    saved = os.environ.pop("OPENAI_API_KEY", None)
+    try:
+        with pytest.raises(ProviderPreflightError) as exc_info:
+            await orchestrator.execute(
+                prompt="goal",
+                context=None,
+                providers={"anthropic": object()},
+                tools={},
+                hooks=None,
+            )
+    finally:
+        if saved is not None:
+            os.environ["OPENAI_API_KEY"] = saved
+    msg = str(exc_info.value)
+    assert "critique_b" in msg
+    assert "OPENAI_API_KEY" in msg
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_execute_with_injected_backend_skips_preflight():
+    """An explicitly injected backend is the injector's responsibility --
+    the preflight must not second-guess it (mock backends make no provider
+    claims)."""
+    spy = _SpyBackend()
+    orchestrator = PipelineOrchestrator(config={"dot_source": _DOT_DECLARED_OPENAI})
+    result_json = await orchestrator.execute(
+        prompt="goal",
+        context=None,
+        providers={},
+        tools={},
+        hooks=None,
+        backend=spy,
+    )
+    result = json.loads(result_json)
+    assert result["status"] == StageStatus.SUCCESS.value, result
+    assert spy.calls == ["critique_b"]
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_execute_serviceable_graph_runs_unaffected(monkeypatch):
+    """Control: a graph whose declared provider IS serviceable (profile +
+    credential present) passes the preflight and runs to completion via the
+    auto-constructed spawn backend -- NOT the injected-backend skip path."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    coordinator = _SpySpawnCoordinator()
+    coordinator.config["agents"]["attractor-agent-openai"] = {
+        "session": {"orchestrator": {"module": "loop-agent"}},
+    }
+    orchestrator = PipelineOrchestrator(
+        config={
+            "dot_source": _DOT_DECLARED_OPENAI,
+            "profiles": {"openai": "attractor-agent-openai"},
+        }
+    )
+    result_json = await orchestrator.execute(
+        prompt="goal",
+        context=None,
+        providers={},
+        tools={},
+        hooks=None,
+        coordinator=coordinator,
+    )
+    result = json.loads(result_json)
+    assert result["status"] == StageStatus.SUCCESS.value, result
+    assert coordinator.spawn_called
+
+
+# ---------------------------------------------------------------------------
+# Backend no-fallback profile resolution (R3 + R5 regression class)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_spawn_path_provider_not_in_profiles_fails_loud_never_falls_back():
+    """R5 regression: declared provider absent from profiles must raise,
+    naming the provider -- NOT silently spawn another provider's profile."""
+    coordinator = _SpySpawnCoordinator()
+    backend = AmplifierBackend(
+        coordinator=coordinator,
+        profiles={"anthropic": "attractor-anthropic"},
+    )
+    from amplifier_module_loop_pipeline.graph import Node
+
+    node = Node(id="critique_b", prompt="review", attrs={"llm_provider": "openai"})
+    with pytest.raises(ValueError, match="openai") as exc_info:
+        await backend.run(node, "review the work", PipelineContext())
+    assert not coordinator.spawn_called, (
+        "spawn must never be reached with another provider's profile"
+    )
+    msg = str(exc_info.value)
+    assert "critique_b" in msg
+    assert "OPENAI_API_KEY" in msg  # names the missing credential
+
+
+@pytest.mark.asyncio
+async def test_spawn_path_empty_profiles_fails_loud():
+    """Empty profiles + spawn available: the old code silently resolved
+    profile_name='' -- now it fails loud naming the provider."""
+    coordinator = _SpySpawnCoordinator()
+    backend = AmplifierBackend(coordinator=coordinator, profiles={})
+    from amplifier_module_loop_pipeline.graph import Node
+
+    node = Node(id="work", prompt="x", attrs={"llm_provider": "anthropic"})
+    with pytest.raises(ValueError, match="anthropic"):
+        await backend.run(node, "task", PipelineContext())
+    assert not coordinator.spawn_called
+
+
+@pytest.mark.asyncio
+async def test_spawn_path_matching_profile_still_routes_correctly():
+    """Control: exact profile match keeps working exactly as before."""
+    coordinator = _SpySpawnCoordinator()
+    backend = AmplifierBackend(
+        coordinator=coordinator,
+        profiles={"anthropic": "attractor-anthropic"},
+    )
+    from amplifier_module_loop_pipeline.graph import Node
+
+    node = Node(id="work", prompt="x", attrs={"llm_provider": "anthropic"})
+    outcome = await backend.run(node, "task", PipelineContext())
+    assert coordinator.spawn_called
+    assert outcome.status == StageStatus.SUCCESS

--- a/modules/pipeline-runner/amplifier_module_pipeline_runner/runner.py
+++ b/modules/pipeline-runner/amplifier_module_pipeline_runner/runner.py
@@ -270,6 +270,23 @@ async def drive_engine(
             # Fail loud on graph-shape problems before spending an LLM call.
             validate_or_raise(graph)
 
+        # Provider preflight (issue #155, EXTENSIONS.md section 36): before
+        # the walk begins, cross-check every node's DECLARED llm_provider
+        # against the profiles this run mounts (and each profile's statically
+        # checkable credential env var) and refuse to start, naming each
+        # failing node, its provider, and the missing credential.  On this
+        # path the AmplifierBackend below spawns per-provider agents via the
+        # `profiles` map -- a declared provider whose profile cannot construct
+        # its provider (missing API key) used to crash on every visit and
+        # drain the entire iteration budget in a crash loop
+        # (`resolve_latest_for: no adapter found for provider 'openai'`).
+        # Always on: the incident path was exactly this invoker.  A hermetic
+        # harness that mocks spawn satisfies the static check by setting the
+        # provider's env var (presence is checked, never validity).
+        from amplifier_module_loop_pipeline.preflight import check_provider_preflight
+
+        check_provider_preflight(graph, profiles=dict(profiles or DEFAULT_PROFILES))
+
         # Default engine/handler observability to the coordinator's own hook stack
         # when the caller didn't supply hooks. A mounted observability hook (e.g.
         # a session-level logging/telemetry hook composed onto the bundle) lives on

--- a/modules/pipeline-runner/tests/test_provider_preflight_drive_engine.py
+++ b/modules/pipeline-runner/tests/test_provider_preflight_drive_engine.py
@@ -1,0 +1,116 @@
+"""drive_engine startup provider preflight (issue #155).
+
+The incident invoker was exactly this path: `attractor run` -> run_pipeline ->
+drive_engine with DEFAULT_PROFILES mapping all three providers.  The 'openai'
+PROFILE existed, but no OPENAI_API_KEY did -- so the critique_b node crashed
+on every visit (`resolve_latest_for: no adapter found for provider 'openai'`)
+and the graph's transient-recovery routing drained the entire iteration
+budget against a defect that had nothing to do with the work.
+
+These tests pin the fix: drive_engine now refuses AT STARTUP -- before any
+node executes, before any LLM call -- naming the node, the provider, and the
+missing credential.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import pytest
+from amplifier_module_pipeline_runner.runner import drive_engine
+
+_DOT_DUAL_CRITIQUE = """\
+digraph dual {
+    graph [goal="dual-family critique fixture"]
+    start [shape=Mdiamond]
+    critique_b [shape=box, llm_provider="openai", prompt="independent review"]
+    done [shape=Msquare]
+    start -> critique_b -> done
+}
+"""
+
+
+class _StubCoordinator:
+    """Coordinator stub with a recording spawn capability."""
+
+    def __init__(self) -> None:
+        self.spawn_called = False
+        self.session = None
+        self.hooks = None
+        self.config: dict[str, Any] = {
+            "agents": {
+                "attractor-agent-openai": {
+                    "session": {"orchestrator": {"module": "loop-agent"}},
+                },
+                "attractor-agent-anthropic": {
+                    "session": {"orchestrator": {"module": "loop-agent"}},
+                },
+            }
+        }
+
+    def get_capability(self, name: str):
+        if name == "session.spawn":
+            return self._spawn_fn
+        return None
+
+    async def _spawn_fn(self, **kwargs):
+        self.spawn_called = True
+        return {
+            "output": json.dumps({"status": "success", "notes": "stub"}),
+            "session_id": "child-1",
+        }
+
+
+def test_drive_engine_refuses_at_startup_missing_credential(
+    tmp_path, monkeypatch
+) -> None:
+    """Incident configuration: openai profile mounted (DEFAULT_PROFILES),
+    OPENAI_API_KEY absent -> refuse before ANY node executes."""
+    from amplifier_module_loop_pipeline.preflight import ProviderPreflightError
+
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    coordinator = _StubCoordinator()
+
+    with pytest.raises(ProviderPreflightError) as exc_info:
+        asyncio.run(
+            drive_engine(
+                _DOT_DUAL_CRITIQUE,
+                coordinator,
+                cwd=tmp_path,
+                logs_root=tmp_path / "logs",
+                transform=True,
+            )
+        )
+
+    msg = str(exc_info.value)
+    assert "critique_b" in msg  # the failing node
+    assert 'llm_provider="openai"' in msg  # its provider
+    assert "OPENAI_API_KEY" in msg  # the missing credential
+    assert not coordinator.spawn_called, (
+        "refusal must happen before any node executes -- zero budget spent"
+    )
+
+
+def test_drive_engine_runs_when_declared_provider_is_serviceable(
+    tmp_path, monkeypatch
+) -> None:
+    """Control: with the credential present, the same graph starts and runs
+    to completion unaffected (presence is checked, never validity -- a
+    hermetic harness sets the env var and mocks spawn)."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-preflight")
+    coordinator = _StubCoordinator()
+
+    outcome = asyncio.run(
+        drive_engine(
+            _DOT_DUAL_CRITIQUE,
+            coordinator,
+            cwd=tmp_path,
+            logs_root=tmp_path / "logs",
+            transform=True,
+        )
+    )
+
+    assert outcome.status.value == "success", outcome
+    assert coordinator.spawn_called

--- a/specs/EXTENSIONS.md
+++ b/specs/EXTENSIONS.md
@@ -1982,3 +1982,78 @@ This is additive at the spawn boundary:
   `modules/loop-agent/tests/test_parallel_gating.py`, and
   `modules/loop-pipeline/tests/test_backend_fidelity.py` — contract tests
 
+---
+
+## 36. Startup Provider Preflight and No-Fallback Profile Resolution (Fail-Loud)
+
+> **depends-on:** none (this closes a fail-open configuration hole; it does not build on or
+> narrow any other ledger entry. It is the same fail-closed doctrine as §25 — refuse loudly at
+> the earliest static checkpoint instead of degrading silently — applied to provider
+> serviceability instead of gate verdicts.)
+>
+> **upstream action:** not applicable — the canonical spec is silent on provider mounting and
+> credential configuration (§4.5 explicitly delegates backend internals to the implementer).
+> A startup serviceability preflight and loud profile resolution are implementer-level
+> configuration validation; no spec change is needed and community `.dot` files written against
+> the canonical spec are unaffected unless they declare a provider the run genuinely cannot
+> serve — in which case they previously crashed per-visit or silently ran on the wrong provider.
+
+**Origin (issue #155):** a live `task-runner.dot` run completed its implementation work at
+iteration 1, then burned its ENTIRE remaining iteration budget in a crash loop —
+`resolve_latest_for: no adapter found for provider 'openai'` — because the `critique_b` node
+declares `llm_provider="openai"` (deliberately: dual-family critique) and the environment had no
+`OPENAI_API_KEY`. Every round the node crashed; every round the graph re-entered via its
+transient-recovery route. Nothing in the run surfaced the cause. Related second mode: with a
+provider missing from the `profiles` map, the spawn path silently substituted ANOTHER provider's
+profile — a run could report a dual-critic quorum while both critics ran on the same model family.
+
+**What (two changes, one doctrine — a provider misconfiguration costs one clear error at startup,
+never a drained budget or a silent substitution):**
+
+1. **Startup preflight** (`loop-pipeline preflight.py`, wired into BOTH engine entry points:
+   `PipelineOrchestrator.execute()` and pipeline-runner `drive_engine()`): before the walk
+   begins, every node's DECLARED `llm_provider` (explicit attribute or stylesheet-assigned;
+   LLM-consuming node types only) is cross-checked against what the run can serve. Unserviceable
+   ⇒ `ProviderPreflightError` naming EACH failing node, its provider, and the missing credential.
+   Zero nodes execute; zero budget is spent. "Serviceable" is static (no live API call): a
+   provider module mounted under that name, or a `profiles` entry whose known credential env var
+   (`ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GEMINI_API_KEY`) is present. Unknown providers with
+   a profile get the benefit of the doubt (nothing to check statically).
+
+2. **No-fallback profile resolution** (`backend.py`): the former
+   `self._profiles.get(provider, next(iter(self._profiles.values()), ""))` silently routed a
+   node whose provider had no profile onto some other provider's profile. The spawn path now
+   fails loud (`ValueError`, terminal in the retry ladder — never a crash loop) naming the node,
+   the provider, the mounted profiles, and the credential to set. The tool-loop path never
+   consumed a profile and is unchanged.
+
+**Deliberate scope boundaries (documented in `preflight.py`):**
+
+- **Declared providers only.** A node with no `llm_provider` uses the engine default
+  (`"anthropic"`); the implicit default is NOT policed by the preflight — policing it would make
+  simulation mode (no providers mounted; a documented degraded mode) and mock-provider harnesses
+  unreachable. The CLI separately preflights the default provider's credential (`cli.py`).
+- **Root graph only.** Nested `dot_file` children are loaded mid-walk; their unserviceable
+  declarations fail loud at first execution via change 2 rather than at startup.
+- **Injected backends skip the preflight.** `execute(..., backend=...)` is the invoker taking
+  responsibility for serviceability (mock backends make no provider claims); the auto-constructed
+  backend path — the production path — is always checked.
+- **Presence, never validity.** The credential check is `env var is set`, not `key works`; a
+  hermetic harness satisfies it with a dummy value. An invalid key still fails at the provider
+  call — loudly, per §25's fail-closed doctrine.
+
+**Behavior change (intended):** a graph that previously "worked" by silently running a declared
+provider on a different provider's profile now refuses (at startup where statically detectable,
+at the node otherwise). Degrading to fewer model families must be an explicit graph/bundle
+change — never a silent fallback (issue #155 ruling R6: silent single-provider fallback is the
+disease, not a remedy).
+
+**Implementation locations:**
+
+- `modules/loop-pipeline/amplifier_module_loop_pipeline/preflight.py` — the check + refusal
+- `modules/loop-pipeline/amplifier_module_loop_pipeline/__init__.py` — orchestrator wiring (step 5b)
+- `modules/pipeline-runner/amplifier_module_pipeline_runner/runner.py` — `drive_engine` wiring
+- `modules/loop-pipeline/amplifier_module_loop_pipeline/backend.py` — no-fallback profile resolution
+- `modules/loop-pipeline/tests/test_provider_preflight.py`,
+  `modules/pipeline-runner/tests/test_provider_preflight_drive_engine.py` — contract + regression
+  tests (including the provider-not-in-profiles class, ruling R5)


### PR DESCRIPTION
## Summary

Fixes #155 per the maintainer ruling (R1–R6). Two changes, one doctrine — a provider misconfiguration costs **one clear error at startup**, never a drained iteration budget or a silent substitution:

1. **Startup provider preflight (R1)** — new `loop-pipeline/preflight.py`, wired into BOTH engine entry points (`PipelineOrchestrator.execute()` step 5b and pipeline-runner `drive_engine()`). Before the walk begins, every node's DECLARED `llm_provider` (explicit attribute or stylesheet-assigned; LLM-consuming node types only) is cross-checked against what the run can serve. Unserviceable ⇒ `ProviderPreflightError` naming **each failing node, its provider, and the missing credential**. Static check only (no live API call): serviceable = a provider module mounted under that name, or a `profiles` entry whose known credential env var is set. Zero nodes execute; zero budget spent. One preflight closes Mode A (crash loop) and Mode B together.
2. **No-fallback profile resolution (R3)** — `backend.py`'s `self._profiles.get(provider, next(iter(self._profiles.values()), ""))` silently routed a node whose declared provider had no profile onto ANOTHER provider's profile (a run could report a dual-critic quorum while both critics ran on the same model family). The spawn path now fails loud (`ValueError`, terminal in the retry ladder — never a crash loop) naming the node, provider, mounted profiles, and the credential to set. The tool-loop path never consumed a profile and is unchanged. This guard is defense-in-depth under R1's preflight (per R2), and also covers nested `dot_file` children the root-graph preflight can't see.

**R6 honored:** no provider declarations weakened, no fallbacks added. The workflow preflight in `capsule-implement.yml` was used as precedent for the error-message shape only — this fix makes the ENGINE refuse, for every graph and invoker.

**Preflight design choice (where + why):** the check lives in `loop-pipeline` (`preflight.py`) and is invoked from the two engine entry points rather than inside `PipelineEngine.run()`, because the engine itself never sees what's mounted — the entry points are where `providers`/`profiles` are known, and they are the seams every shipped invoker (mounted orchestrator, `attractor` CLI → `run_pipeline` → `drive_engine`, library consumers) flows through. Deliberate scope boundaries (each documented in `preflight.py` and EXTENSIONS §36): declared providers only (the implicit `anthropic` default is not policed — policing it would make simulation mode and mock-provider harnesses unreachable; the CLI already preflights the default provider's credential); root graph only (children covered by change 2); injected `backend=` skips the preflight (the invoker took responsibility — mock backends make no provider claims); credential check is presence, never validity.

## Verification checklist

- [x] Unit tests pass (`pytest modules/loop-pipeline/`) — **1830 passed, 1 skipped** (`--extra remote`; baseline at main `d13fbec`: 1813 passed, 1 skipped). pipeline-runner: **60 passed, 1 skipped** (baseline: 58 passed, 1 skipped). 19 new tests.
- [x] Live pipeline run exercising changed code path — refusal run + green control below (backend/orchestrator/runner path; `test_live_graph_gate.py` doesn't cover this path, so a manual live run was done per AGENTS.md's verification gradient).
- [x] AGENTS.md reviewed; repo-specific gates met (dependency-awareness rule checked — no cross-repo references; ledger contiguity + upstream-action format guards pass: `test_extensions_ledger_integrity.py` 8/8).
- [x] Backward-compat path unchanged (if applicable) — **intended behavior change, ledgered**: a graph that previously "worked" by silently running a declared provider on another provider's profile now refuses (at startup where statically detectable, at the node otherwise). Undeclared-provider graphs, simulation mode, injected-backend harnesses, and the tool-loop path are unchanged.
- [x] Observable-contract change includes a `specs/EXTENSIONS.md` entry — **§36** (depends-on: none; upstream action: not applicable — spec §4.5 delegates backend internals).
- [x] PR body includes verification evidence, not just "tests pass".
- [x] CI is green before merge — will confirm `CI Gate (all checks passed)` reports pass; **this PR is not to be merged by the author's agent** (maintainer decision).

## Verification evidence

**RED at main `d13fbec` (the disease, reproduced before the fix):**

Mode B probe — silent single-provider fallback:

```
MAIN BEHAVIOR: node declared llm_provider='openai'; spawned agent_name = attractor-anthropic
outcome: StageStatus.SUCCESS
```

New drive_engine refusal test at main: `1 failed` (no refusal exists — `amplifier_module_loop_pipeline.preflight` not found); new loop-pipeline test file fails collection at main for the same reason. All 19 new tests GREEN at this branch.

**LIVE refusal (real `attractor run`, fixed engine, `env -u OPENAI_API_KEY`, graph declaring `llm_provider="openai"`):** exit code **1**, stderr verbatim:

```
attractor: pipeline execution failed: ProviderPreflightError: PROVIDER PREFLIGHT FAILED -- refusing to start the pipeline (issue #155, EXTENSIONS.md section 36). The following nodes declare an llm_provider this run cannot serve:
  - node 'critique_b' declares llm_provider="openai": profile 'attractor-agent-openai' is mounted for it, but its credential OPENAI_API_KEY is not set
An unserviceable provider would otherwise crash on every visit and can drain the entire iteration budget in a crash loop, or silently degrade to a different provider -- both are the failure class this preflight exists to prevent (e.g. dual-family critique silently collapsing to one model family). Fix: mount a provider/profile for each provider named above and set its credential env var, or change the node's llm_provider. Degrading to fewer providers must be an explicit graph/bundle change, never a silent fallback.
```

Zero LLM calls / zero budget: the run's logs dir contains only `pipeline.dot` — **0** node `status.json` files, **0** `trace.jsonl` records, no session dirs.

**LIVE green control (same engine, serviceable provider, real Anthropic call):** exit **0**, `status=success`; node prompt asked for `421337 + 88` written to `answer.txt` via `must_write=` — file contains `421425`. `trace.jsonl`:

```
{"iteration": 0, "node_id": "start", "status": "success", ..., "is_explicit": true}
{"iteration": 0, "node_id": "work", "status": "success", ..., "duration_ms": 10000.78, "session_id": "a91f980d-7905-4d23-a30d-134694078b33"}
```

**Identity probe (stale-code discipline):** the invoked CLI's venv serves the fixed engine —

```
IDENTITY PROBE preflight: .../pipeline-runner/.venv/lib/python3.13/site-packages/amplifier_module_loop_pipeline/preflight.py
marker present: True
```

(and the refusal text itself contains the §36 marker that exists only on this branch).

**Run 31457205539 gate-attack (task item):** the run's artifact (`capsule-specify-issue-155-...`) contains **no** `.ai/capsule/DEFINITION.verify.sh` — the specify run failed before packaging a capsule (its `out/` holds only `rival.patch`). Nothing to attack; nothing from that run is cited as acceptance evidence. Acceptance here = the ruling's behavioral spec + the regression tests above.

## Notes for reviewers

- **Intended break:** configurations that silently substituted providers now fail. The refusal message tells the author exactly what to mount/set. Per ruling R6, degrading to fewer model families must be an explicit change, never a silent fallback.
- The `PROVIDER_KEY_ENV` map now exists in both `loop-pipeline/preflight.py` and `pipeline-runner/runner.py` (the runner's compat gate forbids engine imports at module import time; both carry cross-reference comments).
- `preflight.py` tolerates graph stand-ins without `.nodes` (some seam tests drive `drive_engine` with bare stubs and `validate=False`) — no visible nodes means nothing to check, same posture as `validate_or_raise` being opt-out on those paths.
- The remaining known gap (documented in §36): the implicit default provider on graphs with no declarations is policed by the CLI's existing default-provider key check, not by the engine preflight — deliberate, to keep simulation mode reachable.
