### PR TITLE
fix(security): a git SHA inside a URL is not high entropy -- fire 8's six false findings

### DIFF
--- a/.github/capsule-pipeline/scrub_secrets.py
+++ b/.github/capsule-pipeline/scrub_secrets.py
@@ -237,6 +237,70 @@ ASSIGNMENT_PATTERN = re.compile(
 ENTROPY_CANDIDATE = re.compile(r"[A-Za-z0-9+/_\-=]{28,}")
 ENTROPY_THRESHOLD = 4.5  # bits/char; random base64-ish material sits above
 
+# THE PURE-HEX EXCLUSION IS STRUCTURAL, NOT WHOLE-RUN (incident, run
+# 31754414275 -- the second consecutive CONVERGED capsule destroyed at the
+# publication door, six findings, every one shape=high-entropy-token).
+#
+# `_entropy_suspicious` has always excluded a candidate that is ENTIRELY
+# hex, and that exclusion is not a bias -- it is arithmetic: 16 symbols
+# cannot carry more than log2(16) = 4.0 bits/char, so a git SHA or a sha256
+# digest is PROVABLY below the 4.5 threshold and can never be honest
+# evidence of randomness. But ENTROPY_CANDIDATE's character class contains
+# `/` (base64 uses it as DATA, so it cannot simply be dropped), which means
+# a SHA sitting inside a URL or a path is never a candidate BY ITSELF: the
+# regex swallows the entire path into ONE run, and the all-hex test then
+# fails on the merged string. Measured, from the incident's own shapes:
+#
+#   dae6d114d7821e2081a05d6e4bcd350c88dc2a41                     H = 3.63  clean
+#   com/microsoft/amplifier-module-provider-anthropic/
+#     amplifier_module_provider_anthropic/_cost                  H = 4.14  clean
+#   ...the same two, merged across `/` by the character class     H = 4.62  FIRES
+#
+# Neither half is random; the MIXTURE reads as random. Shannon entropy of a
+# concatenation is not a weighted mean of its parts' entropies: hex digits
+# and path words draw from near-disjoint alphabets (14 distinct symbols +
+# 20 distinct symbols -> 30), so the union histogram is FLATTER than either
+# part's and the plug-in estimator reports more bits/char than either
+# constituent (the length-weighted mean of the two parts is 3.98). Alphabet
+# heterogeneity across a separator is not evidence of randomness. It is,
+# however, exactly what a capsule looks like: the criteria REQUIRE the gate
+# to vendor its provider-rates oracle as a plain file and to record "its
+# exact version/commit in capsule provenance", so every artifact that names
+# that oracle -- DEFINITION.md, the vendored oracle's own header, the gate
+# script, and the gate's log output quoted into the rival finding -- carries
+# a 40-hex commit SHA inside a long URL path. One structural requirement,
+# six findings, one blocked capsule.
+#
+# So the exclusion this file already makes is applied where it actually
+# lives: a digest-length pure-hex SEGMENT is removed from the run before the
+# entropy estimate, exactly as `-` and `_` already are. A run containing no
+# such segment is scored BYTE-IDENTICALLY to before -- this narrows nothing
+# else, and it does not touch the threshold.
+#
+# The length floor is what keeps this from being a hiding place. A hex-only
+# span this long is a SHA/digest by construction, not a coincidence: the
+# chance that N characters of genuinely random base64 are all hex digits is
+# (16/64)**N = 4**-N, i.e. ~2.3e-10 at N=16. Random secret material cannot
+# be smuggled through this exclusion at any useful length.
+#
+# REAL HEX-SHAPED CREDENTIALS ARE UNAFFECTED, and were never this layer's
+# job: an all-hex API key is ALREADY excluded here today by the whole-run
+# test. They are covered by layer 1 (the `sk-` / `ghp_` / `github_pat_`
+# prefixes), layer 2 (end-anchored sensitive assignments -- `API_KEY=<hex>`
+# still fires, and its value is redacted), and layer 3 (the literal values
+# of this job's own secrets, matched regardless of shape). This change
+# touches ONLY the shape GUESS in layer 4, and only where that guess was
+# arithmetically wrong.
+HEX_SEGMENT_MIN = 16
+
+# A maximal alphanumeric segment of a candidate run that is entirely hex and
+# at least HEX_SEGMENT_MIN long. The lookarounds are what make it MAXIMAL:
+# inside a candidate the only non-alphanumeric characters are the structural
+# separators `/ + - _ =`, so requiring a non-alphanumeric boundary on both
+# sides means `dae6...a41` in `.../dae6...a41/...` matches whole, while the
+# leading hex of a mixed segment (`abcdef1234567890xyz`) matches nothing.
+STRUCTURAL_HEX_SEGMENT = re.compile(r"(?<![A-Za-z0-9])[0-9a-fA-F]{%d,}(?![A-Za-z0-9])" % HEX_SEGMENT_MIN)
+
 # The one shape `gate` may quarantine instead of blocking on. Named, not
 # inlined, because the whole split verdict turns on this exact string: it
 # is the shape `scan_text` reports for layer 4 and nothing else.
@@ -249,13 +313,31 @@ def _shannon_entropy(s: str) -> float:
     return -sum((c / n) * math.log2(c / n) for c in counts.values())
 
 
+def _without_structural_hex(token: str) -> str:
+    """`token` with its digest-length pure-hex segments removed.
+
+    A git SHA / sha256 digest cannot exceed 4.0 bits/char (16 symbols), so
+    it is never itself evidence of randomness -- but concatenated with
+    neighbouring path text across the `/` in ENTROPY_CANDIDATE's character
+    class it INFLATES the plug-in Shannon estimate above what either part
+    scores alone (see the STRUCTURAL_HEX_SEGMENT block above). Removing
+    those segments before the estimate is the same exclusion the whole-run
+    hex test already makes, applied to the segment it actually describes.
+
+    A token with no such segment comes back unchanged, so every other run
+    in the corpus is scored exactly as before.
+    """
+    return STRUCTURAL_HEX_SEGMENT.sub("", token)
+
+
 def _entropy_suspicious(token: str) -> bool:
     """True if `token` looks like random secret material.
 
     Exclusions (a documented false-negative bias -- each excluded shape is
     something routine evidence is full of): pure hex (git SHAs, sha256
     digests), pure digits (ids, timestamps), and letters-only runs (long
-    identifiers/words).
+    identifiers/words). The hex exclusion applies both to a whole run and
+    to a digest-length hex SEGMENT of one (a SHA inside a URL path).
     """
     core = token.strip("=").replace("-", "").replace("_", "")
     if not core:
@@ -265,7 +347,10 @@ def _entropy_suspicious(token: str) -> bool:
         return False  # hex: git SHAs / digests
     if core.isdigit() or core.isalpha():
         return False
-    return _shannon_entropy(token) >= ENTROPY_THRESHOLD
+    # Score the run with its provably-sub-threshold hex segments removed.
+    # Identity for any run that has none; for a provenance URL it is the
+    # difference between measuring the path and measuring path+SHA mixed.
+    return _shannon_entropy(_without_structural_hex(token)) >= ENTROPY_THRESHOLD
 
 
 def redact_entropy_text(text: str) -> tuple[str, int]:

--- a/.github/capsule-pipeline/test_scrub_secrets.py
+++ b/.github/capsule-pipeline/test_scrub_secrets.py
@@ -126,6 +126,75 @@ CAPSULE_LINE_WITH_ENTROPY = (
 )
 
 
+# ---- run 31754414275: the CAPSULE-PROVENANCE false positive ----
+#
+# The pipeline CONVERGED and packaged a feature capsule; the pre-publication
+# capsule-artifacts `scan` then reported shape=high-entropy-token in SIX
+# capsule files and blocked the capsule PR -- the second consecutive
+# converged capsule destroyed at the door.
+#
+# Not one of the six was a secret. The maintainer-ratified criteria REQUIRE
+# the gate to vendor the provider-rates oracle as a plain file (a pinned copy
+# of amplifier_module_provider_anthropic/_cost.py) AND to record "its exact
+# version/commit in capsule provenance". A capsule that obeys therefore emits
+# a 40-hex commit SHA inside a long URL path in: DEFINITION.md's provenance
+# section, the vendored oracle's own header, the gate script (twice -- the two
+# ACs that consult the oracle), and the gate's header output, which the rival
+# lane copies verbatim into verify-rival.log and then quotes again into
+# rival-red-unadjudicated.md via `tail -20`.
+#
+# ENTROPY_CANDIDATE's character class contains `/` (base64 uses it as data),
+# so the regex swallows the whole URL into ONE run and the pure-hex exclusion
+# -- which correctly clears the bare SHA -- never gets to see it. Measured:
+# SHA alone 3.63 bits/char, path alone 4.14, the two merged 4.62. See the
+# STRUCTURAL_HEX_SEGMENT block in scrub_secrets.py.
+ORACLE_COMMIT = "dae6d114d7821e2081a05d6e4bcd350c88dc2a41"
+ORACLE_RAW_URL = (
+    "https://raw.githubusercontent.com/microsoft/amplifier-module-provider-anthropic/"
+    f"{ORACLE_COMMIT}/amplifier_module_provider_anthropic/_cost.py"
+)
+ORACLE_BLOB_URL = (
+    "https://github.com/microsoft/amplifier-module-provider-anthropic/blob/"
+    f"{ORACLE_COMMIT}/amplifier_module_provider_anthropic/_cost.py"
+)
+
+# One reconstructed line per incident site. None of these is a credential;
+# every one is content the capsule contract requires.
+CAPSULE_PROVENANCE_LINES = (
+    # <id>.md:39 -- DEFINITION.md provenance row
+    f"| `oracle.py` | pinned copy | {ORACLE_BLOB_URL} |",
+    # <id>.oracle.py:4 -- the vendored oracle's own vendoring header
+    f"# Vendored from {ORACLE_RAW_URL}",
+    # <id>.verify.sh:369 -- AC-1's oracle load, provenance comment
+    f"# oracle (AC-1 parity): vendored from {ORACLE_RAW_URL}",
+    # <id>.verify.sh:772 -- AC-3's oracle load, same provenance comment
+    f"#   expected values derived from {ORACLE_RAW_URL}",
+    # <id>.verify-rival.log:2 -- the gate's own header line, and (because the
+    # log is shorter than 20 lines) the same bytes again at
+    # <id>.rival-red-unadjudicated.md:10 via `tail -20 .ai/verify-rival.log`
+    f"Oracle:    .ai/capsule/oracle.py <- {ORACLE_RAW_URL}",
+    # the bare provenance shapes the same contract emits
+    f"Oracle:    .ai/capsule/oracle.py (commit {ORACLE_COMMIT})",
+    f"base_sha={ORACLE_COMMIT}",
+    f"repos/microsoft/amplifier-module-provider-anthropic/contents/_cost.py?ref={ORACLE_COMMIT}",
+)
+
+# THE EXCLUSION MUST NOT BECOME A HIDING PLACE. Each of these carries real
+# random material; a digest-length hex segment sitting next to it changes
+# nothing, and every one must still fire.
+ENTROPY_MUST_STILL_FIRE = (
+    # a genuinely random 32-char base64 token: mixed case + digits + / and +
+    "attachment=T3k9/Qm2+Wz7XbR4pLdV6sYh1NcAg8Uj",
+    # the same, parked next to a git SHA in a path -- the SHA is removed from
+    # the estimate, the random blob is not
+    f"artifacts/{ORACLE_COMMIT}/T3k9/Qm2+Wz7XbR4pLdV6sYh1NcAg8Uj",
+    # base64url random material (the `-`/`_` alphabet)
+    "resume=qm7Zt0Xb-Rk3LpW9sVh2Ye8NcAd1Gf6U",
+    # an AWS-style secret access key: base64 alphabet including `/`
+    "wJalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLEKEY9x",
+)
+
+
 def run_cli(args: list[str], env_extra: dict[str, str] | None = None) -> subprocess.CompletedProcess:
     env = {k: v for k, v in os.environ.items() if k not in scrub_secrets.DEFAULT_WATCH_ENV}
     env["SCRUB_WATCH_ENV"] = ""
@@ -542,6 +611,118 @@ class ScrubTests(unittest.TestCase):
         self.assertIn(b"[REDACTED:github-token]", data)
         # Non-matched bytes preserved.
         self.assertTrue(data.startswith(bytes(range(256))))
+
+    # ---- run 31754414275 capsule-provenance regression, BOTH directions ----
+
+    def test_capsule_provenance_shapes_do_not_trip_entropy(self) -> None:
+        """Every reconstructed incident line must scan CLEAN.
+
+        BEFORE this fix each URL-shaped line reported
+        shape=high-entropy-token and hard-failed the capsule-artifacts scan
+        (no quarantine arm exists for the pair -- a finding there fails the
+        whole run), destroying a converged capsule over a 40-hex commit SHA
+        the criteria REQUIRE the capsule to carry.
+        """
+        for line in CAPSULE_PROVENANCE_LINES:
+            with self.subTest(line=line[:60]):
+                self.assertEqual(
+                    scrub_secrets.scan_text(line, {}),
+                    [],
+                    f"capsule provenance must not be secret-shaped: {line}",
+                )
+
+    def test_capsule_artifacts_scan_clean_end_to_end(self) -> None:
+        """The six incident sites, as files, through the real CLI verb the
+        workflow runs on the capsule pair."""
+        cid = "per-call-cost-exposure"
+        self.write(f"out/{cid}.md", f"| `oracle.py` | pinned copy | {ORACLE_BLOB_URL} |\n")
+        self.write(
+            f"out/{cid}.oracle.py",
+            '"""Anthropic pricing rates and cost computation."""\n'
+            "#\n"
+            f"# Vendored from {ORACLE_RAW_URL}\n"
+            "from decimal import Decimal\n",
+        )
+        self.write(
+            f"out/{cid}.verify.sh",
+            "set -euo pipefail\n"
+            f"# oracle (AC-1 parity): vendored from {ORACLE_RAW_URL}\n"
+            f"#   expected values derived from {ORACLE_RAW_URL}\n",
+        )
+        self.write(
+            f"out/{cid}.verify-rival.log",
+            "=== DEFINITION.verify.sh: per-call cost exposure gate ===\n"
+            f"Oracle:    .ai/capsule/oracle.py <- {ORACLE_RAW_URL}\n"
+            f"Base SHA:  {ORACLE_COMMIT}\n",
+        )
+        self.write(
+            f"out/{cid}.rival-red-unadjudicated.md",
+            "# Finding: RIVAL RED\n\n"
+            "--- gate output under the rival patch (tail of .ai/verify-rival.log) ---\n"
+            "=== DEFINITION.verify.sh: per-call cost exposure gate ===\n"
+            f"Oracle:    .ai/capsule/oracle.py <- {ORACLE_RAW_URL}\n",
+        )
+        proc = run_cli(["scan", str(self.root)])
+        self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+        self.assertIn("no secret-shaped material", proc.stdout)
+        self.assertNotIn(scrub_secrets.ENTROPY_SHAPE, proc.stdout)
+
+    def test_structural_hex_segments_are_removed_before_the_estimate(self) -> None:
+        """The mechanism, directly: a digest-length pure-hex SEGMENT is
+        dropped exactly as `-`/`_` already are; anything else is identity."""
+        run = (
+            "com/microsoft/amplifier-module-provider-anthropic/"
+            f"{ORACLE_COMMIT}/amplifier_module_provider_anthropic/_cost"
+        )
+        reduced = scrub_secrets._without_structural_hex(run)
+        self.assertNotIn(ORACLE_COMMIT, reduced)
+        self.assertIn("amplifier-module-provider-anthropic", reduced)
+        # The whole point: the mixture scored above threshold, neither part does.
+        self.assertGreaterEqual(scrub_secrets._shannon_entropy(run), scrub_secrets.ENTROPY_THRESHOLD)
+        self.assertLess(scrub_secrets._shannon_entropy(reduced), scrub_secrets.ENTROPY_THRESHOLD)
+        self.assertLess(scrub_secrets._shannon_entropy(ORACLE_COMMIT), 4.0)
+        # Identity for a run with no digest-length hex segment.
+        for token in ("T3k9/Qm2+Wz7XbR4pLdV6sYh1NcAg8Uj", "abcdef1234/notahexsegment"):
+            self.assertEqual(scrub_secrets._without_structural_hex(token), token)
+        # A short hex span is NOT structure -- it stays in the estimate.
+        self.assertEqual(scrub_secrets._without_structural_hex("beefcafe"), "beefcafe")
+
+    def test_entropy_still_fires_on_random_material(self) -> None:
+        """The narrowing must never buy random material a pass -- including
+        random material parked right next to a git SHA."""
+        for line in ENTROPY_MUST_STILL_FIRE:
+            with self.subTest(line=line[:60]):
+                self.assertIn(
+                    scrub_secrets.ENTROPY_SHAPE,
+                    scrub_secrets.scan_text(line, {}),
+                    f"random material must still be detected: {line}",
+                )
+
+    def test_real_credential_battery_still_detected(self) -> None:
+        """End-to-end, through the CLI: every known credential shape, a
+        sensitive assignment, and a genuinely random base64 token still fail
+        the scan. Values are never echoed into the log."""
+        random_b64 = "T3k9/Qm2+Wz7XbR4pLdV6sYh1NcAg8Uj"
+        cases = {
+            "openai-key": (f"OPENAI_API_KEY={FAKE_OPENAI}", "openai-key"),
+            "github-token": (f"tok {FAKE_GHP} end", "github-token"),
+            "github-fine-grained-pat": (f"pat {FAKE_FG_PAT} end", "github-fine-grained-pat"),
+            "assignment": ("CLIENT_SECRET=hunter2-value-9931", "assignment:CLIENT_SECRET"),
+            "random-base64": (f"blob: {random_b64}", scrub_secrets.ENTROPY_SHAPE),
+            "sha-adjacent-random": (
+                f"artifacts/{ORACLE_COMMIT}/{random_b64}",
+                scrub_secrets.ENTROPY_SHAPE,
+            ),
+        }
+        for name, (content, shape) in cases.items():
+            with self.subTest(case=name):
+                sub = tempfile.TemporaryDirectory()
+                self.addCleanup(sub.cleanup)
+                Path(sub.name, "x.log").write_text(content + "\n")
+                proc = run_cli(["scan", sub.name])
+                self.assertEqual(proc.returncode, 1, f"{name}: {proc.stdout}")
+                self.assertIn(f"shape={shape}", proc.stdout)
+                self.assertIn("The upload must be blocked", proc.stdout)
 
     def test_missing_root_is_not_an_error(self) -> None:
         proc = run_cli(["scrub", str(self.root / "does-not-exist")])


### PR DESCRIPTION
## The incident

Run [31754414275](https://github.com/microsoft/amplifier-bundle-attractor/actions/runs/31754414275) (`feature-specify.yml`) **converged** and packaged the feature capsule `per-call-cost-exposure`. The pre-publication capsule-artifacts scan ("Capsule artifacts: a secret finding FAILS the run, never redacts") then reported `shape=high-entropy-token` in **six** capsule files and blocked the capsule PR — the second consecutive converged capsule destroyed at the door. Neither one carried a secret.

The runner's files are gone (the evidence upload was blocked by the same findings — the fenced short-circuit documented in `scrub_secrets.py`'s docstring), so this was reproduced locally from first principles.

## Reproduction — byte-exact, all six findings

Fixture rebuilt from what the pipeline demonstrably emits: the criteria REQUIRE the gate to vendor the provider-rates oracle as a plain file (a pinned copy of `amplifier_module_provider_anthropic/_cost.py` from `microsoft/amplifier-module-provider-anthropic` @ `dae6d114d7821e2081a05d6e4bcd350c88dc2a41`) **and** to record "its exact version/commit in capsule provenance". Fire 5's log shows the gate printing its `Oracle: … (commit dae6d114…)` header; `feature-capsule.dot`'s `package` node ships every plain `.ai/capsule/` sibling as `$id.<name>`; the rival lane copies the gate's log to `$id.verify-rival.log` and then quotes it again into `$id.rival-red-unadjudicated.md` via `tail -20`.

**BEFORE** — scanner at `f172ca5`, over the reconstructed capsule:

```
scan FINDING out/per-call-cost-exposure.rival-red-unadjudicated.md:10: shape=high-entropy-token
scan FINDING out/per-call-cost-exposure.oracle.py:4: shape=high-entropy-token
scan FINDING out/per-call-cost-exposure.verify-rival.log:2: shape=high-entropy-token
scan FINDING out/per-call-cost-exposure.md:39: shape=high-entropy-token
scan FINDING out/per-call-cost-exposure.verify.sh:369: shape=high-entropy-token
scan FINDING out/per-call-cost-exposure.verify.sh:772: shape=high-entropy-token
scrub_secrets: RESIDUAL SECRET-SHAPED MATERIAL FOUND (scanned 5 file(s)). The upload must be blocked.
EXIT=1
```

Same six `file:line` sites as the incident, in the same shape. **AFTER** — this PR:

```
scrub_secrets: clean -- scanned 5 file(s), no secret-shaped material.
EXIT=0
```

Note `.verify-rival.log:2` and `.rival-red-unadjudicated.md:10` are the **same source line** — the finding file's `tail -20` quote block starts at its line 9 (confirmed against the pilot-6 capsule, where that block starts at line 8+1), so a gate log shorter than 20 lines lands log-line-2 at finding-line-10 exactly.

### Reproduction table

| Incident site | Reconstructed content | Matched run (`ENTROPY_CANDIDATE`) | True Shannon | Why it fired | Fixed? |
|---|---|---|---|---|---|
| `.md:39` | DEFINITION.md provenance row naming the oracle's pinned blob URL | `com/microsoft/amplifier-module-provider-anthropic/blob/dae6d114…a41/amplifier_module_provider_anthropic/_cost` (137 ch) | **4.640** | SHA merged with path across `/` | ✅ clean |
| `.oracle.py:4` | the vendored oracle's own `# Vendored from https://raw.githubusercontent.com/…` header | `com/microsoft/amplifier-module-provider-anthropic/dae6d114…a41/amplifier_module_provider_anthropic/_cost` (132 ch) | **4.622** | same | ✅ clean |
| `.verify.sh:369` | AC-1's oracle-parity load, provenance comment (same raw URL) | same 132-char run | **4.622** | same | ✅ clean |
| `.verify.sh:772` | AC-3's oracle-derived expectations, same provenance comment | same 132-char run | **4.622** | same | ✅ clean |
| `.verify-rival.log:2` | the gate's own header line: `Oracle:  .ai/capsule/oracle.py <- <raw URL>` | same 132-char run | **4.622** | same | ✅ clean |
| `.rival-red-unadjudicated.md:10` | **the same log line**, quoted by `tail -20 .ai/verify-rival.log` | same 132-char run | **4.622** | same | ✅ clean |

Honest negatives from the same reproduction (things that did **not** fire, and were therefore ruled out):

* The **real** upstream `_cost.py` at the pinned commit, fetched via `gh api … | base64 -d`, scans **clean** at `f172ca5` — the oracle's own 272 lines of bytes were never the problem. Only the vendoring header the pipeline prepends is.
* A **bare** 40-hex SHA (`commit dae6d114…a41`, H = 3.631) is already correctly excluded, as are `base_sha=<sha>` (3.946), `?ref=<sha>` (3.848), a bare sha256 digest (3.971), and `pkg@<sha>` (backtick/`@` split the run).
* A URL with **no** SHA in it (`…/repos/microsoft/amplifier-module-provider-anthropic/contents/_cost.py`) scores 4.143 — under threshold. The SHA is what pushes the merged run over.

## Diagnosis

`ENTROPY_CANDIDATE = [A-Za-z0-9+/_\-=]{28,}` includes `/`, because base64 uses it as **data**. Consequence: a git SHA inside a URL or path is never a candidate **by itself** — the regex swallows the whole path into ONE run, and `_entropy_suspicious`'s existing all-hex exclusion then fails on the merged string.

```
dae6d114d7821e2081a05d6e4bcd350c88dc2a41                      H = 3.63  clean (hex-excluded)
com/microsoft/amplifier-module-provider-anthropic/
  amplifier_module_provider_anthropic/_cost                   H = 4.14  clean
…the same two, merged across `/` by the character class       H = 4.62  FIRES
```

Neither half is random; the **mixture** reads as random. Shannon entropy of a concatenation is not a weighted mean of its parts' entropies: hex digits and path words draw from near-disjoint alphabets (14 + 20 distinct symbols → 30), so the union histogram is **flatter** than either part's and the plug-in estimator reports more bits/char than either constituent (length-weighted mean of the parts: 3.98). **Alphabet heterogeneity across a separator is not evidence of randomness.**

The whole-run hex exclusion was already right and already arithmetic — 16 symbols cannot carry more than log2(16) = 4.0 bits/char. It was just being applied to the wrong string.

## The fix

One behavioral change: **the pure-hex exclusion is applied structurally, not only whole-run.** A digest-length (≥ 16) pure-hex *segment* is removed from a candidate run before the entropy estimate — exactly as `-` and `_` already are:

```python
STRUCTURAL_HEX_SEGMENT = re.compile(r"(?<![A-Za-z0-9])[0-9a-fA-F]{16,}(?![A-Za-z0-9])")

def _without_structural_hex(token: str) -> str: ...

return _shannon_entropy(_without_structural_hex(token)) >= ENTROPY_THRESHOLD
```

The lookarounds make the match **maximal**: inside a candidate the only non-alphanumeric characters are the structural separators `/ + - _ =`, so `.../dae6…a41/...` matches whole while the leading hex of a mixed segment (`abcdef1234567890xyz`) matches nothing. A run containing no such segment is scored **byte-identically** to before.

What did **not** change: `ENTROPY_CANDIDATE`, `ENTROPY_THRESHOLD`, the tokenization for every non-hex-bearing run, `scan`'s read-only-ness, the `--never-redact` fence, the split verdict, the fail-loud messages, and the quarantine arm. All 16 pre-existing tests pass untouched.

### Why this is not a weakening

* **Not a hiding place.** The chance that N characters of genuinely random base64 are all hex digits is (16/64)^N = 4^−N — ≈ 2.3e-10 at N = 16. Random secret material cannot be smuggled through this exclusion at any useful length. Proven directly: `artifacts/dae6d114…a41/T3k9/Qm2+Wz7XbR4pLdV6sYh1NcAg8Uj` — random blob parked next to a git SHA — **still fires**.
* **Real hex-shaped credentials are unaffected, and were never this layer's job.** An all-hex API key is *already* excluded here today by the whole-run test. They remain covered by **layer 1** (`sk-` / `ghp_` / `github_pat_` prefixes), **layer 2** (end-anchored sensitive assignments — `API_KEY=<hex>` still fires and its value is redacted), and **layer 3** (this job's own literal secret values, matched regardless of shape). This PR touches only the shape *guess* in layer 4, and only where that guess was arithmetically wrong.
* Deliberately **not** done: raising the threshold, or dropping `/` from the candidate charset. Dropping `/` would split an AWS-style key (`wJalrXUtnFEMI/K7MDENG/bPxRfiCY…`) into sub-28-char fragments and lose it. That key is still detected here.

## Proof

**Real-credential regression battery — identical output before and after (14 findings, unchanged):**

```
scan FINDING battery/creds.log:1: shape=openai-key                              # sk-proj-…
scan FINDING battery/creds.log:1: shape=assignment:OPENAI_API_KEY
scan FINDING battery/creds.log:2: shape=github-token                            # ghp_…
scan FINDING battery/creds.log:3: shape=github-fine-grained-pat                 # github_pat_…
scan FINDING battery/creds.log:4: shape=assignment:CLIENT_SECRET
scan FINDING battery/creds.log:5: shape=assignment:AWS_SECRET_ACCESS_KEY
scan FINDING battery/creds.log:5: shape=high-entropy-token                      # AWS key w/ `/` separators
scan FINDING battery/creds.log:6: shape=assignment:DB_PASSWORD
scan FINDING battery/creds.log:7: shape=assignment:GOOGLE_APPLICATION_CREDENTIALS
scan FINDING battery/creds.log:7: shape=high-entropy-token
scan FINDING battery/creds.log:8: shape=high-entropy-token                      # random base64 32 (mixed case+digits+/+)
scan FINDING battery/creds.log:9: shape=high-entropy-token                      # random base64url 32
scan FINDING battery/creds.log:10: shape=high-entropy-token                     # novel-prefix xai-…
scan FINDING battery/creds.log:11: shape=high-entropy-token                     # random blob adjacent to a git SHA
scrub_secrets: RESIDUAL SECRET-SHAPED MATERIAL FOUND (scanned 1 file(s)). The upload must be blocked.
EXIT=1
```

**Differential over a real corpus** (same input, two scanners): `.github/` → 41 findings before, 41 after, `diff` empty. Pilot-4 and pilot-5 capsule pairs: 0 → 0.

**Pilot-6 known-good capsule pair** (read-only `scan`, directory verified byte-identical afterward):

```
scrub_secrets: clean -- scanned 17 file(s), no secret-shaped material.
EXIT=0
```

**Tests:** 16 pre-existing → **21** (`python3 -m unittest test_scrub_secrets` → `Ran 21 tests … OK`). Five new, both directions:

* `test_capsule_provenance_shapes_do_not_trip_entropy` — 8 provenance line shapes, must be clean
* `test_capsule_artifacts_scan_clean_end_to_end` — the six incident sites as files, through the real CLI verb
* `test_structural_hex_segments_are_removed_before_the_estimate` — the mechanism, incl. identity cases and "a short hex span is not structure"
* `test_entropy_still_fires_on_random_material` — 4 random shapes incl. SHA-adjacent and AWS-style
* `test_real_credential_battery_still_detected` — 6 credential classes end-to-end, values never echoed

`python3 -m py_compile` clean on both files; `git diff --check` clean.

## Not fixable at the scanner — named follow-up

`feature-capsule.dot`'s **RC-8** rule requires synthetic probe identifiers to be *born at gate runtime* from "random alphanumerics carrying NO domain vocabulary." A probe token generated that way and echoed into the gate log is **genuinely random** — a 32-char runtime token measures 5.00 bits/char, and the scanner is correct to flag it. None of fire 8's six findings is this shape (all six are the provenance URL), so nothing is being papered over here, but the class is real and the scanner cannot honestly fix it.

The honest fix is at the **source**, and it is out of scope for this PR (which touches only `scrub_secrets.py`): authoring guidance in the vendored `feature-capsule.dot` should require runtime-born probe identifiers **shorter than the 28-char `ENTROPY_CANDIDATE` floor** (a 12–16 char random suffix is more than enough to defeat name enumeration, which is the rule's actual purpose). Filing that as a follow-up against the pipeline `.dot`, not this scanner.

---

Does **not** touch issue #204 or its proposals directory. Do not merge without review.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)
