### PR TITLE
feat(examples): the objective layer — state an objective, not a pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,12 @@ The goal lives in the DOT itself: `graph [goal="Add user avatar upload with S3 s
 
 ## Pipeline Gallery
 
+### Objective-first — state the objective, not the pipeline
+
+| Pipeline | What it does |
+|----------|--------------|
+| [Objective Runner](examples/objective/README.md) | You state an **objective**; it diagnoses, then **selects** a shipped lane, **composes** a purpose-built child pipeline, or **redirects** with an honest written no |
+
 ### Canonical attractor exemplars — teach the shape
 
 | Pipeline | What it teaches |
@@ -198,6 +204,25 @@ task (or control node like fork/join/gate), and edges define the flow between th
 For each LLM node, the orchestrator spawns a **loop-agent** sub-session that runs
 an agentic tool loop -- call LLM, execute tools, feed results back -- until the
 node's task completes. Results flow forward along edges to the next node.
+
+### The objective layer
+
+The graph is the program — but choosing *which* graph is still a decision, and
+it is usually the one a user cannot make. `examples/objective/objective-runner.dot`
+takes that decision as its input: you pass an **objective**, and the runner
+diagnoses it with the three-question test, then **selects** one of the shipped
+practical pipelines, **composes** a purpose-built child graph (which must clear
+`attractor lint` and a structural contract check before it is allowed to run), or
+**redirects** — exiting green with a written diagnosis when the honest answer is
+that the work wants a recipe, a conversation, or a one-shot.
+
+It stacks the same doctrine one level up rather than relaxing it. The first
+routing decision runs on a schema-validated artifact written by a worker and
+admitted by a *code* gate, not on the worker's self-report. A child pipeline's
+own success is used for loud fail-routing only — satisfaction is decided by the
+parent re-running the definition-of-done command itself, plus a delta assertion
+against an anchor recorded before any work began. It is author-level content
+only: one `.dot`, two stdlib scripts, no engine surface.
 
 ## Provider Profiles
 

--- a/agents/attractor-expert.md
+++ b/agents/attractor-expert.md
@@ -100,6 +100,39 @@ The bundle includes 16 example pipelines you can reference:
   `feature-build.dot`, `pr-review.dot`, `refactor.dot`, `test-gen.dot`
 - Programmatic usage: `@attractor:examples/programmatic_usage.py`
 
+## Objective-first entry
+
+When a user arrives with an **objective** rather than a pipeline choice -- "the
+save path crashes on unicode filenames", "operators have no runbook" -- do not
+open by asking which `.dot` they want. They usually do not know, and the answer
+is often "none of them."
+
+Point them at `@attractor:examples/objective/objective-runner.dot`: state the
+objective as `--param goal=...`, and the runner diagnoses and routes it. It
+applies the three-question test to the objective itself, writes a schema-validated
+triage record, and then either **selects** one of the five shipped practical
+lanes, **composes** a purpose-built child pipeline (gated by `attractor lint` plus
+a structural contract check before it is allowed to run), or **redirects** --
+exiting green with a written diagnosis when the honest answer is that this wants
+a recipe, a conversation, or a one-shot. Read
+`@attractor:examples/objective/README.md` before recommending it.
+
+Two things to teach along with it, because they are the transferable part:
+
+- **The first routing decision runs on a machine artifact, not a self-report.**
+  The intake worker writes `.objective/triage.json`; a code-tier gate validates
+  it and prints the routing token. Routing on the worker's own
+  `preferred_label` would put the run's first decision inside the context that
+  produced it.
+- **The parent re-runs the definition of done itself.** A child pipeline's
+  terminal outcome is used for loud fail-routing only. Files and exit codes
+  decide satisfaction -- plus a delta assertion against an anchor recorded
+  before any work, so a green check on an unchanged workspace cannot pass.
+
+Still recommend a specific `.dot` when the user already knows the shape they
+want. The objective layer earns its keep when they know the objective and not
+the shape.
+
 ## Session entry point
 
 If a user is deciding whether to build a pipeline at all, or needs a guided

--- a/context/pipeline-awareness.md
+++ b/context/pipeline-awareness.md
@@ -46,6 +46,16 @@ When the user asks you to do a complex task, decide:
    a full pipeline with conditional routing, retries, or parallel fan-out.
    Example: "Build a comprehensive test suite for 3 modules" uses parallel fan-out.
 
+4. **Complex task where you do not know which shape fits** — don't guess: target
+   `@attractor:examples/objective/objective-runner.dot` with the objective as
+   `goal` and let it triage. You don't pick the pipeline; the runner diagnoses
+   the objective and either selects a shipped lane, composes a purpose-built
+   child, or redirects. Read `.objective/disposition` when it returns:
+   `satisfied` (evidence in `.objective/evidence-*.log`), `redirected` (the
+   honest no, written up in `.objective/redirect.md` — relay it, do not retry),
+   or `escalated` (nonzero exit; the analysis is in
+   `.objective/postmortem/report.md`).
+
 When generating a pipeline, refer to the DOT Reference Card (loaded in your context)
 for the available node shapes, attributes, and patterns.
 

--- a/docs/DOT-AUTHORING-GUIDE.md
+++ b/docs/DOT-AUTHORING-GUIDE.md
@@ -942,6 +942,16 @@ The `goal` value comes from the graph-level `goal` attribute. Override it at run
 time with `--param goal="..."` on the `attractor run` CLI, or the `goal`
 parameter in `run_pipeline`.
 
+**`$goal` in a `tool_command` resolves differently than in a `prompt`.** LLM-node
+prompts are given `$goal` from the graph's `goal` attribute directly. Tool
+commands are substituted against the pipeline *context*, where the graph
+attribute lives under the dotted key `graph.goal` -- a bare `goal` key exists
+only when one was passed in (`--param goal="..."`, or a `params` entry). So a
+`tool_command` that must work regardless of how the pipeline was invoked --
+notably inside a `shape=folder` child, which inherits `graph.goal` from its
+parent but not necessarily a flat `goal` param -- should reference
+`${graph.goal}`, or accept `goal` as an explicit param.
+
 `$iteration` is seeded to `"0"` at pipeline start and increments by 1 on each
 `loop_restart` edge traversal. Use it in prompts to let the LLM know which
 attempt it is on:

--- a/docs/PIPELINE_PATTERNS.md
+++ b/docs/PIPELINE_PATTERNS.md
@@ -338,6 +338,56 @@ verbatim.
 
 ---
 
+### Pattern: schema-validated artifact as the routing signal
+
+The strongest form of the middle row is worth naming on its own, because it is what
+you reach for when the decision being routed is *consequential* — which pipeline
+runs, whether the work ships, whether the run exits at all.
+
+Instead of `agent → keyword → edge`, use:
+
+1. The agent writes a **structured artifact** to a declared path (JSON, not prose),
+   with `must_write=` making the absence of that artifact a fail-closed contract
+   violation rather than a silent pass.
+2. A `parallelogram` node validates the artifact against a **schema kept in a
+   separate file** and prints ONE token from a closed vocabulary.
+3. Edges route on `context.tool.last_line`, with the `&& outcome=success`
+   conjunction (§7 above, and `examples/gates/README.md`).
+
+```dot
+propose [shape=box, must_write=".objective/triage.json",
+         prompt="Write .objective/triage.json with fields: shape (one of ...), rationale."]
+admit   [shape=parallelogram, max_retries=0,
+         tool_command="python3 \"$runner_dir/validate_triage.py\" --triage .objective/triage.json --schema \"$runner_dir/triage-schema.json\""]
+
+propose -> admit
+admit -> lane_a  [condition="context.tool.last_line=alpha && outcome=success"]
+admit -> lane_b  [condition="context.tool.last_line=beta && outcome=success"]
+admit -> propose [condition="context.tool.last_line=rejected && outcome=success"]
+admit -> halt    [condition="outcome=fail"]
+```
+
+What this buys over routing on `preferred_label`:
+
+- **The vocabulary is enforced, not hoped for.** An off-vocabulary value is a
+  rejection with a report the proposer can read, not an unmatched edge.
+- **Cross-field rules become checks.** "A non-redirect shape must name a real
+  evidence command" is a schema rule; as a prompt instruction it is a suggestion.
+- **The rejection is bounded and distinct from a tool failure.** A bad *record*
+  is a judgement token that loops (fuse-bounded); a validator that cannot *run*
+  exits nonzero and routes through `outcome=fail` to a different place entirely.
+- **The decision is auditable after the fact.** The artifact and the validation
+  report are both on disk.
+
+The cost is one more node and one more file, so reserve it for decisions that
+deserve it. A worker steering its own next step within a loop is fine on
+`preferred_label`; a worker choosing which pipeline runs is not.
+
+Shipped instance: `examples/objective/objective-runner.dot` (`frame` →
+`triage_gate`), with the schema at `examples/objective/triage-schema.json`.
+
+---
+
 ## 8. Cross-References
 
 | Topic | Where to look |

--- a/docs/designs/2026-08-15-objective-layer.md
+++ b/docs/designs/2026-08-15-objective-layer.md
@@ -1,0 +1,661 @@
+# The Objective Layer — an objective-runner exemplar for amplifier-bundle-attractor
+
+**Status:** SHIPPED as an exemplar. Designed and probed 2026-08-14; built, live-proved,
+and merged into `examples/objective/` in the PR that also lands this document. The
+design below is preserved as written; §11 records what actually changed on contact
+with the build, and §12 records the maintainer rulings that closed §10's open
+questions.
+**Destination:** `docs/designs/` in `microsoft/amplifier-bundle-attractor`.
+**Charter:** Maintainer ruling 2026-08-14 — build "attractor + one layer up" **in-bundle** as a
+**shipped exemplar** plus guidance-wave improvements, explicitly NOT a platform service and NOT
+Resolve/TeamPulse integration. Vision anchor (maintainer's recorded design conversation):
+*"The user might never pick an attractor explicitly. The system infers it from the objective."*
+Node semantics: nodes publish *objective, constraints, available tools, required evidence, exit
+conditions* — "edges might represent 'objective not satisfied' instead of 'next step.'"
+Hierarchy: **orchestrator RUNS, graph DEFINES, model ADAPTS**; layering **objective →
+composition → attractors → execution**.
+
+All engine facts below were probed against a `/tmp` worktree of `origin/main` @ `02fcaa8`
+("docs: ship the human-facing explainer page + its drift guard") using the standalone
+`attractor` CLI from `modules/pipeline-runner` (uv-synced, real engine, real runs). Probe
+artifacts live under `/tmp/objprobe/{p1..p5}` (graphs, scripts, run logs, checkpoints).
+
+---
+
+## 1. The objective-runner graph
+
+### 1.1 What the exemplar is
+
+One shipped `.dot` — `examples/objective/objective-runner.dot` — whose **basin is "the stated
+objective is satisfied with machine evidence, or honestly redirected."** It is invoked with an
+*objective*, not a pipeline choice:
+
+```bash
+cd <workspace>
+attractor run $BUNDLE/examples/objective/objective-runner.dot \
+    --param goal="users report a crash when saving a file whose name contains unicode" \
+    --param target_dir=$PWD \
+    --cwd .
+```
+
+The objective travels as the canonical `goal` param (probe P2, §2: flat `--param` keys reach
+every child pipeline via the cloned context, and the bundle's practical pipelines already
+consume `$goal` — so *the objective IS the goal*, no adapter layer). `target_dir` follows the
+`task-runner.dot` convention (it is prompt/path text; tool-node cwd comes from `--cwd`).
+
+### 1.2 Node/edge sketch
+
+```
+start(Mdiamond)
+  → frame(box)                       # diagnose: write .objective/triage.json + objective.md
+  → triage_gate(parallelogram)       # machine-validate triage; print routing token
+      —bugfix→   lane_bugfix(folder → ../pipelines/practical/bug-fix.dot)
+      —feature→  lane_feature(folder → ../pipelines/practical/feature-build.dot)
+      —refactor→ lane_refactor(folder → ../pipelines/practical/refactor.dot)
+      —testgen→  lane_testgen(folder → ../pipelines/practical/test-gen.dot)
+      —review→   lane_review(folder → ../pipelines/practical/pr-review.dot)
+      —compose→  compose(box)        # WRITE a purpose-built child .dot + dod.sh
+                   → lint_gate(parallelogram: attractor lint <generated>)
+                   → contract_gate(parallelogram: check_child_contract.py)
+                   → run_child(folder → $target_dir/.objective/generated/child.dot)
+      —redirect→ redirect_report(box) # the honest no: recipe/conversation, with quotes
+      —triage_bad→ frame              # corrective: malformed triage (bounded fuse)
+  lanes/run_child → evidence_gate(parallelogram, goal_gate=true)
+      —evidence_ok→  approve(hexagon human gate)
+      —evidence_bad→ feedback(box) → back to the lane/compose entry (corrective, spends budget)
+      —exhausted→    postmortem(box) → escalated(parallelogram, exit 1)   # LOUD red terminal
+  approve —[R] Reject→ feedback ; —[A] Approve→ finalize
+  redirect_report → finalize(parallelogram)  # requires a disposition artifact
+  finalize → done(Msquare)                   # the ONE exit (engine rule, §2 P-extra)
+  any box —outcome=fail→ postmortem → escalated
+```
+
+Two honest terminals, expressed in the engine's own verified idioms (probe P-extra in §2:
+`validate_or_raise` **requires exactly one exit node**, so "two terminals" cannot be two
+`Msquare`s):
+
+- **Honest no / redirect** — a *successful* completion whose deliverable is
+  `.objective/redirect.md` ("this wants a recipe/conversation, not an attractor"), reaching the
+  single green exit through `finalize`, which mechanically requires a disposition artifact.
+- **Budget-exhausted escalate** — the `bug-fix.dot` idiom: `escalated` writes
+  `.objective/postmortem/escalation.md` then `printf escalated; exit 1` with `max_retries=0`
+  and no fail-route — the engine hard-fails LOUD (run `status=fail`, CLI exit 1; probed).
+
+### 1.3 Node contracts (Objective / Constraints / Capabilities / Required evidence / Exit)
+
+Per the vision's node semantics, every node's header comment in the shipped `.dot` carries this
+contract block. The load-bearing ones:
+
+| Node | Objective | Constraints | Capabilities | Required evidence | Exit condition |
+|---|---|---|---|---|---|
+| `frame` (box) | Classify `$goal` with the repo's three-question test (PIPELINE_DESIGN_PRINCIPLES §0) and choose a shape | Do NOT do the work; do NOT self-route; vocabulary fixed; must name a machine `evidence_command` or `NONE` | read repo, read `$goal` | `.objective/triage.json` (schema-valid) + `.objective/objective.md` (restated objective, constraints, required evidence) | triage.json exists and parses |
+| `triage_gate` (tool) | Admit only well-formed triage | code-tier only; vocabulary equality is exact lowercase | `python` + `triage-schema.json` | validated triage.json; prints ONE token from the vocabulary | token printed && exit 0; malformed → `triage_bad` (fuse-bounded) |
+| `lane_*` (folder) | Satisfy the objective via the shipped practical pipeline | child carries its OWN gates (already true of every `practical/*.dot`); fresh session boundary (EXTENSIONS §11) | child graph's own | the child's own evidence files (e.g. `.ai/test.log`, artifacts in workspace) | child terminal outcome returns to parent (P3) |
+| `compose` (box) | WRITE `child.dot` + `dod.sh` satisfying the composed-child contract (§4) | gates OUTSIDE workers; single exit; cycle + budget mandatory; build ONLY from bundle-shipped patterns (§4.3) | write files; read `patterns/`, `gates/`, contract doc | `$target_dir/.objective/generated/child.dot`, `dod.sh` | files exist (checked by next gates) |
+| `lint_gate` (tool) | Machine-reject broken generated graphs BEFORE execution | ERRORs block; warnings pass (contract_gate owns shape checks) | `attractor lint` (exit 1 on errors — probed P5) | `lint-report.txt` | `lint_pass` token && exit 0; `lint_fail` → compose_fix loop |
+| `contract_gate` (tool) | Enforce the composed-child contract structurally | deterministic checks only | `check_child_contract.py` | `contract-report.txt` | `contract_ok` / `contract_bad` |
+| `run_child` (folder) | Execute the generated child | dot_file resolves lazily at node execution (P1) | child graph | child's evidence files under workspace | child outcome |
+| `evidence_gate` (tool, `goal_gate=true`) | Verify the objective is satisfied by RE-RUNNING the DoD — never by the child's self-report (P3) | file-based only; owns the iteration fuse (`.objective/iter` vs `$max_iterations`) | `bash dod.sh` / `evidence_command`, anchored-delta gate (`examples/gates/base-sha-anchor.dot` idiom) | `evidence-<n>.log`, appended `.objective/convergence.jsonl` | `evidence_ok` / `evidence_bad` / `exhausted` |
+| `approve` (hexagon) | Consequential human approval | choices from edge labels; safe choice FIRST (unattended auto-approve picks first — task-runner doctrine); CLI default `--on-human-gate fail` stays honest | human | recorded gate answer in run log | Approve / Reject |
+| `redirect_report` (box) | The honest no, with receipts | must quote the failing three-question answers; must name the better home (recipe / conversation / one-shot) | write file | `.objective/redirect.md` | file exists (finalize checks) |
+| `postmortem` (box) → `escalated` (tool) | Salvage value from a non-converging run, then fail LOUD | escalated: `max_retries=0`, `exit 1`, no fail-route | write files | `.objective/postmortem/report.md`, `escalation.md` | pipeline `status=fail`, CLI exit 1 |
+| `finalize` (tool) | Refuse a green exit without a disposition | code-tier | file test | `.objective/disposition` = satisfied\|redirected + the artifact it points to | exit 0 only if disposition artifact present |
+
+**Budget fuse arithmetic (shown, not implied).** Engine safety net: `max_steps = nodes × 50`
+(`engine.py:137` `_MAX_GOAL_GATE_RETRIES: int = 50`, `engine.py:611`) — for this ~16-node graph,
+800 steps; the exemplar's own fuses fire far earlier. Runner fuses: `triage_bad` loop ≤ 2
+re-frames (`.objective/frame-iter`); compose-fix loop ≤ `$max_compose` (default 2 → at most 3
+lint/contract attempts); evidence loop ≤ `$max_iterations` (default 3) counted in
+`.objective/iter` by `evidence_gate` itself, `bug-fix.dot`-style, so *every* re-entry spends
+budget. Worst-case LLM-node executions ≈ frame(3) + compose(3) + per-evidence-iteration child
+runs(3 × child's own internal budget, default 6) + feedback(3) + postmortem(1) — bounded and
+inspectable. Each composed child additionally carries its own `$max_iterations` wall (§4).
+
+---
+
+## 2. Probe results — verified engine facts
+
+Method: real runs of the standalone CLI (`attractor run` / `attractor lint`) from
+`/tmp/objprobe-wt` (git worktree of `origin/main` @ `02fcaa8`), tool-node graphs for
+determinism plus two live LLM runs for the intake idiom. Quotes are verbatim from runs, source,
+or `git show origin/main:<path>`.
+
+### P1 — Write-then-run composition: **WORKS TODAY (lazy resolution), and validation/lint do NOT check existence**
+
+- Run-proven: a 3-node graph — tool node writes `gen/child.dot`, `shape=folder,
+  dot_file="gen/child.dot"` executes it. Result: `attractor: status=success`; the child's own
+  artifact `child-proof.txt` appeared (`child-evidence-1786761403`). The file did not exist at
+  parse/validate time.
+- Source-of-record: EXTENSIONS §10 — resolution is a precedence chain, *"the first non-empty
+  candidate wins, **with no existence check**"*; the handler opens the file only at node
+  execution (`handlers/pipeline.py` step 3) and returns
+  `Outcome(FAIL, "Child DOT file not found: …")` if absent.
+- Validate/lint phase: with the target absent, `attractor lint parent.dot` produced only
+  `WARNING: [acyclic_graph] …` and **rc=0** — no missing-file diagnostic. A never-written
+  target fails **late and loud** at run time:
+  `[PIPELINE] ✗ Error at child (no_matching_edge): Child DOT file not found:
+  /tmp/objprobe/p1/never/exists.dot` → `attractor: status=fail`, CLI exit **1**.
+- Open issue **#200** confirms and complains about exactly this (*"resolved … with no check
+  that the resulting file actually exists"*). **Compat watch (finding F2, §2.6):** #200's fix
+  must not become a parse-time admission gate, or write-then-run composition dies.
+
+### P2 — Params/context INTO a child: **context clone + `context.*` attrs; pass the objective as `goal`**
+
+Run-proven with parent → `child.dot` (folder) → child tool node:
+
+```
+objective=[prove-param-flow-p2]        # --param objective=…  → flat context key → cloned into child (handler step 6) → $objective substituted in child tool_command
+mission=[injected-by-folder-attr]      # folder-node attr context.mission=…  → injected into child context (step 6b)
+goal=[]                                # $goal is NOT a substitution key in tool_command …
+graph.goal=[parent-goal-sentinel]      # … but ${graph.goal} IS, inherited from the parent via the clone
+```
+
+EXTENSIONS §21 covers `$param`/`${key}` substitution; `PipelineHandler.execute()` step 6
+(`context.clone()`) and step 6b (`context.*` attr injection) are the mechanisms. Note the
+folder handler also **clears `preferred_label`** at the boundary (step 6a — stale-label
+hygiene) and child goal falls back to the parent's (`child_graph.goal or
+context.get("graph.goal")`, step 10). Design consequence: invoke the runner with
+`--param goal="<objective>"` so lanes and composed children consume it natively; `context.*`
+attrs are the per-lane knob channel (probed again in P4: `context.lane` reached the child).
+
+### P3 — What comes BACK from a child: **verbatim terminal outcome + declared `outputs=` merge + (leaky) `context_updates` — so the gate reads FILES**
+
+Run-proven (`outputs="verdict,artifact_path"` on the folder node; child emits JSON via
+`parse_json=true`):
+
+- Parent checkpoint recorded the folder node's outcome as the child's terminal outcome
+  **verbatim** (handler step 12): `{"status": "success", "preferred_label": null, …,
+  "is_explicit": true, "notes": "Tool completed: bash emit_verdict.sh"}`.
+- Declared keys merged on success (step 11b2) and **drove parent routing**: path
+  `['start', 'child', 'route_pass']` via `condition="context.verdict=pass"`.
+- **Leak (fact, not bug):** the child's *undeclared* `undeclared_key: 'should-not-cross'` ALSO
+  appeared in parent context — the child's terminal outcome carries `context_updates`, and the
+  parent engine applies them generically (`engine.py:1142` — *"Step 4: Apply context updates
+  from outcome"*). The folder boundary is therefore **leakier than `outputs=` suggests**.
+- Fail path: #182/#172 fixed `failure_reason` propagation and subgraph-dead-end silent success;
+  the missing-file FAIL in P1 surfaced loudly in the parent.
+
+**Design ruling:** the parent `evidence_gate` trusts only (a) files on disk and (b) its own
+re-execution of the DoD command. Child `status` is used solely for loud fail-routing; merged
+context keys are routing hints, never evidence. This is the doc'd doctrine made mechanical:
+*"Verification inside the context that produced the evidence is not verification"*
+(PIPELINE_DESIGN_PRINCIPLES §0, the fabricated `convergence.jsonl` incident).
+
+### P4 — Conditional routing among folder nodes: **evidence-token routing proven; live LLM run exposed a verdict-transport gap (F1)**
+
+- Deterministic idiom (run-proven twice): one intake tool node prints a token; edges
+  `condition="context.tool.last_line=<token> && outcome=success"` (ROUTING-REFERENCE's
+  stale-label discipline: *"conjoin `&& outcome=success` onto every last_line edge that shares
+  a source node with a failure edge"*). Objective "users report a crash on save" → path
+  `['start', 'intake', 'lane_bugfix']`; "please add a feature for csv export" →
+  `['start', 'intake', 'lane_feature']`. The doctrine's other idiom — `outcome=<label>`
+  resolving `preferred_label` first — is ledgered as EXTENSIONS §22 / ATX-5 and covered by
+  repo tests.
+- Live LLM run 1 (box intake, plain instruction to use `report_outcome`): the spawned agent
+  answered in prose; engine recorded `is_explicit=false, preferred_label=None,
+  notes="Plain text response: **Classification: `bugfix`**…"`; **no edge matched** and the
+  engine failed LOUD exactly as EXTENSIONS §33 promises:
+  `[PIPELINE] ✗ Error at intake (no_matching_edge): No matching edge from node 'intake'`.
+- Live LLM run 2 (strong MUST-call prompt + catch-all
+  `condition="outcome!=bugfix && outcome!=feature && outcome!=novel && outcome!=fail"` →
+  bounded reprompt loop): the catch-all corrective edge **fired and looped** (9 cycles observed
+  before I killed the run) — and inside one completed intake session the agent **did** call the
+  tool: events.jsonl shows `tool:pre {"tool_input": {"preferred_label": "bugfix", "status":
+  "success"}, "tool_name": "report_outcome"}` and `tool:post … "result": "{\"message\":
+  \"Outcome reported: success (preferred_label=bugfix)\""` — yet the engine still recorded
+  `preferred_label=None, is_explicit=False` for that node. **The verdict was lost between the
+  spawned agent and the parent engine on the standalone-CLI spawn path.** → Finding **F1**
+  (§2.6).
+
+**Design ruling:** the intake routes on a **machine artifact + code-tier token gate**
+(`frame` writes `triage.json`; `triage_gate` validates and prints the token). That is (a) immune
+to F1, and (b) independently better doctrine — routing evidence lives outside the worker's
+self-report, exactly like every shipped gate. `preferred_label` remains the documented idiom
+for nodes that legitimately steer themselves; the exemplar simply refuses to hang the *first*
+routing decision on an unverified LLM verdict.
+
+### P5 — `attractor lint` as an in-graph gate on a GENERATED graph: **works; exit 1 on ERRORs only; `--strict` promotes warnings**
+
+Run-proven end to end, generated-then-linted inside one pipeline:
+
+- Deliberately broken generated child (TOPO-001 dead conditional edge):
+  in-graph gate `…/attractor lint gen/child-candidate.dot && echo lint_pass || echo lint_fail`
+  routed to `blocked` — path `['start', 'gen', 'lint_gate', 'blocked']`. Execution of the broken
+  child was **prevented by machine evidence**. Report: `ERROR: [dead_conditional_edge] …` /
+  `attractor lint: gen/child-candidate.dot: 1 error(s), 2 warning(s)`; direct exit code **1**.
+- Clean-but-warning child (acyclic → `WARNING: [acyclic_graph]`): exit **0**, gate printed
+  `lint_pass`, path `['start', 'gen', 'lint_gate', 'run_child']`, child artifact created.
+  `--strict` on the same file: exit **1**. Matches EXTENSIONS §32's contract: *"errors → exit
+  1, warnings → exit 0 unless `--strict`"*.
+- Bonus: lint on a *missing* path exits 1 (`attractor lint: DOT file not found: …`) — the gate
+  also catches "the composer never wrote the file." And origin/main lint already includes
+  TOPO-006 `fail_routed_to_exit` (the silent-success class) — the contract checker doesn't need
+  to re-implement it.
+
+### P-extra — facts discovered by probing that shape the design
+
+- **Exactly one exit node** is admission-gating: `ValidationError: Validation failed: Pipeline
+  has 2 exit nodes (pass_exit, fail_exit); exactly one is required` (CLI exit 1, run refused).
+  Honest terminals must be one green exit + a fail-loud escalation node (§1.2).
+- Engine step cap: `max_steps = len(graph.nodes) × 50` (`engine.py:137,611`).
+- A FAIL outcome is fail-fast (no plain-edge drift; EXTENSIONS §16), and no-matching-edge is a
+  LOUD hard fail (§33) — both observed live in P4.
+
+### 2.6 Gap findings (named, not designed around silently)
+
+- **F1 — spawned-agent `report_outcome` verdict lost on the standalone CLI path.** Evidence in
+  P4: tool call succeeded in the child session (`tool:post` result *"Outcome reported: success
+  (preferred_label=bugfix)"*) but the node outcome came back `is_explicit=false,
+  preferred_label=None`. EXTENSIONS §35 documents the intended transport
+  (`orchestrator:complete` → `metadata.report_outcome` → `backend.py` outcome reconstruction,
+  *"report_outcome tool call was made → authoritative"*, backend.py:814). The mounted-
+  orchestrator path has live e2e coverage (`profiles/attractor-e2e-*.yaml` mount
+  `tool-report-outcome`); the loss reproduced only via `pipeline-runner`'s
+  `make_spawn_fn` → `prepared.spawn` path. **Smallest fix shape:** ensure the spawn-result dict
+  returned through `make_spawn_fn` carries the child's `metadata.report_outcome` envelope to
+  `AmplifierBackend._run_with_spawn`'s reconstruction (one seam, additive; plus a
+  pipeline-runner e2e asserting `is_explicit=true` after a child `report_outcome`). The
+  exemplar does not depend on the fix (artifact-token intake), but the fix unblocks
+  `preferred_label` intake as a documented alternative.
+- **F2 — issue #200 vs write-then-run (compat watch, not a bug).** The requested "upfront
+  existence check" must stay out of `validate_or_raise`, or runtime-generated `dot_file`
+  targets (this exemplar's compose path, and any future composition layer) become impossible.
+  Proposed shape: keep admission lazy; improve the *node-entry* error to name the candidate
+  chain (kills the misleading `no_matching_edge` framing #200 quotes); optionally a lint
+  WARNING when a *static* relative target is absent — advisory, per §32's entry-point
+  discriminator.
+- **F3 — `$goal` is not a tool-command substitution key** (P2: `goal=[]` vs
+  `graph.goal=[parent-goal-sentinel]`). Not a bug — but guidance-worthy: children reference
+  `${graph.goal}` or a passed `goal` param. One paragraph in the authoring guide (§6).
+
+---
+
+## 3. Select vs compose vs redirect — the intake decision logic
+
+`frame` applies the repo's own three-question test (PIPELINE_DESIGN_PRINCIPLES §0: cycle? /
+evidence-gated exit? / survives one LLM bad day?) *prospectively* to the stated objective, and
+writes `triage.json`:
+
+```json
+{
+  "shape": "bugfix | feature | refactor | testgen | review | compose | redirect",
+  "three_question": {"cycle": "...", "evidence_gate": "...", "bad_day": "..."},
+  "evidence_command": "<shell command that exits 0 iff the objective is satisfied, or NONE>",
+  "rationale": "..."
+}
+```
+
+**Routing vocabulary** = exactly the eight tokens above plus `triage_bad` (emitted by the gate,
+not the model). Tokens are single lowercase words because condition matching is exact string
+equality (ROUTING-REFERENCE §3).
+
+Decision logic, enforced mechanically by `triage_gate` rather than trusted:
+
+1. **redirect** iff `evidence_command == NONE` **or** the test says no cycle is wanted — *no
+   attractor without machine evidence* is a schema rule, not a vibe: the gate rejects any
+   non-redirect shape whose `evidence_command` is `NONE`. (The honest no is part of the vision;
+   `attractorify`'s "the honest no is reserved for asks with no machine gate" becomes an
+   executable check.)
+2. **select** (`bugfix|feature|refactor|testgen|review`) iff the objective maps onto ONE
+   shipped practical pipeline's contract — its walk-up params are satisfiable from `$goal` +
+   workspace, and its gate form fits the evidence_command (e.g. pytest-shaped DoD → bug-fix /
+   test-gen). The five lanes are the bundle's existing `examples/pipelines/practical/*.dot`,
+   unmodified — they already carry their own internal gates, budgets, and escalation.
+3. **compose** otherwise — machine-checkable but not lane-shaped (multi-phase, novel artifact,
+   bespoke DoD). The composer writes a child graph built from shipped patterns (§4).
+
+The intake's authority is deliberately thin: `frame` proposes, `triage_gate` admits, the
+evidence gate decides. Edges out of `triage_gate` mean "this sub-objective is not yet
+satisfied"; the corrective edges (`triage_bad`, `evidence_bad`, lint/contract failures) are the
+vision's "objective not satisfied" edges in the flesh.
+
+---
+
+## 4. The composed-child contract
+
+### 4.1 What every generated child MUST contain
+
+1. **Single `Msquare` exit** (engine admission rule) reached only through a deterministic gate.
+2. **≥1 evidence gate OUTSIDE the worker nodes**: a `parallelogram` whose `tool_command` runs
+   the *provided* `dod.sh` / `evidence_command` — never an `echo pass`, never an LLM verdict as
+   the only gate (the measured reason: external gates caught the fabricated-evidence incident;
+   one adaptive mega-node would have shipped it).
+3. **≥1 corrective cycle** — gate-fail routes back to the worker with feedback
+   (`feedback_from=` or `.ai/feedback/` file convention, both shipped in
+   `patterns/convergence-factory.dot`).
+4. **A budget wall inside the child** — iteration fuse (`$max_iterations`, default 6) checked
+   *in the gate node* so green and red paths both spend budget (task-runner doctrine), with an
+   `exhausted` route to a fail-loud escalation node (`exit 1`, `max_retries=0`).
+5. **Honest failure routing** — every gate has an `outcome=fail` route; no TOPO-006
+   silent-success shape; stale-label conjunctions on shared-source token edges.
+6. **Parameter hygiene** — consumes `$goal` (cloned from the parent, P2); writes all evidence
+   under the workspace (`.objective/…` or `.ai/…`), because files are the only trusted
+   return channel (P3).
+
+### 4.2 How the contract is enforced BEFORE execution (machine evidence, gates outside the composer)
+
+- `lint_gate`: `attractor lint <generated>` — parse errors, dead conditional edges (TOPO-001),
+  fail-routed-to-exit (TOPO-006), goal-gate/retry integrity; exit 1 blocks (P5-proved).
+- `contract_gate`: `check_child_contract.py <generated> dod.sh` — the structural checks lint
+  deliberately doesn't own (design-quality vs executability, §32): has-cycle, gate-node
+  present and its `tool_command` invokes `dod.sh`/`evidence_command` (string-level check),
+  budget fuse present, single exit, `outcome=fail` routes from every gate, no gate colocated
+  in a `box` node. ~100 lines of stdlib Python parsing via the engine's own
+  `parse_dot` (import from the installed module; no new engine surface).
+- Both gates loop back to `compose` with the report as feedback, fused at `$max_compose`.
+- The parent's `evidence_gate` then re-verifies AFTER execution regardless (defense in depth —
+  the composed child's green is necessary, not sufficient).
+
+### 4.3 Primitive source — stated choice
+
+The T3-6 verify-and-validate / recover subgraphs live in a **private** repo and are NOT
+available to this bundle. **Choice: build from what the bundle ships** —
+`examples/patterns/task-runner.dot` (convergence skeleton), `patterns/convergence-factory.dot`
+(context.*-injected factory loop), `examples/gates/*` (token/exit-code gate idioms,
+base-SHA-anchored delta assertion) — plus one fresh, minimal exemplar-owned asset:
+`compose-contract.md` (the contract above, written as instructions the composer embeds) and
+`check_child_contract.py`. No new primitive *library* is proposed; if the private primitives
+are ever published, the composer's prompt references them additively.
+
+---
+
+## 5. Evidence-flow design (how the parent verifies without trusting self-report)
+
+Channels across the folder boundary, per probes:
+
+| Channel | Probed behavior | Trust policy in this design |
+|---|---|---|
+| Files on disk (shared `--cwd`) | child artifacts land in the parent's workspace (P1/P3) | **The evidence channel.** Gate re-runs `dod.sh`; reads `.objective/…` artifacts |
+| Child terminal `Outcome` (status/notes/failure_reason) | returned verbatim (P3); FAIL propagates loudly (#172/#182) | Fail-routing only — `outcome=fail` edges to postmortem |
+| Declared `outputs=` context merge | merged on success, drove parent routing (P3) | Routing hints only, never gate evidence |
+| Undeclared `context_updates` | **leak across the boundary** (P3, engine.py:1142) | Explicitly distrusted; documented in the exemplar guide |
+| `preferred_label` | cleared entering the child (step 6a); null on return in probes | Not used across the boundary |
+
+`evidence_gate` mechanics: (1) increment `.objective/iter`, wall against `$max_iterations`
+FIRST (every visit spends budget); (2) assert required artifacts exist; (3) re-run
+`evidence_command`/`dod.sh` capturing `evidence-<n>.log`; (4) anchored delta assertion —
+"did durable work land since `base-sha`" (`examples/gates/base-sha-anchor.dot` idiom) so a
+no-op child cannot pass on a stale green; (5) append `{"iteration", "gate", "pass"}` to
+`.objective/convergence.jsonl` (descent visible, task-runner convention); (6) print
+`evidence_ok|evidence_bad|exhausted` — token edges carry the stale-label conjunction.
+
+---
+
+## 6. Guidance wave — objective-first usage (exact files)
+
+1. **`agents/attractor-expert.md`** — add an "Objective layer" section: when a user brings an
+   *objective* rather than a pipeline choice, the expert's first move is the objective-runner
+   (or its triage discipline manually): three-question test → select/compose/redirect; teach
+   the select-vs-compose criteria (§3), the composed-child contract (§4), and F1/F3 as current
+   sharp edges. The expert stops recommending "pick a .dot" as the entry move.
+2. **`skills/attractorify/SKILL.md`** — close the loop after diagnosis: verdict `attractor` now
+   ends with "run it through `examples/objective/objective-runner.dot`" (and when a shipped
+   lane fits, name it via the same vocabulary the runner uses); verdict `recipe`/`one-shot`
+   maps to the runner's `redirect` disposition so conversational and pipeline triage agree —
+   one triage doctrine, two front doors.
+3. **`context/pipeline-awareness.md`** — extend the decision heuristic: for a complex objective,
+   `run_pipeline` may target the objective-runner itself with `goal=<objective>` — "you don't
+   pick the pipeline; the runner triages" — plus the two-line honest-outcome contract
+   (redirect.md / escalation.md) so agents relay honest exits instead of retrying blindly.
+4. **`README.md`** — Pipeline Gallery gains an "Objective-first" row and the Quick Start gains
+   the §1.1 invocation as the *first* example: state an objective, get either verified
+   satisfaction, an honest redirect, or a loud escalation.
+5. **`docs/PIPELINE_DESIGN_PRINCIPLES.md`** (§0 cross-ref) + **`docs/DOT-AUTHORING-GUIDE.md`**
+   — one subsection each: "The objective layer" naming the layering (objective → composition →
+   attractors → execution), the composed-child contract, and the F3 note (`${graph.goal}` vs
+   `$goal` in tool commands); authoring guide points at `compose-contract.md` as the checklist
+   for ANY parent-writes-child graph.
+6. **`examples/pipelines/practical/README.md`** — one paragraph: these five pipelines are the
+   objective-runner's *lanes*; their walk-up contracts (params, DoD shape) are what makes them
+   selectable — keep them stable.
+
+---
+
+## 7. Live-proof plan (three real objectives, machine-checkable passes)
+
+Shipped as `examples/objective/evidence/<run>/` (repo convention), each with a `verify.sh` the
+CI or a reviewer can re-run:
+
+1. **SELECT** — objective: *"Fix the TypeError in get_display_name when a user's avatar is
+   None"* against the shipped `practical/sample/`. PASS iff: run `status=success` ∧
+   `triage.json .shape=="bugfix"` ∧ checkpoint `completed_nodes` contains `lane_bugfix` and
+   no compose/redirect node ∧ independent re-run of `pytest -q` in the sample exits 0 ∧
+   `.objective/convergence.jsonl` non-empty.
+2. **COMPOSE** — objective: *"Create CONTRIBUTING.md whose sections satisfy the provided
+   `check_contrib.py`"* (checker shipped in the evidence fixture; no lane fits, DoD is
+   machine-checkable). PASS iff: `generated/child.dot` exists ∧ `lint-report.txt` shows 0
+   errors ∧ `contract-report.txt` = contract_ok ∧ a `subgraph_run_child*` dir exists in the
+   run logs ∧ independent `python check_contrib.py` exits 0 ∧ run `status=success`.
+3. **REDIRECT (the honest no)** — objective: *"Summarize this repo's architecture for a
+   newcomer"* (no machine gate exists). PASS iff: run `status=success` ∧
+   `.objective/redirect.md` exists, names `recipe|conversation`, and quotes Q2=no ∧
+   `completed_nodes` contains **no** lane/compose folder node ∧ disposition=`redirected`.
+
+Negative proof (already probed, re-shipped as fixture): a compose run whose generated child is
+broken routes `lint_gate → compose` and, at `$max_compose`, exits via `escalated` with CLI
+exit 1 — never executes the broken child.
+
+---
+
+## 8. Non-goals
+
+- **No platform service / scheduler / portfolio orchestrator** — the "orchestrator as a
+  service", event-driven resident system, and portfolio layer from the vision conversation are
+  explicitly out (maintainer: in-bundle exemplar only).
+- **No Resolve/TeamPulse integration**, no dashboards, no telemetry beyond existing run logs.
+- **No repo split / rename** (the "graph runtime" naming thread is the maintainer's to pursue).
+- **No uber-attractor / adaptive mega-node** — gates stay outside workers; the runner routes to
+  *separate* children with their own gates.
+- **No engine changes** in the exemplar PR. F1/F2 are filed as issues with smallest-fix shapes,
+  not patched here; nothing in §1 depends on them.
+- **No learned template selection / auto-tuning** — selection is a declared, inspectable gate.
+- **No new top-level directory or module** — `examples/` weight only (§10 Q1).
+
+Compat statement (SPEC_CONFORMANCE doctrine): everything here is additive author-level content
+— new `.dot` + docs + one stdlib checker script. No new attributes, shapes, or semantics; a
+spec-conformant community `.dot` is unaffected. The exemplar consumes only ledgered extensions
+(§10 folder/dot_file, §20 tool.last_line, §21 params, §24 $iteration, §27 must_write where
+useful, §32 lint CLI).
+
+---
+
+## 9. File-touch inventory + build order
+
+New (all under `examples/objective/` unless noted):
+
+| # | File | Role |
+|---|---|---|
+| 1 | `objective-runner.dot` | the exemplar graph (§1) |
+| 2 | `objective-runner.md` | walk-up guide (pair convention) |
+| 3 | `triage-schema.json` | intake vocabulary + required-fields contract |
+| 4 | `compose-contract.md` | composed-child contract, embedded by the composer prompt |
+| 5 | `check_child_contract.py` | structural gate (§4.2) |
+| 6 | `evidence/…` (3 runs + negative fixture) | live proofs (§7) |
+| 7 | `docs/designs/DESIGN-objective-layer.md` | this doc |
+
+Modified (guidance wave, §6): `agents/attractor-expert.md`, `skills/attractorify/SKILL.md`,
+`context/pipeline-awareness.md`, `README.md`, `docs/PIPELINE_DESIGN_PRINCIPLES.md`,
+`docs/DOT-AUTHORING-GUIDE.md`, `examples/pipelines/practical/README.md`.
+
+Filed, not built: issue F1 (verdict transport, with the P4 evidence bundle), comment on #200
+(F2 compat shape), doc-nit F3.
+
+**Build order:** (1) `triage-schema.json` + `check_child_contract.py` + unit fixtures →
+(2) `objective-runner.dot` with lanes only (select + redirect paths), lint-clean, live-proof
+runs 1 and 3 → (3) compose path + `compose-contract.md`, negative fixture, live-proof run 2 →
+(4) walk-up guide + evidence dirs → (5) guidance wave → (6) file F1/F2/F3. Each step ends
+runnable; steps 2–3 each gated by their own live proof before the next begins.
+
+---
+
+## 10. Open taste questions for the maintainer
+
+1. **Placement/naming:** `examples/objective/objective-runner.dot` (own dir, like
+   `patterns/task-runner`'s ecosystem) vs a flat `examples/patterns/objective-runner.dot`?
+   And is "objective-runner" the word, or does the vision's vocabulary ("composition",
+   "playbook") belong in the name?
+2. **Param name:** ship as `goal` (zero-friction with existing lanes, P2-proven) with
+   "objective" living in the docs/artifacts — or introduce `objective` as a first-class alias
+   and thread it? (Alias costs a mapping mechanism the engine doesn't have today.)
+3. **Intake vocabulary breadth:** the five lanes + compose + redirect, or start narrower
+   (bugfix/testgen/compose/redirect) and grow lanes as their walk-up contracts prove stable?
+4. **`preferred_label` intake:** once F1 is fixed, should the exemplar *switch* its intake to
+   `report_outcome`/`preferred_label` (doctrine's self-steering idiom) or keep the
+   artifact+token gate as the taught pattern for *first-hop* routing? (I lean artifact+token —
+   evidence outside the worker — but it's a doctrine statement worth your ruling.)
+5. **Lint strictness on generated children:** plain `lint` (ERRORs block; probed) + contract
+   checker, or `--strict` with a curated warning allowlist?
+6. **#200 disposition:** do you want the exemplar PR to carry the improved node-entry error
+   message proposal (F2) as its one engine-adjacent suggestion, or keep the PR purely
+   additive-content and file everything?
+7. **Redirect disposition:** is "honest no" a green exit with `redirect.md` (my design — the
+   diagnosis IS the deliverable) or should redirect exit nonzero so unattended callers can't
+   mistake it for "objective satisfied"? (A `--param strict_disposition=true` could flip it.)
+
+---
+
+### Appendix — probe inventory
+
+| Probe | Graph/run | Key artifact |
+|---|---|---|
+| P1 | `/tmp/objprobe/p1/parent.dot`, `missing.dot` | `child-proof.txt`; lint rc=0 with absent target; late-fail quote |
+| P2 | `/tmp/objprobe/p2/parent.dot` + `child.dot` | `p2-evidence.txt` (4-line substitution matrix) |
+| P3 | `/tmp/objprobe/p3/parent.dot` + `child.dot` | checkpoint child outcome; merged + leaked keys; routed path |
+| P4 | `/tmp/objprobe/p4/route.dot`, `route-llm.dot`, `route-llm2.dot` | two lane routes; no_matching_edge quote; `tool:pre/post report_outcome` events vs `is_explicit=false` |
+| P5 | `/tmp/objprobe/p5/gate.dot` + generators | blocked vs executed paths; lint rc matrix (1 / 0 / `--strict` 1) |
+
+Engine anchors: `handlers/pipeline.py` (folder handler steps 1–12), `engine.py:137,611`
+(step cap), `engine.py:1142` (context_updates application), `validation.py` (`lint()` vs
+`validate_or_raise()`, single-exit rule), `specs/EXTENSIONS.md` §10/§11/§16/§20/§21/§22/§24/
+§32/§33/§35, `docs/ROUTING-REFERENCE.md` §3–4, `docs/PIPELINE_DESIGN_PRINCIPLES.md` §0.
+
+
+---
+
+## 11. As shipped — where the build diverged from this design
+
+Recorded honestly, because a design doc that quietly matches the code it produced
+is a design doc nobody re-reads. Everything below was found by building the thing
+and running it for real; nothing here required an engine change.
+
+### 11.1 The human gate lists **Approve** first, not Reject
+
+§1.2/§1.3 put `[R] Reject` first, reasoning from the task-runner doctrine that the
+"safe" choice goes first because an unattended `--on-human-gate auto-approve` run
+selects edge one.
+
+That doctrine holds where task-runner uses it — its human gate is on the *failure*
+path, so "Abandon" first fails safe. The objective runner's `approve` gate sits on
+the *success* path, immediately after a gate that already passed on machine
+evidence. Reject-first there means every unattended run rejects a verified result,
+spends an evidence iteration, rejects again, and finally escalates: a **false red**
+after burning the whole budget. Approve-first accepts what the machine evidence
+already established, and the CLI default (`--on-human-gate fail`) still refuses to
+guess — an unattended caller has to opt in explicitly.
+
+The generalizable rule, which §1.3 stated too narrowly: **the first choice should
+be the one that does not fabricate an outcome.** On a failure-path gate that is
+"abandon"; on a success-path gate downstream of real evidence it is "approve".
+
+### 11.2 The delta anchor is a workspace digest, not a base-SHA/commit delta
+
+§5 specified the `examples/gates/base-sha-anchor.dot` idiom — "did durable commits
+land since `base-sha`". Shipping that would have made the exemplar fail on its own
+first live proof: **none of the five shipped practical lanes commit anything.** A
+commit-delta assertion goes red after a perfectly successful `bug-fix.dot` run.
+
+Shipped instead: `preflight` records a digest of the workspace file tree (pruning
+`.git`, `.objective`, `.ai`, `__pycache__`, `.pytest_cache`, `.ruff_cache`,
+`node_modules`, `.venv`), and `evidence_gate` recomputes it and requires it to have
+moved. That buys the property the design actually wanted — a no-op child cannot
+pass on a stale green — without requiring the children to commit. Pruning the
+runner's own state directories is load-bearing: without it, `.ai/test.log` alone
+would satisfy the delta and the gate would be decorative.
+
+### 11.3 `check_child_contract.py` ships its own DOT reader
+
+§4.2 said "parsing via the engine's own `parse_dot` (import from the installed
+module)". In practice the gate runs under whatever `python3` is on `PATH` in the
+*target workspace*, which is not the `attractor` CLI's virtualenv — importing the
+engine would have made the gate environment-dependent in exactly the situation
+where it must be reliable.
+
+Shipped: ~200 lines of stdlib tokenizer + parser for the DOT subset the shipped
+graphs use, fail-closed on anything it cannot read (a graph with no
+`digraph`/`graph` header, or an unparseable one, is `contract_bad`, never
+`contract_ok`). The risk this introduces — two parsers disagreeing — is guarded by
+a test that asserts both produce identical node sets and edge counts for
+`bug-fix.dot`, `test-gen.dot`, `task-runner.dot` and `objective-runner.dot`. It also
+runs *after* `attractor lint` has already accepted the file, so the engine's parser
+is always the first opinion.
+
+### 11.4 A third param: `runner_dir`
+
+§1.1 showed `goal` + `target_dir`. The gates need to invoke `validate_triage.py`
+and `check_child_contract.py`, which live beside the `.dot` — and a `tool_command`
+runs with cwd = the *workspace*, with no context key naming the graph's own
+directory. `runner_dir` is the honest fix, validated at `preflight` (a missing or
+wrong `runner_dir` prints `blocked` and exits 1 before an LLM is ever paid) rather
+than discovered as a confusing failure three nodes later.
+
+### 11.5 `validate_triage.py` — a mechanism the file inventory omitted
+
+§9 listed `triage-schema.json` but no validator. The schema is data; something has
+to enforce it, and §1.3's "code-tier only" rules out doing it in the prompt. Shipped
+as a stdlib script implementing a deliberately small JSON-Schema subset (`type`,
+`required`, `properties`, `enum`, `min_length`) plus the three cross-field rules,
+and owning the re-frame fuse. `jsonschema` is deliberately not a dependency: an
+exemplar gate that needs `pip install` to run is not an exemplar.
+
+### 11.6 Evidence lives outside the repo; the walk-up guide is `README.md`
+
+§7/§9 proposed shipping `examples/objective/evidence/<run>/`. Maintainer ruling:
+run artifacts are never committed. The three live proofs and the negative control
+were archived outside the repository, and §7's pass criteria were executed against
+them rather than published as fixtures. The `objective-runner.md` walk-up pair
+became `examples/objective/README.md` (maintainer ruling on placement).
+
+### 11.7 Guidance wave, as scoped
+
+Shipped: `agents/attractor-expert.md`, `skills/attractorify/SKILL.md`,
+`context/pipeline-awareness.md`, `README.md`,
+`examples/pipelines/practical/README.md`, one pattern entry in
+`docs/PIPELINE_PATTERNS.md` (§7, "schema-validated artifact as the routing
+signal" — it fit the existing structure better than a renumbered new section), and
+the F3 note in `docs/DOT-AUTHORING-GUIDE.md`. `docs/PIPELINE_DESIGN_PRINCIPLES.md`
+was left alone: §0 already states the doctrine the exemplar implements, and adding
+a cross-reference there would have been decoration.
+
+### 11.8 What the live proofs found that no probe could
+
+- **A lane's tooling must actually exec.** LP1's first attempt failed because the
+  host's `pytest` shim had a dangling shebang (`#!/opt/az/bin/python3.13`), so
+  `sh -c pytest` reported "not found" while `command -v pytest` resolved happily.
+  The exemplar behaved correctly — child escalated, parent routed
+  `outcome=fail` → postmortem → escalated, CLI exit 1 — and, notably, the child's
+  worker had *actually fixed the bug* and written "Status: COMPLETE" in its own
+  scratch file. The pipeline still refused to report success. That is the doctrine
+  paying for itself: a worker's self-report bought exactly nothing.
+- **The two generated-child gates catch different things, and both are needed.**
+  A deliberately-broken child with a dead conditional edge is blocked by
+  `lint_gate` while `contract_gate` says `contract_ok`; a child that is acyclic with
+  `goal_gate=true` on its worker passes `attractor lint` with warnings only and is
+  blocked by `contract_gate`. Neither gate subsumes the other.
+- **`frame` writes serviceable but imperfect DoDs.** LP1's evidence command piped
+  through `tee /tmp/pytest-out.txt` — non-vacuous (it greps for a passing test whose
+  name mentions the None-avatar case) but writing scratch outside the workspace.
+  Worth a future tightening of the `frame` prompt; recorded rather than hidden.
+
+---
+
+## 12. Maintainer rulings on §10's open questions
+
+| # | Question | Ruling |
+|---|---|---|
+| 1 | Placement/naming | `examples/objective/` as its own directory; the graph is `objective-runner.dot` |
+| 2 | Param name | Ship as `goal`. The objective IS the goal; no new param vocabulary |
+| 3 | Intake vocabulary breadth | All five practical lanes + `compose` + `redirect` |
+| 4 | `preferred_label` intake | Keep the artifact+token gate. It is the taught doctrine — evidence outside the worker — and it happens to also dodge F1 |
+| 5 | Lint strictness on generated children | Plain `lint` (ERRORs block, warnings do not) + the contract checker. Warnings are recorded in the run record |
+| 6 | #200 disposition | Keep the PR purely additive content. F2 is filed as a comment on #200, not patched here |
+| 7 | Redirect disposition | Green exit. The honest diagnosis is a successful deliverable; `.objective/disposition` is what lets an unattended caller tell the outcomes apart |

--- a/docs/designs/2026-08-15-objective-layer.md
+++ b/docs/designs/2026-08-15-objective-layer.md
@@ -102,8 +102,10 @@ contract block. The load-bearing ones:
 | `finalize` (tool) | Refuse a green exit without a disposition | code-tier | file test | `.objective/disposition` = satisfied\|redirected + the artifact it points to | exit 0 only if disposition artifact present |
 
 **Budget fuse arithmetic (shown, not implied).** Engine safety net: `max_steps = nodes × 50`
-(`engine.py:137` `_MAX_GOAL_GATE_RETRIES: int = 50`, `engine.py:611`) — for this ~16-node graph,
-800 steps; the exemplar's own fuses fire far earlier. Runner fuses: `triage_bad` loop ≤ 2
+(`engine.py:137` `_MAX_GOAL_GATE_RETRIES: int = 50`, `engine.py:611`) — for the graph as
+shipped (21 nodes, 50 edges), 1050 steps; the exemplar's own fuses fire far earlier.
+*(Corrected post-review: the design said "~16-node graph, 800 steps", which was the estimate
+at design time and never the shipped number.)* Runner fuses: `triage_bad` loop ≤ 2
 re-frames (`.objective/frame-iter`); compose-fix loop ≤ `$max_compose` (default 2 → at most 3
 lint/contract attempts); evidence loop ≤ `$max_iterations` (default 3) counted in
 `.objective/iter` by `evidence_gate` itself, `bug-fix.dot`-style, so *every* re-entry spends
@@ -645,6 +647,56 @@ a cross-reference there would have been decoration.
   through `tee /tmp/pytest-out.txt` — non-vacuous (it greps for a passing test whose
   name mentions the None-avatar case) but writing scratch outside the workspace.
   Worth a future tightening of the `frame` prompt; recorded rather than hidden.
+
+### 11.9 Post-review: the DoD rule was prose, and prose is a suggestion
+
+An adversarial review of this PR found the exemplar breaking its own first rule.
+§4.1 and `compose-contract.md` both required a `dod.sh` that is *red before the
+work exists* — but that requirement lived only in the composer's prompt. The
+review verified the consequence by execution: a composer writing `exit 0`
+satisfies C1–C8, its child converges on the first attempt, and `evidence_gate`
+re-runs the same vacuous script and agrees (`rc=0`, `delta=changed` →
+`evidence_ok` → `disposition=satisfied`). A false green with zero work product —
+the incident shape §5 was written to prevent, reproduced by the graph that
+prevents it.
+
+Fixed by making the rule a check:
+
+- **C9** — `check_child_contract.py` now *executes* `dod.sh` once, at admission,
+  bounded by `--dod-timeout` (default 120s), and requires exit **1**. Exit 0 is
+  "already green"; exit ≥2, a signal, or a timeout is a *broken script*, named
+  separately so a crash is never mistaken for convergence pressure.
+- **The sha-pin** — C9 proves the DoD was red at admission; it cannot prove the
+  script re-run later is the same one. The review verified that dodge too: a
+  child that rewrites `.objective/gen/dod.sh` (or a lane child that rewrites
+  `.objective/evidence-command`) after admission gets `evidence_ok` from one
+  unrelated file touch. So `contract_gate` and `triage_gate` now record
+  `sha256` of what they admitted, and `evidence_gate` re-hashes *before*
+  re-running — a mismatch prints `tampered`, exits 1, and leaves through
+  `postmortem → escalated`.
+
+  This is **anti-accident, not anti-adversary**, and the docs say so in those
+  words. `.objective/` is inside the workspace the child writes to, so a child
+  determined to defeat the pin can rewrite the script and the pin together.
+  Closing that structurally needs custody outside the workspace (the pin held
+  where the child cannot reach, or the DoD executed from a copy taken at
+  admission). Deliberately out of scope for an exemplar: an honestly-stated
+  boundary teaches more than a defence that only looks complete.
+- **`frame` had no `outcome=fail` route** — the one worker in the graph without
+  one, contradicting the C7 rule this same graph enforces on generated children.
+  Added; 49 → 50 edges.
+- **`sha256sum` is now a preflight precondition**, alongside `md5sum` and `find`,
+  so a host missing it refuses at `preflight` rather than failing every run at
+  the evidence gate.
+
+Two smaller things the review named, resolved in the file rather than silently:
+`lint_gate`'s entry-checked wall lets `compose` run a fourth, never-linted time
+before `compose_exhausted` — bounded, on a path already headed to postmortem, and
+now stated in the graph as a recorded trade rather than an accident; and
+`goal_gate=true` on `evidence_gate` cannot actually fail (Idiom A always exits 0,
+and a tool node's exit 0 is an explicit SUCCESS verdict), so it is kept as a
+*declaration* of which node owns the verdict, with the comment saying exactly
+that and pointing at `finalize` as the enforcement that really holds.
 
 ---
 

--- a/examples/objective/README.md
+++ b/examples/objective/README.md
@@ -1,0 +1,198 @@
+# The Objective Layer
+
+One layer up from an attractor. You do not pick a pipeline — you state an
+**objective**, and `objective-runner.dot` diagnoses it, routes it, converges on
+it against machine evidence, and tells you honestly when there is no machine
+evidence to be had.
+
+```
+objective  ->  composition  ->  attractors  ->  execution
+(this graph)   (compose path)   (the lanes)     (their own gates)
+```
+
+The basin: **the stated objective is satisfied with machine evidence, or it is
+honestly redirected.** Both are green exits, and they are told apart by a
+disposition artifact. A run that can do neither escalates loudly with a nonzero
+exit — never through the success door.
+
+---
+
+## Run it
+
+```bash
+OBJ="$PWD/examples/objective"          # capture the absolute path BEFORE cd
+cd /path/to/your/workspace
+attractor run "$OBJ/objective-runner.dot" \
+    --param goal="get_display_name() raises TypeError when a user has no avatar. Fix it and add a regression test." \
+    --param runner_dir="$OBJ" \
+    --param target_dir="$PWD" \
+    --cwd .
+```
+
+Process cwd must equal `--cwd` for box-node (agent) pipelines — see
+[`../../modules/pipeline-runner/KNOWN_ISSUES.md`](../../modules/pipeline-runner/KNOWN_ISSUES.md).
+
+| Param | Required | What it is |
+|---|---|---|
+| `goal` | yes | **The objective.** It travels as the canonical `goal` param, so every shipped lane consumes it natively — no adapter layer, no new vocabulary. |
+| `runner_dir` | yes | Absolute path to *this* directory. The gates run `validate_triage.py` and `check_child_contract.py` from here. |
+| `target_dir` | yes | Absolute path to the workspace. The generated child's `dot_file` must be absolute, because a relative `dot_file` resolves against the runner's own directory first. |
+| `max_iterations` | no (3) | Evidence-loop budget. |
+| `max_compose` | no (2) | Compose-fix budget — at most 3 lint/contract attempts. |
+| `max_frames` | no (2) | How many malformed triage records to tolerate. |
+
+**Add `--on-human-gate auto-approve`** for an unattended run. The `approve`
+hexagon sits *after* the machine evidence gate; the CLI default
+(`--on-human-gate fail`) deliberately refuses to guess on your behalf.
+
+**Environment.** Whatever your objective's definition of done needs must be on
+`PATH` for the tool nodes — `pytest`, your build, your linter. A missing tool
+shows up as a red gate, which is honest but slower to read than checking first.
+
+### Reading the result
+
+```bash
+cat .objective/disposition        # satisfied | redirected | escalated
+```
+
+| Disposition | Exit | What you got | Where to look |
+|---|---|---|---|
+| `satisfied` | 0 | The objective's definition of done passed **in the parent**, and the workspace actually changed | `.objective/evidence-*.log`, `.objective/convergence.jsonl` |
+| `redirected` | 0 | The honest no: this is not an attractor, and here is why and where it belongs | `.objective/redirect.md` |
+| `escalated` | **1** | Could not converge within budget; the value salvaged is the analysis | `.objective/postmortem/report.md`, `.objective/postmortem/escalation.md` |
+
+---
+
+## What it does, in order
+
+1. **`preflight`** (tool) — makes the run's preconditions true or refuses before
+   an LLM is ever paid, and records `.objective/anchor`: a digest of the
+   workspace *before* any work.
+2. **`frame`** (LLM) — diagnoses the objective with this repo's own
+   [three-question test](../../docs/PIPELINE_DESIGN_PRINCIPLES.md) and writes
+   `.objective/triage.json` + `.objective/objective.md`. It **proposes**; it
+   does not route.
+3. **`triage_gate`** (tool) — validates the record against
+   [`triage-schema.json`](triage-schema.json) and prints the routing token. This
+   is the node that decides.
+4. One of three paths:
+   - **select** — a shipped `examples/pipelines/practical/*.dot` runs as a
+     `folder` node, unmodified, carrying its own gates and budgets.
+   - **compose** — an LLM writes a purpose-built child `.dot` + `dod.sh`; two
+     gates outside its context check the result before it is allowed to run.
+   - **redirect** — the honest no, written up as `.objective/redirect.md`.
+5. **`evidence_gate`** (tool, the load-bearing one) — **re-runs the definition of
+   done itself**, in the parent, and asserts the workspace changed since the
+   anchor. On failure, `feedback` writes the descent signal and the run
+   re-enters through `triage_gate` — same shape, fresh context.
+6. **`approve`** (human) → **`finalize`** (tool) → `done`. `finalize` refuses to
+   open without a disposition artifact.
+
+---
+
+## The three ideas worth copying
+
+### 1. The first routing decision runs on a machine artifact, not a self-report
+
+The obvious design has `frame` call `report_outcome(preferred_label="bugfix")`
+and routes on that. This graph deliberately does not. `frame` writes a JSON
+record; `triage_gate` — code, outside the worker's context — validates it and
+prints the token.
+
+That is the same rule every gate in this repo obeys, applied to the one decision
+authors usually exempt: *verification inside the context that produced the
+evidence is not verification.* The schema's cross-field rules make it bite —
+`CF-1` rejects any non-redirect shape whose `evidence_command` is `NONE`, so
+"no attractor without machine evidence" is a check rather than a slogan.
+
+### 2. The parent never trusts the child's self-report
+
+A child pipeline's terminal outcome is used for **loud fail-routing only**.
+Whether the objective is *satisfied* is decided by `evidence_gate`, which re-runs
+the definition-of-done command itself.
+
+This is defense in depth on purpose. A child's green is necessary, never
+sufficient — in this repo's own history, a worker fabricated its convergence
+evidence and the gate reading that file passed it. The gates that caught it were
+outside the worker's context.
+
+The second half of that gate is the **delta assertion**: a green check on an
+unchanged workspace means nothing happened and the check was already passing.
+Both halves must hold, which is why `preflight` records an anchor first.
+
+### 3. The honest no is a deliverable, not a failure
+
+`redirect` exits **green** with `.objective/redirect.md` — the objective
+restated, the three-question answers quoted verbatim, the better home named
+(recipe / conversation / one-shot), and *what would make it an attractor*: the
+specific machine check that does not exist yet.
+
+An accurate "no, and here is why" is worth more than a run. The disposition
+artifact is what lets an unattended caller tell that outcome apart from
+"satisfied" without reading prose.
+
+---
+
+## Files here
+
+| File | Role |
+|---|---|
+| [`objective-runner.dot`](objective-runner.dot) | the graph — every node carries its objective / constraints / capabilities / required evidence / exit condition as a header comment |
+| [`triage-schema.json`](triage-schema.json) | the intake contract: routing vocabulary, required fields, and the cross-field rules |
+| [`validate_triage.py`](validate_triage.py) | `triage_gate`'s mechanism — stdlib only, no `jsonschema` dependency |
+| [`compose-contract.md`](compose-contract.md) | what every generated child must satisfy, written as the composer reads it |
+| [`check_child_contract.py`](check_child_contract.py) | `contract_gate`'s mechanism — the eight structural checks |
+
+---
+
+## Budgets and how a run ends
+
+| Fuse | Default | Counted by | Where it goes when spent |
+|---|---|---|---|
+| re-frame on a malformed triage record | `max_frames` = 2 | `validate_triage.py` (`.objective/frame-iter`) | `triage_exhausted` → postmortem |
+| compose rewrite after a blocked child | `max_compose` = 2 | `lint_gate` (`.objective/compose-iter`) | `compose_exhausted` → postmortem |
+| evidence iterations | `max_iterations` = 3 | `evidence_gate` (`.objective/iter`) | `exhausted` → postmortem |
+
+Every fuse is counted **inside a gate**, so green and red paths both spend
+budget, and a persistent provider outage drains the budget and escalates
+honestly instead of looping. The engine's own step cap (`nodes × 50` = 1050 here)
+is a backstop that should never be what stops a run — if it is, the graph has a
+bug.
+
+`postmortem` writes the analysis; `escalated` writes the handoff and then
+`exit 1` with `max_retries=0` and no fail-route, so the engine hard-fails loud.
+
+---
+
+## What this deliberately is NOT
+
+- **Not a service.** No daemon, no scheduler, no event loop, no resident
+  process. It is a `.dot` file you run.
+- **Not a portfolio orchestrator.** One objective per invocation. There is no
+  queue, no prioritization, no cross-run state.
+- **Not a Resolve / Team Pulse integration.** No dashboards, no telemetry beyond
+  the run logs the engine already writes.
+- **Not an uber-attractor.** It does not absorb the lanes into one adaptive
+  mega-node. It routes to *separate* children that keep their own gates —
+  because one adaptive node with a self-assessed exit is exactly the shape that
+  ships fabricated evidence.
+- **Not a replacement for picking a pipeline.** If you already know you want
+  `bug-fix.dot`, run `bug-fix.dot`. This layer earns its keep when you know the
+  objective and not the shape.
+- **Not learned or adaptive selection.** Routing is a declared, inspectable
+  gate over a schema-validated record. You can read why it chose what it chose.
+- **Not engine surface.** Everything here is author-level content: one `.dot`,
+  two stdlib scripts, and docs. No new attributes, shapes, or semantics.
+
+---
+
+## Related
+
+| Topic | Where |
+|---|---|
+| Designing a NEW pipeline from a conversation | [`/attractorify`](../../skills/attractorify/SKILL.md) — this runner *selects and composes* from what exists; attractorify *designs* what doesn't |
+| The convergence skeleton this borrows from | [`../patterns/task-runner.dot`](../patterns/task-runner.dot) |
+| The lanes | [`../pipelines/practical/`](../pipelines/practical/) |
+| Gate idioms and the stale-label rule | [`../gates/README.md`](../gates/README.md) |
+| Why gates live outside workers | [`../../docs/PIPELINE_DESIGN_PRINCIPLES.md`](../../docs/PIPELINE_DESIGN_PRINCIPLES.md) |
+| The design and its engine probes | [`../../docs/designs/2026-08-15-objective-layer.md`](../../docs/designs/2026-08-15-objective-layer.md) |

--- a/examples/objective/README.md
+++ b/examples/objective/README.md
@@ -80,6 +80,8 @@ cat .objective/disposition        # satisfied | redirected | escalated
      `folder` node, unmodified, carrying its own gates and budgets.
    - **compose** — an LLM writes a purpose-built child `.dot` + `dod.sh`; two
      gates outside its context check the result before it is allowed to run.
+     One of them (**C9**) *executes* the `dod.sh` and rejects it unless it is
+     genuinely red — a definition of done that cannot fail is not one.
    - **redirect** — the honest no, written up as `.objective/redirect.md`.
 5. **`evidence_gate`** (tool, the load-bearing one) — **re-runs the definition of
    done itself**, in the parent, and asserts the workspace changed since the
@@ -120,6 +122,24 @@ The second half of that gate is the **delta assertion**: a green check on an
 unchanged workspace means nothing happened and the check was already passing.
 Both halves must hold, which is why `preflight` records an anchor first.
 
+Two later additions close the ways a green could still be manufactured, both
+found by an adversarial review of this exemplar rather than in theory:
+
+- **C9** — `contract_gate` *runs* the generated `dod.sh` once, at admission,
+  and requires exit 1. "The DoD must be red before the work exists" used to be
+  a line in the composer's prompt, and a prompt instruction is a suggestion: a
+  composer writing `exit 0` satisfied every structural check, its child
+  converged instantly, and this gate re-ran the same vacuous script and agreed.
+- **The sha-pin** — `triage_gate` and `contract_gate` record `sha256` of what
+  they admitted (`.objective/evidence-command.sha256`, `.objective/dod.sha256`);
+  `evidence_gate` re-hashes *before* re-running and refuses loudly on a
+  mismatch, so a check rewritten after it was approved cannot be the check that
+  gets run. It is **anti-accident, not anti-adversary** — the workspace is
+  child-writable, so a determined child could update the pin too. Closing that
+  structurally needs custody outside the workspace, which is deliberately out
+  of scope for an exemplar; see
+  [`compose-contract.md`](compose-contract.md#the-pin-and-what-it-is-not).
+
 ### 3. The honest no is a deliverable, not a failure
 
 `redirect` exits **green** with `.objective/redirect.md` — the objective
@@ -141,7 +161,7 @@ artifact is what lets an unattended caller tell that outcome apart from
 | [`triage-schema.json`](triage-schema.json) | the intake contract: routing vocabulary, required fields, and the cross-field rules |
 | [`validate_triage.py`](validate_triage.py) | `triage_gate`'s mechanism — stdlib only, no `jsonschema` dependency |
 | [`compose-contract.md`](compose-contract.md) | what every generated child must satisfy, written as the composer reads it |
-| [`check_child_contract.py`](check_child_contract.py) | `contract_gate`'s mechanism — the eight structural checks |
+| [`check_child_contract.py`](check_child_contract.py) | `contract_gate`'s mechanism — eight structural checks plus **C9**, which *runs* the generated `dod.sh` at admission and rejects it unless it is red |
 
 ---
 

--- a/examples/objective/check_child_contract.py
+++ b/examples/objective/check_child_contract.py
@@ -1,0 +1,600 @@
+#!/usr/bin/env python3
+"""Structural gate on a GENERATED child pipeline (the composed-child contract).
+
+``objective-runner.dot``'s compose path lets an LLM node WRITE a purpose-built
+child ``.dot`` and its definition-of-done script, then executes it. That is only
+safe if the generated graph is checked by something outside the composer's
+context before it is allowed to run. Two gates do that, in order:
+
+1. ``attractor lint`` -- executability and the topology bug classes the engine
+   itself knows about (dead conditional edges, stale-label collisions,
+   fail-routed-to-exit, pipe-masked gate exit codes). ERRORs block.
+2. this script -- the *design* checks lint deliberately does not own: does the
+   generated graph actually have the shape of an attractor, and is its gate
+   really outside its workers?
+
+See ``compose-contract.md`` for the contract in the composer's own words, and
+``docs/PIPELINE_DESIGN_PRINCIPLES.md`` section 0 for why the gate must live
+outside the context that produced the artifact.
+
+Token contract (Idiom A -- always exit 0 so ``tool.last_line`` is always fresh):
+
+  contract_ok    every check passed; the child may run
+  contract_bad   at least one check failed; route back to the composer
+
+A nonzero exit means this script could not run at all (unreadable child file,
+unwritable report). That routes through ``outcome=fail`` to the postmortem path
+-- deliberately distinct from ``contract_bad``, which is a judgement about the
+generated graph.
+
+DOT parsing is deliberately stdlib-only and self-contained: this gate must run
+under whatever ``python3`` is on PATH in the target workspace, which is not the
+``attractor`` CLI's own virtualenv. It is a *second* opinion, and it runs only
+after the engine's own parser has already accepted the file via ``attractor
+lint`` -- so a disagreement fails closed (``contract_bad``) rather than silently
+admitting a graph neither tool understood.
+
+Usage:
+    check_child_contract.py --child .objective/gen/child.dot \\
+                            --dod .objective/gen/dod.sh \\
+                            --report .objective/contract-report.txt
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# A small DOT reader -- only what the structural checks need
+# ---------------------------------------------------------------------------
+
+_TOKEN_RE = re.compile(
+    r"""
+    (?P<string>"(?:[^"\\]|\\.)*")        # quoted string (backslash escapes)
+  | (?P<arrow>->|--)                      # edge operators
+  | (?P<punct>[\[\]{};,=])                # structural punctuation
+  | (?P<ident>[A-Za-z_\u0080-\uffff][A-Za-z_0-9.\u0080-\uffff]*|-?\.?[0-9][0-9.]*)
+    """,
+    re.VERBOSE,
+)
+
+_KEYWORDS = {"digraph", "graph", "strict", "subgraph", "node", "edge"}
+
+
+def _strip_comments(text: str) -> str:
+    """Remove //, #, and /* */ comments without touching quoted strings."""
+    out: list[str] = []
+    i = 0
+    n = len(text)
+    while i < n:
+        ch = text[i]
+        if ch == '"':
+            out.append(ch)
+            i += 1
+            while i < n:
+                out.append(text[i])
+                if text[i] == "\\" and i + 1 < n:
+                    out.append(text[i + 1])
+                    i += 2
+                    continue
+                if text[i] == '"':
+                    i += 1
+                    break
+                i += 1
+            continue
+        if text.startswith("//", i):
+            while i < n and text[i] != "\n":
+                i += 1
+            continue
+        if text.startswith("/*", i):
+            end = text.find("*/", i + 2)
+            i = n if end == -1 else end + 2
+            continue
+        if ch == "#" and (not out or out[-1] == "\n"):
+            while i < n and text[i] != "\n":
+                i += 1
+            continue
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+
+def _unquote(token: str) -> str:
+    if len(token) >= 2 and token[0] == '"' and token[-1] == '"':
+        body = token[1:-1]
+        return re.sub(r"\\(.)", lambda m: "\n" if m.group(1) == "n" else m.group(1), body)
+    return token
+
+
+def _tokenize(text: str) -> list[str]:
+    tokens: list[str] = []
+    for match in _TOKEN_RE.finditer(_strip_comments(text)):
+        tokens.append(match.group(0))
+    return tokens
+
+
+@dataclass
+class DotNode:
+    node_id: str
+    attrs: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class DotEdge:
+    src: str
+    dst: str
+    attrs: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class DotGraph:
+    nodes: dict[str, DotNode] = field(default_factory=dict)
+    edges: list[DotEdge] = field(default_factory=list)
+    graph_attrs: dict[str, str] = field(default_factory=dict)
+    node_defaults: dict[str, str] = field(default_factory=dict)
+
+    def node(self, node_id: str) -> DotNode:
+        node = self.nodes.get(node_id)
+        if node is None:
+            node = DotNode(node_id)
+            self.nodes[node_id] = node
+        return node
+
+    def attr(self, node_id: str, key: str, default: str = "") -> str:
+        node = self.nodes.get(node_id)
+        if node is not None and key in node.attrs:
+            return node.attrs[key]
+        return self.node_defaults.get(key, default)
+
+    def outgoing(self, node_id: str) -> list[DotEdge]:
+        return [e for e in self.edges if e.src == node_id]
+
+
+class DotParseError(Exception):
+    """The child .dot could not be read as a graph."""
+
+
+def parse_dot_min(text: str) -> DotGraph:
+    """Parse the subset of DOT the shipped pipelines actually use."""
+    tokens = _tokenize(text)
+    if not tokens or tokens[0] not in ("strict", "digraph", "graph"):
+        raise DotParseError(
+            "does not start with a graph header (strict/digraph/graph) -- "
+            "this is not a DOT graph"
+        )
+    graph = DotGraph()
+    i = 0
+    total = len(tokens)
+
+    def read_attr_list(idx: int) -> tuple[dict[str, str], int]:
+        attrs: dict[str, str] = {}
+        assert tokens[idx] == "["
+        idx += 1
+        while idx < total and tokens[idx] != "]":
+            if tokens[idx] in (",", ";"):
+                idx += 1
+                continue
+            key = _unquote(tokens[idx])
+            idx += 1
+            if idx < total and tokens[idx] == "=":
+                idx += 1
+                if idx >= total:
+                    raise DotParseError("attribute list ended after '='")
+                attrs[key] = _unquote(tokens[idx])
+                idx += 1
+            else:
+                attrs[key] = "true"
+        if idx >= total:
+            raise DotParseError("unterminated attribute list")
+        return attrs, idx + 1
+
+    while i < total:
+        tok = tokens[i]
+
+        if tok in ("{", "}", ";", ","):
+            i += 1
+            continue
+
+        # `graph|node|edge [ ... ]` -- attribute defaults. Checked BEFORE the
+        # header-keyword branch, because `graph` is both a keyword and the name
+        # of the graph-attribute statement.
+        if tok in ("graph", "node", "edge") and i + 1 < total and tokens[i + 1] == "[":
+            defaults, i = read_attr_list(i + 1)
+            if tok == "node":
+                graph.node_defaults.update(defaults)
+            elif tok == "graph":
+                graph.graph_attrs.update(defaults)
+            continue
+
+        if tok in ("digraph", "graph", "strict", "subgraph"):
+            # Skip the header keyword and any graph name; the body is flat for
+            # our purposes (cluster subgraphs are flattened by the engine too).
+            i += 1
+            while i < total and tokens[i] not in ("{", ";"):
+                i += 1
+            continue
+
+        # A bare `key = value` at statement level is a graph attribute.
+        if i + 2 < total and tokens[i + 1] == "=" and tok not in _KEYWORDS:
+            graph.graph_attrs[_unquote(tok)] = _unquote(tokens[i + 2])
+            i += 3
+            continue
+
+        # Node statement or edge chain.
+        chain = [_unquote(tok)]
+        i += 1
+        while i < total and tokens[i] in ("->", "--"):
+            i += 1
+            if i >= total:
+                raise DotParseError("edge chain ended after '->'")
+            chain.append(_unquote(tokens[i]))
+            i += 1
+
+        stmt_attrs: dict[str, str] = {}
+        if i < total and tokens[i] == "[":
+            stmt_attrs, i = read_attr_list(i)
+
+        if len(chain) == 1:
+            graph.node(chain[0]).attrs.update(stmt_attrs)
+        else:
+            for src, dst in zip(chain, chain[1:], strict=False):
+                graph.node(src)
+                graph.node(dst)
+                graph.edges.append(DotEdge(src, dst, dict(stmt_attrs)))
+
+    if not graph.nodes:
+        raise DotParseError("no nodes found")
+    return graph
+
+
+# ---------------------------------------------------------------------------
+# Shape helpers -- mirror the engine's own resolution order
+# ---------------------------------------------------------------------------
+
+
+def _is_exit(graph: DotGraph, node_id: str) -> bool:
+    return (
+        graph.attr(node_id, "shape") == "Msquare"
+        or graph.attr(node_id, "type") == "exit"
+        or node_id.lower() in ("exit", "end")
+    )
+
+
+def _is_start(graph: DotGraph, node_id: str) -> bool:
+    return (
+        graph.attr(node_id, "shape") == "Mdiamond"
+        or graph.attr(node_id, "type") == "start"
+        or node_id.lower() == "start"
+    )
+
+
+def _is_tool(graph: DotGraph, node_id: str) -> bool:
+    return graph.attr(node_id, "shape") == "parallelogram" or bool(
+        graph.attr(node_id, "tool_command")
+    )
+
+
+def _is_worker(graph: DotGraph, node_id: str) -> bool:
+    """A codergen (LLM) node: shape=box, or no shape at all (box is the default)."""
+    if _is_start(graph, node_id) or _is_exit(graph, node_id):
+        return False
+    if graph.attr(node_id, "type"):
+        return False
+    return graph.attr(node_id, "shape") in ("", "box")
+
+
+def _is_truthy(value: str) -> bool:
+    return value.strip().strip('"').lower() in ("true", "1", "yes", "on")
+
+
+def _has_cycle(graph: DotGraph) -> bool:
+    adjacency: dict[str, list[str]] = {n: [] for n in graph.nodes}
+    for edge in graph.edges:
+        adjacency.setdefault(edge.src, []).append(edge.dst)
+    state: dict[str, int] = {}
+
+    def visit(node_id: str) -> bool:
+        state[node_id] = 1
+        for nxt in adjacency.get(node_id, []):
+            mark = state.get(nxt, 0)
+            if mark == 1:
+                return True
+            if mark == 0 and visit(nxt):
+                return True
+        state[node_id] = 2
+        return False
+
+    sys.setrecursionlimit(10000)
+    return any(state.get(n, 0) == 0 and visit(n) for n in graph.nodes)
+
+
+def _reachable_from_start(graph: DotGraph) -> set[str]:
+    starts = [n for n in graph.nodes if _is_start(graph, n)]
+    seen: set[str] = set()
+    stack = list(starts)
+    while stack:
+        node_id = stack.pop()
+        if node_id in seen:
+            continue
+        seen.add(node_id)
+        stack.extend(e.dst for e in graph.outgoing(node_id))
+    return seen
+
+
+_FAIL_COND_RE = re.compile(r"outcome\s*=\s*fail\b")
+
+
+def _has_fail_route(graph: DotGraph, node_id: str) -> bool:
+    if graph.attr(node_id, "retry_target") or graph.graph_attrs.get("retry_target"):
+        return True
+    for edge in graph.outgoing(node_id):
+        if _FAIL_COND_RE.search(edge.attrs.get("condition", "")):
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# The contract checks
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CheckResult:
+    check_id: str
+    title: str
+    passed: bool
+    detail: str
+
+
+def run_checks(graph: DotGraph, dod_path: str) -> list[CheckResult]:
+    results: list[CheckResult] = []
+    dod_basename = os.path.basename(dod_path)
+    reachable = _reachable_from_start(graph)
+
+    # --- C1: exactly one exit node (also an engine admission rule) ------------
+    exits = sorted(n for n in graph.nodes if _is_exit(graph, n))
+    results.append(
+        CheckResult(
+            "C1",
+            "exactly one exit node",
+            len(exits) == 1,
+            f"exit nodes found: {exits or 'none'}"
+            + ("" if len(exits) == 1 else " -- the engine refuses to run a graph without exactly one"),
+        )
+    )
+
+    # --- C2: an evidence gate OUTSIDE the workers, running the provided DoD ---
+    gate_nodes = [
+        n
+        for n in graph.nodes
+        if _is_tool(graph, n) and dod_basename and dod_basename in graph.attr(n, "tool_command")
+    ]
+    results.append(
+        CheckResult(
+            "C2",
+            f"a tool node runs the provided definition of done ({dod_basename})",
+            bool(gate_nodes),
+            f"tool nodes invoking {dod_basename}: {sorted(gate_nodes) or 'none'}"
+            + (
+                ""
+                if gate_nodes
+                else " -- the child's exit must be gated on the DoD the parent will re-run, "
+                "not on an LLM's opinion of its own work"
+            ),
+        )
+    )
+
+    # --- C3: no goal gate colocated inside a worker ---------------------------
+    colocated = sorted(
+        n for n in graph.nodes if _is_worker(graph, n) and _is_truthy(graph.attr(n, "goal_gate"))
+    )
+    results.append(
+        CheckResult(
+            "C3",
+            "no goal_gate on an LLM worker node",
+            not colocated,
+            f"workers carrying goal_gate=true: {colocated or 'none'}"
+            + (
+                ""
+                if not colocated
+                else " -- verification inside the context that produced the evidence "
+                "is not verification"
+            ),
+        )
+    )
+
+    # --- C4: at least one corrective cycle ------------------------------------
+    has_cycle = _has_cycle(graph)
+    results.append(
+        CheckResult(
+            "C4",
+            "at least one corrective cycle",
+            has_cycle,
+            "cycle present" if has_cycle else "graph is acyclic -- this should have been a recipe",
+        )
+    )
+
+    # --- C5: a budget wall inside the gate, with an exhaustion route ----------
+    budget_nodes: list[str] = []
+    for node_id in graph.nodes:
+        if not _is_tool(graph, node_id):
+            continue
+        command = graph.attr(node_id, "tool_command")
+        if "max_iterations" not in command and "budget" not in command:
+            continue
+        if any(
+            "exhausted" in edge.attrs.get("condition", "") for edge in graph.outgoing(node_id)
+        ):
+            budget_nodes.append(node_id)
+    results.append(
+        CheckResult(
+            "C5",
+            "a tool node walls an iteration budget and routes exhaustion",
+            bool(budget_nodes),
+            f"budget-walling gates: {sorted(budget_nodes) or 'none'}"
+            + (
+                ""
+                if budget_nodes
+                else " -- a corrective loop with no wall spends until the engine step cap "
+                "kills it with a bare FAIL"
+            ),
+        )
+    )
+
+    # --- C6: a fail-loud escalation terminal ----------------------------------
+    escalators = sorted(
+        n
+        for n in graph.nodes
+        if _is_tool(graph, n)
+        and re.search(r"\bexit\s+[1-9]", graph.attr(n, "tool_command"))
+        and n in reachable
+    )
+    results.append(
+        CheckResult(
+            "C6",
+            "a reachable node fails the run loudly when it cannot converge",
+            bool(escalators),
+            f"fail-loud terminals: {escalators or 'none'}"
+            + (
+                ""
+                if escalators
+                else " -- a non-converging run must exit nonzero, not leave through the "
+                "success door"
+            ),
+        )
+    )
+
+    # --- C7: every worker has a real failure route ---------------------------
+    unrouted = sorted(
+        n
+        for n in graph.nodes
+        if _is_worker(graph, n) and n in reachable and not _has_fail_route(graph, n)
+    )
+    results.append(
+        CheckResult(
+            "C7",
+            "every LLM worker has an outcome=fail route or a retry_target",
+            not unrouted,
+            f"workers with no failure route: {unrouted or 'none'}"
+            + (
+                ""
+                if not unrouted
+                else " -- a FAIL does not traverse plain edges; an unrouted worker failure "
+                "runs the pipeline off the rim"
+            ),
+        )
+    )
+
+    # --- C8: the child actually consumes the objective ------------------------
+    haystack = " ".join(
+        [
+            " ".join(graph.graph_attrs.values()),
+            *(
+                " ".join(node.attrs.values())
+                for node in graph.nodes.values()
+            ),
+        ]
+    )
+    consumes_goal = "$goal" in haystack or "${goal}" in haystack or "${graph.goal}" in haystack
+    results.append(
+        CheckResult(
+            "C8",
+            "the child consumes the objective ($goal / ${graph.goal})",
+            consumes_goal,
+            "objective referenced"
+            if consumes_goal
+            else "no $goal / ${graph.goal} reference -- the child would work on nothing in particular",
+        )
+    )
+
+    return results
+
+
+def render_report(child: str, dod: str, results: list[CheckResult], verdict: str) -> str:
+    lines = [
+        "COMPOSED-CHILD CONTRACT REPORT",
+        f"child:   {child}",
+        f"dod:     {dod}",
+        f"verdict: {verdict}",
+        "",
+    ]
+    for result in results:
+        lines.append(f"[{'PASS' if result.passed else 'FAIL'}] {result.check_id} {result.title}")
+        lines.append(f"       {result.detail}")
+    failed = [r for r in results if not r.passed]
+    if failed:
+        lines += [
+            "",
+            "Fix every FAIL above and rewrite the child graph. See compose-contract.md.",
+        ]
+    return "\n".join(lines) + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Structural gate on a generated child pipeline.")
+    parser.add_argument("--child", required=True, help="path to the generated child .dot")
+    parser.add_argument("--dod", required=True, help="path to the generated definition-of-done script")
+    parser.add_argument(
+        "--report",
+        default=".objective/contract-report.txt",
+        help="where to write the human-readable report",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    report_path = Path(args.report)
+    try:
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:  # pragma: no cover - environment failure
+        print(f"check_child_contract: cannot create report dir: {exc}", file=sys.stderr)
+        return 2
+
+    child_path = Path(args.child)
+    dod_path = Path(args.dod)
+
+    problems: list[CheckResult] = []
+    graph: DotGraph | None = None
+    try:
+        graph = parse_dot_min(child_path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        problems.append(CheckResult("C0", "child graph exists", False, f"{child_path}: not found"))
+    except OSError as exc:
+        problems.append(CheckResult("C0", "child graph readable", False, f"{child_path}: {exc}"))
+    except DotParseError as exc:
+        problems.append(
+            CheckResult("C0", "child graph parses", False, f"{child_path}: {exc}")
+        )
+
+    if not dod_path.is_file():
+        problems.append(
+            CheckResult(
+                "C0b",
+                "definition-of-done script exists",
+                False,
+                f"{dod_path}: not found -- the parent evidence gate re-runs this file",
+            )
+        )
+    elif dod_path.stat().st_size == 0:
+        problems.append(
+            CheckResult("C0b", "definition-of-done script is non-empty", False, f"{dod_path}: empty")
+        )
+
+    results = list(problems)
+    if graph is not None:
+        results.extend(run_checks(graph, str(dod_path)))
+
+    verdict = "contract_ok" if all(r.passed for r in results) and results else "contract_bad"
+    report_path.write_text(render_report(args.child, args.dod, results, verdict), encoding="utf-8")
+    print(verdict, end="")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - thin CLI wrapper
+    raise SystemExit(main())

--- a/examples/objective/check_child_contract.py
+++ b/examples/objective/check_child_contract.py
@@ -10,8 +10,24 @@ context before it is allowed to run. Two gates do that, in order:
    itself knows about (dead conditional edges, stale-label collisions,
    fail-routed-to-exit, pipe-masked gate exit codes). ERRORs block.
 2. this script -- the *design* checks lint deliberately does not own: does the
-   generated graph actually have the shape of an attractor, and is its gate
-   really outside its workers?
+   generated graph actually have the shape of an attractor, is its gate really
+   outside its workers, and (C9) does the definition of done actually FAIL
+   before the work exists?
+
+C9 is the one check that is not structural. It EXECUTES ``dod.sh`` once, here,
+at admission time. Everything else about a vacuous ``exit 0`` definition of done
+looks perfect: the graph is shaped correctly, the gate runs the script, the
+child converges on the first attempt, and the parent's evidence gate re-runs the
+same script and agrees. Only running it *before the work exists* distinguishes
+"this check can go green" from "this check was always green". The rule used to
+live in the composer's prompt; as a prompt instruction it was a suggestion.
+
+On admission this script also PINS the bytes it approved (``--pin``, default
+``.objective/dod.sha256``). The parent's evidence gate re-hashes ``dod.sh``
+against that pin before re-running it, so a child that rewrites the definition
+of done *after* admission is caught rather than believed. See
+``compose-contract.md`` -- "The pin, and what it is not" -- for the honest
+boundary: the pin is anti-accident, not anti-adversary.
 
 See ``compose-contract.md`` for the contract in the composer's own words, and
 ``docs/PIPELINE_DESIGN_PRINCIPLES.md`` section 0 for why the gate must live
@@ -43,11 +59,19 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import hashlib
 import os
 import re
+import subprocess
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
+
+#: How long C9's admission-time DoD probe may run. The contract tells the
+#: composer to keep ``dod.sh`` fast -- it is executed at least three times per
+#: iteration (here at admission, by the child's own gate, and again by the
+#: parent's evidence gate).
+DOD_PROBE_TIMEOUT_S = 120
 
 # ---------------------------------------------------------------------------
 # A small DOT reader -- only what the structural checks need
@@ -515,6 +539,90 @@ def run_checks(graph: DotGraph, dod_path: str) -> list[CheckResult]:
     return results
 
 
+def check_dod_is_red(dod_path: Path, timeout_s: int = DOD_PROBE_TIMEOUT_S) -> CheckResult:
+    """C9 -- EXECUTE the definition of done once, here, before the child runs.
+
+    The contract has always told the composer that ``dod.sh`` must be red before
+    the work exists. As a prompt instruction that is a *suggestion*: a composer
+    that writes ``exit 0`` satisfies every structural check, its child converges
+    instantly, and the parent's evidence gate then re-runs the same vacuous
+    script and agrees. ``rc=0 && delta=changed`` is a false green -- the exact
+    shape of the incident this whole exemplar exists to prevent.
+
+    So the gate runs it, once, at admission time -- outside the composer's
+    context, before any work exists -- and reads the exit status:
+
+      rc == 1        PASS. The check is genuinely red, so it can go green later.
+      rc == 0        FAIL. Already satisfied before the work exists; whatever it
+                     asserts, it is not this objective.
+      rc >= 2, <0    FAIL, named separately: a script that cannot run (syntax
+                     error, missing interpreter, missing tool) is BROKEN, not
+                     red. Conflating the two would teach the composer to ship a
+                     crash as a definition of done.
+      timeout        FAIL, named separately: the DoD is re-run at least three
+                     times per iteration, so one that never finishes is unusable.
+
+    This is a probe of a script the composer wrote and the child is about to run
+    anyway; running it one extra time here buys the only trustworthy answer to
+    "can this check ever fail?"
+    """
+    title = "the definition of done is red before the work exists"
+    try:
+        # Executing the DoD is the entire point of C9: it is the only way to
+        # distinguish "this check can go red" from "this check is a constant".
+        completed = subprocess.run(
+            ["bash", str(dod_path)],
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return CheckResult(
+            "C9",
+            title,
+            False,
+            f"{dod_path}: did not finish within {timeout_s}s -- a definition of done is "
+            "re-run by the child's gate and again by the parent; it must terminate",
+        )
+    except OSError as exc:
+        return CheckResult(
+            "C9", title, False, f"{dod_path}: could not be executed: {exc}"
+        )
+
+    rc = completed.returncode
+    tail = (completed.stdout + completed.stderr).strip().splitlines()
+    excerpt = f" | last output: {tail[-1][:160]}" if tail else ""
+
+    if rc == 0:
+        return CheckResult(
+            "C9",
+            title,
+            False,
+            f"{dod_path}: exited 0 BEFORE any work was done -- this check is already "
+            "green, so it proves nothing and can never fail. Assert something that is "
+            "false right now and becomes true only when the objective is satisfied"
+            + excerpt,
+        )
+    if rc == 1:
+        return CheckResult(
+            "C9", title, True, f"{dod_path}: exited 1 before the work exists -- red, as required"
+        )
+    return CheckResult(
+        "C9",
+        title,
+        False,
+        f"{dod_path}: exited {rc} -- that is a BROKEN script, not a red check. A "
+        "definition of done signals 'not satisfied' with exit 1; 2 or more (or a "
+        "signal) means it could not run at all" + excerpt,
+    )
+
+
+def sha256_file(path: Path) -> str:
+    """Hex digest of a file's bytes -- the same number ``sha256sum`` prints."""
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
 def render_report(child: str, dod: str, results: list[CheckResult], verdict: str) -> str:
     lines = [
         "COMPOSED-CHILD CONTRACT REPORT",
@@ -543,6 +651,22 @@ def build_parser() -> argparse.ArgumentParser:
         "--report",
         default=".objective/contract-report.txt",
         help="where to write the human-readable report",
+    )
+    parser.add_argument(
+        "--pin",
+        default=".objective/dod.sha256",
+        help=(
+            "where to record the sha256 of the ADMITTED dod.sh (default: "
+            ".objective/dod.sha256). The parent's evidence gate re-hashes the "
+            "file against this pin before re-running it, so a child that "
+            "rewrites the definition of done after admission is caught."
+        ),
+    )
+    parser.add_argument(
+        "--dod-timeout",
+        type=int,
+        default=DOD_PROBE_TIMEOUT_S,
+        help=f"seconds C9's admission-time DoD probe may run (default: {DOD_PROBE_TIMEOUT_S})",
     )
     return parser
 
@@ -590,7 +714,31 @@ def main(argv: list[str] | None = None) -> int:
     if graph is not None:
         results.extend(run_checks(graph, str(dod_path)))
 
+    # C9 runs LAST and only when there is a non-empty script to run: a missing or
+    # empty dod.sh is already C0b's judgement, and executing nothing would say
+    # nothing. It is a *behavioural* check, so it deliberately does not depend on
+    # the child graph parsing -- a vacuous DoD is disqualifying on its own.
+    dod_runnable = not any(r.check_id == "C0b" for r in problems)
+    if dod_runnable:
+        results.append(check_dod_is_red(dod_path, args.dod_timeout))
+
     verdict = "contract_ok" if all(r.passed for r in results) and results else "contract_bad"
+
+    # The sha-pin: record the bytes we just admitted, so `evidence_gate` can tell
+    # "the DoD I approved" from "a DoD rewritten after I approved it". Written
+    # ONLY on admission; a rejected child leaves no pin behind to be matched
+    # against later. See compose-contract.md, "The pin, and what it is not".
+    pin_path = Path(args.pin)
+    try:
+        if verdict == "contract_ok" and dod_path.is_file():
+            pin_path.parent.mkdir(parents=True, exist_ok=True)
+            pin_path.write_text(sha256_file(dod_path) + "\n", encoding="utf-8")
+        else:
+            pin_path.unlink(missing_ok=True)
+    except OSError as exc:  # pragma: no cover - environment failure
+        print(f"check_child_contract: cannot write pin {pin_path}: {exc}", file=sys.stderr)
+        return 2
+
     report_path.write_text(render_report(args.child, args.dod, results, verdict), encoding="utf-8")
     print(verdict, end="")
     return 0

--- a/examples/objective/compose-contract.md
+++ b/examples/objective/compose-contract.md
@@ -10,7 +10,7 @@ Two gates outside your context check your output before it is allowed to run:
 | Gate | What it is | What it owns |
 |---|---|---|
 | `lint_gate` | `attractor lint` — the engine's own linter | executability: parse errors, dead conditional edges (TOPO-001), stale-label collisions (TOPO-002), failure routed into the success exit (TOPO-006), pipe-masked gate exit codes (CMD-001/002). **ERRORs block.** Warnings are recorded, not fatal. |
-| `contract_gate` | `check_child_contract.py` | design shape: the eight checks below. Any FAIL sends you back here with the report. |
+| `contract_gate` | `check_child_contract.py` | design shape: the nine checks below — and C9 *executes* your `dod.sh` once, before your child ever runs. Any FAIL sends you back here with the report. |
 
 Neither gate can be argued with, and neither one is you. That is deliberate: in a
 live run of this repo's own pipelines, a worker fabricated its own convergence
@@ -30,10 +30,14 @@ before every rewrite — they name exactly what failed.
 A shell script, run from the workspace root, that **exits 0 if and only if the
 objective is satisfied**.
 
-- It must be able to *fail*. Run it before you write any of the work: it should
-  be **red right now**. A DoD that is already green proves nothing, and the
-  parent's evidence gate will notice — it also asserts that the workspace
-  actually changed, so a no-op cannot pass on a stale green.
+- It must be able to *fail*, and it must be **red right now**, before any of the
+  work exists. Say so with **exit code 1** — not 0 (already satisfied), and not
+  2 or more (a script that crashed is broken, not red). This is **C9**, and it is
+  not advice: `contract_gate` runs your `dod.sh` once at admission and returns
+  `contract_bad` unless it exits 1. Run it yourself first and check `$?`.
+- On admission the gate records **`sha256(dod.sh)`** in `.objective/dod.sha256`.
+  The parent re-hashes before it re-runs the file, so the DoD that gets re-run is
+  the one that was admitted. See *The pin, and what it is not*, below.
 - No `echo pass`. No "an LLM said it looked right". Assert something: a test
   runs, a file exists with required content, a schema validates, a command
   exits 0.
@@ -56,7 +60,7 @@ invent new machinery:
 
 ---
 
-## The eight checks (`check_child_contract.py`)
+## The nine checks (`check_child_contract.py`)
 
 | # | Check | Why it exists |
 |---|---|---|
@@ -68,6 +72,36 @@ invent new machinery:
 | C6 | **A reachable node exits nonzero when it cannot converge** | A non-converging run must be a LOUD red, not a quiet green. Use the `bug-fix.dot` idiom: `max_retries=0`, `printf escalated; exit 1`, no fail-route out of it. |
 | C7 | **Every `box` node has an `outcome=fail` route or a `retry_target`** | A FAIL does not traverse plain edges. An unrouted worker failure runs the pipeline off the rim. |
 | C8 | **The child consumes `$goal`** | The objective is cloned into your child's context as `goal`. If nothing reads it, your pipeline is working on nothing in particular. |
+| C9 | **`dod.sh` exits 1 when run right now** | The only check that *executes* anything. Everything else about a vacuous `exit 0` definition of done looks perfect: the shape passes, the child converges on its first attempt, and the parent re-runs the same vacuous script and agrees. Running it *before the work exists* is the only way to tell "this check can go green" from "this check was always green". |
+
+---
+
+## The pin, and what it is not
+
+C9 proves your `dod.sh` was red **at admission**. It cannot, by itself, prove the
+script the parent re-runs later is the same one. So on admission `contract_gate`
+records `sha256(dod.sh)` in `.objective/dod.sha256`, and `triage_gate` does the
+same for `.objective/evidence-command`. Before the parent's `evidence_gate`
+re-runs anything, it re-hashes both. A mismatch is not a red check and not a
+retry — the gate prints `tampered`, exits nonzero, and the run leaves through
+`postmortem → escalated` with the altered path named on stderr.
+
+That closes a real accident class. Without it, a child could pass every gate
+honestly and then, mid-run, overwrite `.objective/gen/dod.sh` with `exit 0`;
+one file touch anywhere gives `delta=changed`, and `rc=0 && delta=changed` is
+`evidence_ok`. The pin turns "the check I approved" and "the check I ran" into
+the same question.
+
+**Be clear about what this is.** The pin is **anti-accident, not
+anti-adversary.** `.objective/` lives in the workspace the child writes to, so a
+child determined to defeat the pin can rewrite `dod.sh` *and* `dod.sha256`
+together. Closing that structurally means custody outside the workspace — the
+pin held somewhere the child cannot reach, or the DoD executed from a copy taken
+at admission. That is deliberately out of scope here: this is an exemplar, and
+the honest statement of a boundary teaches more than a defence that only looks
+complete. What the pin does buy is that **drift, overwrite, and cleanup scripts
+now fail loudly instead of passing quietly** — and a child would have to take a
+second, deliberate step to get past it.
 
 ---
 
@@ -126,10 +160,15 @@ digraph ComposedChild {
 ## Things that will get you sent back
 
 - **A DoD that cannot fail.** `printf pass`, `true`, `test -d .` — or any check
-  that was already green before the work existed.
-- **Weakening `dod.sh` to get past a gate.** The parent re-runs it in its own
-  context afterwards. A hollow DoD buys a louder failure later, not an easier
-  one.
+  that was already green before the work existed. C9 runs it and reads `$?`.
+- **A DoD that crashes.** Exit 2, 127, or a signal is a *broken script*, not a
+  red check. C9 names that case separately, because a crash that happens to be
+  nonzero would otherwise look like healthy convergence pressure.
+- **Weakening `dod.sh` to get past a gate.** This does **not** buy a louder
+  failure later — it is refused at admission. C9 executes the script before your
+  child runs; a hollow DoD never gets to run at all. And rewriting it *after*
+  admission does not work either: the pin no longer matches, and the parent's
+  evidence gate hard-fails the run instead of re-running it.
 - **Putting the gate inside the worker** (`goal_gate=true` on a `box`, or a
   worker that writes its own "converged" file for a gate to read).
 - **A straight line.** `plan -> implement -> test` with no back-edge is a recipe

--- a/examples/objective/compose-contract.md
+++ b/examples/objective/compose-contract.md
@@ -1,0 +1,140 @@
+# The composed-child contract
+
+You are the `compose` node of `objective-runner.dot`. No shipped lane fits this
+objective, but the objective *is* machine-checkable — so you are going to write a
+purpose-built child pipeline for it, and then the runner is going to execute what
+you wrote.
+
+Two gates outside your context check your output before it is allowed to run:
+
+| Gate | What it is | What it owns |
+|---|---|---|
+| `lint_gate` | `attractor lint` — the engine's own linter | executability: parse errors, dead conditional edges (TOPO-001), stale-label collisions (TOPO-002), failure routed into the success exit (TOPO-006), pipe-masked gate exit codes (CMD-001/002). **ERRORs block.** Warnings are recorded, not fatal. |
+| `contract_gate` | `check_child_contract.py` | design shape: the eight checks below. Any FAIL sends you back here with the report. |
+
+Neither gate can be argued with, and neither one is you. That is deliberate: in a
+live run of this repo's own pipelines, a worker fabricated its own convergence
+evidence and the gate reading that file passed it. The gates that caught it were
+the ones outside the worker's context. Write for those gates.
+
+You get `max_compose` rewrites (default 2, so 3 attempts total) before the run
+escalates. Read `.objective/lint-report.txt` and `.objective/contract-report.txt`
+before every rewrite — they name exactly what failed.
+
+---
+
+## Write exactly two files
+
+### 1. `.objective/gen/dod.sh` — the definition of done
+
+A shell script, run from the workspace root, that **exits 0 if and only if the
+objective is satisfied**.
+
+- It must be able to *fail*. Run it before you write any of the work: it should
+  be **red right now**. A DoD that is already green proves nothing, and the
+  parent's evidence gate will notice — it also asserts that the workspace
+  actually changed, so a no-op cannot pass on a stale green.
+- No `echo pass`. No "an LLM said it looked right". Assert something: a test
+  runs, a file exists with required content, a schema validates, a command
+  exits 0.
+- Keep it fast and idempotent. It is run at least twice: once by your child's
+  gate, and again by the parent, in a different context, after your child
+  finishes.
+- Write its output somewhere under `.objective/gen/` so failures are readable.
+
+### 2. `.objective/gen/child.dot` — the child pipeline
+
+A complete, runnable attractor. Build it from what this bundle ships — do not
+invent new machinery:
+
+| Source | What to take from it |
+|---|---|
+| `examples/patterns/task-runner.dot` | the convergence skeleton: attempt → verify → critique → budget wall → postmortem |
+| `examples/pipelines/practical/bug-fix.dot` | the shape of a lean 2-loop attractor with a root-cause wall and a fail-loud escalation node |
+| `examples/gates/README.md` | the gate idioms (A: always exit 0; B: exit-code gate) and the stale-label discipline |
+| `examples/gates/base-sha-anchor.dot` | how to make "did work actually land?" a machine question |
+
+---
+
+## The eight checks (`check_child_contract.py`)
+
+| # | Check | Why it exists |
+|---|---|---|
+| C1 | **Exactly one exit node** (`shape=Msquare`) | An engine admission rule: `validate_or_raise` refuses a graph with zero or two exits. Two "terminals" are expressed as one green exit plus a fail-loud escalation node. |
+| C2 | **A tool node runs `dod.sh`** | The child's exit must be gated on the same definition of done the parent will re-run. A gate the composer can satisfy by writing a file is not a gate. |
+| C3 | **No `goal_gate=true` on a `box` node** | Verification inside the context that produced the evidence is not verification. Gates are `parallelogram`; workers are `box`. |
+| C4 | **At least one cycle** | If there is no path backwards, nothing converges — and this should have been a recipe, not an attractor. |
+| C5 | **A tool node walls an iteration budget and routes exhaustion** | Put the counter *in the gate* so green and red paths both spend it. A loop with no wall runs until the engine's step cap kills it with a bare FAIL, bypassing your postmortem. |
+| C6 | **A reachable node exits nonzero when it cannot converge** | A non-converging run must be a LOUD red, not a quiet green. Use the `bug-fix.dot` idiom: `max_retries=0`, `printf escalated; exit 1`, no fail-route out of it. |
+| C7 | **Every `box` node has an `outcome=fail` route or a `retry_target`** | A FAIL does not traverse plain edges. An unrouted worker failure runs the pipeline off the rim. |
+| C8 | **The child consumes `$goal`** | The objective is cloned into your child's context as `goal`. If nothing reads it, your pipeline is working on nothing in particular. |
+
+---
+
+## A child that satisfies every check
+
+Copy the shape, not the words.
+
+```dot
+digraph ComposedChild {
+    graph [goal="$goal",
+           default_max_retries=2,
+           default_fidelity="compact",
+           max_pipeline_duration="3600s"]
+
+    start [shape=Mdiamond]
+    done  [shape=Msquare]
+
+    // The worker. Reads accumulated feedback FIRST -- that is the descent signal.
+    work [shape=box,
+          prompt="Advance this objective: $goal. Read .objective/gen/feedback.md if it exists -- it is the critique of your last attempt. Read .objective/gen/dod.log for the exact failing output. Your work is verified by .objective/gen/dod.sh; do not weaken it."]
+
+    // The gate. Budget FIRST (every entry spends it), then the real check.
+    // Idiom A: always exit 0, so tool.last_line is always fresh.
+    dod_gate [shape=parallelogram, max_retries=0, goal_gate=true, retry_target="work",
+        tool_command="mi=$max_iterations; B=${mi:-6}; n=$(($(cat .objective/gen/iter 2>/dev/null || echo 0)+1)); echo $n > .objective/gen/iter; if [ \"$n\" -gt \"$B\" ]; then printf exhausted; else bash .objective/gen/dod.sh > .objective/gen/dod.log 2>&1 && printf green || printf red; fi"]
+
+    critique [shape=box,
+        prompt="The definition of done failed. Read .objective/gen/dod.log and write .objective/gen/feedback.md: the key finding, what to change, and why. The next attempt runs in a fresh context and will only know what you write here."]
+
+    postmortem [shape=box,
+        must_write=".objective/gen/postmortem.md",
+        prompt="The budget is spent without converging. Read .objective/gen/dod.log and .objective/gen/feedback.md and write .objective/gen/postmortem.md: what was attempted, whether the loop was descending or oscillating, and your best hypothesis for why it did not converge."]
+
+    escalated [shape=parallelogram, max_retries=0,
+        tool_command="printf escalated; exit 1"]
+
+    start -> work -> dod_gate
+
+    // Stale-label conjunctions: dod_gate also carries an outcome=fail edge.
+    dod_gate -> done       [condition="context.tool.last_line=green && outcome=success"]
+    dod_gate -> critique   [condition="context.tool.last_line=red && outcome=success"]
+    dod_gate -> postmortem [condition="context.tool.last_line=exhausted && outcome=success"]
+    dod_gate -> postmortem [condition="outcome=fail"]
+
+    critique -> work       [loop_restart="true"]
+
+    work       -> postmortem [condition="outcome=fail"]
+    critique   -> postmortem [condition="outcome=fail"]
+    postmortem -> escalated  [condition="outcome=fail"]
+    postmortem -> escalated
+}
+```
+
+---
+
+## Things that will get you sent back
+
+- **A DoD that cannot fail.** `printf pass`, `true`, `test -d .` — or any check
+  that was already green before the work existed.
+- **Weakening `dod.sh` to get past a gate.** The parent re-runs it in its own
+  context afterwards. A hollow DoD buys a louder failure later, not an easier
+  one.
+- **Putting the gate inside the worker** (`goal_gate=true` on a `box`, or a
+  worker that writes its own "converged" file for a gate to read).
+- **A straight line.** `plan -> implement -> test` with no back-edge is a recipe
+  wearing a graph's clothes.
+- **An unbounded loop.** No budget wall means the engine's step cap terminates
+  the run with a bare FAIL and your postmortem never runs.
+- **A `.dot` that only exists in your head.** Write both files to disk. The
+  next gate opens them.

--- a/examples/objective/objective-runner.dot
+++ b/examples/objective/objective-runner.dot
@@ -1,0 +1,376 @@
+// ============================================================================
+// Objective Runner -- one layer up from an attractor
+// ============================================================================
+// You do not pick a pipeline. You state an OBJECTIVE, and this graph diagnoses
+// it, routes it, converges on it against machine evidence, and -- when there is
+// no machine evidence to be had -- says so honestly instead of pretending.
+//
+//   objective  ->  composition  ->  attractors  ->  execution
+//   (this graph)   (compose path)  (the lanes)     (their own gates)
+//
+// The basin: "the stated objective is satisfied with machine evidence, or is
+// honestly redirected." Both are green exits. A run that can do neither
+// escalates LOUDLY (nonzero) rather than leaving through the success door.
+//
+// Invocation (per KNOWN_ISSUES: process cwd MUST equal --cwd for box nodes):
+//   OBJ=/abs/path/to/examples/objective
+//   cd <workspace>
+//   attractor run "$OBJ/objective-runner.dot" \
+//       --param goal="users report a crash when saving a file whose name has unicode" \
+//       --param runner_dir="$OBJ" \
+//       --param target_dir="$PWD" \
+//       --cwd .
+//
+// Parameters:
+//   goal            THE OBJECTIVE. It travels as the canonical `goal` param, so
+//                   every shipped lane consumes it natively -- no adapter layer,
+//                   no new param vocabulary.
+//   runner_dir      Absolute path to this file's directory (the gates run
+//                   validate_triage.py / check_child_contract.py from here).
+//   target_dir      Absolute path to the workspace. Used for the generated
+//                   child's dot_file, which must be absolute because a relative
+//                   dot_file resolves against THIS file's directory first
+//                   (specs/EXTENSIONS.md section 10 precedence chain).
+//   max_iterations  Evidence-loop budget (default 3).
+//   max_compose     Compose-fix budget (default 2 -> at most 3 lint attempts).
+//   max_frames      Malformed-triage budget (default 2 re-frames).
+//
+// SHAPE (the doctrine, made visible):
+//   - INTAKE ROUTES ON A MACHINE ARTIFACT, NOT ON A SELF-REPORT. `frame` (LLM)
+//     writes .objective/triage.json; `triage_gate` (code) validates it against
+//     triage-schema.json and prints the routing token. The first routing
+//     decision of the run is therefore evidence outside the worker's context --
+//     the same rule every gate in this repo obeys.
+//   - THE PARENT NEVER TRUSTS THE CHILD'S SELF-REPORT. A child pipeline's
+//     terminal outcome is used for LOUD FAIL ROUTING ONLY. Satisfaction is
+//     decided by `evidence_gate`, which RE-RUNS the definition-of-done command
+//     itself and additionally asserts a durable workspace delta since the
+//     anchor recorded at `preflight`. A no-op child cannot pass on a stale
+//     green.
+//   - THE COMPOSER'S OUTPUT IS GATED BEFORE IT RUNS. `compose` writes a child
+//     graph; `lint_gate` (the engine's own linter -- ERRORs block, warnings are
+//     recorded) and `contract_gate` (check_child_contract.py) both sit OUTSIDE
+//     the composer's context and can send it back.
+//   - BUDGET AS A DECISION POINT. evidence_gate spends an iteration on EVERY
+//     entry (green and red alike) and routes exhaustion to postmortem ->
+//     escalated, never to a bare FAIL.
+//   - ONE GREEN EXIT. `validate_or_raise` requires exactly one exit node, so the
+//     two honest terminals are expressed as: `done` (Msquare, reached only
+//     through `finalize`, which refuses to open without a disposition artifact)
+//     and `escalated` (a tool node that exits 1 with max_retries=0 and no
+//     fail-route -- the bug-fix.dot idiom, a LOUD red).
+//
+// VERIFIED ENGINE SEMANTICS THIS FILE DEPENDS ON:
+//   - STALE-LABEL RULE: a tool node that exits nonzero does NOT refresh
+//     tool.last_line, so a stale label can match at the same time as an
+//     outcome=fail edge. Every last_line edge below whose source also carries a
+//     failure edge conjoins `&& outcome=success` (docs/ROUTING-REFERENCE.md
+//     section 3).
+//   - dot_file= is resolved lazily, at node execution, with NO existence check
+//     (specs/EXTENSIONS.md section 10). That is what makes the compose path's
+//     write-then-run possible: .objective/gen/child.dot does not exist at parse
+//     or validate time. A never-written target fails late and LOUD.
+//   - A sub-pipeline is a fresh session boundary (section 11): each lane and the
+//     generated child run with their own context. Files are the only channel
+//     this graph trusts across that boundary.
+//   - PARAM NAMESPACE: substitution rewrites $name/${name} for any context key.
+//     The shell variables here (rd, mi, mc, mf, n, B, w, ev, rc, res, now, base,
+//     delta) are safe only because no param shares their name. Never add a param
+//     named like a shell var.
+// ============================================================================
+
+digraph ObjectiveRunner {
+    graph [
+        goal="$goal",
+        label="Objective Runner",
+        params="goal, runner_dir, target_dir, max_iterations, max_compose, max_frames",
+        default_max_retries=2,
+        default_fidelity="compact",
+        max_pipeline_duration="14400s"
+    ]
+
+    start [shape=Mdiamond, label="Start"]
+    done  [shape=Msquare,  label="Done"]
+
+    // ---------- preflight: deterministic admission + the delta anchor --------
+    // OBJECTIVE   Make the run's own preconditions true, or refuse before an
+    //             LLM is ever paid.
+    // CONSTRAINTS code-tier only; no judgement.
+    // EVIDENCE    .objective/anchor -- a digest of the workspace as it was
+    //             BEFORE any work, excluding .git and .objective themselves.
+    // EXIT        ready (all preconditions hold) | blocked (exit 1, LOUD)
+    // WHY THE ANCHOR: green evidence certifies the tree's state, not that new
+    // work exists in it. Without a recorded base, "did work happen?" is
+    // structurally unanswerable (see examples/gates/base-sha-anchor.dot and the
+    // 2026-07-28 incident). This is the commit-free form of that anchor, so it
+    // works in a workspace whose child pipelines do not commit.
+    preflight [
+        shape=parallelogram, label="Preflight", max_retries=0,
+        tool_command="mkdir -p .objective/postmortem .objective/gen .objective/feedback || { printf blocked; exit 1; }; rd=\"$runner_dir\"; for f in validate_triage.py check_child_contract.py triage-schema.json compose-contract.md; do [ -f \"$rd/$f\" ] || { echo \"FATAL: --param runner_dir must name the examples/objective directory; missing $f under '$rd'\" >&2; printf blocked; exit 1; }; done; case \"$target_dir\" in /*) ;; *) echo \"FATAL: --param target_dir must be an absolute path (got '$target_dir')\" >&2; printf blocked; exit 1;; esac; find . -name .git -prune -o -name .objective -prune -o -name .ai -prune -o -name __pycache__ -prune -o -name .pytest_cache -prune -o -name .ruff_cache -prune -o -name node_modules -prune -o -name .venv -prune -o -type f -exec md5sum {} + 2>/dev/null | LC_ALL=C sort | md5sum | cut -d' ' -f1 > .objective/anchor; [ -s .objective/anchor ] && printf ready || { printf blocked; exit 1; }"
+    ]
+
+    // ---------- frame: diagnose the objective; do NOT do the work ------------
+    // OBJECTIVE    Classify $goal with this repo's own three-question test and
+    //              propose a shape plus a machine definition of done.
+    // CONSTRAINTS  Do not do the work. Do not self-route (the token comes from
+    //              the gate, not from you). The vocabulary is fixed.
+    // CAPABILITIES read the workspace, read $goal.
+    // EVIDENCE     .objective/triage.json (schema-valid) and
+    //              .objective/objective.md (the objective restated).
+    // EXIT         triage.json exists and parses (must_write + triage_gate).
+    frame [
+        shape=box, label="Frame the Objective",
+        must_write=".objective/triage.json",
+        prompt="An objective has been stated: $goal\n\nYour job is to DIAGNOSE it, not to do it. Survey the workspace at $target_dir enough to answer honestly, then apply this repo's three-question test (docs/PIPELINE_DESIGN_PRINCIPLES.md section 0): (1) Is there a cycle -- work that can be attempted, checked by machine, and re-attempted? (2) Is the exit gated on machine-checkable evidence EXTERNAL to the worker? (3) Would it still land if any one LLM node had a bad day -- a single plausible-but-wrong response?\n\nWrite .objective/objective.md: the objective restated as an end-state of the world, the constraints you can see, and what evidence would prove it satisfied.\n\nThen write .objective/triage.json with exactly these fields:\n  shape             one of: bugfix, feature, refactor, testgen, review, compose, redirect\n  three_question    {cycle, evidence_gate, bad_day} -- each answer MUST begin with 'yes' or 'no', then say why\n  evidence_command  a shell command that exits 0 if and only if the objective is satisfied, run from $target_dir -- or the literal string NONE\n  rationale         why this shape\n\nChoosing the shape:\n  bugfix|feature|refactor|testgen|review -- the objective maps onto ONE shipped practical pipeline (examples/pipelines/practical/) whose gate form fits your evidence_command. Prefer a lane when one fits: they are battle-tested and carry their own gates, budgets, and escalation.\n  compose  -- machine-checkable but not lane-shaped (novel artifact, bespoke definition of done). Choosing this means a purpose-built child pipeline will be WRITTEN for this objective. If you choose compose, evidence_command MUST be exactly: bash .objective/gen/dod.sh\n  redirect -- there is no machine-checkable definition of done. Set evidence_command to NONE. This is a legitimate, useful answer, not a failure: some work wants a recipe, a conversation, or a one-shot, and saying so is the deliverable.\n\nDo not invent a hollow evidence_command to avoid choosing redirect. A gate that cannot fail is worse than no gate: it converts an honest 'this is not an attractor' into a false green. If .objective/triage-report.txt exists, a previous record of yours was REJECTED -- read it and fix exactly what it names."
+    ]
+
+    // ---------- triage_gate: admit the triage; print the routing token -------
+    // OBJECTIVE    Admit only a well-formed triage record, and be the thing that
+    //              decides the route.
+    // CONSTRAINTS  code-tier only; vocabulary equality is exact lowercase.
+    // EVIDENCE     .objective/triage-report.txt, .objective/shape,
+    //              .objective/evidence-command
+    // EXIT         one of the 7 shape tokens | triage_bad | triage_exhausted
+    // Idiom A (always exit 0) so tool.last_line is always fresh. A nonzero exit
+    // here means the gate itself could not run, which is a different thing from
+    // a bad record -- and it routes differently, to the postmortem path.
+    // This node is also the loop's re-entry point: `feedback` routes back here,
+    // so a corrective iteration re-enters the SAME lane the record named.
+    triage_gate [
+        shape=parallelogram, label="Admit Triage / Route", max_retries=0,
+        tool_command="mf=$max_frames; python3 \"$runner_dir/validate_triage.py\" --triage .objective/triage.json --schema \"$runner_dir/triage-schema.json\" --state-dir .objective --max-frames \"${mf:-2}\""
+    ]
+
+    // ---------- the five lanes: shipped practical pipelines, unmodified ------
+    // OBJECTIVE    Satisfy the objective through a battle-tested attractor.
+    // CONSTRAINTS  The child is used AS SHIPPED. It carries its own gates,
+    //              budgets, and escalation; this graph adds a second, external
+    //              verification pass rather than reaching inside.
+    // CAPABILITIES the child graph's own.
+    // EVIDENCE     the child's own evidence files in the shared workspace.
+    // EXIT         the child's terminal outcome (fail-routing only).
+    // $goal is cloned into the child's context, and every shipped practical
+    // pipeline already consumes $goal -- which is exactly why the objective
+    // travels as `goal` and needs no adapter.
+    lane_bugfix   [shape=folder, label="Lane: Bug Fix",     dot_file="../pipelines/practical/bug-fix.dot"]
+    lane_feature  [shape=folder, label="Lane: Feature",     dot_file="../pipelines/practical/feature-build.dot"]
+    lane_refactor [shape=folder, label="Lane: Refactor",    dot_file="../pipelines/practical/refactor.dot"]
+    lane_testgen  [shape=folder, label="Lane: Test Gen",    dot_file="../pipelines/practical/test-gen.dot"]
+    lane_review   [shape=folder, label="Lane: PR Review",   dot_file="../pipelines/practical/pr-review.dot"]
+
+    // ---------- compose: WRITE a purpose-built child -------------------------
+    // OBJECTIVE    Write a child pipeline and its definition-of-done script for
+    //              an objective that is machine-checkable but not lane-shaped.
+    // CONSTRAINTS  Gates OUTSIDE workers. One exit. A cycle and a budget wall
+    //              are mandatory. Build only from bundle-shipped patterns.
+    // CAPABILITIES write files; read examples/patterns/, examples/gates/, and
+    //              compose-contract.md.
+    // EVIDENCE     .objective/gen/child.dot and .objective/gen/dod.sh
+    // EXIT         both files exist AND pass lint_gate AND contract_gate.
+    compose [
+        shape=box, label="Compose a Child Pipeline",
+        must_write=".objective/gen/child.dot",
+        prompt="No shipped lane fits this objective, but it IS machine-checkable. Write a purpose-built child pipeline for it.\n\nObjective: $goal\n\nRead $runner_dir/compose-contract.md IN FULL first -- it is the contract your output must satisfy, and two gates outside your context will check it mechanically before your graph is allowed to run. Also read $runner_dir/../patterns/task-runner.dot (the convergence skeleton), $runner_dir/../gates/README.md (the gate idioms and the stale-label rule), and .objective/objective.md.\n\nWrite exactly two files:\n  .objective/gen/dod.sh    the definition of done. A shell script, run from $target_dir, that exits 0 if and only if the objective is satisfied and nonzero otherwise. It must be able to FAIL -- write it so that it is red right now, before the work exists, and confirm that by running it.\n  .objective/gen/child.dot the child pipeline. Its gate must RUN .objective/gen/dod.sh; its exit must be unreachable except through that gate.\n\nIf .objective/lint-report.txt or .objective/contract-report.txt exists, a previous attempt of yours was BLOCKED -- read both and fix exactly what they name. Do not weaken dod.sh to get past a gate: the parent re-runs it after your child finishes, and a hollow DoD only buys a louder failure later."
+    ]
+
+    // ---------- lint_gate: the engine's own linter, as an in-graph gate ------
+    // OBJECTIVE    Machine-reject a broken generated graph BEFORE executing it.
+    // CONSTRAINTS  ERRORs block; WARNINGs pass but are recorded (no --strict).
+    //              contract_gate owns the design-shape checks.
+    // CAPABILITIES `attractor lint` (exit 1 on errors, 0 on warnings).
+    // EVIDENCE     .objective/lint-report.txt, warning count in convergence.jsonl
+    // EXIT         lint_pass | lint_fail | compose_exhausted | lint_unavailable(exit 1)
+    // This node also carries the compose-fix budget: every re-entry from either
+    // gate passes through here, so every compose attempt spends budget.
+    lint_gate [
+        shape=parallelogram, label="Lint Generated Child", max_retries=0,
+        tool_command="mc=$max_compose; B=${mc:-2}; n=$(($(cat .objective/compose-iter 2>/dev/null || echo 0)+1)); echo $n > .objective/compose-iter; if [ \"$n\" -gt $((B+1)) ]; then printf compose_exhausted; else command -v attractor >/dev/null 2>&1 || { echo 'FATAL: the attractor CLI is not on PATH; the generated child cannot be lint-gated' >&2; printf lint_unavailable; exit 1; }; if attractor lint .objective/gen/child.dot > .objective/lint-report.txt 2>&1; then res=lint_pass; else res=lint_fail; fi; w=$(grep -c '^WARNING' .objective/lint-report.txt 2>/dev/null); printf '{\"iteration\": %s, \"gate\": \"lint\", \"result\": \"%s\", \"warnings\": %s}\n' \"$n\" \"$res\" \"${w:-0}\" >> .objective/convergence.jsonl; printf %s \"$res\"; fi"
+    ]
+
+    // ---------- contract_gate: the composed-child contract, structurally -----
+    // OBJECTIVE    Enforce the shape checks lint deliberately does not own:
+    //              is this actually an attractor, and is its gate really
+    //              outside its workers?
+    // CONSTRAINTS  deterministic checks only.
+    // EVIDENCE     .objective/contract-report.txt (per-check PASS/FAIL)
+    // EXIT         contract_ok | contract_bad
+    contract_gate [
+        shape=parallelogram, label="Composed-Child Contract", max_retries=0,
+        tool_command="python3 \"$runner_dir/check_child_contract.py\" --child .objective/gen/child.dot --dod .objective/gen/dod.sh --report .objective/contract-report.txt"
+    ]
+
+    // ---------- run_child: execute the generated pipeline --------------------
+    // The dot_file is absolute (via $target_dir) on purpose: a relative value
+    // would resolve against THIS file's directory first, not the workspace.
+    // It is written at run time and read at node entry -- lazy resolution is
+    // what makes write-then-run composition possible at all.
+    run_child [
+        shape=folder, label="Run Generated Child",
+        dot_file="$target_dir/.objective/gen/child.dot"
+    ]
+
+    // ---------- redirect_report: the honest no, with receipts ----------------
+    // OBJECTIVE    Deliver the diagnosis as the work product.
+    // CONSTRAINTS  Must quote the failing three-question answers verbatim and
+    //              name the better home for this work.
+    // EVIDENCE     .objective/redirect.md
+    // EXIT         the file exists and is non-trivial (must_write + finalize).
+    // This path exits GREEN. The diagnosis IS the deliverable; the disposition
+    // artifact is what distinguishes it from "objective satisfied" for an
+    // unattended caller.
+    redirect_report [
+        shape=box, label="Honest Redirect",
+        must_write=".objective/redirect.md",
+        prompt="The triage concluded that this objective is NOT an attractor: $goal\n\nRead .objective/triage.json and .objective/objective.md. Write .objective/redirect.md -- the deliverable of this run. It must contain:\n  1. The objective, restated.\n  2. The three-question test, with your three answers QUOTED VERBATIM from triage.json, and a sentence on which question failed and why.\n  3. Where this work actually belongs: a recipe (staged, sequential, human approval gates), a conversation (judgement all the way down, no stable definition of done), or a one-shot (small enough that a loop buys nothing). Name one, and say what the first step there looks like.\n  4. What WOULD make it an attractor: the specific machine-checkable definition of done that does not exist today. If someone later writes that check, this objective becomes routable -- say exactly what it would have to assert.\n\nBe direct. A wrong 'yes, let us build a pipeline' costs hours and produces nothing; an accurate 'no, and here is why' is worth more than a run."
+    ]
+
+    // ---------- evidence_gate: the load-bearing gate -------------------------
+    // OBJECTIVE    Decide whether the objective is SATISFIED -- by re-running
+    //              the definition of done here, in the parent, outside every
+    //              child's context.
+    // CONSTRAINTS  Files and exit codes only. Never the child's self-report.
+    //              Owns the iteration fuse, checked FIRST so every entry
+    //              (green, red, or transient) spends budget.
+    // CAPABILITIES the admitted evidence_command; the workspace digest.
+    // EVIDENCE     .objective/evidence-N.log, .objective/convergence.jsonl,
+    //              .objective/evidence-pass
+    // EXIT         evidence_ok | evidence_bad | exhausted
+    // The delta assertion is the second half of the gate: a green DoD with an
+    // UNCHANGED workspace means nothing happened and the check was already
+    // passing -- the shape of the 2.4h/zero-work-product incident. Both halves
+    // must hold.
+    evidence_gate [
+        shape=parallelogram, label="Objective Satisfied?", max_retries=0,
+        goal_gate=true, retry_target="feedback",
+        tool_command="mi=$max_iterations; B=${mi:-3}; n=$(($(cat .objective/iter 2>/dev/null || echo 0)+1)); echo $n > .objective/iter; if [ \"$n\" -gt \"$B\" ]; then printf '{\"iteration\": %s, \"gate\": \"evidence\", \"budget\": \"exhausted\"}\n' \"$n\" >> .objective/convergence.jsonl; printf exhausted; else ev=$(cat .objective/evidence-command 2>/dev/null); now=$(find . -name .git -prune -o -name .objective -prune -o -name .ai -prune -o -name __pycache__ -prune -o -name .pytest_cache -prune -o -name .ruff_cache -prune -o -name node_modules -prune -o -name .venv -prune -o -type f -exec md5sum {} + 2>/dev/null | LC_ALL=C sort | md5sum | cut -d' ' -f1); base=$(cat .objective/anchor 2>/dev/null); [ \"$now\" != \"$base\" ] && delta=changed || delta=unchanged; if [ -z \"$ev\" ]; then rc=99; else bash -c \"$ev\" > .objective/evidence-$n.log 2>&1; rc=$?; fi; printf '{\"iteration\": %s, \"gate\": \"evidence\", \"dod_exit\": %s, \"delta\": \"%s\"}\n' \"$n\" \"$rc\" \"$delta\" >> .objective/convergence.jsonl; if [ $rc -eq 0 ] && [ \"$delta\" = changed ]; then : > .objective/evidence-pass; printf evidence_ok; else rm -f .objective/evidence-pass; printf evidence_bad; fi; fi"
+    ]
+
+    // ---------- feedback: teach the NEXT attempt ----------------------------
+    // The next iteration re-enters through triage_gate, which re-emits the same
+    // shape token -- so the same lane runs again, in a FRESH context. This file
+    // is the only thing that crosses; that is the point.
+    feedback [
+        shape=box, label="Write Feedback",
+        must_write=".objective/feedback",
+        prompt="The objective is not yet satisfied: $goal\n\nRead .objective/convergence.jsonl (the descent record -- is this loop DESCENDING, OSCILLATING, or WANDERING?), the most recent .objective/evidence-*.log (the actual failing output of the definition-of-done command), and .objective/objective.md. Note that a 'delta: unchanged' record means the last attempt produced NO durable change to the workspace at all -- that is a different failure from a red check, and it needs a different response.\n\nRead .objective/iter for the current iteration number N, then write .objective/feedback/N-next.md: Key finding (one sentence) / What to change (3-5 bullets, specific, citing the failing output) / Why it matters. Then curate: consolidate or delete earlier feedback files that are stale or addressed.\n\nThe next attempt runs in a FRESH context and will not remember anything you do not write down. This file is the entire descent signal."
+    ]
+
+    // ---------- approve: the consequential human checkpoint ------------------
+    // OBJECTIVE    Let a human accept or reject a machine-verified result.
+    // Choice ORDER matters: an unattended run driven with
+    // `--on-human-gate auto-approve` selects the FIRST edge. Approve is first
+    // because the gate BELOW this one already passed on machine evidence -- a
+    // reject-first ordering would make every unattended run burn its budget and
+    // then report a false red. The CLI default (`--on-human-gate fail`) still
+    // refuses to guess: an unattended caller must opt in explicitly.
+    approve [
+        shape=hexagon, label="Ship this result?",
+        prompt="The objective's definition-of-done command passed in the parent context, and the workspace changed since the run began. Review .objective/evidence-*.log, .objective/convergence.jsonl, and the actual changes before choosing."
+    ]
+
+    // ---------- finalize: refuse a green exit without a disposition ----------
+    // OBJECTIVE    Make "the run ended" and "the run produced a disposition"
+    //              the same event.
+    // EVIDENCE     .objective/disposition = satisfied | redirected
+    // EXIT         finalized | no_disposition (exit 1, LOUD)
+    // This is what lets an unattended caller tell the two green outcomes apart:
+    // read .objective/disposition, then read the artifact it implies.
+    finalize [
+        shape=parallelogram, label="Finalize", max_retries=0,
+        tool_command="if [ -f .objective/evidence-pass ]; then echo satisfied > .objective/disposition; elif [ -s .objective/redirect.md ]; then echo redirected > .objective/disposition; else echo 'FATAL: no disposition artifact -- neither verified evidence nor an honest redirect' >&2; printf no_disposition; exit 1; fi; printf finalized"
+    ]
+
+    // ---------- postmortem -> escalated: salvage, then fail LOUD -------------
+    postmortem [
+        shape=box, label="Postmortem",
+        must_write=".objective/postmortem/report.md",
+        prompt="This run reached a decision point without converging on the objective: $goal\n\nRead .objective/convergence.jsonl, .objective/triage.json, .objective/triage-report.txt, .objective/lint-report.txt and .objective/contract-report.txt (if they exist), the .objective/evidence-*.log files, and .objective/feedback/. Write .objective/postmortem/report.md: what each iteration attempted, whether the loop was DESCENDING / OSCILLATING / WANDERING (cite the record), your best hypothesis for why it did not converge, and -- specifically -- whether the failure was in the OBJECTIVE (ambiguous, too large), the TRIAGE (wrong shape chosen; say which shape you would choose now), the DEFINITION OF DONE (wrong or unachievable check), or the WORK itself. Then state the options: change the objective, change the shape, raise the budget, or take it to a human.\n\nThis report is the value salvaged from a non-converging run. Be honest; a run that fails and explains itself is worth more than one that fails quietly."
+    ]
+
+    escalated [
+        shape=parallelogram, label="Escalated", max_retries=0,
+        tool_command="mkdir -p .objective/postmortem; if [ -s .objective/postmortem/report.md ]; then echo 'Read .objective/postmortem/report.md and .objective/convergence.jsonl, then choose: change the objective, change the shape, raise the budget, or take it to a human.' > .objective/postmortem/escalation.md; else echo 'Postmortem could not be produced. Preserve the run logs and escalate to a human.' > .objective/postmortem/escalation.md; fi; echo escalated > .objective/disposition; printf escalated; exit 1"
+    ]
+
+    // ========================= edges =========================
+    start -> preflight
+
+    preflight -> frame     [condition="context.tool.last_line=ready && outcome=success", label="preconditions hold"]
+    preflight -> escalated [condition="outcome=fail",                                    label="blocked -- refuse before spending an LLM"]
+
+    frame -> triage_gate
+
+    // Intake routing. Every token edge carries the stale-label conjunction
+    // because triage_gate also has an outcome=fail edge.
+    triage_gate -> lane_bugfix      [condition="context.tool.last_line=bugfix && outcome=success",   label="bugfix"]
+    triage_gate -> lane_feature     [condition="context.tool.last_line=feature && outcome=success",  label="feature"]
+    triage_gate -> lane_refactor    [condition="context.tool.last_line=refactor && outcome=success", label="refactor"]
+    triage_gate -> lane_testgen     [condition="context.tool.last_line=testgen && outcome=success",  label="testgen"]
+    triage_gate -> lane_review      [condition="context.tool.last_line=review && outcome=success",   label="review"]
+    triage_gate -> compose          [condition="context.tool.last_line=compose && outcome=success",  label="compose"]
+    triage_gate -> redirect_report  [condition="context.tool.last_line=redirect && outcome=success", label="redirect -- the honest no"]
+    // Corrective: a malformed record is a judgement, and it is fuse-bounded.
+    triage_gate -> frame            [condition="context.tool.last_line=triage_bad && outcome=success",       label="malformed -- re-frame"]
+    triage_gate -> postmortem       [condition="context.tool.last_line=triage_exhausted && outcome=success", label="cannot produce a valid triage"]
+    // A nonzero exit here means the GATE could not run, not that the record was bad.
+    triage_gate -> postmortem       [condition="outcome=fail", label="gate could not run"]
+
+    // Lanes: the child's own gates decide the child; this graph re-verifies.
+    lane_bugfix   -> evidence_gate
+    lane_feature  -> evidence_gate
+    lane_refactor -> evidence_gate
+    lane_testgen  -> evidence_gate
+    lane_review   -> evidence_gate
+    lane_bugfix   -> postmortem [condition="outcome=fail", label="child could not converge"]
+    lane_feature  -> postmortem [condition="outcome=fail", label="child could not converge"]
+    lane_refactor -> postmortem [condition="outcome=fail", label="child could not converge"]
+    lane_testgen  -> postmortem [condition="outcome=fail", label="child could not converge"]
+    lane_review   -> postmortem [condition="outcome=fail", label="child could not converge"]
+
+    // Compose path: write -> lint -> contract -> run. Both gates can send it back.
+    compose -> lint_gate
+    compose -> postmortem [condition="outcome=fail", label="hard failure"]
+
+    lint_gate -> contract_gate [condition="context.tool.last_line=lint_pass && outcome=success", label="no lint errors"]
+    lint_gate -> compose       [condition="context.tool.last_line=lint_fail && outcome=success", label="lint errors -- rewrite"]
+    lint_gate -> postmortem    [condition="context.tool.last_line=compose_exhausted && outcome=success", label="compose budget spent"]
+    lint_gate -> postmortem    [condition="outcome=fail", label="linter unavailable"]
+
+    contract_gate -> run_child  [condition="context.tool.last_line=contract_ok && outcome=success",  label="contract satisfied"]
+    contract_gate -> compose    [condition="context.tool.last_line=contract_bad && outcome=success", label="contract violated -- rewrite"]
+    contract_gate -> postmortem [condition="outcome=fail", label="contract gate could not run"]
+
+    run_child -> evidence_gate
+    run_child -> postmortem [condition="outcome=fail", label="generated child could not converge"]
+
+    // The honest no reaches the single green exit through finalize.
+    redirect_report -> finalize
+    redirect_report -> postmortem [condition="outcome=fail", label="hard failure"]
+
+    // The load-bearing decision.
+    evidence_gate -> approve    [condition="context.tool.last_line=evidence_ok && outcome=success",   label="evidence holds"]
+    evidence_gate -> feedback   [condition="context.tool.last_line=evidence_bad && outcome=success",  label="not satisfied -- iterate"]
+    evidence_gate -> postmortem [condition="context.tool.last_line=exhausted && outcome=success",     label="budget spent -- decision point"]
+    evidence_gate -> postmortem [condition="outcome=fail",                                            label="gate could not run"]
+
+    // Corrective re-entry: back through the gate that owns the route, so the
+    // same shape runs again in a fresh context with the feedback file as its
+    // only inheritance. loop_restart increments $iteration and resets completed
+    // nodes; the budget counters are files and survive on purpose.
+    feedback -> triage_gate [loop_restart="true", label="fresh iteration, kept learning"]
+    feedback -> postmortem  [condition="outcome=fail", label="hard failure"]
+
+    // Human checkpoint. Approve FIRST -- see the node comment.
+    approve -> finalize [label="[A] Approve -- accept the verified result"]
+    approve -> feedback [label="[R] Reject -- another iteration with my notes"]
+
+    finalize -> done       [condition="context.tool.last_line=finalized && outcome=success", label="disposition recorded"]
+    finalize -> postmortem [condition="outcome=fail",                                        label="no disposition -- refuse to exit green"]
+
+    // Escalation is a deterministic non-terminal handoff, not a second
+    // successful exit. It writes a fallback handoff even if the postmortem LLM
+    // itself failed, then exits 1 DELIBERATELY: max_retries=0 and no fail-route,
+    // so the engine hard-fails LOUD (run status=fail, CLI exit 1).
+    postmortem -> escalated [condition="outcome=fail", label="postmortem failed"]
+    postmortem -> escalated [label="escalate"]
+}

--- a/examples/objective/objective-runner.dot
+++ b/examples/objective/objective-runner.dot
@@ -106,7 +106,7 @@ digraph ObjectiveRunner {
     // works in a workspace whose child pipelines do not commit.
     preflight [
         shape=parallelogram, label="Preflight", max_retries=0,
-        tool_command="mkdir -p .objective/postmortem .objective/gen .objective/feedback || { printf blocked; exit 1; }; rd=\"$runner_dir\"; for f in validate_triage.py check_child_contract.py triage-schema.json compose-contract.md; do [ -f \"$rd/$f\" ] || { echo \"FATAL: --param runner_dir must name the examples/objective directory; missing $f under '$rd'\" >&2; printf blocked; exit 1; }; done; case \"$target_dir\" in /*) ;; *) echo \"FATAL: --param target_dir must be an absolute path (got '$target_dir')\" >&2; printf blocked; exit 1;; esac; find . -name .git -prune -o -name .objective -prune -o -name .ai -prune -o -name __pycache__ -prune -o -name .pytest_cache -prune -o -name .ruff_cache -prune -o -name node_modules -prune -o -name .venv -prune -o -type f -exec md5sum {} + 2>/dev/null | LC_ALL=C sort | md5sum | cut -d' ' -f1 > .objective/anchor; [ -s .objective/anchor ] && printf ready || { printf blocked; exit 1; }"
+        tool_command="mkdir -p .objective/postmortem .objective/gen .objective/feedback || { printf blocked; exit 1; }; rd=\"$runner_dir\"; for f in sha256sum md5sum find; do command -v \"$f\" >/dev/null 2>&1 || { echo \"FATAL: '$f' is not on PATH; the anchor digest and the DoD sha-pin both need it\" >&2; printf blocked; exit 1; }; done; for f in validate_triage.py check_child_contract.py triage-schema.json compose-contract.md; do [ -f \"$rd/$f\" ] || { echo \"FATAL: --param runner_dir must name the examples/objective directory; missing $f under '$rd'\" >&2; printf blocked; exit 1; }; done; case \"$target_dir\" in /*) ;; *) echo \"FATAL: --param target_dir must be an absolute path (got '$target_dir')\" >&2; printf blocked; exit 1;; esac; find . -name .git -prune -o -name .objective -prune -o -name .ai -prune -o -name __pycache__ -prune -o -name .pytest_cache -prune -o -name .ruff_cache -prune -o -name node_modules -prune -o -name .venv -prune -o -type f -exec md5sum {} + 2>/dev/null | LC_ALL=C sort | md5sum | cut -d' ' -f1 > .objective/anchor; [ -s .objective/anchor ] && printf ready || { printf blocked; exit 1; }"
     ]
 
     // ---------- frame: diagnose the objective; do NOT do the work ------------
@@ -170,7 +170,7 @@ digraph ObjectiveRunner {
     compose [
         shape=box, label="Compose a Child Pipeline",
         must_write=".objective/gen/child.dot",
-        prompt="No shipped lane fits this objective, but it IS machine-checkable. Write a purpose-built child pipeline for it.\n\nObjective: $goal\n\nRead $runner_dir/compose-contract.md IN FULL first -- it is the contract your output must satisfy, and two gates outside your context will check it mechanically before your graph is allowed to run. Also read $runner_dir/../patterns/task-runner.dot (the convergence skeleton), $runner_dir/../gates/README.md (the gate idioms and the stale-label rule), and .objective/objective.md.\n\nWrite exactly two files:\n  .objective/gen/dod.sh    the definition of done. A shell script, run from $target_dir, that exits 0 if and only if the objective is satisfied and nonzero otherwise. It must be able to FAIL -- write it so that it is red right now, before the work exists, and confirm that by running it.\n  .objective/gen/child.dot the child pipeline. Its gate must RUN .objective/gen/dod.sh; its exit must be unreachable except through that gate.\n\nIf .objective/lint-report.txt or .objective/contract-report.txt exists, a previous attempt of yours was BLOCKED -- read both and fix exactly what they name. Do not weaken dod.sh to get past a gate: the parent re-runs it after your child finishes, and a hollow DoD only buys a louder failure later."
+        prompt="No shipped lane fits this objective, but it IS machine-checkable. Write a purpose-built child pipeline for it.\n\nObjective: $goal\n\nRead $runner_dir/compose-contract.md IN FULL first -- it is the contract your output must satisfy, and two gates outside your context will check it mechanically before your graph is allowed to run. Also read $runner_dir/../patterns/task-runner.dot (the convergence skeleton), $runner_dir/../gates/README.md (the gate idioms and the stale-label rule), and .objective/objective.md.\n\nWrite exactly two files:\n  .objective/gen/dod.sh    the definition of done. A shell script, run from $target_dir, that exits 0 if and only if the objective is satisfied and nonzero otherwise. It MUST be red right now, before the work exists, and it must say so with EXIT CODE 1 -- not 0 (already satisfied), and not 2+ (a broken script). Run it yourself and check the exit status before you finish: the contract gate runs it too, once, before your child is allowed to run, and rejects it on C9 if it does not exit 1.\n  .objective/gen/child.dot the child pipeline. Its gate must RUN .objective/gen/dod.sh; its exit must be unreachable except through that gate.\n\nIf .objective/lint-report.txt or .objective/contract-report.txt exists, a previous attempt of yours was BLOCKED -- read both and fix exactly what they name. Do not weaken dod.sh to get past a gate. A hollow DoD does not buy a louder failure later -- it is caught at admission: contract_gate executes dod.sh before your child runs and returns contract_bad on C9 if it exits 0. It also pins sha256(dod.sh) at that moment, and the parent re-hashes before re-running, so rewriting the file after it was admitted makes the run refuse outright."
     ]
 
     // ---------- lint_gate: the engine's own linter, as an in-graph gate ------
@@ -182,6 +182,14 @@ digraph ObjectiveRunner {
     // EXIT         lint_pass | lint_fail | compose_exhausted | lint_unavailable(exit 1)
     // This node also carries the compose-fix budget: every re-entry from either
     // gate passes through here, so every compose attempt spends budget.
+    // KNOWN, BOUNDED WASTE (measured, not hidden): the wall is checked on ENTRY,
+    // so with the default $max_compose=2 the run executes `compose` a FOURTH
+    // time and only then reads compose_exhausted -- one LLM node execution whose
+    // output is never linted. Closing it fully means making the OTHER re-entry
+    // point (contract_gate's contract_bad -> compose edge) budget-aware too,
+    // which puts a copy of the counter in a second gate. The trade taken here is
+    // one wasted call on the exhaustion path -- a path already headed to
+    // postmortem -- over a budget split across two gates that can disagree.
     lint_gate [
         shape=parallelogram, label="Lint Generated Child", max_retries=0,
         tool_command="mc=$max_compose; B=${mc:-2}; n=$(($(cat .objective/compose-iter 2>/dev/null || echo 0)+1)); echo $n > .objective/compose-iter; if [ \"$n\" -gt $((B+1)) ]; then printf compose_exhausted; else command -v attractor >/dev/null 2>&1 || { echo 'FATAL: the attractor CLI is not on PATH; the generated child cannot be lint-gated' >&2; printf lint_unavailable; exit 1; }; if attractor lint .objective/gen/child.dot > .objective/lint-report.txt 2>&1; then res=lint_pass; else res=lint_fail; fi; w=$(grep -c '^WARNING' .objective/lint-report.txt 2>/dev/null); printf '{\"iteration\": %s, \"gate\": \"lint\", \"result\": \"%s\", \"warnings\": %s}\n' \"$n\" \"$res\" \"${w:-0}\" >> .objective/convergence.jsonl; printf %s \"$res\"; fi"
@@ -189,14 +197,26 @@ digraph ObjectiveRunner {
 
     // ---------- contract_gate: the composed-child contract, structurally -----
     // OBJECTIVE    Enforce the shape checks lint deliberately does not own:
-    //              is this actually an attractor, and is its gate really
-    //              outside its workers?
+    //              is this actually an attractor, is its gate really outside
+    //              its workers, and (C9) can its definition of done FAIL?
     // CONSTRAINTS  deterministic checks only.
-    // EVIDENCE     .objective/contract-report.txt (per-check PASS/FAIL)
+    // EVIDENCE     .objective/contract-report.txt (per-check PASS/FAIL),
+    //              .objective/dod.sha256 (the admitted DoD's sha-pin)
     // EXIT         contract_ok | contract_bad
+    // C9 IS THE ONE CHECK THAT EXECUTES SOMETHING. It runs dod.sh once, here,
+    // before the child runs, and requires exit 1. "The DoD must be red before
+    // the work exists" used to live only in the composer's prompt -- and a
+    // prompt instruction is a suggestion. A composer that wrote `exit 0` passed
+    // every structural check, its child converged instantly, and this graph's
+    // own evidence gate re-ran the same vacuous script and agreed: rc=0 with a
+    // changed workspace is `evidence_ok`. C9 is what makes the rule a check.
+    // THE SHA-PIN: on admission the gate records sha256(dod.sh). evidence_gate
+    // re-hashes before re-running, so rewriting the DoD after it was admitted is
+    // caught rather than believed. Anti-accident, not anti-adversary -- see
+    // compose-contract.md, "The pin, and what it is not".
     contract_gate [
         shape=parallelogram, label="Composed-Child Contract", max_retries=0,
-        tool_command="python3 \"$runner_dir/check_child_contract.py\" --child .objective/gen/child.dot --dod .objective/gen/dod.sh --report .objective/contract-report.txt"
+        tool_command="python3 \"$runner_dir/check_child_contract.py\" --child .objective/gen/child.dot --dod .objective/gen/dod.sh --report .objective/contract-report.txt --pin .objective/dod.sha256"
     ]
 
     // ---------- run_child: execute the generated pipeline --------------------
@@ -239,10 +259,24 @@ digraph ObjectiveRunner {
     // UNCHANGED workspace means nothing happened and the check was already
     // passing -- the shape of the 2.4h/zero-work-product incident. Both halves
     // must hold.
+    // THE PIN IS CHECKED FIRST, BEFORE THE BUDGET. A definition of done that was
+    // altered after admission is not a red iteration -- it is a refusal to
+    // evaluate at all, so it does not spend an iteration; it prints `tampered`
+    // and exits 1. Nonzero means tool.last_line is NOT refreshed, so every
+    // `&& outcome=success` edge below is dead and only outcome=fail can match:
+    // postmortem -> escalated, CLI exit 1.
+    // ON goal_gate=true, HONESTLY: this node uses Idiom A (always exit 0), and a
+    // tool node's exit 0 is an explicit SUCCESS verdict (handlers/tool.py), so
+    // the engine's exit-time gate check can never actually fail here -- even an
+    // `evidence_bad` run satisfies it. It is kept as a DECLARATION of which node
+    // owns the verdict (the same thing C3 enforces on generated children: the
+    // goal gate belongs on the parallelogram, never on a box). The enforcement
+    // that really holds is structural: `done` is reachable only through
+    // `finalize`, which refuses to open without a disposition artifact.
     evidence_gate [
         shape=parallelogram, label="Objective Satisfied?", max_retries=0,
         goal_gate=true, retry_target="feedback",
-        tool_command="mi=$max_iterations; B=${mi:-3}; n=$(($(cat .objective/iter 2>/dev/null || echo 0)+1)); echo $n > .objective/iter; if [ \"$n\" -gt \"$B\" ]; then printf '{\"iteration\": %s, \"gate\": \"evidence\", \"budget\": \"exhausted\"}\n' \"$n\" >> .objective/convergence.jsonl; printf exhausted; else ev=$(cat .objective/evidence-command 2>/dev/null); now=$(find . -name .git -prune -o -name .objective -prune -o -name .ai -prune -o -name __pycache__ -prune -o -name .pytest_cache -prune -o -name .ruff_cache -prune -o -name node_modules -prune -o -name .venv -prune -o -type f -exec md5sum {} + 2>/dev/null | LC_ALL=C sort | md5sum | cut -d' ' -f1); base=$(cat .objective/anchor 2>/dev/null); [ \"$now\" != \"$base\" ] && delta=changed || delta=unchanged; if [ -z \"$ev\" ]; then rc=99; else bash -c \"$ev\" > .objective/evidence-$n.log 2>&1; rc=$?; fi; printf '{\"iteration\": %s, \"gate\": \"evidence\", \"dod_exit\": %s, \"delta\": \"%s\"}\n' \"$n\" \"$rc\" \"$delta\" >> .objective/convergence.jsonl; if [ $rc -eq 0 ] && [ \"$delta\" = changed ]; then : > .objective/evidence-pass; printf evidence_ok; else rm -f .objective/evidence-pass; printf evidence_bad; fi; fi"
+        tool_command="if [ -f .objective/evidence-command.sha256 ] && [ \"$(sha256sum .objective/evidence-command 2>/dev/null | cut -d' ' -f1)\" != \"$(cat .objective/evidence-command.sha256)\" ]; then echo 'FATAL: .objective/evidence-command was altered after triage_gate admitted it -- refusing to re-run a definition of done this run never approved' >&2; printf tampered; exit 1; fi; if [ -f .objective/dod.sha256 ] && [ \"$(sha256sum .objective/gen/dod.sh 2>/dev/null | cut -d' ' -f1)\" != \"$(cat .objective/dod.sha256)\" ]; then echo 'FATAL: .objective/gen/dod.sh was altered after contract_gate admitted it -- refusing to re-run a definition of done this run never approved' >&2; printf tampered; exit 1; fi; mi=$max_iterations; B=${mi:-3}; n=$(($(cat .objective/iter 2>/dev/null || echo 0)+1)); echo $n > .objective/iter; if [ \"$n\" -gt \"$B\" ]; then printf '{\"iteration\": %s, \"gate\": \"evidence\", \"budget\": \"exhausted\"}\n' \"$n\" >> .objective/convergence.jsonl; printf exhausted; else ev=$(cat .objective/evidence-command 2>/dev/null); now=$(find . -name .git -prune -o -name .objective -prune -o -name .ai -prune -o -name __pycache__ -prune -o -name .pytest_cache -prune -o -name .ruff_cache -prune -o -name node_modules -prune -o -name .venv -prune -o -type f -exec md5sum {} + 2>/dev/null | LC_ALL=C sort | md5sum | cut -d' ' -f1); base=$(cat .objective/anchor 2>/dev/null); [ \"$now\" != \"$base\" ] && delta=changed || delta=unchanged; if [ -z \"$ev\" ]; then rc=99; else bash -c \"$ev\" > .objective/evidence-$n.log 2>&1; rc=$?; fi; printf '{\"iteration\": %s, \"gate\": \"evidence\", \"dod_exit\": %s, \"delta\": \"%s\"}\n' \"$n\" \"$rc\" \"$delta\" >> .objective/convergence.jsonl; if [ $rc -eq 0 ] && [ \"$delta\" = changed ]; then : > .objective/evidence-pass; printf evidence_ok; else rm -f .objective/evidence-pass; printf evidence_bad; fi; fi"
     ]
 
     // ---------- feedback: teach the NEXT attempt ----------------------------
@@ -299,6 +333,11 @@ digraph ObjectiveRunner {
     preflight -> escalated [condition="outcome=fail",                                    label="blocked -- refuse before spending an LLM"]
 
     frame -> triage_gate
+    // The same rule this graph's own contract gate enforces on generated
+    // children (C7): every box node needs a real failure route. `frame` retries
+    // its must_write violation first; a hard FAIL after that lands here rather
+    // than running the pipeline off the rim.
+    frame -> postmortem [condition="outcome=fail", label="hard failure"]
 
     // Intake routing. Every token edge carries the stale-label conjunction
     // because triage_gate also has an outcome=fail edge.
@@ -351,7 +390,7 @@ digraph ObjectiveRunner {
     evidence_gate -> approve    [condition="context.tool.last_line=evidence_ok && outcome=success",   label="evidence holds"]
     evidence_gate -> feedback   [condition="context.tool.last_line=evidence_bad && outcome=success",  label="not satisfied -- iterate"]
     evidence_gate -> postmortem [condition="context.tool.last_line=exhausted && outcome=success",     label="budget spent -- decision point"]
-    evidence_gate -> postmortem [condition="outcome=fail",                                            label="gate could not run"]
+    evidence_gate -> postmortem [condition="outcome=fail",                                            label="gate could not run, or the pinned check was altered"]
 
     // Corrective re-entry: back through the gate that owns the route, so the
     // same shape runs again in a fresh context with the feedback file as its

--- a/examples/objective/triage-schema.json
+++ b/examples/objective/triage-schema.json
@@ -1,0 +1,71 @@
+{
+  "title": "objective-runner triage record",
+  "description": "The intake contract for examples/objective/objective-runner.dot. The `frame` node (an LLM worker) PROPOSES a triage record at .objective/triage.json; `triage_gate` (a code-tier node running validate_triage.py) ADMITS it. Routing happens on the admitted record -- never on the worker's self-report -- because verification inside the context that produced the evidence is not verification (docs/PIPELINE_DESIGN_PRINCIPLES.md section 0).",
+  "schema_dialect": "A deliberately small subset of JSON Schema: type, required, properties, enum, min_length. validate_triage.py implements exactly this subset with the standard library and nothing else -- no jsonschema dependency, so the gate runs anywhere python3 does.",
+  "type": "object",
+  "required": ["shape", "three_question", "evidence_command", "rationale"],
+  "properties": {
+    "shape": {
+      "type": "string",
+      "description": "The routing token. Single lowercase words, because condition matching is exact string equality (docs/ROUTING-REFERENCE.md section 3).",
+      "enum": [
+        "bugfix",
+        "feature",
+        "refactor",
+        "testgen",
+        "review",
+        "compose",
+        "redirect"
+      ]
+    },
+    "three_question": {
+      "type": "object",
+      "description": "The repo's own three-question test (docs/PIPELINE_DESIGN_PRINCIPLES.md section 0) applied PROSPECTIVELY to the stated objective. Each answer must begin with a bare yes or no so the diagnosis is machine-auditable, then say why.",
+      "required": ["cycle", "evidence_gate", "bad_day"],
+      "properties": {
+        "cycle": {
+          "type": "string",
+          "description": "Q1 -- Is there a cycle? Is there work that can be attempted, checked by machine, and re-attempted?",
+          "min_length": 4
+        },
+        "evidence_gate": {
+          "type": "string",
+          "description": "Q2 -- Is the exit gated on machine-checkable evidence external to the worker, rather than on step completion?",
+          "min_length": 4
+        },
+        "bad_day": {
+          "type": "string",
+          "description": "Q3 -- Would it still land if any one LLM node had a bad day -- a single response that is plausible but wrong?",
+          "min_length": 4
+        }
+      }
+    },
+    "evidence_command": {
+      "type": "string",
+      "description": "A shell command that exits 0 if and only if the objective is satisfied, or the literal string NONE. This is the definition of done that the parent's evidence_gate RE-RUNS itself after the child pipeline finishes -- the child's own green is necessary, never sufficient.",
+      "min_length": 1
+    },
+    "rationale": {
+      "type": "string",
+      "description": "Why this shape, in the frame node's own words. Read by a human when a run is surprising.",
+      "min_length": 10
+    }
+  },
+  "cross_field_rules": [
+    {
+      "id": "CF-1",
+      "rule": "shape != redirect implies evidence_command != NONE",
+      "why": "No attractor without machine evidence. A lane or composed child whose definition of done is NONE has nothing for the evidence gate to re-run, so its exit would rest on an LLM's opinion of its own work -- the exact shape the redirect disposition exists to name honestly."
+    },
+    {
+      "id": "CF-2",
+      "rule": "shape == compose implies evidence_command == bash .objective/gen/dod.sh",
+      "why": "The composed child's definition of done lives at a fixed path so the parent's evidence gate can re-run it without trusting anything the composer wrote about itself. See compose-contract.md."
+    },
+    {
+      "id": "CF-3",
+      "rule": "each three_question answer starts with yes or no (case-insensitive)",
+      "why": "Keeps the diagnosis machine-auditable as well as readable; redirect.md quotes these answers verbatim."
+    }
+  ]
+}

--- a/examples/objective/validate_triage.py
+++ b/examples/objective/validate_triage.py
@@ -29,6 +29,14 @@ Side effects on an admitted record, all under ``--state-dir``:
   shape              the admitted token (audit trail)
   evidence-command   the definition-of-done command text, for the evidence gate
                      to re-run itself (absent for the redirect shape)
+  evidence-command.sha256
+                     the sha-pin of the file above, recorded at the moment it was
+                     admitted. ``evidence_gate`` re-hashes before re-running, so a
+                     child that overwrites the evidence command mid-run is caught
+                     rather than obeyed. Anti-accident, not anti-adversary: the
+                     workspace is child-writable, so a determined child could
+                     update the pin too (see compose-contract.md, "The pin, and
+                     what it is not").
   triage-report.txt  human-readable admission report (written on every run)
 
 Usage:
@@ -41,6 +49,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import sys
 from pathlib import Path
@@ -264,11 +273,19 @@ def main(argv: list[str] | None = None) -> int:
 
     (state_dir / "shape").write_text(shape + "\n", encoding="utf-8")
     evidence_path = state_dir / "evidence-command"
+    pin_path = state_dir / "evidence-command.sha256"
     if shape == "redirect":
         # Nothing for the evidence gate to re-run: the deliverable is the diagnosis.
         evidence_path.unlink(missing_ok=True)
+        pin_path.unlink(missing_ok=True)
     else:
         evidence_path.write_text(evidence_command + "\n", encoding="utf-8")
+        # Pin the bytes we just published. The evidence gate re-hashes this file
+        # before it re-runs the command, so "the check triage admitted" and "the
+        # check the parent ran" are the same question.
+        pin_path.write_text(
+            hashlib.sha256(evidence_path.read_bytes()).hexdigest() + "\n", encoding="utf-8"
+        )
 
     report = [
         "TRIAGE ADMITTED",

--- a/examples/objective/validate_triage.py
+++ b/examples/objective/validate_triage.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""Admit or reject the intake triage record for objective-runner.dot.
+
+This is the code half of the objective layer's first routing decision. The
+``frame`` node (an LLM worker) writes ``.objective/triage.json``; this script --
+run by the ``triage_gate`` parallelogram node, outside the worker's context --
+validates it against ``triage-schema.json`` and prints exactly ONE routing token
+on stdout.
+
+Why routing runs on a validated artifact rather than on the worker's own
+``report_outcome`` / ``preferred_label``: verification inside the context that
+produced the evidence is not verification (docs/PIPELINE_DESIGN_PRINCIPLES.md
+section 0). The worker proposes; this gate admits.
+
+Token contract (Idiom A -- always exit 0 so ``tool.last_line`` is always fresh):
+
+  bugfix | feature | refactor | testgen | review | compose | redirect
+                          the admitted shape; route to that lane / path
+  triage_bad              the record is missing or malformed; re-frame
+  triage_exhausted        too many malformed records; stop re-framing
+
+A nonzero exit means this gate could not run at all (schema unreadable, state
+directory unwritable). That is a genuine tool failure and the graph routes it to
+the postmortem path via ``outcome=fail`` -- deliberately distinct from
+``triage_bad``, which is a *judgement* about the record.
+
+Side effects on an admitted record, all under ``--state-dir``:
+
+  shape              the admitted token (audit trail)
+  evidence-command   the definition-of-done command text, for the evidence gate
+                     to re-run itself (absent for the redirect shape)
+  triage-report.txt  human-readable admission report (written on every run)
+
+Usage:
+    validate_triage.py --triage .objective/triage.json \\
+                       --schema /abs/path/to/triage-schema.json \\
+                       --state-dir .objective \\
+                       --max-frames 2
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+COMPOSE_DOD_COMMAND = "bash .objective/gen/dod.sh"
+
+
+# ---------------------------------------------------------------------------
+# The JSON Schema subset (see triage-schema.json's `schema_dialect` field)
+# ---------------------------------------------------------------------------
+
+
+def _type_name(value: Any) -> str:
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, str):
+        return "string"
+    if isinstance(value, dict):
+        return "object"
+    if isinstance(value, list):
+        return "array"
+    if isinstance(value, (int, float)):
+        return "number"
+    if value is None:
+        return "null"
+    return type(value).__name__
+
+
+def validate_against_schema(instance: Any, schema: dict[str, Any], path: str = "") -> list[str]:
+    """Validate ``instance`` against the supported schema subset.
+
+    Supports exactly: ``type`` (object/string), ``required``, ``properties``,
+    ``enum``, ``min_length``. Anything else in the schema document is treated as
+    documentation and ignored -- deliberately, so the schema file can carry prose
+    for humans without the validator pretending to enforce it.
+    """
+    errors: list[str] = []
+    where = path or "<root>"
+
+    expected_type = schema.get("type")
+    if expected_type and _type_name(instance) != expected_type:
+        return [f"{where}: expected type {expected_type}, got {_type_name(instance)}"]
+
+    if expected_type == "object":
+        assert isinstance(instance, dict)
+        for key in schema.get("required", []):
+            if key not in instance:
+                errors.append(f"{where}: missing required field '{key}'")
+        for key, subschema in schema.get("properties", {}).items():
+            if key in instance:
+                child = f"{path}.{key}" if path else key
+                errors.extend(validate_against_schema(instance[key], subschema, child))
+
+    if expected_type == "string":
+        assert isinstance(instance, str)
+        enum = schema.get("enum")
+        if enum is not None and instance not in enum:
+            errors.append(f"{where}: '{instance}' is not one of {enum}")
+        min_length = schema.get("min_length")
+        if min_length is not None and len(instance.strip()) < min_length:
+            errors.append(
+                f"{where}: string is shorter than min_length {min_length} "
+                f"(got {len(instance.strip())})"
+            )
+
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# Cross-field rules (triage-schema.json `cross_field_rules`)
+# ---------------------------------------------------------------------------
+
+
+def check_cross_field_rules(record: dict[str, Any]) -> list[str]:
+    """Apply the rules a per-field schema cannot express."""
+    errors: list[str] = []
+    shape = record.get("shape")
+    evidence_command = record.get("evidence_command")
+
+    # CF-1: no attractor without machine evidence.
+    if (
+        isinstance(shape, str)
+        and shape != "redirect"
+        and isinstance(evidence_command, str)
+        and evidence_command.strip() == "NONE"
+    ):
+        errors.append(
+            "CF-1: shape is '"
+            + shape
+            + "' but evidence_command is NONE. An objective with no machine-checkable "
+            "definition of done cannot be gated on evidence -- the honest shape is "
+            "'redirect'."
+        )
+
+    # CF-2: the composed child's DoD lives at a fixed path.
+    if (
+        shape == "compose"
+        and isinstance(evidence_command, str)
+        and evidence_command.strip() != COMPOSE_DOD_COMMAND
+    ):
+        errors.append(
+            "CF-2: shape is 'compose' so evidence_command must be exactly "
+            f"'{COMPOSE_DOD_COMMAND}' (got '{evidence_command.strip()}'). The parent "
+            "evidence gate re-runs the DoD from a fixed path so it never has to trust "
+            "what the composer wrote about itself."
+        )
+
+    # CF-3: the three-question answers must be machine-auditable.
+    three_question = record.get("three_question")
+    if isinstance(three_question, dict):
+        for key in ("cycle", "evidence_gate", "bad_day"):
+            answer = three_question.get(key)
+            if not isinstance(answer, str):
+                continue
+            first = answer.strip().lower().lstrip("*_` ")
+            if not first.startswith(("yes", "no")):
+                errors.append(
+                    f"CF-3: three_question.{key} must begin with 'yes' or 'no' "
+                    f"(got: {answer.strip()[:60]!r})"
+                )
+
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# Fuse -- bounded re-framing
+# ---------------------------------------------------------------------------
+
+
+def bump_frame_counter(state_dir: Path) -> int:
+    counter = state_dir / "frame-iter"
+    try:
+        current = int(counter.read_text(encoding="utf-8").strip())
+    except (OSError, ValueError):
+        current = 0
+    current += 1
+    counter.write_text(f"{current}\n", encoding="utf-8")
+    return current
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__, add_help=True)
+    parser.add_argument("--triage", required=True, help="path to the triage record JSON")
+    parser.add_argument("--schema", required=True, help="path to triage-schema.json")
+    parser.add_argument(
+        "--state-dir",
+        default=".objective",
+        help="directory for the gate's own bookkeeping (default: .objective)",
+    )
+    parser.add_argument(
+        "--max-frames",
+        type=int,
+        default=2,
+        help="how many malformed records to tolerate before giving up (default: 2)",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    # --- things that make this gate UNABLE to run: exit nonzero, print nothing.
+    try:
+        schema = json.loads(Path(args.schema).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"validate_triage: cannot read schema {args.schema}: {exc}", file=sys.stderr)
+        return 2
+
+    state_dir = Path(args.state_dir)
+    try:
+        state_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        print(f"validate_triage: cannot create state dir {state_dir}: {exc}", file=sys.stderr)
+        return 2
+
+    report_path = state_dir / "triage-report.txt"
+
+    # --- things that make the RECORD bad: exit 0, print a judgement token.
+    errors: list[str] = []
+    record: Any = None
+    triage_path = Path(args.triage)
+    try:
+        record = json.loads(triage_path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        errors.append(f"{triage_path}: file not found -- the frame node wrote no triage record")
+    except OSError as exc:
+        errors.append(f"{triage_path}: unreadable: {exc}")
+    except json.JSONDecodeError as exc:
+        errors.append(f"{triage_path}: not valid JSON: {exc}")
+
+    if not errors:
+        errors.extend(validate_against_schema(record, schema))
+    if not errors and isinstance(record, dict):
+        errors.extend(check_cross_field_rules(record))
+
+    if errors:
+        attempt = bump_frame_counter(state_dir)
+        token = "triage_bad" if attempt <= args.max_frames else "triage_exhausted"
+        report = [
+            "TRIAGE REJECTED",
+            f"record:   {triage_path}",
+            f"attempt:  {attempt} of {args.max_frames} permitted",
+            f"verdict:  {token}",
+            "",
+            "Findings (fix these and rewrite the record):",
+            *(f"  - {e}" for e in errors),
+        ]
+        report_path.write_text("\n".join(report) + "\n", encoding="utf-8")
+        print(token, end="")
+        return 0
+
+    assert isinstance(record, dict)
+    shape = str(record["shape"])
+    evidence_command = str(record["evidence_command"]).strip()
+
+    (state_dir / "shape").write_text(shape + "\n", encoding="utf-8")
+    evidence_path = state_dir / "evidence-command"
+    if shape == "redirect":
+        # Nothing for the evidence gate to re-run: the deliverable is the diagnosis.
+        evidence_path.unlink(missing_ok=True)
+    else:
+        evidence_path.write_text(evidence_command + "\n", encoding="utf-8")
+
+    report = [
+        "TRIAGE ADMITTED",
+        f"record:           {triage_path}",
+        f"shape:            {shape}",
+        f"evidence_command: {evidence_command}",
+        "",
+        "Three-question test (docs/PIPELINE_DESIGN_PRINCIPLES.md section 0):",
+        f"  cycle:         {record['three_question']['cycle']}",
+        f"  evidence_gate: {record['three_question']['evidence_gate']}",
+        f"  bad_day:       {record['three_question']['bad_day']}",
+        "",
+        f"rationale: {record['rationale']}",
+    ]
+    report_path.write_text("\n".join(report) + "\n", encoding="utf-8")
+    print(shape, end="")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - thin CLI wrapper
+    raise SystemExit(main())

--- a/examples/pipelines/practical/README.md
+++ b/examples/pipelines/practical/README.md
@@ -16,6 +16,15 @@ start there). The links below point at the guides.
 | Feature Build | [feature-build.md](feature-build.md) | Parse spec → parallel implement → integration test → human review gate | bring-your-own repo |
 | Multi-Lens Review | [multi-lens-review.md](multi-lens-review.md) | Same code reviewed by 3 providers wearing 3 lenses → synthesized verdict | self-contained |
 
+These five task pipelines (`bug-fix`, `feature-build`, `refactor`, `test-gen`,
+`pr-review`) are also the **lanes** of
+[`examples/objective/`](../../objective/README.md)'s objective runner: state an
+objective, and it triages which of these fits and runs it unmodified as a
+sub-pipeline. What makes them selectable is their walk-up contract — each takes
+`goal` and nothing else, and each carries its own gates, budget, and escalation.
+Keep that contract stable; a lane that starts requiring bespoke params stops
+being routable.
+
 ## Run one walk-up
 
 `bug-fix`, `refactor`, and `test-gen` ship a runnable target in [`sample/`](sample/)

--- a/modules/loop-pipeline/tests/test_objective_layer_gates.py
+++ b/modules/loop-pipeline/tests/test_objective_layer_gates.py
@@ -23,8 +23,12 @@ pattern as ``test_examples_lint_clean.py``.
 
 from __future__ import annotations
 
+import hashlib
 import importlib.util
 import json
+import os
+import shutil
+import subprocess
 import sys
 from pathlib import Path
 from types import ModuleType
@@ -114,19 +118,49 @@ def triage() -> ModuleType:
     return _load("validate_triage.py")
 
 
-def _write_child(tmp_path: Path, dot_text: str, *, with_dod: bool = True) -> tuple[Path, Path]:
+#: A definition of done that is genuinely RED before the work exists: the
+#: sentinel is absent, so ``test -f`` exits 1.  C9 executes the DoD at admission
+#: and requires exactly that, so every conforming fixture has to be honestly red
+#: rather than merely plausible-looking.
+_RED_DOD = "#!/usr/bin/env bash\n# red until the work lands\ntest -f {sentinel}\n"
+
+#: The vacuous DoD from the adversarial review: structurally perfect, and a lie.
+_VACUOUS_DOD = "#!/usr/bin/env bash\nexit 0\n"
+
+#: Nonzero, but not a red check -- a script that could not run at all.
+_BROKEN_DOD = "#!/usr/bin/env bash\nthis-command-does-not-exist\n"
+
+
+def _write_child(
+    tmp_path: Path,
+    dot_text: str,
+    *,
+    with_dod: bool = True,
+    dod_body: str | None = None,
+) -> tuple[Path, Path]:
     gen = tmp_path / ".objective" / "gen"
     gen.mkdir(parents=True, exist_ok=True)
     child = gen / "child.dot"
     child.write_text(dot_text, encoding="utf-8")
     dod = gen / "dod.sh"
     if with_dod:
-        dod.write_text("#!/usr/bin/env bash\npython3 tools/check.py\n", encoding="utf-8")
+        body = dod_body or _RED_DOD.format(sentinel=tmp_path / "work-landed")
+        dod.write_text(body, encoding="utf-8")
     return child, dod
 
 
-def _run_contract(contract: ModuleType, child: Path, dod: Path, report: Path) -> tuple[int, str]:
-    rc = contract.main(["--child", str(child), "--dod", str(dod), "--report", str(report)])
+def _run_contract(
+    contract: ModuleType,
+    child: Path,
+    dod: Path,
+    report: Path,
+    pin: Path | None = None,
+) -> tuple[int, str]:
+    argv = ["--child", str(child), "--dod", str(dod), "--report", str(report)]
+    # Always pin somewhere hermetic: the default is workspace-relative, and a
+    # test must never write into the repo it is run from.
+    argv += ["--pin", str(pin or report.parent / "dod.sha256")]
+    rc = contract.main(argv)
     return rc, report.read_text(encoding="utf-8")
 
 
@@ -253,6 +287,298 @@ def test_minimal_parser_agrees_with_the_engine_on_shipped_graphs(contract, shipp
 
     assert set(mini_graph.nodes) == set(engine_graph.nodes)
     assert len(mini_graph.edges) == len(engine_graph.edges)
+
+
+# ---------------------------------------------------------------------------
+# C9 -- the DoD must be RED before the work exists
+#
+# The adversarial review on PR #232 verified the hole this closes: the rule used
+# to live only in the composer's prompt (`objective-runner.dot`'s compose node,
+# `compose-contract.md`), and a prompt instruction is a suggestion.  A composer
+# writing `exit 0` passed C1-C8, its child converged on the first attempt, and
+# the parent's evidence gate re-ran the same vacuous script and agreed:
+# `rc=0 && delta=changed` is `evidence_ok`.  A false green, in 2.4 hours, with
+# zero work product -- the exact incident shape the exemplar exists to prevent.
+# ---------------------------------------------------------------------------
+
+
+def test_c9_blocks_a_vacuous_dod(contract, tmp_path, capsys):
+    """`exit 0` before the work exists is not a definition of done."""
+    child, dod = _write_child(tmp_path, _GOOD_CHILD, dod_body=_VACUOUS_DOD)
+    report = tmp_path / "contract-report.txt"
+    rc, text = _run_contract(contract, child, dod, report)
+
+    assert rc == 0
+    assert capsys.readouterr().out == "contract_bad"
+    failed = {line.split()[1] for line in text.splitlines() if line.startswith("[FAIL]")}
+    # C9 alone -- every structural check still passes, which is precisely why
+    # C9 had to exist: nothing about the graph was wrong.
+    assert failed == {"C9"}, text
+    assert "exited 0 BEFORE any work was done" in text
+
+
+def test_c9_admits_a_genuinely_red_dod(contract, tmp_path, capsys):
+    """The conforming fixture's DoD exits 1, and C9 says so explicitly."""
+    child, dod = _write_child(tmp_path, _GOOD_CHILD)
+    report = tmp_path / "contract-report.txt"
+    rc, text = _run_contract(contract, child, dod, report)
+
+    assert rc == 0
+    assert capsys.readouterr().out == "contract_ok"
+    assert "[PASS] C9" in text
+    assert "exited 1 before the work exists" in text
+
+
+def test_c9_names_a_broken_dod_separately_from_a_green_one(contract, tmp_path, capsys):
+    """rc>=2 is a script that could not run, not a red check -- say which.
+
+    Conflating the two would teach the composer that shipping a crash is an
+    acceptable definition of done, because a crash is also "nonzero".
+    """
+    child, dod = _write_child(tmp_path, _GOOD_CHILD, dod_body=_BROKEN_DOD)
+    report = tmp_path / "contract-report.txt"
+    rc, text = _run_contract(contract, child, dod, report)
+
+    assert rc == 0
+    assert capsys.readouterr().out == "contract_bad"
+    assert "[FAIL] C9" in text
+    assert "BROKEN script, not a red check" in text
+    assert "exited 0 BEFORE" not in text
+
+
+def test_c9_names_a_dod_that_never_terminates(contract, tmp_path, capsys):
+    """The DoD is re-run at least three times per iteration; it must finish."""
+    child, dod = _write_child(
+        tmp_path, _GOOD_CHILD, dod_body="#!/usr/bin/env bash\nsleep 30\n"
+    )
+    report = tmp_path / "contract-report.txt"
+    rc = contract.main(
+        [
+            "--child", str(child),
+            "--dod", str(dod),
+            "--report", str(report),
+            "--pin", str(tmp_path / "dod.sha256"),
+            "--dod-timeout", "1",
+        ]
+    )
+    text = report.read_text(encoding="utf-8")
+
+    assert rc == 0
+    assert capsys.readouterr().out == "contract_bad"
+    assert "did not finish within 1s" in text
+
+
+def test_c9_is_not_reported_when_there_is_no_dod_to_run(contract, tmp_path, capsys):
+    """A missing DoD is C0b's judgement; running nothing would prove nothing."""
+    child, dod = _write_child(tmp_path, _GOOD_CHILD, with_dod=False)
+    report = tmp_path / "contract-report.txt"
+    rc, text = _run_contract(contract, child, dod, report)
+
+    assert rc == 0
+    assert capsys.readouterr().out == "contract_bad"
+    assert "C0b" in text
+    assert "C9" not in text
+
+
+# ---------------------------------------------------------------------------
+# The sha-pin -- "the DoD I admitted" vs "the DoD that got re-run"
+# ---------------------------------------------------------------------------
+
+
+def test_admission_pins_the_dod_and_rejection_leaves_no_pin(contract, tmp_path, capsys):
+    """The pin records exactly the bytes that passed C9, and only those."""
+    child, dod = _write_child(tmp_path, _GOOD_CHILD)
+    report = tmp_path / "contract-report.txt"
+    pin = tmp_path / "dod.sha256"
+
+    _run_contract(contract, child, dod, report, pin)
+    assert capsys.readouterr().out == "contract_ok"
+    expected = hashlib.sha256(dod.read_bytes()).hexdigest()
+    assert pin.read_text(encoding="utf-8").strip() == expected
+
+    # A rejected child must not leave a pin behind for a later run to match.
+    dod.write_text(_VACUOUS_DOD, encoding="utf-8")
+    _run_contract(contract, child, dod, report, pin)
+    assert capsys.readouterr().out == "contract_bad"
+    assert not pin.exists()
+
+
+def test_the_pin_matches_what_sha256sum_prints(contract, tmp_path, capsys):
+    """The graph compares this pin using shell `sha256sum`; the two must agree."""
+    child, dod = _write_child(tmp_path, _GOOD_CHILD)
+    report = tmp_path / "contract-report.txt"
+    pin = tmp_path / "dod.sha256"
+    _run_contract(contract, child, dod, report, pin)
+    assert capsys.readouterr().out == "contract_ok"
+
+    shell = subprocess.run(
+        ["sha256sum", str(dod)], capture_output=True, text=True, check=True
+    ).stdout.split()[0]
+    assert pin.read_text(encoding="utf-8").strip() == shell
+
+
+def test_triage_pins_the_evidence_command_it_published(triage, tmp_path, capsys):
+    """Lane runs get the same protection: the gate pins what it published."""
+    _run_triage(triage, tmp_path, _VALID_TRIAGE)
+    assert capsys.readouterr().out == "bugfix"
+    state = tmp_path / ".objective"
+    published = state / "evidence-command"
+    pin = state / "evidence-command.sha256"
+    assert pin.read_text(encoding="utf-8").strip() == hashlib.sha256(
+        published.read_bytes()
+    ).hexdigest()
+
+
+def test_triage_redirect_clears_the_evidence_command_pin(triage, tmp_path, capsys):
+    """No command to re-run means no pin left lying around to match against."""
+    _run_triage(triage, tmp_path, _VALID_TRIAGE)
+    capsys.readouterr()
+    assert (tmp_path / ".objective" / "evidence-command.sha256").exists()
+
+    _run_triage(triage, tmp_path, dict(_VALID_TRIAGE, shape="redirect", evidence_command="NONE"))
+    assert capsys.readouterr().out == "redirect"
+    assert not (tmp_path / ".objective" / "evidence-command.sha256").exists()
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: the REAL tool_command text, taken from the graph the engine runs
+#
+# These drive the shell the pipeline actually executes -- extracted from
+# objective-runner.dot by the engine's own parser -- rather than a paraphrase of
+# it.  A fix that only holds in a hand-written approximation of the gate is not
+# a fix.
+# ---------------------------------------------------------------------------
+
+_SHELL_GATES = pytest.mark.skipif(
+    not (shutil.which("bash") and shutil.which("sha256sum")),
+    reason="the shipped gate commands need bash and sha256sum",
+)
+
+
+def _tool_command(node_id: str) -> str:
+    """The verbatim tool_command of a node, read through the engine's parser."""
+    from amplifier_module_loop_pipeline.dot_parser import parse_dot
+
+    graph = parse_dot(
+        (_OBJECTIVE_DIR / "objective-runner.dot").read_text(encoding="utf-8")
+    )
+    return graph.nodes[node_id].attrs["tool_command"]
+
+
+def _objective_workspace(tmp_path: Path, dod_body: str) -> Path:
+    """A workspace at the point `contract_gate` is about to run on a compose route."""
+    (tmp_path / ".objective" / "gen").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "src").mkdir(exist_ok=True)
+    (tmp_path / "src" / "app.py").write_text("def f(): pass\n", encoding="utf-8")
+    # preflight's anchor, over the workspace as it was before any work.
+    subprocess.run(
+        "find . -name .git -prune -o -name .objective -prune -o -type f -exec md5sum {} + "
+        "2>/dev/null | LC_ALL=C sort | md5sum | cut -d' ' -f1 > .objective/anchor",
+        shell=True, cwd=tmp_path, check=True,
+    )
+    # triage_gate admitted a compose shape (CF-2 pins this exact command).
+    (tmp_path / ".objective" / "evidence-command").write_text(
+        "bash .objective/gen/dod.sh\n", encoding="utf-8"
+    )
+    (tmp_path / ".objective" / "gen" / "child.dot").write_text(_GOOD_CHILD, encoding="utf-8")
+    (tmp_path / ".objective" / "gen" / "dod.sh").write_text(dod_body, encoding="utf-8")
+    return tmp_path
+
+
+def _run_gate(node_id: str, workspace: Path) -> subprocess.CompletedProcess[str]:
+    env = {
+        **os.environ,
+        "runner_dir": str(_OBJECTIVE_DIR),
+        "target_dir": str(workspace),
+        "max_iterations": "3",
+    }
+    return subprocess.run(
+        _tool_command(node_id),
+        shell=True, cwd=workspace, env=env, capture_output=True, text=True, check=False,
+    )
+
+
+@_SHELL_GATES
+def test_real_contract_gate_command_blocks_the_vacuous_dod(tmp_path):
+    """The review's exact scenario, through the shell the pipeline really runs.
+
+    Before C9 this printed `contract_ok`, `run_child` ran a child that converged
+    instantly, and `evidence_gate` returned `evidence_ok`.
+    """
+    workspace = _objective_workspace(tmp_path, _VACUOUS_DOD)
+    result = _run_gate("contract_gate", workspace)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "contract_bad"
+    # contract_bad routes back to `compose`; `run_child` is never reached, so
+    # the vacuous DoD never gets to be re-run by the evidence gate at all.
+    assert not (workspace / ".objective" / "dod.sha256").exists()
+    assert "[FAIL] C9" in (workspace / ".objective" / "contract-report.txt").read_text(
+        encoding="utf-8"
+    )
+
+
+@_SHELL_GATES
+def test_real_evidence_gate_command_refuses_a_dod_rewritten_after_admission(tmp_path):
+    """The rewrite-after-admission dodge, closed by the pin.
+
+    An honestly-red DoD is admitted; the child then overwrites it with `exit 0`
+    and touches a file, which used to be enough for `rc=0 && delta=changed`.
+    """
+    red = "#!/usr/bin/env bash\ngrep -q MARKER_WORK_LANDED src/app.py\n"
+    workspace = _objective_workspace(tmp_path, red)
+
+    admitted = _run_gate("contract_gate", workspace)
+    assert admitted.stdout == "contract_ok", admitted.stderr
+    assert (workspace / ".objective" / "dod.sha256").is_file()
+
+    # The child does not do the work. It rewrites the check instead.
+    (workspace / ".objective" / "gen" / "dod.sh").write_text(_VACUOUS_DOD, encoding="utf-8")
+    (workspace / "src" / "app.py").write_text("def f(): pass\n# touched\n", encoding="utf-8")
+
+    result = _run_gate("evidence_gate", workspace)
+
+    assert result.returncode != 0, "a tampered pin must be a LOUD nonzero, not a token"
+    assert result.stdout == "tampered"
+    assert ".objective/gen/dod.sh was altered after contract_gate admitted it" in result.stderr
+    # Nonzero means tool.last_line is NOT refreshed, so every `&& outcome=success`
+    # edge is dead and only `outcome=fail -> postmortem` can match.
+    assert not (workspace / ".objective" / "evidence-pass").exists()
+
+
+@_SHELL_GATES
+def test_real_evidence_gate_command_refuses_a_rewritten_evidence_command(tmp_path):
+    """Same close, on the lane route: the evidence command is pinned too."""
+    workspace = _objective_workspace(tmp_path, "#!/usr/bin/env bash\nexit 1\n")
+    pin = hashlib.sha256(
+        (workspace / ".objective" / "evidence-command").read_bytes()
+    ).hexdigest()
+    (workspace / ".objective" / "evidence-command.sha256").write_text(
+        pin + "\n", encoding="utf-8"
+    )
+
+    # A lane child overwrites what the parent is about to re-run.
+    (workspace / ".objective" / "evidence-command").write_text("true\n", encoding="utf-8")
+    result = _run_gate("evidence_gate", workspace)
+
+    assert result.returncode != 0
+    assert result.stdout == "tampered"
+    assert ".objective/evidence-command was altered after triage_gate admitted it" in result.stderr
+
+
+@_SHELL_GATES
+def test_real_evidence_gate_command_still_passes_an_untampered_run(tmp_path):
+    """The pin must not break the honest path -- a negative control for the guard."""
+    workspace = _objective_workspace(tmp_path, "#!/usr/bin/env bash\ntest -f DONE\n")
+    assert _run_gate("contract_gate", workspace).stdout == "contract_ok"
+
+    # The child does the work the DoD asks for, and touches nothing else.
+    (workspace / "DONE").write_text("", encoding="utf-8")
+    result = _run_gate("evidence_gate", workspace)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "evidence_ok"
+    assert (workspace / ".objective" / "evidence-pass").exists()
 
 
 # ---------------------------------------------------------------------------

--- a/modules/loop-pipeline/tests/test_objective_layer_gates.py
+++ b/modules/loop-pipeline/tests/test_objective_layer_gates.py
@@ -1,0 +1,386 @@
+"""Guards for the objective-layer exemplar's two gate scripts.
+
+`examples/objective/objective-runner.dot` routes on machine artifacts rather
+than on any worker's self-report, which means two small stdlib scripts carry
+real authority:
+
+  * ``validate_triage.py``     -- admits or rejects the intake record, and is
+                                 the thing that decides the run's first route.
+  * ``check_child_contract.py`` -- the structural gate on a GENERATED child
+                                 pipeline, enforcing the shape checks
+                                 ``attractor lint`` deliberately does not own.
+
+Both are gates, so both must **fail closed**: a missing file, an unreadable
+file, or a graph neither tool understands has to produce the rejecting token,
+never the admitting one, and never a traceback (a crashing gate is a nonzero
+exit, which routes to the postmortem path rather than admitting the artifact).
+
+The examples tree lives at the repository root, outside the installed package,
+so these tests run against a source checkout and skip gracefully when the
+examples directory is absent (e.g. an installed-package test run) -- the same
+pattern as ``test_examples_lint_clean.py``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_OBJECTIVE_DIR = _REPO_ROOT / "examples" / "objective"
+
+pytestmark = pytest.mark.skipif(
+    not _OBJECTIVE_DIR.is_dir(),
+    reason="examples/objective/ not present (installed-package run)",
+)
+
+
+def _load(script_name: str) -> ModuleType:
+    """Import a script from examples/objective/ by path, without polluting sys.path."""
+    path = _OBJECTIVE_DIR / script_name
+    spec = importlib.util.spec_from_file_location(f"_objective_{path.stem}", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: a child that satisfies the contract, and ways of breaking it
+# ---------------------------------------------------------------------------
+
+_GOOD_CHILD = """
+// A generated child that satisfies the composed-child contract.
+digraph ComposedChild {
+    graph [goal="$goal", default_max_retries=2]
+
+    start [shape=Mdiamond]
+    done  [shape=Msquare]
+
+    work [shape=box,
+          prompt="Advance this objective: $goal. Read .objective/gen/feedback.md if present."]
+
+    dod_gate [shape=parallelogram, max_retries=0, goal_gate=true, retry_target="work",
+        tool_command="mi=$max_iterations; B=${mi:-6}; n=$(($(cat .objective/gen/iter 2>/dev/null || echo 0)+1)); echo $n > .objective/gen/iter; if [ \\"$n\\" -gt \\"$B\\" ]; then printf exhausted; else bash .objective/gen/dod.sh > .objective/gen/dod.log 2>&1 && printf green || printf red; fi"]
+
+    critique [shape=box, prompt="Write .objective/gen/feedback.md from .objective/gen/dod.log."]
+
+    postmortem [shape=box, prompt="Write .objective/gen/postmortem.md."]
+
+    escalated [shape=parallelogram, max_retries=0, tool_command="printf escalated; exit 1"]
+
+    start -> work -> dod_gate
+    dod_gate -> done       [condition="context.tool.last_line=green && outcome=success"]
+    dod_gate -> critique   [condition="context.tool.last_line=red && outcome=success"]
+    dod_gate -> postmortem [condition="context.tool.last_line=exhausted && outcome=success"]
+    dod_gate -> postmortem [condition="outcome=fail"]
+    critique -> work       [loop_restart="true"]
+    work       -> postmortem [condition="outcome=fail"]
+    critique   -> postmortem [condition="outcome=fail"]
+    postmortem -> escalated  [condition="outcome=fail"]
+    postmortem -> escalated
+}
+"""
+
+# Lint-clean enough to pass `attractor lint` with warnings only, and still not an
+# attractor: acyclic, the gate is colocated inside the worker, no budget wall, no
+# fail-loud terminal, no failure route.  This is the case that justifies shipping
+# a contract checker in addition to the linter.
+_BROKEN_CHILD = """
+digraph BrokenChild {
+    graph [goal="$goal"]
+    start [shape=Mdiamond]
+    done  [shape=Msquare]
+    work  [shape=box, goal_gate=true,
+           prompt="Do the work for $goal and decide for yourself when it is done."]
+    start -> work -> done
+}
+"""
+
+
+@pytest.fixture(scope="module")
+def contract() -> ModuleType:
+    return _load("check_child_contract.py")
+
+
+@pytest.fixture(scope="module")
+def triage() -> ModuleType:
+    return _load("validate_triage.py")
+
+
+def _write_child(tmp_path: Path, dot_text: str, *, with_dod: bool = True) -> tuple[Path, Path]:
+    gen = tmp_path / ".objective" / "gen"
+    gen.mkdir(parents=True, exist_ok=True)
+    child = gen / "child.dot"
+    child.write_text(dot_text, encoding="utf-8")
+    dod = gen / "dod.sh"
+    if with_dod:
+        dod.write_text("#!/usr/bin/env bash\npython3 tools/check.py\n", encoding="utf-8")
+    return child, dod
+
+
+def _run_contract(contract: ModuleType, child: Path, dod: Path, report: Path) -> tuple[int, str]:
+    rc = contract.main(["--child", str(child), "--dod", str(dod), "--report", str(report)])
+    return rc, report.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# check_child_contract.py
+# ---------------------------------------------------------------------------
+
+
+def test_contract_admits_a_conforming_child(contract, tmp_path, capsys):
+    child, dod = _write_child(tmp_path, _GOOD_CHILD)
+    report = tmp_path / "contract-report.txt"
+    rc, text = _run_contract(contract, child, dod, report)
+
+    assert rc == 0
+    assert capsys.readouterr().out == "contract_ok"
+    assert "verdict: contract_ok" in text
+    assert "[FAIL]" not in text
+
+
+def test_contract_blocks_a_child_that_is_not_an_attractor(contract, tmp_path, capsys):
+    """The eight checks must each be load-bearing, not decorative."""
+    child, dod = _write_child(tmp_path, _BROKEN_CHILD)
+    report = tmp_path / "contract-report.txt"
+    rc, text = _run_contract(contract, child, dod, report)
+
+    assert rc == 0
+    assert capsys.readouterr().out == "contract_bad"
+    failed = {line.split()[1] for line in text.splitlines() if line.startswith("[FAIL]")}
+    # C2 no external DoD gate, C3 goal_gate on the worker, C4 no cycle,
+    # C5 no budget wall, C6 no fail-loud terminal, C7 no failure route.
+    assert {"C2", "C3", "C4", "C5", "C6", "C7"} <= failed
+    # ...and the checks that genuinely hold must still pass, or the report is noise.
+    assert "[PASS] C1" in text
+    assert "[PASS] C8" in text
+
+
+@pytest.mark.parametrize(
+    ("mutation", "expected_fail"),
+    [
+        # C1: a second exit node -- the engine refuses to run this at all.
+        (lambda t: t.replace("start -> work -> dod_gate", "extra [shape=Msquare]\n    start -> work -> dod_gate"), "C1"),
+        # C2: the gate stops running the provided definition of done.
+        (lambda t: t.replace("bash .objective/gen/dod.sh > .objective/gen/dod.log 2>&1", "true"), "C2"),
+        # C4: remove the back-edge -- a straight line is a recipe, not an attractor.
+        (lambda t: t.replace('critique -> work       [loop_restart="true"]', ""), "C4"),
+        # C6: the escalation terminal stops exiting nonzero.
+        (lambda t: t.replace('tool_command="printf escalated; exit 1"', 'tool_command="printf escalated"'), "C6"),
+        # C8: the child no longer consumes the objective.
+        (lambda t: t.replace("$goal", "a fixed task"), "C8"),
+    ],
+    ids=["C1_two_exits", "C2_gate_skips_dod", "C4_no_cycle", "C6_escalation_exits_zero", "C8_ignores_goal"],
+)
+def test_contract_catches_each_single_mutation(contract, tmp_path, capsys, mutation, expected_fail):
+    child, dod = _write_child(tmp_path, mutation(_GOOD_CHILD))
+    report = tmp_path / "contract-report.txt"
+    rc, text = _run_contract(contract, child, dod, report)
+
+    assert rc == 0
+    assert capsys.readouterr().out == "contract_bad"
+    failed = {line.split()[1] for line in text.splitlines() if line.startswith("[FAIL]")}
+    assert expected_fail in failed, text
+
+
+def test_contract_fails_closed_when_the_child_was_never_written(contract, tmp_path, capsys):
+    """Lazy dot_file resolution means 'the composer wrote nothing' is a real case."""
+    _, dod = _write_child(tmp_path, _GOOD_CHILD)
+    missing = tmp_path / ".objective" / "gen" / "nope.dot"
+    report = tmp_path / "contract-report.txt"
+    rc, text = _run_contract(contract, missing, dod, report)
+
+    assert rc == 0
+    assert capsys.readouterr().out == "contract_bad"
+    assert "not found" in text
+
+
+def test_contract_fails_closed_when_the_dod_script_is_missing_or_empty(contract, tmp_path, capsys):
+    child, dod = _write_child(tmp_path, _GOOD_CHILD, with_dod=False)
+    report = tmp_path / "contract-report.txt"
+    rc, text = _run_contract(contract, child, dod, report)
+    assert rc == 0
+    assert capsys.readouterr().out == "contract_bad"
+    assert "C0b" in text
+
+    dod.write_text("", encoding="utf-8")
+    rc, text = _run_contract(contract, child, dod, report)
+    assert rc == 0
+    assert capsys.readouterr().out == "contract_bad"
+    assert "empty" in text
+
+
+def test_contract_fails_closed_on_an_unparseable_child(contract, tmp_path, capsys):
+    """A graph the checker cannot read is rejected, not admitted, and never crashes."""
+    child, dod = _write_child(tmp_path, "this is not a graph at all")
+    report = tmp_path / "contract-report.txt"
+    rc, text = _run_contract(contract, child, dod, report)
+
+    assert rc == 0
+    assert capsys.readouterr().out == "contract_bad"
+    assert "C0" in text
+
+
+@pytest.mark.parametrize(
+    "shipped",
+    [
+        "examples/pipelines/practical/bug-fix.dot",
+        "examples/pipelines/practical/test-gen.dot",
+        "examples/patterns/task-runner.dot",
+        "examples/objective/objective-runner.dot",
+    ],
+)
+def test_minimal_parser_agrees_with_the_engine_on_shipped_graphs(contract, shipped):
+    """The checker ships its own DOT reader; keep it honest against the real one.
+
+    It is stdlib-only so the gate runs under whatever ``python3`` is on PATH in
+    the target workspace (not the ``attractor`` CLI's virtualenv). That freedom
+    is only safe if the two parsers agree on node ids and edge count for the
+    graphs this repo actually ships.
+    """
+    from amplifier_module_loop_pipeline.dot_parser import parse_dot
+
+    text = (_REPO_ROOT / shipped).read_text(encoding="utf-8")
+    engine_graph = parse_dot(text)
+    mini_graph = contract.parse_dot_min(text)
+
+    assert set(mini_graph.nodes) == set(engine_graph.nodes)
+    assert len(mini_graph.edges) == len(engine_graph.edges)
+
+
+# ---------------------------------------------------------------------------
+# validate_triage.py -- the intake gate
+# ---------------------------------------------------------------------------
+
+_VALID_TRIAGE = {
+    "shape": "bugfix",
+    "three_question": {
+        "cycle": "yes -- fix, run the suite, re-fix",
+        "evidence_gate": "yes -- pytest exits 0 only when the regression test passes",
+        "bad_day": "yes -- a plausible-but-wrong fix leaves the test red",
+    },
+    "evidence_command": "pytest -q",
+    "rationale": "A reproducible crash with a failing path maps onto the bug-fix lane.",
+}
+
+
+def _run_triage(triage: ModuleType, tmp_path: Path, record, *, max_frames: int = 2) -> str:
+    state = tmp_path / ".objective"
+    state.mkdir(parents=True, exist_ok=True)
+    path = state / "triage.json"
+    path.write_text(record if isinstance(record, str) else json.dumps(record), encoding="utf-8")
+    rc = triage.main(
+        [
+            "--triage", str(path),
+            "--schema", str(_OBJECTIVE_DIR / "triage-schema.json"),
+            "--state-dir", str(state),
+            "--max-frames", str(max_frames),
+        ]
+    )
+    assert rc == 0
+    return rc
+
+
+def test_triage_admits_a_valid_record_and_publishes_the_evidence_command(triage, tmp_path, capsys):
+    _run_triage(triage, tmp_path, _VALID_TRIAGE)
+    assert capsys.readouterr().out == "bugfix"
+    state = tmp_path / ".objective"
+    assert (state / "shape").read_text(encoding="utf-8").strip() == "bugfix"
+    # The gate -- not the worker -- publishes what the evidence gate will re-run.
+    assert (state / "evidence-command").read_text(encoding="utf-8").strip() == "pytest -q"
+
+
+def test_triage_rejects_a_lane_with_no_machine_evidence(triage, tmp_path, capsys):
+    """CF-1: no attractor without machine evidence. The honest shape is redirect."""
+    record = dict(_VALID_TRIAGE, evidence_command="NONE")
+    _run_triage(triage, tmp_path, record)
+    assert capsys.readouterr().out == "triage_bad"
+    assert "CF-1" in (tmp_path / ".objective" / "triage-report.txt").read_text(encoding="utf-8")
+
+
+def test_triage_pins_the_composed_child_dod_path(triage, tmp_path, capsys):
+    """CF-2: the parent re-runs the DoD from a fixed path, so compose cannot move it."""
+    record = dict(_VALID_TRIAGE, shape="compose", evidence_command="bash somewhere/else.sh")
+    _run_triage(triage, tmp_path, record)
+    assert capsys.readouterr().out == "triage_bad"
+    assert "CF-2" in (tmp_path / ".objective" / "triage-report.txt").read_text(encoding="utf-8")
+
+    ok = dict(_VALID_TRIAGE, shape="compose", evidence_command="bash .objective/gen/dod.sh")
+    _run_triage(triage, tmp_path, ok)
+    assert capsys.readouterr().out == "compose"
+
+
+def test_triage_redirect_publishes_no_evidence_command(triage, tmp_path, capsys):
+    record = dict(_VALID_TRIAGE, shape="redirect", evidence_command="NONE")
+    _run_triage(triage, tmp_path, record)
+    assert capsys.readouterr().out == "redirect"
+    assert not (tmp_path / ".objective" / "evidence-command").exists()
+
+
+@pytest.mark.parametrize(
+    ("record", "reason"),
+    [
+        ({**_VALID_TRIAGE, "shape": "improvise"}, "off-vocabulary shape"),
+        ({k: v for k, v in _VALID_TRIAGE.items() if k != "rationale"}, "missing required field"),
+        ("{ not json", "malformed JSON"),
+        (
+            {**_VALID_TRIAGE, "three_question": {**_VALID_TRIAGE["three_question"], "cycle": "it depends"}},
+            "CF-3: answer does not begin with yes/no",
+        ),
+    ],
+    ids=["bad_shape", "missing_field", "malformed_json", "unanchored_answer"],
+)
+def test_triage_rejects_malformed_records(triage, tmp_path, capsys, record, reason):
+    _run_triage(triage, tmp_path, record)
+    assert capsys.readouterr().out == "triage_bad", reason
+
+
+def test_triage_fuse_stops_reframing_forever(triage, tmp_path, capsys):
+    """The re-frame loop is bounded, and exhaustion is a distinct token."""
+    bad = dict(_VALID_TRIAGE, evidence_command="NONE")
+    for _ in range(2):
+        _run_triage(triage, tmp_path, bad, max_frames=2)
+        assert capsys.readouterr().out == "triage_bad"
+    _run_triage(triage, tmp_path, bad, max_frames=2)
+    assert capsys.readouterr().out == "triage_exhausted"
+
+
+def test_triage_missing_record_is_a_judgement_not_a_crash(triage, tmp_path, capsys):
+    state = tmp_path / ".objective"
+    state.mkdir(parents=True, exist_ok=True)
+    rc = triage.main(
+        [
+            "--triage", str(state / "never-written.json"),
+            "--schema", str(_OBJECTIVE_DIR / "triage-schema.json"),
+            "--state-dir", str(state),
+        ]
+    )
+    assert rc == 0
+    assert capsys.readouterr().out == "triage_bad"
+
+
+def test_triage_cannot_run_is_distinct_from_a_bad_record(triage, tmp_path, capsys):
+    """An unreadable schema is a TOOL failure: nonzero exit, no token.
+
+    The graph routes that through ``outcome=fail`` to the postmortem path,
+    deliberately not through the ``triage_bad`` corrective loop.
+    """
+    state = tmp_path / ".objective"
+    state.mkdir(parents=True, exist_ok=True)
+    (state / "triage.json").write_text(json.dumps(_VALID_TRIAGE), encoding="utf-8")
+    rc = triage.main(
+        [
+            "--triage", str(state / "triage.json"),
+            "--schema", str(tmp_path / "no-such-schema.json"),
+            "--state-dir", str(state),
+        ]
+    )
+    assert rc != 0
+    assert capsys.readouterr().out == ""

--- a/skills/attractorify/SKILL.md
+++ b/skills/attractorify/SKILL.md
@@ -410,3 +410,14 @@ If empty, read the current session context to identify the work before diagnosin
   not answer; a fixed intake questionnaire is the anti-pattern this skill exists
   to prevent one level up. (The diagnosis artifact is the skill's own verdict
   record, written from session evidence — never a form posed to the user.)
+- **Not the objective layer.** This skill DESIGNS a new pipeline for work that
+  has none. `examples/objective/objective-runner.dot` SELECTS from — or COMPOSES
+  against — what already ships, at run time, from a stated objective. One triage
+  doctrine, two front doors: both apply the three-question test, and their
+  outcomes line up. A verdict of `attractor` or `existing-attractor` here is the
+  runner's `select`/`compose` route there; a verdict of `recipe` or `one-shot`
+  here is its `redirect` disposition — which the runner writes up as
+  `.objective/redirect.md` and exits green on, for the same reason this skill
+  stops at the artifact: the honest no IS the deliverable. Reach for the runner
+  when the user has an objective and no idea which shape fits; reach for this
+  skill when the shape that fits does not exist yet.


### PR DESCRIPTION
# The objective layer — state an objective, not a pipeline

Ships `examples/objective/` — an exemplar one layer up from an attractor. The unit of
invocation becomes an **objective**; the system infers the attractor from it.

```bash
OBJ="$PWD/examples/objective"
cd /path/to/workspace
attractor run "$OBJ/objective-runner.dot" \
    --param goal="get_display_name() raises TypeError when a user has no avatar. Fix it and add a regression test." \
    --param runner_dir="$OBJ" --param target_dir="$PWD" --cwd .
```

The runner diagnoses the objective with this repo's own three-question test, then **selects**
one of the five shipped practical lanes, **composes** a purpose-built child pipeline, or
**redirects** with an honest written no. Three green-or-loud outcomes, told apart by
`.objective/disposition`.

**Zero engine changes.** One `.dot`, two stdlib scripts, docs, one test file. No new
attributes, shapes, or semantics — a spec-conformant community `.dot` is unaffected.

---

## The doctrine, stacked one level up rather than relaxed

**The first routing decision runs on a machine artifact, not a self-report.** `frame` (LLM)
writes `.objective/triage.json`; `triage_gate` (code, outside the worker's context) validates
it against `triage-schema.json` and prints the routing token. The schema's cross-field rules
make *"no attractor without machine evidence"* a check, not a slogan: `CF-1` rejects any
non-redirect shape whose `evidence_command` is `NONE`.

**The parent never trusts a child's self-report.** A child pipeline's terminal outcome is used
for **loud fail-routing only**. Satisfaction is decided by `evidence_gate` re-running the
definition-of-done command itself, plus a **delta assertion** against an anchor recorded at
`preflight` — so a green check on an unchanged workspace cannot pass.

**The composer's output is gated before it runs.** `attractor lint` (ERRORs block, warnings
recorded in the run record) and `check_child_contract.py` — eight structural checks plus **C9**, which *executes* the generated `dod.sh`) both sit
outside the composer's context and can send it back, fused at `$max_compose`.

**The honest no is a green deliverable.** `redirect` writes `.objective/redirect.md` — the
three-question answers quoted verbatim, the better home named, and the machine check that
*would* make it routable — and exits 0. `finalize` refuses to open without a disposition
artifact, which is what lets an unattended caller tell the two green outcomes apart.

---

## Live proof — three real runs against the real engine, plus a negative control

Evidence archived outside the repo (run dirs, invocations, verdicts); no run artifacts committed.

| Proof | Route | Decisive output | Exit |
|---|---|---|---|
| **LP1 lane-select** | `bugfix` lane on a copy of `practical/sample` | `.objective/convergence.jsonl`: `{"iteration": 1, "gate": "evidence", "dod_exit": 0, "delta": "changed"}`; independent re-run afterwards: `3 passed`, incl. `test_display_name_without_avatar` | 0, `disposition=satisfied` |
| **LP2 compose** | no lane fits: document 4 CLI subcommands against a bespoke `check_runbook.py` (red before the run: `FAIL: 9 problem(s) across 4 command(s)`) | `lint-report.txt`: `OK (no findings)`; `contract-report.txt`: `verdict: contract_ok` (C1–C8 PASS); `subgraph_run_child/` present; independent re-run: `OK: all 4 commands documented` | 0, `disposition=satisfied` |
| **LP3 redirect** | an advisory architecture question with no machine gate | `triage.json` `"evidence_command": "NONE"`; `redirect.md` quotes all three answers and concludes **"This is a conversation."**; `completed_nodes` = `[start, preflight, frame, triage_gate, redirect_report, finalize]` — **no child ran** | 0, `disposition=redirected` |

**Negative control (the gates are real, and neither subsumes the other).** Both gates driven
with the tool_command text taken verbatim from the graph, against two deliberately-broken
children derived from LP2's real generated child:

- **Dead conditional edge (TOPO-001):** `lint_gate → lint_fail` (**BLOCKED**, routes back to
  `compose`) while `contract_gate → contract_ok`.
- **Acyclic, `goal_gate=true` on the `box` worker, no budget wall, no fail-loud terminal:**
  `lint_gate → lint_pass` (2 WARNINGs, recorded, non-blocking per the ruling) while
  `contract_gate → contract_bad` (**BLOCKED**) on C2/C3/C4/C5/C6/C7.

LP1 needed a second attempt. The first failed on a host defect — this machine's `pytest` shim
has a dangling shebang, so `sh -c pytest` reports "not found" while `command -v pytest`
resolves. It is kept in the evidence archive because of what it proved: the child's worker
**had actually fixed the bug** and written `Status: COMPLETE` in its own scratch file, and the
pipeline still refused to report success — child escalated, parent routed `outcome=fail` →
postmortem → escalated, CLI exit 1. A worker's self-report bought exactly nothing.

---

## Maintainer rulings this was built to

| Ruling | How it landed |
|---|---|
| Placement/name | `examples/objective/`, graph is `objective-runner.dot` |
| The objective travels as `goal` | `--param goal=`; every shipped lane already consumes `$goal`, so no adapter and no new param vocabulary |
| All 5 practical lanes + compose + redirect | 7-token vocabulary in `triage-schema.json` |
| Intake routes on the machine artifact, not `preferred_label` | `frame` → `triage.json` → `triage_gate` token. It is the taught doctrine; it also happens to dodge F1 |
| Lint on generated children: errors block, warnings don't | plain `attractor lint` (no `--strict`); warning count written to `.objective/convergence.jsonl` |
| Redirect exits green | `redirect_report` → `finalize` → `done`, exit 0; `.objective/disposition = redirected` is what distinguishes it |
| F1 filed, not fixed | #231 |
| F2 as a comment on #200, not a patch | https://github.com/microsoft/amplifier-bundle-attractor/issues/200#issuecomment-5300435189 |
| F3 fixed as a doc one-liner | `docs/DOT-AUTHORING-GUIDE.md` — `$goal` vs `${graph.goal}` in `tool_command` |

---

## What ships

**Exemplar** — `examples/objective/`: `objective-runner.dot` (21 nodes, 50 edges; every node
carries an *objective / constraints / capabilities / required evidence / exit condition*
header block), `README.md` (the walk-up guide), `triage-schema.json`, `validate_triage.py`,
`compose-contract.md`, `check_child_contract.py`.

**Test** — `modules/loop-pipeline/tests/test_objective_layer_gates.py` (38 cases): both gates
fail closed on missing/empty/unparseable input; each contract check is proven load-bearing by
a single mutation of a conforming child; and the checker's stdlib DOT reader is asserted to
agree with the engine's own parser (identical node sets, identical edge counts) on `bug-fix.dot`,
`test-gen.dot`, `task-runner.dot` and `objective-runner.dot`.

**Guidance wave** (thin, in each file's existing voice) — `agents/attractor-expert.md`,
`skills/attractorify/SKILL.md`, `context/pipeline-awareness.md`, `README.md`,
`examples/pipelines/practical/README.md`, `docs/PIPELINE_PATTERNS.md`,
`docs/DOT-AUTHORING-GUIDE.md`.

**Design record** — `docs/designs/2026-08-15-objective-layer.md`, preserved as designed, with
§11 recording where the build diverged and §12 the rulings above.

### Where the design was wrong, and what changed

- **The human gate lists Approve first, not Reject.** The design applied task-runner's
  "safe choice first" rule, which holds for a gate on the *failure* path. This gate is on the
  *success* path, downstream of machine evidence — reject-first makes every unattended run
  burn its budget and report a **false red**. The generalizable rule: the first choice is the
  one that does not fabricate an outcome.
- **The delta anchor is a workspace digest, not a base-SHA commit delta.** None of the five
  lanes commit anything, so a commit-delta assertion goes red after a *successful* `bug-fix`
  run. The digest form buys the same property without requiring children to commit. Pruning
  `.ai/`, `.objective/` and cache dirs is load-bearing — without it the gate is decorative.
- **`check_child_contract.py` ships its own DOT reader** instead of importing `parse_dot`. The
  gate runs under whatever `python3` is in the target workspace, not the CLI's venv. Guarded
  by the parser-agreement test, and it runs *after* `attractor lint` has already accepted the
  file.
- **A third param, `runner_dir`**, validated at `preflight` — a wrong value prints `blocked`
  and exits 1 before an LLM is paid.
- **`validate_triage.py` was missing from the design's file inventory.** The schema is data;
  something code-tier has to enforce it.

---

## Gates

| Gate | Result |
|---|---|
| `attractor lint examples/objective/objective-runner.dot` | `OK (no findings)` — zero errors, zero warnings |
| loop-pipeline suite | **1951 passed, 1 skipped** (baseline 1912/1; +38 new tests, +1 `test_examples_lint_clean` parametrization for the new `.dot`) |
| pipeline-runner suite | **76 passed, 1 skipped** — unchanged from baseline |
| Leak scan (`scrub_secrets.py scan`) | added files **clean** (8 scanned). Modified files: finding counts identical to `origin/main` — the single `README.md:18` hit is a pre-existing entropy-heuristic false positive on the `REPOSITORY_RULES.md` URL |
| `git diff --check` | clean |
| Strays | `git status` clean — no `.objective/`, no `gen/`, no run artifacts |

---

## Post-review fixes (`9d46c89`)

An independent adversarial review returned **MERGE-AFTER-FIX**. Every finding
below was verified by the reviewer *through execution*, not by inspection — and
every fix is proved the same way, by driving the **real `tool_command` text
extracted from the `.dot` by the engine's own parser**, not a paraphrase of it.

The headline finding is the uncomfortable one: **the exemplar was breaking its
own first rule.** "A composed `dod.sh` must be RED before the work exists" was
stated in the composer's prompt and in `compose-contract.md` — and nowhere else.
This PR's own doctrine already names why that is not enough: *as a prompt
instruction it is a suggestion.*

| # | Finding | Fix | Decisive proof |
|---|---|---|---|
| 1 | **The DoD-must-be-red rule was prose-only.** A composer writing `exit 0` satisfies C1–C8, its child converges on the first attempt, and `evidence_gate` re-runs the same vacuous script and agrees: `rc=0`, `delta=changed` → `evidence_ok` → `disposition=satisfied`. A false green with zero work product. | **C9** — `check_child_contract.py` now **executes** `dod.sh` once at admission, outside the composer's context, and requires exit **1**. Exit 0 = "already green"; exit ≥2 / signal / timeout (`--dod-timeout`, default 120s) = a **broken script**, named separately so a crash is never mistaken for convergence pressure. | Through the real `contract_gate` command: **`contract_bad`**, `[FAIL] C9 … exited 0 BEFORE any work was done`, every other check still `[PASS]` — which is exactly why C9 had to exist. Engine edge selection: `contract_bad → compose`, so `run_child` and `evidence_gate` are never reached. |
| 2 | **`frame` had no `outcome=fail` route** — the only worker without one, contradicting the C7 rule this graph enforces on generated children. | `frame -> postmortem [condition="outcome=fail", label="hard failure"]`, matching the graph's existing idiom. | `attractor lint`: `OK (no findings)`. Engine edge selection: `frame outcome=fail → postmortem`, `outcome=success → triage_gate`. **21 nodes, 49 → 50 edges** (updated in README, design doc, and this body). |
| 3 | **A false claim in two places** — "a hollow DoD only buys a louder failure later" (`objective-runner.dot`, `compose-contract.md`). The review proved it bought a **pass**. | Both passages rewritten to say what actually happens: a vacuous DoD is **refused at admission by C9**, and rewriting it afterwards trips the pin. | Diff on `objective-runner.dot`'s `compose` prompt and `compose-contract.md` §"Things that will get you sent back". |
| 4 | **The rewrite-after-admission dodge.** A child that overwrites `.objective/gen/dod.sh` with `exit 0` after passing the gates (or a lane child that overwrites `.objective/evidence-command`), plus any file touch, gets `evidence_ok`. | **The sha-pin** (the repo's stamp idiom): `contract_gate` and `triage_gate` record `sha256` of what they admitted; `evidence_gate` re-hashes **before** re-running and hard-fails loud, naming the altered path. | Through the real `evidence_gate` command: exit **1**, stdout `tampered`, stderr `FATAL: .objective/gen/dod.sh was altered after contract_gate admitted it …`. Because a nonzero exit does **not** refresh `tool.last_line`, every `&& outcome=success` edge is dead and only `outcome=fail → postmortem` can match (confirmed against the engine's own `select_edge` for stale labels `contract_ok` / `evidence_ok` / `tampered`). A negative control proves an untampered run still reaches `evidence_ok`. |
| 5 | Design doc §1.3 said "~16 nodes / 800 step cap"; `compose`'s 4th-attempt waste; decorative `goal_gate`. | Corrected to the shipped **21 nodes / 1050**. The bounded waste and the `goal_gate` question are each answered *in the graph*, below. | §11.9 of the design record. |

### The honest boundary on the pin — stated in the docs, in these words

The pin is **anti-accident, not anti-adversary.** `.objective/` lives inside the
workspace the child writes to, so a child determined to defeat the pin can
rewrite `dod.sh` *and* `dod.sha256` together. Closing that structurally means
custody outside the workspace — the pin held where the child cannot reach it, or
the DoD executed from a copy taken at admission — and that is **deliberately out
of scope for an exemplar**. What the pin does buy is that drift, overwrite, and
cleanup scripts now fail **loudly** instead of passing quietly, and a child would
have to take a second, deliberate step to get past it. Written up in
`compose-contract.md` §*The pin, and what it is not*, cross-referenced from
`examples/objective/README.md`.

### Two smaller calls, answered in the file rather than silently

- **`lint_gate`'s wall is checked on entry**, so with `$max_compose=2` the run
  executes `compose` a fourth time and only then reads `compose_exhausted` — one
  LLM call whose output is never linted. Closing it fully means making the
  *other* re-entry point (`contract_gate`'s `contract_bad → compose` edge)
  budget-aware too, which puts a copy of the counter in a second gate that can
  disagree with the first. **Kept, and now stated in the graph as a recorded
  trade**: one wasted call on a path already headed to `postmortem`, over a
  budget split across two gates.
- **`goal_gate=true` on `evidence_gate` cannot actually fail** — the node uses
  Idiom A (always exit 0), and a tool node's exit 0 is an explicit SUCCESS
  verdict (`handlers/tool.py`), so even an `evidence_bad` run satisfies it.
  **Kept as a declaration** of which node owns the verdict — the same thing C3
  enforces on generated children — with the comment saying exactly that and
  naming `finalize`'s disposition test as the enforcement that really holds.

### Also hardened

`sha256sum` joins `md5sum` and `find` as a **`preflight` precondition**, so a
host missing it refuses before an LLM is paid rather than failing every run at
the evidence gate.

### Post-fix gates

| Gate | Result |
|---|---|
| `attractor lint examples/objective/objective-runner.dot` | `OK (no findings)` |
| loop-pipeline suite | **1951 passed, 1 skipped** (was 1938/1; **+13** — 5 C9, 4 sha-pin, 4 real-`tool_command` end-to-end) |
| pipeline-runner suite | **76 passed, 1 skipped** — unchanged |
| Leak scan | **clean** on all 7 changed files |
| `git diff --check` | clean |
| Strays | `git status` clean |

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

