### PR TITLE
feat(quality): ship the Layer-3 drift-review attractor, and run the first real Layer-3 review with it

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ The goal lives in the DOT itself: `graph [goal="Add user avatar upload with S3 s
 | [Feature Build](examples/pipelines/practical/feature-build.md) | Parallel implementation + human gate |
 | [Refactoring](examples/pipelines/practical/refactor.md) | Snapshot-safe code improvement |
 | [Multi-Lens Review](examples/pipelines/practical/multi-lens-review.md) | 3 providers × 3 lenses |
+| [Drift Review](examples/drift-review/README.md) | `QUALITY_PROTOCOL.md` Layer 3: holistic semantic review of this repo against the canonical spec and `docs/VISION.md` |
 
 `Bug Fix`, `Test Generation`, and `Refactoring` ship a runnable sample, so they work with no setup. See [examples/pipelines/practical/](examples/pipelines/practical/) for the full set.
 

--- a/docs/QUALITY_PROTOCOL.md
+++ b/docs/QUALITY_PROTOCOL.md
@@ -270,8 +270,11 @@ against the repo's stated vision -- which is [`docs/VISION.md`](VISION.md), not 
 repo collected between reviews, read as a set. Output: findings with `file:line` evidence, filed as
 issues -- not a report that gets read once.
 
-Executed as an agent wave today. The intent is for it to become a **self-review attractor pipeline**
--- the repo reviewing itself with its own machinery (section 8). That pipeline does not exist yet.
+Executed as an agent wave until now. **The executor is
+[`examples/drift-review/`](../examples/drift-review/)** -- a self-review attractor pipeline (section
+8), whose findings gate re-opens every cited `file:line` on *both* sides outside every reviewer's
+context, and whose shape is guarded by
+`modules/loop-pipeline/tests/test_drift_review_gate.py`. It reports; a human triages and files.
 
 ### Layer 4 -- the meta-protocol
 
@@ -431,6 +434,36 @@ This repo's maintainers will help seed a customized version on request -- open a
 ## Changelog
 
 Amendments to this protocol, newest first. Each entry names the evidence that justified it.
+
+### 2026-08-15 -- Layer 3 gets an executor (entry 6)
+
+- **Changed.** Layer 3's closing line flipped from *"that pipeline does not exist yet"* to naming
+  [`examples/drift-review/`](../examples/drift-review/): the holistic review is now run by an
+  attractor, with `check_findings.py` as the gate that decides which proposed findings are shaped
+  and `modules/loop-pipeline/tests/test_drift_review_gate.py` guarding both. Nothing about Layer
+  3's *scope* changed -- docs, examples, guidance surfaces and both ledgers, read against the
+  canonical spec and `docs/VISION.md`.
+- **Evidence that justified it: the triggers in section 6 fired, and the layer had no executor to
+  answer them with.** More than fifteen PRs touching `modules/` and `docs/` have merged since the
+  protocol was captured, and the conformance surface moved repeatedly (the matrix landed, the
+  vision wave amended two pages). Layer 3 was the only layer whose defense was "someone will read
+  everything carefully" -- which is the defense that silently does not happen. The first real pass
+  was run with this executor before it merged; its report is the adoption evidence.
+- **What the executor buys that a careful read does not.** Findings are *shaped* or they do not
+  ship: each cites `file:line` on both sides -- the drifting surface and the normative passage it
+  contradicts -- and the gate re-opens both files rather than believing either citation. That
+  closes the gap an unstructured review leaves, where a plausible-sounding finding costs a human
+  the read and proves nothing.
+- **Deliberately not automated: filing.** The pipeline reports; a human verifies each finding and
+  decides what becomes an issue or a `vision-observation` (section 4). Shape is not truth -- the
+  gate proves a citation resolves, never that two passages actually contradict each other -- and a
+  reviewer that acts on its own findings has re-entered the context it was built to stay outside
+  of.
+- **Scope of this change: additive.** No engine, handler or ledger *behavior* changed. One new
+  example directory, one new guard test, one README gallery row, and this page's Layer-3 line.
+- **Retirement condition.** The layer has none. The *executor* retires if the review it runs stops
+  earning its cost under section 7's retirement review -- if it finds nothing across several
+  cycles, that is itself the finding, and the review that observed it would say so.
 
 ### 2026-08-15 -- the decision matrix stated in authored prose (entry 5)
 

--- a/examples/drift-review/README.md
+++ b/examples/drift-review/README.md
@@ -1,0 +1,252 @@
+# Drift Review -- the Layer-3 executor
+
+The periodic holistic semantic review from
+[`docs/QUALITY_PROTOCOL.md` section 5](../../docs/QUALITY_PROTOCOL.md), built as
+an attractor. The repo reviews itself with its own engine.
+
+| | |
+|---|---|
+| **Graph** | [`drift-review.dot`](drift-review.dot) |
+| **Gate** | [`check_findings.py`](check_findings.py) -- the finding-shape validator |
+| **Contract** | [`finding-contract.md`](finding-contract.md) -- what a finding must be |
+| **Guard** | `modules/loop-pipeline/tests/test_drift_review_gate.py` |
+
+---
+
+## What Layer 3 is
+
+`QUALITY_PROTOCOL.md` names five drift layers. Four of them are already
+mechanical, and all four are **local** -- each checks one claim, one file, one
+section:
+
+| Layer | What it is | What it cannot see |
+|---|---|---|
+| 0 | the vendored upstream nlspec, pinned byte-for-byte | anything about *this* repo |
+| 1 | six guard tests pinning documented claims to the code they came from | a claim nobody wrote a guard for |
+| 2 | the executable conformance matrix asserting every decided divergence | anything outside the conformance surface |
+| 3 | **this** | -- |
+| 4 | the meta-protocol governing layers 0-3 | -- |
+
+Layer 3's own words for the gap it fills:
+
+> "None of them can see that the README teaches one mental model while an
+> exemplar demonstrates another, or that a ledger entry is individually
+> well-formed and collectively obsolete. That is a semantic reading of the
+> whole, and it has to be done as one."
+
+So Layer 3 catches what only judgment sees: a doc paragraph teaching retired
+behavior, an example contradicting doctrine, vocabulary drifting from the
+spec's, a ledger row that parses cleanly and stopped describing reality.
+
+Scope, per the protocol: **docs, examples, guidance surfaces, and both ledgers**,
+read against the canonical spec *and* against
+[`docs/VISION.md`](../../docs/VISION.md). Open `vision-observation` issues are a
+named input (section 4) -- read as a set, because one observation is often noise
+and five of them are a pattern.
+
+---
+
+## When it fires
+
+Section 6's triggers, verbatim in summary. Whichever fires first, fires:
+
+- **Every ~15 merged PRs touching `modules/` or `docs/`** -- the cadence knob.
+- **Any PR that adds or edits an `EXTENSIONS.md` section or a
+  `SPEC_CONFORMANCE.md` ledger row** -- the conformance surface moved, so the
+  claims around it may no longer be true.
+- **Any upstream spec movement** -- a SYNC event (Layer 0).
+- **Any incident or postmortem naming a doc-vs-code contradiction** --
+  immediate, and scoped to that surface class.
+- **A quarterly floor**, regardless. A quiet quarter is not evidence of a
+  correct repo.
+
+---
+
+## How to run it
+
+The repository under review is the **process working directory**. There is
+deliberately no `--param` for it: a second path to configure is a second way to
+review the wrong tree while believing you reviewed the right one. `preflight`
+asserts the normative sources are present in the cwd and refuses otherwise.
+
+```bash
+RD="$PWD/examples/drift-review"      # absolute; the gates run from here
+cd <the repository under review>     # usually the same checkout
+
+attractor run "$RD/drift-review.dot" \
+    --param goal="Layer-3 holistic drift review of this repository" \
+    --param runner_dir="$RD" \
+    --cwd .
+```
+
+Everything the run writes lands under `.drift-review/` in the working
+directory. It is scratch state, not a deliverable to commit -- copy
+`report.md` and `findings.json` wherever the evidence for that review belongs.
+
+| Parameter | Default | What it is |
+|---|---|---|
+| `goal` | *(required)* | the review objective, carried into every worker's prompt |
+| `runner_dir` | *(required)* | absolute path to this directory |
+| `max_revisions` | 2 | findings-repair budget -- at most 3 gate passes |
+| `max_reports` | 2 | report-repair budget -- at most 3 gate passes |
+
+### Outputs
+
+| Path | What it is |
+|---|---|
+| `.drift-review/report.md` | **the deliverable** -- what was swept, every finding with both sides quoted |
+| `.drift-review/findings.json` | the admitted corpus, machine-readable, sorted by severity |
+| `.drift-review/findings-report.txt` | the gate's admission record: what it accepted and what it rejected, with reasons |
+| `.drift-review/disposition` | `findings` \| `clean` \| `escalated` -- how an unattended caller tells the outcomes apart |
+| `.drift-review/inventory/` | the four surface lists the reviewers were scoped to, and their counts |
+
+---
+
+## The shape
+
+```
+start
+  -> preflight        (code)  admission: normative sources present, tools on PATH
+  -> inventory        (code)  git ls-files -> four claim-bearing surface classes
+  -> review_fanout    (fan-out, wait_all, error_policy=continue, max_parallel=4)
+       |- review_core_docs  (LLM)  README, root conventions, docs/
+       |- review_examples   (LLM)  examples/ -- graphs, guides, gate primitives
+       |- review_guidance   (LLM)  agents/, skills/, context/, behaviors/, bundles/
+       `- review_ledgers    (LLM)  SPEC_CONFORMANCE.md, specs/
+  -> reviews_join     (fan-in)
+  -> findings_gate    (code)  check_findings.py -- SHAPE, re-reading every citation
+       |- findings_ok       -> consolidate
+       |- findings_bad      -> revise -> back to findings_gate   [budget: max_revisions]
+       `- revise_exhausted  -> postmortem
+  -> consolidate      (LLM)   writes .drift-review/report.md
+  -> report_gate      (code)  goal gate: every admitted finding appears in the report
+       |- report_ok         -> done
+       |- report_bad        -> consolidate                       [budget: max_reports]
+       `- report_exhausted  -> postmortem
+  -> done             (the single exit)
+
+postmortem (LLM) -> escalated (code, exit 1) -- the only red path
+```
+
+**Four classes, because they fail differently.** A doc lies in prose. An
+exemplar lies by demonstration -- worse, because a reader copies it. A guidance
+surface lies to an agent nobody is watching. A ledger lies by staying true
+sentence-by-sentence while its disposition stops describing reality.
+
+**Each reviewer runs in its own context** and never sees the others' work. That
+independence is the point: four correlated reviewers are one reviewer with a
+larger bill.
+
+### The gates
+
+| Gate | Contract |
+|---|---|
+| `preflight` | **Refuse before spending an LLM.** The five normative sources exist in the cwd; `check_findings.py` and `finding-contract.md` exist under `runner_dir`; `git`, `python3`, `grep`, `sort`, `wc` are on PATH. `ready`, or `blocked` and exit 1. |
+| `inventory` | **Scope is a file, not a recollection.** Four lists from `git ls-files` -- only tracked files, because an untracked scratch file makes no claim on anyone. A class matching nothing is a machinery failure (`no_surfaces`, exit 1), never an empty result: a review that swept an empty list would report "clean" about surfaces it never opened. |
+| `findings_gate` | **Every finding cites `file:line` on both sides, and the gate re-opens both files.** Shape, not truth. `findings_ok` \| `findings_bad` \| `revise_exhausted`; nonzero exit means the gate itself could not run, which routes to the loud terminal rather than into the repair loop. |
+| `report_gate` | **The exit is unreachable if the report dropped a finding.** Re-derives the ids from `findings.json` -- it never believes the report's own table -- and requires all four class names to appear, so a quietly-skipped class cannot read as a clean one. Also writes `disposition`. |
+
+### Honest exits
+
+| Outcome | Exit | Disposition | Meaning |
+|---|---|---|---|
+| findings present | `done`, green | `findings` | **The review succeeded.** Finding drift is the job. |
+| zero findings | `done`, green | `clean` | The review succeeded and says what it swept. |
+| machinery failure | `escalated`, **exit 1** | `escalated` | A gate could not run, a budget was spent without converging, or no corpus was produced. |
+
+A review that finds drift has not failed, and this graph will not let that
+confusion into the exit code. What is red is *the instrument breaking* --
+because an instrument that fails quietly is worse than no instrument, and a
+clean report from a broken sweep is the exact failure Layer 3 exists to prevent.
+
+---
+
+## How findings flow
+
+```
+pipeline  ->  report.md + findings.json
+                 |
+                 v
+human     ->  VERIFY each finding: open both cited sides. Is the drift real?
+                 |
+      +----------+----------+
+      |                     |
+      v                     v
+   real                  not real
+      |                     |
+      v                     v
+ file a GitHub issue    record the decline, with the reason
+ (or a `vision-observation`
+  issue when it bears on
+  docs/VISION.md)
+```
+
+**The pipeline never files anything, and never fixes anything.** That separation
+is the design, not an omission:
+
+- **A reviewer that acts on its own findings has no independent check left.**
+  The whole reason `findings_gate` sits outside every worker's context is that
+  verification inside the context that produced the evidence is not
+  verification. An auto-filing reviewer re-enters that context by the back door.
+- **Shape is not truth.** `check_findings.py` proves a citation *resolves*. It
+  cannot prove the two passages actually contradict each other -- that is
+  judgment, and judgment is what a human is for. A finding that survives the
+  gate is a *checkable claim*, not an established fact.
+- **Filing is consequential.** An issue costs someone's attention, and
+  `docs/VISION.md` records attention as the budgeted resource. A machine that
+  can spend it without a person in the loop will.
+
+Per `QUALITY_PROTOCOL.md` section 4, a verified finding that bears on the vision
+becomes a **`vision-observation` issue** citing the passage it bears on -- one
+observation per issue. A declined finding gets a **recorded decline with the
+reason**: "a declined observation that says why is a smaller version of the same
+value; a silently-closed one is a lost one."
+
+---
+
+## The finding contract, in one paragraph
+
+Every finding cites `file:line` on **both** sides -- the drifting surface and
+the normative passage it contradicts -- with a quote that resolves, verbatim,
+against the tree. The `contradicts` side must be one of `specs/canonical/`,
+`docs/VISION.md`, `SPEC_CONFORMANCE.md`, `specs/EXTENSIONS.md`, or
+`specs/conformance/`; that closed set *is* the definition of drift, and it is
+what keeps a Layer-3 finding meaning the same thing Layers 0-2 mean, one level
+up. Severity comes from a fixed vocabulary. Full rules, with the reasoning, in
+[`finding-contract.md`](finding-contract.md).
+
+A zero-finding class must still list what it **swept**. Otherwise "no drift
+found" and "nothing was looked at" are the same record -- and the first is a
+result while the second is a failure wearing its clothes.
+
+---
+
+## What this instrument does not cover
+
+Named rather than left for a reader to find:
+
+- **Shape, not truth.** See above. The gate proves citations resolve; a human
+  decides whether the contradiction is real.
+- **Recall is not measured.** Nothing here proves the reviewers *found*
+  everything. `swept` records what was opened, which bounds the claim honestly:
+  the review covers the surfaces it names, at the judgment of the model that
+  read them.
+- **Untracked files are out of scope** by construction -- `git ls-files`.
+- **`vision-observation` issues are a protocol input, not a pipeline input.**
+  The graph reads the tree, not the network. Bring the open observation set to
+  the human triage step, where section 4 says it is read *as a set*.
+- **One pass is one opinion.** The four reviewers are independent of each other,
+  not of themselves. A finding a reviewer missed is invisible to this run.
+
+---
+
+## Cross-references
+
+| Topic | Where to look |
+|---|---|
+| The five drift layers, and what each owns | [`docs/QUALITY_PROTOCOL.md` section 5](../../docs/QUALITY_PROTOCOL.md) |
+| When Layer 3 fires | [`docs/QUALITY_PROTOCOL.md` section 6](../../docs/QUALITY_PROTOCOL.md) |
+| The observation duty and its resolution paths | [`docs/QUALITY_PROTOCOL.md` section 4](../../docs/QUALITY_PROTOCOL.md) |
+| Gates outside workers, the three-question test | [`docs/PIPELINE_DESIGN_PRINCIPLES.md` section 0](../../docs/PIPELINE_DESIGN_PRINCIPLES.md) |
+| Gate idioms, the stale-label rule | [`examples/gates/README.md`](../gates/README.md) |
+| The same shape one layer up (objective -> lane -> evidence) | [`examples/objective/README.md`](../objective/README.md) |

--- a/examples/drift-review/check_findings.py
+++ b/examples/drift-review/check_findings.py
@@ -1,0 +1,485 @@
+#!/usr/bin/env python3
+"""Admit or reject the drift-review workers' findings -- the Layer-3 shape gate.
+
+``drift-review.dot`` is the executor for ``docs/QUALITY_PROTOCOL.md`` section 5,
+Layer 3: the periodic holistic semantic review that reads the whole repo against
+the canonical spec and the stated vision. Layers 0-2 pin numbers and ledgered
+behavior; Layer 3 catches what only judgment sees -- a paragraph teaching retired
+behavior, an example contradicting doctrine, vocabulary drifting from the spec's.
+
+Judgment is exactly what cannot be trusted to grade itself. So the review workers
+(LLM ``box`` nodes) propose findings, and this script -- run by the
+``findings_gate`` parallelogram, outside every worker's context -- decides which
+ones are *shaped*: **every finding must cite ``file:line`` on BOTH sides**, the
+drifting surface AND the normative passage it contradicts, with a quote that
+actually resolves against the tree at the cited location.
+
+That is the whole contract, and it is deliberately about shape rather than truth.
+This gate cannot know whether a contradiction is real; a human triages that
+(``README.md``). What it *can* do is make an unfalsifiable finding structurally
+impossible to ship: a finding whose citations do not resolve is not a finding,
+it is a claim, and a Layer-3 review that emits claims is worth nothing to the
+person who has to act on it.
+
+Why the normative side is a closed set (the ``contradicts.file`` rule): "drift"
+in this repo is defined against named sources of truth -- the vendored spec
+(Layer 0), the stated vision, and the two ledgers. A finding that one doc
+disagrees with another doc is a proofreading note; a finding that a doc
+disagrees with ``specs/canonical/`` is drift. Forcing the citation into that set
+is what keeps Layer 3 measuring the same thing Layers 0-2 measure, one level up.
+
+Token contract (Idiom A -- always exit 0 so ``tool.last_line`` is always fresh):
+
+  findings_ok         every class file parsed and every finding is shaped;
+                      ``findings.json`` was written; proceed to consolidate
+  findings_bad        at least one class file or finding is malformed; route
+                      back to the revise worker with the per-finding reasons
+  revise_exhausted    too many malformed rounds; stop revising, go to postmortem
+
+A nonzero exit means this gate could not run at all (the raw directory is
+missing, the repo root is not a directory, the report is unwritable). That is a
+genuine tool failure and the graph routes it through ``outcome=fail`` to the
+loud terminal -- deliberately distinct from ``findings_bad``, which is a
+*judgement* about the workers' output.
+
+Side effects, all under ``--state-dir``:
+
+  findings-report.txt   per-file, per-finding ACCEPT/REJECT with the reason
+                        (written on every run -- the revise worker's only input)
+  findings.json         the consolidated corpus, written ONLY on findings_ok
+  revise-iter           the corrective-loop counter (the budget wall)
+
+Usage:
+    check_findings.py --raw-dir .drift-review/raw \\
+                      --repo-root . \\
+                      --state-dir .drift-review \\
+                      --classes core-docs,examples,guidance,ledgers \\
+                      --max-revisions 2
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# The fixed vocabularies. A finding that invents a severity is not triageable:
+# the human reading the report sorts by this field.
+# ---------------------------------------------------------------------------
+
+#: Severity vocabulary. Fixed, ordered most-severe first.
+SEVERITIES: tuple[str, ...] = ("critical", "high", "medium", "low")
+
+#: The normative sources a finding is allowed to cite on its `contradicts` side.
+#: Prefix match against the repo-relative posix path. This IS the definition of
+#: "drift" for Layer 3: movement away from one of these, not from a sibling doc.
+NORMATIVE_PREFIXES: tuple[str, ...] = (
+    "specs/canonical/",
+    "specs/conformance/",
+    "specs/EXTENSIONS.md",
+    "SPEC_CONFORMANCE.md",
+    "docs/VISION.md",
+)
+
+#: Finding ids: short, unique, human-quotable in an issue title.
+ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{2,63}$")
+
+#: A quote shorter than this cannot anchor anything -- "the" appears everywhere.
+MIN_QUOTE_CHARS = 16
+
+#: `why` has to carry the argument, not just repeat the title.
+MIN_WHY_CHARS = 40
+
+#: `title` has to be a sentence, not a word.
+MIN_TITLE_CHARS = 12
+
+#: Quote resolution window around the cited line, in lines. Generous enough that
+#: a reflowed markdown paragraph still resolves, tight enough that the citation
+#: still means something: a quote that only appears 40 lines away is a wrong
+#: citation, and a wrong citation is the failure this gate exists to catch.
+WINDOW_BEFORE = 2
+WINDOW_AFTER = 6
+
+_WS_RE = re.compile(r"\s+")
+
+
+def normalize(text: str) -> str:
+    """Collapse whitespace so a reflowed quote still matches its source."""
+    return _WS_RE.sub(" ", text).strip()
+
+
+# ---------------------------------------------------------------------------
+# Citation resolution -- the load-bearing half
+# ---------------------------------------------------------------------------
+
+
+def resolve_in_tree(repo_root: Path, rel: str) -> tuple[Path | None, str | None]:
+    """Resolve a repo-relative path, refusing anything that escapes the tree."""
+    if not isinstance(rel, str) or not rel.strip():
+        return None, "path is empty"
+    if rel.startswith("/"):
+        return None, f"'{rel}' is absolute; citations must be repo-relative"
+    candidate = (repo_root / rel).resolve()
+    try:
+        candidate.relative_to(repo_root.resolve())
+    except ValueError:
+        return None, f"'{rel}' resolves outside the repository root"
+    if not candidate.exists():
+        return None, f"'{rel}' does not exist in the tree"
+    if not candidate.is_file():
+        return None, f"'{rel}' is not a regular file"
+    return candidate, None
+
+
+def check_citation(repo_root: Path, cite: Any, side: str) -> list[str]:
+    """Validate one side of a finding: file exists, line is in range, quote resolves."""
+    if not isinstance(cite, dict):
+        return [f"{side}: expected an object with file/line/quote, got {type(cite).__name__}"]
+
+    missing = [key for key in ("file", "line", "quote") if key not in cite]
+    if missing:
+        return [f"{side}: missing required field '{key}'" for key in missing]
+
+    rel = cite["file"]
+    path, why = resolve_in_tree(repo_root, rel if isinstance(rel, str) else "")
+    if path is None:
+        return [f"{side}.file: {why}"]
+
+    line = cite["line"]
+    if isinstance(line, bool) or not isinstance(line, int):
+        return [f"{side}.line: expected an integer line number, got {line!r}"]
+
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError as exc:  # pragma: no cover - unreadable file inside the tree
+        return [f"{side}.file: '{rel}' could not be read: {exc}"]
+
+    if line < 1 or line > len(lines):
+        return [f"{side}.line: {rel} has {len(lines)} lines; cited line {line} is out of range"]
+
+    quote = cite["quote"]
+    if not isinstance(quote, str):
+        return [f"{side}.quote: expected a string, got {type(quote).__name__}"]
+    needle = normalize(quote)
+    if len(needle) < MIN_QUOTE_CHARS:
+        return [
+            f"{side}.quote: {len(needle)} characters after whitespace normalization; "
+            f"at least {MIN_QUOTE_CHARS} are required for the quote to anchor the citation"
+        ]
+
+    lo = max(0, line - 1 - WINDOW_BEFORE)
+    hi = min(len(lines), line + WINDOW_AFTER)
+    window = normalize(" ".join(lines[lo:hi]))
+    if needle not in window:
+        return [
+            f"{side}: the quote does not appear at {rel}:{line} "
+            f"(searched lines {lo + 1}-{hi}). Quote the text that is actually there, "
+            "or cite the line where the text you quoted lives."
+        ]
+    return []
+
+
+# ---------------------------------------------------------------------------
+# Finding shape
+# ---------------------------------------------------------------------------
+
+
+def check_finding(
+    repo_root: Path, finding: Any, expected_class: str, seen_ids: set[str]
+) -> list[str]:
+    """Validate one finding. Returns human-readable rejection reasons."""
+    if not isinstance(finding, dict):
+        return [f"expected a finding object, got {type(finding).__name__}"]
+
+    required = ("id", "severity", "class", "title", "drift", "contradicts", "why")
+    missing = [key for key in required if key not in finding]
+    if missing:
+        return [f"missing required field '{key}'" for key in missing]
+
+    errors: list[str] = []
+
+    fid = finding["id"]
+    if not isinstance(fid, str) or not ID_RE.match(fid):
+        errors.append(
+            f"id: {fid!r} is not a short slug matching {ID_RE.pattern} "
+            "(3-64 chars: letters, digits, dot, underscore, hyphen)"
+        )
+    elif fid in seen_ids:
+        errors.append(f"id: '{fid}' is used more than once; finding ids must be unique")
+    else:
+        seen_ids.add(fid)
+
+    severity = finding["severity"]
+    if severity not in SEVERITIES:
+        errors.append(f"severity: {severity!r} is not one of {list(SEVERITIES)}")
+
+    cls = finding["class"]
+    if cls != expected_class:
+        errors.append(f"class: {cls!r} does not match this file's class '{expected_class}'")
+
+    title = finding["title"]
+    if not isinstance(title, str) or len(title.strip()) < MIN_TITLE_CHARS:
+        errors.append(f"title: must be at least {MIN_TITLE_CHARS} characters of real summary")
+
+    why = finding["why"]
+    if not isinstance(why, str) or len(why.strip()) < MIN_WHY_CHARS:
+        errors.append(
+            f"why: must be at least {MIN_WHY_CHARS} characters stating what the "
+            "contradiction IS -- a citation pair with no argument is not a finding"
+        )
+
+    errors.extend(check_citation(repo_root, finding["drift"], "drift"))
+    errors.extend(check_citation(repo_root, finding["contradicts"], "contradicts"))
+
+    drift = finding["drift"]
+    contradicts = finding["contradicts"]
+    if isinstance(drift, dict) and isinstance(contradicts, dict):
+        normative = contradicts.get("file")
+        if isinstance(normative, str) and not normative.startswith(NORMATIVE_PREFIXES):
+            errors.append(
+                f"contradicts.file: '{normative}' is not a normative source. Layer 3 measures "
+                f"drift against {list(NORMATIVE_PREFIXES)}; a disagreement between two "
+                "non-normative surfaces is a proofreading note, not drift. Cite the spec, "
+                "vision or ledger passage the surface actually contradicts."
+            )
+        if drift.get("file") == contradicts.get("file"):
+            errors.append(
+                "drift.file and contradicts.file are the same file; a finding must name the "
+                "drifting surface AND the separate normative passage it contradicts"
+            )
+
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# Class files
+# ---------------------------------------------------------------------------
+
+
+def check_class_file(
+    repo_root: Path, path: Path, expected_class: str, seen_ids: set[str]
+) -> tuple[list[str], list[dict[str, Any]], list[str]]:
+    """Validate one ``<class>.json`` file. Returns (errors, accepted findings, swept)."""
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return (
+            [
+                f"{path.name}: not written. The '{expected_class}' review worker produced no "
+                "output at all; re-run that class's review, or record honestly what it swept "
+                "with an empty findings list."
+            ],
+            [],
+            [],
+        )
+    except OSError as exc:
+        return ([f"{path.name}: unreadable: {exc}"], [], [])
+    except json.JSONDecodeError as exc:
+        return ([f"{path.name}: not valid JSON: {exc}"], [], [])
+
+    if not isinstance(raw, dict):
+        return ([f"{path.name}: expected a JSON object, got {type(raw).__name__}"], [], [])
+
+    errors: list[str] = []
+    if raw.get("class") != expected_class:
+        errors.append(f"{path.name}: 'class' must be '{expected_class}', got {raw.get('class')!r}")
+
+    swept = raw.get("swept")
+    if not isinstance(swept, list) or not swept:
+        errors.append(
+            f"{path.name}: 'swept' must be a non-empty list of the repo-relative paths this "
+            "class actually read. A zero-finding class still has to say what it swept -- "
+            "otherwise 'no drift found' and 'nothing was looked at' are the same record."
+        )
+        swept = []
+    else:
+        for entry in swept:
+            resolved, why = resolve_in_tree(repo_root, entry if isinstance(entry, str) else "")
+            if resolved is None:
+                errors.append(f"{path.name}: swept entry {entry!r}: {why}")
+
+    findings = raw.get("findings")
+    if not isinstance(findings, list):
+        errors.append(f"{path.name}: 'findings' must be a list (use [] when nothing was found)")
+        return (errors, [], [s for s in swept if isinstance(s, str)])
+
+    accepted: list[dict[str, Any]] = []
+    for index, finding in enumerate(findings):
+        reasons = check_finding(repo_root, finding, expected_class, seen_ids)
+        label = finding.get("id") if isinstance(finding, dict) else None
+        where = f"{path.name}[{index}]" + (f" ({label})" if isinstance(label, str) else "")
+        if reasons:
+            errors.extend(f"{where}: {reason}" for reason in reasons)
+        else:
+            assert isinstance(finding, dict)
+            accepted.append(finding)
+
+    return (errors, accepted, [s for s in swept if isinstance(s, str)])
+
+
+# ---------------------------------------------------------------------------
+# Fuse -- bounded revision
+# ---------------------------------------------------------------------------
+
+
+def bump_revise_counter(state_dir: Path) -> int:
+    counter = state_dir / "revise-iter"
+    try:
+        current = int(counter.read_text(encoding="utf-8").strip())
+    except (OSError, ValueError):
+        current = 0
+    current += 1
+    counter.write_text(f"{current}\n", encoding="utf-8")
+    return current
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Validate drift-review findings", add_help=True)
+    parser.add_argument("--raw-dir", required=True, help="directory holding <class>.json files")
+    parser.add_argument("--repo-root", default=".", help="repository the citations resolve against")
+    parser.add_argument("--state-dir", default=".drift-review", help="gate bookkeeping directory")
+    parser.add_argument(
+        "--classes",
+        default="core-docs,examples,guidance,ledgers",
+        help="comma-separated surface classes, each expected to produce <class>.json",
+    )
+    parser.add_argument(
+        "--max-revisions",
+        type=int,
+        default=2,
+        help="how many malformed rounds to tolerate before giving up (default: 2)",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    # --- things that make this gate UNABLE to run: exit nonzero, print nothing.
+    repo_root = Path(args.repo_root)
+    if not repo_root.is_dir():
+        print(f"check_findings: --repo-root {repo_root} is not a directory", file=sys.stderr)
+        return 2
+
+    raw_dir = Path(args.raw_dir)
+    if not raw_dir.is_dir():
+        print(
+            f"check_findings: --raw-dir {raw_dir} is not a directory; preflight is supposed to "
+            "create it, so this is a machinery failure rather than a bad finding",
+            file=sys.stderr,
+        )
+        return 2
+
+    state_dir = Path(args.state_dir)
+    try:
+        state_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        print(f"check_findings: cannot create state dir {state_dir}: {exc}", file=sys.stderr)
+        return 2
+
+    classes = [c.strip() for c in args.classes.split(",") if c.strip()]
+    if not classes:
+        print("check_findings: --classes resolved to an empty list", file=sys.stderr)
+        return 2
+
+    # --- things that make the FINDINGS bad: exit 0, print a judgement token.
+    errors: list[str] = []
+    accepted: list[dict[str, Any]] = []
+    swept_by_class: dict[str, list[str]] = {}
+    seen_ids: set[str] = set()
+
+    for cls in classes:
+        cls_errors, cls_findings, cls_swept = check_class_file(
+            repo_root, raw_dir / f"{cls}.json", cls, seen_ids
+        )
+        errors.extend(cls_errors)
+        accepted.extend(cls_findings)
+        swept_by_class[cls] = cls_swept
+
+    report_path = state_dir / "findings-report.txt"
+    findings_path = state_dir / "findings.json"
+
+    if errors:
+        attempt = bump_revise_counter(state_dir)
+        token = "findings_bad" if attempt <= args.max_revisions else "revise_exhausted"
+        report = [
+            "FINDINGS REJECTED",
+            f"raw dir:  {raw_dir}",
+            f"classes:  {', '.join(classes)}",
+            f"attempt:  {attempt} of {args.max_revisions} permitted",
+            f"verdict:  {token}",
+            "",
+            "Every finding must cite file:line on BOTH sides -- the drifting surface and the",
+            "normative passage it contradicts -- with quotes that resolve against this tree.",
+            "",
+            "Rejections (fix exactly these; leave everything else alone):",
+            *(f"  - {e}" for e in errors),
+        ]
+        try:
+            report_path.write_text("\n".join(report) + "\n", encoding="utf-8")
+        except OSError as exc:
+            print(f"check_findings: cannot write {report_path}: {exc}", file=sys.stderr)
+            return 2
+        # A rejected round must not leave a stale corpus behind for a later gate
+        # to mistake for this round's output.
+        findings_path.unlink(missing_ok=True)
+        print(token, end="")
+        return 0
+
+    accepted.sort(key=lambda f: (SEVERITIES.index(str(f["severity"])), str(f["id"])))
+    corpus = {
+        "schema": "drift-review/findings/1",
+        "repo_root": str(repo_root),
+        "classes": classes,
+        "swept": swept_by_class,
+        "finding_count": len(accepted),
+        "findings": accepted,
+    }
+    try:
+        findings_path.write_text(json.dumps(corpus, indent=2) + "\n", encoding="utf-8")
+    except OSError as exc:
+        print(f"check_findings: cannot write {findings_path}: {exc}", file=sys.stderr)
+        return 2
+
+    swept_total = sum(len(v) for v in swept_by_class.values())
+    listing = [f"  {f['id']}  {str(f['severity']):<8}  {f['title']}" for f in accepted] or [
+        "  (none -- a clean sweep is a result, not a failure)"
+    ]
+    report = [
+        "FINDINGS ADMITTED",
+        f"raw dir:  {raw_dir}",
+        f"classes:  {', '.join(classes)}",
+        f"findings: {len(accepted)}",
+        f"swept:    {swept_total} surfaces",
+        "",
+        "Per class:",
+        *(
+            f"  {cls}: {sum(1 for f in accepted if f['class'] == cls)} finding(s), "
+            f"{len(swept_by_class[cls])} surface(s) swept"
+            for cls in classes
+        ),
+        "",
+        "Admitted findings (id / severity / title):",
+        *listing,
+    ]
+    try:
+        report_path.write_text("\n".join(report) + "\n", encoding="utf-8")
+    except OSError as exc:
+        print(f"check_findings: cannot write {report_path}: {exc}", file=sys.stderr)
+        return 2
+
+    print("findings_ok", end="")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - thin CLI wrapper
+    raise SystemExit(main())

--- a/examples/drift-review/check_findings.py
+++ b/examples/drift-review/check_findings.py
@@ -117,70 +117,114 @@ def normalize(text: str) -> str:
 # ---------------------------------------------------------------------------
 
 
-def resolve_in_tree(repo_root: Path, rel: str) -> tuple[Path | None, str | None]:
-    """Resolve a repo-relative path, refusing anything that escapes the tree."""
+def resolve_in_tree(repo_root: Path, rel: str) -> tuple[Path | None, str | None, str | None]:
+    """Resolve a repo-relative path, refusing anything that escapes the tree.
+
+    Returns ``(path, resolved_rel, why)``. ``resolved_rel`` is the citation's
+    repo-relative posix form *after* resolution; ``why`` is the rejection
+    reason, and is set exactly when the other two are ``None``.
+
+    Handing back the resolved form is load-bearing rather than a convenience.
+    Every rule downstream that reasons about *which file* a citation names has
+    to judge the file, and the raw citation string is not the file:
+
+      * ``specs/canonical/../../docs/QUALITY_PROTOCOL.md`` satisfies a
+        ``startswith("specs/canonical/")`` test on its raw form while pointing
+        clean out of the closed normative set.
+      * ``specs/canonical/../../README.md`` is a different *string* from
+        ``README.md`` while being the same *file*, which is enough to walk a
+        finding past the rule that the drifting surface and the passage it
+        contradicts must be two different files.
+
+    Both were admissions while the callers tested the raw string. A closed set
+    is only as closed as the path it is closed over.
+    """
     if not isinstance(rel, str) or not rel.strip():
-        return None, "path is empty"
+        return None, None, "path is empty"
     if rel.startswith("/"):
-        return None, f"'{rel}' is absolute; citations must be repo-relative"
+        return None, None, f"'{rel}' is absolute; citations must be repo-relative"
     candidate = (repo_root / rel).resolve()
     try:
-        candidate.relative_to(repo_root.resolve())
+        resolved_rel = candidate.relative_to(repo_root.resolve()).as_posix()
     except ValueError:
-        return None, f"'{rel}' resolves outside the repository root"
+        return None, None, f"'{rel}' resolves outside the repository root"
     if not candidate.exists():
-        return None, f"'{rel}' does not exist in the tree"
+        return None, None, f"'{rel}' does not exist in the tree"
     if not candidate.is_file():
-        return None, f"'{rel}' is not a regular file"
-    return candidate, None
+        return None, None, f"'{rel}' is not a regular file"
+    return candidate, resolved_rel, None
 
 
-def check_citation(repo_root: Path, cite: Any, side: str) -> list[str]:
-    """Validate one side of a finding: file exists, line is in range, quote resolves."""
+def name_path(raw: Any, resolved: str) -> str:
+    """Render a citation path, making the traversal visible when one was used."""
+    return f"'{raw}'" if raw == resolved else f"'{raw}' (which resolves to '{resolved}')"
+
+
+def check_citation(repo_root: Path, cite: Any, side: str) -> tuple[list[str], str | None]:
+    """Validate one side of a finding: file exists, line is in range, quote resolves.
+
+    Returns ``(errors, resolved_rel)``. ``resolved_rel`` is populated whenever
+    the cited path itself resolved inside the tree -- deliberately including the
+    cases where a *later* check (line, quote) then failed, because the
+    closed-normative-set and different-files rules in ``check_finding`` are
+    about the FILE, and they must still judge the file the citation names.
+    """
     if not isinstance(cite, dict):
-        return [f"{side}: expected an object with file/line/quote, got {type(cite).__name__}"]
+        return (
+            [f"{side}: expected an object with file/line/quote, got {type(cite).__name__}"],
+            None,
+        )
 
     missing = [key for key in ("file", "line", "quote") if key not in cite]
     if missing:
-        return [f"{side}: missing required field '{key}'" for key in missing]
+        return ([f"{side}: missing required field '{key}'" for key in missing], None)
 
     rel = cite["file"]
-    path, why = resolve_in_tree(repo_root, rel if isinstance(rel, str) else "")
-    if path is None:
-        return [f"{side}.file: {why}"]
+    path, resolved_rel, why = resolve_in_tree(repo_root, rel if isinstance(rel, str) else "")
+    if path is None or resolved_rel is None:
+        return ([f"{side}.file: {why}"], None)
 
     line = cite["line"]
     if isinstance(line, bool) or not isinstance(line, int):
-        return [f"{side}.line: expected an integer line number, got {line!r}"]
+        return ([f"{side}.line: expected an integer line number, got {line!r}"], resolved_rel)
 
     try:
         lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
     except OSError as exc:  # pragma: no cover - unreadable file inside the tree
-        return [f"{side}.file: '{rel}' could not be read: {exc}"]
+        return ([f"{side}.file: '{rel}' could not be read: {exc}"], resolved_rel)
 
     if line < 1 or line > len(lines):
-        return [f"{side}.line: {rel} has {len(lines)} lines; cited line {line} is out of range"]
+        return (
+            [f"{side}.line: {rel} has {len(lines)} lines; cited line {line} is out of range"],
+            resolved_rel,
+        )
 
     quote = cite["quote"]
     if not isinstance(quote, str):
-        return [f"{side}.quote: expected a string, got {type(quote).__name__}"]
+        return ([f"{side}.quote: expected a string, got {type(quote).__name__}"], resolved_rel)
     needle = normalize(quote)
     if len(needle) < MIN_QUOTE_CHARS:
-        return [
-            f"{side}.quote: {len(needle)} characters after whitespace normalization; "
-            f"at least {MIN_QUOTE_CHARS} are required for the quote to anchor the citation"
-        ]
+        return (
+            [
+                f"{side}.quote: {len(needle)} characters after whitespace normalization; "
+                f"at least {MIN_QUOTE_CHARS} are required for the quote to anchor the citation"
+            ],
+            resolved_rel,
+        )
 
     lo = max(0, line - 1 - WINDOW_BEFORE)
     hi = min(len(lines), line + WINDOW_AFTER)
     window = normalize(" ".join(lines[lo:hi]))
     if needle not in window:
-        return [
-            f"{side}: the quote does not appear at {rel}:{line} "
-            f"(searched lines {lo + 1}-{hi}). Quote the text that is actually there, "
-            "or cite the line where the text you quoted lives."
-        ]
-    return []
+        return (
+            [
+                f"{side}: the quote does not appear at {rel}:{line} "
+                f"(searched lines {lo + 1}-{hi}). Quote the text that is actually there, "
+                "or cite the line where the text you quoted lives."
+            ],
+            resolved_rel,
+        )
+    return ([], resolved_rel)
 
 
 # ---------------------------------------------------------------------------
@@ -232,25 +276,36 @@ def check_finding(
             "contradiction IS -- a citation pair with no argument is not a finding"
         )
 
-    errors.extend(check_citation(repo_root, finding["drift"], "drift"))
-    errors.extend(check_citation(repo_root, finding["contradicts"], "contradicts"))
+    drift_errors, drift_rel = check_citation(repo_root, finding["drift"], "drift")
+    contradicts_errors, contradicts_rel = check_citation(
+        repo_root, finding["contradicts"], "contradicts"
+    )
+    errors.extend(drift_errors)
+    errors.extend(contradicts_errors)
 
+    # BOTH rules below judge the RESOLVED repo-relative path, never the raw
+    # citation string. A citation that did not resolve has already been rejected
+    # by check_citation above, so declining to guess at its intent here costs
+    # nothing; testing the raw string, by contrast, cost two admissions
+    # (see resolve_in_tree).
     drift = finding["drift"]
     contradicts = finding["contradicts"]
-    if isinstance(drift, dict) and isinstance(contradicts, dict):
-        normative = contradicts.get("file")
-        if isinstance(normative, str) and not normative.startswith(NORMATIVE_PREFIXES):
-            errors.append(
-                f"contradicts.file: '{normative}' is not a normative source. Layer 3 measures "
-                f"drift against {list(NORMATIVE_PREFIXES)}; a disagreement between two "
-                "non-normative surfaces is a proofreading note, not drift. Cite the spec, "
-                "vision or ledger passage the surface actually contradicts."
-            )
-        if drift.get("file") == contradicts.get("file"):
-            errors.append(
-                "drift.file and contradicts.file are the same file; a finding must name the "
-                "drifting surface AND the separate normative passage it contradicts"
-            )
+    if contradicts_rel is not None and not contradicts_rel.startswith(NORMATIVE_PREFIXES):
+        raw = contradicts.get("file") if isinstance(contradicts, dict) else contradicts_rel
+        errors.append(
+            f"contradicts.file: {name_path(raw, contradicts_rel)} is not a normative source. "
+            f"Layer 3 measures drift against {list(NORMATIVE_PREFIXES)}; a disagreement between "
+            "two non-normative surfaces is a proofreading note, not drift. Cite the spec, "
+            "vision or ledger passage the surface actually contradicts."
+        )
+    if drift_rel is not None and drift_rel == contradicts_rel:
+        raw_drift = drift.get("file") if isinstance(drift, dict) else drift_rel
+        raw_contradicts = contradicts.get("file") if isinstance(contradicts, dict) else drift_rel
+        errors.append(
+            f"drift.file {name_path(raw_drift, drift_rel)} and contradicts.file "
+            f"{name_path(raw_contradicts, drift_rel)} are the same file; a finding must name "
+            "the drifting surface AND the separate normative passage it contradicts"
+        )
 
     return errors
 
@@ -298,7 +353,8 @@ def check_class_file(
         swept = []
     else:
         for entry in swept:
-            resolved, why = resolve_in_tree(repo_root, entry if isinstance(entry, str) else "")
+            entry_rel = entry if isinstance(entry, str) else ""
+            resolved, _resolved_rel, why = resolve_in_tree(repo_root, entry_rel)
             if resolved is None:
                 errors.append(f"{path.name}: swept entry {entry!r}: {why}")
 

--- a/examples/drift-review/drift-review.dot
+++ b/examples/drift-review/drift-review.dot
@@ -1,0 +1,315 @@
+// ============================================================================
+// Drift Review -- the executor for QUALITY_PROTOCOL Layer 3
+// ============================================================================
+// docs/QUALITY_PROTOCOL.md section 5 defines five drift layers. Layers 0-2 are
+// LOCAL: a vendored spec pinned byte-for-byte, six guard tests pinning each
+// documented number to the code it came from, and an executable conformance
+// matrix asserting every decided divergence. Each checks one claim, one file,
+// one section -- and none of them can see that the README teaches one mental
+// model while an exemplar demonstrates another, or that a ledger entry is
+// individually well-formed and collectively obsolete.
+//
+// That reading is Layer 3, and this graph is it: a periodic holistic semantic
+// review of the whole repository against the canonical spec and the stated
+// vision, producing evidence-cited findings a human triages.
+//
+// It is built as an attractor on purpose. The repo reviews itself through its
+// own engine (section 8, dogfooding) -- which also means the review is subject
+// to the doctrine it is checking: gates outside workers, evidence over
+// self-report, one exit, a budget, a loud failure.
+//
+// Invocation (per KNOWN_ISSUES: process cwd MUST equal --cwd for box nodes):
+//   RD=/abs/path/to/examples/drift-review
+//   cd <the repository under review>
+//   attractor run "$RD/drift-review.dot" \
+//       --param goal="Layer-3 holistic drift review of this repository" \
+//       --param runner_dir="$RD" \
+//       --cwd .
+//
+// Parameters:
+//   goal            The review objective, carried into every worker's prompt.
+//   runner_dir      Absolute path to this file's directory. The findings gate
+//                   runs check_findings.py from here, and every review worker
+//                   is told to read finding-contract.md from here.
+//   max_revisions   Findings-repair budget (default 2 -> at most 3 gate passes).
+//   max_reports     Report-repair budget (default 2 -> at most 3 gate passes).
+//
+// THE REPOSITORY UNDER REVIEW IS THE PROCESS WORKING DIRECTORY. There is no
+// --param for it, deliberately: a second path to configure is a second way to
+// review the wrong tree while believing you reviewed the right one. `preflight`
+// asserts the normative sources are present in the cwd and refuses otherwise.
+//
+// SHAPE (the doctrine, made visible):
+//   - THE GATE IS OUTSIDE EVERY WORKER'S CONTEXT. Four LLM reviewers PROPOSE
+//     findings; check_findings.py -- run by `findings_gate`, in the parent --
+//     DECIDES which are shaped, and it re-reads the cited files itself. A
+//     worker cannot satisfy this gate by asserting more confidently; it can
+//     only satisfy it by citing something that is actually there. This is the
+//     fabricated-convergence.jsonl lesson applied to a review instrument:
+//     verification inside the context that produced the evidence is not
+//     verification (docs/PIPELINE_DESIGN_PRINCIPLES.md section 0).
+//   - EVIDENCE ON BOTH SIDES. A finding must cite file:line for the drifting
+//     surface AND for the normative passage it contradicts. Anything less is
+//     an assertion, and a Layer-3 pass that emits assertions costs a human the
+//     read while proving nothing.
+//   - FINDINGS ARE A SUCCESS. A review that finds drift did its job; a review
+//     that finds none did its job and says what it swept. Both leave through
+//     `done`, distinguished by .drift-review/disposition (findings | clean).
+//     Only a MACHINERY failure is red -- a gate that could not run, a corpus
+//     that never got written, a budget spent without converging.
+//   - THE PIPELINE NEVER FILES ANYTHING. It reports; a human verifies each
+//     finding and decides what becomes an issue or a vision-observation
+//     (QUALITY_PROTOCOL section 4). The separation is the design: an
+//     instrument that acts on its own findings has no independent check left.
+//   - TWO CORRECTIVE LOOPS, EACH WITH ITS OWN WALL. revise <-> findings_gate
+//     repairs unshaped findings ($max_revisions); consolidate <-> report_gate
+//     repairs a report that dropped an admitted finding ($max_reports). Both
+//     counters are files owned by the gates, so they survive every re-entry.
+//   - ONE GREEN EXIT. `done` is reachable only through `report_gate`, which
+//     re-derives the finding ids from findings.json and refuses to open if the
+//     report is missing any of them.
+//
+// WHY THE BACK-EDGES DO NOT CARRY loop_restart: both cycles re-enter a GATE to
+// re-judge an artifact that was just repaired, not a fresh attempt at the whole
+// review. loop_restart resets completed nodes, which would make the (expensive,
+// already-finished) parallel review branch re-runnable -- and re-running four
+// LLM reviewers is not what "fix the citation on finding 3" means. The budgets
+// live in files rather than in $iteration for the same reason.
+//
+// VERIFIED ENGINE SEMANTICS THIS FILE DEPENDS ON:
+//   - STALE-LABEL RULE: a tool node that exits nonzero does NOT refresh
+//     tool.last_line, so a stale label can match at the same time as an
+//     outcome=fail edge. Every last_line edge below whose source also carries
+//     a failure edge conjoins `&& outcome=success`
+//     (docs/ROUTING-REFERENCE.md section 3).
+//   - error_policy=continue on a component node: one failed branch does not
+//     abort its siblings (handlers/parallel.py). The review branches carry no
+//     outcome=fail edges of their own on purpose -- a crashed reviewer shows up
+//     downstream as a missing <class>.json, which findings_gate rejects with a
+//     reason, which is a better signal than a branch quietly leaving the join.
+//   - PARAM NAMESPACE: substitution rewrites $name/${name} for any context key.
+//     The shell variables here (rd, f, c, t, n, B, mr, mv, id, fc, miss) are
+//     safe only because no param shares their name. Never add a param named
+//     like a shell var.
+// ============================================================================
+
+digraph DriftReview {
+    graph [
+        goal="$goal",
+        label="Drift Review (QUALITY_PROTOCOL Layer 3)",
+        params="goal, runner_dir, max_revisions, max_reports",
+        default_max_retries=2,
+        default_fidelity="compact",
+        max_pipeline_duration="10800s"
+    ]
+
+    start [shape=Mdiamond, label="Start"]
+    done  [shape=Msquare,  label="Done"]
+
+    // ---------- preflight: admission, before an LLM is ever paid ------------
+    // OBJECTIVE   Prove this is the repository under review and that the gate
+    //             can run, or refuse loudly.
+    // CONSTRAINTS code-tier only; no judgement.
+    // EVIDENCE    .drift-review/head-sha, .drift-review/started-at
+    // EXIT        ready | blocked (exit 1, LOUD)
+    // The normative-source check is what makes "run it in the wrong directory"
+    // a refusal rather than a review of nothing.
+    preflight [
+        shape=parallelogram, label="Preflight", max_retries=0,
+        tool_command="mkdir -p .drift-review/raw .drift-review/inventory .drift-review/postmortem || { printf blocked; exit 1; }; rd=\"$runner_dir\"; for f in check_findings.py finding-contract.md; do [ -f \"$rd/$f\" ] || { echo \"FATAL: --param runner_dir must name the examples/drift-review directory; missing $f under '$rd'\" >&2; printf blocked; exit 1; }; done; for f in git python3 grep sort wc; do command -v \"$f\" >/dev/null 2>&1 || { echo \"FATAL: '$f' is not on PATH; the inventory and the findings gate both need it\" >&2; printf blocked; exit 1; }; done; for f in specs/canonical/attractor-spec-canonical.md docs/VISION.md docs/QUALITY_PROTOCOL.md SPEC_CONFORMANCE.md specs/EXTENSIONS.md; do [ -f \"$f\" ] || { echo \"FATAL: the working directory is not the repository under review -- $f is missing. Run with --cwd at the repository root.\" >&2; printf blocked; exit 1; }; done; git rev-parse HEAD > .drift-review/head-sha 2>/dev/null || echo unknown > .drift-review/head-sha; date -u > .drift-review/started-at; printf ready"
+    ]
+
+    // ---------- inventory: enumerate the claim-bearing surfaces ------------
+    // OBJECTIVE   Turn 'the whole repo' into four explicit, countable lists, so
+    //             a reviewer's scope is a file rather than its own recollection.
+    // CONSTRAINTS code-tier only; tracked files only (git ls-files) -- an
+    //             untracked scratch file makes no claim on anyone.
+    // EVIDENCE    .drift-review/inventory/{core-docs,examples,guidance,
+    //             ledgers}.txt and summary.txt
+    // EXIT        inventoried | no_surfaces (exit 1, LOUD)
+    // A class that matches nothing is a machinery failure, not an empty
+    // result: it means the tree moved under the patterns, and a review that
+    // swept an empty list would report 'clean' about surfaces it never opened.
+    inventory [
+        shape=parallelogram, label="Inventory Claim-Bearing Surfaces", max_retries=0,
+        tool_command="t=.drift-review/inventory/_tracked.txt; git ls-files > \"$t\" 2>/dev/null || { echo 'FATAL: git ls-files failed; the surfaces under review are this repository tracked files' >&2; printf no_surfaces; exit 1; }; grep -E '^(README|PRINCIPLES|AGENTS|SUPPORT|SECURITY|CODE_OF_CONDUCT)[.]md$|^docs/[^/]+[.](md|html)$' \"$t\" | LC_ALL=C sort > .drift-review/inventory/core-docs.txt; grep -E '^examples/' \"$t\" | LC_ALL=C sort > .drift-review/inventory/examples.txt; grep -E '^(agents|skills|context|behaviors|bundles)/|^bundle[.]md$' \"$t\" | LC_ALL=C sort > .drift-review/inventory/guidance.txt; grep -E '^SPEC_CONFORMANCE[.]md$|^specs/' \"$t\" | LC_ALL=C sort > .drift-review/inventory/ledgers.txt; : > .drift-review/inventory/summary.txt; for c in core-docs examples guidance ledgers; do [ -s .drift-review/inventory/$c.txt ] || { echo \"FATAL: inventory class $c matched no tracked files; the patterns have drifted from the tree\" >&2; printf no_surfaces; exit 1; }; echo \"$c $(wc -l < .drift-review/inventory/$c.txt | tr -d ' ')\" >> .drift-review/inventory/summary.txt; done; printf inventoried"
+    ]
+
+    // ---------- the four reviewers, in parallel, in separate contexts -------
+    // Four classes because they fail differently: a doc lies in prose, an
+    // exemplar lies by demonstration, a guidance surface lies to an agent
+    // nobody is watching, and a ledger lies by staying true sentence-by-
+    // sentence while its disposition stops describing reality.
+    // error_policy=continue: one reviewer failing must not cost the other
+    // three. A missing <class>.json is caught, named and routed by the gate.
+    review_fanout [
+        shape=component,
+        label="Review Surface Classes (Parallel)",
+        join_policy="wait_all",
+        error_policy="continue",
+        max_parallel=4
+    ]
+
+    // ---------- class 1: core docs -----------------------------------------
+    // OBJECTIVE    Find where the teaching surfaces have drifted from the
+    //              normative sources.
+    // CONSTRAINTS  Report only; edit nothing outside .drift-review/. Every
+    //              finding cites file:line on BOTH sides.
+    // CAPABILITIES read the tree; read the inventory list; read the contract.
+    // EVIDENCE     .drift-review/raw/core-docs.json
+    // EXIT         the file exists, parses, and survives findings_gate.
+    review_core_docs [
+        shape=box, label="Review: Core Docs",
+        must_write=".drift-review/raw/core-docs.json",
+        prompt="LAYER-3 HOLISTIC DRIFT REVIEW -- surface class: core-docs.\n\nObjective for this run: $goal\n\nYou are one of four independent reviewers, each reading a different class of surface in the same repository. You will not see the others' work and they will not see yours; that independence is the point.\n\nFIRST, read $runner_dir/finding-contract.md IN FULL. It is the contract your output must satisfy, and a gate outside your context enforces it mechanically -- it re-opens every file you cite and checks that your quote is really there. It will send the file back with the exact reason if it is not.\n\nYOUR SCOPE is every path listed in .drift-review/inventory/core-docs.txt: the README, the root convention files, and docs/. These are the surfaces that TEACH -- a reader learns the system from them and then acts on what they learned.\n\nREAD FOR CONTEXT, then read for drift:\n  specs/canonical/attractor-spec-canonical.md   the vendored upstream nlspec\n  docs/VISION.md                                the repo's stated vision\n  SPEC_CONFORMANCE.md and specs/EXTENSIONS.md   the two ledgers\n  docs/QUALITY_PROTOCOL.md section 5            what each drift layer owns\n\nWHAT TO LOOK FOR, specifically: a paragraph that teaches behavior the engine or the doctrine has retired; a mental model a page teaches that the vision explicitly resists; vocabulary that has slipped from the spec's, so a reader who learns the word here mis-reads it there; a claim that was true when written and is not now; a page describing machinery in the present tense that does not exist, or in the future tense that already shipped.\n\nWHAT NOT TO REPORT: pinned numbers (Layer 1's six guard tests own those), ledgered divergences that flipped (Layer 2's conformance matrix owns those), typos, and the nine unresolvable issue numbers docs/QUALITY_PROTOCOL.md already names as a deliberate gap.\n\nWORK THE EVIDENCE, NOT YOUR MEMORY. For every candidate finding, open both files and copy both lines. Use your tools to get the real line numbers -- a citation you reconstructed is the exact failure the gate exists to catch, and it will bounce.\n\nWRITE .drift-review/raw/core-docs.json in the contract's shape, class core-docs, finding ids prefixed DR-CORE-. List in 'swept' every path you actually opened. Findings may be an empty list: a clean class is a real result, and saying what you swept is what makes it one. Edit nothing outside .drift-review/."
+    ]
+
+    // ---------- class 2: examples ------------------------------------------
+    review_examples [
+        shape=box, label="Review: Examples",
+        must_write=".drift-review/raw/examples.json",
+        prompt="LAYER-3 HOLISTIC DRIFT REVIEW -- surface class: examples.\n\nObjective for this run: $goal\n\nYou are one of four independent reviewers, each reading a different class of surface in the same repository. You will not see the others' work and they will not see yours; that independence is the point.\n\nFIRST, read $runner_dir/finding-contract.md IN FULL. It is the contract your output must satisfy, and a gate outside your context enforces it mechanically -- it re-opens every file you cite and checks that your quote is really there.\n\nYOUR SCOPE is every path listed in .drift-review/inventory/examples.txt: the shipped .dot graphs, their .md guides, the gate primitives, and the objective layer. An exemplar does not teach by assertion, it teaches by DEMONSTRATION -- which is why an example that contradicts doctrine is worse than a paragraph that does. A reader copies it.\n\nREAD FOR CONTEXT, then read for drift:\n  specs/canonical/attractor-spec-canonical.md   the vendored upstream nlspec\n  docs/VISION.md                                especially 'What we deliberately resist'\n  specs/EXTENSIONS.md and SPEC_CONFORMANCE.md   what this engine adds and where it diverges\n  docs/PIPELINE_DESIGN_PRINCIPLES.md sections 0-3 and docs/PIPELINE_PATTERNS.md\n\nWHAT TO LOOK FOR, specifically: a graph that hardcodes cognitive phases as nodes while the vision calls that the anti-pattern; a guide describing behavior its own .dot no longer has; an example depending on an attribute or a routing form the spec or the ledger has moved on from; two exemplars teaching incompatible mental models of the same mechanism; a sample whose comments explain a rule the graph itself stopped obeying.\n\nWHAT NOT TO REPORT: lint findings (attractor lint and test_examples_lint_clean.py own those), and anything a Layer-1 guard test already pins.\n\nWORK THE EVIDENCE, NOT YOUR MEMORY. For every candidate finding, open both files and copy both lines. Use your tools to get the real line numbers.\n\nWRITE .drift-review/raw/examples.json in the contract's shape, class examples, finding ids prefixed DR-EX-. List in 'swept' every path you actually opened. Findings may be an empty list: a clean class is a real result. Edit nothing outside .drift-review/."
+    ]
+
+    // ---------- class 3: guidance surfaces ---------------------------------
+    review_guidance [
+        shape=box, label="Review: Guidance Surfaces",
+        must_write=".drift-review/raw/guidance.json",
+        prompt="LAYER-3 HOLISTIC DRIFT REVIEW -- surface class: guidance.\n\nObjective for this run: $goal\n\nYou are one of four independent reviewers, each reading a different class of surface in the same repository. You will not see the others' work and they will not see yours; that independence is the point.\n\nFIRST, read $runner_dir/finding-contract.md IN FULL. It is the contract your output must satisfy, and a gate outside your context enforces it mechanically -- it re-opens every file you cite and checks that your quote is really there.\n\nYOUR SCOPE is every path listed in .drift-review/inventory/guidance.txt: agents/, skills/, context/, behaviors/, bundles/ and bundle.md. These steer models, usually with no human reading along. A stale instruction here does not mislead a reader -- it silently produces wrong work, over and over, and nobody sees the sentence that caused it.\n\nREAD FOR CONTEXT, then read for drift:\n  specs/canonical/attractor-spec-canonical.md   the vendored upstream nlspec\n  docs/VISION.md                                'Operating principles' and 'What we deliberately resist'\n  specs/EXTENSIONS.md and SPEC_CONFORMANCE.md   what this engine adds and where it diverges\n  context/engine-semantics.md                   the bundle's declared source of truth for shipped-engine behavior\n\nWHAT TO LOOK FOR, specifically: a system prompt or agent brief teaching an engine behavior that has since changed; guidance that steers a model toward a shape the vision explicitly resists; a skill or context file whose vocabulary has drifted from the spec's so a model uses the word wrongly downstream; a capability described as available that the ledger records as not implemented, or vice versa; guidance that contradicts what another guidance surface tells a model to do about the same mechanism.\n\nWHAT NOT TO REPORT: pinned numbers and ledgered divergences -- Layers 1 and 2 own those.\n\nWORK THE EVIDENCE, NOT YOUR MEMORY. For every candidate finding, open both files and copy both lines. Use your tools to get the real line numbers.\n\nWRITE .drift-review/raw/guidance.json in the contract's shape, class guidance, finding ids prefixed DR-GUIDE-. List in 'swept' every path you actually opened. Findings may be an empty list: a clean class is a real result. Edit nothing outside .drift-review/."
+    ]
+
+    // ---------- class 4: ledgers vs repo -----------------------------------
+    review_ledgers [
+        shape=box, label="Review: Ledger vs Repo",
+        must_write=".drift-review/raw/ledgers.json",
+        prompt="LAYER-3 HOLISTIC DRIFT REVIEW -- surface class: ledgers.\n\nObjective for this run: $goal\n\nYou are one of four independent reviewers, each reading a different class of surface in the same repository. You will not see the others' work and they will not see yours; that independence is the point.\n\nFIRST, read $runner_dir/finding-contract.md IN FULL. It is the contract your output must satisfy, and a gate outside your context enforces it mechanically -- it re-opens every file you cite and checks that your quote is really there.\n\nYOUR SCOPE is every path listed in .drift-review/inventory/ledgers.txt: SPEC_CONFORMANCE.md, specs/EXTENSIONS.md, specs/conformance/ and specs/canonical/. Your question is the one docs/QUALITY_PROTOCOL.md says only a whole-repo read can answer: is a ledger entry individually well-formed and COLLECTIVELY obsolete? Structural integrity is already guarded (test_extensions_ledger_integrity.py); numbering and banners are not your job.\n\nWHAT TO LOOK FOR, specifically: an entry whose disposition no longer describes what the engine or the repo actually does; an entry describing a divergence the vendored canonical spec has since absorbed or contradicted; two entries that are each defensible and mutually inconsistent; an entry naming an artifact, guard, module or path that has moved or vanished; a conformance-matrix row whose stated rationale has drifted from the ledger row it cites; a stated retirement condition that has demonstrably fired without the entry being retired.\n\nBECAUSE PARTS OF YOUR SCOPE ARE THEMSELVES NORMATIVE, remember the contract's rule: 'drift' and 'contradicts' must be DIFFERENT files. A ledger entry that contradicts the vendored spec is a finding whose drifting side is the ledger and whose normative side is specs/canonical/.\n\nWHAT NOT TO REPORT: heading numbering, banner grammar, and anything test_extensions_ledger_integrity.py or test_spec_conformance_matrix.py already asserts.\n\nWORK THE EVIDENCE, NOT YOUR MEMORY. For every candidate finding, open both files and copy both lines. Use your tools to get the real line numbers.\n\nWRITE .drift-review/raw/ledgers.json in the contract's shape, class ledgers, finding ids prefixed DR-LEDGER-. List in 'swept' every path you actually opened. Findings may be an empty list: a clean class is a real result. Edit nothing outside .drift-review/."
+    ]
+
+    reviews_join [shape=tripleoctagon, label="Collect Class Findings"]
+
+    // ---------- findings_gate: the load-bearing gate ------------------------
+    // OBJECTIVE    Decide which proposed findings are SHAPED -- by re-opening
+    //              every cited file here, in the parent, outside every
+    //              reviewer's context.
+    // CONSTRAINTS  Files and exit codes only. Never a worker's self-report.
+    //              Shape, not truth: whether the drift is REAL is a human's
+    //              call, and the report says so.
+    // CAPABILITIES check_findings.py; the repository tree.
+    // EVIDENCE     .drift-review/findings-report.txt (always),
+    //              .drift-review/findings.json (only when admitted)
+    // EXIT         findings_ok | findings_bad | revise_exhausted
+    // Idiom A (always exit 0) so tool.last_line is always fresh. A nonzero exit
+    // here means the GATE could not run -- the raw directory is gone, the
+    // report is unwritable -- which is a different thing from bad findings, and
+    // it routes differently: to the loud terminal, not to a repair.
+    // THE COUNTER LIVES IN THE SCRIPT (--max-revisions, .drift-review/revise-
+    // iter), so every rejected round spends budget no matter which reviewer
+    // caused it, and the wall survives every re-entry.
+    findings_gate [
+        shape=parallelogram, label="Findings Shaped?", max_retries=0,
+        tool_command="mv=$max_revisions; python3 \"$runner_dir/check_findings.py\" --raw-dir .drift-review/raw --repo-root . --state-dir .drift-review --classes core-docs,examples,guidance,ledgers --max-revisions \"${mv:-2}\""
+    ]
+
+    // ---------- revise: repair the citations, not the conclusions -----------
+    // OBJECTIVE    Make every rejected finding satisfy the contract, or drop
+    //              the ones that cannot.
+    // CONSTRAINTS  Do not invent findings. Do not weaken a finding to get past
+    //              the gate. Dropping an uncitable finding is the honest move.
+    // EVIDENCE     the repaired .drift-review/raw/*.json files
+    // EXIT         findings_gate admits the corpus.
+    // A finding that cannot be cited is not a finding this instrument can
+    // ship: the human triaging it would have to re-derive the evidence, which
+    // is the work the review was supposed to have done.
+    revise [
+        shape=box, label="Repair Findings",
+        prompt="The findings gate REJECTED this round. Read .drift-review/findings-report.txt: it names every rejection, by file, by finding, with the reason.\n\nRead $runner_dir/finding-contract.md again for the rules you are being held to.\n\nFix exactly what the report names, in .drift-review/raw/*.json. Nothing else. Specifically:\n  - A citation whose quote did not resolve: OPEN the cited file, find the text you meant, and correct the line number and the quote to what is actually there. Do not adjust the quote to fit the line -- adjust the citation to fit the evidence.\n  - A citation whose file does not exist: find the real path, or drop the finding.\n  - A 'contradicts' side that is not a normative source: either cite the spec, vision or ledger passage the surface really contradicts, or drop the finding. Do not retarget it at a random normative file to satisfy the rule.\n  - A missing <class>.json: that reviewer produced nothing. Write the file honestly -- record what that class swept, with an empty findings list if you cannot review it yourself.\n  - A malformed field: fix the field.\n\nDROPPING A FINDING IS A LEGITIMATE REPAIR and often the right one. A finding whose evidence you cannot locate is not a finding; shipping it would cost a human the read and teach them to distrust the instrument.\n\nDo not add new findings in this pass, do not restate accepted ones, and edit nothing outside .drift-review/."
+    ]
+
+    // ---------- consolidate: the report a human will actually read ----------
+    // OBJECTIVE    Turn the admitted corpus into the deliverable.
+    // CONSTRAINTS  Report every admitted finding; invent none; fix none.
+    // EVIDENCE     .drift-review/report.md
+    // EXIT         report_gate admits it (must_write + the id check).
+    consolidate [
+        shape=box, label="Consolidate Report",
+        must_write=".drift-review/report.md",
+        prompt="The findings gate admitted this round's corpus. Write the deliverable.\n\nRead .drift-review/findings.json (every admitted finding, already sorted by severity), .drift-review/findings-report.txt (the admission summary), .drift-review/inventory/summary.txt (how many surfaces each class holds), .drift-review/inventory/*.txt, and .drift-review/head-sha.\n\nWrite .drift-review/report.md. It must contain:\n  1. A header: the commit reviewed (from head-sha), the date, and which QUALITY_PROTOCOL section 6 triggers this pass answers.\n  2. WHAT WAS SWEPT -- name all four classes by their exact names (core-docs, examples, guidance, ledgers), with the count of surfaces each holds and what that class covers. A gate checks that all four names appear: a review that quietly skipped a class must not read as a clean one.\n  3. A findings table: id, severity, class, title.\n  4. One section per finding, in severity order. Quote BOTH sides with their file:line, verbatim from findings.json, then the 'why'. Every finding id in findings.json must appear literally in this report -- a gate outside your context re-derives the ids and refuses the report if any is missing.\n  5. A disposition sentence: either 'this review found N findings' or 'this review found no drift', stated plainly.\n  6. WHAT HAPPENS NEXT: a human verifies each finding by reading both cited sides, then decides what becomes an issue or a vision-observation. State explicitly that this pipeline files nothing and fixes nothing.\n\nIf findings.json holds zero findings, that is a RESULT and the report says so: what was swept, against which normative sources, and that nothing contradicted them. Do not pad it into sounding like a failure, and do not invent findings to justify the run.\n\nReport only. Fix nothing. Edit nothing outside .drift-review/."
+    ]
+
+    // ---------- report_gate: refuse a green exit that drops a finding -------
+    // OBJECTIVE    Make 'the run ended' and 'the report carries every admitted
+    //              finding' the same event.
+    // CONSTRAINTS  deterministic checks only; it re-derives the ids from
+    //              findings.json rather than believing the report's own table.
+    // EVIDENCE     .drift-review/report-gate.txt, .drift-review/disposition
+    // EXIT         report_ok | report_bad | report_exhausted | no_corpus(exit 1)
+    // ON goal_gate=true, HONESTLY: this node uses Idiom A for its judgements,
+    // and a tool node's exit 0 is an explicit SUCCESS verdict, so the engine's
+    // exit-time gate check cannot itself fail here. It is kept as a
+    // DECLARATION of which node owns the verdict -- the same honesty
+    // examples/objective/objective-runner.dot records about its evidence_gate.
+    // The enforcement that really holds is structural: `done` has exactly one
+    // incoming edge and it is this node's report_ok.
+    report_gate [
+        shape=parallelogram, label="Report Complete?", max_retries=0,
+        goal_gate=true, retry_target="consolidate",
+        tool_command="mr=$max_reports; B=${mr:-2}; n=$(($(cat .drift-review/report-iter 2>/dev/null || echo 0)+1)); echo $n > .drift-review/report-iter; if [ ! -s .drift-review/findings.json ]; then echo 'FATAL: .drift-review/findings.json is absent -- the findings gate never admitted a corpus, so there is nothing to report on' >&2; printf no_corpus; exit 1; fi; fc=$(grep -o '\"finding_count\": [0-9]*' .drift-review/findings.json | head -1 | tr -cd '0-9'); if [ \"${fc:-0}\" -gt 0 ]; then echo findings > .drift-review/disposition; else echo clean > .drift-review/disposition; fi; if [ \"$n\" -gt $((B+1)) ]; then printf report_exhausted; else : > .drift-review/report-gate.txt; miss=0; if [ ! -s .drift-review/report.md ]; then echo 'report.md is missing or empty' >> .drift-review/report-gate.txt; miss=1; else for id in $(grep -o '\"id\": \"[^\"]*\"' .drift-review/findings.json | cut -d'\"' -f4); do grep -qF \"$id\" .drift-review/report.md || { echo \"admitted finding $id never appears in report.md\" >> .drift-review/report-gate.txt; miss=1; }; done; for c in core-docs examples guidance ledgers; do grep -qF \"$c\" .drift-review/report.md || { echo \"report.md never names the swept surface class $c\" >> .drift-review/report-gate.txt; miss=1; }; done; fi; if [ \"$miss\" -eq 0 ]; then printf report_ok; else printf report_bad; fi; fi"
+    ]
+
+    // ---------- postmortem -> escalated: salvage, then fail LOUD ------------
+    postmortem [
+        shape=box, label="Postmortem",
+        must_write=".drift-review/postmortem/report.md",
+        prompt="This Layer-3 review reached a decision point without producing a report: $goal\n\nRead .drift-review/findings-report.txt, .drift-review/report-gate.txt (if it exists), .drift-review/inventory/summary.txt, and whatever is in .drift-review/raw/. Write .drift-review/postmortem/report.md: which stage stalled, what each round attempted, and -- specifically -- whether the failure was in the REVIEWERS (could not cite what they claimed), in the CONTRACT (the shape rules reject findings that are actually sound), in the MACHINERY (a gate or the inventory), or in the SCOPE (the classes are too large for one pass). Then state the options: relax nothing, but say whether to re-run, re-scope, raise a budget, or take it to a human.\n\nBe honest, and be specific about what was salvageable: if some classes produced admitted findings and one did not, say which, because a partial sweep is worth more to a human than a discarded run. This report is the value salvaged from a non-converging review."
+    ]
+
+    // Escalation is a deterministic non-terminal handoff, not a second
+    // successful exit. It writes a handoff even if the postmortem LLM itself
+    // failed, then exits 1 DELIBERATELY: max_retries=0 and no fail-route, so
+    // the engine hard-fails LOUD (run status=fail, CLI exit 1).
+    escalated [
+        shape=parallelogram, label="Escalated", max_retries=0,
+        tool_command="mkdir -p .drift-review/postmortem; if [ -s .drift-review/postmortem/report.md ]; then echo 'Read .drift-review/postmortem/report.md and .drift-review/findings-report.txt, then choose: re-run, re-scope the classes, raise a budget, or review by hand.' > .drift-review/postmortem/escalation.md; else echo 'The Layer-3 review could not run. Preserve .drift-review/ and escalate to a human.' > .drift-review/postmortem/escalation.md; fi; echo escalated > .drift-review/disposition; printf escalated; exit 1"
+    ]
+
+    // ========================= edges =========================
+    start -> preflight
+
+    preflight -> inventory [condition="context.tool.last_line=ready && outcome=success", label="preconditions hold"]
+    preflight -> escalated [condition="outcome=fail",                                    label="blocked -- refuse before spending an LLM"]
+
+    inventory -> review_fanout [condition="context.tool.last_line=inventoried && outcome=success", label="surfaces enumerated"]
+    inventory -> escalated     [condition="outcome=fail",                                          label="no surfaces -- the patterns lost the tree"]
+
+    review_fanout -> review_core_docs
+    review_fanout -> review_examples
+    review_fanout -> review_guidance
+    review_fanout -> review_ledgers
+
+    review_core_docs -> reviews_join
+    review_examples  -> reviews_join
+    review_guidance  -> reviews_join
+    review_ledgers   -> reviews_join
+
+    reviews_join -> findings_gate
+
+    findings_gate -> consolidate [condition="context.tool.last_line=findings_ok && outcome=success",      label="every finding is shaped"]
+    findings_gate -> revise      [condition="context.tool.last_line=findings_bad && outcome=success",     label="unshaped -- repair the citations"]
+    findings_gate -> postmortem  [condition="context.tool.last_line=revise_exhausted && outcome=success", label="revision budget spent"]
+    findings_gate -> escalated   [condition="outcome=fail",                                               label="gate could not run"]
+
+    // The corrective cycle: back to the gate that owns the verdict.
+    revise -> findings_gate
+    revise -> postmortem [condition="outcome=fail", label="hard failure"]
+
+    consolidate -> report_gate
+    consolidate -> postmortem [condition="outcome=fail", label="hard failure"]
+
+    report_gate -> done        [condition="context.tool.last_line=report_ok && outcome=success",        label="report carries every admitted finding"]
+    report_gate -> consolidate [condition="context.tool.last_line=report_bad && outcome=success",       label="report dropped a finding -- rewrite"]
+    report_gate -> postmortem  [condition="context.tool.last_line=report_exhausted && outcome=success", label="report budget spent"]
+    report_gate -> escalated   [condition="outcome=fail",                                               label="no corpus -- refuse to exit green"]
+
+    postmortem -> escalated [condition="outcome=fail", label="postmortem failed"]
+    postmortem -> escalated [label="escalate"]
+}

--- a/examples/drift-review/drift-review.dot
+++ b/examples/drift-review/drift-review.dot
@@ -243,6 +243,16 @@ digraph DriftReview {
     //              findings.json rather than believing the report's own table.
     // EVIDENCE     .drift-review/report-gate.txt, .drift-review/disposition
     // EXIT         report_ok | report_bad | report_exhausted | no_corpus(exit 1)
+    // BUDGET       n counts gate passes, B is $max_reports. The gate JUDGES on
+    //              every pass and only then spends the budget: a pass with
+    //              n<=B that finds a gap says report_bad (repair); the pass at
+    //              n=B+1 that still finds one says report_exhausted. So B
+    //              repairs, at most B+1 gate passes, and every repair IS
+    //              judged -- the same arithmetic check_findings.py applies to
+    //              $max_revisions. Two walls in one graph, documented
+    //              identically above, must mean identically. Spending the
+    //              budget BEFORE judging (the earlier `n > B+1`) bought a
+    //              third repair whose output was then thrown away unread.
     // ON goal_gate=true, HONESTLY: this node uses Idiom A for its judgements,
     // and a tool node's exit 0 is an explicit SUCCESS verdict, so the engine's
     // exit-time gate check cannot itself fail here. It is kept as a
@@ -253,7 +263,7 @@ digraph DriftReview {
     report_gate [
         shape=parallelogram, label="Report Complete?", max_retries=0,
         goal_gate=true, retry_target="consolidate",
-        tool_command="mr=$max_reports; B=${mr:-2}; n=$(($(cat .drift-review/report-iter 2>/dev/null || echo 0)+1)); echo $n > .drift-review/report-iter; if [ ! -s .drift-review/findings.json ]; then echo 'FATAL: .drift-review/findings.json is absent -- the findings gate never admitted a corpus, so there is nothing to report on' >&2; printf no_corpus; exit 1; fi; fc=$(grep -o '\"finding_count\": [0-9]*' .drift-review/findings.json | head -1 | tr -cd '0-9'); if [ \"${fc:-0}\" -gt 0 ]; then echo findings > .drift-review/disposition; else echo clean > .drift-review/disposition; fi; if [ \"$n\" -gt $((B+1)) ]; then printf report_exhausted; else : > .drift-review/report-gate.txt; miss=0; if [ ! -s .drift-review/report.md ]; then echo 'report.md is missing or empty' >> .drift-review/report-gate.txt; miss=1; else for id in $(grep -o '\"id\": \"[^\"]*\"' .drift-review/findings.json | cut -d'\"' -f4); do grep -qF \"$id\" .drift-review/report.md || { echo \"admitted finding $id never appears in report.md\" >> .drift-review/report-gate.txt; miss=1; }; done; for c in core-docs examples guidance ledgers; do grep -qF \"$c\" .drift-review/report.md || { echo \"report.md never names the swept surface class $c\" >> .drift-review/report-gate.txt; miss=1; }; done; fi; if [ \"$miss\" -eq 0 ]; then printf report_ok; else printf report_bad; fi; fi"
+        tool_command="mr=$max_reports; B=${mr:-2}; n=$(($(cat .drift-review/report-iter 2>/dev/null || echo 0)+1)); echo $n > .drift-review/report-iter; if [ ! -s .drift-review/findings.json ]; then echo 'FATAL: .drift-review/findings.json is absent -- the findings gate never admitted a corpus, so there is nothing to report on' >&2; printf no_corpus; exit 1; fi; fc=$(grep -o '\"finding_count\": [0-9]*' .drift-review/findings.json | head -1 | tr -cd '0-9'); if [ \"${fc:-0}\" -gt 0 ]; then echo findings > .drift-review/disposition; else echo clean > .drift-review/disposition; fi; : > .drift-review/report-gate.txt; miss=0; if [ ! -s .drift-review/report.md ]; then echo 'report.md is missing or empty' >> .drift-review/report-gate.txt; miss=1; else for id in $(grep -o '\"id\": \"[^\"]*\"' .drift-review/findings.json | cut -d'\"' -f4); do grep -qF \"$id\" .drift-review/report.md || { echo \"admitted finding $id never appears in report.md\" >> .drift-review/report-gate.txt; miss=1; }; done; for c in core-docs examples guidance ledgers; do grep -qF \"$c\" .drift-review/report.md || { echo \"report.md never names the swept surface class $c\" >> .drift-review/report-gate.txt; miss=1; }; done; fi; if [ \"$miss\" -eq 0 ]; then printf report_ok; elif [ \"$n\" -gt \"$B\" ]; then printf report_exhausted; else printf report_bad; fi"
     ]
 
     // ---------- postmortem -> escalated: salvage, then fail LOUD ------------

--- a/examples/drift-review/finding-contract.md
+++ b/examples/drift-review/finding-contract.md
@@ -1,0 +1,167 @@
+# The finding contract
+
+What a Layer-3 drift-review worker must write, and what `check_findings.py` will
+mechanically reject. Read this in full before you write anything.
+
+The gate that enforces this runs **outside your context**. It cannot be argued
+with, it did not read your reasoning, and it will send the file back with the
+exact reason. That is deliberate: *verification inside the context that produced
+the evidence is not verification* (`docs/PIPELINE_DESIGN_PRINCIPLES.md` section
+0). Your job is to produce findings a stranger can check.
+
+---
+
+## What you are looking for
+
+`docs/QUALITY_PROTOCOL.md` section 5 defines five drift layers. Layers 0-2 are
+**local**: a vendored spec pinned byte-for-byte, six guard tests pinning
+documented numbers to the code they came from, and an executable conformance
+matrix asserting every decided divergence. They are already running in CI, and
+they already catch everything they can see.
+
+Layer 3 is what they structurally cannot see:
+
+> "None of them can see that the README teaches one mental model while an
+> exemplar demonstrates another, or that a ledger entry is individually
+> well-formed and collectively obsolete."
+
+Concretely, the finding species worth reporting:
+
+- **A paragraph teaching retired behavior.** The text was true when written; the
+  code or the doctrine moved, and the page did not.
+- **An example contradicting doctrine.** A shipped exemplar demonstrates the
+  shape the vision explicitly resists, or its guide describes behavior its graph
+  no longer has.
+- **Vocabulary drift.** A surface names a concept differently from the canonical
+  spec, so a reader who learns here mis-reads there.
+- **A ledger entry individually well-formed and collectively obsolete.** The row
+  parses, the banner is legal, and the disposition no longer describes reality.
+- **A guidance surface steering an agent against a stated principle.** What
+  `agents/`, `skills/`, `context/` tell a model to do, versus what the vision
+  says the project is.
+
+What is **not** a Layer-3 finding, because something else already owns it:
+
+- A pinned number disagreeing with its source (Layer 1's six guard files).
+- A ledgered divergence that flipped (Layer 2's conformance matrix).
+- A typo, a broken relative link, a stale issue number. Real, but this is not
+  the instrument for it — and the quality protocol already names the issue
+  numbers as a known, deliberate gap.
+
+---
+
+## The shape
+
+Write exactly one JSON file for your class, at
+`.drift-review/raw/<class>.json`:
+
+```json
+{
+  "class": "core-docs",
+  "swept": [
+    "README.md",
+    "docs/GETTING-STARTED.md"
+  ],
+  "findings": [
+    {
+      "id": "DR-CORE-001",
+      "class": "core-docs",
+      "severity": "high",
+      "title": "One line naming the contradiction, not the topic",
+      "drift": {
+        "file": "docs/SOME-GUIDE.md",
+        "line": 214,
+        "quote": "verbatim text copied off that line"
+      },
+      "contradicts": {
+        "file": "specs/canonical/attractor-spec-canonical.md",
+        "line": 981,
+        "quote": "verbatim text copied off that line"
+      },
+      "why": "What the contradiction IS, and what a reader would get wrong."
+    }
+  ]
+}
+```
+
+`swept` is **required and non-empty even when you find nothing.** A zero-finding
+class still has to say what it read — otherwise "no drift found" and "nothing
+was looked at" are the same record, and the first is a result while the second
+is a failure wearing its clothes.
+
+---
+
+## What the gate checks, rule by rule
+
+**Both sides carry `file`, `line`, `quote`.** All three, on `drift` and on
+`contradicts`. A finding with one side is an assertion.
+
+**Both files resolve against the actual tree.** Repo-relative, existing, a
+regular file, inside the repository. Not remembered, not reconstructed.
+
+**Both line numbers are in range** for the file as it exists right now.
+
+**Both quotes appear where you said they do.** The quote must occur, verbatim,
+within a small window around the cited line (2 lines before, 6 after —
+whitespace differences are tolerated so a reflowed markdown paragraph still
+resolves; invented text is not). **Open the file and copy the line.** A quote
+reconstructed from memory is exactly the failure this rule exists to catch.
+
+**Each quote is at least 16 characters** after whitespace normalization. A
+three-word quote anchors nothing.
+
+**`contradicts.file` is a normative source.** One of:
+
+| Source | What it is |
+|---|---|
+| `specs/canonical/` | the vendored upstream nlspec, pinned byte-for-byte (Layer 0) |
+| `docs/VISION.md` | the repo's stated vision |
+| `SPEC_CONFORMANCE.md` | the conformance ledger |
+| `specs/EXTENSIONS.md` | the extensions ledger |
+| `specs/conformance/` | the executable conformance matrix |
+
+This is the definition of drift, not a formatting preference. Two non-normative
+surfaces disagreeing is a proofreading note; a surface disagreeing with one of
+these is drift. If you cannot name the normative passage a thing contradicts,
+you have found something else — and Layer 3 is not the place to file it.
+
+**`drift.file` and `contradicts.file` are different files.** A finding names a
+drifting surface *and* the separate passage it moved away from.
+
+**`severity` is one of `critical`, `high`, `medium`, `low`.** The human triaging
+this sorts by that field, so an invented value costs them the sort.
+
+**`id` is unique across all four classes** and matches `[A-Za-z0-9][A-Za-z0-9._-]{2,63}`.
+Use your class prefix so ids cannot collide: `DR-CORE-`, `DR-EX-`, `DR-GUIDE-`,
+`DR-LEDGER-`.
+
+**`title` is at least 12 characters, `why` at least 40.** `why` carries the
+argument. A citation pair with no argument is a coincidence of two files
+mentioning the same word.
+
+---
+
+## Severity, calibrated
+
+| Severity | Use when |
+|---|---|
+| `critical` | A reader following this surface would ship something wrong, or the surface asserts the opposite of a normative source |
+| `high` | Teaches a retired behavior or a rejected mental model; a reader learns something they will have to unlearn |
+| `medium` | Vocabulary or framing has drifted; the reader is not misled about behavior but is misled about the model |
+| `low` | Stale in a way a careful reader recovers from unaided |
+
+---
+
+## What you must not do
+
+**Do not fix anything.** This review reports; a human triages and files. The
+separation is the design: a reviewer that edits what it reviews has re-entered
+the context it was supposed to stay outside of. Write nothing outside
+`.drift-review/`.
+
+**Do not pad.** A finding whose citations do not resolve is worse than no
+finding: it costs a human the read and it teaches them to distrust the
+instrument. Ten checkable findings beat forty claims.
+
+**Do not report zero findings as a failure.** A clean class is a result. Say
+what you swept, and say it found nothing.

--- a/examples/drift-review/finding-contract.md
+++ b/examples/drift-review/finding-contract.md
@@ -128,6 +128,12 @@ you have found something else — and Layer 3 is not the place to file it.
 **`drift.file` and `contradicts.file` are different files.** A finding names a
 drifting surface *and* the separate passage it moved away from.
 
+**Both rules above judge the path your citation *resolves to*.** Write plain
+repo-relative paths. `specs/canonical/../../docs/SOME-DOC.md` is not a citation
+of `specs/canonical/`, and `specs/canonical/../../README.md` is not a different
+file from `README.md` — the gate resolves both before it decides, so a traversal
+buys exactly nothing except a rejection that names it.
+
 **`severity` is one of `critical`, `high`, `medium`, `low`.** The human triaging
 this sorts by that field, so an invented value costs them the sort.
 

--- a/modules/loop-pipeline/tests/test_drift_review_gate.py
+++ b/modules/loop-pipeline/tests/test_drift_review_gate.py
@@ -30,6 +30,9 @@ from __future__ import annotations
 import copy
 import importlib.util
 import json
+import os
+import shutil
+import subprocess
 import sys
 from pathlib import Path
 from types import ModuleType
@@ -94,6 +97,20 @@ _VISION = """# Vision
 Fail loud; never fall back silently.
 """
 
+#: NOT in NORMATIVE_PREFIXES -- this is where the traversal cases try to land.
+_QUALITY_PROTOCOL = """# Quality Protocol
+
+## 5. Drift layers
+Layer 3 is the periodic holistic semantic review of the whole repository.
+Filler line.
+"""
+
+#: README carries a real sentence so a traversal case can quote it at file:line.
+_README = """# Readme
+
+The repository ships a convergence loop exemplar for new authors.
+"""
+
 
 @pytest.fixture()
 def repo(tmp_path: Path) -> Path:
@@ -103,8 +120,9 @@ def repo(tmp_path: Path) -> Path:
     (root / "specs" / "canonical").mkdir(parents=True)
     (root / "docs" / "SOME-GUIDE.md").write_text(_DRIFTING_DOC, encoding="utf-8")
     (root / "docs" / "VISION.md").write_text(_VISION, encoding="utf-8")
+    (root / "docs" / "QUALITY_PROTOCOL.md").write_text(_QUALITY_PROTOCOL, encoding="utf-8")
     (root / "specs" / "canonical" / "spec.md").write_text(_NORMATIVE_SPEC, encoding="utf-8")
-    (root / "README.md").write_text("# Readme\n\nfiller\n", encoding="utf-8")
+    (root / "README.md").write_text(_README, encoding="utf-8")
     return root
 
 
@@ -308,6 +326,92 @@ def test_rejects_a_finding_that_cites_the_same_file_on_both_sides(checker, repo,
     assert "are the same file" in _report(repo)
 
 
+# ---------------------------------------------------------------------------
+# Path traversal -- the closed set is only as closed as the path it tests
+# ---------------------------------------------------------------------------
+#
+# Both cases below were REPRODUCED as admissions by an adversarial review while
+# `check_finding` tested the raw citation STRING. `resolve_in_tree` now hands
+# back the resolved repo-relative path and both rules judge that instead.
+
+
+_QP_QUOTE = "Layer 3 is the periodic holistic semantic review of the whole repository."
+_README_QUOTE = "The repository ships a convergence loop exemplar for new authors."
+
+
+def test_rejects_a_contradicts_citation_that_traverses_out_of_the_normative_set(
+    checker, repo, capsys
+):
+    """`specs/canonical/../../docs/QUALITY_PROTOCOL.md` satisfies startswith(), lands outside.
+
+    Pre-fix this was ADMITTED: the raw string begins with `specs/canonical/`, so
+    the closed-set test passed while the citation pointed at a doc that is not
+    normative at all -- which would let a Layer-3 finding measure drift against
+    a surface that is itself drifting.
+    """
+    corpus = _corpus()
+    corpus["core-docs"]["findings"][0]["contradicts"] = {
+        "file": "specs/canonical/../../docs/QUALITY_PROTOCOL.md",
+        "line": 4,
+        "quote": _QP_QUOTE,
+    }
+    _write(repo, corpus)
+    assert _run(checker, repo) == 0
+    assert capsys.readouterr().out == "findings_bad"
+    report = _report(repo)
+    assert "is not a normative source" in report
+    # And it names the traversal, so the human triaging the report sees the dodge
+    # rather than a confusing complaint about a path that looks compliant.
+    assert "which resolves to 'docs/QUALITY_PROTOCOL.md'" in report
+
+
+def test_rejects_the_same_file_dodged_through_a_traversal(checker, repo, capsys):
+    """`README.md` vs `specs/canonical/../../README.md`: two strings, one file.
+
+    Pre-fix this was ADMITTED twice over -- the raw strings differ, so the
+    different-files rule passed, and the second one begins with
+    `specs/canonical/`, so the closed-set rule passed too. A finding could
+    therefore cite one file against itself and call it drift.
+    """
+    corpus = _corpus()
+    finding = corpus["core-docs"]["findings"][0]
+    finding["drift"] = {"file": "README.md", "line": 3, "quote": _README_QUOTE}
+    finding["contradicts"] = {
+        "file": "specs/canonical/../../README.md",
+        "line": 3,
+        "quote": _README_QUOTE,
+    }
+    _write(repo, corpus)
+    assert _run(checker, repo) == 0
+    assert capsys.readouterr().out == "findings_bad"
+    assert "are the same file" in _report(repo)
+
+
+def test_the_different_files_rule_holds_inside_the_normative_set_too(checker, repo, capsys):
+    """A traversal that lands back on the same *normative* file: only one rule can fire.
+
+    Both sides resolve to `specs/canonical/spec.md`, so the closed-set rule is
+    satisfied and cannot be what rejects this. That isolates the different-files
+    half of the fix from the closed-set half.
+    """
+    corpus = _corpus()
+    finding = corpus["core-docs"]["findings"][0]
+    spec_cite = {
+        "file": "specs/canonical/spec.md",
+        "line": 12,
+        "quote": "No matching edge is a hard failure and the run stops loudly.",
+    }
+    finding["drift"] = copy.deepcopy(spec_cite)
+    finding["contradicts"] = copy.deepcopy(spec_cite)
+    finding["contradicts"]["file"] = "specs/canonical/../canonical/spec.md"
+    _write(repo, corpus)
+    assert _run(checker, repo) == 0
+    assert capsys.readouterr().out == "findings_bad"
+    report = _report(repo)
+    assert "are the same file" in report
+    assert "is not a normative source" not in report
+
+
 def test_rejects_duplicate_finding_ids_across_classes(checker, repo, capsys):
     """Ids are the handle a human triages by; a collision silently merges two."""
     corpus = _corpus()
@@ -410,6 +514,85 @@ def test_a_gate_that_cannot_run_exits_nonzero_with_no_token(checker, repo, capsy
     argv[index] = str(repo / "no-such-directory")
     assert checker.main(argv) != 0
     assert capsys.readouterr().out == ""
+
+
+# ---------------------------------------------------------------------------
+# The report-repair budget, executed through the shell the pipeline really runs
+# ---------------------------------------------------------------------------
+
+_SHELL_GATE = pytest.mark.skipif(
+    not shutil.which("sh"), reason="the shipped report_gate command needs a POSIX shell"
+)
+
+
+def _report_gate_command() -> str:
+    """The verbatim tool_command of `report_gate`, read through the engine's parser."""
+    from amplifier_module_loop_pipeline.dot_parser import parse_dot
+
+    graph = parse_dot(_DOT_PATH.read_text(encoding="utf-8"))
+    return str(graph.nodes["report_gate"].attrs["tool_command"])
+
+
+def _report_gate_workspace(tmp_path: Path) -> Path:
+    """A workspace holding an admitted corpus and a report that drops its finding."""
+    state = tmp_path / ".drift-review"
+    state.mkdir()
+    (state / "findings.json").write_text(
+        '{"finding_count": 1, "findings": [{"id": "DR-001"}]}\n', encoding="utf-8"
+    )
+    (state / "report.md").write_text(
+        "a report naming neither the admitted finding nor the swept classes\n", encoding="utf-8"
+    )
+    return tmp_path
+
+
+def _run_report_gate(workspace: Path, max_reports: str = "2") -> str:
+    result = subprocess.run(
+        _report_gate_command(),
+        shell=True,
+        cwd=workspace,
+        env={**os.environ, "max_reports": max_reports},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout
+
+
+def _complete_report(workspace: Path) -> None:
+    (workspace / ".drift-review" / "report.md").write_text(
+        "DR-001 across core-docs, examples, guidance, ledgers\n", encoding="utf-8"
+    )
+
+
+@_SHELL_GATE
+def test_the_report_repair_budget_is_the_one_the_header_documents(tmp_path):
+    """`max_reports=2` buys 2 repairs across at most 3 gate passes -- as documented.
+
+    The header and README both say "default 2 -> at most 3 gate passes", and
+    `check_findings.py` spends `--max-revisions` exactly that way. This gate
+    tested its budget BEFORE judging (`n -gt B+1`), which granted a third repair
+    and landed exhaustion on pass 4.
+    """
+    workspace = _report_gate_workspace(tmp_path)
+    verdicts = [_run_report_gate(workspace) for _ in range(3)]
+    assert verdicts == ["report_bad", "report_bad", "report_exhausted"]
+
+
+@_SHELL_GATE
+def test_the_last_permitted_repair_is_still_judged(tmp_path):
+    """The budget is spent on the verdict, never instead of it.
+
+    A wall that fires before reading `report.md` throws away the work of the
+    repair it just paid for. The final permitted pass must still be able to say
+    `report_ok`.
+    """
+    workspace = _report_gate_workspace(tmp_path)
+    assert _run_report_gate(workspace) == "report_bad"
+    assert _run_report_gate(workspace) == "report_bad"
+    _complete_report(workspace)
+    assert _run_report_gate(workspace) == "report_ok"
 
 
 # ---------------------------------------------------------------------------

--- a/modules/loop-pipeline/tests/test_drift_review_gate.py
+++ b/modules/loop-pipeline/tests/test_drift_review_gate.py
@@ -1,0 +1,464 @@
+"""Guards for the drift-review exemplar -- the QUALITY_PROTOCOL Layer-3 executor.
+
+`examples/drift-review/drift-review.dot` runs four LLM reviewers whose entire
+output is *judgement*, and then decides -- outside every one of their contexts --
+which of their findings are shaped. The thing that decides is
+``check_findings.py``, so that script carries the whole weight of the design:
+
+  * A finding must cite ``file:line`` on **both** sides, the drifting surface and
+    the normative passage it contradicts, and the gate **re-opens both files**
+    rather than believing either citation.
+  * "Drift" is measured against a closed set of normative sources, so a Layer-3
+    finding means the same thing Layers 0-2 mean, one level up.
+  * Rejection is a *judgement* (exit 0 plus a token, routed back to a repair
+    worker); an unrunnable gate is a *tool failure* (nonzero exit, no token,
+    routed to the loud terminal). Collapsing those two is how a broken
+    instrument comes to look like a clean repo.
+
+Every case below is the mutation form: take a corpus the gate admits, break one
+thing, and assert the gate rejects it **naming that thing**. A gate never seen
+red is an unproven gate.
+
+The examples tree lives at the repository root, outside the installed package,
+so these tests run against a source checkout and skip gracefully when the
+examples directory is absent (e.g. an installed-package test run) -- the same
+pattern as ``test_examples_lint_clean.py`` and ``test_objective_layer_gates.py``.
+"""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_DRIFT_DIR = _REPO_ROOT / "examples" / "drift-review"
+_DOT_PATH = _DRIFT_DIR / "drift-review.dot"
+
+pytestmark = pytest.mark.skipif(
+    not _DRIFT_DIR.is_dir(),
+    reason="examples/drift-review/ not present (installed-package run)",
+)
+
+_CLASSES = ("core-docs", "examples", "guidance", "ledgers")
+
+
+@pytest.fixture(scope="module")
+def checker() -> ModuleType:
+    """Import check_findings.py by path, without polluting sys.path."""
+    path = _DRIFT_DIR / "check_findings.py"
+    spec = importlib.util.spec_from_file_location("_drift_check_findings", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# ---------------------------------------------------------------------------
+# A miniature repository whose citations really resolve
+# ---------------------------------------------------------------------------
+
+_DRIFTING_DOC = """# Some Guide
+
+Line three is filler.
+The engine picks the alphabetically first edge when nothing matches.
+More filler below.
+Still more filler.
+And a closing line.
+"""
+
+_NORMATIVE_SPEC = """# Canonical Spec
+
+## 1. Overview
+Filler paragraph one, standing in for the spec's front matter.
+Filler paragraph two.
+
+## 2. Nodes
+Filler paragraph three.
+Filler paragraph four.
+
+## 3.3 Edge selection
+No matching edge is a hard failure and the run stops loudly.
+Filler paragraph five.
+Filler paragraph six.
+"""
+
+_VISION = """# Vision
+
+Fail loud; never fall back silently.
+"""
+
+
+@pytest.fixture()
+def repo(tmp_path: Path) -> Path:
+    """A tiny tree with one drifting surface and two normative sources."""
+    root = tmp_path / "repo"
+    (root / "docs").mkdir(parents=True)
+    (root / "specs" / "canonical").mkdir(parents=True)
+    (root / "docs" / "SOME-GUIDE.md").write_text(_DRIFTING_DOC, encoding="utf-8")
+    (root / "docs" / "VISION.md").write_text(_VISION, encoding="utf-8")
+    (root / "specs" / "canonical" / "spec.md").write_text(_NORMATIVE_SPEC, encoding="utf-8")
+    (root / "README.md").write_text("# Readme\n\nfiller\n", encoding="utf-8")
+    return root
+
+
+def _good_finding() -> dict:
+    return {
+        "id": "DR-CORE-001",
+        "class": "core-docs",
+        "severity": "high",
+        "title": "Guide teaches alphabetical fallback the spec removed",
+        "drift": {
+            "file": "docs/SOME-GUIDE.md",
+            "line": 4,
+            "quote": "The engine picks the alphabetically first edge when nothing matches.",
+        },
+        "contradicts": {
+            "file": "specs/canonical/spec.md",
+            "line": 12,
+            "quote": "No matching edge is a hard failure and the run stops loudly.",
+        },
+        "why": "A reader following the guide would expect a silent fallback that no longer exists.",
+    }
+
+
+def _corpus() -> dict[str, dict]:
+    """One admissible raw file per class: findings on core-docs, clean elsewhere."""
+    corpus: dict[str, dict] = {
+        "core-docs": {
+            "class": "core-docs",
+            "swept": ["README.md", "docs/SOME-GUIDE.md"],
+            "findings": [_good_finding()],
+        }
+    }
+    for cls in _CLASSES[1:]:
+        corpus[cls] = {"class": cls, "swept": ["README.md"], "findings": []}
+    return corpus
+
+
+def _write(repo: Path, corpus: dict[str, dict]) -> Path:
+    raw = repo / ".drift-review" / "raw"
+    raw.mkdir(parents=True, exist_ok=True)
+    for cls, body in corpus.items():
+        (raw / f"{cls}.json").write_text(
+            body if isinstance(body, str) else json.dumps(body), encoding="utf-8"
+        )
+    return raw
+
+
+def _run(checker: ModuleType, repo: Path, *, max_revisions: int = 2) -> int:
+    return checker.main(
+        [
+            "--raw-dir", str(repo / ".drift-review" / "raw"),
+            "--repo-root", str(repo),
+            "--state-dir", str(repo / ".drift-review"),
+            "--classes", ",".join(_CLASSES),
+            "--max-revisions", str(max_revisions),
+        ]
+    )
+
+
+def _report(repo: Path) -> str:
+    return (repo / ".drift-review" / "findings-report.txt").read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# The green path
+# ---------------------------------------------------------------------------
+
+
+def test_admits_a_shaped_corpus_and_writes_the_findings_file(checker, repo, capsys):
+    _write(repo, _corpus())
+    assert _run(checker, repo) == 0
+    assert capsys.readouterr().out == "findings_ok"
+
+    written = json.loads((repo / ".drift-review" / "findings.json").read_text(encoding="utf-8"))
+    assert written["finding_count"] == 1
+    assert written["findings"][0]["id"] == "DR-CORE-001"
+    # The swept record survives into the corpus: "clean" and "never looked" must
+    # stay distinguishable downstream.
+    assert written["swept"]["guidance"] == ["README.md"]
+    assert "FINDINGS ADMITTED" in _report(repo)
+
+
+def test_zero_findings_is_a_result_not_a_failure(checker, repo, capsys):
+    corpus = {cls: {"class": cls, "swept": ["README.md"], "findings": []} for cls in _CLASSES}
+    _write(repo, corpus)
+    assert _run(checker, repo) == 0
+    assert capsys.readouterr().out == "findings_ok"
+    written = json.loads((repo / ".drift-review" / "findings.json").read_text(encoding="utf-8"))
+    assert written["finding_count"] == 0
+    assert "clean sweep is a result" in _report(repo)
+
+
+def test_a_reflowed_quote_still_resolves(checker, repo, capsys):
+    """Whitespace differences are tolerated; invented text is not (next test)."""
+    corpus = _corpus()
+    corpus["core-docs"]["findings"][0]["drift"]["quote"] = (
+        "The   engine picks the alphabetically\n  first edge when nothing matches."
+    )
+    _write(repo, corpus)
+    assert _run(checker, repo) == 0
+    assert capsys.readouterr().out == "findings_ok"
+
+
+def test_quote_resolves_from_a_neighbouring_line(checker, repo, capsys):
+    """An off-by-a-couple line number resolves; a wholly wrong one does not."""
+    corpus = _corpus()
+    corpus["core-docs"]["findings"][0]["drift"]["line"] = 3
+    _write(repo, corpus)
+    assert _run(checker, repo) == 0
+    assert capsys.readouterr().out == "findings_ok"
+
+
+# ---------------------------------------------------------------------------
+# The mutations -- each rejection must name what it rejected
+# ---------------------------------------------------------------------------
+
+
+def _mutate(mutator) -> dict[str, dict]:
+    corpus = _corpus()
+    mutator(corpus)
+    return corpus
+
+
+def _drop(finding_key: str):
+    def _apply(corpus: dict) -> None:
+        del corpus["core-docs"]["findings"][0][finding_key]
+
+    return _apply
+
+
+def _set(path: str, value):
+    def _apply(corpus: dict) -> None:
+        node = corpus["core-docs"]["findings"][0]
+        parts = path.split(".")
+        for part in parts[:-1]:
+            node = node[part]
+        node[parts[-1]] = value
+
+    return _apply
+
+
+@pytest.mark.parametrize(
+    ("mutator", "expected_fragment"),
+    [
+        (_drop("drift"), "missing required field 'drift'"),
+        (_drop("why"), "missing required field 'why'"),
+        (_set("severity", "spicy"), "is not one of ['critical', 'high', 'medium', 'low']"),
+        (_set("class", "examples"), "does not match this file's class 'core-docs'"),
+        (_set("id", "x"), "is not a short slug matching"),
+        (_set("title", "short"), "at least 12 characters"),
+        (_set("why", "too short"), "at least 40 characters"),
+        (_set("drift.file", "docs/NO-SUCH-FILE.md"), "does not exist in the tree"),
+        (_set("drift.file", "/etc/passwd"), "citations must be repo-relative"),
+        (_set("drift.file", "../outside.md"), "resolves outside the repository root"),
+        (_set("drift.line", 9999), "cited line 9999 is out of range"),
+        (_set("drift.line", "four"), "expected an integer line number"),
+        (_set("drift.quote", "the engine invents this sentence entirely"), "does not appear at"),
+        (_set("drift.quote", "short"), "characters after whitespace normalization"),
+        (
+            _set("contradicts.file", "docs/SOME-GUIDE.md"),
+            "is not a normative source",
+        ),
+        (_set("contradicts.line", 1), "the quote does not appear at"),
+    ],
+    ids=[
+        "missing_drift_side",
+        "missing_why",
+        "off_vocabulary_severity",
+        "class_mismatch",
+        "malformed_id",
+        "stub_title",
+        "stub_why",
+        "cited_file_absent",
+        "absolute_path",
+        "path_escapes_tree",
+        "line_out_of_range",
+        "non_integer_line",
+        "fabricated_quote",
+        "quote_too_short",
+        "non_normative_contradicts",
+        "quote_at_wrong_line",
+    ],
+)
+def test_rejects_unshaped_findings_naming_the_reason(
+    checker, repo, capsys, mutator, expected_fragment
+):
+    _write(repo, _mutate(mutator))
+    assert _run(checker, repo) == 0
+    assert capsys.readouterr().out == "findings_bad"
+    assert expected_fragment in _report(repo)
+
+
+def test_rejects_a_finding_that_cites_the_same_file_on_both_sides(checker, repo, capsys):
+    """A finding names a drifting surface AND the separate passage it moved from."""
+    corpus = _corpus()
+    finding = corpus["core-docs"]["findings"][0]
+    finding["drift"] = copy.deepcopy(finding["contradicts"])
+    _write(repo, corpus)
+    assert _run(checker, repo) == 0
+    assert capsys.readouterr().out == "findings_bad"
+    assert "are the same file" in _report(repo)
+
+
+def test_rejects_duplicate_finding_ids_across_classes(checker, repo, capsys):
+    """Ids are the handle a human triages by; a collision silently merges two."""
+    corpus = _corpus()
+    clash = copy.deepcopy(corpus["core-docs"]["findings"][0])
+    clash["class"] = "examples"
+    corpus["examples"]["findings"] = [clash]
+    _write(repo, corpus)
+    assert _run(checker, repo) == 0
+    assert capsys.readouterr().out == "findings_bad"
+    assert "is used more than once" in _report(repo)
+
+
+@pytest.mark.parametrize(
+    ("body", "expected_fragment"),
+    [
+        ({"class": "core-docs", "findings": []}, "'swept' must be a non-empty list"),
+        ({"class": "core-docs", "swept": [], "findings": []}, "'swept' must be a non-empty list"),
+        (
+            {"class": "core-docs", "swept": ["docs/GONE.md"], "findings": []},
+            "does not exist in the tree",
+        ),
+        ({"class": "wrong", "swept": ["README.md"], "findings": []}, "'class' must be"),
+        (
+            {"class": "core-docs", "swept": ["README.md"], "findings": {}},
+            "'findings' must be a list",
+        ),
+        ("{ not json", "not valid JSON"),
+        ("[]", "expected a JSON object"),
+    ],
+    ids=[
+        "swept_absent",
+        "swept_empty",
+        "swept_path_absent",
+        "class_label_wrong",
+        "findings_not_a_list",
+        "malformed_json",
+        "not_an_object",
+    ],
+)
+def test_rejects_malformed_class_files(checker, repo, capsys, body, expected_fragment):
+    corpus = _corpus()
+    corpus["core-docs"] = body
+    _write(repo, corpus)
+    assert _run(checker, repo) == 0
+    assert capsys.readouterr().out == "findings_bad"
+    assert expected_fragment in _report(repo)
+
+
+def test_a_reviewer_that_wrote_nothing_is_named_not_silently_skipped(checker, repo, capsys):
+    """A crashed branch must not read as a clean class."""
+    corpus = _corpus()
+    del corpus["guidance"]
+    _write(repo, corpus)
+    assert _run(checker, repo) == 0
+    assert capsys.readouterr().out == "findings_bad"
+    report = _report(repo)
+    assert "guidance.json: not written" in report
+    assert "produced no output at all" in report
+
+
+def test_a_rejected_round_removes_a_stale_findings_file(checker, repo, capsys):
+    """The report gate reads findings.json; a stale corpus would be believed."""
+    _write(repo, _corpus())
+    assert _run(checker, repo) == 0
+    assert capsys.readouterr().out == "findings_ok"
+    findings_path = repo / ".drift-review" / "findings.json"
+    assert findings_path.exists()
+
+    _write(repo, _mutate(_set("drift.line", 9999)))
+    assert _run(checker, repo) == 0
+    assert capsys.readouterr().out == "findings_bad"
+    assert not findings_path.exists()
+
+
+def test_the_repair_loop_is_bounded_and_exhaustion_is_a_distinct_token(checker, repo, capsys):
+    """Three malformed rounds at --max-revisions 2 is a decision point, not a retry."""
+    _write(repo, _mutate(_set("drift.line", 9999)))
+    for _ in range(2):
+        assert _run(checker, repo, max_revisions=2) == 0
+        assert capsys.readouterr().out == "findings_bad"
+    assert _run(checker, repo, max_revisions=2) == 0
+    assert capsys.readouterr().out == "revise_exhausted"
+
+
+# ---------------------------------------------------------------------------
+# Cannot-run is not the same as bad-findings
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("broken", ["raw_dir", "repo_root"], ids=["raw_dir", "repo_root"])
+def test_a_gate_that_cannot_run_exits_nonzero_with_no_token(checker, repo, capsys, broken):
+    """Nonzero exit routes to the loud terminal, not into the repair loop."""
+    _write(repo, _corpus())
+    argv = [
+        "--raw-dir", str(repo / ".drift-review" / "raw"),
+        "--repo-root", str(repo),
+        "--state-dir", str(repo / ".drift-review"),
+    ]
+    index = argv.index("--raw-dir" if broken == "raw_dir" else "--repo-root") + 1
+    argv[index] = str(repo / "no-such-directory")
+    assert checker.main(argv) != 0
+    assert capsys.readouterr().out == ""
+
+
+# ---------------------------------------------------------------------------
+# The graph's own contract
+# ---------------------------------------------------------------------------
+
+
+def test_the_shipped_graph_keeps_its_layer_three_contract():
+    """The structural promises the header makes, asserted against the file."""
+    from amplifier_module_loop_pipeline.dot_parser import parse_dot
+    from amplifier_module_loop_pipeline.validation import lint
+
+    graph = parse_dot(_DOT_PATH.read_text(encoding="utf-8"))
+
+    # Zero ERROR diagnostics -- the bar every shipped example is held to.
+    assert [d for d in lint(graph) if d.severity == "ERROR"] == []
+
+    # Exactly one exit, and it is reachable only through the report gate.
+    exits = [n for n in graph.nodes.values() if n.is_exit_node()]
+    assert len(exits) == 1
+    into_exit = graph.incoming_edges(exits[0].id)
+    assert [e.from_node for e in into_exit] == ["report_gate"]
+
+    # The verdict is owned by a code-tier node, never by a worker.
+    gates = [
+        n
+        for n in graph.nodes.values()
+        if str(n.attrs.get("goal_gate", "")).lower() in ("true", "1", "yes")
+    ]
+    assert [n.id for n in gates] == ["report_gate"]
+    assert graph.nodes["report_gate"].shape == "parallelogram"
+    assert graph.nodes["findings_gate"].shape == "parallelogram"
+
+    # The gate that judges findings runs the checker shipped next to the graph.
+    assert "check_findings.py" in str(graph.nodes["findings_gate"].attrs.get("tool_command"))
+
+    # Both corrective cycles exist: repair findings, and repair the report.
+    pairs = {(e.from_node, e.to_node) for e in graph.edges}
+    assert ("findings_gate", "revise") in pairs
+    assert ("revise", "findings_gate") in pairs
+    assert ("report_gate", "consolidate") in pairs
+    assert ("consolidate", "report_gate") in pairs
+
+    # Every reviewer carries an artifact contract that success cannot declare away.
+    for cls in _CLASSES:
+        node_id = "review_" + cls.replace("-", "_")
+        assert graph.nodes[node_id].attrs.get("must_write") == f".drift-review/raw/{cls}.json"
+
+    # No outcome=fail edge may reach the exit: a machinery failure leaves loudly.
+    for edge in graph.edges:
+        if edge.to_node == exits[0].id:
+            assert "outcome=fail" not in str(edge.condition or "")


### PR DESCRIPTION
## Summary

`docs/QUALITY_PROTOCOL.md` section 5 names five drift layers. Layers 0-2 are mechanical and all three are **local** — each checks one claim, one file, one section. Layer 3 is the semantic reading of the whole, and its own words for the gap it fills are *"none of them can see that the README teaches one mental model while an exemplar demonstrates another, or that a ledger entry is individually well-formed and collectively obsolete."* Until this PR, Layer 3's defense was "someone will read everything carefully," which is the defense that silently does not happen — and the page said so outright: *"That pipeline does not exist yet."*

This ships its executor, built **as an attractor** (section 8, dogfooding), and **runs it for real**. The section 6 triggers had genuinely fired: 45 commits have landed on `main` since the local checkout, the conformance surface moved twice (the matrix landed, then the vision wave), and no holistic pass had answered any of it.

**`examples/drift-review/`**

| File | What it is |
|---|---|
| `drift-review.dot` | the graph: `preflight → inventory → 4 parallel reviewers → findings gate → consolidate → report gate → done`, plus `postmortem → escalated` as the only red path |
| `check_findings.py` | the finding-shape validator (stdlib only) — **the load-bearing gate** |
| `finding-contract.md` | the contract in the reviewer's own words, read by every worker |
| `README.md` | what Layer 3 is, when it fires (§6), how to run it, how findings flow |

**`modules/loop-pipeline/tests/test_drift_review_gate.py`** — **40** cases, every rejection proved red by mutation. (This line said 36 when the PR was opened; `pytest` collected 35. Corrected, and the five post-review cases below take it to 40.)

Wiring is three lines: Layer 3's closing sentence now names the executor, a dated Changelog entry (entry 6) records the amendment, and the README gallery gains one row.

### The design in one paragraph

Four LLM reviewers **propose** findings; `check_findings.py`, run by the `findings_gate` parallelogram **outside every worker's context**, **decides** which are shaped — and it re-opens every cited file itself rather than believing any citation. Every finding must cite `file:line` on **both** sides: the drifting surface *and* the normative passage it contradicts. The `contradicts` side must be one of `specs/canonical/`, `docs/VISION.md`, `SPEC_CONFORMANCE.md`, `specs/EXTENSIONS.md`, `specs/conformance/` — that closed set *is* the definition of drift, and it is what keeps a Layer-3 finding meaning what Layers 0-2 mean, one level up. A worker cannot satisfy this gate by asserting more confidently; only by citing something that is actually there.

**Honest exits.** Findings present → `done`, green, `disposition=findings` (a review that finds drift did its job). Zero findings → `done`, green, `disposition=clean`, and a zero-finding class must still list what it **swept** — otherwise "no drift found" and "nothing was looked at" are the same record. Only *machinery* failure is red.

**The pipeline never files anything and never fixes anything.** Shape is not truth: the gate proves a citation resolves, never that two passages actually contradict. A human verifies and decides what becomes an issue or a `vision-observation` (§4). A reviewer that acts on its own findings has re-entered the context it was built to stay outside of.

## Decision-matrix tier (§3)

**UNCHARTED / EXTENSION.** The nlspec specifies how an engine executes a graph; it is silent on how a repository governs its own quality machinery. That silence is argued rather than assumed: the spec's scope is the execution contract (`§1.1`–`§10`), and a repo-internal review instrument is outside it by subject, not by omission — nothing here asks the engine to behave differently.

- **Additive and non-interfering.** No engine, handler, parser, validation or ledger *behavior* changed. The diff is one new example directory, one new test file, and three documentation lines. A spec-conformant graph behaves identically before and after.
- **No `specs/EXTENSIONS.md` entry.** That requirement attaches to changes in *observable engine contract*. This PR introduces no new attribute, shape, routing form, or event — `drift-review.dot` is written entirely in already-ledgered vocabulary, which is the point: the instrument is built out of the same primitives it reviews. If a reviewer reads the uncharted tier as owing an entry regardless of whether engine behavior moved, say so and it ships in this PR.
- **No `SPEC_CONFORMANCE.md` row / conformance-matrix row.** Those attach to the drift tier. Nothing here moves away from what the spec specifies.
- **Toll paid for the change classes it does touch** (§2): the *exemplar* row — `attractor lint` zero ERRORs, and a live convergence run (below); the *docs-making-factual-claims* row — the Layer-3 line and Changelog entry are held by `test_quality_protocol_guard.py` Q-300, which resolves the named guard file against the repository and was run green.

## Verification evidence

### Live run — the first real Layer-3 review

Run against a pristine worktree of `main` @ `ed5bdef`, using the installed `attractor` CLI. The PR worktree was kept out of it deliberately, so no run artifacts land in the diff (`git status` clean; see below).

```
cd <worktree @ ed5bdef>
attractor run /tmp/driftrev-wt/examples/drift-review/drift-review.dot \
    --param goal="Layer-3 holistic drift review of microsoft/amplifier-bundle-attractor @ ed5bdef" \
    --param runner_dir=/tmp/driftrev-wt/examples/drift-review \
    --logs-root /tmp/driftrev-logs/attempt1 \
    --cwd .

attractor: status=success
```

**One attempt, no machinery bugs, no corrective iterations.** `revise-iter` absent (the findings gate admitted the corpus on its first pass), `report-iter` = 1, `report-gate.txt` empty (no admitted finding was dropped from the report), `disposition` = `findings`.

```
FINDINGS ADMITTED
classes:  core-docs, examples, guidance, ledgers
findings: 10
swept:    129 surfaces

Per class:
  core-docs: 2 finding(s), 19 surface(s) swept
  examples:  3 finding(s), 68 surface(s) swept
  guidance:  3 finding(s), 33 surface(s) swept
  ledgers:   2 finding(s), 9 surface(s) swept
```

The full report, `findings.json`, the four raw class files, the inventory lists and the run directory are in the evidence bundle. **No issues were filed and no finding was fixed** — that separation is the design, and the triage is the maintainer's.

### The 10 findings (author-independent spot-verification below)

| id | sev | class | title |
|---|---|---|---|
| `DR-CORE-001` | high | core-docs | README "Known caveat" describes a bug that has already shipped as fixed |
| `DR-CORE-002` | high | core-docs | README Option B says `DirectProviderBackend` has "no tools" after the correction was recorded as made |
| `DR-EX-002` | high | examples | `12-graph-resume.md` teaches engine-level resume as fundamentally broken; `ATX-2` shipped a design that avoids both described failure modes |
| `DR-GUIDE-001` | high | guidance | Two agent guidance surfaces still label `DirectProviderBackend` "no tools" after the README correction was recorded |
| `DR-LEDGER-001` | high | ledgers | `ATX-2`'s DECIDE section still describes pre-implementation state after resume shipped |
| `DR-EX-001` | medium | examples | `05-parallel-fan-out.md` teaches `k_of_n` / `quorum` as join policies the canonical spec does not define |
| `DR-EX-003` | medium | examples | `PIPELINE_DESIGN_PRINCIPLES.md` uses the legacy alias `default_max_retry` as primary vocabulary |
| `DR-GUIDE-002` | medium | guidance | `dot-reference.md` fidelity comment omits two valid modes |
| `DR-LEDGER-002` | medium | ledgers | Summary table resolved/open counts for attractor omit four decided rows |
| `DR-GUIDE-003` | low | guidance | `dot-reference.md` uses the legacy alias `default_max_retry` as its primary example |

### Independent spot-verification (six of ten, both sides read by hand)

Not the pipeline's word — I opened both cited passages myself, at `ed5bdef`.

- **`DR-CORE-001` — REAL.** `README.md:447` says `suggested_next_ids` mismatches "currently fail to match ... This is a known issue being addressed." `specs/EXTENSIONS.md:1836` is `## 34. suggested_next_ids Type Coercion at Edge Selection (Bug Fix)`, and the fix is in the tree: `edge_selection.py:167 def _coerce_suggested_id`, with `tests/test_spawn_suggested_next_ids_coercion.py` present. The README teaches a workaround for a closed bug.
- **`DR-CORE-002` — REAL, and sharper than the title suggests.** `README.md:418` says "you get `DirectProviderBackend` (LLM-only, no tools)"; `README.md:519` — the same file — says "whatever tools are mounted are passed through." `SPEC_CONFORMANCE.md:281` records the correction as made to the *table*. The prose paragraph was missed, so the README now contradicts itself.
- **`DR-EX-001` — REAL, with a nuance the finding states correctly.** The canonical join-policy table (`specs/canonical/attractor-spec-canonical.md:849-850`) lists exactly `wait_all` and `first_success`; `k_of_n`/`quorum` appear nowhere in the canonical snapshot (grep: zero hits). `specs/EXTENSIONS.md:481-487` records them as a *subtraction candidate* with zero shipped-graph usage. The guide's table presents all four as peers with no note that two are non-canonical extensions nothing uses.
- **`DR-EX-002` — REAL.** `12-graph-resume.md:202` opens "Engine-level resume (fast-forward replay from a checkpoint) has two failure modes" and names "No matching edge from resumed node" and "bakes in routing decisions from the previous run." `SPEC_CONFORMANCE.md:244-246` says the opposite in the same words: "The two PR #66 crash classes are **designed out**, not guarded against ... there is no fast-forward replay." The ledger itself notes the guide was left byte-unchanged at the `ATX-2` merge — which is the moment the drift was created.
- **`DR-LEDGER-002` — REAL.** `SPEC_CONFORMANCE.md:60` reads `3 (ATX-1, ATX-2, ATX-10) | 3 (ATX-3, ATX-6, ATX-7)`. The ATX table 50 lines below carries `ATX-4` **WONTFIX — DECIDED**, `ATX-5` **DONE — DECIDED**, `ATX-11` **DONE — DECIDED**, `ATX-12` **DONE — DECIDED**. Four decided rows are unaccounted for in the summary. This is precisely the "individually well-formed and collectively obsolete" species Layer 3 was defined to catch.
- **`DR-GUIDE-002` — REAL.** `context/dot-reference.md:38` comments `// full|compact|summary:high|summary:low`. The canonical `FidelityMode` production (`specs/canonical/attractor-spec-canonical.md:1141-1146`) has six: `full`, `truncate`, `compact`, `summary:low`, `summary:medium`, `summary:high`. The quick-reference card silently hides `truncate` and `summary:medium` from every model that reads it.

The four I did not hand-verify (`DR-GUIDE-001`, `DR-LEDGER-001`, `DR-EX-003`, `DR-GUIDE-003`) each passed the gate — both citations resolve — but I am not asserting them as true. That is exactly the boundary the instrument draws, and the README says so in those words.

### Suites

```
modules/loop-pipeline   uv sync --extra remote && uv run pytest -q
                        2257 passed, 25 skipped        (main baseline 2216/25; +41
                                                        = 40 gate cases + 1 examples-lint case)
modules/pipeline-runner uv run pytest -q
                        76 passed, 1 skipped           (matches baseline)

test_quality_protocol_guard.py + test_examples_lint_clean.py + test_drift_review_gate.py
                        90 passed                      (Q-300..Q-307 green after the doc edit)

attractor lint examples/drift-review/drift-review.dot
                        OK (no findings)               — zero ERRORs, zero WARNINGs
every examples/**/*.dot  zero ERROR-severity diagnostics

.github/capsule-pipeline/vendor/backlog/check-upstream-leaks.sh <5 added files>
                        clean

git diff --check                      clean
git status --short                    empty — no .drift-review/ or run artifacts in the diff
```

### The gate proved red, not just green

`test_drift_review_gate.py` is written entirely as mutations of a corpus the gate admits. Each case breaks exactly one thing and asserts the rejection **names that thing**: a fabricated quote ("the quote does not appear at ..."), a cited file that does not exist, a line out of range, a non-integer line, an absolute path, a path escaping the tree, a quote too short to anchor, a `contradicts` side that is not a normative source, both sides citing the same file, duplicate ids across classes, seven malformed class-file shapes, a reviewer that wrote nothing at all, the repair budget reaching `revise_exhausted`, and — separately — that an unrunnable gate exits **nonzero with no token**, so a broken instrument routes to the loud terminal instead of into the repair loop. Plus the graph's own structural contract: one exit, reachable only via `report_gate`; the goal gate on a parallelogram, never a box; both corrective cycles present; every reviewer carrying its `must_write`; and no `outcome=fail` edge reaching the exit.

## Observations

Two arose, both filed here for the reviewer rather than resolved in this PR (§4: non-blocking, never gates the work that surfaced them). Neither has a `vision-observation` issue yet — I am naming them for the maintainer to decide, since filing on his behalf is the thing this PR argues machines should not do.

1. **Layer 3's own scope line names an input the executor structurally cannot read.** §5 says *"Open `vision-observation` issues are a named input"* and §4 says they are read *as a set*. `drift-review.dot` reads the tree, not the network — so the shipped executor answers the doc/example/guidance/ledger half of Layer 3's scope and leaves the observation-set half to the human triage step. The README names this as a limit rather than papering over it, but the protocol page still describes one instrument where there are now two halves. Bears on `docs/QUALITY_PROTOCOL.md` §5 (Layer 3, "Output: findings with `file:line` evidence, **filed as issues**") — the shipped instrument deliberately stops one step short of that sentence.

2. **The first real Layer-3 pass produced two findings about the same stale sentence in two different surface classes** (`DR-CORE-002`, `DR-GUIDE-001` — both the `DirectProviderBackend` "no tools" correction). One correction landed in one file and was not swept across the surfaces that repeat it. That is a *pattern* rather than two defects, and it is the kind of thing §4 says is worth reading as a set: it suggests the gap is not "a page went stale" but "a correction has no mechanism for finding its own echoes." Bears on `docs/VISION.md`'s "Evidence over self-report" and on §2's guidance-surfaces row.

## Notes for reviewers

- **Do not merge on my say-so** — the ten findings are *triage input*, not accepted defects. I verified six by hand and said so per finding; the other four are checkable, not checked.
- **The `goal_gate=true` on `report_gate` is honest about being a declaration, not an enforcement.** It uses Idiom A for its judgements, so the engine's exit-time gate check cannot fail there. The comment says exactly that, and names what actually holds: `done` has one incoming edge and it is `report_ok`. This mirrors the same honesty `examples/objective/objective-runner.dot` records about its `evidence_gate`.
- **The back-edges deliberately do not carry `loop_restart`.** Both cycles re-enter a *gate* to re-judge a just-repaired artifact, not a fresh attempt at the whole review; `loop_restart` would reset completed nodes and make the finished parallel review branch re-runnable, which is not what "fix the citation on finding 3" means. Budgets live in gate-owned files instead, so they survive every re-entry. Header comment states this.
- **The review branches carry no `outcome=fail` edges**, against §3's "add transient fail-routes on every ship-path node." The trade is stated in the header: `error_policy=continue` keeps one crashed reviewer from costing the other three, and a crashed branch surfaces downstream as a missing `<class>.json` that `findings_gate` rejects *by name* — a better signal than a branch quietly leaving the join. Test `test_a_reviewer_that_wrote_nothing_is_named_not_silently_skipped` pins that.
- **Evidence bundle** (run directory, report, findings, raw class files, inventory) is at `.amplifier/evaluation/drift-review/20260815T152420Z/` in the workspace, deliberately outside this repo so nothing untracked rides along.

## Post-review fixes

An independent adversarial review returned **MERGE-AFTER-FIX**. Branch rebased onto `main` (PR #239, the authoring attractor — no conflict; the two gallery rows live in different tables) and the three findings are closed in `d2d2dd6`.

### 1. Path traversal defeated the closed normative set — REQUIRED, fixed

`check_findings.py` enforced both the closed-normative-set rule and the different-files rule against the **raw** citation string. A raw string is not a file. The review reproduced two admissions; both are now rejections:

| Citation | Pre-fix | Post-fix |
|---|---|---|
| `contradicts.file="specs/canonical/../../docs/QUALITY_PROTOCOL.md"` | `findings_ok` — satisfies `startswith("specs/canonical/")` while pointing clean out of the set | `findings_bad` — *"`'specs/canonical/../../docs/QUALITY_PROTOCOL.md'` (which resolves to `'docs/QUALITY_PROTOCOL.md'`) is not a normative source"* |
| `drift.file="README.md"` vs `contradicts.file="specs/canonical/../../README.md"` | `findings_ok` — two different strings, so the different-files rule passed, and the second begins with `specs/canonical/`, so the closed-set rule passed too | `findings_bad` — *"drift.file `'README.md'` and contradicts.file `'specs/canonical/../../README.md'` (which resolves to `'README.md'`) are the same file"* |

The first would let a Layer-3 finding measure drift against a surface that is itself drifting — precisely what the closed set exists to prevent. The second would let a finding cite one file against itself and call it drift.

`resolve_in_tree` now returns the resolved repo-relative posix path alongside the absolute one; `check_citation` hands it up (deliberately including the cases where a later line/quote check failed — those two rules are about the *file*); and both rules judge that path. Rejections name the traversal, so the human triaging the report sees the dodge rather than a complaint about a path that looks compliant. `finding-contract.md` tells the reviewers the same thing, so a traversal reads as pointless rather than clever.

**Proved red against the parent commit** — all three new cases returned `findings_ok` against pre-fix `check_findings.py`:

```
FAILED test_rejects_a_contradicts_citation_that_traverses_out_of_the_normative_set
FAILED test_rejects_the_same_file_dodged_through_a_traversal
FAILED test_the_different_files_rule_holds_inside_the_normative_set_too
E       AssertionError: assert 'findings_ok' == 'findings_bad'
```

The third case is not in the review's report: both sides resolve to the same **normative** file (`specs/canonical/spec.md` vs `specs/canonical/../canonical/spec.md`), so the closed-set rule is satisfied and cannot be what rejects it. It isolates the different-files half of the fix from the closed-set half, which the `README.md` variant alone does not.

### 2. Report budget disagreed with its own documentation — fixed, **behavior moved**

`drift-review.dot` tested `n -gt B+1` **before** judging. The header (`:35`) and the README both say *"default 2 → at most 3 gate passes"*, and `check_findings.py` spends `--max-revisions` exactly that way.

I moved the behavior, not the docs, for three reasons: the two walls in this one graph are documented identically and must therefore *mean* identically; `check_findings.py` already implements `B` repairs / `B+1` passes and is the older of the two; and the extra pass was not a free bonus — it ran a third `consolidate` repair and then declared exhaustion **without ever reading what that repair produced**.

The gate now judges on every pass and only then spends the budget (`report_ok`; else `n -gt B` → `report_exhausted`; else `report_bad`), executed at `max_reports=2`:

```
PRE-FIX                                   POST-FIX
  pass 1  n=1  report_bad                   pass 1  n=1  report_bad
  pass 2  n=2  report_bad                   pass 2  n=2  report_bad
  pass 3  n=3  report_bad                   pass 3  n=3  report_exhausted
  pass 4  n=4  report_exhausted
  -> 3 repairs, exhaustion on pass 4        -> 2 repairs, exhaustion on pass 3
     (the 3rd repair judged by nobody)         (every repair judged)
```

Pinned by two cases run through the shell the pipeline really uses. The first is red pre-fix (`['report_bad', 'report_bad', 'report_bad'] != [..., 'report_exhausted']`). The second — that the **last permitted repair is still judged** — is the one a naive "just move the wall earlier" fix would break, and it is green on both sides deliberately: it pins the property the fix had to preserve.

`attractor lint examples/drift-review/drift-review.dot` → **OK (no findings)**.

### 3. Test-count claim — corrected

The Summary said 36; `pytest` collected 35. Corrected above, and it is now 40.

### Gates, on the rebased branch

```
modules/loop-pipeline    2257 passed, 25 skipped   (main baseline 2216/25)
modules/pipeline-runner  76 passed, 1 skipped
test_drift_review_gate   40 passed                 (35 -> 40)
Q-guards trio            90 passed
attractor lint           OK (no findings)
check-upstream-leaks.sh  clean  (4 changed files)
git diff --check         clean
```

No engine, handler or ledger behavior changed; a spec-conformant graph behaves identically.

---

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

