### PR TITLE
fix(ci): detach the engine runtime from the workspace it mutates -- fires 9 + 10

### DIFF
--- a/.github/workflows/capsule-implement.yml
+++ b/.github/workflows/capsule-implement.yml
@@ -221,6 +221,96 @@ jobs:
             echo "skip=$SKIP"
           } >> "$GITHUB_OUTPUT"
 
+      - name: "Detach the engine: snapshot pipeline-runner out of the workspace"
+        if: steps.locate.outputs.skip != 'true'
+        # FIRES 9 (run 31760312250) AND 10 (run 31766094504) -- one mechanism.
+        # This job used to drive the engine as `uv run --project
+        # modules/pipeline-runner`, which puts the ENGINE's own venv, and every
+        # path dependency uv installs into it (loop-pipeline, remote-source,
+        # unified-llm-client), INSIDE the very workspace this pipeline's maker
+        # agents are instructed to rewrite. The engine was standing on its own
+        # subject.
+        #   - Fire 9: a maker cp'd patched unified_llm files into the in-tree
+        #     venv's site-packages; the engine's next glob-model spawn raised
+        #     `No module named 'unified_llm._cost'` and an already-PROVEN round
+        #     was abandoned.
+        #   - Fire 10, quoting its own postmortem: "the engine that spawns the
+        #     critique node uses the pipeline-runner module's venv
+        #     (modules/pipeline-runner/.venv)... stale, incomplete unified_llm
+        #     namespace package... cannot import name 'resolve_latest_for'".
+        #     The gate had CONVERGED. The judge could never run.
+        # The .dot-side guards (maker env-contract, ambient-install reset guard)
+        # shrink the blast radius but cannot close it: a guard that lives inside
+        # the run can be out-argued by the run. This step closes it
+        # STRUCTURALLY -- the engine's source is copied to $RUNNER_TEMP before
+        # anything can touch the workspace, and nothing the pipeline does to the
+        # workspace afterwards can reach it.
+        #
+        # WHY modules/ WHOLESALE: the engine's path dependencies are RELATIVE
+        # siblings -- modules/pipeline-runner's [tool.uv.sources] points at
+        # ../loop-pipeline and ../remote-source, and loop-pipeline's at
+        # ../unified-llm-client. Copying modules/ verbatim preserves that
+        # structure, so `--project $RUNNER_TEMP/engine-src/modules/pipeline-runner`
+        # resolves exactly what `--project modules/pipeline-runner` used to. No
+        # root pyproject.toml is needed: the repo-root one declares no
+        # [tool.uv.workspace], so uv resolves modules/pipeline-runner standalone
+        # (verified locally -- a snapshot of modules/ alone builds and runs).
+        #
+        # WHY bundles/ TOO: runner.py's `_local_bundle_path()` resolves the
+        # engine's default base bundle RELATIVE TO ITS OWN __file__
+        # (`Path(__file__).resolve().parents[3] / "bundles" /
+        # "attractor-pipeline.yaml"`). Moving the engine without that directory
+        # would silently turn a local-sibling hit into a miss and push the
+        # engine onto its git fallback. These workflows all set
+        # ATTRACTOR_PIPELINE_BUNDLE explicitly, so that default is unreachable
+        # here -- but 20K of YAML is a cheap price for a snapshot that behaves
+        # identically to the in-tree layout it replaces, and bundles/ is
+        # engine-side content by the same rule as modules/.
+        #
+        # NOT DETACHED, deliberately: the .dot itself, --cwd, target_dir and
+        # uplift_dir all still point at the WORKSPACE. The subject tree is
+        # supposed to be the live one; only the engine's own code and venv move.
+        #
+        # PLACEMENT: immediately after "Locate and validate the capsule", which
+        # is read-only (gh api + git ls-remote + file-existence checks) and is
+        # the step that decides whether this run happens at all. Strictly before
+        # every step that can write into the workspace, and it carries the same
+        # `if:` guard as the rest of the job.
+        run: |
+          set -euo pipefail
+          ENGINE_SRC="$RUNNER_TEMP/engine-src"
+          rm -rf "$ENGINE_SRC"
+          mkdir -p "$ENGINE_SRC"
+          # tar, not `cp -a`: the exclusions apply at ARCHIVE time, so a
+          # .venv/.git/__pycache__ that somehow already exists in the tree never
+          # enters the snapshot at all rather than being copied in and then
+          # deleted afterwards.
+          tar -cf - \
+            --exclude='.venv' \
+            --exclude='.git' \
+            --exclude='__pycache__' \
+            --exclude='*.pyc' \
+            modules bundles \
+          | tar -xf - -C "$ENGINE_SRC"
+          echo "engine snapshot: $GITHUB_WORKSPACE/{modules,bundles} -> $ENGINE_SRC/"
+          echo "engine snapshot provenance: base SHA $(git rev-parse HEAD)"
+          for required in \
+            "modules/pipeline-runner/pyproject.toml" \
+            "modules/loop-pipeline/pyproject.toml" \
+            "modules/unified-llm-client/pyproject.toml" \
+            "modules/remote-source/pyproject.toml" \
+            "bundles/attractor-pipeline.yaml"; do
+            if [ ! -f "$ENGINE_SRC/$required" ]; then
+              echo "::error::Engine snapshot at $ENGINE_SRC is missing $required -- the detached engine would be unusable and the run step would fail later with a confusing uv error. Refusing to start." >&2
+              exit 1
+            fi
+          done
+          if [ -n "$(find "$ENGINE_SRC" -name .venv -print -quit)" ]; then
+            echo "::error::Engine snapshot at $ENGINE_SRC contains a .venv -- the tar exclusion did not hold, so the engine is not actually detached from the workspace. Refusing to start." >&2
+            exit 1
+          fi
+          echo "engine snapshot verified: pipeline-runner project present, no .venv carried in"
+
       - uses: actions/setup-python@v5
         if: steps.locate.outputs.skip != 'true'
         with:
@@ -291,7 +381,13 @@ jobs:
         run: |
           set -uo pipefail
           mkdir -p "$RUNNER_TEMP/capsule-implement/logs"
-          uv run --project modules/pipeline-runner attractor run \
+          # DETACHED ENGINE (fires 9 + 10): --project points at the
+          # $RUNNER_TEMP snapshot taken before any maker touched the tree, so
+          # the engine's venv and its editable path deps live where workspace
+          # churn cannot reach them. --cwd, target_dir and the .dot path below
+          # deliberately still point at the WORKSPACE: the subject tree is
+          # supposed to be the live one.
+          uv run --project "$RUNNER_TEMP/engine-src/modules/pipeline-runner" attractor run \
             .github/capsule-pipeline/task-runner.dot \
             --cwd "$GITHUB_WORKSPACE" \
             --logs-root "$RUNNER_TEMP/capsule-implement/logs" \

--- a/.github/workflows/capsule-specify.yml
+++ b/.github/workflows/capsule-specify.yml
@@ -91,6 +91,94 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: "Detach the engine: snapshot pipeline-runner out of the workspace"
+        # FIRES 9 (run 31760312250) AND 10 (run 31766094504) -- one mechanism.
+        # This job used to drive the engine as `uv run --project
+        # modules/pipeline-runner`, which puts the ENGINE's own venv, and every
+        # path dependency uv installs into it (loop-pipeline, remote-source,
+        # unified-llm-client), INSIDE the very workspace this pipeline's maker
+        # agents are instructed to rewrite. The engine was standing on its own
+        # subject.
+        #   - Fire 9: a maker cp'd patched unified_llm files into the in-tree
+        #     venv's site-packages; the engine's next glob-model spawn raised
+        #     `No module named 'unified_llm._cost'` and an already-PROVEN round
+        #     was abandoned.
+        #   - Fire 10, quoting its own postmortem: "the engine that spawns the
+        #     critique node uses the pipeline-runner module's venv
+        #     (modules/pipeline-runner/.venv)... stale, incomplete unified_llm
+        #     namespace package... cannot import name 'resolve_latest_for'".
+        #     The gate had CONVERGED. The judge could never run.
+        # The .dot-side guards (maker env-contract, ambient-install reset guard)
+        # shrink the blast radius but cannot close it: a guard that lives inside
+        # the run can be out-argued by the run. This step closes it
+        # STRUCTURALLY -- the engine's source is copied to $RUNNER_TEMP before
+        # anything can touch the workspace, and nothing the pipeline does to the
+        # workspace afterwards can reach it.
+        #
+        # WHY modules/ WHOLESALE: the engine's path dependencies are RELATIVE
+        # siblings -- modules/pipeline-runner's [tool.uv.sources] points at
+        # ../loop-pipeline and ../remote-source, and loop-pipeline's at
+        # ../unified-llm-client. Copying modules/ verbatim preserves that
+        # structure, so `--project $RUNNER_TEMP/engine-src/modules/pipeline-runner`
+        # resolves exactly what `--project modules/pipeline-runner` used to. No
+        # root pyproject.toml is needed: the repo-root one declares no
+        # [tool.uv.workspace], so uv resolves modules/pipeline-runner standalone
+        # (verified locally -- a snapshot of modules/ alone builds and runs).
+        #
+        # WHY bundles/ TOO: runner.py's `_local_bundle_path()` resolves the
+        # engine's default base bundle RELATIVE TO ITS OWN __file__
+        # (`Path(__file__).resolve().parents[3] / "bundles" /
+        # "attractor-pipeline.yaml"`). Moving the engine without that directory
+        # would silently turn a local-sibling hit into a miss and push the
+        # engine onto its git fallback. These workflows all set
+        # ATTRACTOR_PIPELINE_BUNDLE explicitly, so that default is unreachable
+        # here -- but 20K of YAML is a cheap price for a snapshot that behaves
+        # identically to the in-tree layout it replaces, and bundles/ is
+        # engine-side content by the same rule as modules/.
+        #
+        # NOT DETACHED, deliberately: the .dot itself, --cwd, target_dir and
+        # uplift_dir all still point at the WORKSPACE. The subject tree is
+        # supposed to be the live one; only the engine's own code and venv move.
+        #
+        # PLACEMENT: immediately after checkout. This job has no gating
+        # preamble, so the snapshot is literally the first thing that happens
+        # to the tree -- strictly before every step that can write into the
+        # workspace.
+        run: |
+          set -euo pipefail
+          ENGINE_SRC="$RUNNER_TEMP/engine-src"
+          rm -rf "$ENGINE_SRC"
+          mkdir -p "$ENGINE_SRC"
+          # tar, not `cp -a`: the exclusions apply at ARCHIVE time, so a
+          # .venv/.git/__pycache__ that somehow already exists in the tree never
+          # enters the snapshot at all rather than being copied in and then
+          # deleted afterwards.
+          tar -cf - \
+            --exclude='.venv' \
+            --exclude='.git' \
+            --exclude='__pycache__' \
+            --exclude='*.pyc' \
+            modules bundles \
+          | tar -xf - -C "$ENGINE_SRC"
+          echo "engine snapshot: $GITHUB_WORKSPACE/{modules,bundles} -> $ENGINE_SRC/"
+          echo "engine snapshot provenance: base SHA $(git rev-parse HEAD)"
+          for required in \
+            "modules/pipeline-runner/pyproject.toml" \
+            "modules/loop-pipeline/pyproject.toml" \
+            "modules/unified-llm-client/pyproject.toml" \
+            "modules/remote-source/pyproject.toml" \
+            "bundles/attractor-pipeline.yaml"; do
+            if [ ! -f "$ENGINE_SRC/$required" ]; then
+              echo "::error::Engine snapshot at $ENGINE_SRC is missing $required -- the detached engine would be unusable and the run step would fail later with a confusing uv error. Refusing to start." >&2
+              exit 1
+            fi
+          done
+          if [ -n "$(find "$ENGINE_SRC" -name .venv -print -quit)" ]; then
+            echo "::error::Engine snapshot at $ENGINE_SRC contains a .venv -- the tar exclusion did not hold, so the engine is not actually detached from the workspace. Refusing to start." >&2
+            exit 1
+          fi
+          echo "engine snapshot verified: pipeline-runner project present, no .venv carried in"
+
       - name: Record base SHA and issue metadata
         id: base
         run: |
@@ -360,7 +448,13 @@ jobs:
         run: |
           set -uo pipefail
           mkdir -p "$RUNNER_TEMP/capsule-run/out" "$RUNNER_TEMP/capsule-run/logs"
-          uv run --project modules/pipeline-runner attractor run \
+          # DETACHED ENGINE (fires 9 + 10): --project points at the
+          # $RUNNER_TEMP snapshot taken before any maker touched the tree, so
+          # the engine's venv and its editable path deps live where workspace
+          # churn cannot reach them. --cwd, target_dir and the .dot path below
+          # deliberately still point at the WORKSPACE: the subject tree is
+          # supposed to be the live one.
+          uv run --project "$RUNNER_TEMP/engine-src/modules/pipeline-runner" attractor run \
             .github/capsule-pipeline/capsule.dot \
             --cwd "$GITHUB_WORKSPACE" \
             --logs-root "$RUNNER_TEMP/capsule-run/logs" \

--- a/.github/workflows/feature-specify.yml
+++ b/.github/workflows/feature-specify.yml
@@ -217,6 +217,96 @@ jobs:
           echo "skip=$SKIP" >> "$GITHUB_OUTPUT"
           echo "existing=$EXISTING" >> "$GITHUB_OUTPUT"
 
+      - name: "Detach the engine: snapshot pipeline-runner out of the workspace"
+        if: steps.idem.outputs.skip != 'true'
+        # FIRES 9 (run 31760312250) AND 10 (run 31766094504) -- one mechanism.
+        # This job used to drive the engine as `uv run --project
+        # modules/pipeline-runner`, which puts the ENGINE's own venv, and every
+        # path dependency uv installs into it (loop-pipeline, remote-source,
+        # unified-llm-client), INSIDE the very workspace this pipeline's maker
+        # agents are instructed to rewrite. The engine was standing on its own
+        # subject.
+        #   - Fire 9: a maker cp'd patched unified_llm files into the in-tree
+        #     venv's site-packages; the engine's next glob-model spawn raised
+        #     `No module named 'unified_llm._cost'` and an already-PROVEN round
+        #     was abandoned.
+        #   - Fire 10, quoting its own postmortem: "the engine that spawns the
+        #     critique node uses the pipeline-runner module's venv
+        #     (modules/pipeline-runner/.venv)... stale, incomplete unified_llm
+        #     namespace package... cannot import name 'resolve_latest_for'".
+        #     The gate had CONVERGED. The judge could never run.
+        # The .dot-side guards (maker env-contract, ambient-install reset guard)
+        # shrink the blast radius but cannot close it: a guard that lives inside
+        # the run can be out-argued by the run. This step closes it
+        # STRUCTURALLY -- the engine's source is copied to $RUNNER_TEMP before
+        # anything can touch the workspace, and nothing the pipeline does to the
+        # workspace afterwards can reach it.
+        #
+        # WHY modules/ WHOLESALE: the engine's path dependencies are RELATIVE
+        # siblings -- modules/pipeline-runner's [tool.uv.sources] points at
+        # ../loop-pipeline and ../remote-source, and loop-pipeline's at
+        # ../unified-llm-client. Copying modules/ verbatim preserves that
+        # structure, so `--project $RUNNER_TEMP/engine-src/modules/pipeline-runner`
+        # resolves exactly what `--project modules/pipeline-runner` used to. No
+        # root pyproject.toml is needed: the repo-root one declares no
+        # [tool.uv.workspace], so uv resolves modules/pipeline-runner standalone
+        # (verified locally -- a snapshot of modules/ alone builds and runs).
+        #
+        # WHY bundles/ TOO: runner.py's `_local_bundle_path()` resolves the
+        # engine's default base bundle RELATIVE TO ITS OWN __file__
+        # (`Path(__file__).resolve().parents[3] / "bundles" /
+        # "attractor-pipeline.yaml"`). Moving the engine without that directory
+        # would silently turn a local-sibling hit into a miss and push the
+        # engine onto its git fallback. These workflows all set
+        # ATTRACTOR_PIPELINE_BUNDLE explicitly, so that default is unreachable
+        # here -- but 20K of YAML is a cheap price for a snapshot that behaves
+        # identically to the in-tree layout it replaces, and bundles/ is
+        # engine-side content by the same rule as modules/.
+        #
+        # NOT DETACHED, deliberately: the .dot itself, --cwd, target_dir and
+        # uplift_dir all still point at the WORKSPACE. The subject tree is
+        # supposed to be the live one; only the engine's own code and venv move.
+        #
+        # PLACEMENT: the first step after this job's read-only preamble
+        # (checkout, base-SHA record, discrimination pick, idempotency probe --
+        # every one of them a `git rev-parse` / `git ls-remote` read), and
+        # strictly before every step that can write into the workspace. It
+        # carries the job's own `if:` guard so a skipped run does no work.
+        run: |
+          set -euo pipefail
+          ENGINE_SRC="$RUNNER_TEMP/engine-src"
+          rm -rf "$ENGINE_SRC"
+          mkdir -p "$ENGINE_SRC"
+          # tar, not `cp -a`: the exclusions apply at ARCHIVE time, so a
+          # .venv/.git/__pycache__ that somehow already exists in the tree never
+          # enters the snapshot at all rather than being copied in and then
+          # deleted afterwards.
+          tar -cf - \
+            --exclude='.venv' \
+            --exclude='.git' \
+            --exclude='__pycache__' \
+            --exclude='*.pyc' \
+            modules bundles \
+          | tar -xf - -C "$ENGINE_SRC"
+          echo "engine snapshot: $GITHUB_WORKSPACE/{modules,bundles} -> $ENGINE_SRC/"
+          echo "engine snapshot provenance: base SHA $(git rev-parse HEAD)"
+          for required in \
+            "modules/pipeline-runner/pyproject.toml" \
+            "modules/loop-pipeline/pyproject.toml" \
+            "modules/unified-llm-client/pyproject.toml" \
+            "modules/remote-source/pyproject.toml" \
+            "bundles/attractor-pipeline.yaml"; do
+            if [ ! -f "$ENGINE_SRC/$required" ]; then
+              echo "::error::Engine snapshot at $ENGINE_SRC is missing $required -- the detached engine would be unusable and the run step would fail later with a confusing uv error. Refusing to start." >&2
+              exit 1
+            fi
+          done
+          if [ -n "$(find "$ENGINE_SRC" -name .venv -print -quit)" ]; then
+            echo "::error::Engine snapshot at $ENGINE_SRC contains a .venv -- the tar exclusion did not hold, so the engine is not actually detached from the workspace. Refusing to start." >&2
+            exit 1
+          fi
+          echo "engine snapshot verified: pipeline-runner project present, no .venv carried in"
+
       - name: Materialize the issue as issue_file
         id: issue
         if: steps.idem.outputs.skip != 'true'
@@ -551,7 +641,13 @@ jobs:
           # answers it with its FIRST option, [A] Abandon -- the declared
           # fail-safe (option order is load-bearing). The blocked-on-criteria
           # door never reaches escalate at all.
-          uv run --project modules/pipeline-runner attractor run \
+          # DETACHED ENGINE (fires 9 + 10): --project points at the
+          # $RUNNER_TEMP snapshot taken before any maker touched the tree, so
+          # the engine's venv and its editable path deps live where workspace
+          # churn cannot reach them. --cwd, target_dir and the .dot path below
+          # deliberately still point at the WORKSPACE: the subject tree is
+          # supposed to be the live one.
+          uv run --project "$RUNNER_TEMP/engine-src/modules/pipeline-runner" attractor run \
             .github/capsule-pipeline/feature-capsule.dot \
             --cwd "$GITHUB_WORKSPACE" \
             --logs-root "$RUNNER_TEMP/capsule-run/logs" \


### PR DESCRIPTION
## What broke, twice

All three capsule workflows drove the attractor engine as
`uv run --project modules/pipeline-runner attractor run ...`. That puts the
**engine's own venv** — and every path dependency uv installs into it
(`loop-pipeline`, `remote-source`, `unified-llm-client`) — **inside the very
workspace the pipeline's maker agents are instructed to rewrite**. The engine
was standing on its own subject.

| Fire | Run | What actually happened |
|---|---|---|
| 9 | 31760312250 | A maker `cp`'d patched `unified_llm` files into the in-tree venv's `site-packages`. The engine's next glob-model spawn raised `No module named 'unified_llm._cost'`. An **already-proven round was abandoned**. |
| 10 | 31766094504 | Engine spawn ImportError ×6. From its own postmortem: *"the engine that spawns the critique node uses the pipeline-runner module's venv (`modules/pipeline-runner/.venv`)... stale, incomplete unified_llm namespace package... cannot import name `resolve_latest_for`"*. **The gate had CONVERGED. The judge could never run.** |

The `.dot`-side guards already merged (maker env-contract, ambient-install reset
guard) shrink the blast radius but cannot close it: a guard that lives *inside*
the run can be out-argued by the run. This closes it **structurally** — the
engine's runtime is moved somewhere workspace churn cannot reach.

## The fix

A new step in each of the three workflows, placed before anything can write into
the workspace, snapshots the engine to `$RUNNER_TEMP/engine-src/` and records the
base SHA. Every `attractor run` then uses
`--project "$RUNNER_TEMP/engine-src/modules/pipeline-runner"`.

```bash
set -euo pipefail
ENGINE_SRC="$RUNNER_TEMP/engine-src"
rm -rf "$ENGINE_SRC"
mkdir -p "$ENGINE_SRC"
tar -cf - \
  --exclude='.venv' --exclude='.git' --exclude='__pycache__' --exclude='*.pyc' \
  modules bundles \
| tar -xf - -C "$ENGINE_SRC"
echo "engine snapshot: $GITHUB_WORKSPACE/{modules,bundles} -> $ENGINE_SRC/"
echo "engine snapshot provenance: base SHA $(git rev-parse HEAD)"
# ...then refuse to start if any required project file is missing, or if a
# .venv somehow made it into the snapshot.
```

The step script is **byte-identical across all three workflows**
(`sha256(run) = e50fbab0a226c574…` in each).

**Why `tar` and not `cp -a`:** the exclusions apply at *archive* time, so a
`.venv`/`.git`/`__pycache__` that somehow already exists in the tree never enters
the snapshot at all, rather than being copied in and deleted afterwards.

**Why `modules/` wholesale:** the engine's path deps are *relative siblings* —
`modules/pipeline-runner`'s `[tool.uv.sources]` points at `../loop-pipeline` and
`../remote-source`; `loop-pipeline`'s at `../unified-llm-client`. Copying
`modules/` verbatim preserves that layout, so the new `--project` resolves exactly
what the old one did.

**No root `pyproject.toml` needed:** the repo-root one declares no
`[tool.uv.workspace]`, so uv resolves `modules/pipeline-runner` standalone.
Verified — a snapshot of `modules/` alone builds and runs (see proof below).

**Why `bundles/` too:** `runner.py`'s `_local_bundle_path()` resolves the engine's
default base bundle *relative to its own `__file__`*
(`Path(__file__).resolve().parents[3] / "bundles" / "attractor-pipeline.yaml"`).
Moving the engine without that directory silently turns a local-sibling hit into a
miss. Measured before adding it:

```
local sibling bundle resolves to: /tmp/mp-proof-tmp/engine-src/bundles/attractor-pipeline.yaml
exists: False        # modules/ only
exists: True         # modules/ + bundles/
```

All three workflows set `ATTRACTOR_PIPELINE_BUNDLE` explicitly so that default is
unreachable here, but 20 KB of YAML is a cheap price for a snapshot that behaves
identically to the layout it replaces — and `bundles/` is engine-side content by
the same rule as `modules/`.

## Step order chosen, per workflow

| Workflow | Snapshot lands at | Steps before it | Why that is still "before anything mutates the workspace" |
|---|---|---|---|
| `capsule-specify.yml` | step 1 (immediately after `Checkout`) | Checkout | No gating preamble in this job — the snapshot is literally the first thing that happens to the tree. |
| `capsule-implement.yml` | step 2 (after `Locate and validate the capsule`) | Checkout, Locate | `Locate` is read-only: `gh api`, `git ls-remote`, `[ -f ... ]` checks. It is also the step that decides whether the run happens at all, so the snapshot inherits its `if: steps.locate.outputs.skip != 'true'` guard. |
| `feature-specify.yml` | step 4 (after `Idempotency guard`) | Checkout, Record base SHA, Pick discrimination commit, Idempotency guard | All four are read-only `git rev-parse` / `git log` / `git ls-remote` reads. The snapshot carries the job's `if: steps.idem.outputs.skip != 'true'` guard so a skipped run does no work. |

In every case the snapshot precedes **every** step that can write into the
workspace, and precedes the pipeline-run step by a wide margin.

## Call-site table: detached vs workspace

Grep across the three workflows found exactly **three** engine invocations and no
other `attractor` / `uv` calls (no doctor, preflight, or lint steps invoke the
engine).

| Call site | Before | After | Detached? | Justification |
|---|---|---|---|---|
| `feature-specify.yml:554` `uv run --project … attractor run` | `--project modules/pipeline-runner` | `--project "$RUNNER_TEMP/engine-src/modules/pipeline-runner"` | **Detached** | Engine-as-tool. This is the process whose venv fires 9 and 10 corrupted. |
| `capsule-specify.yml:363` `uv run --project … attractor run` | `--project modules/pipeline-runner` | `--project "$RUNNER_TEMP/engine-src/modules/pipeline-runner"` | **Detached** | Same. |
| `capsule-implement.yml:294` `uv run --project … attractor run` | `--project modules/pipeline-runner` | `--project "$RUNNER_TEMP/engine-src/modules/pipeline-runner"` | **Detached** | Same. |
| `.dot` path arg (`.github/capsule-pipeline/{feature-capsule,capsule,task-runner}.dot`) | workspace-relative | *unchanged* | Workspace | The graph is the run's *declared definition*, read once at startup and resolved against the step's cwd (`$GITHUB_WORKSPACE`). It is repo content under test, not engine runtime. Verified the relative path still resolves with a detached `--project` (GREEN-1/GREEN-2 below use a relative `.dot` path). |
| `--cwd "$GITHUB_WORKSPACE"` | workspace | *unchanged* | Workspace | The subject tree is supposed to be the live one. Detaching it would make the pipeline operate on a copy nothing ships. |
| `--param target_dir="$GITHUB_WORKSPACE"` | workspace | *unchanged* | Workspace | Same — this is where makers are meant to work. |
| `--param uplift_dir="$GITHUB_WORKSPACE/.github/capsule-pipeline/vendor"` | workspace | *unchanged* | Workspace | Vendored checker scripts are repo content the graph shells out to and the capsule PR ships; they are subject, not engine. |
| `--logs-root`, `--param capsule_out=` (`$RUNNER_TEMP/…`) | temp | *unchanged* | n/a | Already outside the workspace. |
| `ATTRACTOR_PIPELINE_BUNDLE` | `${{ github.workspace }}/.github/capsule-pipeline/attractor-pipeline-dual.yaml` | *unchanged* | Workspace | See the trace below. |

## `ATTRACTOR_PIPELINE_BUNDLE` trace — verdict: leave it

Traced end to end rather than assumed.

1. **The file's `source:` entries.** Every module the bundle mounts — the two
   providers, `loop-pipeline`, `context-simple`, `tool-filesystem`, `tool-bash`,
   `tool-search`, `tool-report-outcome`, all three `hooks-*`, and the `loop-agent`
   under each of the three child agents — is declared as
   `git+https://github.com/microsoft/…@main[#subdirectory=…]`. **There is not a
   single repo-relative path source in the file.** So the module code the *session*
   mounts is fetched into amplifier's own cache, never read out of the workspace
   tree. Confirmed empirically: `direct_url.json` for the mounted packages resolves
   to `file:///home/…/.amplifier/cache/amplifier-bundle-attractor-<hash>`, not to
   the repo.
2. **When the file itself is read.** `runner.py`'s `_load_base_bundle()` caches into
   a module global (`"Cached in a module global -- loaded once per process"`), and
   `_local_bundle_path()` honours the env override. The engine is one process for
   the whole run, so the YAML is read **once, at the first spawn — before any maker
   agent's code has executed.** A maker rewriting the file mid-run cannot affect
   the already-composed mount plan.
3. **Consistency.** The bundle is the run's *declared configuration*, the same
   category as the `.dot` — and the `.dot` deliberately stays in the workspace.
   Detaching one but not the other would be arbitrary.

Nothing to fix. Left pointing at `${{ github.workspace }}/…`, and the reasoning is
recorded in the step comment so the next reader does not have to re-derive it.

## The money proof — both halves

Fresh scratch clone at `main` (`cb4cf2a`), running **the new step's script
extracted verbatim from the workflow YAML**. Subject: a 2-node tool-only `.dot`
(no LLM nodes — the only thing under test is the engine's own import and execution
path), invoked with a *relative* `.dot` path and `--cwd` = the scratch workspace,
exactly as the workflows do. Full transcript: `/tmp/mp-proof-output.txt`.

**Phase 1 — snapshot (the new step, verbatim):**
```
engine snapshot: /tmp/mp-proof-ws/{modules,bundles} -> /tmp/mp-proof-tmp/engine-src/
engine snapshot provenance: base SHA cb4cf2a7b7a9bb9faf5ec772f60ef6bac7c5024b
engine snapshot verified: pipeline-runner project present, no .venv carried in
  snapshot-step exit=0
```

**GREEN-1 — detached engine, pristine workspace:**
```
attractor: running pipeline cwd=/tmp/mp-proof-ws logs=/tmp/mp-proof-logs/green1
attractor: status=success
  GREEN-1 exit=0
```

**Baseline — in-tree engine, pristine workspace (proves the vandalism, not the
setup, is what breaks it later):**
```
attractor: status=success
  RED-1 exit=0
  in-tree engine venv now exists: /tmp/mp-proof-ws/modules/pipeline-runner/.venv
```

**Vandalism** (what a maker actually did in fires 9 and 10):
```
-- fire-10 shape: make the in-tree engine venv's unified_llm stale/incomplete
removed '/tmp/mp-proof-ws/modules/pipeline-runner/.venv/lib/python3.13/site-packages/unified_llm/resolver.py'
-- fire-9 shape: maker rewrites engine source in-tree
clobbered /tmp/mp-proof-ws/modules/pipeline-runner/amplifier_module_pipeline_runner/cli.py
removed '/tmp/mp-proof-ws/modules/unified-llm-client/unified_llm/resolver.py'
 M modules/pipeline-runner/amplifier_module_pipeline_runner/cli.py
 D modules/unified-llm-client/unified_llm/resolver.py
```

**GREEN-2 — detached engine, VANDALIZED workspace (the money shot):**
```
attractor: running pipeline cwd=/tmp/mp-proof-ws logs=/tmp/mp-proof-logs/green2
attractor: status=success
  GREEN-2 exit=0
```

**RED-β — the OLD invocation (`--project modules/pipeline-runner`) in the same
vandalized workspace:**
```
Traceback (most recent call last):
  File "/tmp/mp-proof-ws/modules/pipeline-runner/.venv/bin/attractor", line 4, in <module>
    from amplifier_module_pipeline_runner.cli import main
  File "/tmp/mp-proof-ws/modules/pipeline-runner/amplifier_module_pipeline_runner/cli.py", line 1
    GARBAGE not-python <<< ???
               ^
SyntaxError: invalid syntax
  RED-beta exit=1
```

**RED-α — fire 10's exact failure, reproduced.** The tool-only probe never reaches
the glob-model spawn path, so the resolver import is exercised directly: this is
the literal line `backend.py:1058` executes when a node's model is a glob/family
token. The in-tree venv is left carrying a *stale, incomplete* `unified_llm.resolver`
(268 of 308 lines — `resolve_latest_for` truncated away), exactly as fire 10's
postmortem describes:

```
-- IN-TREE engine venv (OLD --project modules/pipeline-runner):
    from unified_llm.resolver import resolve_latest, resolve_latest_for, select_latest
ImportError: cannot import name 'resolve_latest_for' from 'unified_llm.resolver' (/tmp/mp-proof-ws/modules/pipeline-runner/.venv/lib/python3.13/site-packages/unified_llm/resolver.py)

-- DETACHED engine venv (NEW --project $RUNNER_TEMP/engine-src/modules/pipeline-runner):
ok: unified_llm.resolver.resolve_latest_for
```

That is fire 10's error text, verbatim, on one side of the change and not the
other.

**Phase 9 — the snapshot is untouched by all of the above:**
```
workspace  modules/unified-llm-client/unified_llm/resolver.py: GONE
detached   modules/unified-llm-client/unified_llm/resolver.py: PRESENT
workspace  modules/pipeline-runner/.../cli.py first line: GARBAGE not-python <<< ???
detached   modules/pipeline-runner/.../cli.py first line: """attractor: run an arbitrary attractor DOT pipeline standalone.
```

One honest note on the vandalism: `uv run` re-syncs the project on every
invocation, but it does **not** restore files deleted or overwritten *inside* an
existing `.venv` (measured — a clobbered `site-packages` file survived a
subsequent `uv run` untouched). That is precisely why an in-tree venv is not
self-healing, and precisely why fires 9 and 10 were terminal rather than
transient.

## Lint / parity

- **`bash -n`** — every `run:` step script in all three workflows, `${{ }}`
  expressions stubbed: **41 run-steps checked, 0 failures** on the branch
  (38/0 on base — the 3 new steps are the delta).
- **YAML** — all three parse; step lists enumerate correctly with the snapshot in
  the expected position.
- **actionlint 1.7.7 parity** — identical findings on base and branch, same three
  pre-existing shellcheck infos in the same three scripts, only line numbers
  shifted. **No new findings.**

  | | base `cb4cf2a` | branch |
  |---|---|---|
  | `feature-specify.yml` | `:699:9` SC2012 info | `:795:9` SC2012 info |
  | `capsule-specify.yml` | `:484:9` SC2012 info | `:578:9` SC2012 info |
  | `capsule-implement.yml` | `:344:9` SC2143 style | `:440:9` SC2143 style |

- **Grep-proof** — `grep -rn -- "--project modules/pipeline-runner" .github/workflows/`
  returns **zero engine invocations**; the only three hits are the words appearing
  inside the new step's explanatory comment in each file.
- **`git diff --check`** — clean.

## CI

**CI itself does not execute these three workflows** — `ci.yml`'s "CI Gate (all
checks passed)" aggregate only `needs:` job IDs defined inside `ci.yml`, and each
of these three files carries a comment saying exactly that. So a green Gate here
proves the YAML is well-formed and nothing else regressed; it does **not** exercise
the change. The live proof is the local behavioral proof above plus the next label
firing.

---
🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)
