### PR TITLE
fix(capsule-pipeline): ship what you verified -- publish fixtures, then re-verify the COMMITTED set

### DIFF
--- a/.github/workflows/capsule-implement.yml
+++ b/.github/workflows/capsule-implement.yml
@@ -357,6 +357,113 @@ jobs:
           fi
           echo "OPENAI_API_KEY is present -- dual-family critique (Anthropic + OpenAI) can be honored. Proceeding."
 
+      - name: "Stage the capsule's vendored gate fixtures beside the gate"
+        id: fixtures
+        if: steps.locate.outputs.skip != 'true'
+        # SHIP WHAT YOU VERIFIED, implement-side half (incident, 2026-08-14,
+        # run 31775541024 -> PR #218). Restoring the dropped fixture on that
+        # branch is necessary but NOT sufficient: as traced below, nothing in
+        # this job or in the vendored task-runner.dot ever puts a capsule's
+        # vendored fixture where its gate looks for it, so a fixture-bearing
+        # capsule would still exit 2 (FATAL) here after a clean merge.
+        #
+        # THE TRACED PATH, end to end:
+        #
+        #   1. This workflow's "Locate and validate the capsule" step resolves
+        #      the pair and exports the .md path:
+        #        CAPSULE_ID="$(basename "$CAPSULE_MD" .md)"
+        #        VERIFY_SH="$(dirname "$CAPSULE_MD")/$CAPSULE_ID.verify.sh"
+        #        echo "capsule_md=$CAPSULE_MD"
+        #
+        #   2. The "Run task-runner.dot" step below passes that path straight
+        #      through as an engine parameter -- it copies nothing:
+        #        --param task_file="$GITHUB_WORKSPACE/${{ steps.locate.outputs.capsule_md }}"
+        #
+        #   3. task-runner.dot's `setup` node does NOT stage a
+        #      .ai/capsule/DEFINITION.{md,verify.sh} pair. It wipes .ai/ and
+        #      only RESOLVES the sibling gate path:
+        #        rm -rf .ai && mkdir -p .ai/feedback .ai/postmortem
+        #        ... VF="$task_file"; VF="${VF%.md}.verify.sh"; ...
+        #        [ -f "$task_file" ] && [ -f "$VF" ] && printf ok || printf missing
+        #
+        #   4. task-runner.dot's `verify` node then runs the gate IN PLACE, at
+        #      its proposals/ path -- there is no .ai/capsule/ copy anywhere:
+        #        VF="$task_file"; VF="${VF%.md}.verify.sh"; ...
+        #        timeout 1800 bash "$VF" > .ai/verify.log 2>&1
+        #
+        #   5. So a gate that resolves its own directory, as #218's does --
+        #        GATE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+        #        ORACLE_PY="$GATE_DIR/oracle.py"
+        #      resolves GATE_DIR to the PROPOSALS dir, and looks for
+        #      `oracle.py` there. The fixture ships prefix-qualified, as
+        #      `<id>.oracle.py`, because that is how the specify stage's
+        #      `package` step names plain files copied out of .ai/capsule/.
+        #      Nothing strips the prefix back off. Result: FATAL, exit 2,
+        #      every iteration, until the budget is gone.
+        #
+        # THE FIX, and why it is HERE and not in the .dot: steps 3 and 4 are
+        # the vendored task-runner.dot, which this repo deliberately keeps
+        # pristine (see that file's own header). Staging is a workflow-layer
+        # concern anyway -- put the files where the engine's contract already
+        # expects to find them, before the engine starts. The alternative,
+        # noted and NOT taken: teach task-runner.dot's `setup` node to
+        # prefix-strip fixtures itself, which would make the .dot capsule-
+        # aware and diverge it from upstream for a problem the caller can
+        # solve without it.
+        #
+        # Prefix-strip idiom and glob (`<id>.*.py` / `<id>.*.json`) are
+        # verify_shipped_gate.sh's, verbatim -- so the fence that PROVES a
+        # capsule and the stage that RUNS it agree on what a fixture is.
+        #
+        # The staged copies are untracked build inputs, not capsule content:
+        # they are added to the repo's exclude file so neither
+        # task-runner.dot's own `ship_check` gate nor this job's pre-push
+        # porcelain check (both `git status --porcelain | grep -v -E '^\?\? \.ai'`)
+        # sees them, and so no maker's `git add -A` can sweep a duplicate into
+        # the fix PR.
+        run: |
+          set -euo pipefail
+          cd "$GITHUB_WORKSPACE"
+          CAPSULE_MD="${{ steps.locate.outputs.capsule_md }}"
+          ID="${{ steps.locate.outputs.capsule_id }}"
+          DIR="$(dirname "$CAPSULE_MD")"
+
+          EXCLUDE="$(git rev-parse --git-common-dir)/info/exclude"
+          mkdir -p "$(dirname "$EXCLUDE")"
+          touch "$EXCLUDE"
+
+          staged=0
+          for fixture in "$DIR/$ID."*.py "$DIR/$ID."*.json; do
+            [ -f "$fixture" ] || continue
+            base="$(basename "$fixture")"
+            staged_name="${base#"$ID."}"
+            dest="$DIR/$staged_name"
+
+            # Never clobber repository content. A capsule fixture whose
+            # stripped name collides with a TRACKED file is a capsule that
+            # cannot be staged safely -- say so and stop, rather than
+            # overwriting a real file and running the gate against a tree
+            # that no longer matches the base SHA it pins.
+            if git ls-files --error-unmatch "$dest" >/dev/null 2>&1; then
+              echo "::error::capsule-implement: staging the vendored fixture $base would overwrite the TRACKED file $dest. Refusing -- the gate would then run against a mutated tree. Rename the fixture in the capsule (it is copied out of .ai/capsule/ as <id>.<original-name>) so its stripped name does not collide." >&2
+              exit 1
+            fi
+
+            cp "$fixture" "$dest"
+            grep -qxF "/$dest" "$EXCLUDE" || echo "/$dest" >> "$EXCLUDE"
+            echo "staged vendored fixture $base -> $dest (sha256 $(sha256sum < "$dest" | awk '{print $1}'))"
+            staged=$((staged + 1))
+          done
+
+          if [ "$staged" -eq 0 ]; then
+            echo "no vendored gate fixtures (<id>.*.py / <id>.*.json) ship with this capsule -- the gate runs with the pair alone."
+          else
+            echo "staged $staged vendored gate fixture(s) beside $DIR/$ID.verify.sh"
+          fi
+          # Prove the staging is invisible to the tree checks that follow.
+          echo "--- git status --porcelain (fixtures must not appear) ---"
+          git status --porcelain || true
+
       - name: Run task-runner.dot (implement stage)
         id: run
         if: steps.locate.outputs.skip != 'true'

--- a/.github/workflows/capsule-specify.yml
+++ b/.github/workflows/capsule-specify.yml
@@ -693,6 +693,58 @@ jobs:
             [ -f "$f" ] && cp "$f" "$DEST/"
           done
 
+          # VENDORED GATE FIXTURES (incident, 2026-08-14, run 31775541024 ->
+          # PR #218 -- the FEATURE lane, but the defect lane's publication
+          # step has the identical shape and therefore the identical defect).
+          # The evidence list above is a FIXED enumeration of suffixes with no
+          # `.py`/`.json` entries, so a capsule shipping a plain sibling file
+          # its gate loads BY PATH would have that file silently dropped from
+          # the commit -- while the shipped-gate check above, which stages
+          # exactly those fixtures, PASSed on the copy that still had them.
+          #
+          # No defect capsule has shipped a fixture yet. That is a fact about
+          # today's capsules, not a property of this step: capsule.dot's
+          # `package` copies plain files out of .ai/capsule/ the same way
+          # feature-capsule.dot does, so the same gate can be written here
+          # tomorrow. Fixed now, while it is a no-op, rather than after it
+          # produces a second unusable capsule PR.
+          #
+          # Same glob as verify_shipped_gate.sh's own fixture glob, so the
+          # verifier and the publisher cannot disagree about what travels.
+          for f in "$OUT/$ID".*.py "$OUT/$ID".*.json; do
+            [ -f "$f" ] && cp "$f" "$DEST/"
+          done
+
+          # -----------------------------------------------------------------
+          # SHIP WHAT YOU VERIFIED -- the authoritative shipped-gate check.
+          # -----------------------------------------------------------------
+          # The `gate_exec` step above verifies $RUNNER_TEMP/capsule-run/out.
+          # This verifies $DEST -- the set that is about to be `git add`ed.
+          # Those two sets were only ever equal by the good behaviour of the
+          # copy commands between them; verifying the SOURCE of a copy proves
+          # nothing about a LOSSY copy. The only honest place to run the check
+          # is the committed set itself.
+          #
+          # The earlier capsule-out invocation is KEPT deliberately: it fails
+          # before `git checkout -b`, so a bad capsule stays cheap to reject --
+          # but THIS invocation is the authoritative one, because it runs the
+          # bytes that become the PR.
+          #
+          # Same lane/id/repo/base-sha as `gate_exec`; a separate --log-dir so
+          # both runs' evidence survives in the uploaded artifact. Failure
+          # aborts this step under `set -e`, before any add/commit/push --
+          # loud, and no PR.
+          echo "ship-what-you-verified: re-running the shipped-gate check against the COMMITTED set ($DEST)"
+          bash .github/capsule-pipeline/verify_shipped_gate.sh \
+            --lane defect \
+            --capsule-dir "$GITHUB_WORKSPACE/$DEST" \
+            --id "$ID" \
+            --repo "$GITHUB_WORKSPACE" \
+            --base-sha "${{ steps.base.outputs.sha }}" \
+            --log-dir "$RUNNER_TEMP/capsule-run/logs/shipped-gate-committed" \
+            --timeout 300
+          echo "ship-what-you-verified: the committed set reproduces the verified capsule. Proceeding to commit."
+
           COMMIT_MSG_FILE="$RUNNER_TEMP/capsule-run/commit-msg.txt"
           {
             echo "specify: work capsule for issue #${ISSUE} (${ID})"

--- a/.github/workflows/feature-specify.yml
+++ b/.github/workflows/feature-specify.yml
@@ -943,6 +943,59 @@ jobs:
             [ -f "$f" ] && cp "$f" "$DEST/"
           done
 
+          # VENDORED GATE FIXTURES (incident, 2026-08-14, run 31775541024 ->
+          # PR #218). The evidence list above is a FIXED enumeration of
+          # suffixes and it has no `.py`/`.json` entries -- so when a capsule
+          # ships a plain sibling file its gate loads BY PATH, that file was
+          # silently not copied into the commit. #218's gate hard-requires
+          # `$GATE_DIR/oracle.py` and exits 2 (FATAL) without it. The run DID
+          # produce `<id>.oracle.py`; the shipped-gate check above staged and
+          # ran against it and PASSed; then this step dropped it. The capsule
+          # that shipped was a strict SUBSET of the capsule that was verified.
+          #
+          # This glob is deliberately verify_shipped_gate.sh's OWN fixture
+          # glob (`<id>.*.py` / `<id>.*.json`) -- one definition of "fixture"
+          # on both sides of the fence, so the verifier and the publisher
+          # cannot disagree about what travels with the pair. Any other suffix
+          # stays with the enumeration above rather than being guessed at.
+          for f in "$OUT/$ID".*.py "$OUT/$ID".*.json; do
+            [ -f "$f" ] && cp "$f" "$DEST/"
+          done
+
+          # -----------------------------------------------------------------
+          # SHIP WHAT YOU VERIFIED -- the authoritative shipped-gate check.
+          # -----------------------------------------------------------------
+          # The structural half of the same incident, and the half that makes
+          # the class un-repeatable rather than just fixing today's instance.
+          #
+          # The `gate_exec` step above verifies $RUNNER_TEMP/capsule-run/out.
+          # This verifies $DEST -- the set that is about to be `git add`ed.
+          # Those two sets were only ever equal by the good behaviour of the
+          # copy commands between them, and they were NOT equal: a fixed
+          # suffix list cannot express "everything that was proven". Verifying
+          # the SOURCE of a copy proves nothing about a LOSSY copy. The only
+          # honest place to run the check is the committed set itself.
+          #
+          # The earlier capsule-out invocation is KEPT deliberately: it fails
+          # before `git checkout -b`, so a bad capsule stays cheap to reject --
+          # but THIS invocation is the authoritative one, because it runs the
+          # bytes that become the PR.
+          #
+          # Same lane/id/repo/base-sha as `gate_exec`; a separate --log-dir so
+          # both runs' evidence survives in the uploaded artifact. Failure
+          # aborts this step under `set -e`, before any add/commit/push --
+          # loud, and no PR.
+          echo "ship-what-you-verified: re-running the shipped-gate check against the COMMITTED set ($DEST)"
+          bash .github/capsule-pipeline/verify_shipped_gate.sh \
+            --lane feature \
+            --capsule-dir "$GITHUB_WORKSPACE/$DEST" \
+            --id "$ID" \
+            --repo "$GITHUB_WORKSPACE" \
+            --base-sha "${{ steps.base.outputs.sha }}" \
+            --log-dir "$RUNNER_TEMP/capsule-run/logs/shipped-gate-committed" \
+            --timeout 300
+          echo "ship-what-you-verified: the committed set reproduces the verified capsule. Proceeding to commit."
+
           COMMIT_MSG_FILE="$RUNNER_TEMP/capsule-run/commit-msg.txt"
           {
             echo "specify(feature): work capsule for issue #${ISSUE} (${ID})"


### PR DESCRIPTION
## Ship what you verified

**The gap, proven.** Fire 11 (run [31775541024](https://github.com/microsoft/amplifier-bundle-attractor/actions/runs/31775541024)) converged, the shipped-gate fence PASSed, and the workflow opened capsule PR #218 — carrying a gate that **cannot run**.

The fence did its job. Its log says so:

```
staged vendored fixture llm-cost-exposure-unified-loop.oracle.py -> .ai/capsule/oracle.py
  (sha256 6b882132e904e3f47768e1a13a9f48e7fc0e0f2599599d1c511adeafeff9ad76)
verify_shipped_gate: PASS -- the SHIPPED gate (sha256 e3aeec70...) runs at b8896433...
```

Then the publication step copied the pair plus a **fixed list of evidence suffixes** — `criteria.md criteria-digest base-sha census-red ... questions-open.md` — with no `.py`/`.json` entries. `$OUT/$ID.oracle.py` never reached the commit. #218's gate hard-requires `ORACLE_PY="$GATE_DIR/oracle.py"` and exits **2 (FATAL)** without it.

**The fence verified capsule-out. The commit shipped a subset of it.** The proof was true about bytes that were never published.

The lesson is not "the list was missing an entry." It is that two sets — the verified set and the shipped set — were held equal only by the good behaviour of the copy commands between them. Verifying the *source* of a copy proves nothing about a *lossy* copy.

---

### `feature-specify.yml` / `capsule-specify.yml` — "Open capsule PR"

**(a) Copy the fixtures**, using `verify_shipped_gate.sh`'s *own* glob (`<id>.*.py` / `<id>.*.json`), so the verifier and the publisher cannot disagree about what a fixture is.

**(b) The structural fix.** After everything is copied into `$DEST` and **before `git add`**, re-run `verify_shipped_gate.sh` with `--capsule-dir "$GITHUB_WORKSPACE/$DEST"` — same lane, id, repo and base SHA as the earlier invocation, separate `--log-dir` so both runs' evidence survives in the artifact. Failure aborts the step under `set -e`, before any add/commit/push: **no PR**.

Verified-set == shipped-set is now a *checked property*, not an assumption — and it stays true for whatever the fixed list forgets next.

> The earlier capsule-out invocation is **kept deliberately**: it fails before `git checkout -b`, so a bad capsule stays cheap to reject. The `$DEST` re-check is the authoritative one.

**Defect lane verdict: same shape, same change.** `capsule-specify.yml`'s PR-push step is structurally identical (pair `cp` + fixed `for extra in base-sha hypothesis.patch ...` list + commit). No defect capsule ships a fixture *today*, but `capsule.dot`'s `package` copies plain files out of `.ai/capsule/` exactly as `feature-capsule.dot` does — the same gate can be written there tomorrow. Fixed while it is still a no-op.

### `capsule-implement.yml` — new step, "Stage the capsule's vendored gate fixtures beside the gate"

Restoring the file on #218's branch is necessary but **not sufficient**. Traced end to end:

1. `locate` resolves the pair and exports `capsule_md`.
2. The run step passes it straight through — it copies nothing:
   `--param task_file="$GITHUB_WORKSPACE/${{ steps.locate.outputs.capsule_md }}"`
3. `task-runner.dot`'s `setup` node wipes `.ai/` and only *resolves* the sibling gate — **there is no `.ai/capsule/DEFINITION.*` staging anywhere**:
   `rm -rf .ai && ... VF="$task_file"; VF="${VF%.md}.verify.sh"; ...`
4. `task-runner.dot`'s `verify` node runs the gate **in place**: `timeout 1800 bash "$VF"`
5. So a gate resolving `GATE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"` looks for `oracle.py` in the **proposals dir**, while the fixture ships prefix-qualified as `<id>.oracle.py`. Nothing strips the prefix. **FATAL rc=2, every iteration, until the budget is gone.**

The new step stages fixtures prefix-stripped beside the gate before the engine starts — same glob and strip idiom as the fence — refusing to overwrite any tracked file, and adding each staged copy to the repo's exclude file so neither `task-runner.dot`'s `ship_check` nor this job's pre-push porcelain check (both `git status --porcelain | grep -v -E '^\?\? \.ai'`) sees it.

**The vendored `task-runner.dot` is deliberately not modified.** The alternative — teaching its `setup` node to prefix-strip — would make the `.dot` capsule-aware and diverge it from upstream for a problem the caller can solve without it. Noted in the step's comment, not taken.

---

### Measured, against fire 11's own evidence artifact

| what | result |
|---|---|
| #218 **as published** (pair only) | `verify_shipped_gate` **FAIL** — gate rc=2, `FATAL: oracle.py not found` |
| patched copy step replayed over the run's capsule-out | **PASS** — gate sha `e3aeec70...`, census matches `<id>.census-red` row-for-row |
| implement-stage invocation on #218's repaired branch, **before** the new staging step | gate **rc=2** (FATAL) |
| same, **after** the new staging step | gate **rc=1**, correct 6-row census |

`actionlint` output is **identical to main** (same 3 pre-existing findings; line numbers shifted only). `bash -n` clean on every changed step; YAML parses; `git diff --check` clean.

**PR #218 has been repaired separately** — the fixture restored byte-identical from the run's own evidence artifact, sha256 verified — and now PASSes the shipped-gate check from its own branch.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)
