### PR TITLE
feat(conformance): ship the spec conformance matrix (tranche 1) -- make the ledger load-bearing

### DIFF
--- a/SPEC_CONFORMANCE.md
+++ b/SPEC_CONFORMANCE.md
@@ -57,7 +57,7 @@ Maintainer ruling, 2026-08-14. The four rules that decide every disposition in t
 |------|----------------|---------------|----------|------|
 | unified-llm | ~35 | 13 | 4 (structured output, all providers) | 9 |
 | coding-agent-loop | ~17 | 9 | 2 (bugs CAL-1, CAL-2) | 7 |
-| attractor | ~30 | 8 | 3 (ATX-1, ATX-2, ATX-10) | 5 |
+| attractor | ~30 | 8 | 3 (ATX-1, ATX-2, ATX-10) | 3 (ATX-3, ATX-6, ATX-7) |
 
 The engine layer (attractor) is the strongest — substantially a **superset** of the spec. The
 material weaknesses are concentrated in the LLM client's per-provider metadata and a small set
@@ -117,8 +117,8 @@ keys. Do not mark "live" until exercised against real providers (e.g. in a DTU w
 | ATX-1 | Node `timeout` unit mismatch (ms stored, consumed as seconds) | `timeout_seconds` | `engine.py:485`, `handlers/tool.py:105` | **DONE** | ALIGN |
 | ATX-2 | Checkpoint-based RESUME (restore context/completed/retry, continue after `current_node`; `full`→`summary:high` degrade) | `§5.3`, DoD `:1857` | `checkpoint.py:load_checkpoint_for_resume` (validation ladder) + `engine.py:PipelineEngine.resume` + `runner.py:resume_pipeline` + `attractor resume <run_dir>`; checkpoint schema v2 is a superset keeping the six §5.3 fields at the §5.6 path. A fresh `run()` still never reads a checkpoint — no call path exists (`tests/test_no_implicit_resume.py`) | **DONE — PROVEN ON A REALLY-KILLED RUN** (`modules/pipeline-runner/tests/test_resume_e2e.py`: SIGKILLed subprocess, separate `attractor resume` invocation, equivalence vs a control run executed at gate runtime) | ALIGN |
 | ATX-3 | Tool-call hooks `tool_hooks.pre`/`.post` (shell around each LLM tool call) | `§9.7` `:1650` | grep `tool_hooks`=0 | OPEN | **DECIDE** (ALIGN vs DIVERGE) |
-| ATX-4 | HTTP server mode (REST + SSE) | `§9.5` (optional) | not present; programmatic tools instead | OPEN | DIVERGE (spec-optional) |
-| ATX-5 | `outcome=` condition resolves to `preferred_label` first | `§10.4 :1693` | `conditions.py:75` returns `preferred_label or status` | OPEN | DIVERGE (intentional; load-bearing for report_outcome routing) |
+| ATX-4 | HTTP server mode (REST + SSE) | `§9.5` (optional) | not present; programmatic tools + CLI instead. The absence is now asserted rather than merely described: matrix row `ATX-M-004n` (`specs/conformance/attractor-matrix.yaml`) fails if an HTTP surface appears | **WONTFIX — DECIDED (NOT-IMPLEMENTED)** | DIVERGE (spec-optional) |
+| ATX-5 | `outcome=` condition resolves to `preferred_label` first | `§10.4 :1693` | `conditions.py:75` returns `preferred_label or status`; both halves asserted by matrix row `ATX-M-022` (`specs/conformance/attractor-matrix.yaml`) | **DONE — DECIDED** | DIVERGE (decided; ledgered — `specs/EXTENSIONS.md` §22) |
 | ATX-6 | Retry on FAIL | spec self-contradicts: `§3.5 :519` (no) vs DoD `:1833` (yes) | retries RETRY only (`retry.py:238`) | OPEN | ALIGN-spec-first (reconcile the spec) |
 | ATX-7 | `stack.child_workdir`; condition literal unquoting (`§10.5`) | `:1743` | not handled | OPEN | ALIGN (minor) |
 | ATX-10 | Multi-match fan-out: non-component nodes with ≥2 simultaneously-matching conditional edges routed to ALL targets in parallel (unledgered dialect; never in spec §3.3) | `§3.3 :421-458` (`best_by_weight_then_lexical`) | `engine.py` (retired `select_all_matching_edges` gate; now routes through `select_edge()` only) | **DONE** | ALIGN — conformance restored (T0-4) |
@@ -197,6 +197,34 @@ Each is currently **OPEN** with disposition pending (ALIGN vs DIVERGE).
 ---
 
 ## Changelog
+
+### 2026-08-15 — ATX-4 / ATX-5 status cells reconciled with the conformance matrix (PR #235)
+
+- **ATX-5 OPEN → DONE — DECIDED — DIVERGE.** The status cell said OPEN while the decision had in
+  fact been made and ledgered: `specs/EXTENSIONS.md` §22 is the divergence record, it is explicit
+  that the behavior is **not** behavior-neutral (a canonical graph matching `outcome=<status>`
+  changes meaning once a node sets a `preferred_label`), and `conditions.py:75` has shipped
+  `preferred_label or status` deliberately for months. Nothing about the behavior changed here —
+  only the cell that had been mis-reporting a made decision as an unmade one. §22 is now cited as
+  the decision record in the Disposition cell, matching the ATX-11 / ATX-12 convention.
+- **ATX-4 OPEN → WONTFIX — DECIDED (NOT-IMPLEMENTED).** Canonical §9.5 is permissive ("*may* expose
+  the pipeline engine as an HTTP service"), so not building it is conformant rather than divergent.
+  The decision is: **not building it absent demand** — the bundle exposes programmatic tools and a
+  CLI instead. Recorded as WONTFIX per this file's own status legend ("recorded divergence, no
+  further action").
+- **Evidence that these were stale cells and not new decisions.** PR #235's conformance matrix
+  independently classified both rows from the spec text and the shipped code: `ATX-M-022` carries
+  `disposition: DIVERGE-DECIDED` citing ATX-5 + EXTENSIONS §22, and `ATX-M-004n` carries
+  `disposition: NOT-IMPLEMENTED-DECIDED` citing ATX-4. Two records of the same decision disagreed;
+  the matrix was right and the ledger cells were behind. Surfaced by independent adversarial review
+  of PR #235.
+- **Both rows are now asserted, not merely described.** `ATX-M-022` pins both halves of the
+  divergence (`outcome=` resolves to the label when set; to the status when not);  `ATX-M-004n` pins
+  the *absence* of an HTTP surface, so shipping one becomes a ledger event rather than a quiet
+  feature. The Impl cells cite the matrix rows, making the ledger↔matrix link bidirectional.
+- **Dispositions unchanged.** Both cells keep their `DIVERGE` disposition, which is what the matrix
+  coverage tripwire (`test_tripwire_every_diverge_atx_row_is_asserted`) reads — a DIVERGE-disposition
+  `ATX-*` row must be cited by at least one matrix row. Verified green after this edit.
 
 ### 2026-08-14 — ATX-2 DONE: engine-level checkpoint resume shipped (issue #224)
 - **ATX-2 DECIDED/IN-PROGRESS → DONE — ALIGN.** Spec §5.3 "Resume behavior" rules 1–6 and DoD

--- a/docs/QUALITY_PROTOCOL.md
+++ b/docs/QUALITY_PROTOCOL.md
@@ -124,12 +124,22 @@ strictly worse than an internal doc going stale.
 
 ### Layer 2 -- executable conformance matrix
 
-**Status: in flight -- designed here, not built.** No conformance-matrix code and no CI job exists
-in this repo today. What follows is the specification for it, not a description of something
-running.
+**Status: shipped (tranche 1).** Two files, run in CI on every PR inside the existing
+loop-pipeline job:
+
+| File | What it is |
+|---|---|
+| `specs/conformance/attractor-matrix.yaml` | The matrix itself -- a reviewed *document*, one row per normative statement cluster, carrying the verbatim spec quote, the disposition, the ledger cite, and the assertion |
+| `modules/loop-pipeline/tests/test_spec_conformance_matrix.py` | The runner -- per-row structural integrity, in-process behavioral probes, the upstream-sync sha pin, and the coverage tripwire |
+
+Tranche 1 covers every decided divergence, every OPEN ledger item, the load-bearing conformances,
+and the SYNC row. Later tranches extend it section by section; ULM/CAL matrices are named as tranche
+3. The design record is [`docs/designs/2026-08-15-conformance-matrix.md`](designs/2026-08-15-conformance-matrix.md).
 
 One row per spec section: **spec section -> executable assertion -> disposition**, where disposition
-is one of `CONFORM`, `DIVERGE-DECIDED`, `EXTENSION`, `NOT-IMPLEMENTED-DECIDED`.
+is one of `CONFORM`, `DIVERGE-DECIDED`, `EXTENSION`, `NOT-IMPLEMENTED-DECIDED`, plus two the build
+earned: `OPEN-PINNED` (pin an undecided behavior without forging a decision the maintainer has not
+made) and `NOT-ASSERTABLE` (aspirational prose, argued per row).
 
 The load-bearing idea is that **decided divergences are asserted too.** A matrix that only asserts
 conformance detects drift in one direction and is blind in the other -- silently drifting *back*
@@ -141,7 +151,15 @@ So a flipped assertion is never merely a red test: its failure message names **t
 must change**. The failure is a prompt to update `SPEC_CONFORMANCE.md` or `specs/EXTENSIONS.md`, or
 to revert -- never to edit the assertion.
 
-Intended to run in CI on every PR, alongside the Layer 1 guards.
+Two mechanisms keep that honest. A **coverage tripwire** requires every DIVERGES-bannered
+`EXTENSIONS.md` entry and every DIVERGE-disposition `ATX-*` row to be cited by at least one matrix
+row, so a future divergence cannot be ledgered without also being asserted. And the **SYNC row**
+pins the canonical file's sha256, turning a re-vendor from a quiet commit into a demanded
+full-matrix re-review -- which is exactly the work the `fb57a55` sync required by hand.
+
+Retirement condition: none for the mechanism. Individual rows retire when upstream absorbs the
+divergence (the `ABSORBED UPSTREAM` banner protocol) or when a decision closes an `OPEN-PINNED`
+row -- in both cases the row changes disposition rather than disappearing.
 
 ### Layer 3 -- periodic holistic semantic review
 
@@ -218,7 +236,9 @@ design that usually goes undone: yesterday's scaffolding is today's tax.
 guard filenames, the canonical SHA, the four issue numbers -- are not machine-pinned today, and by
 section 2's own rule that is a gap, named here rather than left for a reader to find. Adoption
 condition: the first time one of those references is found stale, or the Layer-2 matrix lands
-(whichever comes first), this file gets the guard it asks of everything else.
+(whichever comes first), this file gets the guard it asks of everything else. **That condition has
+now fired** -- the matrix landed 2026-08-15 -- so this file's own guard is owed next, and is
+recorded as such in the Changelog below rather than left for a reader to discover.
 
 ---
 
@@ -279,6 +299,37 @@ This repo's maintainers will help seed a customized version on request -- open a
 ## Changelog
 
 Amendments to this protocol, newest first. Each entry names the evidence that justified it.
+
+### 2026-08-15 -- Layer 2 shipped (entry 2)
+
+- **Changed.** Section 3, Layer 2 flipped from *"in flight -- designed here, not built"* to shipped,
+  naming the two real files: `specs/conformance/attractor-matrix.yaml` (38 tranche-1 rows) and
+  `modules/loop-pipeline/tests/test_spec_conformance_matrix.py` (the runner). The disposition
+  vocabulary gained `OPEN-PINNED` and `NOT-ASSERTABLE`; the coverage tripwire and the SYNC sha pin
+  are described because they now exist.
+- **Evidence that the layer earns its cost, at adoption.** Building tranche 1 was itself the
+  measurement. It surfaced **two unledgered contradictions with the canonical spec** that four
+  existing defenses could not see -- the unknown-shape hard error against section 4.2's
+  default-handler fallback, and `reasoning_effort`'s absent `"high"` default against Appendix A --
+  both filed as [#234](https://github.com/microsoft/amplifier-bundle-attractor/issues/234) and
+  pinned as `OPEN-PINNED` rows rather than silently encoded. It also pinned three points where the
+  canonical spec **contradicts itself** (retry-on-FAIL, reachability severity, and the goal-gate
+  ladder's routing signal), each recorded on the row that chooses a side. Layer 1 could not have
+  found any of these: those guards pin *our docs* to *our code*, and say nothing about the spec.
+- **The mechanism was proven by mutation before it merged.** Per the design's definition of done,
+  one real engine behavior was flipped in a scratch copy (dead-end-with-non-FAIL made to return
+  SUCCESS, the exact un-divergence `ATX-11` forbids) and the matrix produced the specified failure
+  naming spec section 3.2, `ATX-11`, `EXTENSIONS.md` section 33, and the two legal exits; a ledger
+  citation was deleted in a second scratch copy and the structural check failed naming it. A guard
+  never seen red is an unproven guard.
+- **Scope of this change: additive.** No engine, handler, or example code changed. The matrix
+  *indexes* existing coverage rather than duplicating it: 22 of 38 rows cite tests that already
+  exist, verified by AST parse rather than import (indexed cites cross per-module venv boundaries).
+- **Retirement conditions.** The matrix mechanism has none -- it is the executable form of a ledger
+  that is itself permanent. Individual rows retire by changing disposition: when upstream absorbs a
+  divergence, or when a decision closes an `OPEN-PINNED` row. **This document's own missing guard
+  (section 5) is now due**: its stated adoption condition -- "or the Layer-2 matrix lands" -- fired
+  with this entry.
 
 ### 2026-08-15 -- protocol captured (entry 1)
 

--- a/docs/QUALITY_PROTOCOL.md
+++ b/docs/QUALITY_PROTOCOL.md
@@ -70,7 +70,7 @@ may ask for more, never less.
 | **Engine / handler code** | `engine.py`, `handlers/*`, dispatch, routing, retry, checkpoint | Full module suites green **and** a live pipeline run exercising the changed path (paste the `events.jsonl` slice) **and** independent adversarial review **and** a ledger entry if the change is spec-relevant (last row) |
 | **Exemplar / example graphs** | `examples/pipelines/*.dot`, `examples/patterns/*.dot`, `examples/objective/*` | `attractor lint` with **zero ERROR** diagnostics -- warnings are informational, which is exactly the line `modules/loop-pipeline/tests/test_examples_lint_clean.py` enforces -- **and** at least one live convergence run **and** the graph's own gates demonstrated **RED and GREEN**: a negative control proving the gate can fail, a positive control proving it can pass. A gate only ever seen green is an unproven gate |
 | **Guidance surfaces** | `agents/`, `skills/`, `context/`, teaching content in `README.md` and `docs/` | Guidance-eval evidence **once the eval instrument ships**. *That instrument does not exist in this repo today: it is in flight, and a pilot is planned.* Until it lands, the floor is a **fresh-session walk-through** proving the guidance steers as written -- a session with no prior context follows only the changed text and arrives at the intended behavior. Paste the walk-through |
-| **Docs making factual claims** | any doc asserting a number, default, vocabulary, or behavior | A guard test pinning each load-bearing claim to **its source of truth in code**, following the five existing guards (section 3, Layer 1). A page-only assertion ("the page says 500") is tautological: it passes forever and fails only when someone edits the page, which is the one case needing no guard. The assertion must read the value from the code and fail when the **code** moves |
+| **Docs making factual claims** | any doc asserting a number, default, vocabulary, or behavior | A guard test pinning each load-bearing claim to **its source of truth in code**, following the existing guards (section 3, Layer 1). A page-only assertion ("the page says 500") is tautological: it passes forever and fails only when someone edits the page, which is the one case needing no guard. The assertion must read the value from the code and fail when the **code** moves |
 | **Spec-relevant behavior** | anything that conforms to, diverges from, or extends the nlspec | A `specs/EXTENSIONS.md` entry and/or a `SPEC_CONFORMANCE.md` row, **in the same PR**, per the Compatibility doctrine. Entries obey the Entry Format: `depends-on:`, plus `upstream action:` in one of its legal forms whenever the banner states a divergence |
 
 Two of these already have machinery behind them: the `EXTENSIONS.md` requirement is on the PR
@@ -107,7 +107,7 @@ not a property of the repo.
 
 ### Layer 1 -- deterministic guards
 
-Five test files in `modules/loop-pipeline/tests/`, run in CI on every PR. Each pins a documented
+Six test files in `modules/loop-pipeline/tests/`, run in CI on every PR. Each pins a documented
 claim to something that fails when the *code* moves:
 
 | Guard file | What it pins |
@@ -117,6 +117,7 @@ claim to something that fails when the *code* moves:
 | `test_engine_semantics_doc_guard.py` | `context/engine-semantics.md`, the bundle's declared source of truth for shipped-engine behavior -- both text-anchored claims (the no-matching-edge and stale-label rules) and behavior-anchored ones (a real engine run asserting the main loop hard-fails on no matching edge) |
 | `test_explainer_doc_guard.py` | The published explainer page, `docs/attractor-explained.html`: feedback-critique caps, the parallel-branch default, `last_response` truncation, the summary budgets, the fidelity vocabulary and its default, the lifecycle phases, and the shape-to-execution-tier vocabulary -- each read from its source module, never from the page |
 | `test_examples_lint_clean.py` | Every `.dot` under `examples/` lints with zero ERROR diagnostics. Written because the dead-corrective-edge class shipped in eight examples for months, because nothing could see topology |
+| `test_quality_protocol_guard.py` | This document's own external references: every guard-test filename it names exists; the two Layer-2 files exist and Layer 2 still reads *shipped*; the vendored canonical spec exists and the upstream SHA recorded here is the one `SPEC_CONFORMANCE.md`'s `SYNC-1` row records; the Changelog exists with a dated entry. Written because section 5 set its own adoption condition and this file has to keep it (section 5) |
 
 **The rule this layer imposes: a new claim-bearing doc ships with its guard.** The explainer guard
 states the reason plainly -- a page nobody re-reads rots silently and keeps being shared, which is
@@ -232,13 +233,27 @@ Machinery whose retirement condition has fired is **removed in the same wave** -
 not left in place "just in case." This is the self-ablation discipline, and it is the half of process
 design that usually goes undone: yesterday's scaffolding is today's tax.
 
-**This document's own guard.** It ships without one. Its load-bearing external references -- the five
-guard filenames, the canonical SHA, the four issue numbers -- are not machine-pinned today, and by
-section 2's own rule that is a gap, named here rather than left for a reader to find. Adoption
-condition: the first time one of those references is found stale, or the Layer-2 matrix lands
-(whichever comes first), this file gets the guard it asks of everything else. **That condition has
-now fired** -- the matrix landed 2026-08-15 -- so this file's own guard is owed next, and is
-recorded as such in the Changelog below rather than left for a reader to discover.
+**This document's own guard.** It has one:
+`modules/loop-pipeline/tests/test_quality_protocol_guard.py`. The stated adoption condition -- *the
+first time one of those references is found stale, or the Layer-2 matrix lands, whichever comes
+first* -- **fired with the matrix**, and the guard shipped in the same PR rather than in the next
+one. A protocol that defers its own rule while enforcing it on others is not a protocol; that is the
+whole reason the condition was written with a trigger instead of an intention.
+
+What it pins, each claim read from this page and resolved against the repository rather than against
+the page itself: every guard-test filename named here resolves to a real file; the two Layer-2 files
+exist and Layer 2's status still reads *shipped*; `specs/canonical/attractor-spec-canonical.md`
+exists and the upstream SHA recorded in Layer 0 is the SHA `SPEC_CONFORMANCE.md`'s `SYNC-1` row
+records; and the Changelog this section mandates exists carrying at least one dated entry. It skips
+wholesale in a checkout without this file, and fails loud otherwise.
+
+**One reference remains unpinned, deliberately: the issue numbers.** The nine issue and PR numbers
+cited on this page (#144, #146, #156, #172, #175, #182, #204, #223, #234) resolve only over the
+network, and these suites do not reach it. That is a real remaining gap, named here in those words
+rather than left for a reader to find; it belongs to the Layer-3 pass, not to CI.
+
+Retirement condition: none while this page names external references. The guard narrows as the page
+stops naming things, and retires only with the page.
 
 ---
 
@@ -284,7 +299,7 @@ evidence-gated amendments, named retirement conditions, a periodic retirement re
 the structure of a quality system, not about DOT graphs.
 
 **This-repo-specific.** `attractor lint` and its rule IDs; the particular ledgers
-(`SPEC_CONFORMANCE.md`, `specs/EXTENSIONS.md`) and their entry formats; the five named guard files;
+(`SPEC_CONFORMANCE.md`, `specs/EXTENSIONS.md`) and their entry formats; the six named guard files;
 the pinned upstream SHA; the issue-pipeline lanes. Every one of those is the local answer to a
 general question -- *what is your normative source, what pins your claims to it, what is the record
 of deliberate deviation* -- and each repo's answer will look different.
@@ -299,6 +314,37 @@ This repo's maintainers will help seed a customized version on request -- open a
 ## Changelog
 
 Amendments to this protocol, newest first. Each entry names the evidence that justified it.
+
+### 2026-08-15 -- this document's own guard shipped (entry 3)
+
+- **Changed.** Section 5's "**This document's own guard**" passage flipped from *owed next* to
+  shipped, naming `modules/loop-pipeline/tests/test_quality_protocol_guard.py`. Layer 1 goes from
+  five guard files to six and the new guard gets its table row. Section 2's and section 7's
+  pointers at "the five existing guards" / "the five named guard files" were updated with it.
+- **Evidence that justified it: the protocol's own rule fired, and the deferral was the finding.**
+  Entry 2 recorded the adoption condition as met ("the matrix landed") and then deferred the guard
+  to a later PR. Independent adversarial review of that same PR read section 2's "Docs making
+  factual claims" row strictly and called the deferral what it was -- this page shipping a claim
+  with no guard, in the PR whose whole subject is making records load-bearing. The condition was
+  written with a trigger precisely so it could not be deferred by intention; honoring it in the
+  triggering PR is the only reading that leaves the rule meaning anything.
+- **What the guard asserts, and why none of it is tautological.** Four claim classes, each read
+  from this page and resolved against the *repository*: the guard-test filenames it names exist;
+  the two Layer-2 files exist and Layer 2 still reads *shipped*; the vendored canonical spec exists
+  and the SHA recorded in Layer 0 matches `SPEC_CONFORMANCE.md`'s `SYNC-1` row; the Changelog
+  exists with a dated entry. A page-only check ("the page says six") would pass forever and fail
+  only on an edit to the page -- the one case needing no guard. These fail when the **repo** moves:
+  a guard renamed, the matrix relocated, the canonical spec re-vendored to a new upstream SHA.
+- **Proven red before green.** Each assertion was mutated in a scratch copy and observed to fail
+  naming the specific stale reference, then restored. A guard never seen red is an unproven guard
+  -- the same bar entry 2 held the matrix to.
+- **Scope of this change: additive.** One new test module and this page. No engine, handler,
+  example or ledger *behavior* changed.
+- **Honest gap, named not hidden.** The nine issue/PR numbers on this page stay unpinned: they
+  resolve only over the network and these suites do not reach it. Recorded in section 5 in those
+  words, and assigned to the Layer-3 pass rather than to CI.
+- **Retirement condition.** None while this page names external references. The guard narrows as
+  the page stops naming things, and retires only with the page.
 
 ### 2026-08-15 -- Layer 2 shipped (entry 2)
 
@@ -329,7 +375,7 @@ Amendments to this protocol, newest first. Each entry names the evidence that ju
   that is itself permanent. Individual rows retire by changing disposition: when upstream absorbs a
   divergence, or when a decision closes an `OPEN-PINNED` row. **This document's own missing guard
   (section 5) is now due**: its stated adoption condition -- "or the Layer-2 matrix lands" -- fired
-  with this entry.
+  with this entry. *(Discharged by entry 3, same PR: the guard shipped rather than being deferred.)*
 
 ### 2026-08-15 -- protocol captured (entry 1)
 

--- a/docs/designs/2026-08-15-conformance-matrix.md
+++ b/docs/designs/2026-08-15-conformance-matrix.md
@@ -1,0 +1,674 @@
+# Design: The Spec Conformance Matrix
+
+**Repo:** `microsoft/amplifier-bundle-attractor` (design written against `origin/main` @ `0241d85`)
+**Commissioned:** 2026-08-15 — *"what do we have in place to explicitly prevent drift — this domain's
+equivalent of a linting tool, but considering more the semantics/spec of the original nlspec?"*
+**Status:** **TRANCHE 1 SHIPPED.** Feasibility of the three hardest rows was verified by executed
+probes before implementation (§10; 5/5 passing in 0.22s against a `/tmp` worktree of `origin/main`);
+tranche 1 then landed as `specs/conformance/attractor-matrix.yaml` (38 rows) plus
+`modules/loop-pipeline/tests/test_spec_conformance_matrix.py` (198 passed, 24 skipped, 0.3s). The
+document below is the design as written; where construction trued a number up, an
+**implementation note** says so inline rather than rewriting the design after the fact.
+
+**Implementation notes (2026-08-15):**
+
+- **Row count: 38, not 35.** §7's own table B lists 24 rows under a "23 rows" header — the
+  arithmetic in the design was off by one, and the built matrix carries all 24. The other two are
+  the F1 and F4 rows from §13, which the design named as required tranche-1 work without counting
+  them in the §7 tally. Final: 1 SYNC + 7 divergence/extension + 4 OPEN-PINNED/absence + 2 findings
+  + 24 conformances.
+- **Schema addition: `spec.also`.** An optional list of `{section, quote}`, verified verbatim
+  exactly like `spec.quote`. Earned by ATX-M-012, whose divergence spans two non-contiguous spec
+  statements (§2.7's "fresh log directory" and §3.2 step 7's `restart_run(); RETURN`); anchoring
+  only one would leave half the assertion uncited. Used by three rows.
+- **Schema addition: `ledger.issue`.** A third legal cite form, permitted **only** on `OPEN-PINNED`
+  rows. F1 and F4 are unledgered by definition — that is the finding — so they cite the issue
+  carrying the pending decision (#234) instead of a ledger row that does not exist yet. The runner
+  rejects `ledger.issue` on any other disposition: a decided disposition owes a real ledger entry.
+- **F4 resolved empirically, and it does not hold.** §13 predicted the Appendix A
+  `reasoning_effort="high"` default would fail. Confirmed: `Node.reasoning_effort` defaults to
+  `None` and `None` reaches the backend, so the provider's own default applies. Pinned as
+  `ATX-M-F04`; filed with F1 as issue #234.
+- **The tripwire's banner detector reads BOLD declaratives only.** A naive `DIVERG` substring
+  search over entry banners flags §§24, 25, 29, 32, 33, 35 — but §§29/32/35 merely use the word in
+  `upstream action:` boilerplate. Matching `**...DIVERG(ES|ENCE)...**` inside the banner yields
+  exactly §§24, 25, 33, which is the true set. The precision is regression-tested against synthetic
+  positive and negative banners.
+
+---
+
+## 1. The problem, stated precisely
+
+The repo has three drift defenses today, and a hole between them:
+
+| Defense | What it pins | What it cannot see |
+|---|---|---|
+| Doc guards (`test_doc_consistency.py`, `test_engine_semantics_doc_guard.py`, `test_explainer_doc_guard.py`) | Numbers/strings in *our docs* against *our code* | The upstream spec's semantics |
+| Ledgers (`SPEC_CONFORMANCE.md` ATX/CAL/ULM rows; `specs/EXTENSIONS.md` §§1–36) | Every *decided* disposition, in prose | Nothing — they are human-maintained records with no executable teeth |
+| The test suite (~2,000 tests) | Engine behavior | Which spec sentence each behavior answers to, and which ledger entry licenses each divergence |
+
+**Drift** = any behavioral movement not recorded in the ledger, **in either direction**:
+
+1. **Away from spec, unledgered** — the classic case (ATX-11 lived this way for months: the
+   dead-end hard-fail shipped in the initial commit, was load-bearing for
+   `bug-fix.dot`'s `escalated` node, and was only ledgered by a later audit).
+2. **Back toward spec, unledgered** — *un-diverging silently is drift too.* If someone
+   "fixes" the engine to match spec §3.2 step 6 (dead end → SUCCESS), `EXTENSIONS.md` §33 and
+   ATX-11 become lies, and `bug-fix.dot` silently reports success on its designed failure path.
+   The ledger lying is the same incident class as the engine lying.
+
+The matrix makes the ledger **load-bearing**: an executable, CI-run mapping from the canonical
+spec's normative statements to assertions against the real engine, where decided divergences are
+asserted as firmly as conformances. A flipped assertion fails with a message naming the exact
+ledger entry that must move with the behavior.
+
+---
+
+## 2. Decisions at a glance
+
+| Question | Decision |
+|---|---|
+| Unit (row) | YAML row: `id` + `spec{section, quote, line(info-only), conflict?}` + `disposition` (6-value vocabulary incl. **OPEN-PINNED**) + `ledger{conformance, extensions}` + `assertion{kind: probe\|indexed\|absence\|none, …}` + `justification` |
+| Mechanics | Declarative data file `specs/conformance/attractor-matrix.yaml` consumed by one parametrized module `modules/loop-pipeline/tests/test_spec_conformance_matrix.py`. Structural integrity parametrized per row; behavioral probes are named functions keyed by row id, cross-checked both ways |
+| Divergences | Every DIVERGE-DECIDED row asserts (a) our documented behavior occurs AND (b) the spec's behavior does **not** occur, where cheap. Both halves carry the same flip message |
+| Anchoring | Verbatim spec **quotes**, runner-verified byte-for-byte against the canonical file, + a pinned **sha256** of the canonical file recording upstream `fb57a55`. Line numbers stored but *informational only* — never asserted |
+| Coverage | ~154 rows total: ~123 INDEXED to existing tests, ~21 new probes (incl. 4 absence assertions + the SYNC row), ~10 NOT-ASSERTABLE with per-row justification |
+| Probes | All tranche-1 probes run in-process against `PipelineEngine` + `MockBackend`-style doubles: deterministic, no LLM, no network, milliseconds each. Verified by execution (§10) |
+| Scope | v1 = attractor spec only. ULM/CAL named as tranche 3 with the same schema (§12) |
+
+---
+
+## 3. Q1 — The unit: row schema
+
+The commissioned proposal is close; four amendments, each earned by something found in the repo.
+
+```yaml
+# specs/conformance/attractor-matrix.yaml  (illustrative row — the ATX-11 divergence)
+- id: ATX-M-011                      # stable forever; never renumbered, never reused
+  title: dead-end hard-fail (main loop)
+  spec:
+    section: "3.2"                   # canonical § anchor
+    heading: "Core Execution Loop"
+    quote: |                         # verbatim; runner-verified against canonical bytes
+      IF next_edge is NONE:
+          IF outcome.status == FAIL:
+              RETURN outcome
+          RETURN Outcome(status=SUCCESS, notes="Pipeline completed")
+    line: 390                        # informational only — NEVER asserted (see §9)
+  disposition: DIVERGE-DECIDED
+  ledger:
+    conformance: ATX-11              # SPEC_CONFORMANCE.md row id (checked to exist)
+    extensions: 33                   # specs/EXTENSIONS.md § number (checked to exist)
+  assertion:
+    kind: probe
+    probe: test_row_atx_m_011        # function in the matrix module (checked to exist)
+    indexed:                         # existing coverage this row ALSO indexes (checked to exist)
+      - modules/loop-pipeline/tests/test_engine.py::test_no_matching_edge_returns_fail
+      - modules/loop-pipeline/tests/test_pipeline_events.py::TestErrorEvents::test_emits_error_on_no_edge
+  notes: >
+    Load-bearing for examples/pipelines/practical/bug-fix.dot ('escalated' node).
+    Paired doc guard: test_engine_semantics_doc_guard.py D-200/D-202.
+```
+
+**Field semantics and the four amendments:**
+
+1. **`disposition` gains `OPEN-PINNED`** (full vocabulary: `CONFORM | DIVERGE-DECIDED |
+   EXTENSION | NOT-IMPLEMENTED-DECIDED | OPEN-PINNED | NOT-ASSERTABLE`). The ledger has
+   honest OPEN items with pending dispositions (ATX-6 retry-on-FAIL, ATX-7 literal
+   unquoting, ATX-3 tool_hooks, CAL-3). The matrix must not launder them into
+   "DIVERGE-DECIDED" — that would forge a decision the maintainer hasn't made. OPEN-PINNED
+   asserts *current behavior* and cites the open ledger item; its flip message says "either
+   this PR is the ALIGN decision (update ATX-n to DONE and this row to CONFORM) or it is an
+   accident (revert)." Undecided ≠ unpinned.
+2. **`assertion.kind: absence`** — for decided/open *omissions* (tool_hooks §9.7, HTTP mode
+   §9.5, extended condition operators §10.7). The assertion is that the feature is *absent*
+   (e.g. `grep tool_hooks` over `loop-pipeline` source = 0 hits). This is the "un-diverging
+   silently is drift" mechanism for the not-implemented direction: someone who ships
+   tool_hooks without touching ATX-3 gets a red matrix, not a quiet green.
+3. **`spec.conflict`** (optional second `{section, quote}`) — the canonical spec contradicts
+   *itself* in at least three places (§3.5 `:519` vs DoD `:1833` on retry-on-FAIL; §7.2
+   reachability=ERROR vs DoD 11.12 "orphan → warning"; §4.6 pseudocode returns
+   `suggested_next_ids` vs DoD 11.6 "returns selected label as preferred_label"). A row
+   pinning one side must name the other side, or the matrix inherits the spec's ambiguity.
+4. **`failure_contract` is generated, not hand-written.** One helper renders the flip
+   message from row fields (§8). Hand-written per-row prose rots; the ledger-guard tests'
+   great failure messages work because the *shape* is uniform. Rows may append a
+   row-specific hint via `notes`, which the renderer includes.
+
+`ledger` is required (non-null) for every disposition except `CONFORM` and `NOT-ASSERTABLE`;
+`justification` is required for `NOT-ASSERTABLE` and `OPEN-PINNED`. `assertion.kind: none` is
+legal **only** for `NOT-ASSERTABLE`.
+
+---
+
+## 4. Q2 — Mechanics: YAML table + one parametrized module
+
+**Decision: declarative data file + parametrized pytest module.** Specifically:
+
+```
+specs/conformance/attractor-matrix.yaml            # the matrix (a document, reviewed as one)
+modules/loop-pipeline/tests/test_spec_conformance_matrix.py   # the runner (one module)
+```
+
+**Why not a pure-Python table:** the maintainer must be able to read the matrix *like a
+document* — next to `specs/EXTENSIONS.md`, in the same directory family, one row per YAML
+block, diffs that read as "row ATX-M-011 changed disposition." A Python dict-of-dicts is the
+same information wearing a worse reading costume, and it drags every row edit through code
+review conventions (imports, formatting, lint) that have nothing to say about dispositions.
+The repo's own precedent agrees: the ledgers are Markdown documents and the guard tests
+*read* them (`test_extensions_ledger_integrity.py` regex-walks `EXTENSIONS.md`); the matrix
+is the same pattern with the arrow reversed (the document drives the tests).
+
+**Why YAML and not Markdown-table:** rows carry multi-line verbatim quotes and lists of
+node ids; YAML block scalars handle both losslessly. A Markdown table would force quote
+mangling — and the quote is the load-bearing anchor (§9).
+
+**The runner module does exactly four things:**
+
+1. **Structural integrity, parametrized per row** (this is the ledger made load-bearing):
+   - `spec.quote` appears **verbatim** in `specs/canonical/attractor-spec-canonical.md`
+     (whitespace-normalized within lines, line-structure preserved for block quotes);
+   - `ledger.conformance` id exists as a row in `SPEC_CONFORMANCE.md`; `ledger.extensions`
+     number exists as a `## N.` heading in `specs/EXTENSIONS.md` (reusing
+     `test_extensions_ledger_integrity.py`'s heading regex);
+   - every `assertion.indexed` entry resolves: the file exists and the named
+     test/class-method exists in it — verified by **AST parse, never import** (indexed
+     cites cross module venv boundaries, e.g. `pipeline-runner`'s resume e2e; the repo's CI
+     runs each module's suite in its own venv, so the matrix must not import across them);
+   - disposition vocabulary, id uniqueness, required-field presence, and both directions of
+     the probe cross-check (every `kind: probe` row names an existing function; every
+     `test_row_*` function corresponds to a row).
+2. **Behavioral probes**: plain async pytest functions named `test_row_<id>`, in-process
+   engine runs with mock backends (§10 proves the pattern), each ending in asserts whose
+   messages are rendered by the flip-message helper (§8).
+3. **The SYNC row** (§9): sha256 of the canonical file matches the pin.
+4. **A coverage tripwire**: every `## N.` entry in `EXTENSIONS.md` whose banner says
+   DIVERGES must be cited by ≥1 matrix row, and every `ATX-*` ledger row with disposition
+   DIVERGE must be cited by ≥1 row — so a *future* divergence cannot be ledgered without
+   also being asserted. (The reverse — new spec sections — is handled by the SYNC row.)
+
+**Repo-discovery and style** follow the guard-test precedents exactly: `BUNDLE_ROOT =
+Path(__file__).parent.parent.parent.parent`, module docstring naming the incident class it
+guards, "Honest limits" section, RED/GREEN regression proofs for the *checker logic itself*
+(synthetic matrix rows with a wrong quote / missing ledger cite / dangling indexed cite must
+be flagged). One deliberate departure: the guard tests' skip-if-absent discipline applies to
+*optional* docs; the matrix file is **not optional** — a missing or unparseable
+`attractor-matrix.yaml` is a hard failure, because a silently-skipped matrix is a matrix
+that isn't load-bearing.
+
+**CI cost:** one module, in-process probes, no LLM, no network (`test_no_network_dep.py`
+discipline applies). Probe corpus at tranche-1 scale measured at ~0.25s (§10); structural
+checks are file reads + AST parses over ~40 files. Budget: well under 10s inside the
+existing `uv run pytest -q` loop-pipeline job. No new CI job needed.
+
+---
+
+## 5. Q3 — Asserting divergences: the pattern, fully worked
+
+**The rule:** a DIVERGE-DECIDED row must prove **(a)** the engine does our documented
+behavior, and **(b)** the spec's behavior does *not* occur — where (b) is cheap, i.e. an
+extra assert on state already in hand, never a second engine run. Half (b) is what makes
+un-diverging loud: a PR that re-aligns to spec keeps (a) failing, but (b) is the assert that
+*names the spec behavior as the thing that just appeared*.
+
+**Fully worked: ATX-M-011, the dead-end hard-fail (ATX-11 / EXTENSIONS §33 vs spec §3.2
+step 6).** This exact code executed green against `origin/main` (§10, probe P1); only the
+message rendering is added here.
+
+```python
+# in modules/loop-pipeline/tests/test_spec_conformance_matrix.py
+
+class SuccessNoMatchBackend:
+    """Explicit SUCCESS whose preferred_label matches no edge -> dead end."""
+    async def run(self, node, prompt, context, incoming_edge=None, graph=None):
+        return Outcome(status=StageStatus.SUCCESS, preferred_label="nomatch",
+                       is_explicit=True)
+
+@pytest.mark.asyncio
+async def test_row_atx_m_011(tmp_path):
+    row = MATRIX["ATX-M-011"]
+    dot = """
+    digraph M011 {
+        start [shape=Mdiamond]
+        exit  [shape=Msquare]
+        work  [prompt="do work"]
+        sink  [prompt="unreached"]
+        start -> work
+        work -> sink [condition="outcome=fail"]   // exists but will not match
+        sink -> exit
+    }
+    """
+    hooks = EventCollector()
+    engine = build_engine(dot, SuccessNoMatchBackend(), tmp_path, hooks=hooks)
+    outcome = await engine.run()
+
+    # (a) OUR ledgered behavior: hard-fail, traceable, loud.
+    assert outcome.status == StageStatus.FAIL, flip(row,
+        observed=f"pipeline outcome {outcome.status} on a dead end",
+        expected="a dead end ALWAYS terminates with status=FAIL")
+    assert outcome.failure_reason, flip(row,
+        observed="empty failure_reason",
+        expected="terminate_pipeline() carries a traceable failure_reason")
+    assert any(e.get("error_type") == "no_matching_edge"
+               for e in hooks.get(PIPELINE_ERROR)), flip(row,
+        observed="no PIPELINE_ERROR error_type=no_matching_edge event",
+        expected="the hard-fail emits PIPELINE_ERROR error_type=no_matching_edge")
+
+    # (b) The SPEC behavior must NOT occur: spec §3.2 step 6 says a dead end
+    # after a non-FAIL outcome returns Outcome(SUCCESS, "Pipeline completed").
+    assert outcome.status != StageStatus.SUCCESS and \
+           "Pipeline completed" not in (outcome.notes or ""), flip(row,
+        observed="dead end resolved to the spec's SUCCESS 'Pipeline completed'",
+        expected="the spec-literal dead-end-to-SUCCESS behavior stays absent",
+        direction="UN-DIVERGENCE")
+```
+
+And the rendered failure when a future PR re-aligns to spec (see §8 for the contract):
+
+```
+SPEC-CONFORMANCE MATRIX FLIP — row ATX-M-011 "dead-end hard-fail (main loop)"
+  spec:        §3.2 Core Execution Loop — "IF next_edge is NONE: ... RETURN
+               Outcome(status=SUCCESS, notes=\"Pipeline completed\")"
+  disposition: DIVERGE-DECIDED  (ledgered: SPEC_CONFORMANCE.md ATX-11;
+               specs/EXTENSIONS.md §33)
+  direction:   UN-DIVERGENCE — the engine now matches the spec text the ledger
+               says we deliberately diverge from.
+  observed:    dead end resolved to the spec's SUCCESS 'Pipeline completed'
+  expected:    the spec-literal dead-end-to-SUCCESS behavior stays absent
+
+  A dead-ended graph silently reporting success is the incident class this
+  divergence exists to prevent (EXTENSIONS.md §33; the 2026-07-28 false-green
+  run). examples/pipelines/practical/bug-fix.dot ('escalated') depends on the
+  hard-fail. Two legal exits — in THIS PR, not a follow-up:
+    1. Revert the behavior change. The ledger is the record of decided behavior.
+    2. Keep the change AND move the record with it: update SPEC_CONFORMANCE.md
+       ATX-11 (DIVERGE -> ALIGN, dated changelog line), rewrite EXTENSIONS.md §33,
+       update this matrix row (disposition + assertion), and fix the paired doc
+       guards (test_engine_semantics_doc_guard.py D-200/D-202,
+       context/engine-semantics.md §3).
+  Doing neither means main carries a ledger that lies. That is drift.
+```
+
+The same two-direction shape applies to every tranche-1 divergence: ATX-12 asserts
+in-process reset **and** that no fresh log-directory root appears; §25 asserts the gate
+rejects a status-only SUCCESS **and** (control) accepts an explicit one; §16 asserts FAIL
+stops at unconditional edges **and** (control, already in
+`test_edge_selection_no_silent_fallthrough.py`) SUCCESS traverses them; ATX-5 asserts
+`outcome=` matches the label when `preferred_label` is set **and** falls back to status when
+unset (both directions already exist in `test_conditions.py` — that row is INDEXED, no new
+code).
+
+---
+
+## 6. Q4 — Coverage strategy and the row inventory
+
+**Granularity rule:** one row per *normative statement cluster* — the smallest spec text a
+PR could violate independently. Not per sentence (the §3.3 pseudocode is one algorithm, but
+its five steps flip independently → five rows); not per section (§4.5 contains at least
+eight independently-violable claims).
+
+**NOT-ASSERTABLE is legal but earned per row.** Legitimate members found in the walk:
+design-principles prose (§1.3), "single-threaded traversal simplifies reasoning" (§3.8
+rationale — the *isolation* claims beside it are assertable and asserted), the §5.4
+fidelity token-budget approximations ("~600 tokens" — we assert the mode vocabulary and
+preamble shapes instead), manager-loop steer-cooldown prose, the observer-vs-stream event
+consumption patterns (§9.6 tail), and §11's checklists *as such* (the matrix is their
+operationalization; asserting "the checklist exists" would be circular). Each such row
+carries a `justification` and `assertion.kind: none`. Ten rows total — ~6% of the matrix,
+which is the honest size of the spec's aspirational prose.
+
+**The inventory** (per-section counts; "indexed" names the suites that already carry the
+behavior — the matrix *indexes* them, never duplicates them):
+
+| Spec section | Rows | Indexed (existing suites) | New probes | Not-assertable |
+|---|--:|--:|--:|--:|
+| §1 Overview/principles | 2 | 0 | 0 | 2 |
+| §2.1–2.4 grammar, constraints, value types | 4 | 4 — `test_dot_parser.py`, `test_node_timeout_units.py` (ATX-1) | 0 | 0 |
+| §2.5 graph attrs + defaults | 3 | 3 — `test_retry.py::test_retry_policy_default_zero`, `test_fidelity.py::test_resolve_fidelity_default_is_compact`, `test_doc_consistency.py` | 0 | 0 |
+| §2.6 node attrs | 6 | 5 — `test_retry.py` (arithmetic/inheritance), `test_spec_conformance_batch.py` (A1 auto_status, A2 quoted booleans), must_write/allow_partial suites | 1 (Appendix-A defaults spot-check, incl. `reasoning_effort` default — see F4 §13) | 0 |
+| §2.7 edge attrs (`loop_restart`) | 2 | 1 — `test_fidelity.py` (edge fidelity/thread_id overrides) | 1 (**P2**: ATX-12 dual-direction) | 0 |
+| §2.8 + §4.2 shape/handler dispatch | 3 | 1 — `test_no_silent_fallback.py::test_known_shapes_still_dispatch_correctly` | 2 (full 9-shape table parametrized; unknown-shape row — see F1 §13) | 0 |
+| §2.9–2.13 chained edges, subgraphs, default blocks, class | 4 | 4 — `test_dot_parser.py`, `test_stylesheet.py` | 0 | 0 |
+| §3.1 lifecycle phases | 1 | 0 | 0 | 1 |
+| §3.2 core loop | 7 | 4 — `test_engine.py` (start resolution, terminal stop), `test_checkpoint.py::TestCheckpointEngineIntegration` (save-after-node), `test_pipeline_events.py` | 3 (**P1** dead-end dual-direction; step-4 built-in context keys; goal-gate CONTINUE jump) | 0 |
+| §3.3 edge selection (+ §16 divergence) | 7 | 7 — `test_edge_selection.py` (25 tests: priority, normalization, tiebreaks, determinism), `test_edge_selection_no_silent_fallthrough.py` (§16 + runs_on), ATX-10 restoration | 0 | 0 |
+| §3.4 goal gates (+ §25 gate rung) | 5 | 3 — `test_goal_gates.py` (GOAL-001…006), `test_engine.py::test_goal_gate_unsatisfied_returns_fail`, `test_goal_gate_retry_clears_failures.py` | 2 (**P3** is_explicit gate rung; 4-rung retry-target ladder incl. graph-level rungs) | 0 |
+| §3.5–3.6 retry (+ ATX-6 pin) | 8 | 7 — `test_retry.py` (policy, backoff math, jitter, `TestShouldRetry` ×10), `test_spec_conformance_batch.py` (B6 preset table) | 1 (ATX-6: FAIL executes exactly once — OPEN-PINNED) | 0 |
+| §3.7 failure routing | 2 | 2 — `test_failure_routing.py`, `test_folder_node_failure_routing.py` | 0 | 0 |
+| §3.8 concurrency | 3 | 2 — `test_parallel.py`, `test_parallel_branch_nested_isolation.py`, `test_parallel_ignore_does_not_populate_failed_outputs.py` | 0 | 1 |
+| §4.1–4.2 handler interface/registry | 3 | 2 — `test_handlers.py`, `test_validation.py::test_explicit_tool_type_wins_over_codergen_node_type` | 1 (re-register replaces) | 0 |
+| §4.3–4.4 start/exit no-ops | 2 | 2 — `test_handlers.py` | 0 | 0 |
+| §4.5 codergen (+ §25 parser rung) | 8 | 6 — `test_backend.py` (string→SUCCESS wrap for non-gates, `_parse_outcome` ladder), `test_engine_artifacts.py`, `test_run_directory.py`, `test_codergen_failure_capture.py` | 2 (**P3-prose**; simulation-mode text) | 0 |
+| §4.6 human gate | 6 | 5 — `test_human.py` (61 tests: choices, timeout→default, SKIPPED→FAIL, accelerator table), `test_p2_conversational_gate.py` | 1 (unmatched-answer→first-choice fallback, if uncovered on audit) | 0 |
+| §4.7 conditional handler | 1 | 1 — `test_conditional_handler.py` | 0 | 0 |
+| §4.8 parallel (+ §18 extension) | 6 | 5 — `test_parallel.py`, `test_parallel_policies.py` (25), `test_parallel_early_exit.py`, `test_parallel_fanout_contract.py` | 0 | 1 |
+| §4.9 fan-in | 4 | 4 — `test_fan_in_bfs.py`, `test_spec_conformance_batch.py` (B7 `best_outcome` key), handler tests | 0 | 0 |
+| §4.10 tool handler | 4 | 4 — `test_handlers.py`, `test_node_timeout_units.py` (ATX-1), `test_p10_tool_env.py`, `test_tool_failure_capture.py` | 0 | 0 |
+| §4.11 manager loop | 3 | 2 — `test_manager_loop.py`, `test_manager_steer_structured.py` | 0 | 1 |
+| §4.12 custom handlers | 2 | 2 — `test_handlers.py`, `test_retry.py::RaisingHandler` (exception→FAIL) | 0 | 0 |
+| §5.1 context | 4 | 2 — `test_context.py` (14), `test_handler_context.py` | 1 (engine-set built-in keys: `outcome`, `preferred_label`, `graph.goal`, `internal.retry_count.*`) | 1 |
+| §5.2 outcome model | 2 | 2 — `test_outcome.py`, must_write SKIPPED tests | 0 | 0 |
+| §5.3 checkpoint + resume | 6 | 6 — `test_checkpoint.py` (v2 superset keeps the six §5.3 fields), `test_engine_resume.py` (incl. `test_resume_degrades_first_full_hop_once` — rule 6), `test_resume_validation.py`, `test_no_implicit_resume.py`, `pipeline-runner/tests/test_resume_e2e.py` (SIGKILL) | 0 | 0 |
+| §5.4 fidelity | 5 | 4 — `test_fidelity.py` (precedence, thread rungs, modes), `test_backend_fidelity.py`, `test_backend_full_continuity.py` | 0 | 1 |
+| §5.5 artifact store | 3 | 3 — `test_artifacts.py` (27), `test_engine_artifacts.py` | 0 | 0 |
+| §5.6 run directory | 2 | 2 — `test_run_directory.py` (19) | 0 | 0 |
+| §6 interviewer protocol | 4 | 4 — `test_human.py` (Queue/AutoApprove/Callback/timeout) | 0 | 0 |
+| §7 validation | 5 | 5 — `test_validation.py` (41: every §7.2 rule, `validate_or_raise`, diagnostic fields), `test_topological_lint.py` | 0 | 0 |
+| §8 stylesheet | 4 | 4 — `test_stylesheet.py` (25: selectors, specificity, explicit-wins) | 0 | 0 |
+| §9.1–9.4 transforms/composition | 3 | 3 — `test_transforms.py`, `test_subgraph_runner.py`, `test_pipeline_handler.py` | 0 | 0 |
+| §9.5 HTTP server mode | 1 | 0 | 1 (absence — NOT-IMPLEMENTED-DECIDED, ATX-4) | 0 |
+| §9.6 events | 3 | 2 — `test_pipeline_events.py` (34), `hooks-pipeline-observability` suites | 0 | 1 |
+| §9.7 tool call hooks | 1 | 0 | 1 (absence — OPEN-PINNED, ATX-3) | 0 |
+| §10 conditions (+ ATX-5, ATX-7, §10.7) | 8 | 6 — `test_conditions.py` (39: ops, missing-key→"", bare-key truthiness, ATX-5 both directions, `context.` prefix retry) | 2 (ATX-7 literal-unquoting pin; §10.7 extended-operators absence) | 0 |
+| §11 DoD as such | 1 | 0 | 0 | 1 |
+| Appendix A attribute reference | 2 | 1 — doc guards | 1 (defaults spot-check, shared with §2.6 probe) | 0 |
+| Appendix C status-file contract | 2 | 2 — `test_spec_conformance_batch.py` (A1 synthesis), `test_run_directory.py`, `test_outputs_attribute.py` | 0 | 0 |
+| Appendix D error categories | 1 | 1 — `test_retry.py::TestShouldRetry` | 0 | 0 |
+| SYNC canonical pin | 1 | 0 | 1 (sha256) | 0 |
+| **Totals** | **154** | **123** | **21** | **10** |
+
+Counts are the design's estimate at cluster granularity; tranche construction trues them up
+(rows may split, never silently vanish — id retirement requires a matrix-file comment naming
+the successor rows).
+
+---
+
+## 7. Q5 — Tranche 1: the 35 load-bearing rows
+
+Membership rule: **every decided divergence (non-negotiable), every OPEN ledger item
+pinned, the SYNC row, and the behaviors a community `.dot` file stakes its correctness on**
+(Compatibility-doctrine rule 2). Quotes abbreviated here; the matrix file carries them
+verbatim.
+
+**A. Divergences and extensions with teeth (11 rows — all mandatory):**
+
+| id | Spec ref (quote gist) | Disposition | Ledger | Assertion |
+|---|---|---|---|---|
+| ATX-M-011 | §3.2 step 6 `:388-393` — dead end + non-FAIL ⇒ `Outcome(SUCCESS, "Pipeline completed")` | DIVERGE-DECIDED | ATX-11; EXT §33 | **probe** (P1 ✅): FAIL + `PIPELINE_ERROR error_type=no_matching_edge` + spec-SUCCESS absent; indexed: `test_engine.py::test_no_matching_edge_returns_fail`, `test_pipeline_events.py::TestErrorEvents::test_emits_error_on_no_edge` |
+| ATX-M-012 | §2.7 `:177` + §3.2 step 7 `:395-398` — `loop_restart` "terminates the current run and re-launches with a fresh log directory"; `restart_run(...); RETURN` | DIVERGE-DECIDED | ATX-12; EXT §24 | **probe** (P2 ✅): in-process reset — `$iteration` 0→1, `context_updates` survive, work re-executes, `iteration_1/` under the SAME `logs_root`, no fresh root, `run()` returns normally; indexed: `test_convergence_observability.py` |
+| ATX-M-025a | §4.5 `:695-704` — codergen wraps any string response as `Outcome(SUCCESS, "Stage completed: …")` | DIVERGE-DECIDED (goal_gate scope only) | EXT §25 | **probe** (P3-prose ✅): plain prose on a `goal_gate=true` node does NOT exit success; **control**: non-gate prose→SUCCESS preserved (indexed: `test_backend.py::test_backend_plain_text_returns_success`, `test_fail_closed_outcomes.py::test_fc001/fc002/fc010`) |
+| ATX-M-025b | §3.4 `:471-477` — `check_goal_gates`: status ∈ {SUCCESS, PARTIAL_SUCCESS} satisfies the gate | DIVERGE-DECIDED (gate additionally requires `is_explicit`) | EXT §25 | **probe** (P3 ✅): status-only `Outcome(SUCCESS, is_explicit=False)` on a gate ⇒ pipeline FAIL; control `is_explicit=True` ⇒ SUCCESS; indexed: `test_fail_closed_outcomes.py::test_fc008` |
+| ATX-M-016 | §3.3 step 4 `:448-451` — unconditional edges selected by weight *regardless of outcome status* | DIVERGE-DECIDED (FAIL is fail-fast) | EXT §16 | indexed both directions: `test_edge_selection_no_silent_fallthrough.py::test_fail_outcome_does_not_traverse_unconditional_edges` + `::test_success_outcome_traverses_unconditional_edges_as_before` + `runs_on` routes |
+| ATX-M-022 | §10.4 `:1693-1697` — `resolve_key("outcome")` RETURNS `outcome.status`; `preferred_label` is a separate key | DIVERGE-DECIDED | ATX-5; EXT §22 | indexed both directions: `test_conditions.py::test_outcome_resolves_preferred_label_custom_value` + `::test_outcome_resolves_status_when_no_preferred_label` (+`_fail` variant) |
+| ATX-M-036 | §4.5 `:718` — backend internals implementer-delegated (spec-silent on provider serviceability) | EXTENSION (fail-loud preflight; behavior change vs silent fallback) | EXT §36 | indexed: `test_provider_preflight.py`, `pipeline-runner/tests/test_provider_preflight_drive_engine.py`, `test_profile_routing.py` (no-fallback resolution) |
+| ATX-M-006o | §3.5 `:519-520` — `IF outcome.status == FAIL: RETURN outcome` (no retry) — **conflicts** with DoD `:1833` "retried on RETRY or FAIL outcomes" | OPEN-PINNED (ATX-6, disposition pending: reconcile-the-spec) | ATX-6 | **probe**: handler FAIL with `max_retries=2` ⇒ exactly 1 execution; `spec.conflict` cites DoD 11.5; flip message names ATX-6 |
+| ATX-M-007o | §10.5 `:1743-1747` — `parse_literal` strips double quotes from condition literals | OPEN-PINNED (ATX-7) | ATX-7 | **probe**: pin today's behavior (quoted literal compared raw vs unquoted — probe records which; flip demands the ATX-7 decision) |
+| ATX-M-003o | §9.7 `:1650-1657` — `tool_hooks.pre`/`.post` shell commands around each tool call | OPEN-PINNED (ATX-3, DECIDE pending) | ATX-3 | **absence**: `grep -r tool_hooks modules/loop-pipeline/amplifier_module_loop_pipeline/` = 0 — implementing it without deciding ATX-3 flips this row |
+| ATX-M-004n | §9.5 `:1589-1607` — "Implementations **may** expose … HTTP service" | NOT-IMPLEMENTED-DECIDED | ATX-4 | **absence**: no HTTP-server entry point in the bundle; justification: spec-optional, programmatic tools instead |
+
+**B. Load-bearing conformances (23 rows):**
+
+| id | Spec ref | Disposition | Assertion |
+|---|---|---|---|
+| ATX-M-101 | §3.2 — `find_start_node`: shape=Mdiamond, then id `start`/`Start`; error if absent | CONFORM | indexed: `test_engine.py`, `test_validation.py::test_missing_start_node`/`test_multiple_start_nodes` |
+| ATX-M-102 | §3.2 step 4 — engine merges `context_updates`, sets `context["outcome"]`=status, sets `preferred_label` only when non-empty | CONFORM | **probe** (new): run 2-node graph, inspect context between/after nodes |
+| ATX-M-103 | §3.2 step 5 / §5.3 — checkpoint saved after each node completion | CONFORM | indexed: `test_checkpoint.py::TestCheckpointEngineIntegration`, `TestEngineWritesV2` |
+| ATX-M-104 | §3.2 step 1 — terminal node stops execution; gate check runs first | CONFORM | indexed: `test_goal_gates.py`, `test_engine.py` |
+| ATX-M-105 | §3.3 step 1 — condition-matched edges win; best by weight-then-lexical among them | CONFORM | indexed: `test_edge_selection.py::test_condition_matching_takes_priority`, `::test_condition_beats_preferred_label`, `::test_condition_edges_sorted_by_weight` |
+| ATX-M-106 | §3.3 step 2 — preferred-label match on *unconditional* edges only; normalization lowercases/trims/strips `[Y] `-style accelerators | CONFORM | indexed: `::test_preferred_label_match`, `::test_step2_skips_conditional_edge_with_matching_label`, `::test_label_normalization*` (×3) |
+| ATX-M-107 | §3.3 step 3 — `suggested_next_ids` first match, unconditional only | CONFORM | indexed: `::test_suggested_next_ids*` (×3), `::test_preferred_label_beats_suggested_ids` |
+| ATX-M-108 | §3.3 steps 4–5 — weight desc, lexical tiebreak; deterministic | CONFORM | indexed: `::test_weight_tiebreak`, `::test_lexical_tiebreak`, `::test_deterministic_with_same_inputs` |
+| ATX-M-109 | §3.3 — one edge selected, never fan-out for non-component nodes (ATX-10 restoration) | CONFORM | indexed: `test_edge_selection.py` (retired multi-match gate), T0-4 note EXT |
+| ATX-M-110 | §3.4 — SUCCESS and PARTIAL_SUCCESS satisfy gates | CONFORM | indexed: `test_goal_gates.py::test_satisfied_goal_gates_allow_exit`, `::test_partial_success_satisfies_goal_gate` |
+| ATX-M-111 | §3.4 rule 3 — retry-target ladder: node → node fallback → graph → graph fallback | CONFORM | **probe** (new, parametrized over the 4 rungs) + indexed partial: `test_goal_gates.py` |
+| ATX-M-112 | §3.4 rule 4 — no target at any level ⇒ pipeline FAIL | CONFORM | indexed: `test_engine.py::test_goal_gate_unsatisfied_returns_fail` |
+| ATX-M-113 | §3.5 — `max_retries=3` ⇒ 4 executions; node inherits `default_max_retries` (+legacy alias); built-in default 0 | CONFORM | indexed: `test_retry.py::test_retry_policy_from_node_max_retries`, `::test_retry_policy_from_graph_default`, `::test_retry_policy_default_zero` |
+| ATX-M-114 | §3.5 — RETRY: increment, backoff, exhaust ⇒ `allow_partial` ? PARTIAL : FAIL | CONFORM | indexed: `test_retry.py`, `test_engine_must_write.py::test_retry_exhaustion_allow_partial_*` |
+| ATX-M-115 | §3.6 — preset policy table values | CONFORM | indexed: `test_spec_conformance_batch.py` (B6) |
+| ATX-M-116 | §3.6 — default `should_retry`: transient=retryable, auth/400/validation=terminal | CONFORM | indexed: `test_retry.py::TestShouldRetry` (10 tests) |
+| ATX-M-117 | §3.7 — failure routing order: fail edge → retry_target → fallback → terminate | CONFORM | indexed: `test_failure_routing.py` |
+| ATX-M-118 | §2.8/App B — 9-shape → handler-type table | CONFORM | **probe** (new, parametrized over the table) + indexed: `test_no_silent_fallback.py::test_known_shapes_still_dispatch_correctly` |
+| ATX-M-119 | §4.12 — handler exceptions caught ⇒ FAIL outcome | CONFORM | indexed: `test_retry.py` (RaisingHandler terminal path) |
+| ATX-M-120 | §5.3 — checkpoint carries the six fields at `{logs_root}/checkpoint.json` (v2 = superset) | CONFORM (schema superset = EXTENSION note) | indexed: `test_checkpoint.py::TestCheckpointKeyShape`, `::TestCheckpointV2Schema` |
+| ATX-M-121 | §5.3 resume rules 1–5 — restore context/completed/retries; continue after `current_node`; edge selection once from recorded outcome | CONFORM | indexed: `test_engine_resume.py` (×4 incl. control-run equivalence), `test_resume_validation.py` ladder, `pipeline-runner/tests/test_resume_e2e.py` (really-killed run) |
+| ATX-M-122 | §5.3 rule 6 — `full` degrades to `summary:high` for exactly one resumed hop | CONFORM | indexed: `test_engine_resume.py::test_resume_degrades_first_full_hop_once`, `::test_cap_never_leaks_into_a_checkpoint_or_a_later_hop`, `::test_no_degrade_when_the_first_hop_is_not_full` |
+| ATX-M-123 | §5.4 — fidelity precedence edge > node > graph > `compact` | CONFORM | indexed: `test_fidelity.py` (×6) |
+| ATX-M-124 | §7.1/§7.3 — ERROR diagnostics refuse execution; `validate_or_raise` throws; §7.2 rule table (conflict note: DoD 11.12 "orphan → warning" — pinned to §7.2 ERROR) | CONFORM | indexed: `test_validation.py` (per-rule tests + `::test_validate_or_raise_raises_on_errors`) |
+
+**Plus** ATX-M-000 (SYNC row, §9) = **35 rows**: 11 divergence/pin/absence + 24 conformance
++ SYNC. All probe-kind rows verified feasible by the executed pattern in §10.
+
+**Tranche 2+** (the remaining ~119 rows, by section): §2 parser rows; §3.2 residue
+(goal-gate CONTINUE, mirror-attributes); §3.8; §4.1–4.4, §4.6–4.12 handler rows; §5.1–5.2,
+§5.4–5.6 residue; §6; §8; §9.1–9.4, §9.6; §10 residue (bare-key truthiness, `context.`
+prefix retry, §10.7 absence); Appendices A/C/D; NOT-ASSERTABLE rows with justifications.
+Tranche 3 = ULM/CAL matrices (§12).
+
+---
+
+## 8. Q6 — The drift-flip experience
+
+**Scenario:** a future PR changes `engine.py` so a dead end after SUCCESS completes
+successfully ("aligning to spec"). The developer runs the suite (or CI does) and sees, from
+`test_spec_conformance_matrix.py::test_row_atx_m_011`, exactly the message rendered in §5.
+
+**The message contract** — every flip message MUST contain, in order:
+
+1. **The banner** `SPEC-CONFORMANCE MATRIX FLIP — row <id> "<title>"` (greppable).
+2. **The spec anchor**: section + heading + the verbatim quote (the developer should not
+   need to open the spec to know which sentence is in play).
+3. **The current disposition + every ledger cite** (`SPEC_CONFORMANCE.md ATX-n`,
+   `specs/EXTENSIONS.md §n`).
+4. **The direction**: `REGRESSION` (moved off our documented behavior),
+   `UN-DIVERGENCE` (moved onto the spec text we ledgered away from), or
+   `UNDECIDED-MOVEMENT` (OPEN-PINNED row moved before its decision).
+5. **observed / expected**, one line each, concrete.
+6. **The two legal exits**, mirroring the Compatibility doctrine, with the *complete*
+   same-PR checklist for exit 2: ledger row (+ dated changelog line), EXTENSIONS entry,
+   matrix row, and any paired doc guards named in the row's `notes`.
+7. **The closing invariant**: *"Doing neither means main carries a ledger that lies. That
+   is drift."*
+
+Rendered by one `flip(row, observed, expected, direction)` helper so the shape cannot decay
+per-row. The structural-integrity failures (quote no longer in canonical, dangling ledger
+cite, dangling indexed test) use the same banner with direction `MATRIX-INTEGRITY`, so a
+`grep "MATRIX FLIP"` over CI logs finds every conformance event of any kind.
+
+**What the developer does next** is mechanical, not archaeological: exit 1 is `git revert`;
+exit 2 touches four named files in one PR, and the matrix's structural checks verify the
+ledger edits landed (an EXTENSIONS banner flipped to ABSORBED/withdrawn without renumbering
+still satisfies the integrity guard; a deleted ATX row fails the cite check — the ledger's
+append-only discipline is preserved by construction).
+
+---
+
+## 9. Q7 — Upstream-sync hook and the anchoring decision
+
+**The SYNC row (ATX-M-000):** the matrix file header pins
+
+```yaml
+canonical:
+  path: specs/canonical/attractor-spec-canonical.md
+  upstream: strongdm/attractor @ fb57a55
+  sha256: "<computed at matrix creation>"
+```
+
+and the runner asserts the file's sha256 matches. On mismatch the flip message is not "fix
+the hash" — it is: *"specs/canonical has been re-synced. Every matrix row quotes this file;
+a re-sync is a full-matrix re-review event. Re-verify every row against the new text, update
+dispositions/ledger entries that the new upstream text absorbs or invalidates (see the
+EXTENSIONS 'ABSORBED UPSTREAM' banner protocol), then update the pinned sha and `upstream:`
+in the same PR."* This turns SYNC-1-style refreshes from a quiet vendoring commit into a
+demanded review — which is exactly what the 2026-08-14 `fb57a55` sync required by hand
+(EXTENSIONS §§1–7 retconned ABSORBED; §18's `k_of_n`/`quorum` discovered *removed* upstream).
+
+**Line numbers vs anchors — decided: verbatim quotes are the binding anchor; line numbers
+are stored but informational.** The prompt's observation is correct: byte-pinning makes line
+numbers *stable between SYNC events*, so they are not brittle day-to-day. But they carry no
+meaning — a line number can only ever fail *because the sha row already failed*, at which
+point 154 stale integers would demand a mass renumbering edit that reviews nothing. Quotes
+do strictly more work: (a) they make each row self-verifying against the spec's *text*, (b)
+after a re-sync, quote checks fail **only where the normative text actually changed** —
+an automatic, targeted diff of "which rows does the new upstream touch," which is the
+review the SYNC row demands, (c) they make the matrix readable standalone (the row shows
+the sentence it answers to). So: quotes runner-verified; `line:` kept as a reading aid
+(and regenerable by a trivial script); the sha row catches everything else including
+edits that don't touch any quoted sentence.
+
+---
+
+## 10. Q8 — Probes: feasibility, verified by execution
+
+**Claim:** every tranche-1 probe runs in-process against `PipelineEngine` with a
+backend double — deterministic, no LLM, no network, no subprocess. The seams are already
+canonical in the suite: `MockBackend`/`CountingBackend` (`test_goal_gates.py`),
+`CountingRestartBackend` (`test_convergence_observability.py`), `MockHooks` event capture
+(`test_pipeline_events.py`), direct handler construction (`test_handlers.py`), and pure
+functions (`select_edge`, `evaluate_condition`). Any row that seems to need a live LLM is
+mis-specified — the spec's normative statements are about the *engine's* contract with the
+backend, and that contract is exactly the mock seam. (The one genuinely live-ish row class —
+"resume survives a real SIGKILL" — already exists as
+`pipeline-runner/tests/test_resume_e2e.py` and is INDEXED, not duplicated.)
+
+**Verification: the three hardest rows were probed for real** in a `/tmp` worktree at
+`origin/main` (`git worktree add /tmp/cm/wt origin/main`; file
+`modules/loop-pipeline/tests/test_probe_matrix.py`; `uv run pytest` in the module venv):
+
+```
+tests/test_probe_matrix.py::test_p1_dead_end_after_success_hard_fails_with_event PASSED
+tests/test_probe_matrix.py::test_p2_loop_restart_is_in_process_reset_not_relaunch PASSED
+tests/test_probe_matrix.py::test_p3_goal_gate_rejects_non_explicit_success PASSED
+tests/test_probe_matrix.py::test_p3_control_explicit_success_satisfies_gate PASSED
+tests/test_probe_matrix.py::test_p3_plain_prose_on_goal_gate_does_not_exit_success PASSED
+============================== 5 passed in 0.22s ==============================
+```
+
+- **P1 (ATX-M-011)** — dead end after explicit SUCCESS (edges exist, none match):
+  `run()` → FAIL with non-empty `failure_reason`; `PIPELINE_ERROR` event with
+  `error_type="no_matching_edge"` captured via the hooks seam; spec's
+  `SUCCESS/"Pipeline completed"` asserted absent. One engine construction, ~40 lines.
+  (Import gotcha found and recorded: the events module is
+  `amplifier_module_loop_pipeline.pipeline_events`, not `.events`.)
+- **P2 (ATX-M-012)** — `work -> work [loop_restart=true]` graph, backend stops on call 2:
+  `$iteration` seen as `["0", "1"]` inside the backend; `context_updates` from iteration 0
+  (`finding=attempt-0-found-X`) visible in iteration 1; `work` executed twice (completed
+  set cleared); `logs/iteration_1/` exists under the **same** `logs_root`; no sibling
+  run-root created (spec's "fresh log directory" absent); `run()` returned a normal final
+  outcome in-process (spec's `restart_run(); RETURN` absent). No infinite-loop hazard: the
+  backend's stop condition is the loop bound, same pattern as `CountingRestartBackend`.
+- **P3 (ATX-M-025a/b)** — `goal_gate=true` node: `Outcome(SUCCESS, is_explicit=False)`
+  (the spawn status-only shape) ⇒ pipeline FAIL with "gate" in the failure reason — the
+  spec's §3.4 status-only satisfaction demonstrably does not hold; control with
+  `is_explicit=True` ⇒ SUCCESS; plain-prose string return (which spec §4.5 wraps as
+  SUCCESS) ⇒ pipeline does not exit success.
+
+Total probe cost for the three hardest: 0.22s including the two control tests. The
+remaining ~16 tranche-1/2 probes are strictly simpler shapes of the same pattern.
+
+---
+
+## 11. Q9 — Liftability: what other repos can take
+
+**Portable as-is** (candidate for a shared `spec-conformance` skill/bundle doc):
+
+- **The row schema** (§3) — nothing in it is attractor-specific except the ledger file
+  names, which are two config keys.
+- **The disposition vocabulary** — especially the two inventions earned here:
+  `OPEN-PINNED` (pin behavior without forging a decision) and `absence` assertions
+  (make "we don't implement §X" an executable claim). Any repo with a contract has
+  undecided gaps and decided omissions.
+- **The flip-message contract** (§8) — banner, anchor-with-quote, disposition+cite,
+  direction, observed/expected, two-legal-exits, closing invariant. This is the actual
+  product; everything else is plumbing for it.
+- **The anchoring rule** (§9) — verbatim quotes runner-verified + one content-hash SYNC row
+  demanding full re-review; positional references informational only. Works for any
+  byte-pinned upstream artifact (a vendored spec, an OpenAPI schema, a protocol RFC).
+- **The two-direction divergence rule** (§5) and the **coverage tripwire** (every ledgered
+  divergence must be cited by ≥1 row).
+
+**Attractor-specific, do not lift:** the deterministic seams (MockBackend, hooks capture,
+`select_edge`) — every engine has its own; the per-module-venv constraint that forces
+AST-verification of cross-module cites; the ledger *formats* (ATX row grammar, EXTENSIONS
+`## N.` banners) — though the integrity-guard pairing generalizes; the specific
+NOT-ASSERTABLE judgments.
+
+The honest lift-limit: the matrix's value density comes from the *ledger discipline already
+existing here*. A repo without a decided-divergence ledger gets a conformance suite from
+this pattern, not a drift detector — the pattern's first demand on such a repo is "write the
+ledger."
+
+---
+
+## 12. Scope call: the other two canonical specs
+
+Named decision: **v1 scopes to the attractor spec.** The other two canonical specs are
+assertable against this repo's modules, and the schema is deliberately spec-agnostic, but
+they are tranche 3, as separate data files with runner twins in their own module test trees
+(per-module venv reality):
+
+- **unified-llm** (`modules/unified-llm-client`): already has a spec-section-mapped DoD
+  suite (`tests/dod/test_8_1…8_10*.py`) — effectively a proto-matrix without dispositions.
+  A `ulm-matrix.yaml` would mostly INDEX it, add the ledger cites (ULM-1…17), and pin the
+  one decided divergence (ULM-17 Gemini `additionalProperties` sanitizer) plus the OPEN
+  rows (ULM-4/8/11/12/13) as OPEN-PINNED. Cheap, high value, second.
+- **coding-agent-loop** (`modules/loop-agent`): ledger is OPEN-heavy (CAL-3…9 pending
+  decisions), so a `cal-matrix.yaml` would be mostly OPEN-PINNED rows — legitimate but
+  low-signal until the DECIDE items move. Two rows are assertable CONFORM today and worth
+  seeding: CAL-1 (`0 = unlimited tool rounds` — `test_config.py`/`test_agent_session.py`)
+  and CAL-2 (`ContextLengthError` → warn + continue — `test_error_handling.py`). Third.
+
+---
+
+## 13. Honest notes: findings, and what resists the treatment
+
+**Findings the inventory itself surfaced** (evidence the matrix pays for its construction —
+each needs a maintainer decision during tranche 1, filed as ledger work, not silently
+encoded):
+
+- **F1 — unknown-shape hard error is an unledgered candidate divergence.** Spec §4.2's
+  registry pseudocode falls through to the *default handler* for an unknown shape; our
+  engine raises `ValueError` listing supported shapes
+  (`test_no_silent_fallback.py`, whose docstring argues from §2.8's finite table). It is
+  the right behavior under doctrine rule 4 — but it is exactly ATX-11's biography:
+  correct, load-bearing, undocumented. Tranche 1 must either ledger it (recommended:
+  DIVERGE, new ATX row + EXTENSIONS entry) or align it; the matrix row exists either way.
+- **F2 — spec self-contradictions get `spec.conflict` rows**: retry-on-FAIL (§3.5 vs DoD
+  11.5 — the ATX-6 pin); reachability severity (§7.2 ERROR vs DoD 11.12 warning — we
+  implement ERROR, matching §7.2); human-gate routing signal (§4.6 pseudocode
+  `suggested_next_ids` — which our handler implements — vs DoD 11.6 "preferred_label").
+  The matrix pins one side *by named choice*; it cannot make the spec coherent.
+- **F3 — §9.6 event names**: the spec's `PipelineStarted(name, id)` vocabulary vs our
+  `pipeline:start`-family events. The row asserts *semantic* event coverage (each spec
+  lifecycle event has a named counterpart carrying the specified data), disposition
+  CONFORM-with-note, not name-literal equality — asserting the literal names would be
+  conformance theater against a spec that presents them as a typed-event sketch.
+- **F4 — Appendix A defaults spot-check** will likely catch at least `reasoning_effort`
+  default `"high"` (ours is profile/stylesheet-resolved with no unconditional high
+  default). Probe first, then ledger or align — same F1 protocol.
+
+**What genuinely resists the treatment** (and the design's honest answer):
+
+- **Aspirational/approximate prose** — §5.4 token budgets, §1 design principles, §3.8
+  rationale: NOT-ASSERTABLE rows with justifications. ~10 rows, each individually argued.
+- **Randomness at the edge** — backoff jitter is asserted as *bounds* (`0.5x..1.5x`,
+  existing `test_backoff_with_jitter`), not distribution. The spec's `random_uniform` is
+  not further assertable without pretending.
+- **"Others may be cancelled"** (§4.8 first_success) — permissive spec language ("may")
+  can only be pinned as *our* choice, never as conformance/divergence; such rows are
+  CONFORM with the permissiveness noted in the quote itself.
+- **The spec's own checklists (§11)** — the matrix *is* their operationalization;
+  a row asserting the checklist would be self-reference. One NOT-ASSERTABLE meta-row
+  records this so the section isn't silently unaccounted for.
+- **Structural-integrity limits** (inherited honestly from the guard precedents): quote
+  verification proves the *text* is still in the spec, not that our reading of it is
+  right; AST-verified indexed cites prove the test *exists*, not that it still asserts
+  what the row claims — the paired suite's own green is what carries that, and a renamed
+  test fails the cite check loudly (which is the designed behavior).
+
+---
+
+## 14. Build plan (when implementation is commissioned)
+
+1. **PR 1 — skeleton + divergences:** matrix file with header/SYNC pin + the 11 tranche-1A
+   rows; runner with structural checks, flip renderer, RED/GREEN checker self-tests, and
+   the 6 new probe functions (P1/P2/P3 land nearly verbatim from §10). File F1 as a ledger
+   decision item in the same PR.
+2. **PR 2 — tranche-1B conformances:** the 24 rows, 4 new probes (context keys, gate
+   ladder, shape table, ATX-6 pin), coverage tripwire on.
+3. **PR 3+ — tranche 2 by section;** then ULM/CAL matrices (§12). Each PR trues up the §6
+   inventory counts in this doc.
+
+Definition of done for the matrix itself: flipping any asserted behavior in a scratch
+branch produces the §8 message naming the right ledger entry — tested for the three
+divergence classes by mutation (revert the dead-end hard-fail, make the gate accept
+non-explicit SUCCESS, strip a ledger cite) before PR 1 merges.

--- a/modules/loop-pipeline/tests/test_quality_protocol_guard.py
+++ b/modules/loop-pipeline/tests/test_quality_protocol_guard.py
@@ -1,0 +1,315 @@
+"""Drift guard for docs/QUALITY_PROTOCOL.md -- Q-300..Q-303.
+
+Guards the quality protocol itself against its own external references going
+stale.  The doc is binding on contributors and on AI coding agents working
+here, and section 2's "Docs making factual claims" row demands a guard for
+exactly this class of page.  Until now it had none: section 5 named that gap
+out loud and set an adoption condition -- *"the first time one of those
+references is found stale, or the Layer-2 matrix lands (whichever comes
+first)"*.  The matrix landing is this guard's trigger.
+
+**What makes these assertions non-tautological.**  Every check reads a claim
+*from the doc* and resolves it against *the repository*.  A page-only
+assertion ("the doc says five guards") would pass forever and fail only when
+someone edited the doc, which is the one case that needs no guard.  These
+fail when the **repo** moves underneath the doc -- a guard file renamed or
+deleted, the matrix relocated, the canonical spec re-vendored to a new
+upstream sha -- which is the case that actually produces a lying protocol.
+
+Claims guarded, and what each is resolved against:
+
+  Q-300  every ``test_*.py`` the doc names by name
+         -> the file exists under ``modules/loop-pipeline/tests/``
+  Q-301  the Layer-2 files (``specs/conformance/attractor-matrix.yaml`` and
+         the matrix runner module), which the doc states as **shipped**
+         -> both files exist on disk
+  Q-302  the vendored canonical spec and its recorded upstream sha
+         -> ``specs/canonical/attractor-spec-canonical.md`` exists, and the
+            sha the doc records appears in ``SPEC_CONFORMANCE.md`` at the
+            ``SYNC-1`` row the doc names as the pin's home
+  Q-303  the Changelog section the meta-protocol (section 5) requires
+         -> the section exists and carries at least one dated entry
+
+Honest limits:
+  - Q-300 extracts filenames by regex over backticked prose.  A guard file
+    referred to only in running text without backticks is invisible here.
+    That is the same tradeoff the sibling doc guards make, and the failure
+    direction is safe: an unquoted name is unguarded, never falsely red.
+  - Q-302 checks that the sha *string* the doc records is the one the ledger
+    records.  It does not re-fetch upstream or re-verify the vendored bytes;
+    the matrix's SYNC row owns the byte-level sha256 pin.  This check owns
+    the narrower claim that the doc and the ledger name the same commit.
+  - Q-303 asserts a dated entry exists, not that the newest entry describes
+    the newest amendment.  No mechanical check can know that; section 5's
+    review owns it.
+  - This module skips wholesale when ``docs/QUALITY_PROTOCOL.md`` is absent,
+    so the loop-pipeline suite still runs in a module-only/partial checkout.
+
+Reference: ``docs/QUALITY_PROTOCOL.md`` section 3 (Layers 0-2) and section 5
+(the meta-protocol, which is where this guard's own adoption condition is
+recorded).
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Locating the repo root and the doc
+# ---------------------------------------------------------------------------
+
+
+def _find_bundle_root() -> Path | None:
+    """Walk up from this file looking for the bundle repo root.
+
+    Walks rather than hardcoding a parent count, so the guard survives the
+    module being vendored or re-nested, and returns None (-> module skip)
+    rather than pointing at a plausible-but-wrong directory.
+    """
+    for candidate in Path(__file__).resolve().parents:
+        if (candidate / "docs").is_dir() and (
+            candidate / "modules" / "loop-pipeline"
+        ).is_dir():
+            return candidate
+    return None
+
+
+BUNDLE_ROOT = _find_bundle_root()
+DOC_REL = "docs/QUALITY_PROTOCOL.md"
+DOC_PATH = (BUNDLE_ROOT / DOC_REL) if BUNDLE_ROOT is not None else None
+TESTS_DIR_REL = "modules/loop-pipeline/tests"
+
+pytestmark = pytest.mark.skipif(
+    DOC_PATH is None or not DOC_PATH.is_file(),
+    reason=(
+        f"{DOC_REL} not present in this checkout -- the quality protocol ships "
+        "in the bundle repo, not in the loop-pipeline module distribution. "
+        "Nothing to guard here; the rest of the module suite is unaffected."
+    ),
+)
+
+
+def _doc() -> str:
+    assert DOC_PATH is not None  # guaranteed by pytestmark
+    return DOC_PATH.read_text(encoding="utf-8")
+
+
+def _root() -> Path:
+    assert BUNDLE_ROOT is not None  # guaranteed by pytestmark
+    return BUNDLE_ROOT
+
+
+# ---------------------------------------------------------------------------
+# Q-300: every guard-test file the doc names by name must exist
+# ---------------------------------------------------------------------------
+
+# Backticked `test_*.py`, either bare (`test_doc_consistency.py`, as the
+# Layer-1 table writes them) or path-qualified
+# (`modules/loop-pipeline/tests/test_live_graph_gate.py`, as the prose does).
+_TEST_FILE_RE = re.compile(r"`([A-Za-z0-9_./-]*test_[A-Za-z0-9_]+\.py)`")
+
+
+def _named_test_files() -> list[str]:
+    return sorted(set(_TEST_FILE_RE.findall(_doc())))
+
+
+def _resolve_named_test_file(name: str) -> Path:
+    """A bare filename means the loop-pipeline tests dir; a path means itself."""
+    return _root() / (name if "/" in name else f"{TESTS_DIR_REL}/{name}")
+
+
+def test_q300_named_guard_test_files_all_exist():
+    """Every `test_*.py` the protocol names by name resolves to a real file."""
+    named = _named_test_files()
+    assert named, (
+        f"{DOC_REL}: the doc names no test files at all. Layer 1 and Layer 2 "
+        f"are both defined by the files they name; if that prose was rewritten "
+        f"to stop naming them, re-anchor this guard on the new wording rather "
+        f"than deleting it."
+    )
+    missing = [
+        f"{name} (looked for {_resolve_named_test_file(name).relative_to(_root())})"
+        for name in named
+        if not _resolve_named_test_file(name).is_file()
+    ]
+    assert not missing, (
+        f"{DOC_REL} names guard-test files that do not exist:\n"
+        + "".join(f"  - {m}\n" for m in missing)
+        + "  The protocol's authority rests on the machinery it names being real.\n"
+        "  A named-but-absent guard is the protocol claiming an enforcement it\n"
+        "  does not have. Either the file was renamed/deleted -- in which case\n"
+        "  update the doc in the same PR -- or the doc names it wrongly.\n"
+        f"  (Bare filenames are resolved against {TESTS_DIR_REL}/.)"
+    )
+
+
+def test_q300b_the_five_layer1_guards_are_among_them():
+    """The Layer-1 table's five guards specifically, named as a floor.
+
+    Q-300 is generic over whatever the doc names; this pins the five the
+    Layer-1 table is *about*, so silently dropping a row from that table
+    fails here rather than shrinking the guarded set unnoticed.
+    """
+    expected = {
+        "test_extensions_ledger_integrity.py",
+        "test_doc_consistency.py",
+        "test_engine_semantics_doc_guard.py",
+        "test_explainer_doc_guard.py",
+        "test_examples_lint_clean.py",
+    }
+    named = set(_named_test_files())
+    # Path-qualified mentions count as naming the file too.
+    named |= {n.rsplit("/", 1)[-1] for n in named}
+    missing = sorted(expected - named)
+    assert not missing, (
+        f"{DOC_REL}: the Layer-1 table no longer names {missing}.\n"
+        "  Layer 1 IS its five deterministic guards; dropping one from the\n"
+        "  table without retiring the guard (section 5's retirement protocol)\n"
+        "  leaves the doc describing a defense narrower than the one that runs.\n"
+        "  If a guard was genuinely retired, update this expected set in the\n"
+        "  same PR and record the retirement in the Changelog."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Q-301: the Layer-2 files the doc declares shipped must exist
+# ---------------------------------------------------------------------------
+
+LAYER2_FILES = (
+    "specs/conformance/attractor-matrix.yaml",
+    f"{TESTS_DIR_REL}/test_spec_conformance_matrix.py",
+)
+
+
+def test_q301_layer2_is_declared_shipped():
+    """Layer 2's status line must still read as shipped, not 'in flight'."""
+    doc = _doc()
+    match = re.search(
+        r"###\s*Layer 2[^\n]*\n+\*\*Status:\s*([^*]+)\*\*", doc, re.IGNORECASE
+    )
+    assert match is not None, (
+        f"{DOC_REL}: could not find Layer 2's '**Status: ...**' line. Either the "
+        "section was reworded -- re-anchor this pattern -- or the status claim "
+        "was dropped, which is exactly the claim this guard exists to hold."
+    )
+    status = match.group(1).strip().lower()
+    assert "shipped" in status, (
+        f"{DOC_REL}: Layer 2's status reads {match.group(1).strip()!r}, not "
+        "'shipped'. The files below are on disk, so a non-shipped status is the "
+        "doc understating what runs in CI. Update the status or retire the files."
+    )
+
+
+@pytest.mark.parametrize("rel", LAYER2_FILES)
+def test_q301b_layer2_files_exist(rel: str):
+    """Both files Layer 2 names as the shipped matrix must be present."""
+    assert (_root() / rel).is_file(), (
+        f"{DOC_REL} declares Layer 2 shipped and names `{rel}`, but that file "
+        "does not exist.\n"
+        "  Layer 2 is a status claim about CI: the doc asserts these two files "
+        "run on every PR.\n"
+        "  A missing one means the protocol advertises a conformance defense "
+        "that is not there."
+    )
+
+
+def test_q301c_layer2_files_are_named_in_the_doc():
+    """The two Layer-2 paths are named in the doc, not just known to this guard."""
+    doc = _doc()
+    for rel in LAYER2_FILES:
+        assert f"`{rel}`" in doc, (
+            f"{DOC_REL}: Layer 2 no longer names `{rel}`. This guard resolves the "
+            "doc's claims against the repo; if the doc stops making the claim, "
+            "re-anchor the guard (or retire it) rather than letting it assert "
+            "something the page does not say."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Q-302: the vendored canonical spec and its recorded upstream sha
+# ---------------------------------------------------------------------------
+
+CANONICAL_REL = "specs/canonical/attractor-spec-canonical.md"
+LEDGER_REL = "SPEC_CONFORMANCE.md"
+
+
+def _recorded_upstream_sha() -> str:
+    """The sha Layer 0 records as the canonical pin."""
+    doc = _doc()
+    match = re.search(
+        r"pinned byte-for-byte to\s*\n?\s*`strongdm/attractor`\s*@\s*\*\*`([0-9a-f]{7,40})`\*\*",
+        doc,
+    )
+    assert match is not None, (
+        f"{DOC_REL}: could not find Layer 0's canonical sha pin (the "
+        "'pinned byte-for-byte to `strongdm/attractor` @ **`<sha>`**' sentence). "
+        "Either the sentence was reworded -- re-anchor this pattern -- or the "
+        "pin was dropped, which would leave Layer 0's normative claim unsourced."
+    )
+    return match.group(1)
+
+
+def test_q302_canonical_spec_exists():
+    """Layer 0's normative text must actually be vendored in this checkout."""
+    assert (_root() / CANONICAL_REL).is_file(), (
+        f"{DOC_REL} Layer 0 names `{CANONICAL_REL}` as the vendored normative "
+        "text that settles doc-vs-engine disputes about the spec, but the file "
+        "is absent. Layer 0 is the base of the drift model; without the file "
+        "there is nothing for Layers 1-2 to be measured against."
+    )
+
+
+def test_q302b_recorded_sha_matches_the_ledger_pin():
+    """The sha the doc records is the sha the ledger's SYNC-1 row records."""
+    sha = _recorded_upstream_sha()
+    ledger_path = _root() / LEDGER_REL
+    assert ledger_path.is_file(), (
+        f"{DOC_REL} cites `{LEDGER_REL}` (`SYNC-1`) as the home of the canonical "
+        f"pin, but {LEDGER_REL} does not exist in this checkout."
+    )
+    ledger = ledger_path.read_text(encoding="utf-8")
+
+    sync_rows = [ln for ln in ledger.splitlines() if re.match(r"^\|\s*SYNC-1\s*\|", ln)]
+    assert sync_rows, (
+        f"{LEDGER_REL}: no `SYNC-1` row found, but {DOC_REL} Layer 0 cites it as "
+        "where the canonical pin is recorded. Either the ledger row was renamed "
+        "-- update the doc's citation in the same PR -- or the pin's record is gone."
+    )
+    assert any(sha in row for row in sync_rows), (
+        f"CANONICAL PIN DRIFT: {DOC_REL} records the vendored spec as pinned to "
+        f"`{sha}`, but {LEDGER_REL}'s SYNC-1 row does not name that sha:\n"
+        + "".join(f"    {row}\n" for row in sync_rows)
+        + "  Upstream movement is a SYNC event (Layer 0): re-vendor, then re-read\n"
+        "  every ledger entry whose disposition depended on the old text. If the\n"
+        "  re-vendor happened, this doc's sha was left behind -- update it and\n"
+        "  add the Changelog entry section 5 requires."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Q-303: the Changelog the meta-protocol requires
+# ---------------------------------------------------------------------------
+
+_CHANGELOG_ENTRY_RE = re.compile(r"^###\s+(\d{4}-\d{2}-\d{2})\b", re.MULTILINE)
+
+
+def test_q303_changelog_exists_with_at_least_one_dated_entry():
+    """Section 5 requires amendments be recorded, dated, in a Changelog."""
+    doc = _doc()
+    assert re.search(r"^##\s+Changelog\s*$", doc, re.MULTILINE), (
+        f"{DOC_REL}: the `## Changelog` section is gone. Section 5 makes it "
+        "load-bearing -- 'Amendments are recorded in the Changelog at the bottom "
+        "of this file, dated, with the evidence named. The Changelog is the "
+        "amendment history; the sections above are only ever the current state.' "
+        "Without it the doc has no amendment history and the meta-protocol "
+        "cannot be satisfied."
+    )
+    changelog = doc.split("## Changelog", 1)[1]
+    entries = _CHANGELOG_ENTRY_RE.findall(changelog)
+    assert entries, (
+        f"{DOC_REL}: the Changelog section carries no dated `### YYYY-MM-DD` "
+        "entry. Section 5 requires every amendment to be recorded and dated; an "
+        "empty changelog means either the history was dropped or entries stopped "
+        "using the dated heading form this guard (and every reader) relies on."
+    )

--- a/modules/loop-pipeline/tests/test_spec_conformance_matrix.py
+++ b/modules/loop-pipeline/tests/test_spec_conformance_matrix.py
@@ -1,0 +1,1548 @@
+"""The spec conformance matrix runner -- Layer 2 of the drift defense.
+
+Guards the incident class: **the ledger quietly becoming a lie.**
+
+`SPEC_CONFORMANCE.md` and `specs/EXTENSIONS.md` are human-maintained records of
+every decided divergence from the canonical upstream nlspec.  They have had no
+executable teeth: nothing failed when the engine moved away from what they say,
+and -- the half people forget -- nothing failed when the engine moved *back
+toward the spec* at a point where the ledger says we deliberately do not
+conform.  Both directions leave `main` carrying a record that does not describe
+the shipped engine.  That is drift.
+
+This module makes the ledger load-bearing.  It reads
+``specs/conformance/attractor-matrix.yaml`` -- a reviewed document, one row per
+normative statement cluster -- and for every row:
+
+1. **Structural integrity** (parametrized per row): the row's VERBATIM spec
+   quote is still present in the byte-pinned canonical file; the ledger entry
+   it cites still exists; every existing test it indexes still exists.
+2. **Behavioral probes** (named ``test_row_<id>`` functions): in-process engine
+   runs against backend doubles.  Deterministic, no LLM, no network, no
+   subprocess.  A DIVERGE-DECIDED row proves BOTH that our ledgered behavior
+   occurs AND that the spec's behavior does not -- the second half is what
+   makes a silent re-alignment loud.
+3. **The SYNC row**: the canonical file's sha256 matches the recorded pin, so a
+   re-vendor becomes a demanded full-matrix re-review instead of a quiet commit.
+4. **The coverage tripwire**: every DIVERGES-bannered ``EXTENSIONS.md`` section
+   and every DIVERGE-disposition ``ATX-*`` ledger row must be cited by at least
+   one matrix row.  A future divergence cannot be ledgered without also being
+   asserted.
+
+Every failure -- behavioral or structural -- renders through one flip-message
+helper, so ``grep "SPEC-CONFORMANCE MATRIX FLIP"`` over a CI log finds every
+conformance event of any kind.  The message names the spec section, the ledger
+entry, and the two legal exits.  There is no third exit: editing an assertion to
+match new behavior without moving the ledger is the failure this file exists to
+prevent.
+
+Honest limits (inherited from the Layer 1 guard precedents):
+
+- Quote verification proves the spec TEXT is still there, not that our reading
+  of it is right.  A row is an argument; the quote is its citation.
+- An AST-verified indexed cite proves the named test EXISTS, not that it still
+  asserts what the row claims.  The paired suite's own green carries that.  A
+  renamed test fails the cite check loudly -- that is designed, not incidental.
+- Absence assertions are grep-shaped.  They prove the identifier does not appear
+  in the named source roots, which is the same bar `SPEC_CONFORMANCE.md` ATX-3
+  itself uses ("grep `tool_hooks`=0").
+- The matrix file is NOT optional.  Unlike the doc guards' skip-if-absent
+  discipline for optional docs, a missing or unparseable matrix is a hard
+  failure here: a silently-skipped matrix is a matrix that is not load-bearing.
+
+Retirement condition: none for the mechanism.  Individual ROWS retire when
+upstream absorbs the divergence (the EXTENSIONS "ABSORBED UPSTREAM" banner
+protocol) or when a decision closes an OPEN-PINNED row -- in both cases the row
+changes disposition rather than disappearing.
+"""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from amplifier_module_loop_pipeline.context import PipelineContext
+from amplifier_module_loop_pipeline.dot_parser import parse_dot
+from amplifier_module_loop_pipeline.edge_selection import select_edge
+from amplifier_module_loop_pipeline.engine import PipelineEngine
+from amplifier_module_loop_pipeline.graph import Node
+from amplifier_module_loop_pipeline.handlers import HandlerRegistry
+from amplifier_module_loop_pipeline.handlers.context import HandlerContext
+from amplifier_module_loop_pipeline.outcome import Outcome, StageStatus
+from amplifier_module_loop_pipeline.pipeline_events import PIPELINE_ERROR
+from amplifier_module_loop_pipeline.validation import SHAPE_TO_HANDLER, validate_or_raise
+
+BUNDLE_ROOT = Path(__file__).parent.parent.parent.parent
+MATRIX_PATH = BUNDLE_ROOT / "specs" / "conformance" / "attractor-matrix.yaml"
+
+VALID_DISPOSITIONS = frozenset(
+    {
+        "CONFORM",
+        "DIVERGE-DECIDED",
+        "EXTENSION",
+        "OPEN-PINNED",
+        "NOT-IMPLEMENTED-DECIDED",
+        "NOT-ASSERTABLE",
+    }
+)
+VALID_ASSERTION_KINDS = frozenset({"probe", "indexed", "absence", "none"})
+
+#: Dispositions whose rows MUST cite a ledger entry (or, for a row this matrix
+#: itself surfaced, the issue that carries the pending decision).
+LEDGER_REQUIRED = frozenset(
+    {"DIVERGE-DECIDED", "EXTENSION", "OPEN-PINNED", "NOT-IMPLEMENTED-DECIDED"}
+)
+#: Dispositions whose rows MUST carry a written justification.
+JUSTIFICATION_REQUIRED = frozenset({"OPEN-PINNED", "NOT-ASSERTABLE"})
+
+
+# ---------------------------------------------------------------------------
+# Loading -- fail loud, never skip
+# ---------------------------------------------------------------------------
+
+
+def _load_matrix() -> dict[str, Any]:
+    """Load the matrix. A missing or malformed matrix is a HARD failure.
+
+    The guard-test precedents skip when an OPTIONAL doc is absent.  The matrix
+    is not optional: silently skipping it would leave the ledger unguarded
+    while CI stayed green, which is the exact condition this module exists to
+    make impossible.
+    """
+    if not MATRIX_PATH.exists():
+        raise AssertionError(
+            "SPEC-CONFORMANCE MATRIX FLIP -- MATRIX-INTEGRITY\n"
+            f"  The matrix file is missing: {MATRIX_PATH}\n"
+            "  This file is NOT optional. It is the executable form of\n"
+            "  SPEC_CONFORMANCE.md and specs/EXTENSIONS.md; skipping it would\n"
+            "  leave every ledgered divergence unasserted while CI stayed green.\n"
+            "  Restore it, or -- if the matrix is being deliberately retired --\n"
+            "  remove this runner and docs/QUALITY_PROTOCOL.md's Layer 2 claim in\n"
+            "  the same PR.\n"
+            "  Doing neither means main carries a ledger that lies. That is drift."
+        )
+    try:
+        doc = yaml.safe_load(MATRIX_PATH.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:  # pragma: no cover - exercised by the RED self-test
+        raise AssertionError(
+            "SPEC-CONFORMANCE MATRIX FLIP -- MATRIX-INTEGRITY\n"
+            f"  {MATRIX_PATH} does not parse as YAML: {exc}\n"
+            "  Fix the file. An unparseable matrix asserts nothing."
+        ) from exc
+    if not isinstance(doc, dict) or "rows" not in doc or "canonical" not in doc:
+        raise AssertionError(
+            "SPEC-CONFORMANCE MATRIX FLIP -- MATRIX-INTEGRITY\n"
+            f"  {MATRIX_PATH} is missing the required top-level keys "
+            "'canonical' and 'rows'."
+        )
+    return doc
+
+
+MATRIX = _load_matrix()
+ROWS: list[dict[str, Any]] = MATRIX["rows"]
+ROWS_BY_ID: dict[str, dict[str, Any]] = {r["id"]: r for r in ROWS}
+ROW_IDS: list[str] = [r["id"] for r in ROWS]
+
+CANONICAL_PATH = BUNDLE_ROOT / MATRIX["canonical"]["path"]
+CANONICAL_TEXT = CANONICAL_PATH.read_text(encoding="utf-8")
+CONFORMANCE_LEDGER = BUNDLE_ROOT / MATRIX["ledgers"]["conformance"]
+EXTENSIONS_LEDGER = BUNDLE_ROOT / MATRIX["ledgers"]["extensions"]
+
+
+# ---------------------------------------------------------------------------
+# The flip message -- generated, never hand-written per row
+# ---------------------------------------------------------------------------
+
+
+def _ledger_cites(row: dict[str, Any]) -> list[str]:
+    ledger = row.get("ledger") or {}
+    cites: list[str] = []
+    if ledger.get("conformance"):
+        cites.append(f"{MATRIX['ledgers']['conformance']} {ledger['conformance']}")
+    if ledger.get("extensions") is not None:
+        cites.append(f"{MATRIX['ledgers']['extensions']} section {ledger['extensions']}")
+    if ledger.get("issue") is not None:
+        cites.append(f"issue #{ledger['issue']} (decision pending -- no ledger row yet)")
+    return cites or ["(none -- CONFORM rows need no ledger licence)"]
+
+
+def _indent(text: str, pad: str = "               ") -> str:
+    lines = [ln.rstrip() for ln in (text or "").strip().splitlines()]
+    if not lines:
+        return ""
+    return ("\n" + pad).join(lines)
+
+
+def flip(
+    row: dict[str, Any],
+    observed: str,
+    expected: str,
+    direction: str = "REGRESSION",
+) -> str:
+    """Render the failure contract for a row.
+
+    Contract (design section 8), in order: banner, spec anchor with the verbatim
+    quote, disposition + every ledger cite, direction, observed/expected, the two
+    legal exits with the complete same-PR checklist, and the closing invariant.
+    """
+    disposition = row["disposition"]
+    spec = row["spec"]
+    cites = "; ".join(_ledger_cites(row))
+
+    direction_gloss = {
+        "REGRESSION": (
+            "the engine moved OFF the behavior the ledger records as decided."
+        ),
+        "UN-DIVERGENCE": (
+            "the engine now matches the spec text the ledger says we deliberately\n"
+            "               diverge from. Un-diverging silently is drift too."
+        ),
+        "UNDECIDED-MOVEMENT": (
+            "an OPEN-PINNED behavior moved BEFORE its disposition was decided."
+        ),
+        "MATRIX-INTEGRITY": (
+            "the matrix row itself no longer resolves against the spec or the ledger."
+        ),
+    }.get(direction, "unclassified movement.")
+
+    if disposition == "OPEN-PINNED":
+        exit_two = (
+            "    2. Keep the change AND make it the DECISION: move the open ledger\n"
+            f"       item ({cites}) to a decided disposition with a dated changelog\n"
+            "       line, add or update the specs/EXTENSIONS.md entry if the decision\n"
+            "       is DIVERGE, and update this matrix row (disposition + assertion).\n"
+            "       Undecided is not the same as unpinned -- do not let an accident\n"
+            "       become the decision by default."
+        )
+    elif disposition in {"DIVERGE-DECIDED", "EXTENSION", "NOT-IMPLEMENTED-DECIDED"}:
+        exit_two = (
+            "    2. Keep the change AND move the record with it, in THIS PR:\n"
+            f"       update {cites} (status + a dated Changelog line), rewrite the\n"
+            "       specs/EXTENSIONS.md entry body so it describes the new behavior,\n"
+            "       update this matrix row (disposition + assertion), and fix any\n"
+            "       paired doc guards named in the row's notes below."
+        )
+    else:
+        exit_two = (
+            "    2. Keep the change AND record it as a deliberate divergence in THIS\n"
+            "       PR: add a SPEC_CONFORMANCE.md row and a specs/EXTENSIONS.md entry\n"
+            "       per the Compatibility doctrine (name the safety property, cite the\n"
+            "       evidence, fail loud), then update this matrix row's disposition.\n"
+            "       A conformance that stops conforming without a ledger entry is the\n"
+            "       unledgered-divergence class, which is how ATX-11 lived for months."
+        )
+
+    parts = [
+        f'SPEC-CONFORMANCE MATRIX FLIP -- row {row["id"]} "{row["title"]}"',
+        f'  spec:        section {spec["section"]} {spec.get("heading", "")} --',
+        f"               {_indent(spec['quote'])}",
+        f"  disposition: {disposition}  (ledgered: {cites})",
+        f"  direction:   {direction} -- {direction_gloss}",
+        f"  observed:    {observed}",
+        f"  expected:    {expected}",
+    ]
+
+    conflict = spec.get("conflict")
+    if conflict:
+        parts.append(
+            f'  spec conflict: section {conflict["section"]} says --\n'
+            f"               {_indent(conflict['quote'])}\n"
+            f"               {_indent(conflict.get('note', ''))}"
+        )
+
+    if row.get("justification"):
+        parts.append(f"  why pinned:  {_indent(row['justification'])}")
+    if row.get("notes"):
+        parts.append(f"  row note:    {_indent(row['notes'])}")
+
+    parts.append("")
+    parts.append("  Two legal exits -- in THIS PR, not a follow-up:")
+    parts.append(
+        "    1. Revert the behavior change. The ledger is the record of decided\n"
+        "       behavior; the engine does not get to overrule it silently."
+    )
+    parts.append(exit_two)
+    parts.append(
+        "  There is no third exit. Editing this assertion to match the new behavior,\n"
+        "  without moving the ledger, is the failure this matrix exists to prevent."
+    )
+    parts.append("  Doing neither means main carries a ledger that lies. That is drift.")
+    return "\n".join(parts)
+
+
+def integrity_flip(row: dict[str, Any], observed: str, expected: str) -> str:
+    return flip(row, observed, expected, direction="MATRIX-INTEGRITY")
+
+
+# ---------------------------------------------------------------------------
+# Shared checker helpers -- also exercised directly by the RED/GREEN self-tests
+# ---------------------------------------------------------------------------
+
+
+def _normalize_block(text: str) -> str:
+    """Collapse runs of intra-line whitespace; keep line structure.
+
+    Line structure is preserved because the load-bearing quotes are pseudocode
+    blocks whose shape carries meaning.  Intra-line runs are collapsed so a
+    reflowed table cell or a tab/space swap does not produce a false flip.
+    """
+    return "\n".join(
+        re.sub(r"[ \t]+", " ", line).strip() for line in text.strip("\n").splitlines()
+    )
+
+
+_CANONICAL_NORMALIZED = _normalize_block(CANONICAL_TEXT)
+
+
+def quote_is_present(quote: str, haystack_normalized: str = _CANONICAL_NORMALIZED) -> bool:
+    return _normalize_block(quote) in haystack_normalized
+
+
+def conformance_ledger_ids(text: str) -> set[str]:
+    """Every ``ATX-*`` / ``ULM-*`` / ``CAL-*`` / ``SYNC-*`` row id in the ledger."""
+    return {
+        m.group(1)
+        for m in re.finditer(r"^\|\s*((?:ATX|ULM|CAL|SYNC|DEAD)-\d+)\s*\|", text, re.M)
+    }
+
+
+def extensions_section_numbers(text: str) -> set[int]:
+    """Every ``## N.`` heading number in specs/EXTENSIONS.md."""
+    return {int(m.group(1)) for m in re.finditer(r"^## (\d+)\.\s", text, re.M)}
+
+
+def module_symbols(path: Path) -> set[str]:
+    """Top-level functions/classes and ``Class::method`` names, by AST parse.
+
+    NEVER imports.  Indexed cites cross per-module venv boundaries (the
+    pipeline-runner resume e2e test is not importable from this module's venv),
+    so the only sound verification is a parse.
+    """
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    names: set[str] = set()
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            names.add(node.name)
+        if isinstance(node, ast.ClassDef):
+            for child in node.body:
+                if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    names.add(f"{node.name}::{child.name}")
+    return names
+
+
+def resolve_indexed_cite(cite: str) -> tuple[bool, str]:
+    """Return (ok, reason). A cite is ``path`` or ``path::symbol``."""
+    file_part, _, symbol = cite.partition("::")
+    path = BUNDLE_ROOT / file_part
+    if not path.exists():
+        return False, f"file does not exist: {file_part}"
+    if not symbol:
+        return True, ""
+    if symbol not in module_symbols(path):
+        return False, f"symbol '{symbol}' not found in {file_part}"
+    return True, ""
+
+
+_PY_SUFFIXES = {".py"}
+
+
+def grep_source_roots(pattern: str, roots: list[str]) -> list[str]:
+    """Return ``path:line`` hits for a regex over the .py files under roots."""
+    rx = re.compile(pattern)
+    hits: list[str] = []
+    for root in roots:
+        base = BUNDLE_ROOT / root
+        if not base.exists():
+            continue
+        for path in sorted(base.rglob("*")):
+            if path.suffix not in _PY_SUFFIXES or not path.is_file():
+                continue
+            for lineno, line in enumerate(
+                path.read_text(encoding="utf-8", errors="replace").splitlines(), 1
+            ):
+                if rx.search(line):
+                    hits.append(f"{path.relative_to(BUNDLE_ROOT)}:{lineno}")
+    return hits
+
+
+#: A banner "states a divergence" only when it does so in a BOLD declarative --
+#: the Entry Format's own shape ("**This extension DIVERGES from canonical spec
+#: section X.**", "**REFILED ... ALSO records a DIVERGENCE**").  Matching bare
+#: prose would sweep in every entry whose boilerplate merely uses the word.
+_BOLD_DIVERGENCE = re.compile(r"\*\*[^*]*DIVERG(?:ES|ENCE)\b[^*]*\*\*", re.I)
+
+
+def diverges_bannered_extension_sections(text: str) -> set[int]:
+    lines = text.splitlines()
+    heads = [
+        (i, int(m.group(1)))
+        for i, line in enumerate(lines)
+        if (m := re.match(r"^## (\d+)\.\s", line))
+    ]
+    flagged: set[int] = set()
+    for idx, (start, number) in enumerate(heads):
+        end = heads[idx + 1][0] if idx + 1 < len(heads) else len(lines)
+        banner: list[str] = []
+        for line in lines[start + 1 : end]:
+            stripped = line.strip()
+            if stripped.startswith(">"):
+                banner.append(stripped.lstrip("> ").rstrip())
+            elif stripped == "":
+                continue
+            else:
+                break
+        if _BOLD_DIVERGENCE.search(" ".join(banner)):
+            flagged.add(number)
+    return flagged
+
+
+def diverge_disposition_atx_rows(text: str) -> set[str]:
+    """``ATX-*`` ledger rows whose Disposition cell starts with DIVERGE."""
+    found: set[str] = set()
+    for line in text.splitlines():
+        if not re.match(r"^\|\s*ATX-\d+\s*\|", line):
+            continue
+        cells = [c.strip() for c in line.strip().strip("|").split("|")]
+        if len(cells) >= 2 and cells[-1].lstrip("* ").upper().startswith("DIVERGE"):
+            found.add(cells[0])
+    return found
+
+
+# ---------------------------------------------------------------------------
+# 1. Structural integrity -- parametrized per row
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("row_id", ROW_IDS)
+def test_row_schema_is_wellformed(row_id: str):
+    """Vocabulary, required fields, and the ledger/justification obligations."""
+    row = ROWS_BY_ID[row_id]
+
+    assert row["disposition"] in VALID_DISPOSITIONS, (
+        f"row {row_id}: unknown disposition {row['disposition']!r}. "
+        f"Legal values: {sorted(VALID_DISPOSITIONS)}"
+    )
+    kind = row["assertion"]["kind"]
+    assert kind in VALID_ASSERTION_KINDS, (
+        f"row {row_id}: unknown assertion kind {kind!r}. "
+        f"Legal values: {sorted(VALID_ASSERTION_KINDS)}"
+    )
+    assert row.get("title"), f"row {row_id}: title is required (it names the flip banner)"
+    assert row["spec"].get("section"), f"row {row_id}: spec.section is required"
+    assert row["spec"].get("quote", "").strip(), f"row {row_id}: spec.quote is required"
+
+    if kind == "none":
+        assert row["disposition"] == "NOT-ASSERTABLE", (
+            f"row {row_id}: assertion.kind 'none' is legal ONLY for NOT-ASSERTABLE. "
+            "Every other disposition is a claim about behavior, and a claim about "
+            "behavior that asserts nothing is decoration."
+        )
+
+    if row["disposition"] in LEDGER_REQUIRED:
+        ledger = row.get("ledger") or {}
+        assert any(ledger.get(k) is not None for k in ("conformance", "extensions", "issue")), (
+            f"row {row_id}: disposition {row['disposition']} requires a ledger cite "
+            "(SPEC_CONFORMANCE.md row, specs/EXTENSIONS.md section, or -- for a finding "
+            "this matrix surfaced -- the issue carrying the pending decision)."
+        )
+
+    if row["disposition"] in JUSTIFICATION_REQUIRED:
+        assert (row.get("justification") or "").strip(), (
+            f"row {row_id}: disposition {row['disposition']} requires a written "
+            "justification. Pinning an undecided behavior without saying why is how a "
+            "pin gets mistaken for a decision."
+        )
+
+
+@pytest.mark.parametrize("row_id", ROW_IDS)
+def test_row_quote_is_verbatim_in_canonical(row_id: str):
+    """The row's spec quote(s) must still exist in the byte-pinned canonical file."""
+    row = ROWS_BY_ID[row_id]
+    quotes: list[tuple[str, str]] = [("spec.quote", row["spec"]["quote"])]
+    for extra in row["spec"].get("also") or []:
+        quotes.append(("spec.also", extra["quote"]))
+    conflict = row["spec"].get("conflict")
+    if conflict:
+        quotes.append(("spec.conflict", conflict["quote"]))
+
+    for field, quote in quotes:
+        assert quote_is_present(quote), integrity_flip(
+            row,
+            observed=(
+                f"{field} is no longer present in {MATRIX['canonical']['path']}: "
+                f"{_normalize_block(quote)[:120]!r}"
+            ),
+            expected=(
+                "every matrix quote resolves verbatim against the canonical bytes "
+                "(whitespace-normalized within lines)"
+            ),
+        )
+
+
+@pytest.mark.parametrize("row_id", ROW_IDS)
+def test_row_ledger_cites_exist(row_id: str):
+    """A row may not cite a ledger entry that has been deleted or renumbered."""
+    row = ROWS_BY_ID[row_id]
+    ledger = row.get("ledger") or {}
+
+    if ledger.get("conformance"):
+        known = conformance_ledger_ids(CONFORMANCE_LEDGER.read_text(encoding="utf-8"))
+        assert ledger["conformance"] in known, integrity_flip(
+            row,
+            observed=(
+                f"{MATRIX['ledgers']['conformance']} has no row "
+                f"{ledger['conformance']!r}"
+            ),
+            expected=(
+                "the cited ledger row still exists. The ledger is append-only in "
+                "practice: rows change status, they do not vanish."
+            ),
+        )
+
+    if ledger.get("extensions") is not None:
+        known_sections = extensions_section_numbers(
+            EXTENSIONS_LEDGER.read_text(encoding="utf-8")
+        )
+        assert ledger["extensions"] in known_sections, integrity_flip(
+            row,
+            observed=(
+                f"{MATRIX['ledgers']['extensions']} has no "
+                f"'## {ledger['extensions']}.' heading"
+            ),
+            expected=(
+                "the cited EXTENSIONS section still exists. Renumbering or deleting an "
+                "entry breaks every consumer that cites it -- which is exactly what "
+                "test_extensions_ledger_integrity.py was written for after a "
+                "'-Xtheirs' rebase silently discarded three merged entries."
+            ),
+        )
+
+    if ledger.get("issue") is not None:
+        assert isinstance(ledger["issue"], int) and ledger["issue"] > 0, (
+            f"row {row_id}: ledger.issue must be a positive GitHub issue number"
+        )
+        assert row["disposition"] == "OPEN-PINNED", (
+            f"row {row_id}: ledger.issue is legal only on an OPEN-PINNED row. An issue "
+            "records a PENDING decision; a decided disposition owes a real ledger entry."
+        )
+
+
+@pytest.mark.parametrize("row_id", ROW_IDS)
+def test_row_indexed_cites_exist(row_id: str):
+    """Every indexed test must still exist -- verified by AST parse, never import."""
+    row = ROWS_BY_ID[row_id]
+    for cite in row["assertion"].get("indexed") or []:
+        ok, reason = resolve_indexed_cite(cite)
+        assert ok, integrity_flip(
+            row,
+            observed=f"indexed cite does not resolve -- {reason} (cite: {cite})",
+            expected=(
+                "every indexed test still exists. The matrix INDEXES existing coverage "
+                "rather than duplicating it, so a renamed or deleted test silently "
+                "un-covers this spec statement unless this check catches it."
+            ),
+        )
+
+
+@pytest.mark.parametrize("row_id", ROW_IDS)
+def test_row_probe_function_exists(row_id: str):
+    """A ``kind: probe`` row must name a probe function that actually exists here."""
+    row = ROWS_BY_ID[row_id]
+    if row["assertion"]["kind"] != "probe":
+        pytest.skip("row is not probe-kind")
+    probe = row["assertion"].get("probe")
+    assert probe, f"row {row_id}: assertion.kind is 'probe' but no probe is named"
+    assert callable(getattr(sys.modules[__name__], probe, None)), integrity_flip(
+        row,
+        observed=f"no probe function named {probe!r} in this module",
+        expected="every probe-kind row names a probe function that exists and runs",
+    )
+
+
+def test_row_ids_are_unique():
+    seen: set[str] = set()
+    for row in ROWS:
+        assert row["id"] not in seen, (
+            f"duplicate matrix row id {row['id']!r}. Ids are stable forever: never "
+            "renumbered, never reused."
+        )
+        seen.add(row["id"])
+
+
+def test_every_probe_function_is_claimed_by_a_row():
+    """The other direction of the cross-check: no orphan probes.
+
+    A probe with no row asserts behavior nobody wrote down a disposition for --
+    which is a test, but not a conformance claim, and it will not appear in the
+    matrix a reviewer reads.
+    """
+    declared = {
+        row["assertion"].get("probe")
+        for row in ROWS
+        if row["assertion"]["kind"] == "probe"
+    }
+    module = sys.modules[__name__]
+    defined = {
+        name
+        for name in dir(module)
+        if name.startswith("test_row_") and callable(getattr(module, name))
+    }
+    # Structural tests are parametrized over row ids and are not row probes.
+    structural = {
+        "test_row_schema_is_wellformed",
+        "test_row_quote_is_verbatim_in_canonical",
+        "test_row_ledger_cites_exist",
+        "test_row_indexed_cites_exist",
+        "test_row_probe_function_exists",
+        "test_row_ids_are_unique",
+        "test_row_absence_assertion_holds",
+    }
+    orphans = sorted(defined - declared - structural)
+    assert not orphans, (
+        "SPEC-CONFORMANCE MATRIX FLIP -- MATRIX-INTEGRITY\n"
+        f"  probe functions with no matrix row: {orphans}\n"
+        "  Every probe must be claimed by a row, so the matrix a human reads is the\n"
+        "  complete list of what is asserted. Add the row, or rename the function."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. The coverage tripwire -- a new ledgered divergence cannot go unasserted
+# ---------------------------------------------------------------------------
+
+
+def _cited_extension_sections() -> set[int]:
+    return {
+        row["ledger"]["extensions"]
+        for row in ROWS
+        if (row.get("ledger") or {}).get("extensions") is not None
+    }
+
+
+def _cited_conformance_rows() -> set[str]:
+    return {
+        row["ledger"]["conformance"]
+        for row in ROWS
+        if (row.get("ledger") or {}).get("conformance")
+    }
+
+
+def test_tripwire_every_diverges_bannered_extension_is_asserted():
+    """A DIVERGES-bannered EXTENSIONS entry must be cited by at least one row."""
+    bannered = diverges_bannered_extension_sections(
+        EXTENSIONS_LEDGER.read_text(encoding="utf-8")
+    )
+    missing = sorted(bannered - _cited_extension_sections())
+    assert not missing, (
+        "SPEC-CONFORMANCE MATRIX FLIP -- MATRIX-INTEGRITY (coverage tripwire)\n"
+        f"  specs/EXTENSIONS.md sections {missing} carry a DIVERGES banner but no\n"
+        "  matrix row cites them.\n"
+        "  A divergence that is ledgered but not asserted is a promise with no\n"
+        "  enforcement: the engine can drift off it, or silently back onto spec,\n"
+        "  and CI stays green. Add a row to specs/conformance/attractor-matrix.yaml\n"
+        "  asserting BOTH halves -- that our documented behavior occurs, and that the\n"
+        "  spec's behavior does not.\n"
+        "  Doing neither means main carries a ledger that lies. That is drift."
+    )
+
+
+def test_tripwire_every_diverge_atx_row_is_asserted():
+    """An ``ATX-*`` row with a DIVERGE disposition must be cited by a matrix row."""
+    ledger_text = CONFORMANCE_LEDGER.read_text(encoding="utf-8")
+    diverging = diverge_disposition_atx_rows(ledger_text)
+    missing = sorted(diverging - _cited_conformance_rows())
+    assert not missing, (
+        "SPEC-CONFORMANCE MATRIX FLIP -- MATRIX-INTEGRITY (coverage tripwire)\n"
+        f"  SPEC_CONFORMANCE.md rows {missing} carry a DIVERGE disposition but no\n"
+        "  matrix row cites them.\n"
+        "  Recording a divergence in prose and leaving it unasserted is how ATX-11\n"
+        "  lived for months: correct, load-bearing, and invisible to CI. Add a row to\n"
+        "  specs/conformance/attractor-matrix.yaml in the same PR that ledgers it.\n"
+        "  Doing neither means main carries a ledger that lies. That is drift."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. RED/GREEN self-tests for the checker logic itself
+#
+# The checkers are the load-bearing part: a checker that cannot fail is a
+# checker that proves nothing. These exercise each one against synthetic input
+# that SHOULD be rejected, so a future refactor that neuters a check is caught
+# by this file rather than by the next incident.
+# ---------------------------------------------------------------------------
+
+
+def test_selfcheck_quote_verification_rejects_text_not_in_the_spec():
+    assert quote_is_present("The graph is the workflow: nodes are tasks")
+    assert not quote_is_present(
+        "The engine SHALL politely ask the model whether it feels converged."
+    )
+
+
+def test_selfcheck_quote_verification_is_whitespace_tolerant_not_content_tolerant():
+    assert quote_is_present("The    graph  is the workflow:   nodes are tasks")
+    assert not quote_is_present("The graph is the workflow; nodes are chores")
+
+
+def test_selfcheck_indexed_cite_resolution_rejects_dangling_cites():
+    ok, _ = resolve_indexed_cite(
+        "modules/loop-pipeline/tests/test_engine.py::test_no_matching_edge_returns_fail"
+    )
+    assert ok
+    ok, reason = resolve_indexed_cite(
+        "modules/loop-pipeline/tests/test_engine.py::test_this_name_does_not_exist"
+    )
+    assert not ok and "not found" in reason
+    ok, reason = resolve_indexed_cite("modules/loop-pipeline/tests/test_no_such_file.py")
+    assert not ok and "does not exist" in reason
+
+
+def test_selfcheck_ledger_id_extraction_finds_real_rows_and_not_invented_ones():
+    ids = conformance_ledger_ids(CONFORMANCE_LEDGER.read_text(encoding="utf-8"))
+    assert {"ATX-11", "ATX-12", "ATX-5", "ATX-6"} <= ids
+    assert "ATX-9999" not in ids
+
+
+def test_selfcheck_extensions_heading_extraction_is_contiguous_and_real():
+    numbers = extensions_section_numbers(EXTENSIONS_LEDGER.read_text(encoding="utf-8"))
+    assert {24, 25, 33, 36} <= numbers
+    assert max(numbers) not in {0}
+    assert 9999 not in numbers
+
+
+def test_selfcheck_diverges_banner_detection_is_precise():
+    """The banner detector must read the BOLD declarative, not stray prose."""
+    flagged = diverges_bannered_extension_sections(
+        EXTENSIONS_LEDGER.read_text(encoding="utf-8")
+    )
+    # Real DIVERGES banners in the ledger today.
+    assert {24, 25, 33} <= flagged
+    synthetic_positive = (
+        "## 99. Synthetic\n\n"
+        "> **This extension DIVERGES from canonical spec section 1.2.**\n>\n"
+        "> **depends-on:** none\n\ntext\n"
+    )
+    synthetic_negative = (
+        "## 98. Synthetic\n\n"
+        "> **This extension is NOT in the canonical attractor spec.**\n>\n"
+        "> **upstream action:** declining, reason: the divergence is tracked here.\n\n"
+    )
+    assert diverges_bannered_extension_sections(synthetic_positive) == {99}
+    assert diverges_bannered_extension_sections(synthetic_negative) == set()
+
+
+def test_selfcheck_diverge_atx_row_detection_reads_the_disposition_cell():
+    rows = diverge_disposition_atx_rows(CONFORMANCE_LEDGER.read_text(encoding="utf-8"))
+    assert {"ATX-4", "ATX-5", "ATX-11", "ATX-12"} <= rows
+    assert "ATX-1" not in rows  # disposition ALIGN
+    assert "ATX-2" not in rows  # disposition ALIGN
+
+
+def test_selfcheck_flip_message_carries_the_full_contract():
+    """The flip contract is the actual product. Assert its shape, not its prose."""
+    row = ROWS_BY_ID["ATX-M-011"]
+    message = flip(
+        row,
+        observed="dead end resolved to the spec's SUCCESS 'Pipeline completed'",
+        expected="the spec-literal dead-end-to-SUCCESS behavior stays absent",
+        direction="UN-DIVERGENCE",
+    )
+    assert message.startswith("SPEC-CONFORMANCE MATRIX FLIP -- row ATX-M-011")
+    assert "section 3.2" in message
+    assert 'RETURN Outcome(status=SUCCESS, notes="Pipeline completed")' in message
+    assert "SPEC_CONFORMANCE.md ATX-11" in message
+    assert "specs/EXTENSIONS.md section 33" in message
+    assert "UN-DIVERGENCE" in message
+    assert "observed:" in message and "expected:" in message
+    assert "Two legal exits" in message
+    assert "1. Revert the behavior change" in message
+    assert "2. Keep the change AND move the record with it" in message
+    assert message.rstrip().endswith("That is drift.")
+
+
+def test_selfcheck_open_pinned_flip_offers_the_decision_exit_not_the_ledger_exit():
+    """An OPEN-PINNED row must not tell a developer to update a decision nobody made."""
+    message = flip(
+        ROWS_BY_ID["ATX-M-006o"],
+        observed="a FAIL outcome was retried",
+        expected="a FAIL outcome executes exactly once",
+        direction="UNDECIDED-MOVEMENT",
+    )
+    assert "make it the DECISION" in message
+    assert "Undecided is not the same as unpinned" in message
+    assert "SPEC_CONFORMANCE.md ATX-6" in message
+    assert "section 11.5" in message  # the spec's self-contradiction is surfaced
+
+
+# ---------------------------------------------------------------------------
+# 4. Probe harness -- deterministic, in-process, no LLM, no network
+# ---------------------------------------------------------------------------
+
+
+class EventCollector:
+    """Captures emitted pipeline events (the canonical hooks seam)."""
+
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict[str, Any]]] = []
+
+    async def emit(self, event_name: str, data: dict[str, Any]) -> None:
+        self.events.append((event_name, data))
+
+    def get(self, event_name: str) -> list[dict[str, Any]]:
+        return [data for name, data in self.events if name == event_name]
+
+
+class ScriptedBackend:
+    """Returns a scripted result per node id; records the call order."""
+
+    def __init__(self, results: dict[str, Any] | None = None, default: Any = "ok") -> None:
+        self._results = results or {}
+        self._default = default
+        self.calls: list[str] = []
+
+    async def run(self, node, prompt, context, incoming_edge=None, graph=None):
+        self.calls.append(node.id)
+        result = self._results.get(node.id, self._default)
+        if callable(result):
+            return result(len([c for c in self.calls if c == node.id]) - 1, context)
+        return result
+
+
+def build_engine(
+    dot_source: str,
+    backend: Any,
+    tmp_path: Path,
+    hooks: Any | None = None,
+    validate: bool = True,
+) -> PipelineEngine:
+    graph = parse_dot(dot_source)
+    if validate:
+        validate_or_raise(graph)
+    registry = HandlerRegistry(HandlerContext(backend=backend))
+    return PipelineEngine(
+        graph=graph,
+        context=PipelineContext(),
+        handler_registry=registry,
+        logs_root=str(tmp_path),
+        hooks=hooks,
+    )
+
+
+def row(row_id: str) -> dict[str, Any]:
+    return ROWS_BY_ID[row_id]
+
+
+# ---------------------------------------------------------------------------
+# 5. Absence assertions -- "we do not implement section X" as executable claim
+# ---------------------------------------------------------------------------
+
+
+_ABSENCE_ROW_IDS = [r["id"] for r in ROWS if r["assertion"]["kind"] == "absence"]
+
+
+@pytest.mark.parametrize("row_id", _ABSENCE_ROW_IDS)
+def test_row_absence_assertion_holds(row_id: str):
+    """The named feature must remain absent from the named source roots."""
+    r = row(row_id)
+    spec = r["assertion"]["absence"]
+    hits = grep_source_roots(spec["pattern"], spec["roots"])
+    assert not hits, flip(
+        r,
+        observed=(
+            f"pattern {spec['pattern']!r} now appears in the source roots "
+            f"{spec['roots']}: {hits[:6]}"
+        ),
+        expected=(
+            "the feature stays absent while its ledger disposition says it is "
+            "not implemented"
+        ),
+        direction=(
+            "UN-DIVERGENCE"
+            if r["disposition"] == "NOT-IMPLEMENTED-DECIDED"
+            else "UNDECIDED-MOVEMENT"
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 6. Behavioral probes
+# ---------------------------------------------------------------------------
+
+
+def test_row_atx_m_000():
+    """SYNC: the canonical file's sha256 still matches the recorded pin."""
+    r = row("ATX-M-000")
+    actual = hashlib.sha256(CANONICAL_PATH.read_bytes()).hexdigest()
+    pinned = MATRIX["canonical"]["sha256"]
+    assert actual == pinned, (
+        f"SPEC-CONFORMANCE MATRIX FLIP -- row {r['id']} \"{r['title']}\"\n"
+        f"  canonical:   {MATRIX['canonical']['path']}\n"
+        f"  pinned to:   {MATRIX['canonical']['upstream']}  sha256={pinned}\n"
+        f"  actual:      sha256={actual}\n"
+        "  direction:   MATRIX-INTEGRITY -- the vendored spec has been re-synced.\n"
+        "\n"
+        "  This is NOT a 'fix the hash' failure. Every row in\n"
+        "  specs/conformance/attractor-matrix.yaml quotes THIS file, so a re-sync is a\n"
+        "  FULL-MATRIX RE-REVIEW EVENT:\n"
+        "    1. Re-verify every row against the new upstream text -- the quote checks\n"
+        "       will already have failed on exactly the rows whose normative text moved,\n"
+        "       which is your targeted diff of what upstream touched.\n"
+        "    2. Update the dispositions and ledger entries the new text ABSORBS or\n"
+        "       INVALIDATES (see the specs/EXTENSIONS.md 'ABSORBED UPSTREAM' banner\n"
+        "       protocol -- the fb57a55 sync retconned sections 1-7 that way, and found\n"
+        "       section 18's k_of_n/quorum had been removed upstream entirely).\n"
+        "    3. THEN update `sha256:` and `upstream:` in the matrix header, in the same PR.\n"
+        "  Doing neither means main carries a ledger that lies. That is drift."
+    )
+
+
+class _SuccessNoMatchBackend:
+    """Explicit SUCCESS whose preferred_label matches no edge -> a dead end."""
+
+    async def run(self, node, prompt, context, incoming_edge=None, graph=None):
+        return Outcome(
+            status=StageStatus.SUCCESS, preferred_label="nomatch", is_explicit=True
+        )
+
+
+@pytest.mark.asyncio
+async def test_row_atx_m_011(tmp_path):
+    """ATX-11 / EXTENSIONS section 33: a dead end ALWAYS hard-fails."""
+    r = row("ATX-M-011")
+    dot = """
+    digraph M011 {
+        start [shape=Mdiamond]
+        exit  [shape=Msquare]
+        work  [prompt="do work"]
+        sink  [prompt="unreached"]
+        start -> work
+        work -> sink [condition="outcome=fail"]
+        sink -> exit
+    }
+    """
+    hooks = EventCollector()
+    engine = build_engine(dot, _SuccessNoMatchBackend(), tmp_path, hooks=hooks)
+    outcome = await engine.run()
+
+    # (b) FIRST: the SPEC behavior must NOT occur. Checked before our own half
+    # because the likeliest way this row flips is a well-meaning "align to
+    # spec section 3.2" change, and a developer who just made that change is
+    # owed the message that names it as an UN-DIVERGENCE -- not a generic
+    # regression report.
+    assert outcome.status != StageStatus.SUCCESS and "Pipeline completed" not in (
+        outcome.notes or ""
+    ), flip(
+        r,
+        observed="a dead end resolved to the spec's SUCCESS 'Pipeline completed'",
+        expected="the spec-literal dead-end-to-SUCCESS behavior stays absent",
+        direction="UN-DIVERGENCE",
+    )
+
+    # (a) our ledgered behavior: hard-fail, traceable, loud.
+    assert outcome.status == StageStatus.FAIL, flip(
+        r,
+        observed=f"pipeline outcome {outcome.status} on a dead end",
+        expected="a dead end ALWAYS terminates the pipeline with status=FAIL",
+    )
+    assert outcome.failure_reason, flip(
+        r,
+        observed="empty failure_reason on the dead-end termination",
+        expected="terminate_pipeline() carries a traceable failure_reason",
+    )
+    assert any(
+        e.get("error_type") == "no_matching_edge" for e in hooks.get(PIPELINE_ERROR)
+    ), flip(
+        r,
+        observed="no PIPELINE_ERROR event with error_type=no_matching_edge",
+        expected="the hard-fail emits PIPELINE_ERROR error_type=no_matching_edge",
+    )
+
+
+@pytest.mark.asyncio
+async def test_row_atx_m_012(tmp_path):
+    """ATX-12 / EXTENSIONS section 24: loop_restart resets in process."""
+    r = row("ATX-M-012")
+    seen_iterations: list[str] = []
+
+    async def _run(node, prompt, context, incoming_edge=None, graph=None):
+        iteration = str(context.get("iteration", ""))
+        seen_iterations.append(iteration)
+        if len(seen_iterations) == 1:
+            return Outcome(
+                status=StageStatus.SUCCESS,
+                preferred_label="again",
+                is_explicit=True,
+                context_updates={"finding": "attempt-0-found-X"},
+            )
+        return Outcome(
+            status=StageStatus.SUCCESS, preferred_label="done", is_explicit=True
+        )
+
+    backend = type("_LoopBackend", (), {"run": staticmethod(_run)})()
+    dot = """
+    digraph M012 {
+        start [shape=Mdiamond]
+        exit  [shape=Msquare]
+        work  [prompt="iteration $iteration"]
+        start -> work
+        work -> work [label="again", loop_restart="true"]
+        work -> exit [label="done"]
+    }
+    """
+    logs_root = tmp_path / "run"
+    logs_root.mkdir()
+    engine = build_engine(dot, backend, logs_root)
+    outcome = await engine.run()
+
+    # (a) our ledgered behavior: in-process reset.
+    assert len(seen_iterations) == 2, flip(
+        r,
+        observed=f"work executed {len(seen_iterations)} time(s)",
+        expected="loop_restart clears completed nodes so the node executes again",
+    )
+    assert seen_iterations[1] != seen_iterations[0], flip(
+        r,
+        observed=f"$iteration did not advance across the restart: {seen_iterations}",
+        expected="$iteration/$loop_count increment across a loop_restart",
+    )
+    assert engine.context.get("finding") == "attempt-0-found-X", flip(
+        r,
+        observed="context_updates from the pre-restart iteration were discarded",
+        expected="context_updates SURVIVE a loop_restart (what convergence rides on)",
+    )
+    iteration_dirs = sorted(p.name for p in logs_root.glob("iteration_*") if p.is_dir())
+    assert iteration_dirs, flip(
+        r,
+        observed=f"no iteration_N/ sub-tree under the run root {logs_root}",
+        expected="the run directory is RETAINED and gains an iteration_N/ sub-tree",
+    )
+
+    # (b) the SPEC behavior must NOT occur: no fresh log-directory root, and
+    # run() returned a normal final outcome instead of restart_run(); RETURN.
+    siblings = [p for p in tmp_path.iterdir() if p.is_dir() and p != logs_root]
+    assert not siblings, flip(
+        r,
+        observed=f"a fresh sibling run-root appeared beside the retained one: {siblings}",
+        expected="the spec-literal 'fresh log directory' relaunch stays absent",
+        direction="UN-DIVERGENCE",
+    )
+    assert outcome is not None and outcome.status in {
+        StageStatus.SUCCESS,
+        StageStatus.PARTIAL_SUCCESS,
+    }, flip(
+        r,
+        observed=f"run() returned {outcome!r} after a loop_restart",
+        expected=(
+            "run() completes in process and returns a final outcome -- the spec's "
+            "restart_run(...); RETURN stays absent"
+        ),
+        direction="UN-DIVERGENCE",
+    )
+
+
+@pytest.mark.asyncio
+async def test_row_atx_m_025a(tmp_path):
+    """EXTENSIONS section 25: plain prose cannot exit a goal gate -- but still
+    wraps to SUCCESS everywhere else (the control that keeps this additive)."""
+    r = row("ATX-M-025a")
+    dot_gate = """
+    digraph M025a {
+        start [shape=Mdiamond]
+        exit  [shape=Msquare]
+        judge [prompt="judge the work", goal_gate=true]
+        start -> judge
+        judge -> exit
+    }
+    """
+    engine = build_engine(dot_gate, ScriptedBackend(default="Looks good to me!"), tmp_path)
+    outcome = await engine.run()
+
+    # (b) the SPEC behavior must NOT occur on a goal gate.
+    assert outcome.status != StageStatus.SUCCESS, flip(
+        r,
+        observed=(
+            "a plain-prose response on a goal_gate=true node exited the pipeline "
+            "SUCCESS -- the spec's unconditional string-to-SUCCESS wrap"
+        ),
+        expected=(
+            "prose is not evidence of convergence: a goal gate fails closed on an "
+            "unasserted verdict"
+        ),
+        direction="UN-DIVERGENCE",
+    )
+
+    # (a) the control: the spec's wrap is PRESERVED off the gate, which is what
+    # keeps this divergence non-interfering for community graphs.
+    dot_plain = """
+    digraph M025aControl {
+        start [shape=Mdiamond]
+        exit  [shape=Msquare]
+        work  [prompt="do work"]
+        start -> work
+        work -> exit
+    }
+    """
+    control = build_engine(
+        dot_plain, ScriptedBackend(default="Looks good to me!"), tmp_path / "control"
+    )
+    control_outcome = await control.run()
+    assert control_outcome.status == StageStatus.SUCCESS, flip(
+        r,
+        observed=(
+            f"a non-gate node's prose response produced {control_outcome.status} "
+            "instead of the spec's SUCCESS wrap"
+        ),
+        expected=(
+            "the section-25 divergence is SCOPED to goal_gate=true nodes; everywhere "
+            "else the canonical prose-to-SUCCESS wrap is preserved (doctrine rule 3)"
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_row_atx_m_025b(tmp_path):
+    """EXTENSIONS section 25: a status-only SUCCESS does not satisfy a gate."""
+    r = row("ATX-M-025b")
+    dot = """
+    digraph M025b {
+        start [shape=Mdiamond]
+        exit  [shape=Msquare]
+        judge [prompt="judge the work", goal_gate=true]
+        start -> judge
+        judge -> exit
+    }
+    """
+    implicit = Outcome(status=StageStatus.SUCCESS, notes="done", is_explicit=False)
+    engine = build_engine(dot, ScriptedBackend({"judge": implicit}), tmp_path / "implicit")
+    outcome = await engine.run()
+
+    # (b) the SPEC behavior (status in {SUCCESS, PARTIAL_SUCCESS} satisfies) must
+    # NOT hold on its own.
+    assert outcome.status == StageStatus.FAIL, flip(
+        r,
+        observed=(
+            f"a status-only SUCCESS satisfied a goal gate (pipeline {outcome.status}) "
+            "-- the spec's section 3.4 check_goal_gates behavior"
+        ),
+        expected=(
+            "the gate additionally requires is_explicit: a defaulted SUCCESS is "
+            "treated as unsatisfied and fails closed"
+        ),
+        direction="UN-DIVERGENCE",
+    )
+    assert "gate" in (outcome.failure_reason or "").lower(), flip(
+        r,
+        observed=f"failure_reason does not name the gate: {outcome.failure_reason!r}",
+        expected="the fail-closed refusal is traceable to the unsatisfied gate",
+    )
+
+    # (a) the control: an EXPLICIT SUCCESS does satisfy it -- the gate is closed,
+    # not welded shut.
+    explicit = Outcome(status=StageStatus.SUCCESS, notes="done", is_explicit=True)
+    control = build_engine(
+        dot, ScriptedBackend({"judge": explicit}), tmp_path / "explicit"
+    )
+    control_outcome = await control.run()
+    assert control_outcome.status == StageStatus.SUCCESS, flip(
+        r,
+        observed=(
+            f"an EXPLICIT SUCCESS failed to satisfy the goal gate "
+            f"({control_outcome.status})"
+        ),
+        expected=(
+            "an asserted verdict still satisfies the gate -- fail-closed narrows what "
+            "counts as evidence, it does not make gates unsatisfiable"
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_row_atx_m_006o(tmp_path):
+    """ATX-6 (OPEN): a FAIL outcome executes exactly once, even with retries."""
+    r = row("ATX-M-006o")
+    dot = """
+    digraph M006 {
+        start [shape=Mdiamond]
+        exit  [shape=Msquare]
+        work  [prompt="do work", max_retries=2]
+        start -> work
+        work -> exit
+    }
+    """
+    backend = ScriptedBackend(
+        {"work": Outcome(status=StageStatus.FAIL, failure_reason="nope", is_explicit=True)}
+    )
+    engine = build_engine(dot, backend, tmp_path)
+    await engine.run()
+
+    executions = backend.calls.count("work")
+    assert executions == 1, flip(
+        r,
+        observed=f"a FAIL outcome with max_retries=2 executed {executions} time(s)",
+        expected=(
+            "section 3.5's pseudocode returns a FAIL outcome immediately -- FAIL is a "
+            "routing decision, not a flake. The Definition-of-Done checklist says the "
+            "opposite; this engine follows section 3.5"
+        ),
+        direction="UNDECIDED-MOVEMENT",
+    )
+
+
+def test_row_atx_m_007o():
+    """ATX-7 (OPEN): condition literals are compared WITH their quotes."""
+    from amplifier_module_loop_pipeline.conditions import evaluate_condition
+
+    r = row("ATX-M-007o")
+    context = PipelineContext()
+    context.set("mode", "fast")
+    outcome = Outcome(status=StageStatus.SUCCESS)
+
+    unquoted_matches = evaluate_condition("context.mode=fast", outcome, context)
+    quoted_matches = evaluate_condition('context.mode="fast"', outcome, context)
+
+    assert unquoted_matches, flip(
+        r,
+        observed="an UNQUOTED condition literal failed to match its context value",
+        expected="unquoted literals compare by value (the common, working case)",
+    )
+    assert not quoted_matches, flip(
+        r,
+        observed=(
+            "a double-quoted condition literal now matches -- parse_literal-style "
+            "unquoting appears to have been implemented"
+        ),
+        expected=(
+            "today's pinned behavior: quoted literals are compared RAW, including the "
+            "quotes, so a canonical section 10.5 graph does not route as written"
+        ),
+        direction="UNDECIDED-MOVEMENT",
+    )
+
+
+def test_row_atx_m_f01():
+    """F1 (issue #237): an unknown shape hard-errors; it does NOT fall through."""
+    r = row("ATX-M-F01")
+    registry = HandlerRegistry(HandlerContext())
+
+    with pytest.raises(ValueError) as exc_info:
+        registry.get(Node(id="broken_gate", shape="trapezium"))
+    message = str(exc_info.value)
+
+    assert "trapezium" in message, flip(
+        r,
+        observed=f"the error does not name the offending shape: {message!r}",
+        expected="the refusal names the bad shape so the author can fix the typo",
+    )
+    assert "box" in message, flip(
+        r,
+        observed="the error does not list the supported shapes",
+        expected="the refusal lists the recognized shapes",
+    )
+    # The control: known shapes still dispatch. The divergence is a refusal on
+    # the unknown case only -- it does not narrow the canonical table.
+    handler = registry.get(Node(id="ok", shape="box"))
+    assert handler is not None, flip(
+        r,
+        observed="a canonical shape failed to dispatch",
+        expected="the section 2.8 table still resolves; only UNKNOWN shapes are refused",
+    )
+
+
+def test_row_atx_m_f04():
+    """F4 (issue #237): `reasoning_effort` has no built-in default."""
+    r = row("ATX-M-F04")
+    graph = parse_dot(
+        """
+        digraph F04 {
+            start [shape=Mdiamond]
+            exit  [shape=Msquare]
+            work  [prompt="do work"]
+            start -> work -> exit
+        }
+        """
+    )
+    node = graph.nodes["work"]
+    assert node.reasoning_effort is None, flip(
+        r,
+        observed=(
+            f"a node omitting reasoning_effort now resolves to "
+            f"{node.reasoning_effort!r}"
+        ),
+        expected=(
+            "today's pinned behavior: the attribute is UNSET, so the provider's own "
+            "default applies -- Appendix A's `\"high\"` does not hold here"
+        ),
+        direction="UNDECIDED-MOVEMENT",
+    )
+    assert node.attrs.get("reasoning_effort") is None, flip(
+        r,
+        observed="node.attrs surfaced a default reasoning_effort",
+        expected="the attrs proxy agrees with the first-class field: unset is unset",
+        direction="UNDECIDED-MOVEMENT",
+    )
+
+
+@pytest.mark.asyncio
+async def test_row_atx_m_102(tmp_path):
+    """Section 3.2 step 4: context_updates merged; `outcome` always set;
+    `preferred_label` set ONLY when the outcome carries a non-empty one."""
+    r = row("ATX-M-102")
+    seen: list[dict[str, Any]] = []
+
+    async def _run(node, prompt, context, incoming_edge=None, graph=None):
+        seen.append(
+            {
+                "node": node.id,
+                "outcome": context.get("outcome"),
+                "preferred_label": context.get("preferred_label"),
+                "artifact": context.get("artifact_path"),
+            }
+        )
+        if node.id == "first":
+            return Outcome(
+                status=StageStatus.SUCCESS,
+                preferred_label="onward",
+                context_updates={"artifact_path": "src/word_counter.py"},
+                is_explicit=True,
+            )
+        return Outcome(status=StageStatus.SUCCESS, is_explicit=True)
+
+    backend = type("_CtxBackend", (), {"run": staticmethod(_run)})()
+    dot = """
+    digraph M102 {
+        start  [shape=Mdiamond]
+        exit   [shape=Msquare]
+        first  [prompt="one"]
+        second [prompt="two"]
+        start -> first
+        first -> second [label="onward"]
+        second -> exit
+    }
+    """
+    engine = build_engine(dot, backend, tmp_path)
+    await engine.run()
+
+    assert len(seen) == 2, flip(
+        r, observed=f"nodes executed: {[s['node'] for s in seen]}", expected="two nodes run"
+    )
+    assert seen[1]["artifact"] == "src/word_counter.py", flip(
+        r,
+        observed="context_updates from the first node were not visible to the second",
+        expected="step 4 merges outcome.context_updates into the run context",
+    )
+    assert seen[1]["outcome"] == StageStatus.SUCCESS.value, flip(
+        r,
+        observed=f"context['outcome'] was {seen[1]['outcome']!r} at the second node",
+        expected="step 4 sets context['outcome'] to the previous node's status",
+    )
+    assert seen[1]["preferred_label"] == "onward", flip(
+        r,
+        observed=f"context['preferred_label'] was {seen[1]['preferred_label']!r}",
+        expected="step 4 sets context['preferred_label'] when the outcome carries one",
+    )
+    # The "only when non-empty" half: the second node emitted no preferred_label,
+    # so the value must not be re-set by it (it stays as the first node left it,
+    # never overwritten with an empty string).
+    assert engine.context.get("preferred_label") == "onward", flip(
+        r,
+        observed=(
+            "an outcome with an EMPTY preferred_label overwrote the context key "
+            f"(now {engine.context.get('preferred_label')!r})"
+        ),
+        expected=(
+            "step 4 sets preferred_label ONLY when non-empty -- an unconditional "
+            "overwrite is the stale-label bug class"
+        ),
+    )
+
+
+def test_row_atx_m_109():
+    """Section 3.3: edge selection returns exactly ONE edge (ATX-10 restoration)."""
+    r = row("ATX-M-109")
+    graph = parse_dot(
+        """
+        digraph M109 {
+            start [shape=Mdiamond]
+            exit  [shape=Msquare]
+            work  [prompt="work"]
+            a     [prompt="a"]
+            b     [prompt="b"]
+            start -> work
+            work -> a [condition="outcome=success"]
+            work -> b [condition="outcome=success"]
+            a -> exit
+            b -> exit
+        }
+        """
+    )
+    outcome = Outcome(status=StageStatus.SUCCESS, is_explicit=True)
+    selected = select_edge("work", outcome, PipelineContext(), graph)
+
+    assert selected is not None, flip(
+        r,
+        observed="select_edge returned NONE with two matching conditional edges",
+        expected="exactly one edge is selected",
+    )
+    assert not isinstance(selected, (list, tuple, set)), flip(
+        r,
+        observed=f"select_edge returned a collection of edges: {selected!r}",
+        expected=(
+            "ONE edge, never a fan-out from a non-component node. The multi-match "
+            "fan-out dialect was an unledgered divergence, retired under ATX-10 (T0-4)"
+        ),
+    )
+    assert selected.to_node == "a", flip(
+        r,
+        observed=f"tie broken to {selected.to_node!r}",
+        expected="best_by_weight_then_lexical picks 'a' (equal weight, lexical order)",
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "rung,gate_attrs,graph_attrs,expected_target",
+    [
+        ("node retry_target", 'retry_target="fix_a"', "", "fix_a"),
+        ("node fallback", 'fallback_retry_target="fix_b"', "", "fix_b"),
+        ("graph retry_target", "", 'retry_target="fix_c"', "fix_c"),
+        ("graph fallback", "", 'fallback_retry_target="fix_d"', "fix_d"),
+    ],
+)
+async def test_row_atx_m_111(tmp_path, rung, gate_attrs, graph_attrs, expected_target):
+    """Section 3.4 rule 3: the four-rung retry-target ladder, rung by rung."""
+    r = row("ATX-M-111")
+    gate_extra = f", {gate_attrs}" if gate_attrs else ""
+    graph_line = f"    graph [{graph_attrs}]" if graph_attrs else ""
+    dot = f"""
+    digraph M111 {{
+{graph_line}
+        start [shape=Mdiamond]
+        exit  [shape=Msquare]
+        judge [prompt="judge", goal_gate=true{gate_extra}]
+        fix_a [prompt="a"]
+        fix_b [prompt="b"]
+        fix_c [prompt="c"]
+        fix_d [prompt="d"]
+        start -> judge
+        judge -> exit
+        judge -> fix_a [condition="outcome=never_a"]
+        judge -> fix_b [condition="outcome=never_b"]
+        judge -> fix_c [condition="outcome=never_c"]
+        judge -> fix_d [condition="outcome=never_d"]
+        fix_a -> exit
+        fix_b -> exit
+        fix_c -> exit
+        fix_d -> exit
+    }}
+    """
+    engine = build_engine(
+        dot,
+        ScriptedBackend(
+            {"judge": Outcome(status=StageStatus.FAIL, failure_reason="no", is_explicit=True)}
+        ),
+        tmp_path / rung.replace(" ", "_"),
+    )
+    gate_outcome = Outcome(status=StageStatus.FAIL, failure_reason="no", is_explicit=True)
+    engine.node_outcomes["judge"] = gate_outcome
+    engine.completed_nodes.append("judge")
+
+    resolved = await engine._check_goal_gates()
+    assert resolved.status == StageStatus.FAIL, flip(
+        r,
+        observed=f"an unsatisfied gate produced {resolved.status}",
+        expected="an unsatisfied goal gate cannot let the pipeline exit",
+    )
+    assert resolved.suggested_next_ids == [expected_target], flip(
+        r,
+        observed=(
+            f"rung '{rung}': gate retry resolved to {resolved.suggested_next_ids!r}"
+        ),
+        expected=(
+            f"rung '{rung}': the ladder resolves to {expected_target!r} "
+            "(node retry_target > node fallback > graph retry_target > graph fallback)"
+        ),
+    )
+
+
+def test_row_atx_m_118():
+    """Section 2.8 / Appendix B: the nine canonical shapes map to their handler types."""
+    r = row("ATX-M-118")
+    canonical_table = {
+        "Mdiamond": "start",
+        "Msquare": "exit",
+        "box": "codergen",
+        "hexagon": "wait.human",
+        "diamond": "conditional",
+        "component": "parallel",
+        "tripleoctagon": "parallel.fan_in",
+        "parallelogram": "tool",
+        "house": "stack.manager_loop",
+    }
+    for shape, handler_type in canonical_table.items():
+        assert SHAPE_TO_HANDLER.get(shape) == handler_type, flip(
+            r,
+            observed=(
+                f"shape {shape!r} maps to {SHAPE_TO_HANDLER.get(shape)!r} "
+                f"(canonical section 2.8 says {handler_type!r})"
+            ),
+            expected="the nine canonical shape rows map exactly as section 2.8 specifies",
+        )
+    # `folder` is ours, not the spec's -- asserted separately so a reader of this
+    # probe cannot mistake an extension for canonical text.
+    assert SHAPE_TO_HANDLER.get("folder") == "pipeline", flip(
+        r,
+        observed=f"the EXTENSION shape 'folder' maps to {SHAPE_TO_HANDLER.get('folder')!r}",
+        expected="folder -> pipeline (specs/EXTENSIONS.md section 10, additive to section 2.8)",
+    )
+
+
+@pytest.mark.asyncio
+async def test_row_atx_m_119(tmp_path):
+    """Section 3.5: a handler exception becomes a FAIL outcome, never an escaped crash."""
+    r = row("ATX-M-119")
+
+    async def _boom(node, prompt, context, incoming_edge=None, graph=None):
+        raise RuntimeError("backend exploded")
+
+    backend = type("_RaisingBackend", (), {"run": staticmethod(_boom)})()
+    dot = """
+    digraph M119 {
+        start [shape=Mdiamond]
+        exit  [shape=Msquare]
+        work  [prompt="do work"]
+        start -> work
+        work -> exit
+    }
+    """
+    engine = build_engine(dot, backend, tmp_path)
+    try:
+        outcome = await engine.run()
+    except RuntimeError as exc:  # pragma: no cover - the failure path
+        raise AssertionError(
+            flip(
+                r,
+                observed=f"the handler exception escaped run(): {exc!r}",
+                expected=(
+                    "section 3.5's CATCH turns an exception into "
+                    "Outcome(status=FAIL, failure_reason=str(exception))"
+                ),
+            )
+        ) from exc
+
+    assert outcome.status == StageStatus.FAIL, flip(
+        r,
+        observed=f"a raising handler produced {outcome.status}",
+        expected="an exception is caught and returned as a FAIL outcome",
+    )
+    assert "exploded" in (outcome.failure_reason or ""), flip(
+        r,
+        observed=f"failure_reason lost the exception text: {outcome.failure_reason!r}",
+        expected="the failure_reason carries str(exception) so the crash stays traceable",
+    )

--- a/modules/loop-pipeline/tests/test_spec_conformance_matrix.py
+++ b/modules/loop-pipeline/tests/test_spec_conformance_matrix.py
@@ -1227,7 +1227,7 @@ def test_row_atx_m_007o():
 
 
 def test_row_atx_m_f01():
-    """F1 (issue #237): an unknown shape hard-errors; it does NOT fall through."""
+    """F1 (issue #234): an unknown shape hard-errors; it does NOT fall through."""
     r = row("ATX-M-F01")
     registry = HandlerRegistry(HandlerContext())
 
@@ -1256,7 +1256,7 @@ def test_row_atx_m_f01():
 
 
 def test_row_atx_m_f04():
-    """F4 (issue #237): `reasoning_effort` has no built-in default."""
+    """F4 (issue #234): `reasoning_effort` has no built-in default."""
     r = row("ATX-M-F04")
     graph = parse_dot(
         """

--- a/specs/conformance/attractor-matrix.yaml
+++ b/specs/conformance/attractor-matrix.yaml
@@ -1,0 +1,969 @@
+# Spec Conformance Matrix -- attractor
+#
+# Layer 2 of the drift defense described in `docs/QUALITY_PROTOCOL.md` section 3.
+#
+# This file is a DOCUMENT first and a data file second. Read it next to
+# `specs/EXTENSIONS.md` and `SPEC_CONFORMANCE.md`: it is the executable join
+# between them and the canonical upstream nlspec.
+#
+# One row = one normative statement cluster in the canonical spec, with:
+#   - the VERBATIM spec text it answers to (runner-verified against the
+#     canonical file's bytes -- a row cannot cite text that is not there),
+#   - the repo's decided DISPOSITION for it,
+#   - the LEDGER entry that licenses that disposition, and
+#   - an executable ASSERTION that fails when the behavior moves.
+#
+# The load-bearing idea: DECIDED DIVERGENCES ARE ASSERTED TOO. Drift is any
+# behavioral movement not recorded in the ledgers, in EITHER direction --
+# drifting away from spec unledgered, and drifting silently BACK toward spec
+# at a point where the ledger says we deliberately do not conform. The second
+# makes the ledger lie, which is the same incident class as the engine lying.
+#
+# A flipped assertion is never merely a red test. Its failure message names the
+# spec section, the ledger entry, and the two legal exits (revert the behavior,
+# or move the record with it in the SAME PR). Never edit the assertion to
+# match new behavior without moving the ledger -- that is the one illegal exit.
+#
+# Runner: modules/loop-pipeline/tests/test_spec_conformance_matrix.py
+# Design: docs/designs/2026-08-15-conformance-matrix.md
+#
+# ---------------------------------------------------------------- schema ----
+#
+#   id            Stable forever. Never renumbered, never reused. Retiring an
+#                 id requires a comment here naming the successor rows.
+#   title         Short human label, used in the flip banner.
+#   spec:
+#     section     Canonical section anchor, e.g. "3.2".
+#     heading     The section's heading text, for the flip message.
+#     quote       VERBATIM text from the canonical file. Runner-verified.
+#     line        INFORMATIONAL ONLY. Never asserted (see the design, section 9).
+#     also        Optional list of {section, quote} -- additional verbatim
+#                 anchors for a cluster that spans non-contiguous spec text.
+#                 Verified exactly like `quote`.
+#     conflict    Optional {section, quote, note} -- where the canonical spec
+#                 CONTRADICTS ITSELF and this row pins one side by named
+#                 choice. Also verified verbatim.
+#   disposition   CONFORM | DIVERGE-DECIDED | EXTENSION | OPEN-PINNED
+#                 | NOT-IMPLEMENTED-DECIDED | NOT-ASSERTABLE
+#   ledger:
+#     conformance SPEC_CONFORMANCE.md row id (e.g. ATX-11). Checked to exist.
+#     extensions  specs/EXTENSIONS.md section number. Checked to exist.
+#     issue       GitHub issue number, for an OPEN-PINNED row whose ledger
+#                 disposition has not been written yet BECAUSE THIS MATRIX
+#                 SURFACED IT. Pinning behavior is not the same as deciding
+#                 it; the issue is the open decision, and the row's flip
+#                 message points at it.
+#   assertion:
+#     kind        probe | indexed | absence | none
+#     probe       Function name in the runner module. Cross-checked BOTH ways.
+#     indexed     Existing coverage this row indexes (never duplicates).
+#                 Verified by AST parse -- NEVER by import, because these cites
+#                 cross per-module venv boundaries.
+#     absence     {pattern, roots} -- the feature is asserted ABSENT. This is
+#                 how "we do not implement section X" becomes executable:
+#                 shipping it without moving the ledger turns the matrix red.
+#   justification Required for OPEN-PINNED and NOT-ASSERTABLE.
+#   notes         Free text. Included in the flip message as a row-specific hint.
+#
+# --------------------------------------------------------------- tranche ----
+#
+# Tranche 1 (this file): every decided divergence, every OPEN ledger item
+# pinned, the two unledgered findings this matrix's construction surfaced
+# (F1 / F4, issue #234), the load-bearing conformances a community `.dot`
+# stakes its correctness on, and the SYNC row. Tranche 2+ (the remaining
+# rows by section) and tranche 3 (ULM/CAL matrices) are named in the
+# design, section 6 and section 12.
+
+canonical:
+  path: specs/canonical/attractor-spec-canonical.md
+  upstream: strongdm/attractor @ fb57a55
+  # Recomputed ONLY as part of a deliberate SYNC event -- see row ATX-M-000.
+  sha256: "235354496e2bc35cba9822cded2ebd71ff35a8fb7fce4e51f52b2788586e92ec"
+
+ledgers:
+  conformance: SPEC_CONFORMANCE.md
+  extensions: specs/EXTENSIONS.md
+
+rows:
+
+  # ==========================================================================
+  # A. Upstream sync
+  # ==========================================================================
+
+  - id: ATX-M-000
+    title: canonical spec is byte-pinned to the recorded upstream sha
+    spec:
+      section: "1.1"
+      heading: "Problem Statement"
+      quote: |
+        Attractor solves this by letting pipeline authors define multi-stage AI workflows as directed graphs using Graphviz DOT syntax. The graph is the workflow: nodes are tasks, edges are transitions, and attributes configure behavior. The result is a declarative, visual, version-controllable pipeline definition that an execution engine can traverse deterministically.
+      line: 29
+    disposition: CONFORM
+    ledger:
+      conformance: SYNC-1
+    assertion:
+      kind: probe
+      probe: test_row_atx_m_000
+    notes: >
+      Every other row in this file quotes the canonical bytes. A re-sync is
+      therefore a full-matrix re-review event, not a quiet vendoring commit.
+      Precedent: the 2026-08-14 fb57a55 sync retconned EXTENSIONS sections 1-7
+      as ABSORBED and discovered section 18's k_of_n/quorum had been REMOVED
+      upstream.
+
+  # ==========================================================================
+  # B. Decided divergences -- asserted in both directions
+  #
+  # Each of these proves (a) our ledgered behavior occurs AND (b) the spec's
+  # behavior does NOT. Half (b) is what makes silent RE-alignment loud.
+  # ==========================================================================
+
+  - id: ATX-M-011
+    title: dead-end hard-fail (main loop)
+    spec:
+      section: "3.2"
+      heading: "Core Execution Loop"
+      quote: |
+                -- Step 6: Select next edge
+                next_edge = select_edge(node, outcome, context, graph)
+                IF next_edge is NONE:
+                    IF outcome.status == FAIL:
+                        RETURN outcome
+                    RETURN Outcome(status=SUCCESS, notes="Pipeline completed")
+      line: 388
+    disposition: DIVERGE-DECIDED
+    ledger:
+      conformance: ATX-11
+      extensions: 33
+    assertion:
+      kind: probe
+      probe: test_row_atx_m_011
+      indexed:
+        - modules/loop-pipeline/tests/test_engine.py::test_no_matching_edge_returns_fail
+        - modules/loop-pipeline/tests/test_pipeline_events.py::TestErrorEvents::test_emits_error_on_no_edge
+    notes: >
+      A dead-ended graph silently reporting success is the incident class this
+      divergence exists to prevent. Load-bearing for
+      examples/pipelines/practical/bug-fix.dot ('escalated'). Paired doc guard:
+      modules/loop-pipeline/tests/test_engine_semantics_doc_guard.py and
+      context/engine-semantics.md must move with any change here.
+
+  - id: ATX-M-012
+    title: loop_restart is an in-process reset, not a terminate-and-relaunch
+    spec:
+      section: "2.7"
+      heading: "Edge Attributes"
+      quote: |
+        | `loop_restart` | Boolean | `false` | When `true`, terminates the current run and re-launches with a fresh log directory. |
+      line: 177
+      also:
+        - section: "3.2"
+          quote: |
+                    -- Step 7: Handle loop_restart
+                    IF next_edge has loop_restart=true:
+                        restart_run(graph, config, start_at=next_edge.target)
+                        RETURN
+    disposition: DIVERGE-DECIDED
+    ledger:
+      conformance: ATX-12
+      extensions: 24
+    assertion:
+      kind: probe
+      probe: test_row_atx_m_012
+      indexed:
+        - modules/loop-pipeline/tests/test_convergence_observability.py
+    notes: >
+      The spec's terminate-and-relaunch would destroy exactly what convergence
+      needs: $iteration continuity, surviving context_updates, and feedback_from=
+      collection across iterations. Design record:
+      docs/plans/2026-02-24-engine-enhancements-design.md quotes the spec, then
+      chooses otherwise.
+
+  - id: ATX-M-025a
+    title: fail-closed goal gate -- the codergen prose-to-SUCCESS rung
+    spec:
+      section: "4.5"
+      heading: "Codergen Handler"
+      quote: |
+                -- 5. Write status and return outcome
+                outcome = Outcome(
+                    status=SUCCESS,
+                    notes="Stage completed: " + node.id,
+                    context_updates={
+                        "last_stage": node.id,
+                        "last_response": truncate(response_text, 200)
+                    }
+                )
+      line: 694
+    disposition: DIVERGE-DECIDED
+    ledger:
+      extensions: 25
+    assertion:
+      kind: probe
+      probe: test_row_atx_m_025a
+      indexed:
+        - modules/loop-pipeline/tests/test_backend.py::test_backend_plain_text_returns_success
+        - modules/loop-pipeline/tests/test_fail_closed_outcomes.py::test_fc001_goal_gate_plain_prose_returns_retry
+        - modules/loop-pipeline/tests/test_fail_closed_outcomes.py::test_fc002_non_goal_gate_plain_prose_returns_success
+        - modules/loop-pipeline/tests/test_fail_closed_outcomes.py::test_fc010_goal_gate_plain_prose_does_not_exit_success
+    notes: >
+      Scoped to goal_gate=true nodes ONLY -- the spec's prose-to-SUCCESS wrap is
+      preserved everywhere else, which is what keeps this divergence
+      non-interfering for community graphs (doctrine rule 3). The control half of
+      that claim is asserted by the same probe.
+
+  - id: ATX-M-025b
+    title: fail-closed goal gate -- the status-only satisfaction rung
+    spec:
+      section: "3.4"
+      heading: "Goal Gate Enforcement"
+      quote: |
+        FUNCTION check_goal_gates(graph, node_outcomes):
+            FOR EACH (node_id, outcome) IN node_outcomes:
+                node = graph.nodes[node_id]
+                IF node.goal_gate == true:
+                    IF outcome.status NOT IN {SUCCESS, PARTIAL_SUCCESS}:
+                        RETURN (false, node)
+            RETURN (true, NONE)
+      line: 471
+    disposition: DIVERGE-DECIDED
+    ledger:
+      extensions: 25
+    assertion:
+      kind: probe
+      probe: test_row_atx_m_025b
+      indexed:
+        - modules/loop-pipeline/tests/test_fail_closed_outcomes.py::test_fc008_spawn_status_only_is_not_explicit
+        - modules/loop-pipeline/tests/test_fail_closed_outcomes.py::test_fc011_goal_gate_explicit_json_success_exits_success
+    notes: >
+      The gate additionally requires is_explicit -- a status-only SUCCESS (the
+      shape a bare spawn produces) does NOT satisfy it. Evidence: the run in which
+      a judge wrote "NOT CONVERGED -- 2 of 7 criteria pass" in prose and the
+      pipeline recorded convergence and exited with zero work product.
+
+  - id: ATX-M-016
+    title: FAIL is fail-fast at unconditional edges
+    spec:
+      section: "3.3"
+      heading: "Edge Selection Algorithm"
+      quote: |
+            -- Step 4 & 5: Weight with lexical tiebreak (unconditional edges only)
+            unconditional = [e FOR e IN edges WHERE e.condition is empty]
+            IF unconditional is not empty:
+                RETURN best_by_weight_then_lexical(unconditional)
+      line: 448
+    disposition: DIVERGE-DECIDED
+    ledger:
+      extensions: 16
+    assertion:
+      kind: indexed
+      indexed:
+        - modules/loop-pipeline/tests/test_edge_selection_no_silent_fallthrough.py::test_fail_outcome_does_not_traverse_unconditional_edges
+        - modules/loop-pipeline/tests/test_edge_selection_no_silent_fallthrough.py::test_success_outcome_traverses_unconditional_edges_as_before
+    notes: >
+      Canonical step 4 selects the best unconditional edge REGARDLESS of outcome
+      status. This engine stops on FAIL unless the target declares runs_on in
+      {always, failure} or continue_on_fail. Both directions already have
+      dedicated tests -- this row indexes them rather than duplicating them.
+
+  - id: ATX-M-022
+    title: "`outcome=` in a condition resolves to preferred_label first"
+    spec:
+      section: "10.4"
+      heading: "Variable Resolution"
+      quote: |
+        FUNCTION resolve_key(key, outcome, context) -> String:
+            IF key == "outcome":
+                RETURN outcome.status as string
+            IF key == "preferred_label":
+                RETURN outcome.preferred_label
+      line: 1693
+    disposition: DIVERGE-DECIDED
+    ledger:
+      conformance: ATX-5
+      extensions: 22
+    assertion:
+      kind: indexed
+      indexed:
+        - modules/loop-pipeline/tests/test_conditions.py::test_outcome_resolves_preferred_label_custom_value
+        - modules/loop-pipeline/tests/test_conditions.py::test_outcome_resolves_status_when_no_preferred_label
+    notes: >
+      Canonical defines `outcome` as `outcome.status` only, with `preferred_label`
+      as a separate key. Load-bearing for report_outcome-driven routing. Not
+      behavior-neutral: a canonical graph matching `outcome=<status>` changes
+      meaning when a node also sets a preferred_label (EXTENSIONS section 22,
+      "Compatibility").
+
+  - id: ATX-M-036
+    title: startup provider preflight is fail-loud, not silent fallback
+    spec:
+      section: "4.5"
+      heading: "CodergenBackend Interface"
+      quote: |
+        How you implement this interface is up to you. The pipeline engine only cares that it gets a String or Outcome back.
+      line: 718
+    disposition: EXTENSION
+    ledger:
+      extensions: 36
+    assertion:
+      kind: indexed
+      indexed:
+        - modules/loop-pipeline/tests/test_provider_preflight.py
+        - modules/loop-pipeline/tests/test_profile_routing.py
+        - modules/pipeline-runner/tests/test_provider_preflight_drive_engine.py
+    notes: >
+      The canonical spec is silent on provider mounting/serviceability -- section
+      4.5 explicitly delegates backend internals to the implementer -- so this is
+      an EXTENSION into a spec-silent area, not a divergence. It is asserted here
+      anyway because it CHANGED observable behavior (per-visit crash or
+      wrong-provider silent run, now refusal at startup), which is exactly the
+      movement class this matrix exists to notice.
+
+  # ==========================================================================
+  # C. OPEN ledger items -- pinned, not laundered into decisions
+  #
+  # These behaviors are real and asserted. Their DISPOSITION is undecided.
+  # Undecided is not the same as unpinned: the flip message on these rows says
+  # "either this PR is the decision (move the ledger row) or it is an accident".
+  # ==========================================================================
+
+  - id: ATX-M-006o
+    title: a FAIL outcome is returned immediately and never retried
+    spec:
+      section: "3.5"
+      heading: "Retry Logic"
+      quote: |
+                IF outcome.status == FAIL:
+                    RETURN outcome
+      line: 519
+      conflict:
+        section: "11.5"
+        quote: |
+          - [ ] Nodes with `max_retries > 0` are retried on RETRY or FAIL outcomes
+        note: >
+          The canonical spec contradicts itself. Section 3.5's pseudocode returns
+          a FAIL outcome without retrying; the section 11 Definition of Done
+          checklist says FAIL outcomes ARE retried. This engine follows section
+          3.5. ATX-6's recorded disposition is ALIGN-spec-first (reconcile the
+          spec), so the pin is on today's behavior, not on a decision nobody has
+          made.
+    disposition: OPEN-PINNED
+    ledger:
+      conformance: ATX-6
+    justification: >
+      ATX-6 is OPEN with disposition "ALIGN-spec-first (reconcile the spec)".
+      Recording the behavior as DIVERGE-DECIDED here would forge a decision the
+      maintainer has not made; leaving it unasserted would let it move silently
+      while the ledger says the question is still open. OPEN-PINNED does neither.
+    assertion:
+      kind: probe
+      probe: test_row_atx_m_006o
+      indexed:
+        - modules/loop-pipeline/tests/test_retry.py::test_retry_policy_from_node_max_retries
+
+  - id: ATX-M-007o
+    title: condition literals are NOT unquoted before comparison
+    spec:
+      section: "10.5"
+      heading: "Evaluation"
+      quote: |
+        FUNCTION parse_literal(value) -> String:
+            value = trim(value)
+            IF value starts with '"' AND value ends with '"':
+                RETURN unescape_string(value[1..-2])
+            RETURN value
+      line: 1743
+    disposition: OPEN-PINNED
+    ledger:
+      conformance: ATX-7
+    justification: >
+      ATX-7 is OPEN with disposition "ALIGN (minor)". The probe pins TODAY's
+      behavior -- a double-quoted condition literal is compared including its
+      quotes -- so that the eventual ALIGN is a deliberate, ledgered edit rather
+      than an incidental one. A community graph written to canonical section 10.5
+      that quotes a condition literal does not route the way the spec says it
+      will; that compatibility cost is what the open decision is weighing.
+    assertion:
+      kind: probe
+      probe: test_row_atx_m_007o
+
+  - id: ATX-M-003o
+    title: tool_hooks.pre / tool_hooks.post are not implemented
+    spec:
+      section: "9.7"
+      heading: "Tool Call Hooks"
+      quote: |
+        Graph-level or node-level attributes `tool_hooks.pre` and `tool_hooks.post` specify shell commands executed around each LLM tool call:
+      line: 1652
+    disposition: OPEN-PINNED
+    ledger:
+      conformance: ATX-3
+    justification: >
+      ATX-3 is an explicit DECIDE item (ALIGN vs DIVERGE), hinging on whether
+      DOT-author-level per-call guards are wanted or Amplifier's kernel hook
+      mechanism already covers the need. The absence assertion is the
+      "un-diverging silently is drift too" mechanism pointed at the
+      not-implemented direction: shipping tool_hooks without moving ATX-3 turns
+      this row red instead of quietly green.
+    assertion:
+      kind: absence
+      absence:
+        pattern: "tool_hooks"
+        roots:
+          - modules/loop-pipeline/amplifier_module_loop_pipeline
+
+  - id: ATX-M-004n
+    title: no HTTP server mode
+    spec:
+      section: "9.5"
+      heading: "HTTP Server Mode"
+      quote: |
+        Implementations may expose the pipeline engine as an HTTP service for web-based management, remote human interaction, and integration with external systems.
+      line: 1591
+    disposition: NOT-IMPLEMENTED-DECIDED
+    ledger:
+      conformance: ATX-4
+    justification: >
+      Section 9.5 is permissive ("may expose"), so not implementing it is
+      conformant rather than divergent -- ATX-4's "DIVERGE (spec-optional)"
+      records the omission as deliberate. The bundle exposes programmatic tools
+      and a CLI instead. Asserted as an absence so that shipping an HTTP surface
+      becomes a ledger event rather than a quiet feature.
+    assertion:
+      kind: absence
+      absence:
+        pattern: "(?:^|[^A-Za-z_])(?:uvicorn|fastapi|BaseHTTPRequestHandler|HTTPServer)(?:[^A-Za-z_]|$)"
+        roots:
+          - modules/loop-pipeline/amplifier_module_loop_pipeline
+          - modules/pipeline-runner/amplifier_module_pipeline_runner
+
+  # ==========================================================================
+  # D. Findings surfaced by building this matrix -- unledgered today
+  #
+  # NOT decided divergences. These are behaviors that contradict the canonical
+  # spec with no ledger entry licensing them. Filed as issue #234. The rows pin
+  # actual behavior so that the decision, when it comes, is deliberate.
+  # ==========================================================================
+
+  - id: ATX-M-F01
+    title: unknown node shape hard-errors instead of falling back to the default handler
+    spec:
+      section: "4.2"
+      heading: "Handler Registry"
+      quote: |
+                -- 3. Default
+                RETURN default_handler
+      line: 628
+      also:
+        - section: "4.2"
+          quote: |
+            3. **Default handler** (the codergen/LLM handler)
+    disposition: OPEN-PINNED
+    ledger:
+      issue: 234
+    justification: >
+      F1. Canonical section 4.2's resolve() pseudocode falls through to the
+      DEFAULT HANDLER when a shape is unrecognized; HandlerRegistry.get() instead
+      raises ValueError naming the bad shape and listing the supported ones. That
+      is the right behavior under doctrine rule 4 (a typo'd shape silently
+      becoming a full LLM session is a real footgun, argued from section 2.8's
+      finite table in test_no_silent_fallback.py's docstring) -- but it is
+      ATX-11's exact biography: correct, load-bearing, and undocumented. No ATX
+      row and no EXTENSIONS entry licenses it today. Pinned here; decision filed
+      as issue #234, whose two resolution shapes are ledger-it-as-DIVERGE or
+      conform to section 4.2.
+    assertion:
+      kind: probe
+      probe: test_row_atx_m_f01
+      indexed:
+        - modules/loop-pipeline/tests/test_no_silent_fallback.py::test_unknown_shape_raises_value_error
+        - modules/loop-pipeline/tests/test_no_silent_fallback.py::test_known_shapes_still_dispatch_correctly
+
+  - id: ATX-M-F04
+    title: reasoning_effort has no built-in default -- Appendix A's high does not hold
+    spec:
+      section: "2.6"
+      heading: "Node Attributes"
+      quote: |
+        | `reasoning_effort`  | String   | `"high"`        | LLM reasoning effort: `low`, `medium`, `high`. |
+      line: 162
+      also:
+        - section: "Appendix A"
+          quote: |
+            | `reasoning_effort`      | String   | `"high"`      | Reasoning depth: low/medium/high |
+    disposition: OPEN-PINNED
+    ledger:
+      issue: 234
+    justification: >
+      F4, verified empirically rather than assumed. Both the section 2.6
+      attribute table and Appendix A give `reasoning_effort` a default of
+      `"high"`. Parsing a node that omits the attribute yields
+      `Node.reasoning_effort is None`, and None is what reaches the backend -- so
+      the provider's own default applies, not "high". A community graph written
+      to the canonical spec therefore gets a different reasoning depth here than
+      the spec promises. Unledgered; filed together with F1 as issue #234 (same
+      class, same two resolution shapes, one maintainer sitting). Pinned to
+      actual behavior in the meantime.
+    assertion:
+      kind: probe
+      probe: test_row_atx_m_f04
+
+  # ==========================================================================
+  # E. Load-bearing conformances
+  #
+  # Membership rule: the behaviors a community `.dot` file written against the
+  # canonical spec stakes its correctness on (doctrine rule 2). Mostly INDEXED
+  # to the suites that already carry them -- the matrix indexes coverage, it
+  # never duplicates it.
+  # ==========================================================================
+
+  - id: ATX-M-101
+    title: start-node resolution -- shape=Mdiamond, then id start/Start, else error
+    spec:
+      section: "3.2"
+      heading: "Core Execution Loop"
+      quote: |
+            current_node = find_start_node(graph)
+                -- Resolves by: (1) shape=Mdiamond, (2) id="start" or "Start"
+                -- Raises error if not found
+      line: 347
+    disposition: CONFORM
+    assertion:
+      kind: indexed
+      indexed:
+        - modules/loop-pipeline/tests/test_validation.py::test_missing_start_node
+        - modules/loop-pipeline/tests/test_validation.py::test_multiple_start_nodes
+
+  - id: ATX-M-102
+    title: step 4 -- context_updates merged, outcome set, preferred_label set only when non-empty
+    spec:
+      section: "3.2"
+      heading: "Core Execution Loop"
+      quote: |
+                -- Step 4: Apply context updates from outcome
+                FOR EACH (key, value) IN outcome.context_updates:
+                    context.set(key, value)
+                context.set("outcome", outcome.status)
+                IF outcome.preferred_label is not empty:
+                    context.set("preferred_label", outcome.preferred_label)
+      line: 377
+    disposition: CONFORM
+    assertion:
+      kind: probe
+      probe: test_row_atx_m_102
+    notes: >
+      The "only when non-empty" half matters: an unconditional overwrite would
+      let a stale preferred_label from an earlier node steer a later edge. That
+      is a shipped-bug class in this repo's history (the stale-label rule in
+      context/engine-semantics.md).
+
+  - id: ATX-M-103
+    title: a checkpoint is saved after every node completion
+    spec:
+      section: "3.2"
+      heading: "Core Execution Loop"
+      quote: |
+                -- Step 5: Save checkpoint
+                checkpoint = create_checkpoint(context, current_node.id, completed_nodes)
+                save_checkpoint(checkpoint, logs_root)
+      line: 384
+    disposition: CONFORM
+    assertion:
+      kind: indexed
+      indexed:
+        - modules/loop-pipeline/tests/test_checkpoint.py::TestCheckpointEngineIntegration
+
+  - id: ATX-M-104
+    title: reaching a terminal node runs the goal-gate check before the run may end
+    spec:
+      section: "3.2"
+      heading: "Core Execution Loop"
+      quote: |
+                -- Step 1: Check for terminal node
+                IF is_terminal(node):
+                    gate_ok, failed_gate = check_goal_gates(graph, node_outcomes)
+      line: 354
+    disposition: CONFORM
+    assertion:
+      kind: indexed
+      indexed:
+        - modules/loop-pipeline/tests/test_goal_gates.py::test_satisfied_goal_gates_allow_exit
+        - modules/loop-pipeline/tests/test_engine.py::test_goal_gate_unsatisfied_returns_fail
+
+  - id: ATX-M-105
+    title: edge selection step 1 -- condition-matching edges win, best by weight then lexical
+    spec:
+      section: "3.3"
+      heading: "Edge Selection Algorithm"
+      quote: |
+            -- Step 1: Condition matching
+            condition_matched = []
+            FOR EACH edge IN edges:
+                IF edge.condition is not empty:
+                    IF evaluate_condition(edge.condition, outcome, context) == true:
+                        condition_matched.append(edge)
+            IF condition_matched is not empty:
+                RETURN best_by_weight_then_lexical(condition_matched)
+      line: 425
+    disposition: CONFORM
+    assertion:
+      kind: indexed
+      indexed:
+        - modules/loop-pipeline/tests/test_edge_selection.py::test_condition_matching_takes_priority
+        - modules/loop-pipeline/tests/test_edge_selection.py::test_condition_beats_preferred_label
+
+  - id: ATX-M-106
+    title: edge selection step 2 -- preferred label matches UNCONDITIONAL edges only, after normalization
+    spec:
+      section: "3.3"
+      heading: "Edge Selection Algorithm"
+      quote: |
+        **Step 2: Preferred label match.** If no condition-matching edges were found and the node's outcome includes a `preferred_label`, find the first unconditional edge whose `label` matches after normalization. Label normalization: lowercase, trim whitespace, strip accelerator prefixes (patterns like `[Y] `, `Y) `, `Y - `).
+      line: 412
+    disposition: CONFORM
+    assertion:
+      kind: indexed
+      indexed:
+        - modules/loop-pipeline/tests/test_edge_selection.py::test_preferred_label_match
+        - modules/loop-pipeline/tests/test_edge_selection.py::test_step2_skips_conditional_edge_with_matching_label
+
+  - id: ATX-M-107
+    title: edge selection step 3 -- first suggested_next_ids match, unconditional edges only
+    spec:
+      section: "3.3"
+      heading: "Edge Selection Algorithm"
+      quote: |
+            -- Step 3: Suggested next IDs
+            IF outcome.suggested_next_ids is not empty:
+                FOR EACH suggested_id IN outcome.suggested_next_ids:
+                    FOR EACH edge IN edges:
+                        IF edge.condition is empty AND edge.to_node == suggested_id:
+                            RETURN edge
+      line: 441
+    disposition: CONFORM
+    assertion:
+      kind: indexed
+      indexed:
+        - modules/loop-pipeline/tests/test_edge_selection.py::test_preferred_label_beats_suggested_ids
+
+  - id: ATX-M-108
+    title: edge selection steps 4-5 -- weight descending, lexical tiebreak, deterministic
+    spec:
+      section: "3.3"
+      heading: "Edge Selection Algorithm"
+      quote: |
+        FUNCTION best_by_weight_then_lexical(edges):
+            SORT edges BY (weight DESCENDING, to_node ASCENDING)
+            RETURN edges[0]
+      line: 456
+    disposition: CONFORM
+    assertion:
+      kind: indexed
+      indexed:
+        - modules/loop-pipeline/tests/test_edge_selection.py::test_weight_tiebreak
+        - modules/loop-pipeline/tests/test_edge_selection.py::test_lexical_tiebreak
+        - modules/loop-pipeline/tests/test_edge_selection.py::test_deterministic_with_same_inputs
+
+  - id: ATX-M-109
+    title: exactly ONE edge is selected -- never a fan-out from a non-component node
+    spec:
+      section: "3.3"
+      heading: "Edge Selection Algorithm"
+      quote: |
+        After a node completes, the engine selects the next edge from the node's outgoing edges. The selection is deterministic and follows a five-step priority order:
+      line: 408
+    disposition: CONFORM
+    ledger:
+      conformance: ATX-10
+    assertion:
+      kind: probe
+      probe: test_row_atx_m_109
+    notes: >
+      This is a RESTORED conformance, not a never-broken one: an unledgered
+      multi-match fan-out dialect shipped and was retired under ATX-10 (T0-4).
+      Asserted rather than merely indexed because re-introducing it is a
+      plausible "feature", and the ledger says it is not one.
+
+  - id: ATX-M-110
+    title: SUCCESS and PARTIAL_SUCCESS both satisfy a goal gate
+    spec:
+      section: "3.4"
+      heading: "Goal Gate Enforcement"
+      quote: |
+        2. If any goal gate node has a non-success outcome (not SUCCESS or PARTIAL_SUCCESS), the pipeline cannot exit.
+      line: 466
+    disposition: CONFORM
+    ledger:
+      extensions: 4
+    assertion:
+      kind: indexed
+      indexed:
+        - modules/loop-pipeline/tests/test_goal_gates.py::test_satisfied_goal_gates_allow_exit
+        - modules/loop-pipeline/tests/test_goal_gates.py::test_partial_success_satisfies_goal_gate
+
+  - id: ATX-M-111
+    title: goal-gate retry-target ladder -- node, node fallback, graph, graph fallback
+    spec:
+      section: "3.4"
+      heading: "Goal Gate Enforcement"
+      quote: |
+        3. Instead, jump to the `retry_target` of the unsatisfied goal gate node. If that is not set, try `fallback_retry_target`. If that is also not set, try the graph-level `retry_target` and `fallback_retry_target`.
+      line: 467
+    disposition: CONFORM
+    assertion:
+      kind: probe
+      probe: test_row_atx_m_111
+    notes: >
+      Probed rather than indexed because the four rungs degrade independently and
+      the graph-level rungs are the least exercised in the existing suite.
+
+  - id: ATX-M-112
+    title: no retry target at any level ends the pipeline with FAIL
+    spec:
+      section: "3.4"
+      heading: "Goal Gate Enforcement"
+      quote: |
+        4. If no retry target exists at any level, the pipeline ends with a FAIL outcome.
+      line: 468
+    disposition: CONFORM
+    assertion:
+      kind: indexed
+      indexed:
+        - modules/loop-pipeline/tests/test_engine.py::test_goal_gate_unsatisfied_returns_fail
+
+  - id: ATX-M-113
+    title: max_retries is ADDITIONAL attempts; graph default inherited; built-in default 0
+    spec:
+      section: "3.5"
+      heading: "Retry Logic"
+      quote: |
+        The `max_retries` attribute specifies additional attempts. So `max_retries=3` means a total of 4 executions (1 initial + 3 retries). Internally this maps to `max_attempts = max_retries + 1`.
+      line: 490
+    disposition: CONFORM
+    ledger:
+      extensions: 3
+    assertion:
+      kind: indexed
+      indexed:
+        - modules/loop-pipeline/tests/test_retry.py::test_retry_policy_from_node_max_retries
+        - modules/loop-pipeline/tests/test_retry.py::test_retry_policy_from_graph_default
+        - modules/loop-pipeline/tests/test_retry.py::test_retry_policy_default_zero
+
+  - id: ATX-M-114
+    title: RETRY exhaustion yields PARTIAL_SUCCESS when allow_partial, else FAIL
+    spec:
+      section: "3.5"
+      heading: "Retry Logic"
+      quote: |
+                IF outcome.status == RETRY:
+                    IF attempt < retry_policy.max_attempts:
+                        increment_retry_counter(node.id)
+                        delay = retry_policy.backoff.delay_for_attempt(attempt)
+                        sleep(delay)
+                        CONTINUE
+                    ELSE:
+                        IF node.allow_partial == true:
+                            RETURN Outcome(status=PARTIAL_SUCCESS, notes="retries exhausted, partial accepted")
+                        RETURN Outcome(status=FAIL, failure_reason="max retries exceeded")
+      line: 509
+    disposition: CONFORM
+    assertion:
+      kind: indexed
+      indexed:
+        - modules/loop-pipeline/tests/test_engine_must_write.py
+        - modules/loop-pipeline/tests/test_retry.py::TestShouldRetry
+
+  - id: ATX-M-115
+    title: preset retry-policy table values
+    spec:
+      section: "3.6"
+      heading: "Retry Policy"
+      quote: |
+        | `standard`   | 5           | 200ms         | 2.0    | General-purpose. Delays: 200, 400, 800, 1600, 3200ms. |
+      line: 557
+    disposition: CONFORM
+    assertion:
+      kind: indexed
+      indexed:
+        - modules/loop-pipeline/tests/test_spec_conformance_batch.py
+
+  - id: ATX-M-116
+    title: default should_retry -- transient retryable, auth/400/validation terminal
+    spec:
+      section: "3.6"
+      heading: "Retry Policy"
+      quote: |
+        **Default should_retry predicate:** Returns `true` for network errors, rate limit errors (HTTP 429), server errors (HTTP 5xx), and provider-reported transient failures. Returns `false` for authentication errors (HTTP 401, 403), bad request errors (HTTP 400), validation errors, and configuration errors.
+      line: 562
+    disposition: CONFORM
+    assertion:
+      kind: indexed
+      indexed:
+        - modules/loop-pipeline/tests/test_retry.py::TestShouldRetry
+
+  - id: ATX-M-117
+    title: failure-routing order -- fail edge, retry_target, fallback, terminate
+    spec:
+      section: "3.7"
+      heading: "Failure Routing"
+      quote: |
+        1. **Fail edge:** An outgoing edge with `condition="outcome=fail"`. If found, follow it.
+        2. **Retry target:** Node attribute `retry_target`. Jump to that node.
+        3. **Fallback retry target:** Node attribute `fallback_retry_target`. Jump to that node.
+        4. **Pipeline termination:** No failure route found. The pipeline fails with the stage's failure reason.
+      line: 568
+    disposition: CONFORM
+    assertion:
+      kind: indexed
+      indexed:
+        - modules/loop-pipeline/tests/test_failure_routing.py
+        - modules/loop-pipeline/tests/test_folder_node_failure_routing.py
+
+  - id: ATX-M-118
+    title: the nine-shape to handler-type mapping table
+    spec:
+      section: "2.8"
+      heading: "Shape-to-Handler-Type Mapping"
+      quote: |
+        The `shape` attribute on a node determines which handler executes it, unless overridden by an explicit `type` attribute. This table defines the canonical mapping:
+      line: 181
+    disposition: CONFORM
+    assertion:
+      kind: probe
+      probe: test_row_atx_m_118
+      indexed:
+        - modules/loop-pipeline/tests/test_no_silent_fallback.py::test_known_shapes_still_dispatch_correctly
+    notes: >
+      Probed as a parametrized table so that a single row silently changing tier
+      (the exact class the explainer doc guard also watches) fails by name.
+      `folder` is an EXTENSION shape (EXTENSIONS section 10), not canonical -- the
+      probe asserts the nine canonical rows and treats folder separately.
+
+  - id: ATX-M-119
+    title: a handler exception becomes a FAIL outcome, not a crash
+    spec:
+      section: "3.5"
+      heading: "Retry Logic"
+      quote: |
+                CATCH exception:
+                    IF retry_policy.should_retry(exception) AND attempt < retry_policy.max_attempts:
+      line: 496
+    disposition: CONFORM
+    ledger:
+      extensions: 6
+    assertion:
+      kind: probe
+      probe: test_row_atx_m_119
+
+  - id: ATX-M-120
+    title: checkpoint carries the six section 5.3 fields at the section 5.6 path
+    spec:
+      section: "5.3"
+      heading: "Checkpoint"
+      quote: |
+        Checkpoint:
+            timestamp       : Timestamp              -- when this checkpoint was created
+            current_node    : String                  -- ID of the last completed node
+            completed_nodes : List<String>            -- IDs of all completed nodes in order
+            node_retries    : Map<String, Integer>    -- retry counters per node
+            context_values  : Map<String, Any>        -- serialized snapshot of the context
+            logs            : List<String>            -- run log entries
+      line: 1101
+    disposition: CONFORM
+    ledger:
+      conformance: ATX-2
+    assertion:
+      kind: indexed
+      indexed:
+        - modules/loop-pipeline/tests/test_checkpoint.py::TestCheckpointKeyShape
+        - modules/loop-pipeline/tests/test_checkpoint.py::TestCheckpointV2Schema
+    notes: >
+      Schema v2 is a strict SUPERSET: the six fields keep their exact names and
+      shapes at {logs_root}/checkpoint.json, plus schema_version, run_state,
+      node_outcomes, engine_state and graph.
+
+  - id: ATX-M-121
+    title: resume rules 1-5 -- restore state, continue after current_node
+    spec:
+      section: "5.3"
+      heading: "Checkpoint"
+      quote: |
+        1. Load the checkpoint from `{logs_root}/checkpoint.json`.
+        2. Restore context state from `context_values`.
+        3. Restore `completed_nodes` to skip already-finished work.
+        4. Restore retry counters from `node_retries`.
+        5. Determine the next node to execute (the one after `current_node` in the traversal).
+      line: 1129
+    disposition: CONFORM
+    ledger:
+      conformance: ATX-2
+    assertion:
+      kind: indexed
+      indexed:
+        - modules/loop-pipeline/tests/test_engine_resume.py::test_resume_degrades_first_full_hop_once
+        - modules/loop-pipeline/tests/test_resume_validation.py
+        - modules/loop-pipeline/tests/test_no_implicit_resume.py
+        - modules/pipeline-runner/tests/test_resume_e2e.py
+    notes: >
+      test_resume_e2e.py is the live-proof rung -- a really-SIGKILLed subprocess
+      resumed by a separate `attractor resume` invocation. It lives in another
+      module's venv, which is exactly why indexed cites are verified by AST parse
+      and never by import.
+
+  - id: ATX-M-122
+    title: resume rule 6 -- full degrades to summary:high for exactly one hop
+    spec:
+      section: "5.3"
+      heading: "Checkpoint"
+      quote: |
+        6. If the previous node used `full` fidelity, degrade to `summary:high` for the first resumed node, because in-memory LLM sessions cannot be serialized. After this one degraded hop, subsequent nodes may use `full` fidelity again.
+      line: 1134
+    disposition: CONFORM
+    ledger:
+      conformance: ATX-2
+    assertion:
+      kind: indexed
+      indexed:
+        - modules/loop-pipeline/tests/test_engine_resume.py::test_resume_degrades_first_full_hop_once
+        - modules/loop-pipeline/tests/test_engine_resume.py::test_no_degrade_when_the_first_hop_is_not_full
+
+  - id: ATX-M-123
+    title: fidelity precedence -- edge, node, graph, then compact
+    spec:
+      section: "5.4"
+      heading: "Context Fidelity"
+      quote: |
+        1. Edge `fidelity` attribute (on the incoming edge)
+        2. Target node `fidelity` attribute
+        3. Graph `default_fidelity` attribute
+        4. Default when unset: `compact`
+      line: 1160
+    disposition: CONFORM
+    assertion:
+      kind: indexed
+      indexed:
+        - modules/loop-pipeline/tests/test_fidelity.py::test_resolve_fidelity_default_is_compact
+
+  - id: ATX-M-124
+    title: ERROR-severity diagnostics refuse execution
+    spec:
+      section: "7.1"
+      heading: "Diagnostic Model"
+      quote: |
+        Validation produces a list of diagnostics, each with a severity level. The engine must refuse to execute a pipeline with error-severity diagnostics.
+      line: 1375
+      conflict:
+        section: "11.12"
+        quote: |
+          | Validate: orphan node -> warning                 | [ ] |
+        note: >
+          The canonical spec contradicts itself on reachability severity. Section
+          7.2's lint-rule table gives `reachability` severity ERROR; the section
+          11 Definition of Done checklist calls the same finding a warning. This
+          engine implements section 7.2 (ERROR), pinned here by named choice: a
+          `.dot` with an orphan node is refused, not merely flagged.
+    disposition: CONFORM
+    assertion:
+      kind: indexed
+      indexed:
+        - modules/loop-pipeline/tests/test_validation.py::test_validate_or_raise_raises_on_errors


### PR DESCRIPTION
## Summary

Ships **Layer 2** of the drift defense in `docs/QUALITY_PROTOCOL.md` section 3 — the repo's "semantic lint" — as tranche 1. Until now Layer 2 existed only as a design; the doc said so in those words. It now exists as two files.

`SPEC_CONFORMANCE.md` and `specs/EXTENSIONS.md` record every decided divergence from the canonical upstream nlspec, in prose, with **no executable teeth**. Nothing failed when the engine moved away from what they say — and, the half people forget, nothing failed when the engine drifted silently *back toward the spec* at a point where the ledger says we deliberately do not conform. Both leave `main` carrying a record that does not describe the shipped engine. **Drift is any behavioral movement not in the ledgers, in either direction.**

This makes the ledger load-bearing: an executable mapping from the byte-pinned canonical spec to assertions against the real engine, where **decided divergences are asserted as firmly as conformances**. A flipped assertion fails with a message naming the spec section, the current ledger disposition, and the two legal exits.

| File | What it is |
|---|---|
| `specs/conformance/attractor-matrix.yaml` | The matrix — a reviewed **document**, 38 rows, each carrying the verbatim spec quote, the disposition, the ledger cite, and the assertion |
| `modules/loop-pipeline/tests/test_spec_conformance_matrix.py` | The runner — per-row structural integrity, 14 in-process probes, the SYNC sha pin, the coverage tripwire, and the flip-message renderer |

No engine, handler, or example code changed.

## Rows by disposition

| Disposition | Rows | Which |
|---|--:|---|
| `CONFORM` | 25 | 24 load-bearing conformances (`ATX-M-101`…`124`) + the SYNC row `ATX-M-000` |
| `DIVERGE-DECIDED` | 6 | `ATX-M-011` (ATX-11 / §33) · `ATX-M-012` (ATX-12 / §24) · `ATX-M-025a` + `ATX-M-025b` (the two §25 fail-closed rungs) · `ATX-M-016` (§16 FAIL fail-fast) · `ATX-M-022` (ATX-5 / §22) |
| `EXTENSION` | 1 | `ATX-M-036` (§36 provider preflight — spec-silent area, but observable behavior changed) |
| `OPEN-PINNED` | 5 | `ATX-M-006o` (ATX-6) · `ATX-M-007o` (ATX-7) · `ATX-M-003o` (ATX-3) · **`ATX-M-F01`** + **`ATX-M-F04`** (findings, issue #234) |
| `NOT-IMPLEMENTED-DECIDED` | 1 | `ATX-M-004n` (ATX-4, HTTP server mode) |
| `NOT-ASSERTABLE` | 0 | Deferred to tranche 2 with the aspirational-prose sections they cover |
| **Total** | **38** | |

By assertion kind: **14 probe · 22 indexed · 2 absence**. The matrix *indexes* existing coverage rather than duplicating it — 22 rows cite tests that already exist, verified by **AST parse, never import** (indexed cites cross per-module venv boundaries; `pipeline-runner`'s SIGKILL resume e2e is not importable from loop-pipeline's venv).

Every one of the 38 quotes is verified **verbatim** against `specs/canonical/attractor-spec-canonical.md`. Two initial quotes were wrong on first write and the runner caught them — the check is not decorative.

## The 14 probes

| Probe | Row | What it asserts |
|---|---|---|
| `test_row_atx_m_000` | SYNC | canonical sha256 matches the `fb57a55` pin; on mismatch the message demands a **full-matrix re-review**, not a hash bump |
| `test_row_atx_m_011` | ATX-11 / §33 | dead end ⇒ FAIL + `PIPELINE_ERROR error_type=no_matching_edge` + spec's `SUCCESS "Pipeline completed"` **absent** |
| `test_row_atx_m_012` | ATX-12 / §24 | in-process reset: `$iteration` advances, `context_updates` survive, node re-executes, `iteration_N/` under the **same** root, **no** fresh sibling root, `run()` returns normally |
| `test_row_atx_m_025a` | §25 | prose on a `goal_gate=true` node does not exit SUCCESS — **and the control**: prose off the gate still wraps to SUCCESS (what keeps the divergence non-interfering) |
| `test_row_atx_m_025b` | §25 | status-only `SUCCESS(is_explicit=False)` ⇒ pipeline FAIL naming the gate — **and the control**: `is_explicit=True` ⇒ SUCCESS (closed, not welded shut) |
| `test_row_atx_m_006o` | ATX-6 | a FAIL outcome with `max_retries=2` executes **exactly once** |
| `test_row_atx_m_007o` | ATX-7 | unquoted literals match; **quoted literals are compared raw** (today's pinned behavior) |
| `test_row_atx_m_f01` | F1 / #234 | unknown shape raises naming the shape + supported list; known shapes still dispatch |
| `test_row_atx_m_f04` | F4 / #234 | `reasoning_effort` is `None` when unset — Appendix A's `"high"` does not hold |
| `test_row_atx_m_102` | §3.2 step 4 | `context_updates` merged, `outcome` set, `preferred_label` set **only when non-empty** (the stale-label bug class) |
| `test_row_atx_m_109` | ATX-10 | `select_edge` returns **one** edge, never a fan-out (the retired multi-match dialect) |
| `test_row_atx_m_111` ×4 | §3.4 rule 3 | the retry-target ladder, parametrized rung by rung: node → node fallback → graph → graph fallback |
| `test_row_atx_m_118` | §2.8 | the nine canonical shape→handler rows; `folder` asserted separately as ours, not the spec's |
| `test_row_atx_m_119` | §3.5 | a raising handler becomes a FAIL outcome carrying `str(exception)`, never an escaped crash |

Plus `test_row_absence_assertion_holds` ×2 (`tool_hooks` absent; no HTTP-server entry point) — the "un-diverging silently is drift too" mechanism pointed at the *not-implemented* direction.

**Result: 198 passed, 24 skipped, 0.30s.** (The 24 skips are `test_row_probe_function_exists` on non-probe rows.) The runner also carries **10 RED/GREEN self-tests of the checker logic itself** — a checker that cannot fail proves nothing.

## The flip demo — the money proof

Per the design's definition of done, both failure classes were proven by mutation in a scratch worktree before this PR.

### 1. Behavioral — the exact un-divergence `ATX-11` forbids

Mutation: make dead-end-with-non-FAIL return `Outcome(SUCCESS, notes="Pipeline completed")` per spec §3.2 step 6.

```
E       AssertionError: SPEC-CONFORMANCE MATRIX FLIP -- row ATX-M-011 "dead-end hard-fail (main loop)"
E           spec:        section 3.2 Core Execution Loop --
E                        -- Step 6: Select next edge
E                        next_edge = select_edge(node, outcome, context, graph)
E                        IF next_edge is NONE:
E                            IF outcome.status == FAIL:
E                                RETURN outcome
E                            RETURN Outcome(status=SUCCESS, notes="Pipeline completed")
E           disposition: DIVERGE-DECIDED  (ledgered: SPEC_CONFORMANCE.md ATX-11; specs/EXTENSIONS.md section 33)
E           direction:   UN-DIVERGENCE -- the engine now matches the spec text the ledger says we deliberately
E                        diverge from. Un-diverging silently is drift too.
E           observed:    a dead end resolved to the spec's SUCCESS 'Pipeline completed'
E           expected:    the spec-literal dead-end-to-SUCCESS behavior stays absent
E           row note:    A dead-ended graph silently reporting success is the incident class this divergence exists to prevent. Load-bearing for examples/pipelines/practical/bug-fix.dot ('escalated'). Paired doc guard: modules/loop-pipeline/tests/test_engine_semantics_doc_guard.py and context/engine-semantics.md must move with any change here.
E
E           Two legal exits -- in THIS PR, not a follow-up:
E             1. Revert the behavior change. The ledger is the record of decided
E                behavior; the engine does not get to overrule it silently.
E             2. Keep the change AND move the record with it, in THIS PR:
E                update SPEC_CONFORMANCE.md ATX-11; specs/EXTENSIONS.md section 33 (status + a dated Changelog line), rewrite the
E                specs/EXTENSIONS.md entry body so it describes the new behavior,
E                update this matrix row (disposition + assertion), and fix any
E                paired doc guards named in the row's notes below.
E           There is no third exit. Editing this assertion to match the new behavior,
E           without moving the ledger, is the failure this matrix exists to prevent.
E           Doing neither means main carries a ledger that lies. That is drift.
```

Restored byte-identical — `sha256sum -c` on `engine.py`: **OK** (`1c07147258d65e04e22db5e079484c4b85745e3f81ff9c24ce3c826322ab25ff`), matrix back to 198 passed.

*(The probe deliberately checks the "spec behavior must NOT occur" half **first**, so a developer who just made a well-meaning "align to spec" change is handed the message that names it an `UN-DIVERGENCE` rather than a generic regression report.)*

### 2. Structural — a deleted ledger citation target

Mutation: strip `## 33.`'s number from `specs/EXTENSIONS.md` — the exact `-Xtheirs` rebase failure mode that `test_extensions_ledger_integrity.py` was written for.

```
E           AssertionError: SPEC-CONFORMANCE MATRIX FLIP -- row ATX-M-011 "dead-end hard-fail (main loop)"
E               spec:        section 3.2 Core Execution Loop --
E                            -- Step 6: Select next edge
E                            ...
E               disposition: DIVERGE-DECIDED  (ledgered: SPEC_CONFORMANCE.md ATX-11; specs/EXTENSIONS.md section 33)
E               direction:   MATRIX-INTEGRITY -- the matrix row itself no longer resolves against the spec or the ledger.
E               observed:    specs/EXTENSIONS.md has no '## 33.' heading
E               expected:    the cited EXTENSIONS section still exists. Renumbering or deleting an entry breaks every consumer that cites it -- which is exactly what test_extensions_ledger_integrity.py was written for after a '-Xtheirs' rebase silently discarded three merged entries.
```

And the **tripwire** half, mutated separately by dropping the §33 cite from the row while §33's banner stayed:

```
E       AssertionError: SPEC-CONFORMANCE MATRIX FLIP -- MATRIX-INTEGRITY (coverage tripwire)
E           specs/EXTENSIONS.md sections [33] carry a DIVERGES banner but no
E           matrix row cites them.
E           A divergence that is ledgered but not asserted is a promise with no
E           enforcement: the engine can drift off it, or silently back onto spec,
E           and CI stays green. Add a row to specs/conformance/attractor-matrix.yaml
E           asserting BOTH halves -- that our documented behavior occurs, and that the
E           spec's behavior does not.
E           Doing neither means main carries a ledger that lies. That is drift.
```

Both restored byte-identical (`sha256sum -c specs/EXTENSIONS.md`: OK); scratch worktree removed.

## What building it found

Constructing tranche 1 required walking the canonical spec statement-by-statement against the shipped engine. That walk paid for itself:

**Two unledgered contradictions with the spec → [#234](https://github.com/microsoft/amplifier-bundle-attractor/issues/234)**, both verified empirically, not assumed:

- **F1** — `HandlerRegistry.get()` raises `ValueError` for an unknown shape; canonical §4.2's `resolve()` pseudocode falls through to the **default handler**. Probably the right behavior (doctrine rule 4, argued in `test_no_silent_fallback.py` from §2.8's finite table) — but it is a behavior change for a spec-conformant graph, with no ledger entry licensing it. This is `ATX-11`'s exact biography.
- **F4** — `Node.reasoning_effort` defaults to `None` and `None` reaches the backend; canonical §2.6 **and** Appendix A both give it a default of `"high"`. A community graph written to the spec gets a different reasoning depth here than the spec promises.

**Both are pinned as `OPEN-PINNED`, not laundered into `DIVERGE-DECIDED`** — that would forge a decision the maintainer has not made. Their flip messages say, in effect: *either this PR is the decision (move the ledger) or it is an accident (revert). Undecided is not the same as unpinned.*

**Three places the canonical spec contradicts itself (F2)**, each pinned by named choice via `spec.conflict`, quoting **both** passages and stating which one the engine follows — mirroring the existing `SPEC_CONFORMANCE` practice:

- retry-on-FAIL: §3.5's pseudocode (no retry) vs DoD 11.5 (`retried on RETRY or FAIL outcomes`) → engine follows §3.5 (`ATX-M-006o`)
- reachability severity: §7.2's rule table (`ERROR`) vs DoD 11.12 (`Validate: orphan node -> warning`) → engine follows §7.2 (`ATX-M-124`)
- `loop_restart`: §2.7's attribute definition vs §3.2 step 7's `restart_run(); RETURN` → both anchored on `ATX-M-012` via `spec.also`

**A tripwire-precision finding.** A naive `DIVERG` substring search over EXTENSIONS banners flags §§24, 25, 29, 32, 33, 35 — but §§29/32/35 merely use the word inside `upstream action:` boilerplate. Matching the **bold declarative** (`**…DIVERGES…**`) yields exactly §§24, 25, 33, the true set. Regression-tested against synthetic positive/negative banners so the detector cannot silently loosen.

## Design deviations (stated, per the brief)

Three, all additive, all recorded as inline implementation notes in the shipped design doc:

1. **Row count 38, not "~35".** The design's §7 table B lists 24 rows under a "23 rows" header — its own arithmetic was off by one, and the built matrix carries all 24. The other two are the F1/F4 rows, which §13 named as required tranche-1 work without counting them in the §7 tally. The design explicitly licenses this: *"tranche construction trues them up."*
2. **`spec.also`** — an optional list of extra verbatim anchors, verified exactly like `spec.quote`. Earned by `ATX-M-012`, whose divergence spans two non-contiguous spec statements; anchoring one would leave half the assertion uncited. Used by 3 rows.
3. **`ledger.issue`** — a third legal cite form, permitted **only** on `OPEN-PINNED` rows (the runner rejects it elsewhere). F1/F4 are unledgered *by definition* — that is the finding — so they cite the issue carrying the pending decision. The brief called for exactly this ("citing the new issue number"); the schema addition is how it is enforced rather than commented.

**F4 disposition:** filed **with** F1 in one issue rather than separately. Same class (unledgered spec contradiction surfaced by matrix construction), same two resolution shapes (ledger it / conform), one maintainer sitting. The issue says to split it if the maintainer would rather decide them apart.

## Verification checklist

- [x] Unit tests pass — `loop-pipeline` **2149 passed / 25 skipped** (baseline 1951/1; +198 passed, +24 skipped, all from this module)
- [x] `pipeline-runner` **76 passed / 1 skipped**
- [x] Live pipeline run — **N/A**: no `engine.py` or handler code changed. The matrix's own 14 probes *are* real in-process engine runs through the real parser, validator, and handler dispatch (`test_row_atx_m_011/012/025a/025b/102/111/119` each construct and `run()` a real `PipelineEngine`), and `test_live_graph_gate.py` is green in the suite above.
- [x] AGENTS.md reviewed; repo-specific gates met
- [x] Backward-compat path unchanged — additive only
- [x] **Observable contract:** no observable contract changed, so no new `specs/EXTENSIONS.md` entry is owed. This PR *reads* both ledgers and adds the machinery that keeps them honest.
- [x] **Doc claims:** `docs/QUALITY_PROTOCOL.md` section 3 Layer 2 flips from "in flight — designed here, not built" to shipped, pointing at the two real files, with a dated Changelog entry per that document's own meta-protocol. Its claims are about files that exist and about counts asserted by the runner itself — and section 5's stated adoption condition for this document's own guard (*"or the Layer-2 matrix lands"*) has now fired, which the Changelog entry records rather than leaving for a reader to find.
- [x] PR body includes verification evidence — the flip demo above, quoted verbatim, both classes
- [x] Existing doc guards green (`test_doc_consistency`, `test_engine_semantics_doc_guard`, `test_explainer_doc_guard`, `test_extensions_ledger_integrity`, `test_examples_lint_clean` — all inside the 2149)
- [x] Leak scan on added files: `scrub_secrets.py scan` → **clean, 0 hits**
- [x] `git diff --check` clean
- [x] **CI must be green before merge** — `CI Gate (all checks passed)`

## Notes for reviewers

**Read the YAML as a document, not a data file.** It is meant to sit next to `specs/EXTENSIONS.md` and review the same way: one row per normative statement, a diff that reads as *"row `ATX-M-011` changed disposition."* The header carries the full schema.

**The one illegal exit.** Every flip message names two legal responses and explicitly forbids the third — editing the assertion to match new behavior without moving the ledger. That sentence is the product; the rest is plumbing for it.

**Honest limits**, stated in the module docstring rather than discovered later: a quote check proves the spec *text* is still there, not that our reading of it is right; an AST-verified indexed cite proves the test *exists*, not that it still asserts what the row claims (the paired suite's green carries that, and a rename fails loudly by design); absence assertions are grep-shaped — the same bar `ATX-3` itself uses.

**Deliberate departure from the guard-test precedent:** the skip-if-absent discipline applies to *optional* docs. The matrix is not optional — a missing or unparseable `attractor-matrix.yaml` is a hard failure, because a silently-skipped matrix is a matrix that is not load-bearing.

**Follow-ups, not blockers:** tranche 2 (the remaining rows by section, incl. the `NOT-ASSERTABLE` rows with their per-row justifications) and tranche 3 (ULM/CAL matrices) are scoped in the design, §6 and §12. Issue #234 carries the F1/F4 decision.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)


---

## Post-review fixes (commit `96d0145`)

Independent adversarial review returned **MERGE-AFTER-FIX** with three findings, all verified by execution. All three are closed on this branch. No engine, handler or example behavior changed.

| # | Finding | Fix |
|---|---|---|
| 1 | `test_spec_conformance_matrix.py:1230` and `:1259` cited **issue #237**, which does not exist — the real issue is **#234** | Both probe docstrings now cite `#234`, matching the YAML rows, the issue body and the rendered flip messages. Zero remaining `237` in the module |
| 2 | Matrix said DECIDED, ledger still said OPEN: `ATX-M-022` is `DIVERGE-DECIDED` while `SPEC_CONFORMANCE.md` ATX-5 read OPEN; `ATX-M-004n` is `NOT-IMPLEMENTED-DECIDED` while ATX-4 read OPEN | **The matrix was right; the ledger cells were stale.** ATX-5 → `**DONE — DECIDED**` / `DIVERGE (decided; ledgered — specs/EXTENSIONS.md §22)`; ATX-4 → `**WONTFIX — DECIDED (NOT-IMPLEMENTED)**`. Dated Changelog entry added; summary-table Open count corrected 5 → 3 |
| 3 | `docs/QUALITY_PROTOCOL.md` §5's own adoption condition fired with this PR ("…or the Layer-2 matrix lands, whichever comes first"), but the PR recorded the guard as *owed next* — violating §2's own row | Guard shipped: `modules/loop-pipeline/tests/test_quality_protocol_guard.py` (9 tests). §5 passage rewritten to record it, Layer-1 table five → six guards, §2/§7 pointers updated, Changelog entry 3 added |

### Finding 2 — the two rows as rewritten

```
| ATX-4 | HTTP server mode (REST + SSE) | `§9.5` (optional) | not present; programmatic tools + CLI
instead. The absence is now asserted rather than merely described: matrix row `ATX-M-004n`
(`specs/conformance/attractor-matrix.yaml`) fails if an HTTP surface appears |
**WONTFIX — DECIDED (NOT-IMPLEMENTED)** | DIVERGE (spec-optional) |

| ATX-5 | `outcome=` condition resolves to `preferred_label` first | `§10.4 :1693` |
`conditions.py:75` returns `preferred_label or status`; both halves asserted by matrix row
`ATX-M-022` (`specs/conformance/attractor-matrix.yaml`) | **DONE — DECIDED** |
DIVERGE (decided; ledgered — `specs/EXTENSIONS.md` §22) |
```

Rationale, in the ledger's own terms. ATX-5's decision genuinely exists: EXTENSIONS §22 is the divergence record, it is explicit that the behavior is **not** behavior-neutral, and `conditions.py:75` has shipped it deliberately for months — the cell was mis-reporting a made decision as an unmade one. ATX-4's canonical §9.5 is permissive ("*may* expose"), so not building it is conformant rather than divergent; the decision is *not building it absent demand*, recorded as `WONTFIX` per this file's own status legend ("recorded divergence, no further action"). Status format follows ATX-11 / ATX-12 (`**DONE — DECIDED**` + a disposition naming the decision record).

**Dispositions deliberately unchanged.** Both cells keep a `DIVERGE`-prefixed disposition, which is what `diverge_disposition_atx_rows()` reads — so `test_tripwire_every_diverge_atx_row_is_asserted` and `test_selfcheck_diverge_atx_row_detection_reads_the_disposition_cell` both stay green. Verified after the edit; nothing outside `test_spec_conformance_matrix.py` greps `SPEC_CONFORMANCE.md`.

### Finding 3 — what the new guard asserts

Four claim classes, each **read from the page and resolved against the repository** (never page-against-page):

- **Q-300** — every ``test_*.py`` the doc names (regex over backticked prose, bare names resolved against `modules/loop-pipeline/tests/`) exists on disk. **Q-300b** pins the five Layer-1 guards specifically, so the check cannot go vacuous by the table shrinking.
- **Q-301 / Q-301b / Q-301c** — Layer 2's status still reads *shipped*; both files it names (`specs/conformance/attractor-matrix.yaml`, the matrix runner) exist; the doc still names them.
- **Q-302 / Q-302b** — `specs/canonical/attractor-spec-canonical.md` exists, and the upstream SHA recorded in Layer 0 (`fb57a55`) is the SHA `SPEC_CONFORMANCE.md`'s `SYNC-1` row records.
- **Q-303** — the `## Changelog` §5 mandates exists and carries ≥1 dated `### YYYY-MM-DD` entry.

Skip-if-absent for the doc itself (partial-checkout discipline, matching `test_explainer_doc_guard.py`); fail loud otherwise.

**Proven red before green** — each claim class mutated, observed failing with a message naming the specific stale reference, then restored:

```
# (a) a named guard file renamed on disk
E  AssertionError: docs/QUALITY_PROTOCOL.md names guard-test files that do not exist:
E      - modules/loop-pipeline/tests/test_examples_lint_clean.py (looked for ...)
E      - test_examples_lint_clean.py (looked for ...)

# (b) the Layer-2 matrix YAML moved
E  AssertionError: docs/QUALITY_PROTOCOL.md declares Layer 2 shipped and names
E  `specs/conformance/attractor-matrix.yaml`, but that file does not exist.

# (c) canonical re-vendored + ledger updated, doc left behind
E  AssertionError: CANONICAL PIN DRIFT: docs/QUALITY_PROTOCOL.md records the vendored spec as
E  pinned to `fb57a55`, but SPEC_CONFORMANCE.md's SYNC-1 row does not name that sha:
E        | SYNC-1 | Re-sync vendored `specs/canonical/` ... (canonical @ `9c1de40`) | ALIGN |

# (d) the Changelog section dropped
E  AssertionError: docs/QUALITY_PROTOCOL.md: the `## Changelog` section is gone.
```

**Honest gap, named rather than omitted:** the nine issue/PR numbers on that page stay unpinned — they resolve only over the network and these suites do not reach it. §5 now says so in those words and assigns the check to the Layer-3 pass, not CI.

### Gates re-run

| Gate | Result |
|---|---|
| loop-pipeline full suite | **2158 passed, 25 skipped** in 27.71s (2149 baseline + 9 new guard tests) |
| pipeline-runner | **76 passed, 1 skipped** |
| matrix module alone | **198 passed, 24 skipped in 0.28s** — still well under the 10s budget |
| existing doc/ledger guards | green inside the full suite (`test_doc_consistency`, `test_engine_semantics_doc_guard`, `test_explainer_doc_guard`, `test_extensions_ledger_integrity`, `test_examples_lint_clean`) |
| leak scan on changed files | **clean, 0 hits** |
| `git diff --check` | clean |
