### PR TITLE
feat(examples): ship the authoring attractor -- a pipeline that authors pipelines under executed gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ The goal lives in the DOT itself: `graph [goal="Add user avatar upload with S3 s
 | Pipeline | What it does |
 |----------|--------------|
 | [Objective Runner](examples/objective/README.md) | You state an **objective**; it diagnoses, then **selects** a shipped lane, **composes** a purpose-built child pipeline, or **redirects** with an honest written no |
+| [Authoring Attractor](examples/authoring/README.md) | You state a design **brief**; it diagnoses, **authors** a new reusable pipeline, converges it under `attractor lint` + a structural contract + an independent critique, and publishes it with provenance — or **redirects** with an honest written no |
 
 ### Canonical attractor exemplars — teach the shape
 

--- a/examples/authoring/README.md
+++ b/examples/authoring/README.md
@@ -1,0 +1,252 @@
+# The Authoring Attractor
+
+A pipeline that authors pipelines, under executed machine gates.
+
+You state a **design brief** for work you want a reusable pipeline to do.
+`pipeline-author.dot` diagnoses the brief, drafts a new pipeline, hardens it
+against `attractor lint` and a structural authoring contract, submits it to an
+independent doctrine critique that inherits nothing from the author, and
+publishes it with provenance — or tells you honestly that the work described
+does not want an attractor at all.
+
+The basin: **a new pipeline exists that lints clean, satisfies the authoring
+contract, and survives an independent critique — or the brief is honestly
+redirected.** Both are green exits, told apart by a disposition artifact. A run
+that can do neither escalates loudly with a nonzero exit, never through the
+success door.
+
+---
+
+## Why this exists
+
+Writing a good attractor is convergence-shaped work. You draft, you find out the
+draft is wrong, you fix it, you find out again. That is a corrective loop with a
+machine-checkable gate at the end of it — which is exactly the shape this repo
+says deserves a pipeline.
+
+It also has the repo's own measured evidence behind it. `/attractorify` learned
+the hard way that prompt text alone does not deliver authoring discipline: its
+diagnosis rules only became reliable once they were backed by an **executed**
+form gate and an independent verifier. The same lesson is the whole subject of
+`docs/QUALITY_PROTOCOL.md` §1 — *"the test passes" is not "it works"* — and of
+`examples/objective/check_child_contract.py`'s C9, where a rule that lived only
+in a composer's prompt was being ignored until something ran it.
+
+So the doctrine here is not stated at the author and hoped for. It is executed
+at the draft.
+
+---
+
+## Three front doors, one doctrine
+
+This is the third of three surfaces that all apply the same three-question test
+and reach the same conclusions. They differ in **who is present** and **what
+comes out**.
+
+| Surface | Who is in the loop | What it produces | Reach for it when |
+|---|---|---|---|
+| [`/attractorify`](../../skills/attractorify/SKILL.md) | a **human**, conversationally | a validated *intent*: a diagnosis artifact, a design, an invocation | you are in a session, the shape is unclear, and you want to think it through with someone |
+| **`examples/authoring/`** (here) | **nobody** — it runs unattended | a *reusable pipeline*, converged under executed gates, published with provenance | you know what the pipeline must converge on, and you want the artifact hardened rather than hand-reviewed |
+| [`examples/objective/`](../objective/README.md) | nobody | a *satisfied objective* — via a shipped lane, or a single-purpose child composed at run time and thrown away | you have work to get done and no interest in which pipeline does it |
+
+The relationship in one line each:
+
+- **attractorify DESIGNS** — conversationally, with a person, ending at an
+  artifact and a recommendation. It never runs anything.
+- **this CONVERGES the artifact** — under `attractor lint`, a structural
+  contract, and an independent critique, ending at a published `.dot` + `.md`
+  someone else can run next month.
+- **objective-runner's compose path AUTHORS RUN-TIME CHILDREN** — a
+  single-purpose graph for one objective, admitted by
+  `check_child_contract.py`, executed immediately, and not intended to be
+  reused.
+
+They compose. `/attractorify`'s conversational design produces a validated
+intent; handing that intent here as a brief is how it becomes a hardened
+artifact instead of a hand-off document. The skill offers exactly that at the
+end of its design step.
+
+**When NOT to use this.** If you want *one* thing done once, you do not want a
+reusable pipeline — use the objective runner, or just do the work. If the brief
+describes a staged sequence with human approval and no machine check, this run
+will tell you so and exit green with a redirect; that is a correct outcome, but
+you can save the round trip by reading
+[`docs/PIPELINE_DESIGN_PRINCIPLES.md`](../../docs/PIPELINE_DESIGN_PRINCIPLES.md)
+§0 first.
+
+---
+
+## Run it
+
+```bash
+AUTH="$PWD/examples/authoring"        # capture the absolute path BEFORE cd
+cd /path/to/your/workspace
+attractor run "$AUTH/pipeline-author.dot" \
+    --param brief="Objective: every factual claim in README.md that names a
+                   command must actually run. Evidence: the commands are in
+                   fenced bash blocks; a script can extract and execute them.
+                   Budget: 4 iterations, 30 minutes." \
+    --param authoring_dir="$AUTH" \
+    --param target_dir="$PWD" \
+    --param pipeline_name="doc-claims-verified" \
+    --cwd .
+```
+
+Process cwd must equal `--cwd` for box-node (agent) pipelines — see
+[`../../modules/pipeline-runner/KNOWN_ISSUES.md`](../../modules/pipeline-runner/KNOWN_ISSUES.md).
+
+| Param | Required | What it is |
+|---|---|---|
+| `brief` | yes | **The design brief.** The objective the pipeline should converge on, the evidence sources available to it, and the budget it should carry. Prose is fine; the more concretely you can name the machine check, the better the draft. |
+| `authoring_dir` | yes | Absolute path to *this* directory. The doctrine gate runs `check_authored_pipeline.py` from here, and the author reads the repo's doctrine docs relative to it. |
+| `target_dir` | yes | Absolute path to the workspace. Prompt text for box nodes. |
+| `pipeline_name` | no (`authored-pipeline`) | Published basename under `out/`. Validated at preflight against `[A-Za-z0-9._-]+` — it becomes a filename. |
+| `max_iterations` | no (4) | Author-attempt budget. Every corrective leg spends one. |
+| `max_frames` | no (2) | How many unreadable triage records to tolerate before giving up on the diagnosis. |
+
+**Environment.** `attractor`, `python3` and `sha256sum` must be on `PATH`;
+preflight refuses loudly before paying for an LLM if any is missing.
+
+### Reading the result
+
+```bash
+cat .authoring/disposition        # authored | redirected | escalated
+```
+
+| Disposition | Exit | What you got | Where to look |
+|---|---|---|---|
+| `authored` | 0 | A new pipeline that lints clean, satisfies the contract, and a fresh-context critic said SHIP to | `out/<name>.dot`, `out/<name>.md`, `.authoring/PROVENANCE.md` |
+| `redirected` | 0 | The honest no: this work does not want an attractor, here is why and where it belongs | `.authoring/redirect.md` |
+| `escalated` | **1** | Could not converge within budget; the value salvaged is the analysis | `.authoring/postmortem/report.md`, `.authoring/convergence.jsonl` |
+
+Nothing reaches `out/` until every gate is green. The author works in
+`.authoring/draft/`; `package` publishes only what the critique accepted. Draft
+and published are different words on purpose.
+
+---
+
+## What it does, in order
+
+1. **`preflight`** (tool) — makes the run's preconditions true or refuses before
+   an LLM is ever paid: state directories, `attractor`/`python3`/`sha256sum` on
+   `PATH`, the checker present, and a `pipeline_name` that is safe as a filename.
+2. **`triage`** (LLM) — applies the repo's own
+   [three-question test](../../docs/PIPELINE_DESIGN_PRINCIPLES.md) to the
+   **brief**, restates the brief durably into `.authoring/triage.md`, names the
+   sink, and ends with an anchored `VERDICT:` line. It **proposes**; it does not
+   route.
+3. **`triage_gate`** (tool) — reads the last line and decides. This is the node
+   that routes, and it is outside the worker's context.
+4. Either the honest no — **`redirect_report`** (LLM) writes
+   `.authoring/redirect.md` and the run exits green — or the authoring loop:
+5. **`author`** (LLM) — writes `.authoring/draft/pipeline.dot` and its `.md`
+   companion, having read the doctrine docs, the shipped exemplars, and any gate
+   reports left by a previous attempt.
+6. **`lint_gate`** (tool) — `attractor lint`. ERRORs block; warnings are recorded.
+   **This node also owns the one budget counter**, checked on entry.
+7. **`doctrine_gate`** (tool) — `check_authored_pipeline.py`, the structural
+   contract below. Failures route back to the author with the report.
+8. **`critique`** (LLM, `fidelity="truncate"`) — an independent doctrine critique
+   that inherits nothing from the author's context. Ends with an anchored
+   `VERDICT: SHIP` or `VERDICT: ITERATE`.
+9. **`verdict_gate`** (tool) — last-line anchored, case-insensitive exact match.
+   Fails closed: a missing, empty or unparseable critique is `noverdict`, which
+   routes to another iteration, never to the exit.
+10. **`package`** (tool) — publishes `out/<name>.dot` + `out/<name>.md` and
+    assembles `.authoring/PROVENANCE.md` from the real artifacts, with sha256
+    digests. Assembled by a shell rather than a model on purpose: a provenance
+    record a model wrote is a summary; one a shell assembled is a record.
+11. **`finalize`** (tool) — refuses to open the exit without a disposition
+    artifact. **`postmortem` → `escalated`** is the loud path when it cannot
+    converge.
+
+Full node-by-node contracts are in
+[`pipeline-author.md`](pipeline-author.md).
+
+---
+
+## The authoring contract
+
+`check_authored_pipeline.py` is the second gate. It owns the design checks
+`attractor lint` deliberately does not, or owns only as advice. It is
+stdlib-only for the same reason the objective layer's checker is: it has to run
+under whatever `python3` is on `PATH` in the target workspace, not the
+`attractor` CLI's own virtualenv.
+
+It is a **stated contract, not a guessing game** — the author node is pointed at
+this section by name, so every check below is something it was told before it
+wrote a line.
+
+| Check | What it requires | Why |
+|---|---|---|
+| **A0** | the `.dot` exists, is readable, and parses | a second opinion is only useful if it read the same graph; a disagreement with the engine's parser fails closed |
+| **A1** | exactly one exit node | the engine refuses anything else. A second honest terminal is a LOUD nonzero tool node, never a second `Msquare` |
+| **A2** | at least one corrective cycle | *"If your pipeline graph has no cycle, it should probably have been a recipe."* |
+| **A3** | at least one evidence-bearing gate: a tool node running a **real** command whose result routes the graph | a node that only `printf`s a constant cannot fail, so nothing behind it is gated. This is the code-tier form of *"is the model here for judgment, or just to type?"* |
+| **A4** | **the exit is structurally unreachable without passing such a gate** | the load-bearing check. A1–A3 all pass on a graph with a corrective loop off to one side and `done` hanging straight off a worker. A4 deletes every evidence gate and asks whether the exit is still reachable |
+| **A5** | a tool node walls an iteration budget and routes exhaustion | a loop with no wall spends until the engine's step cap kills it with a bare FAIL, bypassing every salvage path |
+| **A6** | every reachable LLM worker has an `outcome=fail` route or a `retry_target` | a FAIL does not traverse plain edges. One transient provider error at an unrouted node ends the run, however much work already landed |
+| **A7** | label-routing edges conjoin `&& outcome=success` where the source can also fail | a failing tool node does not refresh `context.tool.last_line`, so a **stale** label can match alongside the failure edge on a later visit ([`docs/ROUTING-REFERENCE.md`](../../docs/ROUTING-REFERENCE.md) §3) |
+| **A8** | no failure outcome routed into the terminal success node | this converts a failure into a successful run. The engine's own lint calls this `TOPO-006` and **warns**; here it **blocks** |
+| **A9** | a companion `.md` exists and names every reachable LLM worker | every exemplar in this repo ships with a paired guide, because a graph shows what it does and not why it is shaped that way. Coverage is the machine-checkable core of the node contract |
+
+**A5's vocabulary is deliberately explicit**, because a check nobody can satisfy
+on purpose is a trap. The budget node's `tool_command` must name one of
+`max_iteration`, `max_round`, `max_attempt`, `max_retries`, `budget`, `iter`;
+one of its outgoing edges must carry a `condition` or `label` naming one of
+`exhaust`, `budget`, `stall`, `over_budget`, `give_up`, `spent`.
+
+**Token contract** (Idiom A — always exit 0, so `tool.last_line` is always
+fresh):
+
+```
+doctrine_ok     every check passed
+doctrine_bad    at least one check failed; route back to the author
+```
+
+A nonzero exit means the script could not run at all, which routes to the
+postmortem path — deliberately distinct from `doctrine_bad`, a judgement about
+the graph. A missing or unparseable `.dot` is a judgement, not a crash: the
+author node is the one that was supposed to write it.
+
+### What it deliberately does not check
+
+**Whether the pipeline is any good for the brief it came from.** Structure is
+checkable; fitness for purpose is not. A gate can be structurally perfect and
+assert the wrong thing, or assert something that was already true. That is the
+critique node's job, and it is why the authoring pipeline still pays for an LLM
+after both machine gates are already green.
+
+### Calibration: it admits the repo's own exemplars
+
+The checker is pinned against shipped, battle-tested graphs — if it rejected
+`task-runner.dot` it would be the checker that was wrong, not the exemplar:
+
+```bash
+python3 examples/authoring/check_authored_pipeline.py \
+    --pipeline examples/patterns/task-runner.dot \
+    --companion examples/patterns/task-runner.md \
+    --report /tmp/report.txt
+```
+
+`examples/pipelines/00-convergence-loop.dot` **fails** A5 and A6, correctly: it
+is a deliberately minimal teaching graph, not a production attractor, and its
+own guide says so. The checker is calibrated for pipelines meant to be run on
+real work.
+
+And it admits `pipeline-author.dot` itself. The exemplar obeys the contract it
+hands out; a test in
+`modules/loop-pipeline/tests/test_authoring_layer_gates.py` keeps that true.
+
+---
+
+## Files
+
+| File | What it is |
+|---|---|
+| [`pipeline-author.dot`](pipeline-author.dot) | the authoring attractor |
+| [`pipeline-author.md`](pipeline-author.md) | its companion guide — node-by-node contracts and the design record |
+| [`check_authored_pipeline.py`](check_authored_pipeline.py) | the structural authoring contract (A0–A9), stdlib-only |
+
+Run artifacts (`.authoring/`, `out/`) are written into the **workspace** you
+point the run at, never into this directory.

--- a/examples/authoring/check_authored_pipeline.py
+++ b/examples/authoring/check_authored_pipeline.py
@@ -1,0 +1,888 @@
+#!/usr/bin/env python3
+"""Structural gate on an AUTHORED pipeline (the authoring contract).
+
+``pipeline-author.dot`` lets an LLM node WRITE a new reusable attractor pipeline
+from a design brief. That is only worth doing if the result is checked by
+something outside the author's context before anyone is asked to trust it. Three
+gates do that, in order:
+
+1. ``attractor lint`` -- executability and the topology bug classes the engine
+   itself knows about (dead conditional edges, stale-label collisions,
+   fail-routed-to-exit, pipe-masked gate exit codes). ERRORs block.
+2. this script -- the *doctrine* checks lint deliberately does not own, or owns
+   only as advice: is the authored graph actually an attractor, is its exit
+   really unreachable without machine evidence, does it carry a budget wall,
+   and does every worker have somewhere to fail to?
+3. an independent critique, in a fresh context, which reads what these two
+   printed and judges what neither can.
+
+**The load-bearing check is A4.** A1-A3 can all pass on a graph whose exit is
+reachable by a path that never touches a gate: a corrective loop can sit off to
+one side while ``done`` hangs directly off a worker. A4 deletes every
+evidence-bearing gate from the graph and asks whether the exit is still
+reachable from ``start``. If it is, the exit was never gated on evidence --
+which is the one property the whole doctrine rests on
+(``docs/PIPELINE_DESIGN_PRINCIPLES.md`` section 0).
+
+**What this script deliberately does NOT do** is judge whether the authored
+pipeline is any *good* for the brief it came from. Structure is checkable;
+fitness for purpose is not. That is the critique node's job, and it is why the
+authoring pipeline still pays for an LLM after these gates have already run.
+
+Token contract (Idiom A -- always exit 0 so ``tool.last_line`` is always fresh):
+
+  doctrine_ok    every check passed; the authored pipeline may go to critique
+  doctrine_bad   at least one check failed; route back to the author
+
+A nonzero exit means this script could not run at all (unwritable report). That
+routes through ``outcome=fail`` to the postmortem path -- deliberately distinct
+from ``doctrine_bad``, which is a judgement about the authored graph. A missing
+or unparseable pipeline file is a *judgement* (``doctrine_bad``), not a crash:
+the author node is the one that was supposed to write it.
+
+DOT parsing is deliberately stdlib-only and self-contained, for the same reason
+``examples/objective/check_child_contract.py`` is: this gate must run under
+whatever ``python3`` is on PATH in the target workspace, which is not the
+``attractor`` CLI's own virtualenv. It is a *second* opinion, and it runs only
+after the engine's own parser has already accepted the file via ``attractor
+lint`` -- so a disagreement fails closed (``doctrine_bad``) rather than silently
+admitting a graph neither tool understood.
+
+Usage:
+    check_authored_pipeline.py --pipeline out/my-pipeline.dot \
+                               --companion out/my-pipeline.md \
+                               --report .authoring/doctrine-report.txt
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# A small DOT reader -- only what the structural checks need
+#
+# Adapted from examples/objective/check_child_contract.py, which is pinned
+# against the engine's own parser by a shipped test. This copy carries its own
+# parser-agreement test for the same reason: a second opinion is only worth
+# anything if it reads the same graph the engine reads.
+# ---------------------------------------------------------------------------
+
+_TOKEN_RE = re.compile(
+    r"""
+    (?P<string>"(?:[^"\\]|\\.)*")        # quoted string (backslash escapes)
+  | (?P<arrow>->|--)                      # edge operators
+  | (?P<punct>[\[\]{};,=])                # structural punctuation
+  | (?P<ident>[A-Za-z_\u0080-\uffff][A-Za-z_0-9.\u0080-\uffff]*|-?\.?[0-9][0-9.]*)
+    """,
+    re.VERBOSE,
+)
+
+_KEYWORDS = {"digraph", "graph", "strict", "subgraph", "node", "edge"}
+
+
+def _strip_comments(text: str) -> str:
+    """Remove //, #, and /* */ comments without touching quoted strings."""
+    out: list[str] = []
+    i = 0
+    n = len(text)
+    while i < n:
+        ch = text[i]
+        if ch == '"':
+            out.append(ch)
+            i += 1
+            while i < n:
+                out.append(text[i])
+                if text[i] == "\\" and i + 1 < n:
+                    out.append(text[i + 1])
+                    i += 2
+                    continue
+                if text[i] == '"':
+                    i += 1
+                    break
+                i += 1
+            continue
+        if text.startswith("//", i):
+            while i < n and text[i] != "\n":
+                i += 1
+            continue
+        if text.startswith("/*", i):
+            end = text.find("*/", i + 2)
+            i = n if end == -1 else end + 2
+            continue
+        if ch == "#" and (not out or out[-1] == "\n"):
+            while i < n and text[i] != "\n":
+                i += 1
+            continue
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+
+def _unquote(token: str) -> str:
+    """Strip the quotes and process escapes exactly as the engine's parser does.
+
+    ORDER MATTERS, and it is the engine's order (``dot_parser._parse_value``):
+    ``\\\\`` collapses to ``\\`` FIRST, so a source ``\\\\n`` -- the escape
+    pattern the shipped graphs use between shell statements -- becomes a real
+    newline rather than a backslash followed by one.  Reproducing the order
+    rather than approximating it is what lets the parser-agreement test compare
+    attribute *values*, not just node ids: a reader that agreed on the shape of
+    the graph while disagreeing about what a gate's command says would gate on
+    a string the engine never runs.
+    """
+    if len(token) >= 2 and token[0] == '"' and token[-1] == '"':
+        body = token[1:-1]
+        body = body.replace("\\\\", "\\")
+        body = body.replace('\\"', '"')
+        body = body.replace("\\n", "\n")
+        body = body.replace("\\t", "\t")
+        return body
+    return token
+
+
+def _tokenize(text: str) -> list[str]:
+    return [m.group(0) for m in _TOKEN_RE.finditer(_strip_comments(text))]
+
+
+@dataclass
+class DotNode:
+    node_id: str
+    attrs: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class DotEdge:
+    src: str
+    dst: str
+    attrs: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class DotGraph:
+    nodes: dict[str, DotNode] = field(default_factory=dict)
+    edges: list[DotEdge] = field(default_factory=list)
+    graph_attrs: dict[str, str] = field(default_factory=dict)
+    node_defaults: dict[str, str] = field(default_factory=dict)
+
+    def node(self, node_id: str) -> DotNode:
+        node = self.nodes.get(node_id)
+        if node is None:
+            node = DotNode(node_id)
+            self.nodes[node_id] = node
+        return node
+
+    def attr(self, node_id: str, key: str, default: str = "") -> str:
+        node = self.nodes.get(node_id)
+        if node is not None and key in node.attrs:
+            return node.attrs[key]
+        return self.node_defaults.get(key, default)
+
+    def outgoing(self, node_id: str) -> list[DotEdge]:
+        return [e for e in self.edges if e.src == node_id]
+
+
+class DotParseError(Exception):
+    """The authored .dot could not be read as a graph."""
+
+
+def parse_dot_min(text: str) -> DotGraph:
+    """Parse the subset of DOT the shipped pipelines actually use."""
+    tokens = _tokenize(text)
+    if not tokens or tokens[0] not in ("strict", "digraph", "graph"):
+        raise DotParseError(
+            "does not start with a graph header (strict/digraph/graph) -- "
+            "this is not a DOT graph"
+        )
+    graph = DotGraph()
+    i = 0
+    total = len(tokens)
+
+    def read_attr_list(idx: int) -> tuple[dict[str, str], int]:
+        attrs: dict[str, str] = {}
+        assert tokens[idx] == "["
+        idx += 1
+        while idx < total and tokens[idx] != "]":
+            if tokens[idx] in (",", ";"):
+                idx += 1
+                continue
+            key = _unquote(tokens[idx])
+            idx += 1
+            if idx < total and tokens[idx] == "=":
+                idx += 1
+                if idx >= total:
+                    raise DotParseError("attribute list ended after '='")
+                attrs[key] = _unquote(tokens[idx])
+                idx += 1
+            else:
+                attrs[key] = "true"
+        if idx >= total:
+            raise DotParseError("unterminated attribute list")
+        return attrs, idx + 1
+
+    while i < total:
+        tok = tokens[i]
+
+        if tok in ("{", "}", ";", ","):
+            i += 1
+            continue
+
+        # `graph|node|edge [ ... ]` -- attribute defaults. Checked BEFORE the
+        # header-keyword branch, because `graph` is both a keyword and the name
+        # of the graph-attribute statement.
+        if tok in ("graph", "node", "edge") and i + 1 < total and tokens[i + 1] == "[":
+            defaults, i = read_attr_list(i + 1)
+            if tok == "node":
+                graph.node_defaults.update(defaults)
+            elif tok == "graph":
+                graph.graph_attrs.update(defaults)
+            continue
+
+        if tok in ("digraph", "graph", "strict", "subgraph"):
+            # Skip the header keyword and any graph name; the body is flat for
+            # our purposes (cluster subgraphs are flattened by the engine too).
+            i += 1
+            while i < total and tokens[i] not in ("{", ";"):
+                i += 1
+            continue
+
+        # A bare `key = value` at statement level is a graph attribute.
+        if i + 2 < total and tokens[i + 1] == "=" and tok not in _KEYWORDS:
+            graph.graph_attrs[_unquote(tok)] = _unquote(tokens[i + 2])
+            i += 3
+            continue
+
+        # Node statement or edge chain.
+        chain = [_unquote(tok)]
+        i += 1
+        while i < total and tokens[i] in ("->", "--"):
+            i += 1
+            if i >= total:
+                raise DotParseError("edge chain ended after '->'")
+            chain.append(_unquote(tokens[i]))
+            i += 1
+
+        stmt_attrs: dict[str, str] = {}
+        if i < total and tokens[i] == "[":
+            stmt_attrs, i = read_attr_list(i)
+
+        if len(chain) == 1:
+            graph.node(chain[0]).attrs.update(stmt_attrs)
+        else:
+            for src, dst in zip(chain, chain[1:], strict=False):
+                graph.node(src)
+                graph.node(dst)
+                graph.edges.append(DotEdge(src, dst, dict(stmt_attrs)))
+
+    if not graph.nodes:
+        raise DotParseError("no nodes found")
+    return graph
+
+
+# ---------------------------------------------------------------------------
+# Shape helpers -- mirror the engine's own resolution order
+# ---------------------------------------------------------------------------
+
+
+def _is_exit(graph: DotGraph, node_id: str) -> bool:
+    return (
+        graph.attr(node_id, "shape") == "Msquare"
+        or graph.attr(node_id, "type") == "exit"
+        or node_id.lower() in ("exit", "end")
+    )
+
+
+def _is_start(graph: DotGraph, node_id: str) -> bool:
+    return (
+        graph.attr(node_id, "shape") == "Mdiamond"
+        or graph.attr(node_id, "type") == "start"
+        or node_id.lower() == "start"
+    )
+
+
+def _is_tool(graph: DotGraph, node_id: str) -> bool:
+    return graph.attr(node_id, "shape") == "parallelogram" or bool(
+        graph.attr(node_id, "tool_command")
+    )
+
+
+def _is_worker(graph: DotGraph, node_id: str) -> bool:
+    """A codergen (LLM) node: shape=box, or no shape at all (box is the default)."""
+    if _is_start(graph, node_id) or _is_exit(graph, node_id):
+        return False
+    if graph.attr(node_id, "type"):
+        return False
+    return graph.attr(node_id, "shape") in ("", "box")
+
+
+def _starts(graph: DotGraph) -> list[str]:
+    return sorted(n for n in graph.nodes if _is_start(graph, n))
+
+
+def _reachable(graph: DotGraph, sources: list[str], blocked: set[str] | None = None) -> set[str]:
+    """Nodes reachable from *sources*, never entering any node in *blocked*."""
+    blocked = blocked or set()
+    seen: set[str] = set()
+    stack = [s for s in sources if s not in blocked]
+    while stack:
+        node_id = stack.pop()
+        if node_id in seen:
+            continue
+        seen.add(node_id)
+        for edge in graph.outgoing(node_id):
+            if edge.dst not in blocked:
+                stack.append(edge.dst)
+    return seen
+
+
+def _has_cycle(graph: DotGraph) -> bool:
+    adjacency: dict[str, list[str]] = {n: [] for n in graph.nodes}
+    for edge in graph.edges:
+        adjacency.setdefault(edge.src, []).append(edge.dst)
+    state: dict[str, int] = {}
+
+    def visit(node_id: str) -> bool:
+        state[node_id] = 1
+        for nxt in adjacency.get(node_id, []):
+            mark = state.get(nxt, 0)
+            if mark == 1:
+                return True
+            if mark == 0 and visit(nxt):
+                return True
+        state[node_id] = 2
+        return False
+
+    sys.setrecursionlimit(10000)
+    return any(state.get(n, 0) == 0 and visit(n) for n in graph.nodes)
+
+
+_IS_FAIL_RE = re.compile(r"outcome\s*=\s*fail\b")
+_NOT_SUCCESS_RE = re.compile(r"outcome\s*!=\s*success\b")
+_SUCCESS_CONJUNCTION_RE = re.compile(r"outcome\s*=\s*success\b")
+_LAST_LINE_RE = re.compile(r"context\.tool\.last_line\s*=")
+
+
+def _is_failure_condition(condition: str) -> bool:
+    """Does this edge condition select the FAILURE branch of its source node?"""
+    return bool(_IS_FAIL_RE.search(condition) or _NOT_SUCCESS_RE.search(condition))
+
+
+def _is_truthy(value: str) -> bool:
+    return value.strip().strip('"').lower() in ("true", "1", "yes", "on")
+
+
+def _has_fail_route(graph: DotGraph, node_id: str) -> bool:
+    if graph.attr(node_id, "retry_target") or graph.graph_attrs.get("retry_target"):
+        return True
+    if graph.attr(node_id, "fallback_retry_target"):
+        return True
+    if _is_truthy(graph.attr(node_id, "continue_on_fail")):
+        return True
+    return any(
+        _is_failure_condition(edge.attrs.get("condition", "")) for edge in graph.outgoing(node_id)
+    )
+
+
+# ---------------------------------------------------------------------------
+# "Is this command checking something, or just typing?"
+#
+# A gate whose command only ever emits a constant is not a gate -- it is an
+# assertion wearing a parallelogram. `printf gate_pass` cannot fail, so nothing
+# behind it is gated on anything. This is the code-tier form of the doctrine's
+# own self-test: "is the model here for judgment, or just to type?"
+# ---------------------------------------------------------------------------
+
+#: Head words that only ever emit or arrange -- they never *check* anything.
+_CONSTANT_EMITTERS = frozenset(
+    {
+        "printf", "echo", "exit", "return", "true", "false", ":", "cd", "mkdir",
+        "touch", "sleep", "shift", "set", "umask", "export", "unset", "break",
+        "continue", "rm", "cp", "mv", "chmod",
+    }
+)
+
+#: Shell keywords and grouping tokens -- skip past them to the real head word.
+_SHELL_KEYWORDS = frozenset(
+    {
+        "if", "then", "else", "elif", "fi", "while", "until", "do", "done",
+        "case", "esac", "for", "select", "function", "time", "!", "in",
+    }
+)
+
+_ASSIGNMENT_RE = re.compile(r"^[A-Za-z_][A-Za-z_0-9]*=")
+_REDIRECT_RE = re.compile(r"^\d*[<>]")
+
+
+def _split_segments(command: str) -> list[str]:
+    """Split a shell command into command positions, respecting quotes.
+
+    Deliberately approximate -- a lint-grade reader in the same spirit as the
+    engine's own CMD-001 rule, not a shell. It errs toward *more* segments,
+    which can only make the substantive-command search more generous, never
+    less; the fail-closed direction is preserved because what gets rejected is
+    a command with no substantive head word anywhere in it.
+    """
+    segments: list[str] = []
+    current: list[str] = []
+    quote: str | None = None
+    i = 0
+    n = len(command)
+    while i < n:
+        ch = command[i]
+        if quote:
+            if ch == "\\" and i + 1 < n:
+                current.append(ch)
+                current.append(command[i + 1])
+                i += 2
+                continue
+            current.append(ch)
+            if ch == quote:
+                quote = None
+            i += 1
+            continue
+        if ch in ("'", '"'):
+            quote = ch
+            current.append(ch)
+            i += 1
+            continue
+        if command.startswith("&&", i) or command.startswith("||", i):
+            segments.append("".join(current))
+            current = []
+            i += 2
+            continue
+        if ch in (";", "|", "&", "\n", "(", ")", "{", "}", "`"):
+            segments.append("".join(current))
+            current = []
+            i += 1
+            continue
+        current.append(ch)
+        i += 1
+    segments.append("".join(current))
+    return segments
+
+
+def _head_word(segment: str) -> str:
+    """The command word a segment actually runs, or '' if it runs nothing."""
+    for word in segment.split():
+        if word in _SHELL_KEYWORDS:
+            continue
+        if _ASSIGNMENT_RE.match(word) or _REDIRECT_RE.match(word):
+            continue
+        return word.strip('"').strip("'")
+    return ""
+
+
+def substantive_commands(command: str) -> list[str]:
+    """Head words in *command* that check or compute something real.
+
+    ``[``, ``test``, ``grep``, ``pytest``, ``python3``, ``bash``, ``git``,
+    ``attractor`` -- anything that is not purely an emitter or a file
+    arrangement.
+    """
+    found: list[str] = []
+    for segment in _split_segments(command):
+        head = _head_word(segment)
+        if not head or head in _CONSTANT_EMITTERS:
+            continue
+        found.append(head)
+    return found
+
+
+#: Vocabulary A5 accepts as evidence that a node is counting something. Stated
+#: here and in README.md so the author is told the contract, not made to guess.
+_BUDGET_TOKENS = ("max_iteration", "max_round", "max_attempt", "max_retries", "budget", "iter")
+
+#: Vocabulary A5 accepts on an outgoing edge as the exhaustion route.
+_EXHAUSTION_TOKENS = ("exhaust", "budget", "stall", "over_budget", "give_up", "spent")
+
+
+# ---------------------------------------------------------------------------
+# The contract checks
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CheckResult:
+    check_id: str
+    title: str
+    passed: bool
+    detail: str
+
+
+def evidence_gates(graph: DotGraph) -> list[str]:
+    """Reachable tool nodes that run a real command AND route on the answer.
+
+    Three conditions, each load-bearing:
+
+    * **a tool node** -- ``shape=parallelogram`` or a ``tool_command``. An LLM
+      node's opinion of its own work is not evidence, however confidently it is
+      phrased (``docs/VISION.md``, "Gates outside workers").
+    * **a substantive command** -- something that can come back with an answer
+      the author did not already write. ``printf gate_pass`` is not a gate.
+    * **it routes** -- at least two outgoing edges, at least one conditional. A
+      node whose result changes nothing is not deciding anything.
+    """
+    reachable = _reachable(graph, _starts(graph))
+    gates: list[str] = []
+    for node_id in sorted(graph.nodes):
+        if node_id not in reachable or not _is_tool(graph, node_id):
+            continue
+        command = graph.attr(node_id, "tool_command")
+        if not command or not substantive_commands(command):
+            continue
+        out = graph.outgoing(node_id)
+        if len(out) < 2 or not any(e.attrs.get("condition") for e in out):
+            continue
+        gates.append(node_id)
+    return gates
+
+
+def run_checks(graph: DotGraph, companion: Path | None) -> list[CheckResult]:
+    results: list[CheckResult] = []
+    starts = _starts(graph)
+    reachable = _reachable(graph, starts)
+    exits = sorted(n for n in graph.nodes if _is_exit(graph, n))
+    gates = evidence_gates(graph)
+
+    # --- A1: exactly one exit node -------------------------------------------
+    results.append(
+        CheckResult(
+            "A1",
+            "exactly one exit node",
+            len(exits) == 1,
+            f"exit nodes found: {exits or 'none'}"
+            + (
+                ""
+                if len(exits) == 1
+                else " -- the engine refuses to run a graph without exactly one. Express a "
+                "second honest terminal as a LOUD nonzero tool node (the escalation idiom), "
+                "never as a second Msquare"
+            ),
+        )
+    )
+
+    # --- A2: at least one corrective cycle ------------------------------------
+    has_cycle = _has_cycle(graph)
+    results.append(
+        CheckResult(
+            "A2",
+            "at least one corrective cycle",
+            has_cycle,
+            "cycle present"
+            if has_cycle
+            else "graph is acyclic -- there is nothing to converge to. "
+            "'If your pipeline graph has no cycle, it should probably have been a recipe.'",
+        )
+    )
+
+    # --- A3: an evidence-bearing gate exists ----------------------------------
+    results.append(
+        CheckResult(
+            "A3",
+            "at least one evidence-bearing gate runs a real command and routes on it",
+            bool(gates),
+            f"evidence gates: {gates or 'none'}"
+            + (
+                ""
+                if gates
+                else " -- an evidence gate is a tool node (shape=parallelogram) whose command "
+                "actually checks something (a test, a build, a linter, a grep, a file "
+                "predicate) and whose outgoing edges route on the answer. A node that only "
+                "`printf`s a constant cannot fail, so nothing behind it is gated"
+            ),
+        )
+    )
+
+    # --- A4: the exit is unreachable without passing an evidence gate ---------
+    # THE load-bearing check. Delete every evidence gate; if the exit is still
+    # reachable from start, some path to it never touched machine evidence --
+    # and that path is the one a bad day will find.
+    if len(exits) == 1 and starts:
+        exit_id = exits[0]
+        bypass = exit_id in _reachable(graph, starts, blocked=set(gates))
+        results.append(
+            CheckResult(
+                "A4",
+                "the exit is structurally unreachable without passing an evidence gate",
+                not bypass,
+                f"with gate(s) {gates or 'none'} removed, '{exit_id}' is "
+                + ("STILL reachable from start" if bypass else "unreachable from start")
+                + (
+                    ""
+                    if not bypass
+                    else " -- there is a path from start to the exit that never passes a gate, "
+                    "so the run can finish without any machine evidence at all. Route that "
+                    "path through a deterministic gate (a file predicate is enough) before it "
+                    "reaches the exit"
+                ),
+            )
+        )
+    else:
+        results.append(
+            CheckResult(
+                "A4",
+                "the exit is structurally unreachable without passing an evidence gate",
+                False,
+                "not evaluable: "
+                + ("no start node" if not starts else f"expected exactly one exit, found {exits}"),
+            )
+        )
+
+    # --- A5: a budget wall that routes exhaustion -----------------------------
+    budget_nodes: list[str] = []
+    for node_id in sorted(graph.nodes):
+        if node_id not in reachable or not _is_tool(graph, node_id):
+            continue
+        command = graph.attr(node_id, "tool_command")
+        if not any(token in command for token in _BUDGET_TOKENS):
+            continue
+        for edge in graph.outgoing(node_id):
+            haystack = (edge.attrs.get("condition", "") + " " + edge.attrs.get("label", "")).lower()
+            if any(token in haystack for token in _EXHAUSTION_TOKENS):
+                budget_nodes.append(node_id)
+                break
+    results.append(
+        CheckResult(
+            "A5",
+            "a tool node walls an iteration budget and routes exhaustion somewhere",
+            bool(budget_nodes),
+            f"budget-walling gates: {budget_nodes or 'none'}"
+            + (
+                ""
+                if budget_nodes
+                else " -- a corrective loop with no wall spends until the engine's step cap "
+                "kills it with a bare FAIL, bypassing every salvage path. The wall is a tool "
+                f"node whose command names one of {list(_BUDGET_TOKENS)} and which has an "
+                f"outgoing edge whose condition or label names one of {list(_EXHAUSTION_TOKENS)}"
+            ),
+        )
+    )
+
+    # --- A6: every reachable LLM worker has a failure route -------------------
+    unrouted = sorted(
+        n
+        for n in graph.nodes
+        if _is_worker(graph, n) and n in reachable and not _has_fail_route(graph, n)
+    )
+    results.append(
+        CheckResult(
+            "A6",
+            "every reachable LLM worker has an outcome=fail route or a retry_target",
+            not unrouted,
+            f"workers with no failure route: {unrouted or 'none'}"
+            + (
+                ""
+                if not unrouted
+                else " -- a FAIL does not traverse plain edges. One transient provider error at "
+                "an unrouted node ends the whole run, however much work already landed"
+            ),
+        )
+    )
+
+    # --- A7: stale-label conjunctions where labels route ----------------------
+    # A tool node that exits nonzero does NOT refresh tool.last_line
+    # (docs/ROUTING-REFERENCE.md section 3). So on a node that can both fail and
+    # route on a label, a STALE label can match at the same time as the failure
+    # edge, and the engine's deterministic pick may not be the one you meant.
+    stale_violations: list[str] = []
+    for node_id in sorted(graph.nodes):
+        out = graph.outgoing(node_id)
+        label_edges = [e for e in out if _LAST_LINE_RE.search(e.attrs.get("condition", ""))]
+        fail_edges = [e for e in out if _is_failure_condition(e.attrs.get("condition", ""))]
+        if not label_edges or not fail_edges:
+            continue
+        for edge in label_edges:
+            condition = edge.attrs.get("condition", "")
+            if not _SUCCESS_CONJUNCTION_RE.search(condition):
+                stale_violations.append(f"{node_id} -> {edge.dst} [condition={condition!r}]")
+    results.append(
+        CheckResult(
+            "A7",
+            "label-routing edges conjoin && outcome=success where the source can also fail",
+            not stale_violations,
+            f"unconjoined label edges: {stale_violations or 'none'}"
+            + (
+                ""
+                if not stale_violations
+                else " -- a failing tool node does not refresh context.tool.last_line, so a "
+                "STALE label can match alongside the failure edge on a later visit. Add "
+                "'&& outcome=success' to each label edge listed above"
+            ),
+        )
+    )
+
+    # --- A8: no failure outcome routed into the exit --------------------------
+    fail_to_exit = sorted(
+        f"{e.src} -> {e.dst} [condition={e.attrs.get('condition', '')!r}]"
+        for e in graph.edges
+        if _is_exit(graph, e.dst) and _is_failure_condition(e.attrs.get("condition", ""))
+    )
+    results.append(
+        CheckResult(
+            "A8",
+            "no failure outcome is routed into the terminal success node",
+            not fail_to_exit,
+            f"failure edges into the exit: {fail_to_exit or 'none'}"
+            + (
+                ""
+                if not fail_to_exit
+                else " -- this converts a failure into a successful run. A failure belongs on a "
+                "salvage path (postmortem, escalation) that ends LOUD, not through the success "
+                "door. The engine's own lint calls this TOPO-006 and warns; here it blocks"
+            ),
+        )
+    )
+
+    # --- A9: the companion document covers every worker -----------------------
+    workers = sorted(n for n in graph.nodes if _is_worker(graph, n) and n in reachable)
+    results.append(_check_companion(companion, workers))
+
+    return results
+
+
+def _check_companion(companion: Path | None, workers: list[str]) -> CheckResult:
+    """A9 -- the authored pipeline ships as a pair: the .dot and its .md.
+
+    Every exemplar in this repo has a paired guide, because a graph shows what
+    it does and not why it is shaped that way. The machine-checkable core of the
+    node-contract doctrine is coverage: each LLM worker in the graph has to be
+    named in the prose that explains it.
+    """
+    title = "a companion document names every LLM worker node"
+    if companion is None:
+        return CheckResult(
+            "A9", title, False, "no companion path resolved -- pass --companion or name the .md"
+        )
+    try:
+        prose = companion.read_text(encoding="utf-8", errors="replace")
+    except FileNotFoundError:
+        return CheckResult(
+            "A9",
+            title,
+            False,
+            f"{companion}: not found -- the authored pipeline ships as a pair, the .dot and "
+            "its .md companion",
+        )
+    except OSError as exc:
+        return CheckResult("A9", title, False, f"{companion}: {exc}")
+
+    if not prose.strip():
+        return CheckResult(
+            "A9",
+            title,
+            False,
+            f"{companion}: empty -- state each LLM node's contract: objective, constraints, "
+            "available capabilities, required evidence "
+            "(docs/DOT-AUTHORING-GUIDE.md, 'The node contract')",
+        )
+    missing = [w for w in workers if w not in prose]
+    return CheckResult(
+        "A9",
+        title,
+        not missing,
+        f"{companion}: {len(prose.split())} words; "
+        + (
+            "every worker documented"
+            if not missing
+            else f"undocumented workers: {missing} -- state each one's contract: objective, "
+            "constraints, available capabilities, required evidence "
+            "(docs/DOT-AUTHORING-GUIDE.md, 'The node contract')"
+        ),
+    )
+
+
+def render_report(pipeline: str, companion: str, results: list[CheckResult], verdict: str) -> str:
+    lines = [
+        "AUTHORED-PIPELINE DOCTRINE REPORT",
+        f"pipeline:  {pipeline}",
+        f"companion: {companion}",
+        f"verdict:   {verdict}",
+        "",
+    ]
+    for result in results:
+        lines.append(f"[{'PASS' if result.passed else 'FAIL'}] {result.check_id} {result.title}")
+        lines.append(f"       {result.detail}")
+    if any(not r.passed for r in results):
+        lines += [
+            "",
+            "Fix every FAIL above and rewrite the pipeline. See examples/authoring/README.md and",
+            "docs/PIPELINE_DESIGN_PRINCIPLES.md. Do not weaken a gate to get past this one.",
+        ]
+    return "\n".join(lines) + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Structural doctrine gate on an authored attractor pipeline."
+    )
+    parser.add_argument("--pipeline", required=True, help="path to the authored .dot")
+    parser.add_argument(
+        "--companion",
+        default=None,
+        help="path to the authored .md companion (default: the .dot path with a .md suffix)",
+    )
+    parser.add_argument(
+        "--report",
+        default=".authoring/doctrine-report.txt",
+        help="where to write the human-readable report",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    report_path = Path(args.report)
+    try:
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:  # pragma: no cover - environment failure
+        print(f"check_authored_pipeline: cannot create report dir: {exc}", file=sys.stderr)
+        return 2
+
+    pipeline_path = Path(args.pipeline)
+    companion_path = Path(args.companion) if args.companion else pipeline_path.with_suffix(".md")
+
+    results: list[CheckResult] = []
+    graph: DotGraph | None = None
+    try:
+        graph = parse_dot_min(pipeline_path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        results.append(
+            CheckResult(
+                "A0",
+                "the authored pipeline exists",
+                False,
+                f"{pipeline_path}: not found -- the author node was asked to write exactly this path",
+            )
+        )
+    except OSError as exc:
+        results.append(
+            CheckResult("A0", "the authored pipeline is readable", False, f"{pipeline_path}: {exc}")
+        )
+    except DotParseError as exc:
+        results.append(
+            CheckResult("A0", "the authored pipeline parses", False, f"{pipeline_path}: {exc}")
+        )
+
+    if graph is not None:
+        results.extend(run_checks(graph, companion_path))
+
+    verdict = "doctrine_ok" if results and all(r.passed for r in results) else "doctrine_bad"
+
+    try:
+        report_path.write_text(
+            render_report(str(pipeline_path), str(companion_path), results, verdict),
+            encoding="utf-8",
+        )
+    except OSError as exc:  # pragma: no cover - environment failure
+        print(f"check_authored_pipeline: cannot write report: {exc}", file=sys.stderr)
+        return 2
+
+    print(verdict, end="")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - thin CLI wrapper
+    raise SystemExit(main())

--- a/examples/authoring/pipeline-author.dot
+++ b/examples/authoring/pipeline-author.dot
@@ -1,0 +1,359 @@
+// ============================================================================
+// Pipeline Author -- an attractor that authors attractors
+// ============================================================================
+// You state a DESIGN BRIEF for work you want a reusable pipeline to do. This
+// graph diagnoses the brief, writes a new pipeline, hardens it under executed
+// machine gates plus an independent doctrine critique, and publishes it with
+// provenance -- or tells you honestly that the work described does not want an
+// attractor at all.
+//
+//   brief  ->  triage  ->  draft  ->  machine gates  ->  critique  ->  published
+//                  \                      ^                  |
+//                   \                     +------------------+
+//                    +-> honest redirect (green exit, no pipeline)
+//
+// The basin: **a new pipeline exists that lints clean, satisfies the authoring
+// contract, and survives an independent doctrine critique -- or the brief is
+// honestly redirected.** Both are green exits, told apart by a disposition
+// artifact. A run that can do neither escalates LOUDLY (nonzero) rather than
+// leaving through the success door.
+//
+// WHY THIS EXISTS. `/attractorify` DESIGNS a pipeline conversationally with a
+// human in the loop; `examples/objective/objective-runner.dot` COMPOSES a
+// single-purpose child at run time for one objective. Neither one converges a
+// *reusable* pipeline under executed gates. This does: authoring a pipeline is
+// itself convergence-shaped work -- draft, machine-check, independent critique,
+// revise -- and the repo's own evidence is that prompt text alone does not
+// deliver authoring discipline. Executed gates moved what prose could not.
+//
+// Invocation (per KNOWN_ISSUES: process cwd MUST equal --cwd for box nodes):
+//   AUTH="$PWD/examples/authoring"      # capture BEFORE cd
+//   cd <workspace>
+//   attractor run "$AUTH/pipeline-author.dot" \
+//       --param brief="Objective: ... Evidence: ... Budget: ..." \
+//       --param authoring_dir="$AUTH" \
+//       --param target_dir="$PWD" \
+//       --param pipeline_name="doc-claims-verified" \
+//       --cwd .
+//
+// Parameters:
+//   brief           THE DESIGN BRIEF. What the pipeline should converge on, what
+//                   evidence sources exist, what budget it should carry.
+//   authoring_dir   Absolute path to this file's directory (the doctrine gate
+//                   runs check_authored_pipeline.py from here, and the author
+//                   reads the repo's doctrine docs relative to it).
+//   target_dir      Absolute path to the workspace. Prompt text for box nodes.
+//   pipeline_name   Published basename under out/ (default: authored-pipeline).
+//                   Validated at preflight against [A-Za-z0-9._-]+.
+//   max_iterations  Author-attempt budget (default 4).
+//   max_frames      Malformed-triage budget (default 2 re-frames).
+//
+// SHAPE (the doctrine, made visible):
+//   - THE BRIEF NEVER TOUCHES A SHELL. `$brief` is expanded into PROMPTS only,
+//     never into a tool_command. A design brief is untrusted text; engine
+//     substitution happens before /bin/sh sees the string, so a brief in a
+//     tool_command is a command-injection hole. `triage` restates it into
+//     .authoring/triage.md, and every deterministic node reads the FILE.
+//   - TRIAGE PROPOSES; THE GATE ROUTES. `triage` (LLM) applies the repo's
+//     three-question test to the brief and writes an anchored verdict line;
+//     `triage_gate` (code) reads the last line and decides. The first routing
+//     decision of the run is evidence outside the worker's context.
+//   - THE HONEST NO IS A DELIVERABLE. A brief describing recipe-shaped or
+//     gateless work exits GREEN through `redirect_report`, with a written
+//     recommendation. Refusing to author a pipeline is the useful answer.
+//   - NOTHING LANDS IN out/ UNTIL EVERY GATE IS GREEN. The author works on
+//     .authoring/draft/*; `package` publishes to out/ only after lint, the
+//     doctrine gate, and the critique have all passed. Draft and published are
+//     different words on purpose.
+//   - ONE COUNTER SPANS THE WHOLE CORRECTIVE PATH. Every corrective leg
+//     (lint_fail, doctrine_bad, critique ITERATE, critique transient FAIL)
+//     re-enters through `lint_gate`, which increments and walls the budget on
+//     ENTRY. "Individually-bounded legs do not compose"
+//     (PIPELINE_DESIGN_PRINCIPLES section 3): a persistent failure bouncing
+//     between two separately-counted gates never exhausts either. Here there is
+//     one ledger and every leg pays into it.
+//   - CHEAP GATE BEFORE EXPENSIVE GATE. `attractor lint` and the structural
+//     contract run before an LLM is paid to critique. Do not buy judgment on a
+//     graph that does not parse.
+//   - THE CRITIC INHERITS NOTHING. `critique` runs at fidelity="truncate" --
+//     goal and run id only. It never sees the author's reasoning about why the
+//     graph was right; it sees the artifact and the two gate reports. That
+//     isolation is the property being purchased, not an optimisation.
+//   - ONE GREEN EXIT. `validate_or_raise` requires exactly one exit node, so the
+//     two honest terminals are `done` (Msquare, reachable only through
+//     `finalize`, which refuses to open without a disposition artifact) and
+//     `escalated` (a tool node that exits 1 with max_retries=0 and no
+//     fail-route -- the bug-fix.dot idiom, a LOUD red).
+//
+// VERIFIED ENGINE SEMANTICS THIS FILE DEPENDS ON:
+//   - STALE-LABEL RULE: a tool node that exits nonzero does NOT refresh
+//     tool.last_line, so a stale label can match at the same time as an
+//     outcome=fail edge. Every last_line edge below whose source also carries a
+//     failure edge conjoins `&& outcome=success` (docs/ROUTING-REFERENCE.md
+//     section 3). The doctrine gate enforces the same rule on what this graph
+//     authors (check A7) -- the exemplar obeys the contract it hands out.
+//   - must_write= is NOT context-substituted (must_write.py reads the raw
+//     attribute). Every must_write path here is therefore a literal; the
+//     $pipeline_name knob is spent at `package`, in a shell, where the
+//     `pn=$pipeline_name; N=${pn:-default}` idiom actually works.
+//   - PARAM NAMESPACE: substitution rewrites $name/${name} for any context key.
+//     The shell variables here (mi, mf, pn, B, F, N, n, v, r, w, res) are safe
+//     only because no param shares their name. Never add a param named like a
+//     shell var.
+//   - A codergen node's FAIL does not traverse plain edges, which is why every
+//     box node below carries an explicit outcome=fail route.
+//
+// MODEL DOCTRINE: the expensive model belongs in the gates (critique) -- gate
+// quality determines basin depth; maker quality only affects iteration count.
+// Map via model_stylesheet in your deployment, e.g.:
+//   model_stylesheet=".gate { llm_model: <strong-reasoning-model> } .maker { llm_model: <standard-coding-model> }"
+// ============================================================================
+
+digraph PipelineAuthor {
+    graph [
+        goal="Author a new, reusable attractor pipeline for the stated design brief -- one that lints clean, satisfies the authoring contract under check_authored_pipeline.py, and survives an independent doctrine critique -- or redirect the brief honestly when the work it describes does not want an attractor.",
+        label="Pipeline Author",
+        params="brief, authoring_dir, target_dir, pipeline_name, max_iterations, max_frames",
+        default_max_retries=2,
+        default_fidelity="compact",
+        max_pipeline_duration="14400s"
+    ]
+
+    start [shape=Mdiamond, label="Start"]
+    done  [shape=Msquare,  label="Done"]
+
+    // ---------- preflight: deterministic admission -------------------------
+    // OBJECTIVE    Make the run's preconditions true, or refuse before an LLM
+    //              is ever paid.
+    // CONSTRAINTS  code-tier only; no judgement; never reads $brief.
+    // EVIDENCE     .authoring/ state dirs exist; the checker is present; the
+    //              publish name is safe.
+    // EXIT         ready | blocked (exit 1, LOUD)
+    preflight [
+        shape=parallelogram, class="glue", label="Preflight", max_retries=0,
+        tool_command="mkdir -p .authoring/draft .authoring/postmortem out || { printf blocked; exit 1; }; for f in attractor python3 sha256sum; do command -v \"$f\" >/dev/null 2>&1 || { echo \"FATAL: '$f' is not on PATH; the lint gate, the doctrine gate and the provenance record all need it\" >&2; printf blocked; exit 1; }; done; [ -f \"$authoring_dir/check_authored_pipeline.py\" ] || { echo \"FATAL: --param authoring_dir must name the examples/authoring directory; check_authored_pipeline.py is not under '$authoring_dir'\" >&2; printf blocked; exit 1; }; pn=$pipeline_name; N=${pn:-authored-pipeline}; case \"$N\" in *[!A-Za-z0-9._-]*) echo \"FATAL: --param pipeline_name must match [A-Za-z0-9._-]+ (got '$N'); it becomes a published filename\" >&2; printf blocked; exit 1;; esac; printf '%s\\n' \"$N\" > .authoring/name; printf ready"
+    ]
+
+    // ---------- triage: diagnose the BRIEF; do not author yet ---------------
+    // OBJECTIVE    Decide whether the work the brief describes wants an
+    //              attractor at all, and restate the brief durably.
+    // CONSTRAINTS  Do not write any pipeline. Do not self-route -- the token
+    //              comes from the gate. The verdict vocabulary is fixed and the
+    //              verdict must be the FINAL line of the file.
+    // CAPABILITIES read the repo's doctrine docs and the workspace.
+    // EVIDENCE     .authoring/triage.md (must_write + triage_gate).
+    // EXIT         an anchored TRIAGE: line the gate can read.
+    triage [
+        shape=box, class="maker", label="Triage the Brief",
+        must_write=".authoring/triage.md",
+        prompt="A design brief has been stated for a pipeline that does not exist yet:\n\n--- BRIEF ---\n$brief\n--- END BRIEF ---\n\nYour job is to DIAGNOSE the brief, not to author anything. Read $authoring_dir/../../docs/PIPELINE_DESIGN_PRINCIPLES.md section 0 in full, and survey the workspace at $target_dir enough to answer honestly.\n\nIf .authoring/triage.md already exists, a previous attempt of yours was rejected for not ending in a readable verdict line -- fix exactly that.\n\nWrite .authoring/triage.md, in this order:\n  1. THE BRIEF, restated verbatim under a '## Brief' heading. Downstream gates and the provenance record read this file rather than the raw parameter, so the restatement is the durable copy.\n  2. '## Three-question test' -- the repo's own test, applied to the WORK THE BRIEF DESCRIBES (not to this authoring run):\n       Q1 Is there a cycle -- work that can be attempted, machine-checked, and re-attempted?\n       Q2 Is the exit gated on machine-checkable evidence EXTERNAL to the worker?\n       Q3 Would it still land if any one LLM node had a bad day -- a single plausible-but-wrong response?\n     Answer each with 'yes' or 'no' first, then why, quoting the brief where it decides the answer.\n  3. '## Sink' -- if the answers are yes, name the concrete machine check that would gate the exit: an actual command that exits 0 only when the work is done. If you cannot name one, that is a 'no' on Q2, however appealing a pipeline sounds.\n  4. '## Budget' -- the iteration cap and wall-clock bound the brief implies.\n\nThen end the file with EXACTLY ONE final line, nothing after it:\n  VERDICT: ATTRACTOR   -- all three answers are yes and you named a real machine check\n  VERDICT: REDIRECT    -- any answer is no; the work wants a recipe, a conversation, or a one-shot\n\nBe willing to say REDIRECT. An accurate 'no, and here is where this work belongs' is worth more than a pipeline nobody should run. Do not fish for a cycle that is not in the brief, and do not invent a hollow check to avoid choosing REDIRECT: the check you name here becomes the authored pipeline's gate, and a gate that cannot fail gates nothing."
+    ]
+
+    // ---------- triage_gate: admit the diagnosis; print the routing token ----
+    // Idiom A (always exit 0) so tool.last_line is always fresh. A nonzero exit
+    // means the gate itself could not run, which routes differently -- to the
+    // postmortem path -- from a record it read and rejected.
+    // EXIT  attractor | redirect | triage_bad | triage_exhausted
+    triage_gate [
+        shape=parallelogram, class="gate", label="Admit Triage / Route", max_retries=0,
+        tool_command="mf=$max_frames; F=${mf:-2}; n=$(($(cat .authoring/frame-iter 2>/dev/null || echo 0)+1)); echo $n > .authoring/frame-iter; v=none; if [ -s .authoring/triage.md ]; then tail -n 1 .authoring/triage.md > .authoring/triage-line.txt; if grep -qix 'VERDICT: ATTRACTOR' .authoring/triage-line.txt; then v=attractor; elif grep -qix 'VERDICT: REDIRECT' .authoring/triage-line.txt; then v=redirect; fi; fi; if [ \"$v\" = none ]; then if [ \"$n\" -gt \"$F\" ]; then v=triage_exhausted; else v=triage_bad; fi; fi; printf '{\"frame\": %s, \"gate\": \"triage\", \"verdict\": \"%s\"}\\n' \"$n\" \"$v\" >> .authoring/convergence.jsonl; printf %s \"$v\""
+    ]
+
+    // ---------- redirect_report: the honest no, with receipts ----------------
+    // OBJECTIVE    Deliver the diagnosis as the work product.
+    // CONSTRAINTS  Quote the failing answers from triage.md verbatim; name the
+    //              better home for the work; author no pipeline.
+    // EVIDENCE     .authoring/redirect.md
+    // EXIT         green, through finalize. The diagnosis IS the deliverable.
+    redirect_report [
+        shape=box, class="maker", label="Honest Redirect",
+        must_write=".authoring/redirect.md",
+        prompt="The triage concluded that the work described in this brief does NOT want an attractor pipeline.\n\nRead .authoring/triage.md. Write .authoring/redirect.md -- the deliverable of this run:\n  1. The brief's objective, restated in one paragraph.\n  2. The three-question test with the failing answer(s) QUOTED VERBATIM from .authoring/triage.md, and one sentence on which question failed and why.\n  3. Where this work actually belongs. Name ONE: a recipe (staged, sequential, human approval gates -- see $authoring_dir/../../docs/PIPELINE_DESIGN_PRINCIPLES.md section 0), a conversation (judgement all the way down, no stable definition of done), or a one-shot (small enough that a loop buys nothing). Say what the first step there looks like, concretely.\n  4. What WOULD make it an attractor: the specific machine-checkable check that does not exist today. If someone later writes that check, this brief becomes authorable -- say exactly what it would have to assert, and what it would exit nonzero on.\n\nBe direct. A wrong 'yes, let us build a pipeline' costs hours and produces machinery nobody trusts; an accurate 'no, and here is why' is the more valuable run."
+    ]
+
+    // ---------- author: write the pipeline ----------------------------------
+    // OBJECTIVE    Write a NEW reusable attractor pipeline for the brief, plus
+    //              the companion guide that explains its shape.
+    // CONSTRAINTS  Control plane only -- no plan/implement/test as graph nodes.
+    //              Gates outside workers. One exit. A cycle. A budget wall.
+    //              Never weaken a gate to get past a gate.
+    // CAPABILITIES write files; read the repo's doctrine docs, its shipped
+    //              exemplars, and the gate reports from prior attempts.
+    // EVIDENCE     .authoring/draft/pipeline.dot (must_write) and
+    //              .authoring/draft/pipeline.md
+    // EXIT         both files exist AND pass lint_gate AND doctrine_gate AND
+    //              survive critique.
+    author [
+        shape=box, class="maker", label="Author the Pipeline",
+        must_write=".authoring/draft/pipeline.dot",
+        prompt="Write a NEW, reusable attractor pipeline for the brief recorded in .authoring/triage.md (read that file first -- it holds the brief restated, the three-question analysis, the sink, and the budget).\n\nBEFORE YOU WRITE, READ, in this order:\n  $authoring_dir/README.md -- the authoring contract, including EXACTLY what the doctrine gate checks (A1-A9). It is a stated contract, not a guessing game.\n  $authoring_dir/../../docs/PIPELINE_DESIGN_PRINCIPLES.md -- especially section 0 (control plane vs recipe plane), section 3 (loop convergence and budget walls) and section 4 (LLM output protocol; use last-line anchored verdicts).\n  $authoring_dir/../../docs/DOT-AUTHORING-GUIDE.md -- the node contract, node shapes, the lint rules.\n  $authoring_dir/../../docs/ROUTING-REFERENCE.md -- edge selection and the stale-label rule.\n  $authoring_dir/../patterns/task-runner.dot -- the canonical convergence skeleton. Copy its shape discipline, not its domain.\n  $authoring_dir/../gates/README.md -- the gate idioms (Idiom A vs Idiom B, the token contract).\n\nIF .authoring/lint-report.txt, .authoring/doctrine-report.txt OR .authoring/critique.md EXISTS, a previous attempt was BLOCKED. Read all that exist and fix exactly what they name, then rewrite. Do NOT weaken a gate, delete a check, or relax the pipeline's own definition of done to get past a gate -- the same gates run again, and the critique reads the reports too.\n\nWRITE EXACTLY TWO FILES:\n\n  .authoring/draft/pipeline.dot -- the pipeline. Requirements, all machine-checked:\n    * exactly one exit node (shape=Msquare); express a second honest terminal as a LOUD nonzero tool node, never a second Msquare\n    * at least one corrective cycle\n    * at least one evidence gate: shape=parallelogram, running a REAL command (a test, a build, a linter, a grep, a file predicate) whose result routes the graph. A node that only printfs a constant is not a gate\n    * the exit must be structurally unreachable except through such a gate\n    * a budget wall: a tool node that counts iterations and routes exhaustion to a salvage path -- not a bare FAIL\n    * every LLM (box) node carries an outcome=fail route or a retry_target\n    * every label-routing edge whose source can also fail conjoins '&& outcome=success'\n    * no failure outcome routed into the exit node\n    * every box node's prompt states the node contract: objective, constraints, available capabilities, required evidence -- the contract, never the algorithm\n    * parameters carry sensible defaults; the pipeline must run unchanged on the common case\n\n  .authoring/draft/pipeline.md -- the companion guide. It must NAME EVERY box node id in the graph and, for each, state its contract in prose. Also: what the pipeline converges on, how to invoke it, what each gate proves, and what the honest failure exits look like.\n\nDESIGN ORDER, from the doctrine: name the sink first, build the gate, build the loop, and only then add work nodes. Keep the control plane LEAN -- gates, budgets, walls, feedback channels. Delete domain decomposition: if you find yourself adding plan -> implement -> test as graph nodes, stop; that is the model's job, not the graph's.\n\nThe pipeline you write is for the brief's work, not for this run. Someone else will run it, later, on a task you will never see."
+    ]
+
+    // ---------- lint_gate: the engine's own linter, plus the budget wall -----
+    // OBJECTIVE    Machine-reject a broken draft BEFORE anything expensive
+    //              reads it, and own the one counter that spans every leg.
+    // CONSTRAINTS  ERRORs block; WARNINGs pass but are recorded (no --strict).
+    //              doctrine_gate owns the design-shape checks.
+    // EVIDENCE     .authoring/lint-report.txt, .authoring/convergence.jsonl
+    // EXIT         lint_pass | lint_fail | exhausted | lint_unavailable(exit 1)
+    // THE WALL LIVES HERE because every corrective leg re-enters through this
+    // node: lint_fail, doctrine_bad, critique ITERATE, and a transient critique
+    // FAIL all pass back through `author` -> `lint_gate` or straight here. One
+    // ledger, every leg pays. The budget is checked on ENTRY, so a persistent
+    // provider outage drains it and escalates through the postmortem path
+    // instead of cycling until the engine's step cap kills the run.
+    lint_gate [
+        shape=parallelogram, class="gate", label="Lint the Draft", max_retries=0,
+        tool_command="mi=$max_iterations; B=${mi:-4}; n=$(($(cat .authoring/iter 2>/dev/null || echo 0)+1)); echo $n > .authoring/iter; if [ \"$n\" -gt \"$B\" ]; then printf '{\"iteration\": %s, \"gate\": \"lint\", \"budget\": \"exhausted\"}\\n' \"$n\" >> .authoring/convergence.jsonl; printf exhausted; else command -v attractor >/dev/null 2>&1 || { echo 'FATAL: the attractor CLI left PATH mid-run; the draft cannot be lint-gated' >&2; printf lint_unavailable; exit 1; }; if attractor lint .authoring/draft/pipeline.dot > .authoring/lint-report.txt 2>&1; then res=lint_pass; else res=lint_fail; fi; w=$(grep -c '^WARNING' .authoring/lint-report.txt 2>/dev/null); printf '{\"iteration\": %s, \"gate\": \"lint\", \"result\": \"%s\", \"warnings\": %s}\\n' \"$n\" \"$res\" \"${w:-0}\" >> .authoring/convergence.jsonl; printf %s \"$res\"; fi"
+    ]
+
+    // ---------- doctrine_gate: the authoring contract, structurally ----------
+    // OBJECTIVE    Enforce the shape checks lint deliberately does not own, or
+    //              owns only as advice: is the draft actually an attractor, is
+    //              its exit really unreachable without machine evidence, does it
+    //              carry a budget wall, does every worker have somewhere to fail
+    //              to, and is its companion guide real?
+    // CONSTRAINTS  deterministic checks only; no judgement of fitness.
+    // EVIDENCE     .authoring/doctrine-report.txt (per-check PASS/FAIL)
+    // EXIT         doctrine_ok | doctrine_bad | (exit 1: gate could not run)
+    // The load-bearing check is A4: delete every evidence gate from the drafted
+    // graph and ask whether its exit is still reachable. A graph can carry a
+    // cycle and a gate and still hang `done` off a worker -- A1-A3 all pass and
+    // the exit was never gated on anything.
+    doctrine_gate [
+        shape=parallelogram, class="gate", label="Authoring Contract", max_retries=0,
+        tool_command="n=$(cat .authoring/iter 2>/dev/null || echo 0); r=$(python3 \"$authoring_dir/check_authored_pipeline.py\" --pipeline .authoring/draft/pipeline.dot --companion .authoring/draft/pipeline.md --report .authoring/doctrine-report.txt) || { echo 'FATAL: check_authored_pipeline.py could not run' >&2; printf gate_error; exit 1; }; printf '{\"iteration\": %s, \"gate\": \"doctrine\", \"result\": \"%s\"}\\n' \"$n\" \"$r\" >> .authoring/convergence.jsonl; printf %s \"$r\""
+    ]
+
+    // ---------- critique: the independent, doctrine-armed judgment -----------
+    // OBJECTIVE    Judge what the machine gates cannot: is this pipeline the
+    //              right shape FOR THIS BRIEF, and are its gates real?
+    // CONSTRAINTS  fidelity=truncate -- this node inherits nothing from the
+    //              author's context. Every finding cites executed evidence or a
+    //              gate report. The verdict is the FINAL line, anchored.
+    // CAPABILITIES read the draft, both gate reports, the triage record, and the
+    //              doctrine docs; run commands to check claims.
+    // EVIDENCE     .authoring/critique.md (must_write + verdict_gate)
+    // EXIT         VERDICT: SHIP or VERDICT: ITERATE as the last line.
+    // Verification inside the context that produced the evidence is not
+    // verification -- a live run in this repo's history had a worker author its
+    // own convergence record, and only critics outside its context caught it.
+    critique [
+        shape=box, class="gate", label="Independent Doctrine Critique", fidelity="truncate",
+        must_write=".authoring/critique.md",
+        prompt="You are reviewing a pipeline you did not write, for a brief you have not seen argued. Do not trust the author's reasoning; you do not have it, and that is deliberate.\n\nREAD, in this order:\n  .authoring/triage.md          -- the brief, restated, and the three-question analysis\n  .authoring/draft/pipeline.dot -- the pipeline under review\n  .authoring/draft/pipeline.md  -- its companion guide\n  .authoring/lint-report.txt    -- what the engine's linter said\n  .authoring/doctrine-report.txt-- what the structural contract said, check by check\n  $authoring_dir/../../docs/PIPELINE_DESIGN_PRINCIPLES.md and $authoring_dir/../../docs/VISION.md -- the doctrine you are judging against\n\nThe two gate reports already prove the STRUCTURE. Do not re-litigate what they checked. Judge what they cannot:\n\n  1. DOES THE GATE ACTUALLY PROVE THE BRIEF'S GOAL? A gate can be structurally perfect and assert the wrong thing, or assert something that is already true. Read the gate's command. Would it be RED today, before the work exists, and GREEN only when the brief's objective is satisfied? If you can run it, run it and quote what happened.\n  2. RECIPE PLANE IN THE CONTROL PLANE. Are any nodes domain phases (plan / implement / test / write / review-as-a-stage) rather than control-plane responsibilities? 'When you find yourself adding plan -> implement -> test as graph nodes, stop.'\n  3. CAN THE LOOP DESCEND? Does a failing iteration carry its failure forward as evidence the next attempt can read, or does it re-flip the same coin? Name the channel.\n  4. THE BAD DAY. Pick the single node most likely to return a plausible-but-wrong answer. Trace what happens. If one such response can reach the exit, say so and name the edge.\n  5. NODE CONTRACTS. Do the box prompts state objective / constraints / capabilities / required evidence, or do they enumerate an algorithm the model cannot deviate from when the domain surprises it?\n  6. THE COMPANION. Does .authoring/draft/pipeline.md explain WHY the graph is shaped this way, or only restate what it does?\n\nWrite .authoring/critique.md: specific findings, each citing a file and a node or edge by name, and each grounded in a quoted gate report line or a command you actually ran. A finding with no citation is an opinion; drop it.\n\nThen end the file with EXACTLY ONE final line, nothing after it:\n  VERDICT: SHIP      -- you would run this pipeline on real work as it stands\n  VERDICT: ITERATE   -- name, in the findings above, exactly what must change\n\nBe strict, and be specific. A wrong-but-plausible pipeline that ships is worse than another iteration -- it teaches the anti-pattern by example to everyone who copies it. But do not refuse over taste: if the shape is sound and the gates are real, SHIP is the honest verdict."
+    ]
+
+    // ---------- verdict_gate: deterministic routing on an anchored verdict ---
+    // OBJECTIVE    Turn the critique into a route, without an LLM in the router.
+    // CONSTRAINTS  Last-line anchored, case-insensitive EXACT match. A critique
+    //              that merely QUOTES 'VERDICT: SHIP' mid-prose cannot false-ship,
+    //              because the instruction text is never the last line and -qix
+    //              rejects partial matches.
+    // EVIDENCE     .authoring/verdict-line.txt, .authoring/convergence.jsonl
+    // EXIT         ship (exit 0) | iterate / noverdict (exit 1, LOUD)
+    // FAIL CLOSED: a missing, empty, or unparseable critique is `noverdict`,
+    // which routes to another iteration -- never to the exit. Ambiguity resolves
+    // against shipping, which is the same rule specs/EXTENSIONS.md section 25
+    // applies to goal-gate outcomes. Idiom B (nonzero on the red path) is used
+    // deliberately so goal_gate=true has real teeth here rather than being a
+    // declaration: a red verdict is a genuine FAIL the engine's exit-time check
+    // can see.
+    verdict_gate [
+        shape=parallelogram, class="gate", label="Ship or Iterate?", max_retries=0,
+        goal_gate=true, retry_target="author",
+        tool_command="n=$(cat .authoring/iter 2>/dev/null || echo 0); v=noverdict; if [ -s .authoring/critique.md ]; then tail -n 1 .authoring/critique.md > .authoring/verdict-line.txt; if grep -qix 'VERDICT: SHIP' .authoring/verdict-line.txt; then v=ship; elif grep -qix 'VERDICT: ITERATE' .authoring/verdict-line.txt; then v=iterate; fi; fi; printf '{\"iteration\": %s, \"gate\": \"critique\", \"verdict\": \"%s\"}\\n' \"$n\" \"$v\" >> .authoring/convergence.jsonl; if [ \"$v\" = ship ]; then printf ship; else echo \"critique verdict: $v -- another iteration\" >&2; printf %s \"$v\"; exit 1; fi"
+    ]
+
+    // ---------- package: publish the accepted draft, with provenance ---------
+    // OBJECTIVE    Make the accepted draft a named, traceable deliverable.
+    // CONSTRAINTS  code-tier only. A provenance record assembled by a model is
+    //              a summary; assembled by a shell from the real artifacts, it
+    //              is a record. Nothing reaches out/ before this node runs.
+    // EVIDENCE     out/<name>.dot, out/<name>.md, .authoring/PROVENANCE.md,
+    //              .authoring/published
+    // EXIT         published | publish_failed (exit 1)
+    package [
+        shape=parallelogram, class="glue", label="Publish + Provenance", max_retries=0,
+        tool_command="N=$(cat .authoring/name 2>/dev/null || echo authored-pipeline); mkdir -p out; cp .authoring/draft/pipeline.dot \"out/$N.dot\" || { printf publish_failed; exit 1; }; cp .authoring/draft/pipeline.md \"out/$N.md\" || { printf publish_failed; exit 1; }; { echo \"# Provenance -- $N\"; echo; echo \"Authored by examples/authoring/pipeline-author.dot. Every gate below was executed, in this run, outside the authoring node's context.\"; echo; echo \"## Artifacts\"; echo; sha256sum \"out/$N.dot\" \"out/$N.md\"; echo; echo \"## Iterations\"; echo; echo \"author attempts spent: $(cat .authoring/iter 2>/dev/null || echo 0)\"; echo; echo \"## Convergence record\"; echo; sed 's/^/    /' .authoring/convergence.jsonl 2>/dev/null; echo; echo \"## Triage (the brief, restated, and the three-question test)\"; echo; sed 's/^/    /' .authoring/triage.md 2>/dev/null; echo; echo \"## attractor lint\"; echo; sed 's/^/    /' .authoring/lint-report.txt 2>/dev/null; echo; echo \"## Authoring contract (check_authored_pipeline.py)\"; echo; sed 's/^/    /' .authoring/doctrine-report.txt 2>/dev/null; echo; echo \"## Independent critique\"; echo; sed 's/^/    /' .authoring/critique.md 2>/dev/null; } > .authoring/PROVENANCE.md || { printf publish_failed; exit 1; }; printf '%s\\n' \"out/$N.dot out/$N.md\" > .authoring/published; printf published"
+    ]
+
+    // ---------- finalize: refuse a green exit without a disposition ----------
+    // OBJECTIVE    Make 'the run ended' and 'the run produced a disposition'
+    //              the same event, so an unattended caller can tell the two
+    //              green outcomes apart by reading one file.
+    // EVIDENCE     .authoring/disposition = authored | redirected
+    // EXIT         finalized | no_disposition (exit 1, LOUD)
+    finalize [
+        shape=parallelogram, class="glue", label="Finalize", max_retries=0,
+        tool_command="if [ -s .authoring/published ]; then echo authored > .authoring/disposition; elif [ -s .authoring/redirect.md ]; then echo redirected > .authoring/disposition; else echo 'FATAL: no disposition artifact -- neither a published pipeline nor an honest redirect' >&2; printf no_disposition; exit 1; fi; printf finalized"
+    ]
+
+    // ---------- postmortem -> escalated: salvage, then fail LOUD -------------
+    postmortem [
+        shape=box, class="gate", label="Postmortem",
+        must_write=".authoring/postmortem/report.md",
+        prompt="This authoring run reached a decision point without converging.\n\nRead .authoring/convergence.jsonl (the descent record), .authoring/triage.md, and whichever of .authoring/lint-report.txt, .authoring/doctrine-report.txt and .authoring/critique.md exist. Write .authoring/postmortem/report.md:\n  * what each iteration attempted, and whether the loop was DESCENDING, OSCILLATING or WANDERING -- cite the record\n  * your best hypothesis for why it did not converge, and specifically whether the failure was in the BRIEF (ambiguous, or describing work with no machine check), the TRIAGE (wrong verdict; say which you would give now), the DRAFT (the pipeline shape itself), or the CRITIQUE (a bar no draft could clear)\n  * the options: change the brief, raise the budget, redirect instead, or take it to a human\n\nThis report is the value salvaged from a non-converging run. Be honest -- a run that fails and explains itself is worth more than one that fails quietly."
+    ]
+
+    // Deterministic salvage terminal. Writes a handoff even when the postmortem
+    // node itself failed, then exits 1 DELIBERATELY: max_retries=0 and no
+    // fail-route, so the engine hard-fails LOUD (run status=fail, CLI exit 1).
+    escalated [
+        shape=parallelogram, class="glue", label="Escalated", max_retries=0,
+        tool_command="mkdir -p .authoring/postmortem; if [ -s .authoring/postmortem/report.md ]; then echo 'Read .authoring/postmortem/report.md and .authoring/convergence.jsonl, then choose: change the brief, raise the budget, redirect instead, or take it to a human.' > .authoring/postmortem/escalation.md; else echo 'Postmortem could not be produced. Preserve the run logs and escalate to a human.' > .authoring/postmortem/escalation.md; fi; echo escalated > .authoring/disposition; printf escalated; exit 1"
+    ]
+
+    // ========================= edges =========================
+    start -> preflight
+
+    preflight -> triage    [condition="context.tool.last_line=ready && outcome=success", label="preconditions hold"]
+    preflight -> escalated [condition="outcome=fail",                                    label="blocked -- refuse before spending an LLM"]
+
+    triage -> triage_gate
+    triage -> postmortem [condition="outcome=fail", label="hard failure"]
+
+    triage_gate -> author          [condition="context.tool.last_line=attractor && outcome=success",        label="attractor -- author it"]
+    triage_gate -> redirect_report [condition="context.tool.last_line=redirect && outcome=success",         label="redirect -- the honest no"]
+    triage_gate -> triage          [condition="context.tool.last_line=triage_bad && outcome=success",       label="no readable verdict -- re-frame"]
+    triage_gate -> postmortem      [condition="context.tool.last_line=triage_exhausted && outcome=success", label="cannot produce a readable triage"]
+    triage_gate -> postmortem      [condition="outcome=fail",                                               label="gate could not run"]
+
+    redirect_report -> finalize
+    redirect_report -> postmortem [condition="outcome=fail", label="hard failure"]
+
+    author -> lint_gate
+    author -> postmortem [condition="outcome=fail", label="hard failure"]
+
+    lint_gate -> doctrine_gate [condition="context.tool.last_line=lint_pass && outcome=success", label="no lint errors"]
+    lint_gate -> author        [condition="context.tool.last_line=lint_fail && outcome=success", label="lint errors -- rewrite"]
+    lint_gate -> postmortem    [condition="context.tool.last_line=exhausted && outcome=success", label="budget spent -- decision point"]
+    lint_gate -> postmortem    [condition="outcome=fail",                                        label="linter unavailable"]
+
+    doctrine_gate -> critique   [condition="context.tool.last_line=doctrine_ok && outcome=success",  label="contract satisfied"]
+    doctrine_gate -> author     [condition="context.tool.last_line=doctrine_bad && outcome=success", label="contract violated -- rewrite"]
+    doctrine_gate -> postmortem [condition="outcome=fail",                                           label="contract gate could not run"]
+
+    critique -> verdict_gate
+    // Transient recovery: a provider error at the ship-path critique node used
+    // to be able to kill a run whose draft was already green. Re-enter through
+    // the cheap gate, which re-lints in seconds AND spends an iteration -- so a
+    // persistent outage drains the budget and escalates honestly.
+    critique -> lint_gate [condition="outcome=fail", label="transient -- re-enter via the cheap gate"]
+
+    verdict_gate -> package [condition="context.tool.last_line=ship && outcome=success", label="ship"]
+    // ITERATE and NOVERDICT both exit nonzero, so tool.last_line is NOT
+    // refreshed and only this edge can match. The distinction is preserved
+    // where it belongs -- in .authoring/convergence.jsonl -- rather than in a
+    // route that would have to read a stale label to tell them apart.
+    verdict_gate -> author  [condition="outcome=fail", loop_restart="true", label="iterate (or no parseable verdict) -- fresh attempt, kept reports"]
+
+    package -> finalize
+    package -> postmortem [condition="outcome=fail", label="could not publish"]
+
+    finalize -> done       [condition="context.tool.last_line=finalized && outcome=success", label="disposition recorded"]
+    finalize -> postmortem [condition="outcome=fail",                                        label="no disposition -- refuse to exit green"]
+
+    postmortem -> escalated [condition="outcome=fail", label="postmortem failed"]
+    postmortem -> escalated [label="escalate"]
+}

--- a/examples/authoring/pipeline-author.md
+++ b/examples/authoring/pipeline-author.md
@@ -1,0 +1,322 @@
+# `pipeline-author.dot` — companion guide
+
+The authoring attractor, node by node: what each node is responsible for, what
+it is forbidden to do, what it is allowed to reach for, and what artifact proves
+it did its job. For what this pipeline *is* and how to run it, read
+[`README.md`](README.md) first; this page is the design record.
+
+---
+
+## The sink, named first
+
+**A new pipeline exists at `out/<name>.dot`, with a companion at
+`out/<name>.md`, that: lints clean under `attractor lint`; satisfies A1–A9 of
+[`check_authored_pipeline.py`](check_authored_pipeline.py); and a critic that
+never saw the author's reasoning said `VERDICT: SHIP` to.**
+
+Or, the second honest sink: **`.authoring/redirect.md` exists, saying the work
+described does not want an attractor and where it belongs instead.**
+
+Everything below is the skeleton carved around those two, in the design order
+the doctrine prescribes: name the sink, build the gate, build the loop, and only
+then add work nodes.
+
+---
+
+## Why the graph is shaped this way
+
+### The brief never touches a shell
+
+`$brief` is expanded into **prompts only**. It is never interpolated into a
+`tool_command`.
+
+Engine substitution happens before `/bin/sh` ever sees the string, so a brief in
+a `tool_command` is a command-injection hole — a brief containing `$(...)`, a
+semicolon, or an unbalanced quote would execute or corrupt the gate. The brief
+is untrusted text by construction: it comes from a human, or from
+`/attractorify`'s handoff, or from another pipeline.
+
+The consequence is a small design obligation: `triage` restates the brief
+verbatim into `.authoring/triage.md`, and every deterministic node downstream —
+including the provenance record — reads the **file**. The durable copy is the
+LLM's transcription, and that is a deliberate, named trade: fidelity to the
+original parameter is traded for never handing user text to a shell.
+
+### One counter spans the whole corrective path
+
+`lint_gate` owns the only iteration counter, and it increments on **entry**,
+before it lints anything.
+
+That placement is the point. Four different corrective legs exist —
+`lint_fail`, `doctrine_bad`, critique `ITERATE`, and a transient critique FAIL —
+and every one of them re-enters through `lint_gate`, either directly or via
+`author`. `PIPELINE_DESIGN_PRINCIPLES.md` §3 records why this matters:
+*"individually-bounded legs do not compose."* A persistent failure bouncing
+between two separately-counted gates never exhausts either one, because neither
+counter ever sees the other leg's attempts. Here there is one ledger and every
+leg pays into it.
+
+It also means a persistent provider outage **drains** the budget rather than
+cycling forever: each transient FAIL at `critique` costs an iteration, and
+exhaustion routes to `postmortem` → `escalated`, a loud nonzero, instead of
+letting the engine's step cap kill the run with a bare FAIL that bypasses every
+salvage path.
+
+### Cheap gate before expensive gate
+
+`attractor lint` and the structural contract both run before an LLM is paid to
+critique anything. A graph that does not parse cannot be usefully judged, and
+judgment is the expensive tier. This is the composite pattern from
+`PIPELINE_DESIGN_PRINCIPLES.md` §2, applied to the authoring problem.
+
+### The critic inherits nothing
+
+`critique` runs at `fidelity="truncate"` — goal and run id only, no summary of
+what came before.
+
+This is not a token optimisation. It is the property being purchased. A live run
+in this repo's history had a worker hand-author its own `convergence.jsonl` to
+satisfy a gate, and only critics *outside its context* caught it. A critic that
+inherited the author's reasoning would inherit the author's confidence with it;
+this one sees the artifact and the two gate reports, and nothing else.
+
+### Nothing lands in `out/` until every gate is green
+
+The author works in `.authoring/draft/`. `package` publishes to `out/` only
+after lint, the contract, and the critique have all passed. Draft and published
+are different words on purpose: a reader who finds a file in `out/` can know,
+without checking, that three gates said yes to it.
+
+### `must_write=` paths are literals
+
+`must_write.py` reads the raw attribute — it is **not** context-substituted. So
+every `must_write` path in this graph is a literal, and the `$pipeline_name`
+knob is spent exactly once, at `package`, inside a shell where the
+`pn=$pipeline_name; N=${pn:-default}` idiom actually works. This was verified by
+reading the engine rather than assumed; a design premised on what the engine
+*ought* to do is how contracts come to rest on false premises.
+
+---
+
+## The nodes
+
+### `preflight` — tool
+
+- **Objective.** Make the run's preconditions true, or refuse before an LLM is
+  ever paid.
+- **Constraints.** Code-tier only, no judgement. Never reads `$brief`.
+- **Capabilities.** `command -v`, the filesystem.
+- **Required evidence.** `.authoring/` and `out/` exist; `attractor`, `python3`
+  and `sha256sum` resolve; `check_authored_pipeline.py` is where
+  `$authoring_dir` says; `pipeline_name` is safe as a filename, and the resolved
+  name is written to `.authoring/name`.
+- **Exit.** `ready` | `blocked` (exit 1, loud).
+
+The name validation is not paranoia: `pipeline_name` becomes a path under
+`out/`, and preflight is the last place a bad one can be refused for free.
+
+### `triage` — LLM (`class="maker"`)
+
+- **Objective.** Decide whether the work the brief describes wants an attractor
+  at all, and restate the brief durably.
+- **Constraints.** Author nothing. Do not self-route — the routing token comes
+  from the gate. The verdict vocabulary is fixed and must be the file's **final
+  line**.
+- **Capabilities.** Reads `docs/PIPELINE_DESIGN_PRINCIPLES.md` §0 and the
+  workspace.
+- **Required evidence.** `.authoring/triage.md` — the brief restated, the
+  three-question test answered with quotes, the named sink, the implied budget,
+  and an anchored `VERDICT:` line. Enforced by `must_write=`.
+- **Exit.** A last line `triage_gate` can read.
+
+`triage` applies the three-question test to **the work the brief describes**,
+not to this authoring run. Its most valuable output is often `REDIRECT`.
+
+### `triage_gate` — tool
+
+- **Objective.** Admit the diagnosis and be the thing that decides the route.
+- **Constraints.** Deterministic; last-line anchored, case-insensitive exact
+  match. Idiom A — always exit 0, so `tool.last_line` is always fresh.
+- **Required evidence.** `.authoring/triage-line.txt`,
+  `.authoring/convergence.jsonl`.
+- **Exit.** `attractor` | `redirect` | `triage_bad` | `triage_exhausted`.
+
+A nonzero exit here means the gate itself could not run, which routes to the
+postmortem path — deliberately distinct from a record it read and rejected.
+`triage_bad` is fuse-bounded by `max_frames`: an LLM that cannot produce a
+readable verdict line in three tries is not going to on the fourth.
+
+### `redirect_report` — LLM (`class="maker"`)
+
+- **Objective.** Deliver the diagnosis as the work product.
+- **Constraints.** Quote the failing three-question answers verbatim from
+  `triage.md`; name exactly one better home; author no pipeline.
+- **Capabilities.** Reads `.authoring/triage.md` and the doctrine docs.
+- **Required evidence.** `.authoring/redirect.md`, enforced by `must_write=`.
+- **Exit.** Green, through `finalize`.
+
+This path exits **green**. The diagnosis *is* the deliverable, and the
+disposition artifact is what lets an unattended caller tell it apart from
+"pipeline authored."
+
+### `author` — LLM (`class="maker"`)
+
+- **Objective.** Write a new, reusable attractor pipeline for the brief, plus
+  the companion guide that explains its shape.
+- **Constraints.** Control plane only — no `plan -> implement -> test` as graph
+  nodes. Gates outside workers. One exit, one cycle, one budget wall, fail routes
+  on every worker. **Never weaken a gate to get past a gate.**
+- **Capabilities.** Writes files. Reads the authoring contract in
+  [`README.md`](README.md), the doctrine docs, the shipped exemplars
+  (`examples/patterns/task-runner.dot`, `examples/gates/`), and every gate report
+  left by a previous attempt.
+- **Required evidence.** `.authoring/draft/pipeline.dot` (enforced by
+  `must_write=`) and `.authoring/draft/pipeline.md`.
+- **Exit.** Both files exist, pass `lint_gate` and `doctrine_gate`, and survive
+  `critique`.
+
+The prompt states the contract and the design order, and points at the checks by
+name — A1 through A9 are a **stated** contract, not a guessing game. What the
+prompt deliberately does not contain is a procedure for writing a graph. A node
+that carries the algorithm cannot absorb a model's bad day.
+
+### `lint_gate` — tool (`class="gate"`)
+
+- **Objective.** Machine-reject a broken draft before anything expensive reads
+  it, and own the one counter that spans every corrective leg.
+- **Constraints.** ERRORs block, warnings pass and are recorded (no `--strict`);
+  `doctrine_gate` owns the design-shape checks. Budget checked on entry, before
+  the linter runs.
+- **Required evidence.** `.authoring/lint-report.txt`,
+  `.authoring/convergence.jsonl`, `.authoring/iter`.
+- **Exit.** `lint_pass` | `lint_fail` | `exhausted` | `lint_unavailable`
+  (exit 1).
+
+`lint_unavailable` is distinct from `lint_fail` on purpose: the CLI leaving
+`PATH` mid-run is an environment failure, not a verdict on the draft, and it
+routes to the salvage path rather than to another rewrite.
+
+### `doctrine_gate` — tool (`class="gate"`)
+
+- **Objective.** Enforce the shape checks lint does not own, or owns only as
+  advice.
+- **Constraints.** Deterministic checks only. It judges structure, never fitness
+  for the brief.
+- **Capabilities.** `check_authored_pipeline.py` under whatever `python3` is on
+  `PATH`.
+- **Required evidence.** `.authoring/doctrine-report.txt`, one line per check.
+- **Exit.** `doctrine_ok` | `doctrine_bad` | `gate_error` (exit 1).
+
+The load-bearing check is **A4**: delete every evidence gate from the drafted
+graph and ask whether its exit is still reachable from `start`. A graph can
+carry a cycle *and* a gate and still hang `done` directly off a worker — A1–A3
+all pass, and the exit was never gated on anything. A4 is the one that notices.
+
+### `critique` — LLM (`class="gate"`, `fidelity="truncate"`)
+
+- **Objective.** Judge what the machine gates cannot: is this the right pipeline
+  *for this brief*, and are its gates real?
+- **Constraints.** Inherits nothing. Every finding cites a file and a node or
+  edge by name, and is grounded in a quoted gate-report line or a command it
+  actually ran. The verdict is the file's final line, anchored.
+- **Capabilities.** Reads the draft, both gate reports, the triage record and the
+  doctrine docs; may run commands to check claims.
+- **Required evidence.** `.authoring/critique.md`, enforced by `must_write=`.
+- **Exit.** `VERDICT: SHIP` or `VERDICT: ITERATE` as the last line.
+
+Its six questions are the ones structure cannot answer: does the gate actually
+prove the brief's goal (would it be red today?); is any node a domain phase; can
+the loop descend, or does it re-flip the same coin; what happens on the bad day;
+do the node prompts carry contracts or algorithms; does the companion explain
+*why*.
+
+### `verdict_gate` — tool (`class="gate"`, `goal_gate=true`)
+
+- **Objective.** Turn the critique into a route, with no LLM in the router.
+- **Constraints.** Last-line anchored, case-insensitive **exact** match
+  (`grep -qix`). Idiom B — nonzero on the red path.
+- **Required evidence.** `.authoring/verdict-line.txt`,
+  `.authoring/convergence.jsonl`.
+- **Exit.** `ship` (exit 0) | `iterate` / `noverdict` (exit 1, loud).
+
+Two properties are deliberate here.
+
+**It cannot false-ship on quoted instructions.** A critique that writes "end with
+`VERDICT: SHIP` or `VERDICT: ITERATE`" mid-prose contains both keywords; a bare
+`grep -qi 'SHIP'` would match the instruction text. `tail -n 1` plus `grep -qix`
+is immune — the instruction is never the last line, and `-x` rejects partial
+matches. That exact false-SHIP has been observed in this repo before.
+
+**It fails closed.** A missing, empty or unparseable critique is `noverdict`,
+which routes to another iteration and never to the exit. Ambiguity resolves
+against shipping — the same rule `specs/EXTENSIONS.md` §25 applies to goal-gate
+outcomes.
+
+Idiom B is chosen over Idiom A so that `goal_gate=true` has real teeth: a red
+verdict is a genuine FAIL the engine's exit-time check can see, rather than a
+declaration of intent. The cost is that `iterate` and `noverdict` share one
+outgoing edge, because a nonzero exit does not refresh `tool.last_line` and
+routing them apart would mean reading a stale label. The distinction is kept
+where it belongs instead — in `.authoring/convergence.jsonl`, and on stderr.
+
+### `package` — tool (`class="glue"`)
+
+- **Objective.** Make the accepted draft a named, traceable deliverable.
+- **Constraints.** Code-tier only.
+- **Required evidence.** `out/<name>.dot`, `out/<name>.md`,
+  `.authoring/PROVENANCE.md` (with sha256 digests), `.authoring/published`.
+- **Exit.** `published` | `publish_failed` (exit 1).
+
+Provenance is assembled by a shell, from the real artifacts, rather than written
+by a model. A provenance record a model wrote is a summary of what it believes
+happened; one a shell assembled by concatenating the actual gate reports is a
+record of what did.
+
+### `finalize` — tool (`class="glue"`)
+
+- **Objective.** Make "the run ended" and "the run produced a disposition" the
+  same event.
+- **Required evidence.** `.authoring/disposition` = `authored` | `redirected`.
+- **Exit.** `finalized` | `no_disposition` (exit 1, loud).
+
+`done` is reachable **only** through `finalize`. That is the structural half of
+the exit guarantee; `goal_gate` on `verdict_gate` is the engine-level half.
+
+### `postmortem` — LLM (`class="gate"`) → `escalated` — tool
+
+- **Objective.** Salvage the analysis from a run that could not converge, then
+  fail loudly.
+- **Constraints.** `postmortem` must cite the convergence record and name
+  *where* the failure was: the brief, the triage, the draft, or the critique.
+- **Required evidence.** `.authoring/postmortem/report.md` (`must_write=`);
+  `.authoring/postmortem/escalation.md`, which `escalated` writes **either way**
+  — including when the postmortem node itself failed.
+- **Exit.** `escalated` exits 1 with `max_retries=0` and no fail-route, so the
+  engine hard-fails loud: run status `fail`, CLI exit 1.
+
+`escalated` is a second honest terminal, not a second success exit. The engine
+admits exactly one `Msquare`; a loud nonzero tool node is how the other one is
+expressed.
+
+---
+
+## Honest limits
+
+- **The brief's fidelity depends on `triage`'s transcription.** The durable copy
+  of the brief is the one the LLM wrote into `triage.md`, because the raw
+  parameter is deliberately kept out of every shell. A transcription that drops
+  a constraint drops it for the whole run. The trade is named above; the mitigation
+  is that `triage.md` is embedded verbatim in `PROVENANCE.md`, so the drift is
+  visible after the fact.
+- **The contract checks structure, not fitness.** A1–A9 cannot tell whether the
+  authored gate asserts the *right* thing. `critique` can, and does — but it is
+  an LLM, and the budget wall exists because it can also be wrong in either
+  direction.
+- **A5's vocabulary is a convention, not a semantic analysis.** It recognises a
+  budget wall by the identifiers the command and edges use. An author who counts
+  iterations under an unrecognised name will be told so by name, with the accepted
+  vocabulary printed in the failure detail.
+- **This pipeline does not run what it authors.** It proves the artifact is
+  well-shaped and well-judged; proving it *works* on real input is the authored
+  pipeline's own first run. `examples/authoring/README.md` says which evidence
+  belongs to which.

--- a/modules/loop-pipeline/tests/test_authoring_layer_gates.py
+++ b/modules/loop-pipeline/tests/test_authoring_layer_gates.py
@@ -1,0 +1,707 @@
+"""Guards for the authoring-layer exemplar's structural gate.
+
+``examples/authoring/pipeline-author.dot`` lets an LLM node WRITE a new reusable
+attractor pipeline, so the thing that decides whether the draft is any good has
+to live outside the author's context. Two machine gates do, in order:
+``attractor lint`` (the engine's own linter, already guarded by
+``test_examples_lint_clean.py``) and ``check_authored_pipeline.py`` -- the
+*doctrine* checks lint deliberately does not own, or owns only as advice.
+
+This file holds that second gate to the same bar the objective layer's gates are
+held to:
+
+  * it must **fail closed** -- a missing, unreadable or unparseable draft
+    produces the rejecting token, never the admitting one, and never a traceback;
+  * every check must be seen **RED**, by mutation, not just green (a check never
+    seen red is an unproven check);
+  * its stdlib-only DOT reader must **agree with the engine's parser** on the
+    graphs this repo actually ships;
+  * it must be **calibrated** -- it admits the repo's own battle-tested
+    exemplars, including the authoring attractor itself. A gate that rejects
+    ``task-runner.dot`` is a wrong gate, not a strict one.
+
+The examples tree lives at the repository root, outside the installed package,
+so these tests run against a source checkout and skip gracefully when the
+examples directory is absent (e.g. an installed-package test run) -- the same
+pattern as ``test_examples_lint_clean.py``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_AUTHORING_DIR = _REPO_ROOT / "examples" / "authoring"
+
+pytestmark = pytest.mark.skipif(
+    not _AUTHORING_DIR.is_dir(),
+    reason="examples/authoring/ not present (installed-package run)",
+)
+
+
+def _load(script_name: str) -> ModuleType:
+    """Import a script from examples/authoring/ by path, without polluting sys.path."""
+    path = _AUTHORING_DIR / script_name
+    spec = importlib.util.spec_from_file_location(f"_authoring_{path.stem}", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def checker() -> ModuleType:
+    return _load("check_authored_pipeline.py")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: a draft that satisfies the contract, and ways of breaking it
+# ---------------------------------------------------------------------------
+
+#: A conforming authored pipeline. Deliberately small -- it carries exactly the
+#: skeleton A1-A9 require and nothing else, so a mutation below can only be
+#: breaking the property it names.
+_GOOD_PIPELINE = """
+// An authored pipeline that satisfies the authoring contract.
+digraph Authored {
+    graph [goal="$goal", default_max_retries=2]
+
+    start [shape=Mdiamond]
+    done  [shape=Msquare]
+
+    work [shape=box,
+          prompt="Advance the objective: $goal. Read .run/feedback.md if it exists."]
+
+    dod_gate [shape=parallelogram, max_retries=0, goal_gate=true, retry_target="work",
+        tool_command="mi=$max_iterations; B=${mi:-6}; n=$(($(cat .run/iter 2>/dev/null || echo 0)+1)); echo $n > .run/iter; if [ \\"$n\\" -gt \\"$B\\" ]; then printf exhausted; else bash dod.sh > .run/dod.log 2>&1 && printf green || { printf red; exit 1; }; fi"]
+
+    critique [shape=box, prompt="Write .run/feedback.md from .run/dod.log."]
+
+    postmortem [shape=box, prompt="Write .run/postmortem.md."]
+
+    escalated [shape=parallelogram, max_retries=0, tool_command="printf escalated; exit 1"]
+
+    start -> work
+    work -> dod_gate
+    work -> postmortem [condition="outcome=fail"]
+
+    dod_gate -> done       [condition="context.tool.last_line=green && outcome=success"]
+    dod_gate -> critique   [condition="outcome=fail", label="not yet -- iterate"]
+    dod_gate -> postmortem [condition="context.tool.last_line=exhausted && outcome=success", label="budget spent"]
+
+    critique -> work       [loop_restart="true"]
+    critique -> postmortem [condition="outcome=fail"]
+
+    postmortem -> escalated
+    postmortem -> escalated [condition="outcome=fail"]
+}
+"""
+
+#: A companion that names every worker in _GOOD_PIPELINE.
+_GOOD_COMPANION = """# Authored pipeline
+
+`work` advances the objective; `critique` distils the failing DoD output into
+feedback the next attempt reads; `postmortem` salvages the analysis when the
+budget is spent. Each states objective, constraints, capabilities and evidence.
+"""
+
+
+def _write_draft(
+    tmp_path: Path,
+    dot_text: str = _GOOD_PIPELINE,
+    *,
+    companion: str | None = _GOOD_COMPANION,
+) -> tuple[Path, Path]:
+    draft = tmp_path / "draft"
+    draft.mkdir(parents=True, exist_ok=True)
+    pipeline = draft / "pipeline.dot"
+    pipeline.write_text(dot_text, encoding="utf-8")
+    companion_path = draft / "pipeline.md"
+    if companion is not None:
+        companion_path.write_text(companion, encoding="utf-8")
+    return pipeline, companion_path
+
+
+def _run_checker(
+    checker: ModuleType, pipeline: Path, companion: Path, report: Path
+) -> tuple[int, str]:
+    rc = checker.main(
+        ["--pipeline", str(pipeline), "--companion", str(companion), "--report", str(report)]
+    )
+    return rc, report.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# The happy path
+# ---------------------------------------------------------------------------
+
+
+def test_checker_admits_a_conforming_pipeline(checker, tmp_path, capsys):
+    pipeline, companion = _write_draft(tmp_path)
+    rc, text = _run_checker(checker, pipeline, companion, tmp_path / "report.txt")
+
+    assert rc == 0
+    assert capsys.readouterr().out == "doctrine_ok"
+    assert "verdict:   doctrine_ok" in text
+    assert "[FAIL]" not in text
+
+
+# ---------------------------------------------------------------------------
+# RED cases -- one mutation per check.  A check never seen red is an unproven
+# check, so each of A1-A9 is broken here in isolation and observed to fire.
+# ---------------------------------------------------------------------------
+
+_A1_SECOND_EXIT = ('done  [shape=Msquare]', 'done  [shape=Msquare]\n    done2 [shape=Msquare]')
+_A2_NO_CYCLE = ('critique -> work       [loop_restart="true"]', "")
+_A3_HOLLOW_GATE = (
+    'tool_command="mi=$max_iterations; B=${mi:-6}; n=$(($(cat .run/iter 2>/dev/null || echo 0)+1)); echo $n > .run/iter; if [ \\"$n\\" -gt \\"$B\\" ]; then printf exhausted; else bash dod.sh > .run/dod.log 2>&1 && printf green || { printf red; exit 1; }; fi"',
+    'tool_command="printf green"',
+)
+_A4_BYPASS = ("start -> work", "start -> work\n    work -> done")
+_A5_NO_WALL = (
+    'dod_gate -> postmortem [condition="context.tool.last_line=exhausted && outcome=success", label="budget spent"]',
+    "",
+)
+_A6_UNROUTED_WORKER = ('work -> postmortem [condition="outcome=fail"]', "")
+_A7_STALE_LABEL = (
+    'condition="context.tool.last_line=green && outcome=success"',
+    'condition="context.tool.last_line=green"',
+)
+_A8_FAIL_TO_EXIT = (
+    "critique -> work       [loop_restart=\"true\"]",
+    'critique -> work       [loop_restart="true"]\n    critique -> done [condition="outcome=fail"]',
+)
+
+
+@pytest.mark.parametrize(
+    ("mutation", "expected_fail"),
+    [
+        pytest.param(_A1_SECOND_EXIT, "A1", id="A1-two-exit-nodes"),
+        pytest.param(_A2_NO_CYCLE, "A2", id="A2-acyclic-should-have-been-a-recipe"),
+        pytest.param(_A3_HOLLOW_GATE, "A3", id="A3-gate-that-only-printfs-a-constant"),
+        pytest.param(_A4_BYPASS, "A4", id="A4-exit-reachable-without-a-gate"),
+        pytest.param(_A5_NO_WALL, "A5", id="A5-no-budget-wall"),
+        pytest.param(_A6_UNROUTED_WORKER, "A6", id="A6-worker-with-no-failure-route"),
+        pytest.param(_A7_STALE_LABEL, "A7", id="A7-label-edge-without-the-conjunction"),
+        pytest.param(_A8_FAIL_TO_EXIT, "A8", id="A8-failure-routed-into-the-exit"),
+    ],
+)
+def test_checker_catches_each_single_mutation(checker, tmp_path, capsys, mutation, expected_fail):
+    """Break exactly one property; the check that owns it must fire."""
+    old, new = mutation
+    assert old in _GOOD_PIPELINE, "mutation anchor drifted out of the fixture"
+    pipeline, companion = _write_draft(tmp_path, _GOOD_PIPELINE.replace(old, new, 1))
+    rc, text = _run_checker(checker, pipeline, companion, tmp_path / "report.txt")
+
+    assert rc == 0
+    assert capsys.readouterr().out == "doctrine_bad"
+    assert f"[FAIL] {expected_fail}" in text, text
+
+
+def test_a9_fires_when_the_companion_is_missing(checker, tmp_path, capsys):
+    pipeline, companion = _write_draft(tmp_path, companion=None)
+    rc, text = _run_checker(checker, pipeline, companion, tmp_path / "report.txt")
+
+    assert rc == 0
+    assert capsys.readouterr().out == "doctrine_bad"
+    assert "[FAIL] A9" in text
+    assert "not found" in text
+
+
+def test_a9_fires_when_the_companion_skips_a_worker(checker, tmp_path, capsys):
+    """A companion that documents some nodes and quietly drops one still fails."""
+    pipeline, companion = _write_draft(
+        tmp_path, companion="# Authored pipeline\n\nThe work node and the critique node.\n"
+    )
+    _, text = _run_checker(checker, pipeline, companion, tmp_path / "report.txt")
+
+    assert capsys.readouterr().out == "doctrine_bad"
+    assert "[FAIL] A9" in text
+    assert "postmortem" in text
+
+
+def test_a9_fires_on_an_empty_companion(checker, tmp_path, capsys):
+    pipeline, companion = _write_draft(tmp_path, companion="   \n")
+    _, text = _run_checker(checker, pipeline, companion, tmp_path / "report.txt")
+
+    assert capsys.readouterr().out == "doctrine_bad"
+    assert "[FAIL] A9" in text
+    assert "empty" in text
+
+
+# ---------------------------------------------------------------------------
+# Fail closed: a gate that cannot read the artifact must REJECT it
+# ---------------------------------------------------------------------------
+
+
+def test_checker_fails_closed_when_the_pipeline_was_never_written(checker, tmp_path, capsys):
+    report = tmp_path / "report.txt"
+    rc = checker.main(
+        [
+            "--pipeline",
+            str(tmp_path / "draft" / "pipeline.dot"),
+            "--companion",
+            str(tmp_path / "draft" / "pipeline.md"),
+            "--report",
+            str(report),
+        ]
+    )
+
+    assert rc == 0, "an absent draft is a judgement about the author, not a crash"
+    assert capsys.readouterr().out == "doctrine_bad"
+    assert "[FAIL] A0" in report.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        pytest.param("this is not a graph at all\n", id="prose"),
+        pytest.param("digraph Broken { a -> b [label=\n", id="unterminated-attribute-list"),
+        pytest.param("", id="empty-file"),
+    ],
+)
+def test_checker_fails_closed_on_an_unparseable_pipeline(checker, tmp_path, capsys, body):
+    """A graph this reader cannot understand is rejected, never admitted."""
+    pipeline, companion = _write_draft(tmp_path, body)
+    rc, text = _run_checker(checker, pipeline, companion, tmp_path / "report.txt")
+
+    assert rc == 0
+    assert capsys.readouterr().out == "doctrine_bad"
+    assert "[FAIL] A0" in text
+
+
+# ---------------------------------------------------------------------------
+# The stdlib DOT reader must agree with the engine's own parser
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "shipped",
+    [
+        "examples/authoring/pipeline-author.dot",
+        "examples/patterns/task-runner.dot",
+        "examples/pipelines/practical/bug-fix.dot",
+        "examples/objective/objective-runner.dot",
+    ],
+)
+def test_minimal_parser_agrees_with_the_engine_on_shipped_graphs(checker, shipped):
+    """The checker ships its own DOT reader; keep it honest against the real one.
+
+    It is stdlib-only so the gate runs under whatever ``python3`` is on PATH in
+    the target workspace (not the ``attractor`` CLI's own virtualenv). That
+    freedom is only safe if the two parsers agree on node ids, edge count, and
+    the attributes the checks actually read.
+    """
+    from amplifier_module_loop_pipeline.dot_parser import parse_dot
+
+    text = (_REPO_ROOT / shipped).read_text(encoding="utf-8")
+    engine_graph = parse_dot(text)
+    mini_graph = checker.parse_dot_min(text)
+
+    assert set(mini_graph.nodes) == set(engine_graph.nodes)
+    assert len(mini_graph.edges) == len(engine_graph.edges)
+    # The checks read tool_command, shape and goal_gate off nodes; a reader that
+    # agreed on ids while losing an attribute would pass the two asserts above
+    # and still gate on nothing.
+    #
+    # Compared after `str().lower()` normalisation, deliberately: the engine's
+    # parser coerces boolean-valued attributes (`goal_gate=true` -> `True`)
+    # while the stdlib reader keeps the source text and resolves truthiness at
+    # use (`_is_truthy`).  That is a representation difference, not a
+    # disagreement about the graph -- and normalising is what makes the
+    # assertion test the thing it claims to.
+    for node_id, engine_node in engine_graph.nodes.items():
+        for key in ("shape", "tool_command", "goal_gate", "must_write", "retry_target"):
+            engine_value = (engine_node.attrs or {}).get(key)
+            if engine_value is None:
+                continue
+            assert str(mini_graph.attr(node_id, key)).lower() == str(engine_value).lower(), (
+                f"{shipped}: {node_id}.{key} disagrees between the two parsers"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Calibration: the contract admits the repo's own battle-tested exemplars
+#
+# A gate that rejects `task-runner.dot` is a wrong gate, not a strict one -- the
+# exemplar is shipped, documented and has run real work.  This is what keeps the
+# checks honest against doctrine rather than against one author's taste.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "shipped",
+    [
+        "examples/authoring/pipeline-author.dot",
+        "examples/patterns/task-runner.dot",
+        "examples/pipelines/practical/bug-fix.dot",
+    ],
+)
+def test_shipped_exemplars_satisfy_the_authoring_contract(checker, tmp_path, capsys, shipped):
+    dot_path = _REPO_ROOT / shipped
+    companion = dot_path.with_suffix(".md")
+    assert companion.is_file(), f"{shipped} has no paired guide"
+
+    report = tmp_path / "report.txt"
+    rc = checker.main(
+        [
+            "--pipeline",
+            str(dot_path),
+            "--companion",
+            str(companion),
+            "--report",
+            str(report),
+        ]
+    )
+
+    assert rc == 0
+    assert capsys.readouterr().out == "doctrine_ok", report.read_text(encoding="utf-8")
+
+
+def test_the_authoring_attractor_obeys_the_contract_it_enforces(checker, tmp_path, capsys):
+    """Self-application, stated as its own test because it is the load-bearing claim.
+
+    ``pipeline-author.dot`` hands out A1-A9 to everything it writes.  An
+    exemplar that could not satisfy its own contract would be teaching the
+    anti-pattern by example -- which is exactly what this repo says it resists.
+    """
+    report = tmp_path / "report.txt"
+    rc = checker.main(
+        [
+            "--pipeline",
+            str(_AUTHORING_DIR / "pipeline-author.dot"),
+            "--companion",
+            str(_AUTHORING_DIR / "pipeline-author.md"),
+            "--report",
+            str(report),
+        ]
+    )
+
+    assert rc == 0
+    assert capsys.readouterr().out == "doctrine_ok", report.read_text(encoding="utf-8")
+
+
+def test_the_minimal_teaching_graph_is_correctly_not_production_shaped(checker, tmp_path, capsys):
+    """`00-convergence-loop.dot` is a teaching graph, and the gate says so.
+
+    It carries the bowl and nothing else -- no budget wall, no failure route on
+    its single worker -- which its own guide is explicit about.  Pinning that
+    here documents where the contract's bar actually sits: at pipelines meant to
+    be run on real work, not at the four-node illustration of the shape.
+    """
+    dot_path = _REPO_ROOT / "examples" / "pipelines" / "00-convergence-loop.dot"
+    if not dot_path.is_file():  # pragma: no cover - defensive
+        pytest.skip("00-convergence-loop.dot not present")
+
+    report = tmp_path / "report.txt"
+    checker.main(
+        [
+            "--pipeline",
+            str(dot_path),
+            "--companion",
+            str(dot_path.with_suffix(".md")),
+            "--report",
+            str(report),
+        ]
+    )
+
+    assert capsys.readouterr().out == "doctrine_bad"
+    text = report.read_text(encoding="utf-8")
+    assert "[FAIL] A5" in text  # no budget wall
+    assert "[FAIL] A6" in text  # its single worker has no failure route
+    assert "[PASS] A4" in text  # but its exit IS gated on evidence
+
+
+# ---------------------------------------------------------------------------
+# The substantive-command reader -- "is this gate checking, or just typing?"
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("command", "substantive"),
+    [
+        pytest.param("printf gate_pass", False, id="constant-emitter"),
+        pytest.param("echo ok > f; printf green", False, id="echo-into-a-file"),
+        pytest.param("mkdir -p .run && printf ready", False, id="arrangement-only"),
+        pytest.param("printf escalated; exit 1", False, id="loud-terminal-is-not-a-gate"),
+        pytest.param("[ -s report.md ] && printf ok || printf missing", True, id="file-predicate"),
+        pytest.param("pytest -q > out.txt 2>&1 && printf green || printf red", True, id="test-suite"),
+        pytest.param("attractor lint child.dot && printf pass", True, id="linter"),
+        pytest.param(
+            'n=$(cat .run/iter 2>/dev/null || echo 0); if [ "$n" -gt 3 ]; then printf exhausted; fi',
+            True,
+            id="counter-with-a-predicate",
+        ),
+    ],
+)
+def test_substantive_command_reader(checker, command, substantive):
+    assert bool(checker.substantive_commands(command)) is substantive
+
+
+def test_a_printf_only_gate_is_not_an_evidence_gate(checker):
+    """The whole point of A3: a parallelogram is not a gate, a check is."""
+    graph = checker.parse_dot_min(_GOOD_PIPELINE.replace(*_A3_HOLLOW_GATE, 1))
+    assert checker.evidence_gates(graph) == []
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: the REAL tool_command text, taken from the graph the engine runs
+#
+# These drive the shell the pipeline actually executes -- extracted from
+# pipeline-author.dot by the engine's own parser -- rather than a paraphrase of
+# it.  A property that only holds in a hand-written approximation of the gate is
+# not a property of the pipeline.
+# ---------------------------------------------------------------------------
+
+_SHELL_GATES = pytest.mark.skipif(
+    not (shutil.which("bash") and shutil.which("python3")),
+    reason="the shipped gate commands need bash and python3",
+)
+
+
+def _tool_command(node_id: str) -> str:
+    """The verbatim tool_command of a node, read through the engine's parser."""
+    from amplifier_module_loop_pipeline.dot_parser import parse_dot
+
+    graph = parse_dot((_AUTHORING_DIR / "pipeline-author.dot").read_text(encoding="utf-8"))
+    return graph.nodes[node_id].attrs["tool_command"]
+
+
+def _run_gate(node_id: str, workspace: Path, **env_overrides: str) -> subprocess.CompletedProcess[str]:
+    env = {
+        **os.environ,
+        "authoring_dir": str(_AUTHORING_DIR),
+        "target_dir": str(workspace),
+        "max_iterations": "4",
+        "max_frames": "2",
+        **env_overrides,
+    }
+    return subprocess.run(
+        _tool_command(node_id),
+        shell=True,
+        cwd=workspace,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _authoring_workspace(tmp_path: Path) -> Path:
+    (tmp_path / ".authoring" / "draft").mkdir(parents=True, exist_ok=True)
+    (tmp_path / ".authoring" / "postmortem").mkdir(parents=True, exist_ok=True)
+    return tmp_path
+
+
+@_SHELL_GATES
+def test_real_doctrine_gate_command_blocks_a_gateless_draft(tmp_path):
+    """The graph's own doctrine_gate shell, on a draft whose exit is ungated."""
+    workspace = _authoring_workspace(tmp_path)
+    (workspace / ".authoring" / "draft" / "pipeline.dot").write_text(
+        _GOOD_PIPELINE.replace(*_A4_BYPASS, 1), encoding="utf-8"
+    )
+    (workspace / ".authoring" / "draft" / "pipeline.md").write_text(
+        _GOOD_COMPANION, encoding="utf-8"
+    )
+
+    result = _run_gate("doctrine_gate", workspace)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "doctrine_bad"
+    assert "[FAIL] A4" in (workspace / ".authoring" / "doctrine-report.txt").read_text(
+        encoding="utf-8"
+    )
+
+
+@_SHELL_GATES
+def test_real_doctrine_gate_command_admits_a_conforming_draft(tmp_path):
+    workspace = _authoring_workspace(tmp_path)
+    (workspace / ".authoring" / "draft" / "pipeline.dot").write_text(
+        _GOOD_PIPELINE, encoding="utf-8"
+    )
+    (workspace / ".authoring" / "draft" / "pipeline.md").write_text(
+        _GOOD_COMPANION, encoding="utf-8"
+    )
+
+    result = _run_gate("doctrine_gate", workspace)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "doctrine_ok"
+    assert (workspace / ".authoring" / "convergence.jsonl").read_text(encoding="utf-8").strip()
+
+
+@_SHELL_GATES
+@pytest.mark.parametrize(
+    ("critique", "expected"),
+    [
+        pytest.param("findings\n\nVERDICT: SHIP\n", "ship", id="ship"),
+        pytest.param("findings\n\nVERDICT: ITERATE\n", "iterate", id="iterate"),
+        pytest.param("findings\n\nverdict: ship\n", "ship", id="ship-lowercase"),
+        pytest.param(
+            "End with a final line reading exactly 'VERDICT: SHIP' or 'VERDICT: ITERATE'.\n"
+            "The gate looks fine to me.\n",
+            "noverdict",
+            id="quoted-instructions-must-not-false-ship",
+        ),
+        pytest.param("VERDICT: SHIP\n\nand then some more prose\n", "noverdict", id="verdict-not-last"),
+        pytest.param("", "noverdict", id="empty-critique"),
+        pytest.param(None, "noverdict", id="critique-never-written"),
+    ],
+)
+def test_real_verdict_gate_command_fails_closed(tmp_path, critique, expected):
+    """The verdict gate ships only on a last-line, exact, anchored SHIP.
+
+    The quoted-instructions case is a real observed false-SHIP in this repo: a
+    critique that reproduces its own instructions contains both keywords, and a
+    bare ``grep -qi SHIP`` matches the instruction text.  ``tail -n 1`` plus
+    ``grep -qix`` is immune.
+    """
+    workspace = _authoring_workspace(tmp_path)
+    if critique is not None:
+        (workspace / ".authoring" / "critique.md").write_text(critique, encoding="utf-8")
+
+    result = _run_gate("verdict_gate", workspace)
+
+    assert result.stdout == expected
+    # Idiom B: only `ship` exits 0, so a red verdict is a genuine FAIL the
+    # engine's exit-time goal-gate check can see.
+    assert (result.returncode == 0) is (expected == "ship")
+    record = (workspace / ".authoring" / "convergence.jsonl").read_text(encoding="utf-8")
+    assert f'"verdict": "{expected}"' in record
+
+
+@_SHELL_GATES
+def test_real_triage_gate_command_routes_on_the_anchored_verdict(tmp_path):
+    workspace = _authoring_workspace(tmp_path)
+    triage = workspace / ".authoring" / "triage.md"
+
+    triage.write_text("## Brief\n...\n\nVERDICT: ATTRACTOR\n", encoding="utf-8")
+    assert _run_gate("triage_gate", workspace).stdout == "attractor"
+
+    triage.write_text("## Brief\n...\n\nVERDICT: REDIRECT\n", encoding="utf-8")
+    assert _run_gate("triage_gate", workspace).stdout == "redirect"
+
+
+@_SHELL_GATES
+def test_real_triage_gate_fuse_stops_reframing_forever(tmp_path):
+    """An unreadable triage is corrective -- but only up to max_frames."""
+    workspace = _authoring_workspace(tmp_path)
+    (workspace / ".authoring" / "triage.md").write_text("no verdict line here\n", encoding="utf-8")
+
+    seen = [_run_gate("triage_gate", workspace, max_frames="2").stdout for _ in range(4)]
+
+    assert seen[:2] == ["triage_bad", "triage_bad"]
+    assert seen[2:] == ["triage_exhausted", "triage_exhausted"]
+
+
+@_SHELL_GATES
+def test_real_lint_gate_owns_the_one_counter_that_spans_every_leg(tmp_path):
+    """The budget is spent on ENTRY, by every corrective leg, in one ledger.
+
+    'Individually-bounded legs do not compose' -- so the wall lives at the node
+    every leg re-enters through, and is checked before the linter runs.
+    """
+    if not shutil.which("attractor"):
+        pytest.skip("the attractor CLI is not on PATH")
+    workspace = _authoring_workspace(tmp_path)
+    (workspace / ".authoring" / "draft" / "pipeline.dot").write_text(
+        _GOOD_PIPELINE, encoding="utf-8"
+    )
+
+    seen = [_run_gate("lint_gate", workspace, max_iterations="2").stdout for _ in range(3)]
+
+    assert seen == ["lint_pass", "lint_pass", "exhausted"]
+    assert (workspace / ".authoring" / "iter").read_text(encoding="utf-8").strip() == "3"
+
+
+@_SHELL_GATES
+def test_real_finalize_refuses_to_open_the_exit_without_a_disposition(tmp_path):
+    workspace = _authoring_workspace(tmp_path)
+
+    empty = _run_gate("finalize", workspace)
+    assert empty.returncode != 0
+    assert empty.stdout == "no_disposition"
+
+    (workspace / ".authoring" / "redirect.md").write_text("the honest no\n", encoding="utf-8")
+    redirected = _run_gate("finalize", workspace)
+    assert redirected.returncode == 0
+    assert redirected.stdout == "finalized"
+    assert (workspace / ".authoring" / "disposition").read_text(encoding="utf-8").strip() == "redirected"
+
+    (workspace / ".authoring" / "published").write_text("out/x.dot out/x.md\n", encoding="utf-8")
+    authored = _run_gate("finalize", workspace)
+    assert authored.stdout == "finalized"
+    assert (workspace / ".authoring" / "disposition").read_text(encoding="utf-8").strip() == "authored"
+
+
+def _path_without(tool: str) -> str:
+    """The caller's PATH with every directory containing *tool* removed.
+
+    Deterministic in both directions: on a machine where the tool is installed
+    this actually hides it, and on one where it was never installed (CI) the
+    PATH comes back unchanged and the assertion still holds.
+    """
+    kept = [
+        d
+        for d in os.environ.get("PATH", "").split(os.pathsep)
+        if d and not (Path(d) / tool).exists()
+    ]
+    return os.pathsep.join(kept)
+
+
+@_SHELL_GATES
+def test_real_preflight_refuses_loudly_when_a_required_tool_is_missing(tmp_path):
+    """Preflight's whole purpose: refuse before an LLM is ever paid.
+
+    `attractor` absent means `lint_gate` could never run, so there is no honest
+    way to author anything -- and finding that out at preflight costs nothing,
+    while finding it out at `lint_gate` costs the author node's whole call. The
+    refusal has to NAME the missing tool: "blocked" with no reason sends the
+    operator to read a graph instead of their PATH.
+    """
+    workspace = _authoring_workspace(tmp_path)
+
+    result = _run_gate(
+        "preflight", workspace, pipeline_name="doc-claims-verified", PATH=_path_without("attractor")
+    )
+
+    assert result.returncode != 0
+    assert result.stdout == "blocked"
+    assert "attractor" in result.stderr
+    assert "PATH" in result.stderr
+    # And it refused BEFORE recording anything: a blocked run leaves no admitted
+    # name behind for a later node to read.
+    assert not (workspace / ".authoring" / "name").exists()
+
+
+@pytest.mark.skipif(
+    not (shutil.which("attractor") and shutil.which("sha256sum")),
+    reason=(
+        "preflight checks tool availability before it validates the publish name, so this "
+        "assertion needs the tools it checks for actually present -- the missing-tool branch "
+        "is covered unconditionally by the test above"
+    ),
+)
+@_SHELL_GATES
+def test_real_preflight_refuses_an_unsafe_publish_name(tmp_path):
+    """`pipeline_name` becomes a path under out/; preflight is the last free refusal."""
+    workspace = _authoring_workspace(tmp_path)
+
+    bad = _run_gate("preflight", workspace, pipeline_name="../../etc/passwd")
+    assert bad.returncode != 0
+    assert bad.stdout == "blocked"
+    assert "pipeline_name" in bad.stderr
+
+    good = _run_gate("preflight", workspace, pipeline_name="doc-claims-verified")
+    assert good.returncode == 0
+    assert good.stdout == "ready"
+    assert (workspace / ".authoring" / "name").read_text(encoding="utf-8").strip() == "doc-claims-verified"

--- a/skills/attractorify/SKILL.md
+++ b/skills/attractorify/SKILL.md
@@ -371,6 +371,18 @@ the objection's disposition recorded (`caveats:` line if unresolved). Then:
    AND wall-clock duration — must be machine-encoded in graph attributes or
    invocation parameters; scoping or a budget stated only in prose is neither.
 
+7. **Offer the authoring attractor.** This skill's design is reviewed by a
+   verifier and linted; it is not converged under executed gates. When the
+   design step has produced a validated intent — a named sink, a machine
+   check, and the caps — offer `examples/authoring/pipeline-author.dot`, which
+   takes that intent as a `--param brief=` and converges the `.dot` under
+   `attractor lint`, a structural authoring contract, and an independent
+   doctrine critique, publishing it with provenance. The same offer applies
+   when the honest answer here was `attractor` but the graph is larger than a
+   conversation should hand-build. It is an **offer**: launching a pipeline
+   remains the human's explicit call (see "What this skill does NOT do"), and
+   the diagnosis artifact still stands on its own if they decline.
+
 ---
 
 ## Reference surfaces (link, don't restate)
@@ -385,6 +397,9 @@ the objection's disposition recorded (`caveats:` line if unresolved). Then:
 - `examples/patterns/task-runner.dot` — canonical control-plane skeleton
 - `examples/pipelines/practical/bug-fix.dot` — shipped exemplar for "use the
   existing attractor" recommendations
+- `examples/authoring/README.md` — the authoring attractor: converges a *new*
+  `.dot` under executed gates from a design brief. Where a validated intent
+  from Step 3 goes to become a hardened artifact
 - <https://microsoft.github.io/amplifier-bundle-attractor/attractor-explained.html>
   — the visual explainer; if the person is trying to LEARN how attractors work
   rather than convert this session into a pipeline, offer them that link (share


### PR DESCRIPTION
## Summary

`/attractorify` **designs** a pipeline conversationally with a human present.
`examples/objective/`'s compose path **authors a run-time child** for one objective and throws it
away. Neither converges a *reusable* pipeline under executed gates — and authoring one is
convergence-shaped work: draft, machine-check, independent critique, revise.

This PR ships that third front door: **`examples/authoring/`**, an attractor that authors
attractors. You give it a design brief; it applies the three-question test to the brief, drafts a
new pipeline plus its companion guide, hardens the draft against `attractor lint` and a structural
authoring contract, submits it to a doctrine critique that inherits nothing from the author's
context, and publishes it with provenance — or exits **green** with a written redirect when the
work described does not want an attractor at all.

The reason it exists in this form rather than as more prose is the repo's own measured evidence:
`/attractorify`'s diagnosis rules only became reliable once they were backed by an **executed**
form gate plus an independent verifier, and `check_child_contract.py`'s C9 exists because a rule
that lived only in a composer's prompt was being ignored until something ran it
(`docs/QUALITY_PROTOCOL.md` §1). So the doctrine here is not stated at the author and hoped for.
It is executed at the draft.

### Graph shape and each gate's contract

`start → preflight → triage → triage_gate → {redirect_report | author} → lint_gate → doctrine_gate
→ critique → verdict_gate → package → finalize → done`, with `postmortem → escalated` as the loud
terminal.

| Gate | Tier | Contract | Tokens |
|---|---|---|---|
| `preflight` | tool | state dirs exist; `attractor`/`python3`/`sha256sum` on PATH; the checker is where `authoring_dir` says; `pipeline_name` is safe as a filename. Refuses **before** an LLM is paid | `ready` \| `blocked` (exit 1) |
| `triage_gate` | tool | last-line anchored, case-insensitive **exact** match on the triage verdict; fuse-bounded re-framing | `attractor` \| `redirect` \| `triage_bad` \| `triage_exhausted` |
| `lint_gate` | tool | `attractor lint` — ERRORs block, warnings recorded. **Also owns the single iteration counter**, checked on entry | `lint_pass` \| `lint_fail` \| `exhausted` \| `lint_unavailable` (exit 1) |
| `doctrine_gate` | tool | `check_authored_pipeline.py` A0–A9 (below) | `doctrine_ok` \| `doctrine_bad` \| `gate_error` (exit 1) |
| `verdict_gate` | tool, `goal_gate=true` | `tail -n 1` + `grep -qix` on the critique's final line. **Fails closed**: missing/empty/unparseable ⇒ `noverdict` ⇒ another iteration, never the exit. Idiom B so the goal gate has real teeth | `ship` (0) \| `iterate`/`noverdict` (exit 1) |
| `package` | tool | publishes `out/<name>.{dot,md}` + assembles `PROVENANCE.md` from the real artifacts with sha256 digests | `published` \| `publish_failed` (exit 1) |
| `finalize` | tool | refuses to open the exit without a disposition artifact | `finalized` \| `no_disposition` (exit 1) |

Three shape decisions worth the reviewer's attention:

- **The brief never touches a shell.** `$brief` expands into **prompts only**. Engine substitution
  runs before `/bin/sh` sees the string, so a brief in a `tool_command` is a command-injection
  hole. `triage` restates it durably and every deterministic node reads the *file*. The honest cost
  — the durable copy is a transcription — is named in `pipeline-author.md` under "Honest limits".
- **One counter spans the whole corrective path.** All four corrective legs (`lint_fail`,
  `doctrine_bad`, critique `ITERATE`, transient critique `FAIL`) re-enter through `lint_gate`,
  which walls the budget on **entry**. `PIPELINE_DESIGN_PRINCIPLES.md` §3: *"individually-bounded
  legs do not compose."*
- **Nothing lands in `out/` until every gate is green.** The author works in `.authoring/draft/`;
  `package` publishes only what the critique accepted.

### The checker's checks, and their RED proofs

`check_authored_pipeline.py` is stdlib-only for the same reason the objective layer's checker is:
it runs under whatever `python3` is on PATH in the target workspace, not the CLI's virtualenv.

| Check | Requires | RED proof (`test_authoring_layer_gates.py`) |
|---|---|---|
| A0 | the `.dot` exists, is readable, parses | `test_checker_fails_closed_when_the_pipeline_was_never_written`; `..._on_an_unparseable_pipeline` (prose / unterminated attr list / empty) |
| A1 | exactly one exit node | mutation `A1-two-exit-nodes` |
| A2 | at least one corrective cycle | mutation `A2-acyclic-should-have-been-a-recipe` |
| A3 | ≥1 evidence gate: a tool node running a **real** command that routes | mutation `A3-gate-that-only-printfs-a-constant` + `test_a_printf_only_gate_is_not_an_evidence_gate` + 8 parametrized cases on the substantive-command reader |
| **A4** | **the exit is unreachable without passing such a gate** | mutation `A4-exit-reachable-without-a-gate` |
| A5 | a tool node walls a budget and routes exhaustion | mutation `A5-no-budget-wall` |
| A6 | every reachable LLM worker has a fail route | mutation `A6-worker-with-no-failure-route` |
| A7 | label edges conjoin `&& outcome=success` where the source can fail | mutation `A7-label-edge-without-the-conjunction` |
| A8 | no failure outcome routed into the exit | mutation `A8-failure-routed-into-the-exit` |
| A9 | a companion `.md` names every reachable worker | 3 tests: missing / empty / skips-a-worker |

**A4 is the load-bearing one.** A1–A3 all pass on a graph with a corrective loop off to one side
and `done` hanging straight off a worker. A4 deletes every evidence-bearing gate and asks whether
the exit is still reachable from `start`.

**Calibration — the checks are pinned to doctrine, not to one author's taste.** The contract admits
`task-runner.dot`, `bug-fix.dot`, and `pipeline-author.dot` itself (the exemplar obeys the contract
it hands out). `00-convergence-loop.dot` correctly **fails** A5/A6 and is pinned as such, which
documents where the bar sits: at pipelines meant to run on real work, not at the four-node
illustration of the shape. The stdlib DOT reader is pinned against the engine's parser on four
shipped graphs, now comparing **attribute values** and not just node ids — which is how the escape-
ordering divergence in `_unquote` was found and fixed during this build.

---

## Decision-matrix tier (`docs/QUALITY_PROTOCOL.md` §3)

**Toward-spec.** Stated explicitly so a reviewer can disagree.

The upstream nlspec's own thesis is that *"the graph is the workflow"* and that *"pipeline authors
do not write control flow; they declare graph structure"* (spec 1.1/1.3). This PR makes authoring
itself a graph and machine-checks that authored graphs actually declare a convergence structure. It
adds **no engine, handler, parser or dispatch change of any kind** — `pipeline-author.dot` composes
only documented, already-ledgered features (`goal_gate`, `must_write`, `loop_restart`, `condition`,
the shape vocabulary, node-level `fidelity`). Nothing a spec-conformant graph can observe changes.

**No `specs/EXTENSIONS.md` entry is owed, and here is the argument rather than the assumption.**
The ledger tracks observable *contract* changes. Nothing here is one: no new attribute, no new
shape, no new semantic, no change to admission or dispatch. The precedent is exact —
`examples/objective/` shipped as an exemplar composing existing features and carries no
`EXTENSIONS.md` section and no `SPEC_CONFORMANCE.md` row (verified by grep on both files).

**Where a reviewer could reasonably push back**, named rather than buried: A5 (a budget wall) and A9
(a paired companion guide) are *repo* doctrine — `PIPELINE_DESIGN_PRINCIPLES.md` §3 and the
paired-guide convention every shipped exemplar already follows — not spec text. If you read that as
the uncharted tier, its toll is paid anyway: the checks are **additive and non-interfering** by
construction. They run only on graphs authored *through this opt-in exemplar*, never on the engine,
never on `attractor lint`, and never on a community `.dot`. A spec-conformant graph behaves
identically with this PR applied and with it reverted.

**Evidence class** (`§2`, "Exemplar / example graphs"): `attractor lint` zero ERROR ✅, at least one
live convergence run ✅, and the graph's own gates demonstrated **RED and GREEN** — see LP1/LP2 and
the mutation table above.

---

## Verification checklist

- [x] Unit tests pass — `modules/loop-pipeline`: **2215 passed, 25 skipped** (baseline 2166/25; +49 = 48 new tests + 1 new `test_examples_lint_clean` param for `pipeline-author.dot`). `modules/pipeline-runner`: **76 passed, 1 skipped**. Both run with `env -u ANTHROPIC_API_KEY -u OPENAI_API_KEY -u GEMINI_API_KEY -u GOOGLE_API_KEY` per `AGENTS.md`
- [x] Live pipeline run exercising the changed path — two real LLM runs through the installed `attractor` CLI, below
- [x] AGENTS.md reviewed; repo-specific gates met
- [x] Backward-compat path unchanged — no engine/handler/parser change; additive files only
- [x] **No `specs/EXTENSIONS.md` entry needed:** no observable contract change — this is an exemplar composing already-documented features, same as `examples/objective/`. Full argument in the tier section above
- [x] **No new doc claim about code behavior needs a guard beyond what ships here.** The load-bearing claims in `examples/authoring/README.md` are about A0–A9, and `test_authoring_layer_gates.py` pins every one of them to the checker's actual behavior — including the A5 vocabulary, which is read from the module's own constants in the failure detail rather than restated
- [x] PR body includes verification evidence, not just "tests pass"
- [ ] **CI is green before merge** — do not merge; this PR is for review

---

## Verification evidence

Full artifacts: `.amplifier/evaluation/authoring/20260815T152847Z/` (not committed).

### LP1 — the money proof: author a real pipeline, then run it

Invocation:

```bash
cd /tmp/authoring-lp1-ws
attractor run "$AUTH/pipeline-author.dot" \
    --param brief="$(cat brief.txt)" \
    --param authoring_dir="$AUTH" \
    --param target_dir="$PWD" \
    --param pipeline_name="doc-claims-verified" \
    --param max_iterations=4 \
    --cwd .
```

The brief asked for a **doc-claims-verified** convergence pipeline: keep a repo's documented
commands true, gated on a `verify_doc_claims.sh` that extracts every (command, expected output)
pair from `README.md`, runs each, and exits 0 only when every claim holds.

Convergence record (`.authoring/convergence.jsonl`), verbatim:

```json
{"frame": 1, "gate": "triage", "verdict": "attractor"}
{"iteration": 1, "gate": "lint", "result": "lint_pass", "warnings": 0}
{"iteration": 1, "gate": "doctrine", "result": "doctrine_ok"}
{"iteration": 1, "gate": "critique", "verdict": "ship"}
```

`attractor: status=success`, `EXIT=0`, `.authoring/disposition` = `authored`,
`.authoring/verdict-line.txt` = `VERDICT: SHIP`.

**Independent re-checks of the published artifact** (run outside the pipeline, after the fact):

```
$ attractor lint out/doc-claims-verified.dot
attractor lint: out/doc-claims-verified.dot: OK (no findings)          # exit 0

$ python3 examples/authoring/check_authored_pipeline.py \
      --pipeline out/doc-claims-verified.dot --companion out/doc-claims-verified.md
doctrine_ok
[PASS] A1 … [PASS] A2 … [PASS] A3 … [PASS] A4 … [PASS] A5 … [PASS] A6 … [PASS] A7 … [PASS] A8 … [PASS] A9
```

**And it actually RUNS.** The published `.dot` was executed once in a *fresh* copy of the fixture it
was never authored in, where the verifier was red:

```
# before
CLAIM 1 MISMATCH: bash scripts/greet.sh World
    expected: Hello, World!
    actual  : Hi, World!
2 claim(s) checked; at least one MISMATCH above          # exit 1

$ attractor run /tmp/lp1-authored.dot --param target_dir=$PWD --param max_iterations=4 --cwd .
attractor: status=success                                # EXIT=0

# after
CLAIM 1 OK      : bash scripts/greet.sh World
CLAIM 2 OK      : printf 'alpha beta gamma\n' > … ; bash scripts/wordcount.sh …
ALL 2 DOCUMENTED CLAIMS HOLD                             # exit 0
```

And it converged **honestly** — it fixed the code, not the check. The complete diff the authored
pipeline produced:

```diff
--- scripts/greet.sh
+++ scripts/greet.sh
@@ -3 +3 @@
-printf 'Hi, %s!\n' "$1"
+printf 'Hello, %s!\n' "$1"
```

`verify_doc_claims.sh` is byte-identical to the fixture's — the brief's "never edit or weaken the
verifier" constraint held.

### LP2 — negative control: a deliberately recipe-shaped, gateless brief

The brief asked for a 12-step monthly release announcement, stating outright: *"there is no test
for whether an announcement is good"*, that the quality bar is three humans replying in chat, and
*"we do not need it double-checking itself; that would just slow the whole thing down."*

**Result: the honest redirect. Nothing was authored, `out/` stayed empty, the run exited green.**

```
$ cat .authoring/disposition
redirected
$ ls out/
(empty)
EXIT=0
```

`{"frame": 1, "gate": "triage", "verdict": "redirect"}` — and the triage refused the tempting dodge
by name, verbatim from `.authoring/triage.md`:

> **Q2: Is the exit gated on machine-checkable evidence external to the worker?**
>
> No. The brief states plainly: *"there is no test for whether an announcement is good."* … Chat
> replies from three people are not machine-checkable. … inventing a hollow file-presence check
> (e.g., "did the model write a file called approved.txt?") would gate on the worker's own output,
> not on external evidence — exactly the fabrication failure mode the doctrine warns against.

`.authoring/redirect.md` then names the better home (a recipe, with a concrete first node) and —
the part that makes the "no" useful — states exactly what *would* make it an attractor: a
claim-traceability linter asserting that *"every claim in the highlights section can be traced to a
closed issue or merged PR in that milestone."*

This is the first of the two acceptable LP2 outcomes. The second — a gateless draft **blocked** by
the doctrine gate — is proved through the pipeline's own shell in
`test_real_doctrine_gate_command_blocks_a_gateless_draft`, which drives the verbatim
`doctrine_gate` `tool_command` extracted from `pipeline-author.dot` by the engine's parser and
asserts `doctrine_bad` + `[FAIL] A4`. Neither path can silently accept.

### Other gates

- `attractor lint examples/authoring/pipeline-author.dot` → **OK (no findings)**, zero errors, zero
  warnings. Enforced permanently by `test_examples_lint_clean.py`, which now covers it.
- **Leak scan clean on every added/edited file** — `python3 .github/capsule-pipeline/scrub_secrets.py
  scan` over the 6 added/edited files: `clean -- scanned 6 file(s), no secret-shaped material`.
  `README.md` is excluded from that count for an honest reason, stated rather than hidden: it trips
  one `high-entropy-token` finding at line 18, and **the identical finding reproduces on
  `origin/main`'s README.md** (a false positive on a long `REPOSITORY_RULES.md` URL, in text this PR
  does not touch — my diff to that file is one table row at line 163).
- `git diff --check` → clean.
- **No run artifacts committed.** All seven changed paths are source; `.authoring/` and `out/` live
  only in the `/tmp` workspaces the live proofs ran in.

---

## Observations

Two, filed here per §4 so the reviewer sees them without going looking. Both are non-blocking and
neither is resolved in this PR.

1. **The vision's ladder has no rung for authoring.** `docs/VISION.md`, "The layers we converge on",
   runs *node contracts → evidence-gated engine → objective in / verified outcome out → operator
   steers a portfolio*. Producing a **reusable, hardened pipeline** is not any of those: the
   objective layer's compose path deliberately builds a throwaway child for one objective, and this
   PR's exemplar is the first surface whose output is an artifact meant to outlive its run. That may
   be a genuine missing rung, or it may be correctly out of scope — but the page currently does not
   say either. Naming it, not deciding it; a vision amendment needs the maintainer's explicit word.

2. **`examples/objective/objective-runner.dot` has no paired companion guide.** Its guide is
   `README.md`, while every other shipped exemplar pairs `X.dot` with `X.md`. This surfaced
   mechanically: A9 admits `task-runner.dot`, `bug-fix.dot` and `pipeline-author.dot` and is the one
   check `objective-runner.dot` fails, purely on the naming convention. It is a small inconsistency
   in a convention the repo otherwise holds, and this PR now encodes that convention as a check for
   anything authored through it. Not fixed here — renaming or splitting that doc is a separate
   change with its own review.

---

## Notes for reviewers

- **Read `check_authored_pipeline.py` A4 first** if you are short on time. It is the check that
  makes the other eight worth having, and it is the one most likely to be wrong in an interesting
  way.
- **The self-application claim is load-bearing and has its own test.**
  `test_the_authoring_attractor_obeys_the_contract_it_enforces` — an exemplar that could not satisfy
  its own contract would be teaching the anti-pattern by example.
- **Honest limits are stated in the artifact, not just here.** `pipeline-author.md` §"Honest limits"
  names four: the brief's fidelity depends on `triage`'s transcription (the price of keeping user
  text out of every shell); the contract checks structure and not fitness; A5's vocabulary is a
  convention rather than semantic analysis; and this pipeline does not run what it authors — LP1
  ran the authored artifact separately, and the README says which evidence belongs to which.
- **A deliberate asymmetry in `verdict_gate`:** Idiom B means `iterate` and `noverdict` share one
  outgoing edge, because a nonzero exit does not refresh `tool.last_line` and routing them apart
  would require reading a stale label. The distinction is preserved in `convergence.jsonl` and on
  stderr instead. The trade — a real `goal_gate` over a finer route — is argued in the node comment.
- **One engine-behavior finding, fixed in this PR's own code:** the checker's `_unquote` originally
  approximated DOT escape handling with a regex and disagreed with `dot_parser._parse_value` on
  `\\n`. The parser-agreement test caught it because it compares attribute *values*; `_unquote` now
  reproduces the engine's exact replacement order. No engine change — the engine was right.
- **Do not merge.** Maintainer's explicit word required per `AGENTS.md`.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)
