### PR TITLE
fix(pipeline-runner): unblock wiki-weaver installs — float the published amplifier-foundation dep, hold the pin resolver-side (#213)

### DIFF
--- a/modules/pipeline-runner/amplifier_module_pipeline_runner/compat.py
+++ b/modules/pipeline-runner/amplifier_module_pipeline_runner/compat.py
@@ -26,20 +26,62 @@ Three shapes were available to close the version-skew window:
    the required version and the resolution command.  This is the lowest
    friction shape for a single-repo, actively-developed package.
 
-``amplifier-foundation`` pin (formerly an ``@main`` float)
------------------------------------------------------------
-The ``amplifier-foundation`` dep in ``pipeline-runner/pyproject.toml``
-originally floated on ``@main`` (an explicit deferral: the foundation symbols
-the runner uses -- ``Bundle``, ``load_bundle``, imported lazily inside
-functions, never at module level -- are long-stable core API, so there was no
-discriminating symbol to probe).  That deferral did not weigh the CI-hygiene
-cost: with no committed lockfile, every CI run re-resolved foundation's live
-``main``, so an upstream foundation change could redden this repo's CI with no
-local change.  As of microsoft-amplifier/amplifier-support#391 the dep is
-pinned to an immutable commit SHA.  Bumps are deliberate: update the SHA in
-``pyproject.toml`` and verify against this module's test suite.  Apply the
-compat-assert pattern here the moment the runner starts depending on a
-recently-added foundation symbol.
+``amplifier-foundation``: published float, resolver-local pin
+--------------------------------------------------------------
+The ``amplifier-foundation`` dep in ``pipeline-runner/pyproject.toml`` is
+declared in two places on purpose, and the split is the whole design:
+
+* ``[project].dependencies`` -- ``@main``.  This is what consumers resolve.
+* ``[tool.uv] override-dependencies`` -- a SHA.  This is what *we* resolve.
+
+**Why the published requirement must float.**  uv identifies a git dependency
+by its *ref string*, not by the commit that ref resolves to.  Two requirements
+for the same package whose ref strings differ are a hard resolution error --
+``Requirements contain conflicting URLs for package `amplifier-foundation``` --
+even when one ref is an ancestor of the other.  Every other
+``amplifier-foundation`` declaration in the ecosystem (this repo's bundle
+includes, ``amplifier-app-wiki-weaver``, and downstream of it ``repo-weaver``)
+names ``@main``, so any non-``@main`` ref on the published line makes
+pipeline-runner un-co-installable with all of them.  A SHA pin on that line did
+exactly that and blocked every fresh wiki-weaver install by every install verb
+(#213).  A release tag would fail identically -- ``@v2.1.2`` is just as
+different from ``@main`` as a SHA is -- and a bare version range cannot resolve
+at all, since foundation publishes no artifacts to PyPI.  So the published line
+is not a preference; it is the only ref that co-resolves.
+
+**Why the pin still exists.**  The original problem
+(microsoft-amplifier/amplifier-support#391, PR #201) is real: this repo commits
+no lockfile, so an unconstrained ``@main`` meant every CI run re-resolved
+foundation's live tip and an upstream change could redden CI with no local
+change.  ``[tool.uv] override-dependencies`` closes that window without
+touching what anybody else resolves.  uv applies an override only to the
+project it is resolving as *root* -- precisely how CI consumes this module
+(``uv sync`` with ``working-directory: modules/pipeline-runner``) -- and does
+not apply it when this package is somebody else's dependency.  CI gets a fixed
+foundation commit; consumers get plain ``@main``.
+
+**Two mechanisms that look right and are not** (both measured, so nobody has to
+re-derive them):
+
+* ``[tool.uv.sources]`` with a ``rev`` does *not* stay local.  uv reads a git
+  dependency's sources straight out of its checked-out ``pyproject.toml``, so
+  the rev reappears in the dependent's resolution and the conflict returns
+  verbatim -- even though the *built wheel's* ``Requires-Dist`` says ``@main``.
+* ``[tool.uv] constraint-dependencies`` cannot carry a git ref at all: a URL in
+  a constraint is itself a second conflicting URL for the package, so the
+  resolver rejects it before it can constrain anything.
+
+**Bump procedure.**  Update the SHA in ``[tool.uv] override-dependencies`` of
+``pipeline-runner/pyproject.toml`` -- *not* the ``[project].dependencies``
+line, which must stay ``@main`` -- then verify against this module's test suite
+(``uv run pytest -q`` in ``modules/pipeline-runner``).  Bumping is CI-hygiene
+work only; it changes nothing for installed users, who track foundation
+``main`` and are guarded by the startup assertion below.  Apply the
+compat-assert pattern to a foundation symbol the moment the runner starts
+depending on a recently-added one (today it uses only long-stable core API --
+``Bundle``, ``load_bundle``, imported lazily inside functions, and this
+module's own suite exercises them through a stand-in -- so there is no
+discriminating symbol to probe).
 """
 
 from __future__ import annotations

--- a/modules/pipeline-runner/pyproject.toml
+++ b/modules/pipeline-runner/pyproject.toml
@@ -9,11 +9,19 @@ authors = [
 ]
 dependencies = [
     "amplifier-core>=0.1.0",
-    # Pinned to an immutable SHA (re-filed from microsoft-amplifier/amplifier-support#391):
-    # an unpinned @main here let upstream foundation changes redden this repo's CI with
-    # no local change. Bump deliberately: verify the new SHA against this module's test
-    # suite, then update this line. See compat.py's module docstring for the history.
-    "amplifier-foundation @ git+https://github.com/microsoft/amplifier-foundation@4490bf5f3cf9e5a7829365e84c318a7fd9db7e3d",
+    # PUBLISHED requirement -- floats on @main deliberately, and must keep floating.
+    # uv identifies a git dependency by its REF STRING, not by the commit that ref
+    # resolves to, so ANY non-`@main` ref here (SHA or tag) collides with every other
+    # `amplifier-foundation @ ...@main` declaration in the ecosystem the moment the two
+    # refs name different commits:
+    #     Requirements contain conflicting URLs for package `amplifier-foundation`
+    # A SHA pin on this line did exactly that and blocked every wiki-weaver install (#213).
+    # The CI determinism that pin bought (microsoft-amplifier/amplifier-support#391) is
+    # preserved out-of-band by the [tool.uv] override-dependencies entry below, which uv
+    # applies ONLY when this project is the resolution root and never propagates to
+    # anyone who depends on us.
+    # Bump procedure: see compat.py's module docstring.
+    "amplifier-foundation @ git+https://github.com/microsoft/amplifier-foundation@main",
     "amplifier-module-loop-pipeline[remote] @ git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-pipeline",
 ]
 
@@ -28,6 +36,26 @@ build-backend = "hatchling.build"
 
 [tool.uv]
 package = true
+# CI-side foundation pin (microsoft-amplifier/amplifier-support#391, PR #201), held here
+# rather than on the [project] dependency line above -- that line must stay `@main` or
+# nothing that also depends on foundation can co-install with us (#213).
+#
+# `override-dependencies` is the one uv mechanism with exactly the scope this needs: uv
+# applies it only to the project it is resolving as ROOT -- CI's `uv sync` with
+# working-directory modules/pipeline-runner -- and does NOT apply it when this package is
+# somebody else's dependency. So our CI resolves a fixed foundation commit while every
+# consumer resolves plain `@main`.
+#
+# `[tool.uv.sources]` was measured NOT to work here: uv reads a git dependency's sources
+# out of its checked-out pyproject.toml, so a rev there reintroduces the exact conflict.
+# A `constraint-dependencies` entry does not work either -- a git URL in a constraint is
+# itself a second conflicting URL.
+#
+# BUMP: change the SHA below, then `uv run pytest -q` in this directory. Nothing about a
+# bump reaches installed users; see compat.py's module docstring.
+override-dependencies = [
+    "amplifier-foundation @ git+https://github.com/microsoft/amplifier-foundation@4490bf5f3cf9e5a7829365e84c318a7fd9db7e3d",
+]
 
 [tool.uv.sources]
 amplifier-module-loop-pipeline = { path = "../loop-pipeline" }


### PR DESCRIPTION
## Summary

`modules/pipeline-runner/pyproject.toml` pinned `amplifier-foundation` to SHA `4490bf5f`, which made the package impossible to co-install with anything else that depends on foundation. uv identifies a git dependency by its **ref string**, not by the commit that ref resolves to, so `@4490bf5f` and `@main` are two *conflicting URLs* for one package — even though `4490bf5f` is an ancestor of `main`. The moment foundation's `main` advanced past the pinned commit (`c779cba6`, 2026-08-12 18:25:48 UTC), every fresh `wiki-weaver` install started failing, by every install verb, and `repo-weaver` with it. This PR moves the pin off the published requirement and into `[tool.uv] override-dependencies`, which uv applies **only** when this project is the resolution root — so CI keeps the determinism PR #201 bought, and consumers get the plain `@main` ref every other declaration in the ecosystem uses.

Fixes #213

## Root cause, as the reporter hit it

```
x Failed to resolve dependencies for `amplifier-module-pipeline-runner` (v0.1.0)
╰─> Requirements contain conflicting URLs for package `amplifier-foundation`:
    - git+https://github.com/microsoft/amplifier-foundation@main
    - git+https://github.com/microsoft/amplifier-foundation@4490bf5f3cf9e5a7829365e84c318a7fd9db7e3d
hint: `amplifier-module-pipeline-runner` was included because `wiki-weaver` depends on it
```

`amplifier-app-wiki-weaver` declares `amplifier-foundation @ ...@main`, with a comment stating that float is deliberate ("must stay in lockstep with [the installed Amplifier ecosystem], not pinned to a stale commit"). Both requirements land in one resolution because wiki-weaver depends on pipeline-runner. The pin was the **only** pinned `amplifier-foundation` declaration in the ecosystem.

## The fix

```toml
[project].dependencies          ->  @main   # what consumers resolve
[tool.uv] override-dependencies ->  <sha>   # what CI resolves
```

`override-dependencies` is the one uv mechanism with exactly the scope this needs: uv applies it to the project it resolves as **root** — CI's `uv sync` with `working-directory: modules/pipeline-runner` — and does **not** apply it when this package is somebody else's dependency. Measured both directions below.

### Alternatives, each measured rather than assumed

| Candidate | Verdict | Evidence |
|---|---|---|
| Bump the pin to current `main` (`c779cba6`) | **Rejected** — doesn't fix it, just re-arms it | Any non-`@main` ref conflicts; this only closes the window until foundation's main moves again (hours/days) |
| Pin a named release tag (`@v2.1.2`) | **Rejected** — fails identically | Measured: `@v2.1.2` vs `@main` → same "conflicting URLs" error. Also 75 commits behind (per #201) |
| Version range instead of a URL | **Rejected** — cannot resolve at all | `amplifier-foundation` is **quarantined** on PyPI with zero files (`pypi:project-status: quarantined`; JSON API 404). There is no registry distribution to range over |
| Pin via `[tool.uv.sources]` `rev` | **Rejected** — looks local, isn't | Measured: uv reads a git dependency's sources out of its checked-out `pyproject.toml`, so the rev reappears in the dependent's resolution and the conflict returns verbatim — *even though the built wheel's `Requires-Dist` correctly says `@main`* |
| Pin via `[tool.uv] constraint-dependencies` | **Rejected** — rejected by the resolver | Measured: a git URL in a constraint is itself a second conflicting URL |
| Commit a `uv.lock` | **Rejected** — over-pins | Would also freeze the in-repo `path = "../loop-pipeline"` siblings, which are actively developed here; `--locked` would redden CI on unrelated in-repo changes, and `--frozen` would silently install stale siblings. The repo commits no lockfiles anywhere |
| Restore bare `@main`, drop the pin | **Rejected** — silently regresses #201 | This is the reporter's demo branch. It fixes #213 but throws away support#391's CI determinism with nothing in its place |
| Pin wiki-weaver's declaration to match | **Rejected** — wrong repo, moves the bomb | wiki-weaver's `@main` is documented as deliberate; pinning it would break *its* co-installation with the next consumer |

## Verification checklist

- [x] Unit tests pass — `pipeline-runner`: **60 passed, 1 skipped**; `loop-pipeline` (`--extra remote`): **1846 passed, 1 skipped**. Identical counts to PR #201's recorded baseline
- [x] Live pipeline run — N/A: packaging metadata + docstring only, no `engine.py` or handler change. Substituted a stronger proof for this change class: a fresh isolated `uv tool install` of this branch with `attractor doctor` / `--help` exercised (below)
- [x] AGENTS.md reviewed; repo-specific gates met
- [x] Backward-compat path unchanged — no code-path change. Installed users already tracked foundation `main` via bundle includes; they now get the same ref through pip metadata too
- [x] No `specs/EXTENSIONS.md` entry needed: packaging metadata only, no observable contract change (no dispatch/event/validation behavior touched). EXTENSIONS §28's pointer to compat.py's note still resolves — that note now records the published-float / resolver-local-pin split
- [x] PR body includes verification evidence, not just "tests pass"
- [ ] CI is green before merge — will confirm `CI Gate (all checks passed)` reports `pass`. **Not merging this PR.**

## Verification evidence

### 1. BEFORE — the reporter's exact verb, against upstream `main`

```
$ uv tool install git+https://github.com/microsoft/amplifier-app-wiki-weaver@main
  × Failed to resolve dependencies for `amplifier-module-pipeline-runner` (v0.1.0)
  ╰─▶ Requirements contain conflicting URLs for package `amplifier-foundation`:
      - git+https://github.com/microsoft/amplifier-foundation@main
      - git+https://github.com/microsoft/amplifier-foundation@4490bf5f3cf9e5a7829365e84c318a7fd9db7e3d
EXIT CODE = 1
```

Same failure via `uv pip install` into a clean venv (rc=1), reproducing all three of the reporter's paths.

### 2. AFTER — the conflict is gone

Real, unmodified upstream `wiki-weaver`, with the attractor packages pointed at this branch (modelling post-merge state):

```
$ uv lock --refresh
    Updated https://github.com/microsoft/amplifier-bundle-attractor (9d3485e...)
Resolved 49 packages in 1.21s
EXIT CODE = 0

# foundation as resolved:
source = { git = "https://github.com/microsoft/amplifier-foundation?rev=main#c779cba6b86f6f0189646d389ba39258703c4ed5" }
```

Foundation resolves to `main` — i.e. the override provably did **not** leak into the consumer's resolution. Minimal isolated form (`foundation@main` + `pipeline-runner@<branch>`) also resolves, rc=0, where the same probe against `main` fails.

### 3. AFTER — the CI pin still holds

```
$ cd modules/pipeline-runner && uv sync
# uv.lock:
source = { git = "https://github.com/microsoft/amplifier-foundation?rev=4490bf5f...#4490bf5f3cf9e5a7829365e84c318a7fd9db7e3d" }

# and on disk:
$ cat .venv/.../amplifier_foundation-1.0.0.dist-info/direct_url.json
"requested_revision":"4490bf5f3cf9e5a7829365e84c318a7fd9db7e3d"
```

Both directions hold simultaneously — that is the whole point of the change.

### 4. AFTER — fresh isolated tool install of this branch

```
$ uv tool install git+https://github.com/microsoft/amplifier-bundle-attractor@fix/213-foundation-dep-conflict#subdirectory=modules/pipeline-runner
Installed 1 executable: attractor       (rc=0)

$ attractor --help
usage: attractor [-h] {run,doctor,trace,lint} ...        (rc=0)

$ attractor doctor
attractor doctor: OK -- amplifier_module_loop_pipeline importable
attractor doctor: anthropic (ANTHROPIC_API_KEY): present
attractor doctor: gemini (GEMINI_API_KEY): absent
attractor doctor: openai (OPENAI_API_KEY): present      (rc=0)

# foundation in that tool venv:
requested: main      commit: c779cba6b86f6f0189646d389ba39258703c4ed5
```

An end-user install now tracks foundation `main`, exactly as the ecosystem intends, and the runner still works against it.

### 5. Tests

```
modules/pipeline-runner:                60 passed, 1 skipped
modules/loop-pipeline (--extra remote): 1846 passed, 1 skipped
```

## Notes for reviewers

- **The pin is not gone, it moved.** #201's concern is real and is preserved verbatim for CI. What changed is that it no longer travels in published metadata, where it was never able to do anything except break other people's resolutions.
- **Why `override-dependencies` and not `sources`.** This is the counter-intuitive part and it cost a measurement to learn: `[tool.uv.sources]` is *not* resolver-local for git dependencies. uv reads them out of the dependency's checked-out `pyproject.toml`, so a `rev` there re-creates #213 exactly — even though the built wheel's `Requires-Dist` correctly says `@main`. `override-dependencies` was measured to be genuinely root-only. Both findings are recorded in compat.py so nobody has to re-derive them.
- **Bumping is now cheaper, not more expensive.** A bump touches only CI's view; it cannot break an installed user, so it never needs to be coordinated with a release.
- **Blast radius of the foundation dep is small**: `amplifier_foundation` is imported in exactly three places in `runner.py` (`Bundle`, `load_bundle`), all lazily inside functions, and this module's suite exercises them through a stand-in. The pin protects CI's *resolve/install* step, which is what support#391 was actually about.
- **Not addressed here (deliberately):** whether `bundle.md` / `bundles/*.yaml` foundation includes should also pin. Different mechanism (bundle loader, not pip), different tradeoff — same scoping call #201 made.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)
