### PR TITLE
fix: raise feature-capsule fuse to 12000s (fire-3 hit the 9000s wall)

### DIFF
--- a/.github/capsule-pipeline/feature-capsule.dot
+++ b/.github/capsule-pipeline/feature-capsule.dot
@@ -1,26 +1,27 @@
 // ============================================================================
 // VENDORED COPY -- see .github/capsule-pipeline/README.md for provenance,
 // scope, and re-sync instructions. Source: a private working repository
-// (not publicly reachable), pinned at its commit cf5bb0fd6e221841b43d69f5fa311ffc013283a3
-// (runner/feature-capsule.dot, 2026-08-12 -- the FEATURE sibling of
+// (not publicly reachable), pinned at its commit 5d91fe498f70ad6ecdcf5312269faec200385a41
+// (runner/feature-capsule.dot, 2026-08-13 -- the FEATURE sibling of
 // capsule.dot: the defect pipeline's RED-at-base epistemic anchor breaks
 // structurally on feature asks (an absent capability makes EVERY candidate
 // gate RED at base -- correct, wrong, and vacuous alike), so this graph
 // replaces the anchor with BINDING maintainer-authored acceptance criteria
 // arriving over the authenticated issue-comment channel and pins them by
-// digest before any budget is spent. The commit pinned here is the last
-// pipeline-behavior change in the source; the source's own subsequent
-// commit touches only its private task-tracking notes, not this file
-// (verified: `git diff` of runner/feature-capsule.dot between the two is
-// empty). Nodes/edges 41/75, counted the same comment-stripped way the
-// README counts capsule.dot's 35/62.)
+// digest before any budget is spent. The commit pinned here is the source
+// repository's current tip of main and is a FUSE change: it raises
+// max_pipeline_duration 9000s -> 12000s on run-31673398453 evidence (see
+// the round-budget block in the source header below) and re-pins the
+// source's own fuse-arithmetic rig test to the new value. Nodes/edges
+// 41/75 -- UNCHANGED by this sync, counted the same comment-stripped way
+// the README counts capsule.dot's 35/62.)
 //
 // DEVIATION FROM VERBATIM -- READ BEFORE RE-SYNCING (this file differs from
 // its siblings, which are byte-identical below their headers):
 // the GRAPH BODY is byte-identical to the source -- sha256 of this file from
 // its `digraph FeatureCapsulePipeline {` line to EOF ==
-// e0fb3259a5f3976977c1e503edc91de32bdbc1bcb0f0fe4fed22f36a4cd639d0 == the
-// same range of runner/feature-capsule.dot at cf5bb0f -- but THREE comment
+// 684333184e96a9265b421c245f5d1481708bb774284650da8faa839cf9e8b568 == the
+// same range of runner/feature-capsule.dot at 5d91fe4 -- but THREE comment
 // lines in the source's OWN header (below this box, above `digraph`) were
 // rewritten to upstream-truthful equivalents, because this file is
 // upstream-bound text and the source header carried source-repo-internal
@@ -149,8 +150,35 @@
 // file's text on every run): worst single traversal at the 180s default =
 // 1 redgate + 3x(patch leg + base control) + 1 hermeticity probe + 2
 // rival legs + 1 discrimination = 11 x 180s = 1980s tool_worst; + 7 LLM
-// legs x 600s = 4200s allowance; (1980 + 4200) x 1.2 = 7416s <= the
-// 9000s fuse -- half the defect fuse, clearing with margin.
+// legs x 600s = 4200s allowance; (1980 + 4200) x 1.2 = 7416s. That is the
+// FLOOR the rig pins -- ONE traversal, which the fuse must clear.
+//
+// THE FUSE IS SIZED BY THE ROUND BUDGET, NOT BY ONE TRAVERSAL (raised
+// 9000s -> 12000s, 2026-08-13, on fire-3 evidence). A traversal is not a
+// run: retry_target=author re-enters the authoring legs every round, and
+// the upstream feature-specify workflow spends max_iterations=8. Observed
+// round costs on this graph:
+//   pilot 6 (SHIP, budget 8)     6581s / 6 rounds  ~= 1100s per round
+//   pilot 3 (human-door exit)    7474s / 4 rounds  ~= 1870s per round
+//   fire 3 (ratified criteria)   one round measured at 1370s
+// Fire 3 is upstream run 31673398453 (issue #204) under the ratified
+// multi-model-parity + vendored-oracle criteria, which made the authoring
+// rounds heavier. It died on this fuse: `Pipeline exceeded max duration of
+// 9000000ms`, step 06:19:35Z -> 08:53:10Z -- the whole 9000s spent
+// mid-loop, no terminal outcome, no postmortem written. Its 1370s round is
+// measured between that run's own node events (last round-1 `void` attempt
+// 07:04:46Z -> round-2 `mutate_b` 07:27:36Z, an interval spanning void ->
+// nonvacuity_gate -> critique -> verdict -> author -> redgate -> mutate ->
+// mutate_b). At that rate 9000s funds ~6 rounds: the old fuse
+// CONTRADICTED the 8-round budget it was meant to contain and cut it short
+// by two, which is the failure it produced. New sizing: 8 rounds x a 1500s
+// per-round allowance = 12000s. 1500s is the two converged-run rates
+// (1100s, 1370s) rounded up, and THAT ROUNDING IS THE HEADROOM -- no
+// second invented multiplier on top. The pilot-3 outlier (~1870s/round) is
+// NOT covered at 8 rounds and is not claimed to be: the fuse is a
+// wall-clock backstop, not a per-round guarantee. Still under the defect
+// pipeline's 18000s -- recomputed from feature telemetry, never inherited
+// (design sec 3.4).
 //
 // Engine semantics leaned on: verified foot-gun card in context/primer.md
 // sec 6 (FAIL routing #2, stale tool.last_line #11 -- hence
@@ -167,7 +195,7 @@ digraph FeatureCapsulePipeline {
         params="issue_file, criteria_file, target_dir, base_sha, later_commit, uplift_dir, capsule_out, max_iterations, gate_time_ceiling",
         default_max_retries=2,
         default_fidelity="compact",
-        max_pipeline_duration="9000s",
+        max_pipeline_duration="12000s",
         retry_target="author"
     ]
 

--- a/.github/workflows/feature-specify.yml
+++ b/.github/workflows/feature-specify.yml
@@ -99,25 +99,39 @@ jobs:
       ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
     # FUSE ARITHMETIC (the defect workflow's method, recomputed against THIS
     # graph's own fuse -- not inherited): feature-capsule.dot declares
-    # max_pipeline_duration="9000s" (150 min), deliberately HALF capsule.dot's
-    # 18000s. The vendored .dot's header shows that recompute: 11 tool legs x
-    # the 180s gate_time_ceiling (1980s) + 7 LLM legs x 600s (4200s), x1.2 =
-    # 7416s <= the 9000s fuse. That fuse is the ENGINE's internal wall, so
-    # the job wall must clear it plus the non-engine overhead: checkout, uv
-    # install, the two materialize steps, classify, PR creation, comment,
-    # scrub/scan, upload.
+    # max_pipeline_duration="12000s" (200 min), raised from 9000s after run
+    # 31673398453 died ON that fuse ("Pipeline exceeded max duration of
+    # 9000000ms") mid-loop, with no terminal outcome. The vendored .dot's
+    # header carries the re-derivation: the old 9000s was sized from ONE
+    # traversal (11 tool legs x the 180s gate_time_ceiling = 1980s + 7 LLM
+    # legs x 600s = 4200s, x1.2 = 7416s), but retry_target=author re-enters
+    # the authoring legs every round and this workflow spends
+    # max_iterations=8, so the fuse is now sized by the ROUND BUDGET:
+    # 8 rounds x a 1500s/round allowance (observed round costs 1100s-1370s,
+    # rounded up) = 12000s. Still under capsule.dot's 18000s.
     #
-    # capsule-specify.yml sits at 360 (GitHub's hard cap for hosted runners)
-    # over its 300-minute fuse: a ~60-minute margin. That margin is
-    # FIXED-COST work, not fuse-proportional -- the runs it was sized from
-    # measured the non-engine steps in SECONDS (setup ~5s;
-    # classify/PR/comment/upload ~6-10s), with the uv install the only
-    # material item. So this job takes the same ABSOLUTE margin rather than
-    # scaling it down with the fuse: 150 + 60 = 210. (Scaling the ratio
-    # instead would give 150 x 1.2 = 180, a 30-minute margin -- still ample,
-    # but there is no reason to buy a THINNER buffer than the defect lane's
-    # for identical fixed-cost overhead. Both clear the 360 hard cap.)
-    timeout-minutes: 210
+    # That fuse is the ENGINE's internal wall, so the job wall must clear it
+    # plus TWO things the fuse does not cover:
+    #   1. FUSE OVERSHOOT -- the engine only trips the fuse BETWEEN nodes, so
+    #      the step runs past it by however long the crossing node takes. Run
+    #      31673398453 measured this: the step ran 06:19:35Z -> 08:53:10Z
+    #      (9215s) against a 9000s fuse, a 215s overshoot.
+    #   2. NON-ENGINE OVERHEAD -- checkout, uv install, the two materialize
+    #      steps, classify, PR creation, comment, scrub/scan, upload. Still
+    #      measured in SECONDS, and that has not changed: on run 31673398453
+    #      the whole job was 9230s against a 9215s pipeline step, i.e. ~15s
+    #      of everything outside it.
+    #
+    # 200 + 50 = 250. The 50-minute margin is FIXED-COST work plus overshoot,
+    # not fuse-proportional -- it is already two orders of magnitude over the
+    # measured overhead and ~14x the measured overshoot. It is 10 minutes
+    # under the defect lane's absolute 60 (capsule-specify.yml: 360 over a
+    # 300-minute fuse) purely because the fuse itself grew by 50 minutes and
+    # buying the extra 10 would purchase nothing any run has ever needed; if
+    # a future run is ever killed by the JOB wall rather than the fuse, that
+    # is the number to revisit, and it will say so in the log. Clears
+    # GitHub's 360-minute hard cap for hosted runners with 110 to spare.
+    timeout-minutes: 250
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## The evidence

Run [31673398453](https://github.com/microsoft/amplifier-bundle-attractor/actions/runs/31673398453) (issue #204, `feature-specify`) did **not** fail to converge. It was killed by its own fuse:

```
2026-08-13T08:53:09.6284991Z attractor: running pipeline cwd=/home/runner/work/amplifier-bundle-attractor/amplifier-bundle-attractor logs=/home/runner/work/_temp/capsule-run/logs
2026-08-13T08:53:09.6286063Z attractor: status=fail
2026-08-13T08:53:09.6286475Z attractor: logs=/home/runner/work/_temp/capsule-run/logs
2026-08-13T08:53:09.6286936Z attractor: notes:
2026-08-13T08:53:09.6287271Z Pipeline exceeded max duration of 9000000ms
2026-08-13T08:53:09.6288079Z {"status": "fail", "notes": "Pipeline exceeded max duration of 9000000ms", "logs_dir": "/home/runner/work/_temp/capsule-run/logs"}
```

The step ran `06:19:35Z -> 08:53:10Z` — the whole 9000s spent mid-loop, no terminal outcome. The issue got the generic non-convergence comment, which told maintainers the wrong story:

> **What happened:** the pipeline ran, but did not converge on a proven work capsule within its iteration budget.
>
> ````
> (no postmortem report was written)
> ````

There was no postmortem because the run never reached a node that writes one.

## Why 9000s stopped fitting

The 9000s number was sized from **one traversal**: 11 tool legs × the 180s `gate_time_ceiling` (1980s) + 7 LLM legs × 600s (4200s), × 1.2 = 7416s. That is still true and still recomputed by the source rig on every run.

But a traversal is not a run. `retry_target=author` re-enters the authoring legs every round, and this workflow spends `--param max_iterations=8`. The fuse and the budget were sized in different units.

Observed round costs on this graph:

| run | rounds | total | per round |
|---|---|---|---|
| pilot 6 (SHIP, budget 8) | 6 | 6581s | ~1100s |
| pilot 3 (human-door exit) | 4 | 7474s | ~1870s |
| fire 3 (run 31673398453) | — | died at the fuse | 1370s measured |

Fire 3's 1370s is measured between that run's own node events — last round-1 `void` attempt `07:04:46Z` → round-2 `mutate_b` `07:27:36Z`, an interval spanning `void -> nonvacuity_gate -> critique -> verdict -> author -> redgate -> mutate -> mutate_b`.

At ~1370s/round, **9000s funds about 6 of the 8 budgeted rounds**. The fuse was contradicting the budget it was supposed to contain and cutting it short by two. The ratified acceptance criteria on #204 — multi-model golden parity across ≥3 sampled models × 5 cases, plus vendored pinned-oracle licensing executed in a clean environment — are what pushed the authoring rounds above the pilot-6 rate.

## The change

**1. `.github/capsule-pipeline/feature-capsule.dot`** — re-synced from the source per this directory's README and the file's own DEVIATION box. New sizing in the source header: **8 rounds × a 1500s/round allowance = 12000s**, where 1500s is the two converged-run rates (1100s, 1370s) rounded up and *that rounding is the headroom* — no second invented multiplier. The header says plainly that the pilot-3 outlier (~1870s/round) is **not** covered at 8 rounds: the fuse is a wall-clock backstop, not a per-round guarantee. Still under `capsule.dot`'s 18000s.

Vendor discipline, verified:

- **Graph body byte-identical.** sha256 of `digraph FeatureCapsulePipeline {` → EOF is `684333184e96a9265b421c245f5d1481708bb774284650da8faa839cf9e8b568` on **both** sides (source and vendored). Previous pin was `e0fb3259a5f3976977c1e503edc91de32bdbc1bcb0f0fe4fed22f36a4cd639d0`, which also matched on both sides before this sync.
- Provenance box re-pinned `cf5bb0f` → `5d91fe4`, body sha updated, node/edge counts unchanged (41/75).
- The **three** documented upstream-legality edits to the source's own header were re-applied, and a diff of the re-synced header against the source's shows exactly those three hunks and nothing else.

**2. `.github/workflows/feature-specify.yml`** — `timeout-minutes: 210` → **250**, with the arithmetic stated in the existing comment block above the key. The job wall must clear the engine fuse (200 min) plus two things the fuse does not cover, both measured on this very run:

- **fuse overshoot** — the engine only trips the fuse *between* nodes, so the step runs past it by however long the crossing node takes: 9215s of step against a 9000s fuse, a **215s overshoot**;
- **non-engine overhead** — checkout, uv install, materialize ×2, classify, PR creation, comment, scrub/scan, upload: the whole job was 9230s against that 9215s step, i.e. **~15s** outside it.

200 + 50 = 250. The comment also records why the margin is 50 rather than the defect lane's absolute 60, and that 250 still clears GitHub's 360-minute hard cap for hosted runners with 110 to spare.

## Checks

| check | result |
|---|---|
| `attractor lint .github/capsule-pipeline/feature-capsule.dot` | **OK (no findings)**, rc=0 |
| `check-upstream-leaks.sh` on `feature-specify.yml` | **clean** |
| `check-upstream-leaks.sh` on the vendored `.dot` | hit set **byte-for-byte identical** to the copy already on `main` — the pre-existing shared-idiom hits the DEVIATION box documents; **zero new hits** |
| YAML parse | OK (`timeout-minutes: 250`, 20 steps) |
| `bash -n` on every `run:` block | OK (20/20) |
| `git diff --check` | clean |
| source-side rig | **26/26 green**, fuse-arithmetic test re-pinned to 12000 |

The source-side rig test now **pins** the literal fuse (`FUSE -eq 12000`) plus a strict `< 18000` non-inheritance bound, replacing a stale `FUSE <= 9000` ceiling. A fuse that can drift silently is how the units came apart in the first place, so moving it now requires new round-cost evidence in the header *and* a new anchor in the test.

Not merged, not merging — review please.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)
