### PR TITLE
fix(capsule): seed the issue-204 capsule with the prior attempt's blocking findings

### DIFF
--- a/.github/capsule-pipeline/proposals/issue-204/llm-cost-exposure-unified-loop.md
+++ b/.github/capsule-pipeline/proposals/issue-204/llm-cost-exposure-unified-loop.md
@@ -174,3 +174,49 @@ See `.ai/brief.md` RISK-2 and RISK-4 for two unresolved design forks:
 1. **AC-2 "None rate dimension" public surface** (RISK-2): How should the gate exercise the "rate dimension is None" case via public surfaces only? Will the implementation add a model with `null` cost fields to `models.json`, expose a public `ModelInfo`-accepting overload of `compute_cost`, or use another mechanism?
 
 2. **AC-4 scope** (RISK-4): Does `cost_usd` in `provider:response` also apply to `AmplifierBackend._run_with_tool_loop()` (Path B), or only to `DirectProviderBackend`?
+
+---
+
+## Prior-attempt findings (2026-08-14 — maintainer's agent; binding for the next implement run)
+
+An earlier run built this feature to completion. The gate above went GREEN — all
+six ACs MET — and both module suites passed: 724 unified-llm-client tests and
+1836 loop-pipeline tests. It still did not ship. It stalled on the second
+reviewer's documentation findings, three rounds running, and the run was lost
+before the work could be salvaged.
+
+Nothing here changes the acceptance criteria or the gate. These are the three
+things that blocked the last attempt. Address them UP FRONT, in the same change
+as the feature — not after the gate goes green:
+
+1. **README documentation for the new cost surface must exist and be accurate.**
+   `compute_cost`, `usage.cost_usd`, and the `cost_usd` key on the
+   `provider:response` payload each need to be documented in
+   `modules/unified-llm-client/README.md`: what they return, and what `None`
+   means (pricing unknown, never zero). A green gate is not documentation, and
+   the reviewer will hold on its absence.
+
+2. **No repository URLs or cross-repository references inside docstrings.**
+   The prior attempt put an external project name and a commit SHA into
+   `_cost.py`'s module docstring, and that was called out as a violation of this
+   repo's own dependency-awareness rule. Provenance for the vendored rate data
+   belongs in this proposal's oracle-provenance block, not in shipped source.
+
+3. **Every README or doc example must actually run against the real public API.**
+   This is what finally blocked the run. The prior attempt's README added an
+   example at line 30 constructing the client as `Client(adapter=...)` — a
+   keyword `Client.__init__` does not accept. Read the real constructor and use
+   the real construction, then EXECUTE every example you write before claiming
+   it works. An example that raises is worse than no example.
+
+The second reviewer's final blocking finding, verbatim:
+
+> **VERDICT: ITERATE**
+>
+> Blocking finding: the newly added README example uses unsupported `Client(adapter=...)` construction. Fresh reproduction against the current tree confirms it raises:
+>
+> ```text
+> TypeError: Client.__init__() got an unexpected keyword argument 'adapter'
+> ```
+>
+> The DoD gate and unified-client suite were re-run successfully; the loop-pipeline suite could not collect due to a missing `respx` environment dependency.


### PR DESCRIPTION
## Summary

Hands the stalled issue-204 implement work back to the pipeline through its designed input
channel (the #180 precedent): appends a clearly-headed addendum to the merged capsule
`.github/capsule-pipeline/proposals/issue-204/llm-cost-exposure-unified-loop.md`.

Run [31789137305](https://github.com/microsoft/amplifier-bundle-attractor/actions/runs/31789137305)
built this feature **to completion** — gate GREEN, all 6 ACs MET, 724 unified-llm-client + 1836
loop-pipeline tests passing — and stalled on the second reviewer's documentation findings, three
rounds running. Then the run was lost. Without this addendum the next implement run starts from
zero and rediscovers the same three findings the same slow, expensive way.

**Nothing but the `.md` is touched.** The acceptance criteria, the gate script, and every sibling
artifact are byte-identical to `main`.

### The addendum, as written for the worker

> ## Prior-attempt findings (2026-08-14 — maintainer's agent; binding for the next implement run)
>
> An earlier run built this feature to completion. The gate above went GREEN — all six ACs MET —
> and both module suites passed: 724 unified-llm-client tests and 1836 loop-pipeline tests. It
> still did not ship. It stalled on the second reviewer's documentation findings, three rounds
> running, and the run was lost before the work could be salvaged.
>
> Nothing here changes the acceptance criteria or the gate. These are the three things that
> blocked the last attempt. Address them UP FRONT, in the same change as the feature — not after
> the gate goes green:
>
> 1. **README documentation for the new cost surface must exist and be accurate.** `compute_cost`,
>    `usage.cost_usd`, and the `cost_usd` key on the `provider:response` payload each need to be
>    documented in `modules/unified-llm-client/README.md`: what they return, and what `None` means
>    (pricing unknown, never zero). A green gate is not documentation, and the reviewer will hold
>    on its absence.
>
> 2. **No repository URLs or cross-repository references inside docstrings.** The prior attempt put
>    an external project name and a commit SHA into `_cost.py`'s module docstring, and that was
>    called out as a violation of this repo's own dependency-awareness rule. Provenance for the
>    vendored rate data belongs in this proposal's oracle-provenance block, not in shipped source.
>
> 3. **Every README or doc example must actually run against the real public API.** This is what
>    finally blocked the run. The prior attempt's README added an example at line 30 constructing
>    the client as `Client(adapter=...)` — a keyword `Client.__init__` does not accept. Read the
>    real constructor and use the real construction, then EXECUTE every example you write before
>    claiming it works. An example that raises is worse than no example.
>
> The second reviewer's final blocking finding, verbatim:
>
> > **VERDICT: ITERATE**
> >
> > Blocking finding: the newly added README example uses unsupported `Client(adapter=...)` construction. Fresh reproduction against the current tree confirms it raises:
> >
> > ```text
> > TypeError: Client.__init__() got an unexpected keyword argument 'adapter'
> > ```
> >
> > The DoD gate and unified-client suite were re-run successfully; the loop-pipeline suite could not collect due to a missing `respx` environment dependency.

The blocking finding is quoted verbatim from the run's own preserved evidence
(`logs/critique_b/response.md`), so the next worker reads the reviewer's words rather than a
paraphrase of them.

## Verification evidence — the implement lane's own steps, run locally

### 1. Locate step: the pairing logic still resolves exactly one pair

`capsule-implement.yml`'s pairing loop, transcribed verbatim, driven over the capsule-PR file set
(all 17 files in `proposals/issue-204/`):

```
  .md candidates seen : ...author-tree-dirt.md ...criteria.md ...critique.md ...discrimination.md
                        ...md ...rival-red-unadjudicated.md ...stub-greened.md ...stub-report.md
  PAIRED_COUNT        : 1
  CAPSULE_MD          : .github/capsule-pipeline/proposals/issue-204/llm-cost-exposure-unified-loop.md
```

Eight `.md` candidates, exactly one pair. The addendum introduces no ambiguity — this is the same
check that was added after PR #171 silently picked `.discrimination.md`.

### 2. Fixture staging + gate execution at the pinned base

Pristine worktree at the capsule's own `base-sha` (`b889643`), the workflow's
"Stage the capsule's vendored gate fixtures" loop verbatim, then the gate run **in place** at its
proposals path — `task-runner.dot`'s `verify` idiom:

```
base SHA (from llm-cost-exposure-unified-loop.base-sha): b88964330b707473e308f569db374b30a2608247
worktree at: /tmp/fix12/gate-wt  HEAD=b889643
installed the EDITED capsule dir; llm-cost-exposure-unified-loop.md sha256 = 26b39845ff487f...
staged vendored fixture llm-cost-exposure-unified-loop.oracle.py -> .../oracle.py (sha256 6b882132e904...)
staged 1 vendored gate fixture(s) beside .../llm-cost-exposure-unified-loop.verify.sh
=== running: bash .../llm-cost-exposure-unified-loop.verify.sh (cwd=/tmp/fix12/gate-wt) ===
GATE rc=1
...
GATE SUMMARY
  PASS:       1
  FAIL:       5
  INFRA-FAIL: 0
Census:
AC-1: UNMET
AC-2: UNMET
AC-3: UNMET
AC-4: UNMET
AC-5: UNMET
AC-6: MET
GATE RESULT: FAIL (exit 1)
--- diff vs shipped llm-cost-exposure-unified-loop.census-red ---
CENSUS MATCHES the shipped base census exactly.
```

`rc=1`, articulate RED, census byte-identical to the shipped `.census-red`. **The addendum does
not affect gate execution.**

### 3. Leak scan over the changed file — zero new hits

`.github/capsule-pipeline/vendor/backlog/check-upstream-leaks.sh`, the same idiom the `leak_gate`
node uses (`sh <scanner> <file>`; rc 0 = clean):

```
BASELINE (main's copy of the capsule .md)  -> rc=0  clean
HEAD     (the edited capsule .md)          -> rc=0  clean
ADDED BYTES ONLY (46 lines)                -> rc=0  clean
```

And the scanner's own self-test, so that silence is a live check rather than a broken one:

```
self-test ok: RED fixture trips the scanner: t4-9-prefix.RED.txt
self-test ok: RED fixture trips the scanner: t1-7-prefix.RED.txt
self-test ok: RED fixture trips the scanner: t2-7-coordination.RED.txt
self-test ok: RED fixture trips the scanner: t2-7-primer-ref.RED.txt
self-test ok: GREEN fixture (shipped EXTENSIONS text) passes clean
self-test ok: GREEN control — upstream-carried task ids pass the TID_ALLOW carve-out
check-upstream-leaks self-test: PASS (RED x4, GREEN x2)
```

### 4. Housekeeping

`git diff --check` clean. `CI Gate (all checks passed)` runs the full matrix on this PR regardless
(no module code is touched by this diff).

## NOTE — merging this PR fires Capsule Implement, and its locate step will refuse

This PR changes the capsule `.md` **without** its sibling `.verify.sh`, so the merged-PR trigger's
pairing logic sees zero pairs. Measured on this PR's own changed-file set:

```
  .md candidates seen : .github/capsule-pipeline/proposals/issue-204/llm-cost-exposure-unified-loop.md
  PAIRED_COUNT        : 0
  CAPSULE_MD          : <none>
```

The step will exit 1 with *"no capsule (`<id>.md` with its sibling `<id>.verify.sh` in the same
PR) was found among its changed files — refusing to guess."* **That is the guard working as
designed, not a regression** — it is the check added after PR #171's silent wrong-file pick.

Editing `verify.sh` purely to force a trigger was considered and rejected: a byte change to a
proven gate changes what "passed" means, and the whole point of this addendum is that the gate is
untouched. The correct re-run path is `workflow_dispatch` with
`capsule_path=.github/capsule-pipeline/proposals/issue-204/llm-cost-exposure-unified-loop.md` —
after #221 lands, so the run can answer its own human gate instead of crashing at it.

Not auto-merged — a human reviews this.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)
