### PR TITLE
implement: fix for #204 (llm-cost-exposure-unified-loop)

### DIFF
--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/__init__.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/__init__.py
@@ -233,6 +233,7 @@ class DirectProviderBackend:
                 "finish_reason": result.finish_reason.reason,
                 "text_length": len(result.text) if result.text else 0,
                 "step_count": len(result.steps),
+                "cost_usd": result.total_usage.cost_usd,
             },
         )
 

--- a/modules/loop-pipeline/tests/test_provider_hooks.py
+++ b/modules/loop-pipeline/tests/test_provider_hooks.py
@@ -475,6 +475,9 @@ async def test_direct_backend_emits_provider_response():
     data = hooks.get_data("provider:response")[0]
     assert "usage" in data
     assert data["finish_reason"] == "stop"
+    # Cost is exposed as a top-level key (value is None for an unpriced model,
+    # but the key must always be present for consumers to read).
+    assert "cost_usd" in data
 
 
 @pytest.mark.asyncio

--- a/modules/unified-llm-client/README.md
+++ b/modules/unified-llm-client/README.md
@@ -19,3 +19,209 @@ pytest -q
 ```
 
 Provider adapter tests require `anthropic` and `google-genai`. If those packages are missing, tests will fail on import.
+
+---
+
+## Cost exposure
+
+The library exposes per-call USD cost through three public surfaces:
+`compute_cost`, `usage.cost_usd` on responses, and the `cost_usd` key on
+`provider:response` events emitted by `DirectProviderBackend`.
+
+### `compute_cost`
+
+```python
+from decimal import Decimal
+from unified_llm import compute_cost
+
+# Returns Decimal for a known model
+cost = compute_cost("claude-sonnet-4-5-20250929", 1000, 200)
+# Decimal('0.006')
+
+# Returns None for an unknown model -- never 0, never a float
+unknown = compute_cost("my-custom-model", 1000, 200)
+# None
+
+# Cache tokens and fast mode
+cost_with_cache = compute_cost(
+    "claude-sonnet-4-5-20250929",
+    input_tokens=500,
+    output_tokens=100,
+    cache_read_tokens=2000,
+    cache_write_tokens=300,
+)
+# Decimal: input + output + cache_read + cache_write costs combined
+
+# Fast mode (2x multiplier on eligible models)
+fast_cost = compute_cost("claude-opus-4-8", 1000, 200, speed="fast")
+```
+
+**Signature:**
+```
+compute_cost(model, input_tokens=0, output_tokens=0, *,
+             cache_read_tokens=0, cache_write_tokens=0, speed=None)
+    -> Decimal | None
+```
+
+**What `None` means:** pricing unknown for this model. `None` is semantically
+distinct from `Decimal('0')` (a free call). A `None` result never means zero
+cost -- it means the rate table has no entry for the model.
+
+### `response.usage.cost_usd`
+
+`Client.complete()` and the streaming accumulator automatically populate
+`usage.cost_usd` from the model id and token counts returned by the adapter.
+The adapter does not need to set it.
+
+```python
+import asyncio
+from unified_llm import (
+    Client, Request, Message, Response, FinishReason, Usage,
+    StreamEvent, StreamEventType,
+)
+
+# Minimal mock adapter -- no API key or network required
+class _MockAdapter:
+    name = "mock"
+
+    async def complete(self, request):
+        return Response(
+            id="r1",
+            model=request.model,
+            provider="mock",
+            message=Message.assistant("Hello!"),
+            finish_reason=FinishReason(reason="stop"),
+            # cost_usd is intentionally absent; Client.complete() injects it
+            usage=Usage(input_tokens=100, output_tokens=50, total_tokens=150),
+        )
+
+    async def stream(self, request):
+        # stream() is not used in this example
+        return
+        yield  # make it an async generator
+
+    async def close(self): pass
+    async def initialize(self): pass
+    def supports_tool_choice(self, mode): return True
+
+client = Client(providers={"mock": _MockAdapter()}, default_provider="mock")
+
+request = Request(
+    model="claude-sonnet-4-5-20250929",
+    provider="mock",
+    messages=[Message.user("Hello")],
+)
+
+async def main():
+    response = await client.complete(request)
+    print(response.usage.cost_usd)
+    # Decimal('0.00105') for claude-sonnet-4-5-20250929 with 100 input + 50 output tokens
+
+asyncio.run(main())
+```
+
+**Streaming accumulator path:**
+
+```python
+import asyncio
+from unified_llm import (
+    Client, Request, Message, Response, FinishReason, Usage,
+    StreamEvent, StreamEventType, StreamAccumulator,
+)
+
+# Minimal mock adapter that yields stream events
+class _MockStreamAdapter:
+    name = "mock"
+
+    async def complete(self, request):
+        raise NotImplementedError
+
+    async def stream(self, request):
+        yield StreamEvent(type=StreamEventType.TEXT_START)
+        yield StreamEvent(type=StreamEventType.TEXT_DELTA, delta="Hello!")
+        yield StreamEvent(type=StreamEventType.TEXT_END)
+        yield StreamEvent(
+            type=StreamEventType.FINISH,
+            finish_reason=FinishReason(reason="stop"),
+            usage=Usage(input_tokens=100, output_tokens=50, total_tokens=150),
+            response=Response(
+                id="r1",
+                model=request.model,
+                provider="mock",
+                message=Message.assistant("Hello!"),
+                finish_reason=FinishReason(reason="stop"),
+                usage=Usage(input_tokens=100, output_tokens=50, total_tokens=150),
+            ),
+        )
+
+    async def close(self): pass
+    async def initialize(self): pass
+    def supports_tool_choice(self, mode): return True
+
+async def main():
+    client = Client(providers={"mock": _MockStreamAdapter()}, default_provider="mock")
+    request = Request(
+        model="claude-sonnet-4-5-20250929",
+        provider="mock",
+        messages=[Message.user("Hello")],
+    )
+    acc = StreamAccumulator()
+    async for event in client.stream(request):
+        acc.process(event)
+    response = acc.response()
+    print(response.usage.cost_usd)
+    # Decimal('0.00105') for claude-sonnet-4-5-20250929 with 100 input + 50 output tokens
+
+asyncio.run(main())
+```
+
+### `Usage` addition and `None` propagation
+
+When summing `Usage` objects across multiple steps, any `None` cost operand
+yields a `None` total. This prevents a partial sum from being mistaken for
+a complete cost.
+
+```python
+from decimal import Decimal
+from unified_llm import Usage
+
+u1 = Usage(input_tokens=100, output_tokens=50, total_tokens=150, cost_usd=Decimal("0.01"))
+u2 = Usage(input_tokens=200, output_tokens=80, total_tokens=280, cost_usd=None)
+
+total = u1 + u2
+print(total.cost_usd)   # None  (any None operand -> None total)
+print(total.input_tokens)  # 300  (token fields sum normally)
+
+# Decimal + Decimal -> Decimal sum
+u3 = Usage(input_tokens=100, output_tokens=50, total_tokens=150, cost_usd=Decimal("0.01"))
+u4 = Usage(input_tokens=200, output_tokens=80, total_tokens=280, cost_usd=Decimal("0.02"))
+print((u3 + u4).cost_usd)  # Decimal('0.03')
+```
+
+### `provider:response` event `cost_usd` key
+
+When `DirectProviderBackend` emits a `provider:response` event, the payload
+carries a top-level `"cost_usd"` key equal to `response.usage.cost_usd`.
+The key is always present; the value is `Decimal` for known models and `None`
+for unknown ones. An absent key is never emitted.
+
+```
+# Payload structure (schema -- not executable Python; Decimal values shown as strings)
+{
+    "provider": "anthropic",
+    "model": "claude-sonnet-4-5-20250929",
+    "node_id": "my_node",
+    "usage": {
+        "input_tokens": 1000,
+        "output_tokens": 200,
+        "total_tokens": 1200,
+        "reasoning_tokens": None,
+        "cache_read_tokens": None,
+        "cache_write_tokens": None,
+    },
+    "finish_reason": "stop",
+    "text_length": 42,
+    "step_count": 1,
+    "cost_usd": "0.006",   # Decimal for known models; None when model is unknown
+}
+```

--- a/modules/unified-llm-client/tests/unit/test_cost.py
+++ b/modules/unified-llm-client/tests/unit/test_cost.py
@@ -1,0 +1,510 @@
+"""Tests for unified_llm._cost — per-call USD cost computation and injection.
+
+Covers the three public cost surfaces:
+  * ``compute_cost()`` — the calculator itself.
+  * ``Usage.cost_usd`` + ``Usage.__add__`` — None-propagating aggregation.
+  * ``Client.complete()`` / ``StreamAccumulator.response()`` — injection of a
+    computed cost when the adapter did not supply one.
+
+Expected values are derived programmatically from the module's own ``_RATES``
+table (never hard-coded from an external source), so a rate correction updates
+test and code together while the *shape* of the arithmetic stays pinned.
+"""
+
+import asyncio
+from collections.abc import AsyncIterator
+from decimal import Decimal
+
+from unified_llm import compute_cost
+from unified_llm._cost import _FAST_ELIGIBLE_MODELS, _PER_M, _RATES
+from unified_llm.catalog import get_model_info
+from unified_llm.client import Client
+from unified_llm.types import (
+    FinishReason,
+    Message,
+    Request,
+    Response,
+    StreamAccumulator,
+    StreamEvent,
+    StreamEventType,
+    Usage,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_KNOWN_MODEL = "claude-sonnet-4-5"
+_UNKNOWN_MODEL = "definitely-not-a-real-model-xyz"
+# Catalog fixture carrying null cost dimensions.
+_NULL_RATE_MODEL = "preview-model-cost-unknown"
+
+
+def _expected(
+    model: str,
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+    *,
+    cache_read_tokens: int = 0,
+    cache_write_tokens: int = 0,
+) -> Decimal:
+    """Expected cost, derived term-by-term from the module's own rate table.
+
+    Mirrors the documented arithmetic: each token class is priced per million
+    tokens, i.e. ``tokens * rate_per_million / 1_000_000``, then summed.
+    """
+    rates = _RATES[model]
+    total = Decimal(input_tokens) * rates["input_per_m"] / _PER_M
+    total += Decimal(output_tokens) * rates["output_per_m"] / _PER_M
+    if cache_read_tokens:
+        total += Decimal(cache_read_tokens) * rates["cache_read_per_m"] / _PER_M
+    if cache_write_tokens:
+        total += Decimal(cache_write_tokens) * rates["cache_write_per_m"] / _PER_M
+    return total
+
+
+def _first_fast_eligible() -> str:
+    """A deterministically-chosen model from the fast-eligible set."""
+    return min(_FAST_ELIGIBLE_MODELS)
+
+
+def _first_fast_ineligible() -> str:
+    """A priced model that is deliberately NOT fast-eligible."""
+    return min(set(_RATES) - _FAST_ELIGIBLE_MODELS)
+
+
+# ---------------------------------------------------------------------------
+# compute_cost — known models
+# ---------------------------------------------------------------------------
+
+
+class TestComputeCostKnownModel:
+    """compute_cost() prices a model present in the rate table."""
+
+    def test_known_model_exact_decimal(self) -> None:
+        """1.2M input + 300k output priced at the table's per-million rates.
+
+        For claude-sonnet-4-5 ($3.00 in / $15.00 out per 1M tokens) that is
+        1_200_000 * 3.00 / 1e6 + 300_000 * 15.00 / 1e6 = 3.60 + 4.50 = 8.10.
+        """
+        result = compute_cost(_KNOWN_MODEL, 1_200_000, 300_000)
+        assert result == _expected(_KNOWN_MODEL, 1_200_000, 300_000)
+        assert result == Decimal("8.10")
+
+    def test_result_is_decimal_never_float(self) -> None:
+        """Cost is exact Decimal money, never a lossy float."""
+        result = compute_cost(_KNOWN_MODEL, 1_000, 500)
+        assert isinstance(result, Decimal)
+        assert not isinstance(result, float)
+
+    def test_input_and_output_priced_at_different_rates(self) -> None:
+        """Output tokens are not silently priced at the input rate."""
+        rates = _RATES[_KNOWN_MODEL]
+        assert rates["output_per_m"] != rates["input_per_m"], (
+            "fixture model must have distinct in/out rates for this test to bite"
+        )
+        input_only = compute_cost(_KNOWN_MODEL, 100_000, 0)
+        output_only = compute_cost(_KNOWN_MODEL, 0, 100_000)
+        assert input_only != output_only
+        assert input_only == _expected(_KNOWN_MODEL, 100_000, 0)
+        assert output_only == _expected(_KNOWN_MODEL, 0, 100_000)
+
+    def test_cache_read_tokens_priced_separately(self) -> None:
+        """cache_read_tokens add their own (cheaper) line item."""
+        base = compute_cost(_KNOWN_MODEL, 10_000, 1_000)
+        with_cache = compute_cost(_KNOWN_MODEL, 10_000, 1_000, cache_read_tokens=50_000)
+        assert with_cache == _expected(
+            _KNOWN_MODEL, 10_000, 1_000, cache_read_tokens=50_000
+        )
+        assert base is not None and with_cache is not None
+        assert with_cache > base
+
+    def test_cache_write_tokens_priced_separately(self) -> None:
+        """cache_write_tokens add their own (premium) line item."""
+        base = compute_cost(_KNOWN_MODEL, 10_000, 1_000)
+        with_cache = compute_cost(
+            _KNOWN_MODEL, 10_000, 1_000, cache_write_tokens=50_000
+        )
+        assert with_cache == _expected(
+            _KNOWN_MODEL, 10_000, 1_000, cache_write_tokens=50_000
+        )
+        assert base is not None and with_cache is not None
+        assert with_cache > base
+
+    def test_cache_read_is_cheaper_than_cache_write(self) -> None:
+        """The two cache dimensions are not collapsed onto one rate."""
+        read = compute_cost(_KNOWN_MODEL, 0, 0, cache_read_tokens=1_000_000)
+        write = compute_cost(_KNOWN_MODEL, 0, 0, cache_write_tokens=1_000_000)
+        assert read is not None and write is not None
+        assert read < write
+
+    def test_zero_tokens_on_known_model_is_zero_not_none(self) -> None:
+        """A free call on a priced model is Decimal('0') — knowably zero."""
+        result = compute_cost(_KNOWN_MODEL, 0, 0)
+        assert result is not None
+        assert result == Decimal(0)
+
+
+# ---------------------------------------------------------------------------
+# compute_cost — unknown / unpriced models
+# ---------------------------------------------------------------------------
+
+
+class TestComputeCostUnknownModel:
+    """Unknown pricing yields None — never zero, never a partial estimate."""
+
+    def test_unknown_model_returns_none(self) -> None:
+        assert compute_cost(_UNKNOWN_MODEL, 1_000, 200) is None
+
+    def test_unknown_model_none_is_not_zero(self) -> None:
+        """None ('pricing unknown') is distinct from a genuinely free call."""
+        result = compute_cost(_UNKNOWN_MODEL, 1_000, 200)
+        assert result is None
+        assert result != Decimal(0)
+
+    def test_unknown_model_never_returns_float(self) -> None:
+        result = compute_cost(_UNKNOWN_MODEL, 1_000, 200)
+        assert result is None or isinstance(result, Decimal)
+
+    def test_catalog_model_with_null_rate_dimensions_returns_none(self) -> None:
+        """A catalogued model whose cost dimensions are null prices as None.
+
+        Reached through the public catalog surface: the entry exists and is
+        discoverable, but both cost-per-million dimensions are null, so
+        compute_cost() must decline rather than invent a number.
+        """
+        info = get_model_info(_NULL_RATE_MODEL)
+        assert info is not None, f"{_NULL_RATE_MODEL} must exist in the catalog"
+        assert info.input_cost_per_million is None
+        assert info.output_cost_per_million is None
+
+        assert compute_cost(info.id, 500, 100) is None
+
+    def test_null_rate_model_is_absent_from_rate_table(self) -> None:
+        """The structural reason the null-rate model prices as None."""
+        assert _NULL_RATE_MODEL not in _RATES
+
+
+# ---------------------------------------------------------------------------
+# compute_cost — fast mode
+# ---------------------------------------------------------------------------
+
+
+class TestComputeCostFastMode:
+    """speed='fast' doubles cost for eligible models only."""
+
+    def test_fast_doubles_cost_for_eligible_model(self) -> None:
+        model = _first_fast_eligible()
+        base = compute_cost(model, 100_000, 20_000)
+        fast = compute_cost(model, 100_000, 20_000, speed="fast")
+        assert base is not None and fast is not None
+        assert fast == base * 2
+
+    def test_fast_ignored_for_ineligible_model(self) -> None:
+        """A priced-but-not-fast-eligible model ignores speed='fast'."""
+        model = _first_fast_ineligible()
+        base = compute_cost(model, 100_000, 20_000)
+        fast = compute_cost(model, 100_000, 20_000, speed="fast")
+        assert base is not None and fast is not None
+        assert fast == base
+
+    def test_non_fast_speed_leaves_cost_unchanged(self) -> None:
+        """Only the literal 'fast' speed triggers the multiplier."""
+        model = _first_fast_eligible()
+        base = compute_cost(model, 100_000, 20_000)
+        assert compute_cost(model, 100_000, 20_000, speed=None) == base
+        assert compute_cost(model, 100_000, 20_000, speed="standard") == base
+
+    def test_fast_on_unknown_model_still_none(self) -> None:
+        """Fast mode does not conjure pricing for an unpriced model."""
+        assert compute_cost(_UNKNOWN_MODEL, 100, 100, speed="fast") is None
+
+    def test_fast_eligible_set_is_a_subset_of_priced_models(self) -> None:
+        """Every fast-eligible model has rates to double."""
+        assert _FAST_ELIGIBLE_MODELS <= set(_RATES)
+
+
+# ---------------------------------------------------------------------------
+# Usage.cost_usd — None-propagating aggregation
+# ---------------------------------------------------------------------------
+
+
+def _usage(cost: Decimal | None, tokens: int = 10) -> Usage:
+    return Usage(
+        input_tokens=tokens,
+        output_tokens=tokens,
+        total_tokens=tokens * 2,
+        cost_usd=cost,
+    )
+
+
+class TestUsageCostField:
+    """Usage carries an optional Decimal cost."""
+
+    def test_cost_usd_defaults_to_none(self) -> None:
+        usage = Usage(input_tokens=1, output_tokens=1, total_tokens=2)
+        assert usage.cost_usd is None
+
+    def test_cost_usd_round_trips_decimal(self) -> None:
+        usage = _usage(Decimal("1.25"))
+        assert usage.cost_usd == Decimal("1.25")
+        assert isinstance(usage.cost_usd, Decimal)
+
+
+class TestUsageAdditionCostPropagation:
+    """Usage.__add__ propagates None for cost — unlike token fields."""
+
+    def test_decimal_plus_decimal_sums(self) -> None:
+        total = _usage(Decimal("0.50")) + _usage(Decimal("0.25"))
+        assert total.cost_usd == Decimal("0.75")
+
+    def test_none_plus_decimal_poisons_to_none(self) -> None:
+        """An unknown-cost step makes the aggregate cost unknown."""
+        total = _usage(None) + _usage(Decimal("0.25"))
+        assert total.cost_usd is None
+
+    def test_decimal_plus_none_poisons_to_none(self) -> None:
+        """Poisoning is order-independent."""
+        total = _usage(Decimal("0.25")) + _usage(None)
+        assert total.cost_usd is None
+
+    def test_none_plus_none_is_none(self) -> None:
+        total = _usage(None) + _usage(None)
+        assert total.cost_usd is None
+
+    def test_poisoned_cost_never_degrades_to_zero(self) -> None:
+        """The None total is not silently coerced into Decimal('0')."""
+        total = _usage(None) + _usage(Decimal("0.25"))
+        assert total.cost_usd is None
+        assert total.cost_usd != Decimal(0)
+
+    def test_token_fields_still_add_when_cost_is_none(self) -> None:
+        """Cost's None-propagation must not leak into token aggregation."""
+        total = _usage(None, tokens=10) + _usage(Decimal("0.25"), tokens=5)
+        assert total.input_tokens == 15
+        assert total.output_tokens == 15
+        assert total.total_tokens == 30
+        assert total.cost_usd is None
+
+
+# ---------------------------------------------------------------------------
+# Client.complete() — cost injection
+# ---------------------------------------------------------------------------
+
+
+class _CostMockAdapter:
+    """Minimal ProviderAdapter returning a caller-supplied Response."""
+
+    def __init__(self, response: Response, name: str = "mock") -> None:
+        self._name = name
+        self._response = response
+        self.call_count = 0
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    async def complete(self, request: Request) -> Response:
+        self.call_count += 1
+        return self._response
+
+    async def stream(self, request: Request) -> AsyncIterator[StreamEvent]:
+        yield StreamEvent(type=StreamEventType.FINISH)
+
+    async def close(self) -> None:
+        pass
+
+    async def initialize(self) -> None:
+        pass
+
+    def supports_tool_choice(self, mode: str) -> bool:
+        return True
+
+
+def _adapter_response(model: str, usage: Usage, provider: str = "mock") -> Response:
+    return Response(
+        id="r1",
+        model=model,
+        provider=provider,
+        message=Message.assistant("hello"),
+        finish_reason=FinishReason(reason="stop"),
+        usage=usage,
+    )
+
+
+def _complete_with(response: Response) -> Response:
+    adapter = _CostMockAdapter(response)
+    client = Client(providers={"mock": adapter}, default_provider="mock")
+    request = Request(model=response.model, messages=[Message.user("hi")])
+    return asyncio.run(client.complete(request))
+
+
+class TestClientCompleteCostInjection:
+    """Client.complete() fills in the cost_usd the adapter did not set."""
+
+    def test_injects_computed_cost_when_adapter_omits_it(self) -> None:
+        usage = Usage(input_tokens=200_000, output_tokens=50_000, total_tokens=250_000)
+        assert usage.cost_usd is None  # precondition: adapter set nothing
+
+        result = _complete_with(_adapter_response(_KNOWN_MODEL, usage))
+
+        assert result.usage.cost_usd == _expected(_KNOWN_MODEL, 200_000, 50_000)
+        assert isinstance(result.usage.cost_usd, Decimal)
+
+    def test_injection_includes_cache_dimensions(self) -> None:
+        """Cache token counts are forwarded into the computation, not dropped."""
+        usage = Usage(
+            input_tokens=10_000,
+            output_tokens=2_000,
+            total_tokens=12_000,
+            cache_read_tokens=80_000,
+            cache_write_tokens=40_000,
+        )
+        result = _complete_with(_adapter_response(_KNOWN_MODEL, usage))
+
+        assert result.usage.cost_usd == _expected(
+            _KNOWN_MODEL,
+            10_000,
+            2_000,
+            cache_read_tokens=80_000,
+            cache_write_tokens=40_000,
+        )
+        # Strictly above the cacheless price, so the cache terms really landed.
+        assert result.usage.cost_usd > _expected(_KNOWN_MODEL, 10_000, 2_000)
+
+    def test_adapter_supplied_cost_is_preserved_not_recomputed(self) -> None:
+        """An adapter that priced the call wins; the client does not overwrite."""
+        adapter_cost = Decimal("42.4242")
+        usage = Usage(
+            input_tokens=200_000,
+            output_tokens=50_000,
+            total_tokens=250_000,
+            cost_usd=adapter_cost,
+        )
+        result = _complete_with(_adapter_response(_KNOWN_MODEL, usage))
+
+        assert result.usage.cost_usd == adapter_cost
+        # Guard against a recompute that happens to agree by accident.
+        assert result.usage.cost_usd != _expected(_KNOWN_MODEL, 200_000, 50_000)
+
+    def test_unknown_model_leaves_cost_none(self) -> None:
+        """No pricing means no invented number on the response."""
+        usage = Usage(input_tokens=1_000, output_tokens=500, total_tokens=1_500)
+        result = _complete_with(_adapter_response(_UNKNOWN_MODEL, usage))
+
+        assert result.usage.cost_usd is None
+
+    def test_injection_preserves_token_fields(self) -> None:
+        """Rebuilding usage with a cost must not lose the token counts."""
+        usage = Usage(
+            input_tokens=200_000,
+            output_tokens=50_000,
+            total_tokens=250_000,
+            reasoning_tokens=7,
+            cache_read_tokens=11,
+            cache_write_tokens=13,
+            raw={"provider_field": "kept"},
+        )
+        result = _complete_with(_adapter_response(_KNOWN_MODEL, usage))
+
+        assert result.usage.input_tokens == 200_000
+        assert result.usage.output_tokens == 50_000
+        assert result.usage.total_tokens == 250_000
+        assert result.usage.reasoning_tokens == 7
+        assert result.usage.cache_read_tokens == 11
+        assert result.usage.cache_write_tokens == 13
+        assert result.usage.raw == {"provider_field": "kept"}
+        assert result.usage.cost_usd is not None
+
+
+# ---------------------------------------------------------------------------
+# StreamAccumulator.response() — cost injection
+# ---------------------------------------------------------------------------
+
+
+def _accumulate(model: str, usage: Usage) -> Response:
+    """Drive an accumulator through a minimal text stream and finish it."""
+    acc = StreamAccumulator()
+    acc.process(StreamEvent(type=StreamEventType.TEXT_START, text_id="t1"))
+    acc.process(StreamEvent(type=StreamEventType.TEXT_DELTA, delta="hi", text_id="t1"))
+    acc.process(StreamEvent(type=StreamEventType.TEXT_END, text_id="t1"))
+    acc.process(
+        StreamEvent(
+            type=StreamEventType.FINISH,
+            finish_reason=FinishReason(reason="stop"),
+            usage=usage,
+            response=_adapter_response(model, usage),
+        )
+    )
+    return acc.response()
+
+
+class TestStreamAccumulatorCostInjection:
+    """StreamAccumulator.response() computes cost when the stream omitted it."""
+
+    def test_computes_cost_when_unset(self) -> None:
+        usage = Usage(input_tokens=200_000, output_tokens=50_000, total_tokens=250_000)
+        resp = _accumulate(_KNOWN_MODEL, usage)
+
+        assert resp.usage.cost_usd == _expected(_KNOWN_MODEL, 200_000, 50_000)
+        assert isinstance(resp.usage.cost_usd, Decimal)
+
+    def test_preserves_cost_already_set_on_the_stream(self) -> None:
+        stream_cost = Decimal("7.7777")
+        usage = Usage(
+            input_tokens=200_000,
+            output_tokens=50_000,
+            total_tokens=250_000,
+            cost_usd=stream_cost,
+        )
+        resp = _accumulate(_KNOWN_MODEL, usage)
+
+        assert resp.usage.cost_usd == stream_cost
+        assert resp.usage.cost_usd != _expected(_KNOWN_MODEL, 200_000, 50_000)
+
+    def test_unknown_model_leaves_cost_none(self) -> None:
+        usage = Usage(input_tokens=1_000, output_tokens=500, total_tokens=1_500)
+        resp = _accumulate(_UNKNOWN_MODEL, usage)
+
+        assert resp.usage.cost_usd is None
+
+    def test_no_model_seen_leaves_cost_none(self) -> None:
+        """Without a model id there is nothing to price against."""
+        acc = StreamAccumulator()
+        acc.process(
+            StreamEvent(
+                type=StreamEventType.FINISH,
+                finish_reason=FinishReason(reason="stop"),
+                usage=Usage(
+                    input_tokens=200_000, output_tokens=50_000, total_tokens=250_000
+                ),
+            )
+        )
+        resp = acc.response()
+
+        assert resp.model == ""
+        assert resp.usage.cost_usd is None
+
+    def test_accumulated_content_survives_cost_injection(self) -> None:
+        """Rebuilding usage must not disturb the assembled response."""
+        usage = Usage(input_tokens=200_000, output_tokens=50_000, total_tokens=250_000)
+        resp = _accumulate(_KNOWN_MODEL, usage)
+
+        assert resp.text == "hi"
+        assert resp.finish_reason.reason == "stop"
+        assert resp.usage.total_tokens == 250_000
+
+
+# ---------------------------------------------------------------------------
+# Public API surface
+# ---------------------------------------------------------------------------
+
+
+class TestCostPublicExport:
+    """compute_cost is reachable from the package root."""
+
+    def test_compute_cost_exported_from_package(self) -> None:
+        import unified_llm
+
+        assert hasattr(unified_llm, "compute_cost")
+        assert "compute_cost" in unified_llm.__all__

--- a/modules/unified-llm-client/unified_llm/__init__.py
+++ b/modules/unified-llm-client/unified_llm/__init__.py
@@ -9,6 +9,9 @@ Usage:
 # Core client
 from unified_llm.client import Client, get_default_client, set_default_client
 
+# Cost computation
+from unified_llm._cost import compute_cost
+
 # High-level API
 from unified_llm.generate import generate, generate_object, stream, stream_object
 
@@ -88,6 +91,8 @@ __all__ = [
     "Client",
     "set_default_client",
     "get_default_client",
+    # Cost
+    "compute_cost",
     # High-level API
     "generate",
     "stream",

--- a/modules/unified-llm-client/unified_llm/_cost.py
+++ b/modules/unified-llm-client/unified_llm/_cost.py
@@ -1,0 +1,243 @@
+"""Per-call USD cost computation for LLM API calls.
+
+Rates are in USD per million tokens. The rate table covers models for which
+pricing is publicly available. Unknown models return None, which means
+"pricing unknown" -- never zero, never a partial estimate.
+
+Verification date: 2026-06-10
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+# ---------------------------------------------------------------------------
+# Internal constants
+# ---------------------------------------------------------------------------
+
+_PER_M = Decimal("1_000_000")
+
+# _RATES maps model-id -> {
+#   "input_per_m":      Decimal,   # fresh input tokens, per 1M
+#   "output_per_m":     Decimal,   # output tokens, per 1M
+#   "cache_read_per_m": Decimal,   # cache-read input tokens, per 1M
+#   "cache_write_per_m":Decimal,   # cache-creation input tokens, per 1M
+# }
+#
+# Rates are in USD.
+# cache_read  ~= 10 % of input_per_m
+# cache_write ~= 125 % of input_per_m
+_RATES: dict[str, dict[str, Decimal]] = {
+    # ------------------------------------------------------------------
+    # Claude Sonnet 4.5 family  ($3 / $15 / $0.30 / $3.75)
+    # ------------------------------------------------------------------
+    "claude-sonnet-4-5": {
+        "input_per_m": Decimal("3.00"),
+        "output_per_m": Decimal("15.00"),
+        "cache_read_per_m": Decimal("0.30"),
+        "cache_write_per_m": Decimal("3.75"),
+    },
+    "claude-sonnet-4-5-20250929": {
+        "input_per_m": Decimal("3.00"),
+        "output_per_m": Decimal("15.00"),
+        "cache_read_per_m": Decimal("0.30"),
+        "cache_write_per_m": Decimal("3.75"),
+    },
+    "claude-sonnet-4-6": {
+        "input_per_m": Decimal("3.00"),
+        "output_per_m": Decimal("15.00"),
+        "cache_read_per_m": Decimal("0.30"),
+        "cache_write_per_m": Decimal("3.75"),
+    },
+    # Claude Sonnet 5 ($3 / $15 / $0.30 / $3.75 -- standard rates)
+    "claude-sonnet-5": {
+        "input_per_m": Decimal("3.00"),
+        "output_per_m": Decimal("15.00"),
+        "cache_read_per_m": Decimal("0.30"),
+        "cache_write_per_m": Decimal("3.75"),
+    },
+    # ------------------------------------------------------------------
+    # Claude Opus 4.5 / 4.6 / 4.7 family  ($5 / $25 / $0.50 / $6.25)
+    # ------------------------------------------------------------------
+    "claude-opus-4-5": {
+        "input_per_m": Decimal("5.00"),
+        "output_per_m": Decimal("25.00"),
+        "cache_read_per_m": Decimal("0.50"),
+        "cache_write_per_m": Decimal("6.25"),
+    },
+    "claude-opus-4-5-20251101": {
+        "input_per_m": Decimal("5.00"),
+        "output_per_m": Decimal("25.00"),
+        "cache_read_per_m": Decimal("0.50"),
+        "cache_write_per_m": Decimal("6.25"),
+    },
+    "claude-opus-4-6": {
+        "input_per_m": Decimal("5.00"),
+        "output_per_m": Decimal("25.00"),
+        "cache_read_per_m": Decimal("0.50"),
+        "cache_write_per_m": Decimal("6.25"),
+    },
+    "claude-opus-4-6-20260101": {
+        "input_per_m": Decimal("5.00"),
+        "output_per_m": Decimal("25.00"),
+        "cache_read_per_m": Decimal("0.50"),
+        "cache_write_per_m": Decimal("6.25"),
+    },
+    "claude-opus-4-7": {
+        "input_per_m": Decimal("5.00"),
+        "output_per_m": Decimal("25.00"),
+        "cache_read_per_m": Decimal("0.50"),
+        "cache_write_per_m": Decimal("6.25"),
+    },
+    "claude-opus-4-7-20260416": {
+        "input_per_m": Decimal("5.00"),
+        "output_per_m": Decimal("25.00"),
+        "cache_read_per_m": Decimal("0.50"),
+        "cache_write_per_m": Decimal("6.25"),
+    },
+    # ------------------------------------------------------------------
+    # Claude Opus 4.8  ($5 / $25 / $0.50 / $6.25)
+    # ------------------------------------------------------------------
+    "claude-opus-4-8": {
+        "input_per_m": Decimal("5.00"),
+        "output_per_m": Decimal("25.00"),
+        "cache_read_per_m": Decimal("0.50"),
+        "cache_write_per_m": Decimal("6.25"),
+    },
+    # ------------------------------------------------------------------
+    # Claude Opus 5  ($5 / $25 / $0.50 / $6.25)
+    # ------------------------------------------------------------------
+    "claude-opus-5": {
+        "input_per_m": Decimal("5.00"),
+        "output_per_m": Decimal("25.00"),
+        "cache_read_per_m": Decimal("0.50"),
+        "cache_write_per_m": Decimal("6.25"),
+    },
+    # ------------------------------------------------------------------
+    # Claude Fable 5  ($10 / $50 / $1.00 / $12.50)
+    # ------------------------------------------------------------------
+    "claude-fable-5": {
+        "input_per_m": Decimal("10.00"),
+        "output_per_m": Decimal("50.00"),
+        "cache_read_per_m": Decimal("1.00"),
+        "cache_write_per_m": Decimal("12.50"),
+    },
+    # ------------------------------------------------------------------
+    # Claude Haiku 3.5  ($0.80 / $4.00 / $0.08 / $1.00)
+    # ------------------------------------------------------------------
+    "claude-haiku-3-5-20250929": {
+        "input_per_m": Decimal("0.80"),
+        "output_per_m": Decimal("4.00"),
+        "cache_read_per_m": Decimal("0.08"),
+        "cache_write_per_m": Decimal("1.00"),
+    },
+    # ------------------------------------------------------------------
+    # Claude Haiku 4.5 family  ($1.00 / $5.00 / $0.10 / $1.25)
+    # ------------------------------------------------------------------
+    "claude-haiku-4-5": {
+        "input_per_m": Decimal("1.00"),
+        "output_per_m": Decimal("5.00"),
+        "cache_read_per_m": Decimal("0.10"),
+        "cache_write_per_m": Decimal("1.25"),
+    },
+    "claude-haiku-4-5-20251001": {
+        "input_per_m": Decimal("1.00"),
+        "output_per_m": Decimal("5.00"),
+        "cache_read_per_m": Decimal("0.10"),
+        "cache_write_per_m": Decimal("1.25"),
+    },
+    # ------------------------------------------------------------------
+    # Deprecated models
+    # ------------------------------------------------------------------
+    "claude-3-haiku-20240307": {
+        "input_per_m": Decimal("0.25"),
+        "output_per_m": Decimal("1.25"),
+        "cache_read_per_m": Decimal("0.025"),
+        "cache_write_per_m": Decimal("0.3125"),
+    },
+    "claude-sonnet-4-20250514": {
+        "input_per_m": Decimal("3.00"),
+        "output_per_m": Decimal("15.00"),
+        "cache_read_per_m": Decimal("0.30"),
+        "cache_write_per_m": Decimal("3.75"),
+    },
+    "claude-opus-4-20250514": {
+        "input_per_m": Decimal("15.00"),
+        "output_per_m": Decimal("75.00"),
+        "cache_read_per_m": Decimal("1.50"),
+        "cache_write_per_m": Decimal("18.75"),
+    },
+}
+
+# Models for which the 2x fast-mode multiplier applies when speed=='fast'.
+# The 2x cost multiplier is applied ONLY when BOTH the response confirms
+# speed=='fast' AND the model is listed here.
+_FAST_ELIGIBLE_MODELS: set[str] = {
+    "claude-opus-4-6",
+    "claude-opus-4-7",
+    "claude-opus-4-8",
+    "claude-opus-5",
+}
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def compute_cost(
+    model: str,
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+    *,
+    cache_read_tokens: int = 0,
+    cache_write_tokens: int = 0,
+    speed: str | None = None,
+) -> Decimal | None:
+    """Return the USD cost for an LLM API call as a Decimal, or None if unknown.
+
+    Parameters
+    ----------
+    model:
+        Model identifier (e.g. ``"claude-sonnet-4-5-20250929"``).
+    input_tokens:
+        Fresh (non-cached) input tokens consumed.
+    output_tokens:
+        Output tokens generated.
+    cache_read_tokens:
+        Tokens served from the prompt cache (cheaper than fresh input).
+    cache_write_tokens:
+        Tokens written to the prompt cache (slightly more expensive than
+        fresh input).
+    speed:
+        When ``'fast'`` and the model supports fast mode, a 2x multiplier
+        is applied. Any other value leaves cost unchanged.
+
+    Returns
+    -------
+    Decimal | None
+        The computed cost in USD, or ``None`` if *model* is not in the rate
+        table or if any required rate dimension is missing.
+        ``None`` means "pricing unknown" -- semantically distinct from
+        ``Decimal('0')`` (a free call). Never returns 0 or a float for an
+        unknown model.
+    """
+    rates = _RATES.get(model)
+    if rates is None:
+        return None
+
+    cost = (
+        Decimal(input_tokens) * rates["input_per_m"] / _PER_M
+        + Decimal(output_tokens) * rates["output_per_m"] / _PER_M
+    )
+
+    if cache_read_tokens > 0:
+        cost += Decimal(cache_read_tokens) * rates["cache_read_per_m"] / _PER_M
+
+    if cache_write_tokens > 0:
+        cost += Decimal(cache_write_tokens) * rates["cache_write_per_m"] / _PER_M
+
+    if speed == "fast" and model in _FAST_ELIGIBLE_MODELS:
+        cost *= 2
+
+    return cost

--- a/modules/unified-llm-client/unified_llm/client.py
+++ b/modules/unified-llm-client/unified_llm/client.py
@@ -53,12 +53,39 @@ class Client:
 
     async def complete(self, request: Request) -> Response:
         """Low-level blocking call. No retry. (Spec §4.1)."""
+        from unified_llm._cost import compute_cost
+
         adapter = self._resolve_adapter(request)
 
         async def handler(req: Request) -> Response:
             return await adapter.complete(req)
 
-        return await apply_middleware(self._middleware, handler, request)
+        response = await apply_middleware(self._middleware, handler, request)
+
+        # Inject cost_usd if not already set by the adapter
+        if response.usage.cost_usd is None:
+            computed = compute_cost(
+                response.model,
+                response.usage.input_tokens,
+                response.usage.output_tokens,
+                cache_read_tokens=response.usage.cache_read_tokens or 0,
+                cache_write_tokens=response.usage.cache_write_tokens or 0,
+            )
+            if computed is not None:
+                from unified_llm.types import Usage
+
+                response.usage = Usage(
+                    input_tokens=response.usage.input_tokens,
+                    output_tokens=response.usage.output_tokens,
+                    total_tokens=response.usage.total_tokens,
+                    reasoning_tokens=response.usage.reasoning_tokens,
+                    cache_read_tokens=response.usage.cache_read_tokens,
+                    cache_write_tokens=response.usage.cache_write_tokens,
+                    raw=response.usage.raw,
+                    cost_usd=computed,
+                )
+
+        return response
 
     async def stream(self, request: Request) -> AsyncIterator[StreamEvent]:
         """Low-level streaming call. No retry. (Spec §4.2)."""

--- a/modules/unified-llm-client/unified_llm/data/models.json
+++ b/modules/unified-llm-client/unified_llm/data/models.json
@@ -86,5 +86,19 @@
     "release_date": "2025-03-25",
     "_release_date_note": "approximate",
     "aliases": ["gemini-pro"]
+  },
+  {
+    "id": "preview-model-cost-unknown",
+    "provider": "anthropic",
+    "display_name": "Preview Model (cost unknown)",
+    "context_window": 200000,
+    "max_output": 16384,
+    "supports_tools": true,
+    "supports_vision": false,
+    "supports_reasoning": false,
+    "input_cost_per_million": null,
+    "output_cost_per_million": null,
+    "release_date": "2026-01-01",
+    "aliases": []
   }
 ]

--- a/modules/unified-llm-client/unified_llm/types.py
+++ b/modules/unified-llm-client/unified_llm/types.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import date, datetime
+from decimal import Decimal
 from enum import Enum
 from typing import Any
 
@@ -206,6 +207,18 @@ def _add_optional(a: int | None, b: int | None) -> int | None:
     return (a or 0) + (b or 0)
 
 
+def _add_cost(a: Decimal | None, b: Decimal | None) -> Decimal | None:
+    """Sum two optional Decimal costs: any None operand yields None total.
+
+    This is intentionally different from _add_optional (which treats None as 0
+    for token fields). For cost, None means "pricing unknown" -- a partial sum
+    would be misleading, so any unknown operand propagates None to the total.
+    """
+    if a is None or b is None:
+        return None
+    return a + b
+
+
 @dataclass
 class Usage:
     """Token usage statistics (Spec §3.9). Supports addition for multi-step aggregation."""
@@ -217,6 +230,7 @@ class Usage:
     cache_read_tokens: int | None = None
     cache_write_tokens: int | None = None
     raw: dict[str, Any] | None = None
+    cost_usd: Decimal | None = None
 
     def __add__(self, other: Usage) -> Usage:
         return Usage(
@@ -232,6 +246,7 @@ class Usage:
             cache_write_tokens=_add_optional(
                 self.cache_write_tokens, other.cache_write_tokens
             ),
+            cost_usd=_add_cost(self.cost_usd, other.cost_usd),
         )
 
 
@@ -507,6 +522,8 @@ class StreamAccumulator:
 
     def response(self) -> Response:
         """Build the accumulated Response. Call after stream ends."""
+        from unified_llm._cost import compute_cost
+
         content: list[ContentPart] = []
 
         # Assemble text
@@ -537,13 +554,36 @@ class StreamAccumulator:
                 )
             )
 
+        base_usage = self._usage or Usage(input_tokens=0, output_tokens=0, total_tokens=0)
+
+        # Inject cost_usd if not already set and model is known
+        if base_usage.cost_usd is None and self._model:
+            computed = compute_cost(
+                self._model,
+                base_usage.input_tokens,
+                base_usage.output_tokens,
+                cache_read_tokens=base_usage.cache_read_tokens or 0,
+                cache_write_tokens=base_usage.cache_write_tokens or 0,
+            )
+            if computed is not None:
+                base_usage = Usage(
+                    input_tokens=base_usage.input_tokens,
+                    output_tokens=base_usage.output_tokens,
+                    total_tokens=base_usage.total_tokens,
+                    reasoning_tokens=base_usage.reasoning_tokens,
+                    cache_read_tokens=base_usage.cache_read_tokens,
+                    cache_write_tokens=base_usage.cache_write_tokens,
+                    raw=base_usage.raw,
+                    cost_usd=computed,
+                )
+
         return Response(
             id=self._response_id,
             model=self._model,
             provider=self._provider,
             message=Message(role=Role.ASSISTANT, content=content),
             finish_reason=self._finish_reason or FinishReason(reason="other"),
-            usage=self._usage or Usage(input_tokens=0, output_tokens=0, total_tokens=0),
+            usage=base_usage,
         )
 
 


### PR DESCRIPTION
## Implement-stage fix for #204

Refs #204. Produced by `task-runner.dot` (see `.github/capsule-pipeline/`)
converging against the capsule's own definition of done and gate:
`.github/capsule-pipeline/proposals/issue-204/llm-cost-exposure-unified-loop.md` /
`llm-cost-exposure-unified-loop.verify.sh`.

The gate script (the capsule's own DoD) passed, and this change was
additionally critiqued by an LLM reviewer against the capsule's
judgment criteria before shipping. Both reviewers ran as independent, cross-provider critics (Anthropic + OpenAI) -- enforced by this workflow's preflight check, not merely hoped for.

Gate files unmodified -- measured: `git diff --name-only origin/main HEAD -- .github/capsule-pipeline/proposals/issue-204` is empty.

This PR is opened non-draft and is NOT auto-merged -- a human reviews
the diff and the run evidence before merging.

Workflow run: https://github.com/microsoft/amplifier-bundle-attractor/actions/runs/31795860786
