### PR TITLE
fix(pipeline-runner): pin amplifier-foundation to an immutable SHA

### DIFF
--- a/modules/pipeline-runner/amplifier_module_pipeline_runner/compat.py
+++ b/modules/pipeline-runner/amplifier_module_pipeline_runner/compat.py
@@ -26,15 +26,18 @@ Three shapes were available to close the version-skew window:
    the required version and the resolution command.  This is the lowest
    friction shape for a single-repo, actively-developed package.
 
-``amplifier-foundation @main`` float
--------------------------------------
-The ``amplifier-foundation`` dep in ``pipeline-runner/pyproject.toml`` also
-floats on ``@main``.  It is a separate package from a different repository;
-pinning it requires coordinating with that repo's release cadence.  Explicit
-deferral: the foundation symbols the runner uses (``Bundle``, ``load_bundle``
--- imported lazily inside functions, never at module level) are long-stable
-core API, unlike the recently-added engine module that caused the incident,
-so there is currently no discriminating symbol to probe.  Apply the same
+``amplifier-foundation`` pin (formerly an ``@main`` float)
+-----------------------------------------------------------
+The ``amplifier-foundation`` dep in ``pipeline-runner/pyproject.toml``
+originally floated on ``@main`` (an explicit deferral: the foundation symbols
+the runner uses -- ``Bundle``, ``load_bundle``, imported lazily inside
+functions, never at module level -- are long-stable core API, so there was no
+discriminating symbol to probe).  That deferral did not weigh the CI-hygiene
+cost: with no committed lockfile, every CI run re-resolved foundation's live
+``main``, so an upstream foundation change could redden this repo's CI with no
+local change.  As of microsoft-amplifier/amplifier-support#391 the dep is
+pinned to an immutable commit SHA.  Bumps are deliberate: update the SHA in
+``pyproject.toml`` and verify against this module's test suite.  Apply the
 compat-assert pattern here the moment the runner starts depending on a
 recently-added foundation symbol.
 """

--- a/modules/pipeline-runner/pyproject.toml
+++ b/modules/pipeline-runner/pyproject.toml
@@ -9,7 +9,11 @@ authors = [
 ]
 dependencies = [
     "amplifier-core>=0.1.0",
-    "amplifier-foundation @ git+https://github.com/microsoft/amplifier-foundation@main",
+    # Pinned to an immutable SHA (re-filed from microsoft-amplifier/amplifier-support#391):
+    # an unpinned @main here let upstream foundation changes redden this repo's CI with
+    # no local change. Bump deliberately: verify the new SHA against this module's test
+    # suite, then update this line. See compat.py's module docstring for the history.
+    "amplifier-foundation @ git+https://github.com/microsoft/amplifier-foundation@4490bf5f3cf9e5a7829365e84c318a7fd9db7e3d",
     "amplifier-module-loop-pipeline[remote] @ git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-pipeline",
 ]
 


### PR DESCRIPTION
## Summary

`modules/pipeline-runner/pyproject.toml` depended on `amplifier-foundation @ git+https://...@main` — unpinned. This repo commits no lockfile, so every CI run (and every fresh install) re-resolved foundation's live `main`: an upstream foundation change could redden this repo's CI with no local change. This PR pins the dep to an immutable commit SHA. Re-filed from microsoft-amplifier/amplifier-support#391.

Fixes microsoft-amplifier/amplifier-support#391

## The pin chosen, and why

**Pinned to `4490bf5f3cf9e5a7829365e84c318a7fd9db7e3d`** — foundation `main` tip at fix time (`git ls-remote https://github.com/microsoft/amplifier-foundation main`), i.e. the exact ref a fresh `uv sync` resolves today, verified against this module's full test suite (below).

- **Tag considered and rejected:** foundation's newest release tag is `v2.1.2` (2026-05-18), which is **75 commits behind** the commit CI currently resolves (`compare/v2.1.2...` = ahead 0 / behind 75 from the tag's view). Pinning to it would be a 2.5-month downgrade, not a pin — the known-good SHA wins over the stale tag.
- **No existing pin convention to match:** `pipeline-runner` is the only module with a foundation dep, and no lockfile is committed anywhere in the repo.
- **Line 13's self-repo `@main` reference** (loop-pipeline subdirectory dep) is the documented, deliberate one — untouched.
- `compat.py`'s module docstring documented the `@main` float as an explicit deferral; updated to record the pin and the deliberate-bump procedure so the doc stays true. A bump-procedure comment sits on the pinned line itself.

## Verification checklist

- [x] Unit tests pass (`pytest modules/loop-pipeline/`) — 1846 passed, 1 skipped (loop-pipeline, `--extra remote`); pipeline-runner: 60 passed, 1 skipped
- [x] Live pipeline run — N/A: packaging metadata + docstring only; no `engine.py` or handler change
- [x] AGENTS.md reviewed; repo-specific gates met
- [x] Backward-compat path unchanged — no code-path change; installs now resolve the commit CI already resolves today
- [x] No `specs/EXTENSIONS.md` entry needed: packaging pin, no observable contract change (no dispatch/event/validation behavior touched). EXTENSIONS §28's pointer to "compat.py's deferral note" still resolves — that note now records the deferral's history and its supersession by this pin.
- [x] PR body includes verification evidence, not just "tests pass"
- [ ] CI is green before merge — pending; will confirm `CI Gate (all checks passed)` before any merge

## Verification evidence

**Before** (fresh `uv sync` in `modules/pipeline-runner` at `4f8e22d`, no pin — resolves the live tip):

```
name = "amplifier-foundation"
version = "1.0.0"
source = { git = "https://github.com/microsoft/amplifier-foundation?rev=main#4490bf5f3cf9e5a7829365e84c318a7fd9db7e3d" }
```

**After** (same invocation with the pin):

```
name = "amplifier-foundation"
version = "1.0.0"
source = { git = "https://github.com/microsoft/amplifier-foundation?rev=4490bf5f3cf9e5a7829365e84c318a7fd9db7e3d#4490bf5f3cf9e5a7829365e84c318a7fd9db7e3d" }
```

**Tests** (both suites run before AND after the pin — identical counts):

```
modules/pipeline-runner: 60 passed, 1 skipped
modules/loop-pipeline (--extra remote): 1846 passed, 1 skipped
```

**Grep for other `amplifier-foundation@main` references that could defeat the pin** (repo-wide, excluding historical `docs/plans`/`docs/reports` and `.venv`):

```
bundle.md:18                        - bundle: git+.../amplifier-foundation@main
bundles/attractor-agent.yaml:14     - bundle: git+.../amplifier-foundation@main
bundles/attractor-interactive.yaml:20 - bundle: git+.../amplifier-foundation@main
```

These are **bundle includes** — resolved by Amplifier's bundle loader at session-compose time, a separate mechanism from the pip/uv package dependency this PR pins. They do not affect what `uv sync` / `pip install` of pipeline-runner resolves, so they don't defeat the pin. Whether bundle includes should also pin is a separate decision (different mechanism, different tradeoff) and is out of scope here.

## Notes for reviewers

- **Maintenance cost is real and accepted:** foundation bumps are now deliberate. The procedure (verify new SHA against this module's suite, update the line) is documented both on the pinned line and in `compat.py`.
- The existing `compat.py` startup assertion remains the guard for engine-symbol skew; this pin closes the *foundation* skew window it explicitly deferred.
- Diff is 2 files: the pyproject line (+ bump comment) and the compat.py docstring truth-maintenance.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)
