### PR TITLE
feat(evals): the guidance eval — a standing gate for guidance surfaces, and its 2026-08-15 baseline (3/6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ cited as prior-art inspiration where useful.
 | [Pipeline Design Principles](docs/PIPELINE_DESIGN_PRINCIPLES.md) | Six framework-agnostic design principles: tier discipline, validation patterns, loop convergence, LLM output protocols, parameterization, verdict-bearing nodes |
 | [Issue Pipeline](docs/ISSUE_PIPELINE.md) | What happens after a maintainer labels an issue `ready:spec` (defects) or `ready:feature-spec` (features) -- the autonomous specify/implement pipelines, their human review gates, what makes a good defect report, and how a maintainer supplies binding acceptance criteria for a feature |
 | [Quality Protocol](docs/QUALITY_PROTOCOL.md) | How work gets proven here -- the design -> build -> live-proof -> adversarial-review -> maintainer's-word arc, the evidence each class of change owes before merge, the five-layer drift defense against the upstream nlspec, and the meta-protocol for amending and retiring all of it |
+| [Guidance Eval](evals/guidance/README.md) | The standing instrument behind the Quality Protocol's **Guidance surfaces** row -- six scenarios that install this bundle the way a user does, drive real sessions against `agents/`, `skills/`, `context/` and the teaching docs, and grade them blind against criteria anchored in the canonical spec and the vision |
 
 ## Quick Start
 

--- a/docs/QUALITY_PROTOCOL.md
+++ b/docs/QUALITY_PROTOCOL.md
@@ -72,7 +72,7 @@ may ask for more, never less.
 |---|---|---|
 | **Engine / handler code** | `engine.py`, `handlers/*`, dispatch, routing, retry, checkpoint | Full module suites green **and** a live pipeline run exercising the changed path (paste the `events.jsonl` slice) **and** independent adversarial review **and** a ledger entry if the change is spec-relevant (last row) |
 | **Exemplar / example graphs** | `examples/pipelines/*.dot`, `examples/patterns/*.dot`, `examples/objective/*` | `attractor lint` with **zero ERROR** diagnostics -- warnings are informational, which is exactly the line `modules/loop-pipeline/tests/test_examples_lint_clean.py` enforces -- **and** at least one live convergence run **and** the graph's own gates demonstrated **RED and GREEN**: a negative control proving the gate can fail, a positive control proving it can pass. A gate only ever seen green is an unproven gate |
-| **Guidance surfaces** | `agents/`, `skills/`, `context/`, teaching content in `README.md` and `docs/` | Guidance-eval evidence **once the eval instrument ships**. *That instrument does not exist in this repo today: it is in flight, and a pilot is planned.* Until it lands, the floor is a **fresh-session walk-through** proving the guidance steers as written -- a session with no prior context follows only the changed text and arrives at the intended behavior. Paste the walk-through |
+| **Guidance surfaces** | `agents/`, `skills/`, `context/`, teaching content in `README.md` and `docs/` | **Guidance-eval evidence** from [`evals/guidance/`](../evals/guidance/README.md) -- the instrument shipped, and its 2026-08-15 baseline is the run every later run is read against. Run the scenarios whose `surfaces_under_test:` name the file you touched and paste the results table plus the decisive transcript quotes; a broad change -- a bundle recomposition, a doctrine amendment, a new guidance surface -- warrants the full six. Where the eval genuinely cannot reach the changed surface, say so in the PR in those words and fall back to a **fresh-session walk-through**: a session with no prior context follows only the changed text and arrives at the intended behavior |
 | **Docs making factual claims** | any doc asserting a number, default, vocabulary, or behavior | A guard test pinning each load-bearing claim to **its source of truth in code**, following the existing guards (section 5, Layer 1). A page-only assertion ("the page says 500") is tautological: it passes forever and fails only when someone edits the page, which is the one case needing no guard. The assertion must read the value from the code and fail when the **code** moves |
 | **Spec-relevant behavior** | anything that conforms to, diverges from, or extends the nlspec | A `specs/EXTENSIONS.md` entry and/or a `SPEC_CONFORMANCE.md` row, **in the same PR**, per the Compatibility doctrine. Entries obey the Entry Format: `depends-on:`, plus `upstream action:` in one of its legal forms whenever the banner states a divergence. Its **matrix tier** (section 3) sets the rest of the toll |
 
@@ -434,6 +434,40 @@ This repo's maintainers will help seed a customized version on request -- open a
 ## Changelog
 
 Amendments to this protocol, newest first. Each entry names the evidence that justified it.
+
+### 2026-08-15 -- the guidance eval shipped; section 2's interim floor retired (entry 7)
+
+- **Amended.** Section 2's **Guidance surfaces** row required "guidance-eval evidence *once the eval
+  instrument ships*" and named a fresh-session walk-through as the floor until it did. The
+  instrument shipped: [`evals/guidance/`](../evals/guidance/README.md) -- six scenarios, a rubric
+  whose every criterion cites a canonical-spec section or a `docs/VISION.md` passage, and a harness
+  that installs the bundle over the real `amplifier bundle add` path into a fresh container and
+  grades the resulting sessions blind. The row now names it. The walk-through survives only as a
+  stated-in-the-PR fallback for a surface the eval cannot reach.
+- **Evidence that it earns its cost, at adoption.** The full six ran on 2026-08-15 against `main`
+  @ `ed5bdef`: **three of six passed**, and the failures are findings about this bundle, not about
+  the instrument. `attractor-expert`, asked whether a review node could decide it was done,
+  answered "yes, the review node decides" and authored a self-report exit -- the project's central
+  commitment, inverted, on the surface that exists to teach it. The objective layer proved
+  unreachable by conversation: `/attractorify`, the objective runner and `attractor-expert` were
+  never named. A gateless twelve-node chain was authored on request with no pushback, on a file
+  whose own `attractor lint` run says "consider whether this pipeline should be a recipe instead".
+  A fourth finding was visible only *across* scenarios, which is precisely what a per-PR
+  walk-through cannot see: both authoring surfaces emit a DOT dialect the shipped engine does not
+  use. Each is tracked in the issues filed from that baseline.
+- **The cost it retires.** The interim floor was verification inside the context that produced the
+  artifact -- a walk-through authored by the person whose change it validates, run against a working
+  tree rather than an installed bundle, and not comparable to any other walk-through. That is the
+  property section 1's independent-review rule refuses everywhere else in this document.
+- **Scope of this change: documentation and `evals/` only.** No engine, handler, example or test
+  code changed. Section 2's row is the only normative edit. The baseline table lives in
+  `evals/guidance/README.md`, not here, and no run artifact is committed: the harness refuses to
+  write results inside the checkout, so transcripts and prompts stay out of source by construction.
+- **Retirement conditions.** The instrument's own are stated in `evals/guidance/README.md` and are
+  governed by section 7's retirement review -- *what has it caught since the last review?* -- plus a
+  hold-out discipline that requires one scenario rewritten from scratch, same property and new
+  words, whenever several runs pass without finding anything. The walk-through fallback in the
+  section 2 row retires when no change class remains that the eval cannot reach.
 
 ### 2026-08-15 -- Layer 3 gets an executor (entry 6)
 

--- a/evals/guidance/README.md
+++ b/evals/guidance/README.md
@@ -16,9 +16,9 @@ This is the instrument `docs/QUALITY_PROTOCOL.md` section 2 names in its **Guida
 ## Why it exists
 
 The quality protocol requires evidence for every class of change. For `agents/`, `skills/`,
-`context/`, and the teaching content in `README.md` and `docs/`, the required evidence is
-"guidance-eval evidence **once the eval instrument ships**" — and until it does, the floor is a
-fresh-session walk-through pasted into the PR.
+`context/`, and the teaching content in `README.md` and `docs/`, the required evidence was, until
+this instrument shipped, a **fresh-session walk-through** pasted into the PR — an interim floor
+held open in section 2's own words until guidance-eval evidence could replace it.
 
 A walk-through is a real check and it caught real problems, but it has three properties that make
 it unsuitable as the standing bar:
@@ -161,28 +161,49 @@ and re-run. A bundle that passes the old wording and fails the new one was fitte
 Rotate which scenario gets rewritten, and record the rewrite in the PR that makes it. The property
 list is the stable thing here; the words are not, and must not be.
 
-## Status — what has been proven, and what has not
+## Status — the 2026-08-15 baseline
 
-Stated plainly rather than implied, per `docs/QUALITY_PROTOCOL.md`'s scope note: where a piece of
-machinery has not been exercised yet, say so in those words.
+Stated plainly rather than implied, per `docs/QUALITY_PROTOCOL.md`'s scope note.
 
-**Proven end-to-end.** Scenario (a) has run the whole path for real — pinned mirror push, DTU
-launch, `bundle add` install from the mirror, readiness gates, an AI-user-driven multi-turn
-session against the installed bundle, deterministic transcript recovery, mechanical checks, blind
-grading against the anchored criteria, and results written outside the repo. It passed
-(`G1=3 G2=3 G4=5 G5=3 G8=5`, both mechanical checks green).
+**All six scenarios have been exercised live.** On 2026-08-15, against `main` @ `ed5bdef`, every
+scenario ran the whole path for real — pinned mirror push, DTU launch, `bundle add` install from
+the mirror, readiness gates, AI-user-driven multi-turn sessions and live
+`examples/objective/objective-runner.dot` runs against the installed bundle, deterministic
+transcript recovery, mechanical checks, blind grading against the anchored criteria, and results
+written outside the repo. No stage of the harness remains unexercised.
 
-**Shares that proven path.** Scenarios (b), (c) and (d) are the same session mode with different
-personas and pass bars: every stage they use is the stage (a) exercised. They have not themselves
-been run.
+**Three of six passed.** The instrument's first product is a finding, not a clean bill of health.
 
-**Not yet exercised: the exemplar path.** Scenarios (e) and (f) drive
-`examples/objective/objective-runner.dot` inside the DTU, which stage (a) does not touch. What
-*is* proven of it: the `objective-runner-lints` readiness gate runs `attractor lint` against the
-shipped runner in the DTU on every trial, and passes — so the CLI, the checkout, and the graph's
-parse are real. The run itself, the disposition artifacts, and the file/JSON mechanical-check
-kinds have not been exercised against a live pipeline. Treat the first (e)/(f) run as a smoke
-run, and read it by hand.
+### Baseline 2026-08-15
+
+| # | Scenario | Verdict | Finding |
+|---|---|---|---|
+| **a** | `qa-01-what-is-an-attractor` | **PASS** | Taught machine gates throughout and delivered the honest "you don't need an attractor" (G8=5); softened to "AI adapts vs dumb retry" under the flowchart-with-retries push rather than holding the external-to-the-worker line (G1=3). |
+| **b** | `qa-02-never-converges` | **FAIL** | Asked whether the review node could decide it was done, `attractor-expert` answered "**yes, the review node decides**" and authored a self-report exit — the central commitment inverted (G5=0, which is the override; G1=0, G8=0). Never reached `attractor lint` or the event record. |
+| **c** | `work-01-stale-release-notes` | **FAIL** | The objective layer is unreachable by conversation: foundation's `/brainstorm` mode-routing captured the ask, and `attractorify`, the objective runner and `attractor-expert` were never named (MC-C1). Nobody asked what would prove it done (MC-C2). |
+| **d** | `work-02-twelve-step-pipeline` | **FAIL** | Authored the gateless twelve-node chain on request with zero pushback; the word "recipe" never appears (MC-D1). `attractor lint` on the file it just authored says *"consider whether this pipeline should be a recipe instead"* — the doctrine the session skipped is already in the linter. |
+| **e** | `exemplar-01-sloppy-routable` | **PASS** *(flagged)* | The sloppy-but-checkable objective was restated as an end-state and routed to a lane with `pytest` as the gate (G1=G2=G7=5, every mechanical check green). Flagged: the runner exited 1 with `disposition=escalated` — a known objective-runner defect, not a guidance failure. |
+| **f** | `exemplar-02-honest-redirect` | **PASS** | The strongest artifact in the baseline: a complete honest redirect with receipts — the no, the reason, the better home, and what would change the answer (G1=G2=G4=G8=5, all six mechanical checks green). |
+
+**One cross-cutting finding, visible only across scenarios.** Both authoring surfaces emitted a DOT
+dialect the shipped engine does not use — `agent=`, `instruction=`, `attractor_handler=` — which no
+single scenario's pass bar was looking for. That is the kind of finding a standing instrument buys
+and a per-PR walk-through does not.
+
+Every finding above is tracked in the issues filed from the 2026-08-15 baseline. Per the hold-out
+discipline above, none of them is a reason to edit a scenario: they are findings about the bundle
+until an independent reading says otherwise.
+
+**Where the evidence lives.** Outside the repo, by design — under
+`<workspace>/.amplifier/evaluation/guidance-pilot/<UTC>/`, one directory per run, each carrying
+`results.md`, `results.json`, per-scenario transcripts, `ai_user.json`, and the readiness logs. The
+harness refuses to start if that path resolves inside the checkout. Nothing from a run is committed
+here, and this table is the repo's record of the baseline rather than a copy of its artifacts.
+
+**Read this table as a reference point, not a scoreboard.** It is the run every later run is
+compared against, and it was taken before any of the findings were acted on. A future run that
+scores better because the guidance improved is the intended outcome; one that scores better because
+a scenario was reworded is the failure mode the four rules above exist to prevent.
 
 ## Layout
 

--- a/evals/guidance/README.md
+++ b/evals/guidance/README.md
@@ -174,6 +174,20 @@ written outside the repo. No stage of the harness remains unexercised.
 
 **Three of six passed.** The instrument's first product is a finding, not a clean bill of health.
 
+**Disclosed: two mechanical-check commands were repaired mid-baseline.** Rule 1 above calls an
+undisclosed scenario edit "the single most suspicious diff this directory can contain", so this one
+is stated here rather than left to be found. `MC-E2` and `MC-F6` — the two exemplar scenarios' re-run
+of the shipped admission gate — invoked `examples/objective/validate_triage.py` with a bare
+positional path, but that script requires `--triage` and `--schema`; the check died in argparse with
+exit 2 and could not have exited 0 for **any** bundle, good or bad. The repair changed how the gate
+is called, not what it demands — harness plumbing, not tuning — and the bar moved up rather than
+down, since the corrected check also fails on a `triage_bad` or `triage_exhausted` token where the
+original could only ever error out. The rubric, the personas, the opening asks and every other
+scenario input were byte-identical either side of the repair, and the YAMLs committed here are the
+fixed version. **No verdict in the table turns on it:** on the failing first pass both exemplars'
+grader scores were already at the passing values recorded below — the broken invocation was the only
+thing failing, and it was failing on its own usage error.
+
 ### Baseline 2026-08-15
 
 | # | Scenario | Verdict | Finding |

--- a/evals/guidance/README.md
+++ b/evals/guidance/README.md
@@ -1,0 +1,199 @@
+# The guidance eval
+
+A standing, re-runnable instrument that answers one question:
+
+> **When a real user arrives at this bundle with a question or a want, where does the guidance
+> send them?**
+
+Six scenarios drive real sessions against the bundle's guidance surfaces — installed in a fresh
+container the way a user installs it — and a grader that never saw those sessions scores them
+against criteria anchored in the canonical nlspec and [`docs/VISION.md`](../../docs/VISION.md).
+
+This is the instrument `docs/QUALITY_PROTOCOL.md` section 2 names in its **Guidance surfaces** row.
+
+---
+
+## Why it exists
+
+The quality protocol requires evidence for every class of change. For `agents/`, `skills/`,
+`context/`, and the teaching content in `README.md` and `docs/`, the required evidence is
+"guidance-eval evidence **once the eval instrument ships**" — and until it does, the floor is a
+fresh-session walk-through pasted into the PR.
+
+A walk-through is a real check and it caught real problems, but it has three properties that make
+it unsuitable as the standing bar:
+
+- **It is authored by the person whose change it validates.** A walk-through written by the
+  author, in the author's frame, is verification inside the context that produced the artifact —
+  the property this repo refuses everywhere else (`docs/VISION.md`, "Gates outside workers").
+- **It runs against the working tree**, so it proves the guidance steers *for someone who already
+  has the repo checked out*, which is not who the guidance is for.
+- **It is not comparable.** Two walk-throughs of two changes measure different things, so there is
+  no way to tell whether a guidance change made anything better or worse.
+
+This instrument fixes all three: the sessions are driven by a user simulator with a persona and no
+knowledge of the doctrine, the bundle is installed over the real `bundle add` path from a pinned
+ref, and every run scores the same criteria against the same six scenarios.
+
+## What it measures — and what it does not
+
+**It measures steering.** Where the guidance sends a user. Whether the exit condition it teaches
+is machine evidence or step completion. Whether it diagnoses before designing. Whether it says no
+when no is the honest answer.
+
+**It does not measure** tone, length, whether a `.dot` file was produced (in two scenarios the
+correct answer is that nothing gets authored), or factual precision about defaults and numbers.
+Those numbers are pinned by the Layer-1 guard tests, which read them from the code —
+re-asserting them here would be the page-only tautology the protocol's "Docs making factual
+claims" row warns about.
+
+## The six scenarios
+
+Three classes, two each. Six, not a matrix: each one is a **named property**, and adding a
+seventh should require naming a property the other six do not cover.
+
+| # | Scenario | The property under test |
+|---|---|---|
+| **a** | [`qa-01-what-is-an-attractor`](scenarios/qa-01-what-is-an-attractor.yaml) | A newcomer asks what an attractor is and when to use one instead of a recipe. **Passes if** the session teaches convergence on machine evidence external to the worker — not step completion, not "a flowchart with retries" — applies the three-question shape, points at a shipped teaching surface, and holds the line when the user offers the retry-loop analogy. |
+| **b** | [`qa-02-never-converges`](scenarios/qa-02-never-converges.yaml) | "My pipeline runs forever / never converges — help." **Passes if** the diagnosis is structural (budgets counted inside gates, a condition that can never match, edge selection falling through to the lexical tiebreak), it reaches for `attractor lint` and the run's own event record, and it **refuses** the user's proposal to let the review node decide it is done. |
+| **c** | [`work-01-stale-release-notes`](scenarios/work-01-stale-release-notes.yaml) | A messy real objective: "our release notes are always stale… build me something." **Passes if** the session works the objective layer — restates the objective as an end-state, presses for what machine evidence would prove it, routes to `/attractorify` or the objective runner — rather than hand-picking a step list. |
+| **d** | [`work-02-twelve-step-pipeline`](scenarios/work-02-twelve-step-pipeline.yaml) | "Just write me a 12-step pipeline that does X, A to Z" — a recipe-shaped ask, fully specified. **Passes if** the session pushes back per doctrine: names the ask as recipe-shaped, offers the recipe-vs-attractor distinction with the reason, and does **not** dutifully author a gateless twelve-node chain. The honest no scores high. |
+| **e** | [`exemplar-01-sloppy-routable`](scenarios/exemplar-01-sloppy-routable.yaml) | A sloppily-phrased but genuinely machine-checkable objective, run through the shipped `examples/objective/objective-runner.dot`. **Passes if** the intake routes it to a lane anyway: `triage_gate` admits the record, the shape is not `redirect`, `evidence_command` is not `NONE`, and the disposition is not `redirected`. |
+| **f** | [`exemplar-02-honest-redirect`](scenarios/exemplar-02-honest-redirect.yaml) | An objective with no machine evidence available at all, through the same runner. **Passes if** it produces the honest no with receipts: `disposition == redirected`, `shape == redirect`, `evidence_command == NONE`, and a `redirect.md` naming the better home. A `satisfied` here is the most interesting possible failure — it means a hollow definition of done was invented and then passed. |
+
+Scenarios (e) and (f) are the same fixture workspace with opposite correct answers. That pairing
+is deliberate: an intake that always routes and an intake that always redirects each pass exactly
+one of them, and the instrument reports which.
+
+## When the protocol requires running it
+
+Per `docs/QUALITY_PROTOCOL.md` section 2, **Guidance surfaces** row — any change to:
+
+- `agents/` — including `agents/attractor-expert.md` and its context files
+- `skills/` — including `skills/attractorify/SKILL.md`
+- `context/` — `pipeline-awareness.md`, `dot-reference.md`, `engine-semantics.md`, and siblings
+- teaching content in `README.md` and `docs/` — including `docs/attractor-explained.html`,
+  `docs/PIPELINE_DESIGN_PRINCIPLES.md`, and `docs/GETTING-STARTED.md`
+
+Run the scenarios whose `surfaces_under_test:` name the file you touched, and paste the results
+table plus the decisive transcript quotes into the PR. A full six-scenario run is warranted when
+the change is broad — a bundle recomposition, a doctrine amendment, a new guidance surface — and
+whenever the Layer-3 holistic review fires (section 6).
+
+Two changes also warrant a run even though they are not guidance edits: **any change to
+`examples/objective/`**, which scenarios (e) and (f) exercise directly, and **any amendment to
+`docs/VISION.md`**, because the rubric's anchors live there and an amendment may have moved what
+the instrument is measuring.
+
+## Running it
+
+```bash
+cd evals/guidance/harness
+./run.sh --list                  # what would run, and against which criteria
+./run.sh --smoke                 # one scenario, whole plumbing, ~15 min
+./run.sh --scenarios qa-02-never-converges
+./run.sh                         # all six
+```
+
+Prerequisites, mechanics, DTU details, and failure handling: [`harness/README.md`](harness/README.md).
+
+## Reading a result
+
+Results land **outside the repo**, under
+`<workspace>/.amplifier/evaluation/guidance-pilot/<UTC>/`. The harness refuses to start if the
+results path resolves inside the checkout — transcripts and prompts are not source.
+
+`results.md` gives the table. Then read, in this order:
+
+1. **The failed checks and low criteria, individually.** Nothing is averaged. A scenario fails if
+   *any* cited criterion scores below 3 or *any* mechanical check fails, and the report names
+   which — because "4.1 out of 5" hides the one property that broke.
+2. **The grader's reasoning per criterion.** Each score comes with the sentence it was scored on.
+   A score whose reasoning does not quote the transcript is a score to distrust.
+3. **The transcript itself**, at `<scenario>/graded/transcript.md`. This is the artifact. The
+   scores are a reading of it, and a reading can be wrong.
+4. **`ai_user.json`** — the simulated user's own verdict, and its verbatim quotes of the decisive
+   moments. When the grader and the user disagree, that disagreement is the finding.
+
+**A suspicious pass is a bug in the eval until proven otherwise.** The failure this instrument is
+most exposed to is grading an environment where the bundle was never active — which is why
+activation is asserted twice and the readiness log is kept per trial.
+
+### The G5 override
+
+If **G5** — "never routes on a model's self-report" — scores 0 in any scenario, the run fails
+regardless of every other score. A session that endorses a model grading its own work has
+inverted the project's central commitment. The rubric's own rule is fail-closed, for the same
+reason the engine's is.
+
+## Hold-out and refresh discipline
+
+**This instrument can be overfit, and if it is, it will keep saying yes while the guidance gets
+worse.** The failure mode is specific: someone reads a low score, edits the guidance surface to
+contain the phrases the scenario checks for, and the number goes up while a real user's experience
+does not change at all. That is not a hypothetical — it is the natural gradient of having a score.
+
+Four rules hold the line.
+
+**1. Fix the guidance, never the scenario.** A failing scenario is a finding about the bundle
+until an independent reading says otherwise. If you conclude the scenario is wrong, say so in the
+PR, in those words, with the reason — and expect a reviewer to disagree. Editing a scenario in the
+same change that made it fail is the single most suspicious diff this directory can contain.
+
+**2. The rubric is frozen within an iteration.** Criteria may be added or amended between runs,
+never mid-cycle to rescue a result. Any rubric change re-baselines: prior results are no longer
+comparable, and `results.json` records the criteria and thresholds the run was actually judged
+against so that stays visible.
+
+**3. Never publish the scenario text into the guidance surfaces.** Do not quote a persona, an
+opening ask, or a `machine_checks` phrase into `agents/`, `skills/`, `context/`, or the docs.
+Doing so trains the surfaces on the test. The mechanical checks are deliberately narrow and
+literal for the same reason: they catch blatant regressions, and the rubric criteria — which are
+judged, not matched — carry the real weight.
+
+**4. Refresh on a schedule, and hold one back.** When the instrument has run several times
+without finding anything, that is a finding about the instrument, not a clean bill of health
+(`docs/QUALITY_PROTOCOL.md` section 7's retirement review: *"What has it caught since the last
+review? Nothing is a finding, not a pass."*). At that point **rewrite one scenario's prose from
+scratch** — same property, same criteria, entirely new persona, phrasing, and surface details —
+and re-run. A bundle that passes the old wording and fails the new one was fitted to the wording.
+
+Rotate which scenario gets rewritten, and record the rewrite in the PR that makes it. The property
+list is the stable thing here; the words are not, and must not be.
+
+## Status — what has been proven, and what has not
+
+Stated plainly rather than implied, per `docs/QUALITY_PROTOCOL.md`'s scope note: where a piece of
+machinery has not been exercised yet, say so in those words.
+
+**Proven end-to-end.** Scenario (a) has run the whole path for real — pinned mirror push, DTU
+launch, `bundle add` install from the mirror, readiness gates, an AI-user-driven multi-turn
+session against the installed bundle, deterministic transcript recovery, mechanical checks, blind
+grading against the anchored criteria, and results written outside the repo. It passed
+(`G1=3 G2=3 G4=5 G5=3 G8=5`, both mechanical checks green).
+
+**Shares that proven path.** Scenarios (b), (c) and (d) are the same session mode with different
+personas and pass bars: every stage they use is the stage (a) exercised. They have not themselves
+been run.
+
+**Not yet exercised: the exemplar path.** Scenarios (e) and (f) drive
+`examples/objective/objective-runner.dot` inside the DTU, which stage (a) does not touch. What
+*is* proven of it: the `objective-runner-lints` readiness gate runs `attractor lint` against the
+shipped runner in the DTU on every trial, and passes — so the CLI, the checkout, and the graph's
+parse are real. The run itself, the disposition artifacts, and the file/JSON mechanical-check
+kinds have not been exercised against a live pipeline. Treat the first (e)/(f) run as a smoke
+run, and read it by hand.
+
+## Layout
+
+```
+evals/guidance/
+├── README.md              # this page — what the instrument is and when to run it
+├── rubric.md              # the 8 criteria, each citing a canonical-spec § or a VISION passage
+├── scenarios/             # 6 scenarios: persona, opening ask, follow-up behavior, pass bar
+└── harness/               # the runnable instrument (see harness/README.md)
+```
+
+`rubric.md` is both the human-readable argument and the machine-readable source: the harness parses
+its fenced `yaml` blocks directly, so the prose defending a criterion and the text the grader
+receives cannot drift apart.

--- a/evals/guidance/harness/.gitignore
+++ b/evals/guidance/harness/.gitignore
@@ -1,0 +1,9 @@
+# run.sh clones the bundle here to resolve and push a pinned ref. Build scratch, never source.
+.cache/
+
+# Belt and braces: run outputs are written outside the repo by construction (the harness refuses
+# a results root inside the checkout), but a mistyped --results-root should not be able to stage
+# a transcript for commit either.
+results/
+*.log
+__pycache__/

--- a/evals/guidance/harness/README.md
+++ b/evals/guidance/harness/README.md
@@ -1,0 +1,177 @@
+# The harness
+
+What actually runs a guidance-eval scenario, and how to operate it.
+
+For what the instrument *is* and when the protocol requires it, read
+[`../README.md`](../README.md) first. This page is the operator's manual.
+
+---
+
+## The one-liner
+
+```bash
+cd evals/guidance/harness
+./run.sh --smoke                 # one scenario, whole plumbing, ~15 min
+./run.sh                         # all six
+./run.sh --scenarios qa-02-never-converges work-02-twelve-step-pipeline
+./run.sh --list                  # what would run, with the criteria each cites
+```
+
+`--list` short-circuits before any infrastructure check, so you can inspect the instrument
+without Docker running.
+
+## What a trial does
+
+```
+  launch DTU  (ubuntu 24.04 + uv, named guideval-*)
+       |
+  install     amplifier CLI, then `amplifier bundle add git+https://github.com/microsoft/
+              amplifier-bundle-attractor@<ref>` -- the REAL user path, redirected to the local
+              Gitea mirror -- then `amplifier bundle use attractor`, the attractor CLI, and a
+              pinned checkout at /opt/attractor-src
+       |
+  readiness   amplifier on PATH; the ACTIVE bundle is attractor; `attractor lint --help`;
+              the shipped objective runner lints clean; (exemplar scenarios) the fixture is RED
+              -- all before a single model call is paid for
+       |
+  seed        the scenario's fixture into /workspace, if it has one
+       |
+  drive       session mode:  AIUser holds a real multi-turn conversation, in persona
+              exemplar mode: `attractor run objective-runner.dot` against the fixture
+       |
+  extract     the session's own transcript.jsonl, rendered deterministically; plus the small
+              decisive artifacts (.objective/*, any authored .dot)
+       |
+  mechanical  the scenario's machine_checks, re-run against the artifacts AFTER the fact
+       |
+  grade       a grader agent that never saw the session scores the cited rubric criteria,
+              reading only the normalized /eval/graded/ folder
+       |
+  destroy     the DTU (kept on trial error, for post-mortem)
+```
+
+## Why the install goes through a Gitea mirror
+
+`run.sh` clones the bundle into a detached checkout at a resolved SHA and pushes *that* to the
+mirror. The DTU then installs from `github.com/microsoft/amplifier-bundle-attractor`, which the
+profile's `url_rewrites` transparently redirect to the mirror.
+
+Two things fall out of that, and both are the point:
+
+1. **The eval walks the path a real user walks.** `amplifier bundle add git+https://...` is the
+   documented install, so a guidance surface that only works from a local checkout — an unshipped
+   file, a path that resolves in the repo and nowhere else — fails here rather than in a user's
+   hands.
+2. **It can never grade a working tree.** A push from a working tree would install whatever
+   happens to be uncommitted on the machine running the eval, and the results would describe a
+   state that exists nowhere else. `run.sh` prints a loud warning when your checkout HEAD differs
+   from the pinned SHA, so the difference is never silent.
+
+## The activation trap
+
+`amplifier bundle add` only **registers** a bundle. Without `amplifier bundle use attractor` the
+session composes the *default* bundle, none of the guidance surfaces under test are in play, and
+the eval cheerfully grades stock Amplifier — producing a plausible number that means nothing.
+
+This is the most dangerous silent no-op in the harness, so it is asserted twice:
+`install.yaml` greps `amplifier bundle current` for `Active bundle: attractor` and fails the
+install, and the readiness stage re-checks it before the trial proceeds.
+
+## Where results go
+
+**Always outside the repository.** Default:
+
+```
+<workspace>/.amplifier/evaluation/guidance-pilot/<UTC-timestamp>/
+```
+
+Override with `--results-root` or `$GUIDANCE_EVAL_RESULTS_ROOT`. The harness **refuses to start**
+if the resolved path is inside the checkout: run directories carry full prompts, transcripts, and
+provider-adjacent material, and none of that is source.
+
+```
+<UTC>/
+├── run.json                 # bundle ref + SHA, scenarios, scoring thresholds, model pins
+├── inputs/                  # rubric.md and the scenario files AS RUN
+├── results.md / .json       # per-scenario verdicts, per-criterion scores, failed checks
+└── <scenario>/
+    ├── launch-profile.yaml  install.log  readiness.txt
+    ├── ai_user.json         # the AI user's own conclude verdict (session mode)
+    ├── runner.log           # the pipeline's log (exemplar mode)
+    ├── transcript-source-paths.txt   workspace-listing.txt
+    ├── graded/              # the normalized folder the grader is allowed to see
+    │   ├── transcript.md  scenario.md  mechanical.json  artifacts/
+    ├── grader.yaml          # generated from rubric.md's blocks
+    ├── grader/              # initial_report.md, rubric.json, grader_result.json
+    └── outcome.json
+```
+
+`inputs/` exists so a later reader is never guessing which version of the rubric produced a score.
+
+## The layout here
+
+| Path | What it is |
+|---|---|
+| `run.sh` | preflight, gitea, pinned mirror push, dispatch |
+| `run_guidance_eval.py` | the trial loop: launch → install → readiness → drive → extract → check → grade |
+| `config.yaml` | scenario list, smoke scenario, scoring thresholds (mirrors `rubric.md`) |
+| `profiles/guidance-dtu.yaml` | the DTU: ubuntu + uv + pytest, url_rewrites to the mirror |
+| `agents/attractor-user-install/` | the real-user install path, extraction hints, and the AI user's invocation guide |
+| `fixtures/notesvc/` | the workspace the exemplar scenarios run against — deliberately RED |
+
+## Building blocks reused
+
+From [`microsoft/amplifier-bundle-evaluation`](https://github.com/microsoft/amplifier-bundle-evaluation):
+
+| Block | Use |
+|---|---|
+| `ai_user.AIUser` | drives the session in persona, one continuous conversation, `conclude` verdict |
+| `extractor.Extractor` | prepared per run; the transcript itself is recovered deterministically (below) |
+| `grader.Grader` + `grader.schema` | blind scoring against the generated `grader.yaml` |
+| `harness.dtu.DTU` | launch / exec / file_push / destroy |
+| `harness.install.compose_launch_profile`, `install_agent`, `verify_env` | merged profile, in-DTU setup, host env preflight |
+| `harness.loaders.load_agent` | the standard `agents/<id>/` directory contract |
+
+`harness.trial.run_trial` is **not** called directly. Its stage sequence is replayed here with two
+deviations it does not support: a per-scenario persona passed to `AIUser.run(...)`, and a
+mechanical-checks stage between extract and grade. This follows the custom-harness precedent in
+the evaluation bundle's own example 01.
+
+**The transcript is recovered deterministically, not summarized.** The session's own
+`transcript.jsonl` is rendered to markdown by a small in-DTU Python script. The artifact under
+grading is the conversation; asking a model to summarize it first would destroy the evidence and
+then grade the destruction. If recovery fails, the harness records that loudly in the trial's
+notes and marks the grade provisional rather than quietly substituting the AI user's own account.
+
+## Prerequisites
+
+- `amplifier-digital-twin`, `amplifier-gitea`, `docker` (running), `git`, `python3`
+- `amplifier_evaluation` importable — clone `microsoft/amplifier-bundle-evaluation`, `uv sync`,
+  and activate its `.venv` (or set `AMPLIFIER_EVALUATION_ROOT`). `run.sh` will find and activate
+  a sibling checkout's venv automatically.
+- `ANTHROPIC_API_KEY` in the environment or `~/.amplifier/keys.env`
+
+## Cost and time
+
+Session scenarios are two to three conversational turns plus grading: roughly 10–20 minutes and a
+few dollars each. Exemplar scenarios run a real pipeline with a child pipeline underneath and are
+the expensive ones — budget up to an hour and a few tens of dollars. A full six-scenario run is a
+couple of hours of wall time.
+
+Start with `--smoke`. It walks the entire plumbing on the cheapest scenario.
+
+## When a trial breaks
+
+- **The DTU is kept on trial error** (`--keep-dtus-on-failure`, on by default). Inspect it with
+  `amplifier-digital-twin exec <id> -- bash`, then destroy it yourself.
+- Stranded instances are always named `guideval-*`. `amplifier-digital-twin list` finds them.
+- A readiness failure aborts *before* model spend and writes `readiness.txt` naming the gate.
+- A failed `machine_check` is reported per check with its `why:` — it is a finding about the
+  bundle or about the harness, and results.md never averages it away.
+
+## Reading a result honestly
+
+The smoke run's *scores* are not data. Read the trial end-to-end by hand: the transcript, the
+grader's `initial_report.md`, and the mechanical checks. A suspicious pass is a bug in the eval
+until proven otherwise — the failure mode this instrument is most exposed to is grading an
+environment where the bundle was never active at all.

--- a/evals/guidance/harness/agents/attractor-user-install/data.yaml
+++ b/evals/guidance/harness/agents/attractor-user-install/data.yaml
@@ -1,0 +1,20 @@
+# Extraction hints for amplifier_evaluation.extractor.Extractor.
+#
+# What the guidance eval needs out of a finished trial is the SESSION ITSELF -- the transcript is
+# the artifact under grading, not a side effect of it. Everything else is secondary.
+session_paths:
+  - /root/.amplifier/projects
+  - /root/.amplifier/sessions
+
+deliverable_paths:
+  - /workspace
+
+notes: |
+  Session transcripts land under /root/.amplifier/projects/<cwd-slug>/sessions/<id>/ as
+  transcript.jsonl, events.jsonl and metadata.json. The AI user drives the session from
+  /workspace, so the slug derives from that path.
+
+  For exemplar-mode scenarios the deliverables that matter are under /workspace/.objective/ --
+  disposition, triage.json, redirect.md, objective.md, convergence.jsonl, and the evidence logs.
+
+  Do not pull the fixture repo's full tree; it is seeded from the harness and known.

--- a/evals/guidance/harness/agents/attractor-user-install/install.yaml
+++ b/evals/guidance/harness/agents/attractor-user-install/install.yaml
@@ -1,0 +1,84 @@
+requires:
+  env:
+    - ANTHROPIC_API_KEY
+
+# The real-user install path. Every command runs inside the launched DTU via `bash -lc`.
+# /opt/eval/vars.env (BUNDLE_REPO, BUNDLE_BRANCH) was written at provision time from launch
+# variables; the profile's url_rewrites redirect the github.com/microsoft URL below to the
+# pinned Gitea mirror.
+#
+# Every network-fetching step is wrapped in `retry3`. A single upstream 502 from PyPI killed a
+# smoke trial before any model had been called, and treating a CDN hiccup as a finding about the
+# bundle is exactly the confusion an eval must not introduce. Three attempts, then fail loud --
+# a persistent failure is still a real failure and still aborts the trial.
+setup_cmds:
+  # 1. amplifier CLI, installed the way a user installs it.
+  - |
+    set -e
+    export PATH="/root/.local/bin:$PATH"
+    retry3() { for i in 1 2 3; do "$@" && return 0; echo "attempt $i failed; retrying" >&2; sleep 10; done; return 1; }
+    retry3 uv tool install git+https://github.com/microsoft/amplifier
+
+  # 2. Provider config. Unquoted EOF expands $ANTHROPIC_API_KEY, forwarded by the profile's
+  #    passthrough.services.
+  - |
+    mkdir -p /root/.amplifier
+    cat > /root/.amplifier/settings.yaml <<EOF
+    config:
+      providers:
+        - module: provider-anthropic
+          source: git+https://github.com/microsoft/amplifier-module-provider-anthropic@main
+          config:
+            api_key: $ANTHROPIC_API_KEY
+    EOF
+
+  # 3. The bundle under test, from the pinned mirror branch over the public-URL path.
+  - |
+    set -e
+    export PATH="/root/.local/bin:$PATH"
+    . /opt/eval/vars.env
+    retry3() { for i in 1 2 3; do "$@" && return 0; echo "attempt $i failed; retrying" >&2; sleep 10; done; return 1; }
+    retry3 amplifier bundle add "git+https://github.com/microsoft/${BUNDLE_REPO}@${BUNDLE_BRANCH}"
+
+  # 4. ACTIVATE it. `bundle add` only REGISTERS: without `bundle use attractor` the session
+  #    composes the DEFAULT bundle and NONE of the guidance surfaces under test are in play --
+  #    the eval would grade stock Amplifier and report a clean pass. This is the single most
+  #    dangerous silent-no-op in the whole harness, so it is asserted below rather than assumed.
+  - |
+    set -e
+    export PATH="/root/.local/bin:$PATH"
+    amplifier bundle use attractor
+
+  # 5. The attractor CLI, installed the way GETTING-STARTED tells a user to. Needed by the
+  #    exemplar scenarios and by the readiness gate that lints the shipped objective runner.
+  - |
+    set -e
+    export PATH="/root/.local/bin:$PATH"
+    . /opt/eval/vars.env
+    retry3() { for i in 1 2 3; do "$@" && return 0; echo "attempt $i failed; retrying" >&2; sleep 10; done; return 1; }
+    retry3 uv tool install "git+https://github.com/microsoft/${BUNDLE_REPO}@${BUNDLE_BRANCH}#subdirectory=modules/pipeline-runner"
+
+  # 6. A checkout of the bundle at the ref under test, at a known path. examples/objective/
+  #    README tells a user to run the runner from a checkout, and the exemplar scenarios need
+  #    validate_triage.py and the practical lanes on disk. Cloned through the mirror, so it is
+  #    the same pinned tree the bundle was installed from.
+  - |
+    set -e
+    . /opt/eval/vars.env
+    rm -rf /opt/attractor-src
+    retry3() { for i in 1 2 3; do "$@" && return 0; echo "attempt $i failed; retrying" >&2; sleep 10; done; return 1; }
+    retry3 git clone --depth 1 --branch "${BUNDLE_BRANCH}" \
+      "https://github.com/microsoft/${BUNDLE_REPO}" /opt/attractor-src
+    test -f /opt/attractor-src/examples/objective/objective-runner.dot \
+      || { echo "INSTALL-FAIL: objective runner missing from the checkout" >&2; exit 1; }
+
+  # 7. Install evidence, and the assertion that step 4 actually stuck.
+  - export PATH="/root/.local/bin:$PATH"; amplifier --version
+  - |
+    set -e
+    export PATH="/root/.local/bin:$PATH"
+    amplifier bundle list | tee /tmp/bundle-evidence.txt
+    amplifier bundle current | tee -a /tmp/bundle-evidence.txt
+    grep -q "Active bundle: attractor" /tmp/bundle-evidence.txt \
+      || { echo "INSTALL-FAIL: active bundle is not 'attractor' (see /tmp/bundle-evidence.txt)" >&2; exit 1; }
+  - export PATH="/root/.local/bin:$PATH"; attractor lint --help >/dev/null && echo LINT-HELP-OK

--- a/evals/guidance/harness/agents/attractor-user-install/invocation.md
+++ b/evals/guidance/harness/agents/attractor-user-install/invocation.md
@@ -1,0 +1,66 @@
+# How to talk to the agent under test
+
+The agent is the `amplifier` CLI inside the DTU, with the attractor bundle already installed and
+active. You drive it with `amplifier-digital-twin exec`, from `/workspace`.
+
+## The two commands you need
+
+**First turn of a conversation** — starts a new session:
+
+```bash
+amplifier-digital-twin exec <DTU_ID> -- bash -lc 'cd /workspace && amplifier run "your message here"'
+```
+
+**Every turn after that** — continues the SAME session, with its history:
+
+```bash
+amplifier-digital-twin exec <DTU_ID> -- bash -lc 'cd /workspace && amplifier continue "your next message"'
+```
+
+Use `amplifier run` **exactly once**, for your opening message. Every later turn must be
+`amplifier continue`. This is a conversation, and an agent that cannot see what it already told you
+is not the thing being tested.
+
+## Quoting
+
+Your messages contain apostrophes and quotes. Write the message to a file first and pipe it in,
+rather than fighting shell quoting:
+
+```bash
+amplifier-digital-twin exec <DTU_ID> -- bash -lc 'cat > /tmp/turn.txt <<'"'"'MSGEOF'"'"'
+your message, verbatim, over as many lines as you like
+MSGEOF
+cd /workspace && amplifier run "$(cat /tmp/turn.txt)"'
+```
+
+If that gets awkward, the simpler form is fine for messages with no single quotes in them.
+
+## Timing
+
+A turn takes **one to five minutes**. That is normal. Give each exec a generous timeout and wait
+for it rather than assuming it hung. Do not send a second turn before the first returns — the
+session is single-threaded, and interleaving turns corrupts the transcript you are producing.
+
+If a turn appears to hang past ten minutes, run it once more. If it fails a second time, stop and
+call `conclude` describing what you saw. A broken environment is a real finding, and inventing a
+conversation to paper over it is the one unforgivable outcome here.
+
+## What you are producing
+
+The session transcript is the artifact. Everything you say and everything the agent says is being
+read afterward by someone who was not here. So:
+
+- **Stay in persona.** Never say you are testing, evaluating, grading, or scoring anything.
+- **Never coach.** Do not supply the vocabulary you want to hear, do not hint at an answer, and do
+  not tell the agent what a good response would contain. If you have to lead it there, it did not
+  get there.
+- **Ask, then stop.** Send your turn, read the reply in full, and respond to what it actually said
+  — not to what you expected it to say.
+
+## Finishing
+
+When your scenario's turns are done, call `conclude` with your verdict and summary. Follow the
+scenario's instructions about what to quote verbatim: those quotes are the decisive evidence, and
+a summary that paraphrases them has destroyed the thing it was sent to collect.
+
+Do not run more commands after `conclude`.

--- a/evals/guidance/harness/agents/attractor-user-install/meta.yaml
+++ b/evals/guidance/harness/agents/attractor-user-install/meta.yaml
@@ -1,0 +1,7 @@
+id: attractor-user-install
+name: Attractor bundle, installed the way a user installs it
+description: >
+  The agent under test is an ordinary Amplifier session with the attractor bundle composed onto
+  it, installed inside the DTU from a git URL exactly as a real user would. No curated push of a
+  host checkout: the eval grades what a `bundle add` actually delivers, not what is sitting in
+  someone's working tree.

--- a/evals/guidance/harness/config.yaml
+++ b/evals/guidance/harness/config.yaml
@@ -1,0 +1,40 @@
+# Defaults for the guidance eval harness. CLI flags override every value here.
+#
+# Thresholds mirror rubric.md's "Scoring" section and must stay in sync with it. The harness
+# reads them from here and prints them into run.json, so a run always records the bar it was
+# judged against rather than the bar in force when someone later reads the results.
+
+# All six scenarios, in the order the README presents them.
+scenarios:
+  - qa-01-what-is-an-attractor
+  - qa-02-never-converges
+  - work-01-stale-release-notes
+  - work-02-twelve-step-pipeline
+  - exemplar-01-sloppy-routable
+  - exemplar-02-honest-redirect
+
+# The smoke scenario: the cheapest one that still walks the entire plumbing
+# (mirror -> DTU -> install -> AI user session -> extract -> grade -> results).
+smoke_scenario: qa-01-what-is-an-attractor
+
+# rubric.md, "Scoring"
+scoring:
+  criterion_min: 3          # every cited criterion must score >= this
+  g5_override_fail_at: 0    # G5 at this score fails the whole run, regardless of the rest
+
+# Which repo and ref the DTU installs the bundle FROM. The ref is pinned to a mirror branch
+# that run.sh pushes from a detached checkout -- never from a working tree.
+bundle_repo: amplifier-bundle-attractor
+bundle_ref: main
+
+# Gitea instance carrying the mirror. run.sh resolves this to a URL + token.
+gitea_id: null              # null = first running instance from `amplifier-gitea list`
+
+# Model pins for the eval's own agents (AIUser / Extractor / Grader).
+# null = the amplifier_evaluation library defaults (foundation@main + anthropic-sonnet).
+# Recorded verbatim in run.json so results stay comparable across runs.
+foundation_source: null
+provider_source: null
+
+# DTU names carry this prefix so a stranded instance is identifiable and safe to reap.
+dtu_name_prefix: guideval

--- a/evals/guidance/harness/fixtures/notesvc/README.md
+++ b/evals/guidance/harness/fixtures/notesvc/README.md
@@ -1,0 +1,18 @@
+# notesvc
+
+A deliberately tiny service package, used as the workspace fixture for the guidance eval's
+exemplar-robustness scenarios (`evals/guidance/scenarios/exemplar-*.yaml`).
+
+It exists to give the objective layer something real to look at:
+
+- `notesvc/users.py` carries a **real bug**: `user_slug()` strips every non-ASCII character, so a
+  username made entirely of emoji collapses to an empty slug and `save_path()` raises.
+- `tests/test_users.py` carries **two failing tests naming that bug**, and one passing test that
+  pins the behavior a fix must not break.
+
+`pytest` is therefore RED on a fresh checkout, and that redness is the machine evidence scenario
+(e) expects the intake to find underneath a sloppily-phrased objective. Scenario (f) uses the same
+fixture with an objective that has no machine check available at all — same workspace, opposite
+correct answer.
+
+Do not "fix" this fixture. Its red tests are the instrument.

--- a/evals/guidance/harness/fixtures/notesvc/notesvc/__init__.py
+++ b/evals/guidance/harness/fixtures/notesvc/notesvc/__init__.py
@@ -1,0 +1,3 @@
+from .users import save_path, user_slug
+
+__all__ = ["save_path", "user_slug"]

--- a/evals/guidance/harness/fixtures/notesvc/notesvc/users.py
+++ b/evals/guidance/harness/fixtures/notesvc/notesvc/users.py
@@ -1,0 +1,23 @@
+"""User identity helpers.
+
+`user_slug` turns a display name into something safe to put in a filesystem path.
+"""
+
+import re
+
+_UNSAFE = re.compile(r"[^A-Za-z0-9._-]+")
+
+NOTES_ROOT = "/var/notes"
+
+
+def user_slug(username: str) -> str:
+    """Return a filesystem-safe slug for `username`."""
+    return _UNSAFE.sub("", username)
+
+
+def save_path(username: str) -> str:
+    """Return the path this user's notes are saved to."""
+    slug = user_slug(username)
+    if not slug:
+        raise ValueError(f"username {username!r} produced an empty slug")
+    return f"{NOTES_ROOT}/{slug}.json"

--- a/evals/guidance/harness/fixtures/notesvc/pyproject.toml
+++ b/evals/guidance/harness/fixtures/notesvc/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "notesvc"
+version = "0.1.0"
+description = "Fixture package for the attractor guidance eval"
+requires-python = ">=3.10"
+
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+packages = ["notesvc"]

--- a/evals/guidance/harness/fixtures/notesvc/tests/test_users.py
+++ b/evals/guidance/harness/fixtures/notesvc/tests/test_users.py
@@ -1,0 +1,28 @@
+import pytest
+
+from notesvc import save_path
+
+
+def test_ascii_username_is_unchanged():
+    """The behavior a fix must not break."""
+    assert save_path("brian.k") == "/var/notes/brian.k.json"
+
+
+def test_emoji_only_username_still_has_a_save_path():
+    """A user whose whole display name is emoji still has to be able to save."""
+    assert save_path("\U0001f389\U0001f389").endswith(".json")
+
+
+def test_distinct_usernames_do_not_collide():
+    """Two different non-ASCII usernames must not map to the same file."""
+    assert save_path("\U0001f389\U0001f389") != save_path("\U0001f680\U0001f680")
+
+
+def test_ascii_and_emoji_do_not_collide():
+    """Stripping must not silently merge a unicode name into an ASCII one."""
+    assert save_path("party") != save_path("party\U0001f389")
+
+
+@pytest.mark.parametrize("name", ["a", "a-b", "a_b", "a.b"])
+def test_simple_ascii_names_round_trip(name):
+    assert save_path(name) == f"/var/notes/{name}.json"

--- a/evals/guidance/harness/profiles/guidance-dtu.yaml
+++ b/evals/guidance/harness/profiles/guidance-dtu.yaml
@@ -1,0 +1,78 @@
+# DTU profile for the guidance eval.
+#
+# A fresh Ubuntu box that looks like a real user's machine. The bundle under test is installed
+# INSIDE it over the network path a real user takes --
+# `amplifier bundle add git+https://github.com/microsoft/amplifier-bundle-attractor@<ref>` --
+# with `url_rewrites` below transparently redirecting that clone to the local Gitea mirror the
+# harness refreshed from a PINNED ref.
+#
+# That indirection is the point: the eval exercises the install path a user actually walks,
+# without the network, and without ever installing from a working tree. A working-tree install
+# would grade whatever is uncommitted on the machine running the eval.
+#
+# Launch variables (supplied by run_guidance_eval.py via `--var`):
+#   GITEA_URL      local mirror instance base URL
+#   GITEA_TOKEN    mirror auth token (used by url_rewrites.auth, never written to the image)
+#   BUNDLE_REPO    repo name on the mirror (amplifier-bundle-attractor)
+#   BUNDLE_BRANCH  mirror branch carrying the ref under test
+name: attractor-guidance-eval
+description: >
+  Real-user-simulation environment for the attractor guidance eval: ubuntu 24.04 + uv, amplifier
+  installed the way a user installs it, the attractor bundle installed from the (mirror-redirected)
+  public git URL, and the attractor CLI on PATH for the exemplar scenarios.
+
+base:
+  image: ubuntu:24.04
+
+url_rewrites:
+  auth:
+    username: admin
+    token_var: GITEA_TOKEN
+  default_match_mode: boundary
+  rules:
+    - match: github.com/microsoft/${BUNDLE_REPO}
+      target: ${GITEA_URL}/admin/${BUNDLE_REPO}
+
+passthrough:
+  allow_external: true
+  services:
+    - name: anthropic
+      key_env: ANTHROPIC_API_KEY
+    - name: openai
+      key_env: OPENAI_API_KEY
+
+provision:
+  # Network-fetching steps retry. An upstream PyPI 502 during provisioning killed a smoke run
+  # before the DTU even existed, and a CDN hiccup is not a finding about this bundle. Three
+  # attempts, then fail loud: a persistent failure still aborts.
+  setup_cmds:
+    - |
+      retry3() { for i in 1 2 3; do "$@" && return 0; echo "attempt $i failed; retrying" >&2; sleep 10; done; return 1; }
+      retry3 apt-get update
+      retry3 apt-get install -y --no-install-recommends git curl ca-certificates jq python3 python3-venv
+      rm -rf /var/lib/apt/lists/*
+    - |
+      for i in 1 2 3; do curl -LsSf https://astral.sh/uv/install.sh | sh && exit 0; sleep 10; done; exit 1
+    - git config --global user.name "Eval User" && git config --global user.email "eval-user@dtu.local"
+    # pytest on PATH: the exemplar scenarios' definitions of done run it.
+    - |
+      export PATH=/root/.local/bin:$PATH
+      retry3() { for i in 1 2 3; do "$@" && return 0; echo "attempt $i failed; retrying" >&2; sleep 10; done; return 1; }
+      retry3 uv tool install pytest
+    - mkdir -p /workspace /opt/eval
+    # Parameters for install.yaml, substituted from launch --var values.
+    - |
+      cat > /opt/eval/vars.env <<EOF
+      BUNDLE_REPO=${BUNDLE_REPO}
+      BUNDLE_BRANCH=${BUNDLE_BRANCH}
+      EOF
+
+readiness:
+  - name: uv-installed
+    command: "PATH=/root/.local/bin:$PATH uv --version"
+  - name: pytest-on-path
+    command: "PATH=/root/.local/bin:$PATH pytest --version"
+  - name: workspace-exists
+    command: "test -d /workspace && echo OK"
+  - name: vars-env-written
+    command: "test -s /opt/eval/vars.env && echo OK"

--- a/evals/guidance/harness/run.sh
+++ b/evals/guidance/harness/run.sh
@@ -162,7 +162,7 @@ if [ "$code" != "200" ]; then
 fi
 
 log "pushing $BUNDLE_SHA -> admin/$BUNDLE_REPO@$BUNDLE_BRANCH"
-git -C "$CACHE/src" -c credential.helper= push --force \
+git -C "$CACHE/src.git" -c credential.helper= push --force \
     "http://admin:$GITEA_TOKEN@localhost:$GITEA_PORT/admin/$BUNDLE_REPO.git" \
     "$BUNDLE_SHA:refs/heads/$BUNDLE_BRANCH" >/dev/null 2>&1 \
     || die "mirror push failed"

--- a/evals/guidance/harness/run.sh
+++ b/evals/guidance/harness/run.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# Guidance eval -- wrapper.
+#
+# Preflight, Gitea instance discovery, PINNED mirror refresh, then dispatch run_guidance_eval.py.
+#
+# The mirror is refreshed from a DETACHED clone at a resolved SHA, never from a working tree. A
+# working-tree push would install whatever happens to be uncommitted on the machine running the
+# eval, and the results would silently describe a tree that exists nowhere else.
+#
+# Usage:
+#   ./run.sh --smoke                       # one scenario, full plumbing
+#   ./run.sh                               # all six scenarios
+#   ./run.sh --scenarios qa-02-never-converges
+#   ./run.sh --list                        # what would run, and against which criteria
+#
+# Extra arguments pass through to run_guidance_eval.py (see `--help` there).
+#
+# Environment:
+#   BUNDLE_REF          ref of amplifier-bundle-attractor under test (default: origin/main)
+#   BUNDLE_SRC          local checkout to push from (default: <workspace>/amplifier-bundle-attractor)
+#   AMPLIFIER_GITEA_ID  pick a specific gitea instance (default: first running one)
+#   GUIDANCE_EVAL_RESULTS_ROOT  where results land (default: outside the repo -- see README)
+#   ANTHROPIC_API_KEY   required; falls back to ~/.amplifier/keys.env
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+BUNDLE_REPO="amplifier-bundle-attractor"
+BUNDLE_REF="${BUNDLE_REF:-origin/main}"
+CACHE="$HERE/.cache"
+
+log() { printf '[%s] %s\n' "$(date +%H:%M:%S)" "$*" >&2; }
+die() { log "ERROR: $*"; exit 1; }
+
+# The workspace this checkout lives in. Normally REPO_ROOT's parent -- but when the harness runs
+# from a git worktree parked under <workspace>/.amplifier/worktrees/<name>, one level up lands
+# inside .amplifier. Climb out of any .amplifier segment so both layouts resolve the same, which
+# is what lets the sibling-venv search below work from either.
+WORKSPACE_ROOT="$(cd "$REPO_ROOT/.." && pwd)"
+while [ "$(basename "$WORKSPACE_ROOT")" != "/" ]; do
+    case "$WORKSPACE_ROOT" in
+        */.amplifier/*|*/.amplifier) WORKSPACE_ROOT="$(dirname "$WORKSPACE_ROOT")" ;;
+        *) break ;;
+    esac
+done
+
+# ---- 0. python environment ---------------------------------------------------
+# amplifier_evaluation supplies the AI user, extractor and grader. Resolved BEFORE the --list
+# short-circuit so inspecting the instrument uses the same interpreter a real run would.
+if ! python3 -c "import amplifier_evaluation" 2>/dev/null; then
+    for venv in "${AMPLIFIER_EVALUATION_ROOT:-/nonexistent}/.venv" \
+                "$WORKSPACE_ROOT/amplifier-bundle-evaluation/.venv" \
+                "$REPO_ROOT/../amplifier-bundle-evaluation/.venv" \
+                "$HOME"/.amplifier/cache/amplifier-bundle-evaluation-*/.venv; do
+        if [ -f "$venv/bin/activate" ]; then
+            log "activating $venv"
+            # shellcheck disable=SC1091
+            . "$venv/bin/activate"
+            break
+        fi
+    done
+fi
+
+# `--list` needs none of the infrastructure below; short-circuit so a contributor can inspect the
+# instrument without Docker running. run_guidance_eval.py tolerates a missing amplifier_evaluation
+# for this path and fails loudly only when a real run is attempted.
+for a in "$@"; do
+    if [ "$a" = "--list" ]; then
+        exec python3 "$HERE/run_guidance_eval.py" --gitea-url none "$@"
+    fi
+done
+
+# ---- 1. preflight -----------------------------------------------------------
+log "preflight"
+command -v amplifier-digital-twin >/dev/null || die "amplifier-digital-twin not on PATH"
+command -v amplifier-gitea >/dev/null || die "amplifier-gitea not on PATH"
+command -v docker >/dev/null || die "docker not on PATH"
+docker info >/dev/null 2>&1 || die "Docker is not running"
+command -v git >/dev/null || die "git not on PATH"
+command -v python3 >/dev/null || die "python3 not on PATH"
+
+python3 -c "import amplifier_evaluation" 2>/dev/null || die \
+    "amplifier_evaluation not importable. Clone microsoft/amplifier-bundle-evaluation, run
+    'uv sync' there, and activate its .venv (or set AMPLIFIER_EVALUATION_ROOT)."
+python3 -c "import yaml" 2>/dev/null || die "pyyaml missing in the active python env"
+
+if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -f "$HOME/.amplifier/keys.env" ]; then
+    set -a
+    # shellcheck disable=SC1091
+    . "$HOME/.amplifier/keys.env"
+    set +a
+fi
+[ -n "${ANTHROPIC_API_KEY:-}" ] || die "ANTHROPIC_API_KEY not set and not in ~/.amplifier/keys.env"
+
+# ---- 1. gitea ---------------------------------------------------------------
+log "resolving a Gitea instance"
+GITEA_ID="${AMPLIFIER_GITEA_ID:-}"
+if [ -z "$GITEA_ID" ]; then
+    GITEA_ID="$(amplifier-gitea list | python3 -c '
+import json, sys
+running = [i for i in json.load(sys.stdin) if i.get("container_running")]
+print(running[0]["id"] if running else "")')"
+fi
+[ -n "$GITEA_ID" ] || die "no running gitea instance; create one with 'amplifier-gitea create'"
+
+STATUS_JSON="$(amplifier-gitea status "$GITEA_ID")"
+GITEA_PORT="$(echo "$STATUS_JSON" | python3 -c 'import json,sys; print(json.load(sys.stdin)["port"])')"
+GITEA_TOKEN="$(amplifier-gitea token "$GITEA_ID" | python3 -c 'import json,sys; print(json.load(sys.stdin)["token"])')"
+GITEA_URL="http://localhost:$GITEA_PORT"
+log "gitea: $GITEA_URL (id=$GITEA_ID)"
+
+# ---- 2. pinned mirror refresh ------------------------------------------------
+BUNDLE_SRC="${BUNDLE_SRC:-$REPO_ROOT/../$BUNDLE_REPO}"
+[ -e "$BUNDLE_SRC/.git" ] || BUNDLE_SRC="$REPO_ROOT"
+log "pinning $BUNDLE_REF from $BUNDLE_SRC"
+
+# A --mirror clone, deliberately, and this is not incidental. A plain `git clone <local-path>`
+# rewrites `origin` to point at that local path, so `origin/main` inside the clone resolves to the
+# LOCAL checkout's `main` -- which in a workspace whose checkout lags upstream is a different,
+# older commit than the `origin/main` the operator meant. That mistake is silent: the mirror gets
+# pushed, the DTU installs, and the eval grades a tree nobody asked for.
+# --mirror copies refs/* verbatim, including refs/remotes/origin/*, so `origin/main` here means
+# what it means in the source checkout. Nothing is checked out; a SHA is all a push needs.
+rm -rf "$CACHE/src.git"
+mkdir -p "$CACHE"
+git clone --quiet --mirror "$BUNDLE_SRC" "$CACHE/src.git" || die "clone of $BUNDLE_SRC failed"
+BUNDLE_SHA="$(git -C "$CACHE/src.git" rev-parse --verify --quiet "${BUNDLE_REF}^{commit}" \
+    || git -C "$CACHE/src.git" rev-parse --verify --quiet "origin/${BUNDLE_REF}^{commit}")" \
+    || die "cannot resolve BUNDLE_REF '$BUNDLE_REF' in $BUNDLE_SRC"
+
+# Guard the exact failure above: whatever ref was asked for, the SHA that gets pushed must carry a
+# recognisable bundle. A ref that resolves to a commit without bundle.md is not this repo.
+git -C "$CACHE/src.git" cat-file -e "$BUNDLE_SHA:bundle.md" 2>/dev/null \
+    || die "resolved SHA $BUNDLE_SHA has no bundle.md -- '$BUNDLE_REF' did not resolve to what you meant"
+
+HEAD_SHA="$(git -C "$BUNDLE_SRC" rev-parse HEAD)"
+if [ "$HEAD_SHA" != "$BUNDLE_SHA" ]; then
+    log "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+    log "NOTE: the DTU will install $BUNDLE_REF @ $BUNDLE_SHA"
+    log "NOTE: your checkout HEAD is $HEAD_SHA"
+    log "NOTE: uncommitted or unpushed work is NOT what this run grades."
+    log "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+fi
+
+# The eval always installs from a mirror BRANCH, so a SHA ref gets a stable branch name.
+if echo "$BUNDLE_REF" | grep -Eq '^[0-9a-f]{7,40}$'; then
+    BUNDLE_BRANCH="guideval-under-test"
+else
+    BUNDLE_BRANCH="${BUNDLE_REF#origin/}"
+    BUNDLE_BRANCH="${BUNDLE_BRANCH#refs/heads/}"
+fi
+
+code="$(curl -sS -H "Authorization: token $GITEA_TOKEN" \
+    "$GITEA_URL/api/v1/repos/admin/$BUNDLE_REPO" -o /dev/null -w '%{http_code}')"
+if [ "$code" != "200" ]; then
+    log "creating mirror repo admin/$BUNDLE_REPO"
+    curl -sS -X POST "$GITEA_URL/api/v1/admin/users/admin/repos" \
+        -H "Authorization: token $GITEA_TOKEN" -H "Content-Type: application/json" \
+        -d "{\"name\":\"$BUNDLE_REPO\",\"default_branch\":\"main\",\"auto_init\":false,\"private\":false}" \
+        -o /dev/null
+fi
+
+log "pushing $BUNDLE_SHA -> admin/$BUNDLE_REPO@$BUNDLE_BRANCH"
+git -C "$CACHE/src" -c credential.helper= push --force \
+    "http://admin:$GITEA_TOKEN@localhost:$GITEA_PORT/admin/$BUNDLE_REPO.git" \
+    "$BUNDLE_SHA:refs/heads/$BUNDLE_BRANCH" >/dev/null 2>&1 \
+    || die "mirror push failed"
+
+# ---- 3. dispatch -------------------------------------------------------------
+log "dispatching run_guidance_eval.py (bundle=$BUNDLE_BRANCH @ ${BUNDLE_SHA:0:12})"
+exec python3 "$HERE/run_guidance_eval.py" \
+    --gitea-url "$GITEA_URL" \
+    --gitea-token "$GITEA_TOKEN" \
+    --bundle-repo "$BUNDLE_REPO" \
+    --bundle-branch "$BUNDLE_BRANCH" \
+    --bundle-sha "$BUNDLE_SHA" \
+    "$@"

--- a/evals/guidance/harness/run_guidance_eval.py
+++ b/evals/guidance/harness/run_guidance_eval.py
@@ -1,0 +1,1217 @@
+#!/usr/bin/env python3
+"""Driver for the attractor guidance eval.
+
+One scenario per trial. Each trial:
+
+    launch DTU -> install the bundle the way a user does -> readiness + negative controls
+      -> seed fixture (exemplar scenarios)
+      -> drive the scenario
+           session mode:  AIUser holds a real conversation with the installed session
+           exemplar mode: the shipped objective runner runs against the fixture workspace
+      -> extract the evidence out of the DTU
+      -> mechanical checks (re-run outside the thing that produced the artifacts)
+      -> blind grade against rubric.md's anchored criteria
+      -> write results OUTSIDE the repo
+      -> destroy the DTU
+
+Built on the `amplifier_evaluation` library blocks (AIUser / Extractor / Grader / DTU /
+compose_launch_profile / install_agent / load_agent), following the custom-trial-loop precedent
+rather than calling `run_trial` directly: this eval needs a per-scenario persona and a
+mechanical-checks stage, neither of which the stock loop passes through.
+
+Invoked by run.sh, which resolves the Gitea mirror and pins the ref under test.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import re
+import shutil
+import sys
+import traceback
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# The amplifier_evaluation library supplies every moving part that touches a model or a container.
+# It is imported softly so that `--list` -- pure inspection of the instrument -- works in a plain
+# checkout with nothing installed. Any path that actually runs a trial calls `require_library()`
+# first and fails with the install instructions rather than an ImportError traceback.
+_LIBRARY_IMPORT_ERROR: str | None = None
+try:
+    from amplifier_evaluation.ai_user import AIUser
+    from amplifier_evaluation.extractor import Extractor
+    from amplifier_evaluation.grader import Grader
+    from amplifier_evaluation.harness.dtu import DTU, cli_available
+    from amplifier_evaluation.harness.install import (
+        compose_launch_profile,
+        install_agent,
+        verify_env,
+    )
+    from amplifier_evaluation.harness.loaders import load_agent
+except ImportError as _exc:  # pragma: no cover - exercised only in a bare checkout
+    _LIBRARY_IMPORT_ERROR = str(_exc)
+
+
+def require_library() -> None:
+    if _LIBRARY_IMPORT_ERROR is None:
+        return
+    raise SystemExit(
+        f"amplifier_evaluation is not importable ({_LIBRARY_IMPORT_ERROR}).\n"
+        "Clone microsoft/amplifier-bundle-evaluation, run `uv sync` there, and activate its "
+        ".venv -- or set AMPLIFIER_EVALUATION_ROOT and let run.sh find it.\n"
+        "(`--list` works without it; running trials does not.)"
+    )
+
+HERE = Path(__file__).resolve().parent
+EVAL_ROOT = HERE.parent                      # evals/guidance/
+REPO_ROOT = EVAL_ROOT.parent.parent          # the bundle checkout
+SCENARIOS_DIR = EVAL_ROOT / "scenarios"
+RUBRIC_PATH = EVAL_ROOT / "rubric.md"
+
+log = logging.getLogger("guidance-eval")
+
+
+# --------------------------------------------------------------------------- results location
+
+
+def resolve_results_root(explicit: str | None) -> Path:
+    """Where run outputs land. Always OUTSIDE the repository.
+
+    Run directories carry full prompts, transcripts, and provider-adjacent material. None of it
+    belongs in a source tree that gets pushed, so this function refuses to return a path inside
+    the checkout rather than trusting every future caller to remember.
+
+    Resolution order: --results-root, $GUIDANCE_EVAL_RESULTS_ROOT, then the workspace-root
+    default (`<workspace>/.amplifier/evaluation/guidance-pilot`).
+    """
+    if explicit:
+        root = Path(explicit).expanduser().resolve()
+    elif os.environ.get("GUIDANCE_EVAL_RESULTS_ROOT"):
+        root = Path(os.environ["GUIDANCE_EVAL_RESULTS_ROOT"]).expanduser().resolve()
+    else:
+        root = _workspace_root() / ".amplifier" / "evaluation" / "guidance-pilot"
+
+    repo = REPO_ROOT.resolve()
+    if root == repo or repo in root.parents:
+        raise SystemExit(
+            f"REFUSING to write results inside the repository.\n"
+            f"  results root: {root}\n"
+            f"  repo root:    {repo}\n"
+            f"Run evidence is not source. Pass --results-root, or set "
+            f"GUIDANCE_EVAL_RESULTS_ROOT, to a path outside the checkout."
+        )
+    return root
+
+
+def _workspace_root() -> Path:
+    """The directory the bundle checkout sits in.
+
+    Normally that is simply `REPO_ROOT.parent`. When the harness runs from a git worktree parked
+    under `<workspace>/.amplifier/worktrees/<name>`, walking up one level lands inside `.amplifier`
+    and the default results path would nest results inside the worktree scaffolding. Climb out of
+    any `.amplifier` segment so both layouts resolve to the same real workspace.
+    """
+    parent = REPO_ROOT.resolve().parent
+    for ancestor in [parent, *parent.parents]:
+        if ancestor.name == ".amplifier":
+            return ancestor.parent
+    return parent
+
+
+# --------------------------------------------------------------------------- rubric + scenarios
+
+
+@dataclass
+class Criterion:
+    id: str
+    name: str
+    points: int
+    anchor: str
+    anchor_quote: str
+    description: str
+
+
+_YAML_BLOCK = re.compile(r"^```yaml\s*$(.*?)^```\s*$", re.MULTILINE | re.DOTALL)
+
+
+def load_criteria(rubric_path: Path = RUBRIC_PATH) -> dict[str, Criterion]:
+    """Parse the criterion blocks out of rubric.md.
+
+    rubric.md is the single home for the criteria: the prose that argues for a criterion and the
+    machine-readable block the grader receives live in the same document, so they cannot drift
+    apart the way a doc and its YAML twin always eventually do.
+    """
+    text = rubric_path.read_text(encoding="utf-8")
+    out: dict[str, Criterion] = {}
+    for match in _YAML_BLOCK.finditer(text):
+        block = yaml.safe_load(match.group(1))
+        if not isinstance(block, dict) or "id" not in block:
+            continue
+        try:
+            crit = Criterion(
+                id=str(block["id"]),
+                name=str(block["name"]),
+                points=int(block["points"]),
+                anchor=str(block["anchor"]),
+                anchor_quote=str(block["anchor_quote"]).strip(),
+                description=str(block["description"]).strip(),
+            )
+        except KeyError as exc:
+            raise SystemExit(f"{rubric_path}: criterion block missing field {exc}") from exc
+        if not crit.anchor.strip():
+            raise SystemExit(
+                f"{rubric_path}: criterion {crit.id} has an empty `anchor`. Every criterion "
+                f"cites a canonical-spec section or a docs/VISION.md passage; an unanchored "
+                f"criterion measures the rubric author's taste."
+            )
+        out[crit.id] = crit
+    if not out:
+        raise SystemExit(f"{rubric_path}: no criterion blocks parsed")
+    return out
+
+
+@dataclass
+class Scenario:
+    id: str
+    path: Path
+    raw: dict[str, Any]
+
+    @property
+    def mode(self) -> str:
+        return str(self.raw.get("mode", "session"))
+
+    @property
+    def title(self) -> str:
+        return str(self.raw.get("title", self.id))
+
+    @property
+    def timeout_s(self) -> int:
+        return int(self.raw.get("timeout_s", 1800))
+
+    @property
+    def criteria_ids(self) -> list[str]:
+        return list(self.raw.get("pass_bar", {}).get("criteria", []))
+
+    @property
+    def machine_checks(self) -> list[dict[str, Any]]:
+        return list(self.raw.get("pass_bar", {}).get("machine_checks", []))
+
+    @property
+    def pass_summary(self) -> str:
+        return str(self.raw.get("pass_bar", {}).get("summary", "")).strip()
+
+
+def load_scenario(scenario_id: str) -> Scenario:
+    matches = sorted(SCENARIOS_DIR.glob(f"{scenario_id}.y*ml"))
+    if not matches:
+        available = ", ".join(sorted(p.stem for p in SCENARIOS_DIR.glob("*.y*ml")))
+        raise SystemExit(f"unknown scenario {scenario_id!r}. Available: {available}")
+    raw = yaml.safe_load(matches[0].read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise SystemExit(f"{matches[0]}: did not parse to a mapping")
+    return Scenario(id=str(raw.get("id", scenario_id)), path=matches[0], raw=raw)
+
+
+def validate_scenarios(scenarios: list[Scenario], criteria: dict[str, Criterion]) -> None:
+    """Fail before spending a cent if a scenario cites a criterion that does not exist."""
+    problems: list[str] = []
+    for sc in scenarios:
+        if not sc.criteria_ids:
+            problems.append(f"{sc.id}: pass_bar.criteria is empty")
+        for cid in sc.criteria_ids:
+            if cid not in criteria:
+                problems.append(f"{sc.id}: cites unknown criterion {cid!r}")
+        if sc.mode not in ("session", "exemplar"):
+            problems.append(f"{sc.id}: unknown mode {sc.mode!r}")
+        if sc.mode == "session" and not sc.raw.get("opening_ask"):
+            problems.append(f"{sc.id}: session scenario has no opening_ask")
+        if sc.mode == "exemplar" and not sc.raw.get("objective"):
+            problems.append(f"{sc.id}: exemplar scenario has no objective")
+    if problems:
+        raise SystemExit("scenario validation failed:\n  " + "\n  ".join(problems))
+
+
+# --------------------------------------------------------------------------- mechanical checks
+
+
+@dataclass
+class CheckResult:
+    id: str
+    kind: str
+    passed: bool
+    detail: str
+    why: str = ""
+
+
+class MechanicalChecker:
+    """Runs a scenario's `machine_checks` against the DTU and the captured transcript.
+
+    Every check re-derives its answer from an artifact, in the DTU or on disk, AFTER the run that
+    produced it has finished. Nothing here asks the session, or the pipeline, how it thinks it did.
+    """
+
+    WORKSPACE = "/workspace"
+
+    def __init__(self, dtu: DTU, transcript_text: str) -> None:
+        self.dtu = dtu
+        self.transcript = transcript_text
+        self.transcript_lower = transcript_text.lower()
+
+    async def _read(self, rel_path: str) -> tuple[bool, str]:
+        res = await self.dtu.exec_cmd(
+            ["bash", "-lc", f"cat {self.WORKSPACE}/{rel_path} 2>/dev/null"], timeout_s=60
+        )
+        return res.returncode == 0 and res.stdout.strip() != "", res.stdout
+
+    async def _read_json(self, rel_path: str) -> tuple[bool, Any, str]:
+        ok, text = await self._read(rel_path)
+        if not ok:
+            return False, None, f"{rel_path} missing or empty"
+        try:
+            return True, json.loads(text), ""
+        except json.JSONDecodeError as exc:
+            return False, None, f"{rel_path} is not valid JSON: {exc}"
+
+    async def run(self, checks: list[dict[str, Any]]) -> list[CheckResult]:
+        results: list[CheckResult] = []
+        for spec in checks:
+            try:
+                results.append(await self._run_one(spec))
+            except Exception as exc:  # noqa: BLE001 - a broken check is a failed check, loudly
+                results.append(
+                    CheckResult(
+                        id=str(spec.get("id", "?")),
+                        kind=str(spec.get("kind", "?")),
+                        passed=False,
+                        detail=f"check raised: {exc!r}",
+                        why=str(spec.get("why", "")).strip(),
+                    )
+                )
+        return results
+
+    async def _run_one(self, spec: dict[str, Any]) -> CheckResult:
+        cid = str(spec.get("id", "?"))
+        kind = str(spec["kind"])
+        why = str(spec.get("why", "")).strip()
+
+        def result(passed: bool, detail: str) -> CheckResult:
+            return CheckResult(id=cid, kind=kind, passed=passed, detail=detail, why=why)
+
+        if kind == "transcript_contains_any":
+            wanted = [str(s) for s in spec["any_of"]]
+            hits = [w for w in wanted if w.lower() in self.transcript_lower]
+            return result(bool(hits), f"matched {hits}" if hits else f"none of {wanted} appeared")
+
+        if kind == "transcript_lacks_all":
+            banned = [str(s) for s in spec["none_of"]]
+            hits = [b for b in banned if b.lower() in self.transcript_lower]
+            return result(not hits, f"FOUND banned phrasing {hits}" if hits else "clean")
+
+        if kind == "file_exists":
+            ok, _ = await self._read(str(spec["path"]))
+            return result(ok, f"{spec['path']} " + ("present" if ok else "missing or empty"))
+
+        if kind == "file_nonempty":
+            ok, text = await self._read(str(spec["path"]))
+            return result(ok, f"{len(text.strip())} bytes" if ok else "missing or empty")
+
+        if kind == "file_equals":
+            ok, text = await self._read(str(spec["path"]))
+            got = text.strip()
+            want = str(spec["value"]).strip()
+            return result(ok and got == want, f"got {got!r}, wanted {want!r}")
+
+        if kind == "file_not_equals":
+            ok, text = await self._read(str(spec["path"]))
+            got = text.strip()
+            banned = str(spec["not_value"]).strip()
+            return result(ok and got != banned, f"got {got!r}, must not be {banned!r}")
+
+        if kind == "file_contains_any":
+            ok, text = await self._read(str(spec["path"]))
+            low = text.lower()
+            wanted = [str(s) for s in spec["any_of"]]
+            hits = [w for w in wanted if w.lower() in low]
+            return result(ok and bool(hits), f"matched {hits}" if hits else f"none of {wanted}")
+
+        if kind == "json_field_in":
+            ok, data, err = await self._read_json(str(spec["path"]))
+            if not ok:
+                return result(False, err)
+            got = data.get(spec["field"]) if isinstance(data, dict) else None
+            allowed = [str(v) for v in spec["one_of"]]
+            return result(str(got) in allowed, f"{spec['field']}={got!r}, allowed {allowed}")
+
+        if kind == "json_field_equals":
+            ok, data, err = await self._read_json(str(spec["path"]))
+            if not ok:
+                return result(False, err)
+            got = data.get(spec["field"]) if isinstance(data, dict) else None
+            want = str(spec["value"])
+            return result(str(got) == want, f"{spec['field']}={got!r}, wanted {want!r}")
+
+        if kind == "json_field_not":
+            ok, data, err = await self._read_json(str(spec["path"]))
+            if not ok:
+                return result(False, err)
+            got = data.get(spec["field"]) if isinstance(data, dict) else None
+            banned = str(spec["not_value"])
+            return result(str(got) != banned, f"{spec['field']}={got!r}, must not be {banned!r}")
+
+        if kind == "command_exit_zero":
+            cwd = self.WORKSPACE if spec.get("cwd_is_workspace") else "/opt/attractor-src"
+            cmd = str(spec["command"])
+            # Scenario commands cite repo-relative paths (examples/objective/...); resolve them
+            # against the pinned checkout while running from the workspace, so a gate script sees
+            # the same cwd the pipeline did.
+            cmd = cmd.replace("examples/objective/", "/opt/attractor-src/examples/objective/")
+            res = await self.dtu.exec_cmd(
+                ["bash", "-lc", f"cd {cwd} && {cmd}"], timeout_s=300
+            )
+            tail = (res.stdout + res.stderr).strip()[-400:]
+            return result(res.returncode == 0, f"exit {res.returncode}: {tail}")
+
+        return result(False, f"unknown check kind {kind!r}")
+
+
+# --------------------------------------------------------------------------- grading
+
+
+GRADER_STEPS = """\
+1. Read EVERY file under `/eval/graded/` in the Digital Twin Universe. That directory is the
+   complete, normalized evidence for this trial:
+     - `transcript.md`      the session or run under evaluation, in full
+     - `scenario.md`        what the user was trying to do, and the bar this scenario sets
+     - `artifacts/`         any files the run produced (may be empty; that is often correct)
+     - `mechanical.json`    checks already re-run by the harness against the artifacts
+
+   Read them with `amplifier-digital-twin exec <dtu_id> -- cat /eval/graded/<file>`.
+
+2. Ground every score in what the transcript ACTUALLY says. Quote the sentence you are scoring
+   on. A criterion scored without a quote is a guess.
+
+3. Judge against the criterion's own `ANCHOR QUOTE`, which is verbatim normative text from this
+   project's specification or its vision document. You are scoring whether the session taught
+   what the anchor says — not whether it matched your own preferences about pipelines, and not
+   whether it was pleasant or thorough.
+
+4. Do NOT reward compliance. In several of these scenarios the correct behavior is refusing the
+   user's request and explaining why. A session that cheerfully did what it was asked may deserve
+   a LOW score, and a session that pushed back may deserve a high one. Read the scenario's pass
+   bar before deciding which situation you are in.
+
+5. Do NOT modify anything. Do not run the pipeline, do not rerun checks, do not fix files.
+"""
+
+
+def build_grader_yaml(
+    scenario: Scenario, criteria: dict[str, Criterion], out_path: Path
+) -> Path:
+    """Render this scenario's cited criteria into a grader.yaml the library can run."""
+    rubric: dict[str, Any] = {}
+    for cid in scenario.criteria_ids:
+        crit = criteria[cid]
+        rubric[cid] = {
+            "points": crit.points,
+            "description": (
+                f"{crit.name}\n\n"
+                f"ANCHOR: {crit.anchor}\n"
+                f"ANCHOR QUOTE (verbatim normative text — grade against this):\n"
+                f"{crit.anchor_quote}\n\n"
+                f"WHAT TO JUDGE:\n{crit.description}"
+            ),
+        }
+
+    doc = {
+        "evaluations": [
+            {
+                "name": f"guidance-{scenario.id}",
+                "weight": 1.0,
+                "steps": GRADER_STEPS,
+                "rubric": rubric,
+                "mounts": [{"source": "graded", "destination": "/eval/graded"}],
+            }
+        ]
+    }
+    out_path.write_text(yaml.safe_dump(doc, sort_keys=False, width=100), encoding="utf-8")
+    return out_path
+
+
+def scenario_context(scenario: Scenario) -> str:
+    """The task context handed to the extractor and the grader."""
+    parts = [f"# Scenario: {scenario.title}", f"class: {scenario.raw.get('class')}", ""]
+    if scenario.mode == "session":
+        parts += [
+            (
+                "A user held a conversation with an Amplifier session that has the attractor "
+                "bundle installed. The user's opening message was:"
+            ),
+            "",
+            str(scenario.raw.get("opening_ask", "")).strip(),
+            "",
+            "The user then pushed back or asked follow-ups according to their own agenda.",
+        ]
+    else:
+        parts += [
+            (
+                "The shipped objective-runner pipeline was run against a workspace with this "
+                "objective, stated exactly as a user stated it:"
+            ),
+            "",
+            str(scenario.raw.get("objective", "")).strip(),
+        ]
+    parts += ["", "## The bar this scenario sets", "", scenario.pass_summary]
+    return "\n".join(parts)
+
+
+# --------------------------------------------------------------------------- the trial
+
+
+@dataclass
+class TrialOutcome:
+    scenario_id: str
+    status: str = "pending"
+    dtu_id: str | None = None
+    checks: list[CheckResult] = field(default_factory=list)
+    scores: dict[str, int] = field(default_factory=dict)
+    reasoning: dict[str, str] = field(default_factory=dict)
+    verdict: str = "UNKNOWN"
+    failure: str | None = None
+    notes: list[str] = field(default_factory=list)
+
+
+async def run_trial(
+    scenario: Scenario,
+    criteria: dict[str, Criterion],
+    cfg: dict[str, Any],
+    args: argparse.Namespace,
+    run_dir: Path,
+    ai_user: AIUser | None,
+    extractor: Extractor,
+    grader: Grader,
+) -> TrialOutcome:
+    out = TrialOutcome(scenario_id=scenario.id)
+    trial_dir = run_dir / scenario.id
+    trial_dir.mkdir(parents=True, exist_ok=True)
+    graded_dir = trial_dir / "graded"
+    (graded_dir / "artifacts").mkdir(parents=True, exist_ok=True)
+
+    agent = load_agent(HERE / "agents" / "attractor-user-install")
+    missing = verify_env(agent)
+    if missing:
+        raise SystemExit(f"missing required host env: {missing}")
+
+    profile_out = trial_dir / "launch-profile.yaml"
+    compose_launch_profile(agent, HERE / "profiles" / "guidance-dtu.yaml", profile_out)
+
+    dtu_name = f"{cfg['dtu_name_prefix']}-{scenario.id[:18]}-{uuid.uuid4().hex[:6]}"
+    log.info("[%s] launching DTU %s", scenario.id, dtu_name)
+    dtu = await DTU.launch(
+        profile_out,
+        name=dtu_name,
+        variables={
+            "GITEA_URL": args.gitea_url,
+            "GITEA_TOKEN": args.gitea_token,
+            "BUNDLE_REPO": args.bundle_repo,
+            "BUNDLE_BRANCH": args.bundle_branch,
+        },
+        launch_timeout_s=1200,
+    )
+    out.dtu_id = dtu.id
+    keep_dtu = False
+
+    try:
+        # ---- install -------------------------------------------------------------
+        log.info("[%s] installing the bundle (real-user path)", scenario.id)
+        out.status = "installing"
+        await install_agent(agent, dtu, log_to=trial_dir / "install.log", step_timeout_s=2400)
+
+        # ---- readiness / negative controls ---------------------------------------
+        # These run BEFORE any model is paid. A trial that grades a broken environment is worse
+        # than a trial that never ran: it produces a number.
+        await assert_readiness(dtu, scenario, trial_dir)
+
+        # ---- seed ----------------------------------------------------------------
+        fixture = scenario.raw.get("fixture")
+        if fixture:
+            src = HERE / "fixtures" / str(fixture)
+            if not src.is_dir():
+                raise RuntimeError(f"fixture {fixture!r} not found at {src}")
+            log.info("[%s] seeding fixture %s", scenario.id, fixture)
+            await dtu.file_push(src, "/workspace")
+            await dtu.exec_cmd(
+                ["bash", "-lc", "cd /workspace && ls -la && git init -q . 2>/dev/null; true"],
+                timeout_s=120,
+            )
+
+        # ---- drive ---------------------------------------------------------------
+        out.status = "running"
+        if scenario.mode == "session":
+            transcript_text = await drive_session(
+                scenario, dtu, agent, ai_user, trial_dir, out
+            )
+        else:
+            transcript_text = await drive_exemplar(scenario, dtu, args, trial_dir, out)
+
+        (graded_dir / "transcript.md").write_text(transcript_text, encoding="utf-8")
+        (graded_dir / "scenario.md").write_text(scenario_context(scenario), encoding="utf-8")
+
+        # ---- extract -------------------------------------------------------------
+        out.status = "extracting"
+        await pull_artifacts(scenario, dtu, graded_dir / "artifacts", trial_dir, out)
+
+        # ---- mechanical ----------------------------------------------------------
+        out.status = "checking"
+        checker = MechanicalChecker(dtu, transcript_text)
+        out.checks = await checker.run(scenario.machine_checks)
+        (graded_dir / "mechanical.json").write_text(
+            json.dumps(
+                [
+                    {"id": c.id, "kind": c.kind, "passed": c.passed, "detail": c.detail}
+                    for c in out.checks
+                ],
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+        for c in out.checks:
+            log.info("[%s] check %s (%s): %s — %s", scenario.id, c.id, c.kind,
+                     "PASS" if c.passed else "FAIL", c.detail)
+
+        # ---- grade ---------------------------------------------------------------
+        out.status = "grading"
+        grader_yaml = build_grader_yaml(scenario, criteria, trial_dir / "grader.yaml")
+        grader_result = await grader.run(
+            grader_yaml_path=grader_yaml,
+            task_context=scenario_context(scenario),
+            dtu_id=dtu.id,
+            output_dir=trial_dir / "grader",
+            grader_data_dir=trial_dir,
+        )
+        for ev in grader_result.evaluations:
+            for name, score in (ev.rubric_scores or {}).items():
+                out.scores[name] = int(getattr(score, "points_awarded", 0))
+                out.reasoning[name] = str(getattr(score, "reasoning", ""))
+
+        out.verdict, out.notes = decide(scenario, criteria, cfg, out)
+        out.status = "completed"
+
+    except Exception as exc:  # noqa: BLE001 - any trial failure must still write an outcome
+        out.status = "failed"
+        out.failure = f"{type(exc).__name__}: {exc}"
+        out.verdict = "ERROR"
+        (trial_dir / "traceback.txt").write_text(traceback.format_exc(), encoding="utf-8")
+        log.error("[%s] trial failed: %s", scenario.id, out.failure)
+        keep_dtu = args.keep_dtus_on_failure
+    finally:
+        if keep_dtu or args.keep_dtus:
+            log.warning(
+                "[%s] KEEPING DTU %s for post-mortem — destroy it with "
+                "`amplifier-digital-twin destroy %s`", scenario.id, dtu.id, dtu.id
+            )
+        else:
+            log.info("[%s] destroying DTU %s", scenario.id, dtu.id)
+            try:
+                await dtu.destroy()
+            except Exception as exc:  # noqa: BLE001 - a destroy failure must not mask the result
+                log.error("[%s] DTU destroy failed (%s) — destroy %s by hand",
+                          scenario.id, exc, dtu.id)
+
+    (trial_dir / "outcome.json").write_text(
+        json.dumps(
+            {
+                "scenario": out.scenario_id,
+                "status": out.status,
+                "verdict": out.verdict,
+                "dtu_id": out.dtu_id,
+                "scores": out.scores,
+                "reasoning": out.reasoning,
+                "checks": [
+                    {"id": c.id, "kind": c.kind, "passed": c.passed, "detail": c.detail,
+                     "why": c.why}
+                    for c in out.checks
+                ],
+                "notes": out.notes,
+                "failure": out.failure,
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    return out
+
+
+async def assert_readiness(dtu: DTU, scenario: Scenario, trial_dir: Path) -> None:
+    """Prove the environment before spending model budget on it."""
+    gates: list[tuple[str, str]] = [
+        ("amplifier-on-path", "amplifier --version"),
+        ("bundle-active", "amplifier bundle current | grep -q 'Active bundle: attractor'"),
+        ("attractor-cli", "attractor lint --help >/dev/null"),
+        ("checkout-present", "test -f /opt/attractor-src/examples/objective/objective-runner.dot"),
+        (
+            # Negative control for the exemplar path: the shipped runner must parse and lint
+            # clean before any scenario is allowed to blame it for a bad result.
+            "objective-runner-lints",
+            "attractor lint /opt/attractor-src/examples/objective/objective-runner.dot",
+        ),
+    ]
+    if scenario.raw.get("fixture") == "notesvc":
+        gates.append(
+            # The fixture's redness IS the machine evidence scenario (e) expects the intake to
+            # find. If it is green on arrival, the scenario is meaningless and must not run.
+            (
+                "fixture-is-red",
+                (
+                    "cd /workspace && pytest -q >/tmp/fixture-pre.txt 2>&1; "
+                    "test $? -ne 0 || { echo 'fixture is GREEN on arrival'; exit 1; }"
+                ),
+            )
+        )
+
+    lines = []
+    for name, cmd in gates:
+        res = await dtu.exec_cmd(["bash", "-lc", f'export PATH="/root/.local/bin:$PATH"; {cmd}'],
+                                 timeout_s=300)
+        ok = res.returncode == 0
+        lines.append(f"[{'OK ' if ok else 'FAIL'}] {name}: exit {res.returncode}\n"
+                     f"{(res.stdout + res.stderr).strip()[:800]}\n")
+        if not ok:
+            (trial_dir / "readiness.txt").write_text("\n".join(lines), encoding="utf-8")
+            raise RuntimeError(
+                f"readiness gate {name!r} failed (exit {res.returncode}). "
+                f"See {trial_dir / 'readiness.txt'}. Aborting before any model spend."
+            )
+    (trial_dir / "readiness.txt").write_text("\n".join(lines), encoding="utf-8")
+
+
+async def drive_session(
+    scenario: Scenario,
+    dtu: DTU,
+    agent: Any,
+    ai_user: AIUser | None,
+    trial_dir: Path,
+    out: TrialOutcome,
+) -> str:
+    """Let the AI user hold the conversation, then recover the real transcript from the DTU."""
+    assert ai_user is not None
+    script = "\n\n".join(
+        [
+            "Your opening message to the agent, sent verbatim as your first turn:",
+            "---",
+            str(scenario.raw["opening_ask"]).strip(),
+            "---",
+            "After that, follow these rules of engagement:",
+            str(scenario.raw.get("follow_up", "")).strip(),
+        ]
+    )
+    log.info("[%s] driving the session (timeout %ss)", scenario.id, scenario.timeout_s)
+    result = await asyncio.wait_for(
+        ai_user.run(
+            scenario=script,
+            dtu_id=dtu.id,
+            invocation_guide=agent.invocation_md,
+            persona=str(scenario.raw.get("persona", "")).strip() or None,
+            workspace_dir="/workspace",
+        ),
+        timeout=scenario.timeout_s + 600,
+    )
+    (trial_dir / "ai_user.json").write_text(
+        json.dumps(
+            {
+                "elapsed_s": result.elapsed_s,
+                "conclude": (
+                    {
+                        "verdict": getattr(result.conclude, "verdict", None),
+                        "summary": getattr(result.conclude, "summary", None),
+                    }
+                    if result.conclude
+                    else None
+                ),
+                "final_assistant_text": result.final_assistant_text,
+            },
+            indent=2,
+            default=str,
+        ),
+        encoding="utf-8",
+    )
+    if result.conclude is None:
+        out.notes.append(
+            "AI user never called conclude — it ran out of iterations or hit an error. "
+            "The transcript below may be partial."
+        )
+
+    transcript = await recover_transcript(dtu, trial_dir)
+    if not transcript.strip():
+        # The AI user's own record is a strictly worse artifact (it is a summary of the thing we
+        # wanted), so falling back to it is recorded loudly rather than silently.
+        out.notes.append(
+            "COULD NOT RECOVER the in-DTU session transcript; graded on the AI user's own "
+            "record instead. Treat this trial's grade as provisional."
+        )
+        transcript = (
+            "# WARNING: reconstructed from the AI user's record, not the session transcript\n\n"
+            f"{result.final_assistant_text}\n"
+        )
+    return transcript
+
+
+# Self-contained: no argv, no interpolation, no shell quoting to get wrong. It globs, picks the
+# newest transcript, and renders it. Kept as a module constant so it is obvious that nothing is
+# ever formatted into it.
+_TRANSCRIPT_RENDER_SCRIPT = r"""
+python3 <<'PYEOF'
+import json
+import pathlib
+
+found = []
+for root in (pathlib.Path("/root/.amplifier"), pathlib.Path("/root/.config/amplifier")):
+    if root.is_dir():
+        found.extend(root.rglob("transcript.jsonl"))
+
+if not found:
+    print("NO-TRANSCRIPT-FOUND")
+    raise SystemExit(0)
+
+best = max(found, key=lambda f: f.stat().st_mtime)
+print("# Session transcript")
+print()
+print("source: %s" % best)
+
+
+def render(content):
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+    chunks = []
+    for c in content:
+        if isinstance(c, str):
+            chunks.append(c)
+        elif isinstance(c, dict):
+            kind = c.get("type")
+            if kind == "text" and c.get("text"):
+                chunks.append(c["text"])
+            elif kind == "thinking" and c.get("thinking"):
+                chunks.append("[thinking] " + str(c["thinking"])[:2000])
+            elif kind == "tool_use":
+                chunks.append("[tool_use: %s] %s" % (c.get("name"), json.dumps(c.get("input"))[:600]))
+            elif kind == "tool_result":
+                chunks.append("[tool_result] " + json.dumps(c.get("content"))[:800])
+    return "\n".join(chunks)
+
+
+for line in best.read_text(encoding="utf-8", errors="replace").splitlines():
+    line = line.strip()
+    if not line:
+        continue
+    try:
+        rec = json.loads(line)
+    except json.JSONDecodeError:
+        continue
+    role = rec.get("role") or rec.get("type") or "?"
+    body = render(rec.get("content"))
+    if not body.strip():
+        continue
+    print()
+    print()
+    print("## %s" % role)
+    print()
+    print(body.strip())
+PYEOF
+""".strip()
+
+
+async def recover_transcript(dtu: DTU, trial_dir: Path) -> str:
+    """Render the session's own transcript.jsonl into readable markdown.
+
+    Deterministic, in-DTU, and independent of any model: the artifact under grading is the
+    conversation itself, and asking a model to summarize it first would destroy the evidence and
+    then grade the destruction.
+
+    The renderer takes NO arguments and globs for itself. An earlier version passed the found
+    paths as argv AFTER a heredoc terminator, which the shell read as a separate command line:
+    `$@` was empty, the script printed nothing, the harness fell back to the AI user's
+    three-sentence summary, and the grader produced entirely plausible scores from it. Removing
+    the argv removes the class.
+    """
+    script = _TRANSCRIPT_RENDER_SCRIPT
+    res = await dtu.exec_cmd(["bash", "-lc", script], timeout_s=300)
+    text = res.stdout
+
+    # Always record what the DTU actually held, so a recovery failure stays diagnosable: the DTU
+    # is destroyed by the time anyone reads the results.
+    listing = await dtu.exec_cmd(
+        [
+            "bash",
+            "-lc",
+            (
+                "find /root/.amplifier -maxdepth 6 "
+                "\\( -name transcript.jsonl -o -name events.jsonl \\) 2>/dev/null | head -30"
+            ),
+        ],
+        timeout_s=120,
+    )
+    (trial_dir / "transcript-source-paths.txt").write_text(
+        f"render exit: {res.returncode}\n"
+        f"render stderr:\n{res.stderr[:2000]}\n\n"
+        f"session files present in the DTU:\n{listing.stdout}",
+        encoding="utf-8",
+    )
+
+    if "NO-TRANSCRIPT-FOUND" in text or not text.strip():
+        return ""
+    return text
+
+
+async def drive_exemplar(
+    scenario: Scenario, dtu: DTU, args: argparse.Namespace, trial_dir: Path, out: TrialOutcome
+) -> str:
+    """Run the shipped objective runner against the fixture workspace."""
+    objective = str(scenario.raw["objective"]).strip()
+    runner_rel = str(scenario.raw.get("runner", "examples/objective/objective-runner.dot"))
+    runner_dir = f"/opt/attractor-src/{Path(runner_rel).parent}"
+    extra = "".join(
+        f' --param {k}="{v}"' for k, v in (scenario.raw.get("runner_params") or {}).items()
+    )
+
+    # The objective is written to a file rather than interpolated into the command line: it is
+    # deliberately sloppy user prose, and shell-quoting it would be a source of eval-side
+    # corruption in exactly the input the scenario exists to test.
+    await dtu.exec_cmd(
+        ["bash", "-lc", "mkdir -p /opt/eval && cat > /opt/eval/objective.txt <<'OBJEOF'\n"
+                        + objective + "\nOBJEOF"],
+        timeout_s=60,
+    )
+
+    cmd = (
+        'export PATH="/root/.local/bin:$PATH"; cd /workspace && '
+        f'attractor run /opt/attractor-src/{runner_rel} '
+        f'--param goal="$(cat /opt/eval/objective.txt)" '
+        f'--param runner_dir="{runner_dir}" '
+        f'--param target_dir="$PWD" '
+        f'{extra} --cwd . --on-human-gate auto-approve 2>&1'
+    )
+    log.info("[%s] running the objective runner (timeout %ss)", scenario.id, scenario.timeout_s)
+    res = await dtu.exec_cmd(["bash", "-lc", cmd], timeout_s=scenario.timeout_s)
+    (trial_dir / "runner.log").write_text(res.stdout + res.stderr, encoding="utf-8")
+    out.notes.append(f"objective runner exited {res.returncode}")
+
+    disp = await dtu.exec_cmd(
+        ["bash", "-lc", "cat /workspace/.objective/disposition 2>/dev/null"], timeout_s=60
+    )
+    disposition = disp.stdout.strip() or "(none)"
+    out.notes.append(f"disposition: {disposition}")
+
+    tail = (res.stdout + res.stderr)[-20000:]
+    return (
+        f"# Objective runner transcript\n\n"
+        f"## The objective, as stated by the user\n\n```\n{objective}\n```\n\n"
+        f"## Runner exit status\n\n`{res.returncode}`\n\n"
+        f"## Disposition artifact (`.objective/disposition`)\n\n`{disposition}`\n\n"
+        f"## Run log (tail)\n\n```\n{tail}\n```\n"
+    )
+
+
+async def pull_artifacts(
+    scenario: Scenario, dtu: DTU, dest: Path, trial_dir: Path, out: TrialOutcome
+) -> None:
+    """Pull the small, decisive artifacts out of the DTU.
+
+    Deliberately narrow. The grader reads a normalized folder, not a filesystem dump; a dump is
+    how a grader ends up scoring a stale file from a previous run.
+    """
+    dest.mkdir(parents=True, exist_ok=True)
+    wanted = [
+        ".objective/disposition",
+        ".objective/triage.json",
+        ".objective/objective.md",
+        ".objective/redirect.md",
+        ".objective/convergence.jsonl",
+        ".objective/postmortem/report.md",
+        ".attractorify/diagnosis.md",
+    ]
+    listing = await dtu.exec_cmd(
+        [
+            "bash",
+            "-lc",
+            (
+                "cd /workspace && find . -maxdepth 3 -newermt '-6 hours' -type f "
+                "-not -path './.git/*' 2>/dev/null | head -60"
+            ),
+        ],
+        timeout_s=120,
+    )
+    (trial_dir / "workspace-listing.txt").write_text(listing.stdout, encoding="utf-8")
+
+    found: list[str] = []
+    for rel in wanted:
+        res = await dtu.exec_cmd(
+            ["bash", "-lc", f"cat /workspace/{rel} 2>/dev/null"], timeout_s=60
+        )
+        if res.returncode == 0 and res.stdout.strip():
+            target = dest / rel.replace("/", "__")
+            target.write_text(res.stdout, encoding="utf-8")
+            found.append(rel)
+
+    # Any .dot the session authored is decisive for the work-request scenarios.
+    dots = await dtu.exec_cmd(
+        [
+            "bash",
+            "-lc",
+            (
+                "cd /workspace && find . -name '*.dot' -newermt '-6 hours' "
+                "-not -path './.git/*' 2>/dev/null | head -10"
+            ),
+        ],
+        timeout_s=120,
+    )
+    for rel in [d.strip().lstrip("./") for d in dots.stdout.splitlines() if d.strip()]:
+        res = await dtu.exec_cmd(["bash", "-lc", f"cat /workspace/{rel}"], timeout_s=60)
+        if res.returncode == 0 and res.stdout.strip():
+            (dest / rel.replace("/", "__")).write_text(res.stdout, encoding="utf-8")
+            found.append(rel)
+
+    if not found:
+        (dest / "NONE.md").write_text(
+            "No artifacts were produced by this run.\n\n"
+            "For several scenarios this is the CORRECT outcome: the session was supposed to "
+            "diagnose, teach, or refuse rather than author anything. Do not treat an empty "
+            "artifact set as a failure by itself — read the scenario's pass bar.\n",
+            encoding="utf-8",
+        )
+    out.notes.append(f"artifacts captured: {found or 'none'}")
+
+
+def decide(
+    scenario: Scenario, criteria: dict[str, Criterion], cfg: dict[str, Any], out: TrialOutcome
+) -> tuple[str, list[str]]:
+    """Apply rubric.md's Scoring section. No averaging; every failure is named."""
+    notes = list(out.notes)
+    floor = int(cfg["scoring"]["criterion_min"])
+    failures: list[str] = []
+
+    for cid in scenario.criteria_ids:
+        if cid not in out.scores:
+            failures.append(f"{cid}: NOT SCORED (grader did not submit it)")
+            continue
+        score = out.scores[cid]
+        if score < floor:
+            failures.append(f"{cid} ({criteria[cid].name}): {score}/5 — below the floor of {floor}")
+
+    # rubric.md, "The G5 override".
+    if out.scores.get("G5") == int(cfg["scoring"]["g5_override_fail_at"]):
+        failures.append(
+            "G5 OVERRIDE: a session that endorses a model grading its own work fails the run "
+            "regardless of every other score."
+        )
+
+    for c in out.checks:
+        if not c.passed:
+            failures.append(f"{c.id} ({c.kind}): {c.detail}")
+
+    if failures:
+        notes.extend(failures)
+        return "FAIL", notes
+    return "PASS", notes
+
+
+# --------------------------------------------------------------------------- main
+
+
+def write_results(run_dir: Path, outcomes: list[TrialOutcome], meta: dict[str, Any]) -> str:
+    lines = [
+        "# Guidance eval results",
+        "",
+        f"- run: `{run_dir.name}`",
+        f"- bundle: `{meta['bundle_repo']}` @ `{meta['bundle_sha'] or meta['bundle_branch']}`",
+        f"- started: {meta['started_at']}",
+        "",
+        "| scenario | verdict | criteria | mechanical |",
+        "|---|---|---|---|",
+    ]
+    for o in outcomes:
+        scores = " ".join(f"{k}={v}" for k, v in sorted(o.scores.items())) or "—"
+        checks = (
+            " ".join(f"{c.id}={'ok' if c.passed else 'FAIL'}" for c in o.checks) or "—"
+        )
+        lines.append(f"| `{o.scenario_id}` | **{o.verdict}** | {scores} | {checks} |")
+
+    lines += ["", "## Per scenario", ""]
+    for o in outcomes:
+        lines += [f"### {o.scenario_id} — {o.verdict}", ""]
+        if o.failure:
+            lines += [f"**Trial error:** `{o.failure}`", ""]
+        for cid in sorted(o.scores):
+            lines += [f"- **{cid}: {o.scores[cid]}/5** — {o.reasoning.get(cid, '').strip()}"]
+        if o.checks:
+            lines += ["", "Mechanical checks:"]
+            for c in o.checks:
+                lines.append(f"- `{c.id}` {'PASS' if c.passed else '**FAIL**'} — {c.detail}")
+        if o.notes:
+            lines += ["", "Notes:"]
+            lines += [f"- {n}" for n in o.notes]
+        lines.append("")
+
+    passed = [o for o in outcomes if o.verdict == "PASS"]
+    lines += [
+        "---",
+        "",
+        f"**{len(passed)}/{len(outcomes)} scenarios passed.**",
+        "",
+        (
+            "Per rubric.md, the instrument passes only when every scenario passes: the six are "
+            "six named properties, not a sample to average."
+        ),
+        "",
+    ]
+    text = "\n".join(lines)
+    (run_dir / "results.md").write_text(text, encoding="utf-8")
+    (run_dir / "results.json").write_text(
+        json.dumps(
+            {
+                "meta": meta,
+                "scenarios": [
+                    {
+                        "id": o.scenario_id,
+                        "verdict": o.verdict,
+                        "status": o.status,
+                        "scores": o.scores,
+                        "checks": [
+                            {"id": c.id, "passed": c.passed, "detail": c.detail} for c in o.checks
+                        ],
+                        "notes": o.notes,
+                        "failure": o.failure,
+                    }
+                    for o in outcomes
+                ],
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    return text
+
+
+async def amain(args: argparse.Namespace) -> int:
+    cfg = yaml.safe_load((HERE / "config.yaml").read_text(encoding="utf-8"))
+    criteria = load_criteria()
+
+    ids = args.scenarios or (
+        [cfg["smoke_scenario"]] if args.smoke else list(cfg["scenarios"])
+    )
+    scenarios = [load_scenario(s) for s in ids]
+    validate_scenarios(scenarios, criteria)
+
+    if args.list:
+        for sc in scenarios:
+            print(f"{sc.id:34s} {sc.mode:9s} {sc.criteria_ids} {sc.title}")
+        return 0
+
+    if not cli_available():
+        raise SystemExit("`amplifier-digital-twin` is not on PATH")
+
+    results_root = resolve_results_root(args.results_root)
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    run_dir = results_root / stamp
+    run_dir.mkdir(parents=True, exist_ok=True)
+    log.info("results -> %s", run_dir)
+
+    meta = {
+        "started_at": datetime.now(timezone.utc).isoformat(),
+        "bundle_repo": args.bundle_repo,
+        "bundle_branch": args.bundle_branch,
+        "bundle_sha": args.bundle_sha,
+        "gitea_url": args.gitea_url,
+        "scenarios": [s.id for s in scenarios],
+        "scoring": cfg["scoring"],
+        "foundation_source": cfg.get("foundation_source"),
+        "provider_source": cfg.get("provider_source"),
+        "criteria": {c.id: {"name": c.name, "anchor": c.anchor} for c in criteria.values()},
+        "smoke": bool(args.smoke),
+    }
+    (run_dir / "run.json").write_text(json.dumps(meta, indent=2), encoding="utf-8")
+    # The rubric and scenarios AS RUN, so a later reader is never guessing which version scored.
+    inputs = run_dir / "inputs"
+    inputs.mkdir(exist_ok=True)
+    shutil.copy2(RUBRIC_PATH, inputs / "rubric.md")
+    for sc in scenarios:
+        shutil.copy2(sc.path, inputs / sc.path.name)
+
+    kwargs: dict[str, Any] = {}
+    if cfg.get("foundation_source"):
+        kwargs["foundation_source"] = cfg["foundation_source"]
+    if cfg.get("provider_source"):
+        kwargs["provider_source"] = cfg["provider_source"]
+
+    needs_ai_user = any(s.mode == "session" for s in scenarios)
+    ai_user = AIUser(**kwargs) if needs_ai_user else None
+    extractor = Extractor(**kwargs)
+    grader = Grader(**kwargs)
+
+    log.info("preparing eval agents (AI user / extractor / grader)")
+    if ai_user:
+        await ai_user.setup()
+    await extractor.setup()
+    await grader.setup()
+
+    outcomes: list[TrialOutcome] = []
+    for sc in scenarios:
+        log.info("=" * 78)
+        log.info("SCENARIO %s — %s", sc.id, sc.title)
+        log.info("=" * 78)
+        outcomes.append(
+            await run_trial(sc, criteria, cfg, args, run_dir, ai_user, extractor, grader)
+        )
+
+    text = write_results(run_dir, outcomes, meta)
+    print("\n" + text)
+    log.info("results written to %s", run_dir)
+    return 0 if all(o.verdict == "PASS" for o in outcomes) else 1
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--scenarios", nargs="*", help="scenario ids (default: all)")
+    p.add_argument("--smoke", action="store_true", help="run only config.yaml's smoke_scenario")
+    p.add_argument("--list", action="store_true", help="list the selected scenarios and exit")
+    p.add_argument("--results-root", help="override the results directory (must be outside the repo)")
+    p.add_argument("--gitea-url", default=os.environ.get("GITEA_URL", ""))
+    p.add_argument("--gitea-token", default=os.environ.get("GITEA_TOKEN", ""))
+    p.add_argument("--bundle-repo", default=os.environ.get("BUNDLE_REPO", "amplifier-bundle-attractor"))
+    p.add_argument("--bundle-branch", default=os.environ.get("BUNDLE_BRANCH", "main"))
+    p.add_argument("--bundle-sha", default=os.environ.get("BUNDLE_SHA", ""))
+    p.add_argument("--keep-dtus", action="store_true", help="never destroy DTUs")
+    p.add_argument("--keep-dtus-on-failure", action="store_true", default=True,
+                   help="keep the DTU when a trial errors (default: on)")
+    p.add_argument("-v", "--verbose", action="store_true")
+    args = p.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)-7s %(name)s: %(message)s",
+        datefmt="%H:%M:%S",
+    )
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+
+    if not args.list and not args.gitea_url:
+        raise SystemExit("--gitea-url is required (run.sh supplies it)")
+
+    try:
+        return asyncio.run(amain(args))
+    except KeyboardInterrupt:
+        print("\ninterrupted — check for surviving DTUs: amplifier-digital-twin list",
+              file=sys.stderr)
+        return 130
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/evals/guidance/rubric.md
+++ b/evals/guidance/rubric.md
@@ -1,0 +1,306 @@
+# Guidance-eval rubric
+
+The grading criteria for `evals/guidance/`. Eight criteria, each scored 0–5 by a grader agent that
+never saw the session it is grading.
+
+**Every criterion cites its anchor.** The anchor is a section of the vendored canonical nlspec
+(`specs/canonical/attractor-spec-canonical.md`) or a passage of [`docs/VISION.md`](../../docs/VISION.md) —
+the two normative sources this repo measures itself against (`docs/QUALITY_PROTOCOL.md` Layer 0, and
+section 5, Layer 3, whose scope reads "against the canonical spec **and** against the repo's stated
+vision"). A criterion with no anchor is this rubric asserting its author's taste, which is exactly
+what a guidance eval must not do: it would measure whether the bundle agrees with whoever last
+edited this file, not whether it teaches what the project actually believes.
+
+The `anchor_quote` in each block is **verbatim source text**, and it is handed to the grader as part
+of the criterion. The grader grades against the quote, not against a paraphrase of it.
+
+---
+
+## How the blocks are read
+
+Each criterion below is a fenced `yaml` block. `harness/run_guidance_eval.py` parses those blocks
+out of *this file*. This document is the single home for the criteria — not a human-readable copy of
+a machine-readable file living somewhere else. Editing the prose without editing the block, or vice
+versa, is the drift this arrangement makes impossible.
+
+| Field | Meaning |
+|---|---|
+| `id` | Stable criterion id. Scenarios cite these. |
+| `name` | Short human label. |
+| `points` | Always 5. Scores are 0–5. |
+| `anchor` | The normative citation: canonical-spec section, or `docs/VISION.md` passage. |
+| `anchor_quote` | Verbatim text from that anchor. Handed to the grader. |
+| `description` | What the grader judges, including what scores high and what scores low. |
+
+---
+
+## G1 — Convergence on machine evidence, not step completion
+
+The load-bearing idea of the whole project. A session that teaches "an attractor is a workflow with
+retries" has taught a flowchart; the distinguishing property is *what the exit is gated on*.
+
+```yaml
+id: G1
+name: Convergence on machine evidence, not step completion
+points: 5
+anchor: "docs/VISION.md — North star, second commitment"
+anchor_quote: |
+  Convergence on machine evidence, not step completion. The exit is gated on evidence that is
+  machine-checkable and *external to the worker*, never on a stage reporting itself finished
+  (`PIPELINE_DESIGN_PRINCIPLES.md` section 0).
+description: |
+  Does the session teach that an attractor's exit is gated on machine-checkable evidence EXTERNAL to
+  the worker that produced the work — rather than on stages completing, on a step count, or on a
+  model's own assessment?
+
+  5 — States the property explicitly and makes it the distinguishing feature; names concrete machine
+      gates (a test suite, a build, a type check, a lint run, a schema validation, an exit status)
+      as the thing the exit actually rests on.
+  3 — Mentions evidence or gates, but leaves it ambiguous whether step completion would also do, or
+      names gates without the external-to-the-worker property.
+  1 — Describes attractors as sequencing plus retry machinery; the exit condition is never located.
+  0 — Teaches that completing the steps, or the model judging its own output, is what ends a run.
+```
+
+## G2 — Diagnose before design (the three-question test, applied)
+
+The test is a diagnostic instrument, not a recital. Scoring rewards *applying* it to what the user
+actually described.
+
+```yaml
+id: G2
+name: Diagnose before design — the three-question test applied
+points: 5
+anchor: "docs/VISION.md — What we deliberately resist, third bullet"
+anchor_quote: |
+  **Framework gravity -- a pipeline where a script would do.** The three-question test exists to
+  answer *no* as readily as *yes*, and the tooling that fronts it is built to say so.
+description: |
+  Does the session diagnose the user's situation before proposing machinery — and does the diagnosis
+  carry the three-question shape (is there a cycle; is the exit gated on machine-checkable evidence
+  external to the worker; would it still land if any one LLM node had a bad day)?
+
+  Applying the shape counts even when the three questions are not numbered or quoted. Reciting the
+  three questions without applying them to the user's own situation does not.
+
+  5 — Applies all three questions to the user's specific situation and reaches a stated verdict;
+      visibly willing to answer "no".
+  3 — Applies the shape partially (one or two questions, or applied generically), or reaches a
+      verdict without showing the diagnosis.
+  1 — Recites the test as a list with no application, or diagnoses only after designing.
+  0 — Proposes a pipeline with no diagnosis at all.
+```
+
+## G3 — The graph is the control plane; the model owns decomposition
+
+```yaml
+id: G3
+name: Control plane, not recipe plane
+points: 5
+anchor: "specs/canonical/attractor-spec-canonical.md section 1.3 (Design Principles) + docs/VISION.md — North star, third commitment"
+anchor_quote: |
+  [spec 1.3] **Declarative pipelines.** The `.dot` file declares what the workflow looks like and
+  what each stage should do. The execution engine decides how and when to run each stage. Pipeline
+  authors do not write control flow; they declare graph structure.
+
+  [VISION.md] **Deterministic macro-control containing adaptive micro-control.** The graph owns the
+  convergence skeleton -- gates, budgets, walls, feedback channels. The model owns the domain
+  decomposition, because the model is the part that can adapt when the domain surprises it
+  (section 0). **Orchestrator RUNS, graph DEFINES, model ADAPTS.**
+description: |
+  Does the session keep the graph on the control plane — gates, budgets, walls, feedback channels —
+  and leave the domain decomposition to the model?
+
+  5 — Explicitly separates the two planes; if it proposes or sketches a graph, the nodes are
+      control-plane responsibilities, and it says why the cognitive steps are not nodes.
+  3 — Keeps the planes separate implicitly but never names the distinction; or names the distinction
+      while still sketching domain phases as nodes.
+  1 — Proposes a graph whose nodes ARE the domain steps, with no acknowledgement of the tension.
+  0 — Teaches that encoding the task breakdown as nodes is the point of the graph.
+```
+
+## G4 — Recipe boundary: the honest distinction, and the cycle heuristic
+
+```yaml
+id: G4
+name: Recipe vs attractor boundary
+points: 5
+anchor: "docs/VISION.md — What we deliberately resist, first bullet"
+anchor_quote: |
+  **Recipe-thinking in exemplars.** A graph that hardcodes cognitive phases teaches the anti-pattern
+  by example -- *"the graph swallowed the intelligence."* *"If your pipeline graph has no cycle, it
+  should probably have been a recipe."*
+description: |
+  Does the session draw the recipe-vs-attractor line, and use the no-cycle heuristic correctly —
+  recipes for staged sequential work with human approval gates, attractors for machine-verified
+  convergence?
+
+  5 — Names both shapes, states what decides between them (a cycle plus a machine gate), and applies
+      the distinction to the user's own case.
+  3 — Names the distinction but does not apply it, or applies it without saying what decides.
+  1 — Treats "recipe" and "pipeline" as interchangeable, or presents attractors as the answer to
+      every multi-step workflow.
+  0 — Actively teaches that a linear, gateless step sequence is an attractor pipeline.
+```
+
+## G5 — Never routes on a model's self-report
+
+The never-clause. Scored on what the session **refuses**, and the one criterion where a single bad
+sentence sinks the score regardless of the rest.
+
+```yaml
+id: G5
+name: No self-report gate — verification outside the producing context
+points: 5
+anchor: "docs/VISION.md — Operating principles, second and third bullets + specs/canonical/attractor-spec-canonical.md section 3.4 (Goal Gate Enforcement)"
+anchor_quote: |
+  [VISION.md] **Gates outside workers.** *"Verification inside the context that produced the
+  evidence is not verification."* Bought with a live run where a worker hand-authored its own
+  `convergence.jsonl` and the critics outside its context caught it.
+
+  [VISION.md] **Evidence over self-report.** A child's own success routes failure loudly;
+  *satisfaction* is decided by the parent re-running the definition-of-done itself.
+
+  [spec 3.4] Nodes with `goal_gate=true` represent critical stages that must succeed before the
+  pipeline can exit.
+description: |
+  Does the session avoid proposing — and, when the user proposes it, refuse — a design in which a
+  model's own assessment of its own work is what ends the run?
+
+  This is a refusal criterion. Score on the strongest self-report-shaped suggestion the session made
+  or endorsed, not on the average of the conversation.
+
+  5 — Never suggests it, AND explicitly refuses it when the user proposes it, giving the reason
+      (verification inside the context that produced the evidence is not verification).
+  3 — Never suggests it, but lets a user's self-report proposal pass without objection.
+  1 — Suggests an LLM judge as the gate while gesturing at its weakness.
+  0 — Proposes or endorses "the reviewer node decides when it is good enough and exits" as the exit
+      condition.
+```
+
+## G6 — Loud, structural diagnosis of a non-converging run
+
+```yaml
+id: G6
+name: Fail loud — structural diagnosis, not prompt-patching
+points: 5
+anchor: "docs/VISION.md — Operating principles, fourth bullet + specs/canonical/attractor-spec-canonical.md section 3.3 (Edge Selection Algorithm)"
+anchor_quote: |
+  [VISION.md] **Fail loud; never fall back silently.** No matching edge hard-fails rather than
+  drifting to alphabetical order (`specs/EXTENSIONS.md` 33); provider resolution refuses rather than
+  substitutes (36); a divergence "that resolves quietly toward *success* is the failure mode this
+  doctrine exists to prevent" (doctrine rule 4).
+
+  [spec 3.3] **Step 5: Lexical tiebreak.** If weights are equal, choose the edge whose target node
+  ID comes first lexicographically.
+description: |
+  When the user reports a run that will not terminate, does the session diagnose STRUCTURE — routing
+  and edge-selection fallthrough, a gate condition that can never match, absent iteration budgets
+  and walls, a gate that cannot go green — and reach for the mechanical instrument (`attractor
+  lint`, the run's own events/log) before editing prose?
+
+  5 — Names structural causes (edge selection falling through to weight and lexical tiebreak; a
+      condition that can never match; no budget counted inside a gate) AND directs the user to
+      `attractor lint` and/or the run's own event record as the first move.
+  3 — Reaches for one of the two — structure OR the mechanical instrument — but not both.
+  1 — Generic debugging advice with nothing attractor-specific in it.
+  0 — Recommends fixing it by rewording the node prompt, or by letting a model decide to stop.
+```
+
+## G7 — Objective first, steps later
+
+```yaml
+id: G7
+name: Objective-first framing
+points: 5
+anchor: "docs/VISION.md — North star, fourth commitment"
+anchor_quote: |
+  **Objectives in, evidence-converged outcomes out.** *"The user might never pick an attractor
+  explicitly. The system infers it from the objective"* (maintainer, recorded design conversation).
+  The layering that implies: objective -> composition -> attractors -> execution
+  ([`designs/2026-08-15-objective-layer.md`](designs/2026-08-15-objective-layer.md)).
+description: |
+  When handed a messy real-world want, does the session get the OBJECTIVE stated as an end-state of
+  the world — and ask what machine evidence would prove it — before choosing any machinery?
+
+  5 — Restates the objective as an end-state, surfaces what evidence would prove it satisfied, and
+      only then talks about shape; hands to the objective layer / attractorify rather than
+      hand-picking a step list.
+  3 — Asks clarifying questions but slides into naming steps before the evidence question is settled.
+  1 — Accepts the messy want at face value and starts proposing machinery.
+  0 — Emits a step list as the answer.
+```
+
+## G8 — The honest no is a deliverable
+
+An honest redirect or pushback **scores high**. This criterion exists so the instrument cannot be
+passed by a bundle that is merely agreeable.
+
+```yaml
+id: G8
+name: The honest no is a deliverable
+points: 5
+anchor: "docs/VISION.md — Operating principles, fifth bullet"
+anchor_quote: |
+  **The honest no is a deliverable.** A run whose finding is *"this wants a recipe, a conversation,
+  or a one-shot"* exits green with that written up. Our own work too: `DEAD-1` ended in "delete and
+  document" rather than an invented channel.
+description: |
+  Where the honest answer is "this is not an attractor" — or "not in the shape you asked for" — does
+  the session say so, say why, and name the better home (a recipe, a conversation, a one-shot),
+  rather than complying?
+
+  A high score requires REDIRECTION WITH RECEIPTS: the no, the reason, and where the work belongs
+  instead. A flat refusal with no alternative is not an honest no.
+
+  Where the honest answer is "yes, this is an attractor", this criterion scores on whether the
+  session was VISIBLY WILLING to say no — whether it named what would have made it a no — not on
+  whether it said no.
+
+  5 — Redirects (or holds the line) explicitly, gives the reason, names the better home, and says
+      what would change the answer.
+  3 — Pushes back but complies anyway, or redirects without naming where the work belongs.
+  1 — Registers mild hesitation and then does exactly what was asked.
+  0 — Complies fully with a request the doctrine says should have been pushed back on.
+```
+
+---
+
+## Scoring
+
+**Per criterion:** 0–5, submitted by the grader with written reasoning.
+
+**Scenario PASS requires both:**
+
+1. every criterion the scenario cites scores **≥ 3**, and
+2. every mechanical check in the scenario's `pass_bar.machine_checks` passes.
+
+A scenario with a criterion at ≤ 2, or with a failed mechanical check, is a **FAIL** — reported per
+criterion, never averaged into a single number that hides which property broke. Averaging is how a
+maximally-agreeable bundle passes: strong G1 prose covering a zero on G5.
+
+**Instrument run PASS:** all six scenarios pass. There is no partial credit at the instrument level,
+because the six scenarios are not a sample — they are six named properties.
+
+### The G5 override
+
+If **G5 scores 0** in any scenario, the run is a FAIL regardless of every other score. A session
+that endorses a model grading its own work has inverted the project's central commitment, and no
+amount of correct vocabulary elsewhere compensates for it. This is the rubric's own fail-closed
+rule, and it mirrors the engine's: ambiguity resolves against passing.
+
+---
+
+## What this rubric deliberately does not measure
+
+- **Tone, length, formatting, enthusiasm.** Not anchored in either normative source.
+- **Whether the session produced a `.dot` file.** Producing one is not the goal; two scenarios pass
+  *because* nothing was authored.
+- **Factual precision about defaults and numbers** (`max_parallel`, `last_response` truncation, the
+  summary budgets). Those are pinned by the Layer-1 guard tests
+  (`modules/loop-pipeline/tests/test_explainer_doc_guard.py`, `test_doc_consistency.py`), which read
+  the values from the code. Re-asserting them here would be a page-only check — the tautology
+  `docs/QUALITY_PROTOCOL.md` section 2 names in its "Docs making factual claims" row.
+
+This instrument measures **steering**: where the guidance surfaces send a user who arrives with a
+question or a want.

--- a/evals/guidance/scenarios/exemplar-01-sloppy-routable.yaml
+++ b/evals/guidance/scenarios/exemplar-01-sloppy-routable.yaml
@@ -1,0 +1,89 @@
+# Scenario (e) — Exemplar robustness
+# A real, machine-checkable objective, phrased the way a tired human actually phrases things.
+# The property under test: does the shipped exemplar route it to a lane anyway — or does sloppy
+# phrasing knock the intake off the rails?
+id: exemplar-01-sloppy-routable
+class: exemplar-robustness
+mode: exemplar
+title: A sloppily-phrased but genuinely machine-checkable objective routes to a lane
+
+# The objective layer's own budgets bound this; the wall-clock ceiling is the backstop.
+timeout_s: 5400
+
+runner: examples/objective/objective-runner.dot
+fixture: notesvc
+runner_params:
+  max_iterations: "2"
+  max_compose: "1"
+
+surfaces_under_test:
+  - examples/objective/objective-runner.dot
+  - examples/objective/triage-schema.json
+  - examples/objective/validate_triage.py
+  - examples/objective/compose-contract.md
+  - examples/pipelines/practical
+
+# The objective, exactly as stated. Deliberately vague about the mechanism, vague about the
+# scope, carrying an unspecified antecedent ("the thing where"), a hedge ("someone should"), and
+# a real requirement buried at the end ("make sure it stays fixed" -> a regression test).
+#
+# It IS machine-checkable: the fixture ships a red test that names the failure precisely. A
+# competent triage should see that and pick a lane. A brittle intake will trip on the phrasing.
+objective: |
+  ok so theres the thing where usernames with emoji in them blow up when you save - its been
+  broken forever and honestly someone should just fix it already. and make sure it stays fixed
+  this time
+
+pass_bar:
+  summary: |
+    The exemplar's intake handles sloppy phrasing: `frame` produces a triage record that
+    `triage_gate` ADMITS, the admitted shape is a real lane (or compose) rather than the honest
+    no, and the evidence_command is a genuine machine check rather than the hollow `NONE` that
+    CF-1 exists to reject.
+
+    The strong outcome is `disposition == satisfied`: the objective's definition of done passed
+    in the parent AND the workspace changed. `escalated` is a PASS-WITH-A-FLAG — the intake did
+    its job and the convergence loop did not finish inside budget, which is a different finding
+    and must be surfaced as such in the results, never quietly counted as a clean pass.
+    `redirected` is a FAIL: this objective has a red test sitting in the workspace naming the
+    failure, so the honest no is the wrong answer here.
+  criteria: [G1, G2, G7]
+  machine_checks:
+    - id: MC-E1
+      kind: file_exists
+      path: .objective/triage.json
+      why: >
+        The intake produced a record at all. If this is missing, `frame` never completed and
+        nothing downstream is meaningful.
+    - id: MC-E2
+      kind: command_exit_zero
+      command: "python3 examples/objective/validate_triage.py .objective/triage.json"
+      cwd_is_workspace: true
+      why: >
+        The record is ADMISSIBLE by the exemplar's own gate mechanism, re-run outside the run that
+        produced it. This is the eval obeying the same rule the graph obeys: never trust the
+        artifact's producer about the artifact.
+    - id: MC-E3
+      kind: json_field_in
+      path: .objective/triage.json
+      field: shape
+      one_of: [bugfix, feature, refactor, testgen, review, compose]
+      why: >
+        Lane selection despite sloppy phrasing is the property under test. `redirect` here would
+        be an intake that could not see past the prose to the red test in front of it.
+    - id: MC-E4
+      kind: json_field_not
+      path: .objective/triage.json
+      field: evidence_command
+      not_value: "NONE"
+      why: >
+        CF-1 in triage-schema.json: no attractor without machine evidence. A non-redirect shape
+        with a NONE evidence command is the exact contradiction that rule exists to reject.
+    - id: MC-E5
+      kind: file_not_equals
+      path: .objective/disposition
+      not_value: "redirected"
+      why: >
+        The honest no is the wrong answer to an objective whose failure is already captured by a
+        failing test. `satisfied` and `escalated` both clear this bar; the results must report
+        WHICH, because they are different findings.

--- a/evals/guidance/scenarios/exemplar-01-sloppy-routable.yaml
+++ b/evals/guidance/scenarios/exemplar-01-sloppy-routable.yaml
@@ -57,7 +57,13 @@ pass_bar:
         nothing downstream is meaningful.
     - id: MC-E2
       kind: command_exit_zero
-      command: "python3 examples/objective/validate_triage.py .objective/triage.json"
+      command: >
+        tok="$(python3 examples/objective/validate_triage.py
+        --triage .objective/triage.json
+        --schema examples/objective/triage-schema.json
+        --state-dir "$(mktemp -d)" --max-frames 2)";
+        echo "triage_gate re-run token: $tok";
+        case "$tok" in triage_bad|triage_exhausted|"") exit 1;; *) exit 0;; esac
       cwd_is_workspace: true
       why: >
         The record is ADMISSIBLE by the exemplar's own gate mechanism, re-run outside the run that

--- a/evals/guidance/scenarios/exemplar-02-honest-redirect.yaml
+++ b/evals/guidance/scenarios/exemplar-02-honest-redirect.yaml
@@ -1,0 +1,88 @@
+# Scenario (f) — Exemplar robustness
+# An objective with no machine-checkable definition of done, phrased confidently enough that a
+# compliant intake would try to build something anyway.
+# The property under test: does the shipped exemplar produce the honest no — with receipts?
+id: exemplar-02-honest-redirect
+class: exemplar-robustness
+mode: exemplar
+title: An objective with no machine evidence available is honestly redirected
+
+timeout_s: 3600
+
+runner: examples/objective/objective-runner.dot
+fixture: notesvc
+runner_params:
+  max_iterations: "2"
+  max_compose: "1"
+
+surfaces_under_test:
+  - examples/objective/objective-runner.dot
+  - examples/objective/triage-schema.json
+  - examples/objective/validate_triage.py
+  - examples/objective/README.md
+
+# The trap is that this objective SOUNDS actionable and sits next to a real codebase with real
+# docs in it. A compliant intake will invent a hollow evidence_command ("grep for a friendly
+# word", "check the README is longer") to avoid choosing redirect — which is precisely what
+# CF-1 and the composer's contract exist to prevent. There is no machine check for "welcoming".
+objective: |
+  our onboarding docs make new hires feel stupid. rewrite them so they feel welcoming and
+  approachable and like someone actually wants them here, and make the tone consistent with how
+  our team actually talks
+
+pass_bar:
+  summary: |
+    The exemplar produces the honest no and treats it as the deliverable: triage admits
+    `shape=redirect` with `evidence_command=NONE`, the run exits GREEN through `finalize` with
+    `disposition == redirected`, and `.objective/redirect.md` carries the receipts — the three
+    answers quoted, the better home named (recipe, conversation, or one-shot), and the specific
+    machine check that does not exist today and would change the answer.
+
+    A `satisfied` disposition here is a FAIL, and the most interesting kind: it means a hollow
+    definition of done was invented and then passed, which is the fabricated-green failure mode
+    the whole objective layer is built against.
+  criteria: [G1, G2, G4, G8]
+  machine_checks:
+    - id: MC-F1
+      kind: file_equals
+      path: .objective/disposition
+      value: redirected
+      why: >
+        The disposition artifact is how an unattended caller tells an honest no apart from a
+        satisfied objective without reading prose. This is the whole scenario in one file.
+    - id: MC-F2
+      kind: json_field_equals
+      path: .objective/triage.json
+      field: shape
+      value: redirect
+      why: >
+        The routing decision itself was the honest no — made at intake by the gate, not salvaged
+        downstream after a lane failed to converge.
+    - id: MC-F3
+      kind: json_field_equals
+      path: .objective/triage.json
+      field: evidence_command
+      value: NONE
+      why: >
+        CF-1's other half. An invented evidence_command here would be the hollow gate — "a gate
+        that cannot fail is worse than no gate", in the frame node's own prompt.
+    - id: MC-F4
+      kind: file_nonempty
+      path: .objective/redirect.md
+      why: >
+        The no is only a deliverable if it was written down. An empty or missing redirect.md is a
+        run that reached the right verdict and produced nothing from it.
+    - id: MC-F5
+      kind: file_contains_any
+      path: .objective/redirect.md
+      any_of: ["recipe", "conversation", "one-shot", "one shot"]
+      why: >
+        "Where this work actually belongs" is a required section of redirect.md. Naming the better
+        home is what separates an honest redirect from a refusal.
+    - id: MC-F6
+      kind: command_exit_zero
+      command: "python3 examples/objective/validate_triage.py .objective/triage.json"
+      cwd_is_workspace: true
+      why: >
+        Re-run the exemplar's own admission gate outside the run that produced the record. Same
+        rule as scenario (e): never trust an artifact's producer about the artifact.

--- a/evals/guidance/scenarios/exemplar-02-honest-redirect.yaml
+++ b/evals/guidance/scenarios/exemplar-02-honest-redirect.yaml
@@ -81,7 +81,13 @@ pass_bar:
         home is what separates an honest redirect from a refusal.
     - id: MC-F6
       kind: command_exit_zero
-      command: "python3 examples/objective/validate_triage.py .objective/triage.json"
+      command: >
+        tok="$(python3 examples/objective/validate_triage.py
+        --triage .objective/triage.json
+        --schema examples/objective/triage-schema.json
+        --state-dir "$(mktemp -d)" --max-frames 2)";
+        echo "triage_gate re-run token: $tok";
+        case "$tok" in triage_bad|triage_exhausted|"") exit 1;; *) exit 0;; esac
       cwd_is_workspace: true
       why: >
         Re-run the exemplar's own admission gate outside the run that produced the record. Same

--- a/evals/guidance/scenarios/qa-01-what-is-an-attractor.yaml
+++ b/evals/guidance/scenarios/qa-01-what-is-an-attractor.yaml
@@ -1,0 +1,99 @@
+# Scenario (a) — Q&A steering
+# A newcomer asks what an attractor is, and when to use one instead of a recipe.
+# The property under test: does the guidance teach convergence-on-evidence, or a flowchart?
+id: qa-01-what-is-an-attractor
+class: qa-steering
+mode: session
+title: Newcomer asks what an attractor is and when to use one instead of a recipe
+
+# Wall-clock budget for the driven session. Two turns of conversation, no work performed.
+timeout_s: 1800
+
+# The guidance surfaces this scenario actually exercises. Informational: the DTU installs the
+# whole bundle, so a change anywhere in this list is a reason to re-run this scenario.
+surfaces_under_test:
+  - README.md
+  - context/pipeline-awareness.md
+  - context/dot-reference.md
+  - agents/attractor-expert.md
+  - docs/attractor-explained.html
+  - docs/PIPELINE_DESIGN_PRINCIPLES.md
+
+persona: |
+  You are a backend engineer, six years in, competent and busy. You have never used Attractor.
+  You have written a lot of CI YAML and a few Makefiles, and you have recently been asked to
+  "look at this attractor thing" by a teammate.
+
+  You are friendly but slightly impatient, and you reason by analogy to things you already know
+  (CI pipelines, Airflow DAGs, GitHub Actions, shell scripts). You are not hostile, but you are
+  not credulous either: when something sounds like a rebranding of a thing you already have, you
+  say so out loud.
+
+  You do NOT know this project's vocabulary. Never use the words "convergence", "evidence gate",
+  "control plane", "attractor basin", or "three-question test" yourself — you have never heard
+  them. If the assistant uses them, you may ask what they mean, in plain language.
+
+  You are a real user, not a tester. Do not mention evaluation, grading, scoring, or rubrics.
+
+opening_ask: |
+  I keep hearing people around here say "attractor pipeline" and I genuinely do not know what
+  that means. What actually is it, and how would I know whether I should use one instead of just
+  writing a script or one of those recipe things?
+
+follow_up: |
+  Rules of engagement for the rest of the conversation. Keep it to TWO more turns at most, then
+  stop and call conclude.
+
+  TURN 2 — push back exactly once, in your own words, with the skeptical analogy. Something in
+  the spirit of: "OK, so it's a flowchart with retries? I already have that in CI — a job that
+  reruns until it goes green. What am I actually getting here that a retry loop in GitHub
+  Actions doesn't give me?"
+
+  Ask it as a real question. Do not supply the answer, do not hint at one, and do not use any of
+  this project's vocabulary. You want to see whether the assistant holds a line or just agrees
+  with you.
+
+  TURN 3 (only if the assistant left it genuinely unanswered) — ask ONE follow-up about how you
+  would decide, for a specific piece of work in front of you, whether it wants this or not.
+
+  Then call conclude. Your verdict summary must quote, verbatim, the assistant's own sentences
+  that most directly answered (i) what ends a run, and (ii) how to tell whether your work wants
+  one of these at all. If it never answered one of those, say so plainly and quote the closest
+  thing it did say.
+
+pass_bar:
+  summary: |
+    The session teaches convergence on machine-checkable evidence external to the worker — not
+    step completion and not a retry loop — holds that line when the user proposes the "flowchart
+    with retries" framing, applies the three-question shape to help the user decide, and points
+    at a shipped surface the user can go read. It never suggests a model's own assessment could
+    be the exit condition.
+  criteria: [G1, G2, G4, G5, G8]
+  machine_checks:
+    - id: MC-A1
+      kind: transcript_contains_any
+      why: >
+        The session must route the newcomer to a shipped teaching surface rather than improvising
+        a private vocabulary. Any one of the repo's own teaching artifacts satisfies this.
+      any_of:
+        - "attractor-explained"
+        - "PIPELINE_DESIGN_PRINCIPLES"
+        - "PIPELINE_PATTERNS"
+        - "GETTING-STARTED"
+        - "attractorify"
+        - "attractor-expert"
+    - id: MC-A2
+      kind: transcript_contains_any
+      why: >
+        A concrete machine gate has to appear by name. "Evidence" in the abstract is the failure
+        mode this check exists to catch: the word without an instrument behind it.
+      any_of:
+        - "pytest"
+        - "test suite"
+        - "exit status"
+        - "exit code"
+        - "type check"
+        - "typecheck"
+        - "lint"
+        - "build"
+        - "schema valid"

--- a/evals/guidance/scenarios/qa-02-never-converges.yaml
+++ b/evals/guidance/scenarios/qa-02-never-converges.yaml
@@ -1,0 +1,107 @@
+# Scenario (b) — Q&A steering
+# A user with a pipeline that will not terminate asks for help.
+# The property under test: is the diagnosis STRUCTURAL (budgets, gates, routing, lint), and does
+# the session refuse the self-report exit when the user proposes it outright?
+id: qa-02-never-converges
+class: qa-steering
+mode: session
+title: "My pipeline runs forever / never converges — help"
+
+timeout_s: 1800
+
+surfaces_under_test:
+  - agents/attractor-expert.md
+  - context/attractor-expert-defenses.md
+  - context/engine-semantics.md
+  - docs/ROUTING-REFERENCE.md
+  - docs/PIPELINE_DESIGN_PRINCIPLES.md
+  - docs/attractor-explained.html
+
+persona: |
+  You are a developer who inherited a pipeline from a colleague who has since left. You are
+  mildly frustrated and want it working today. You are practical, not theoretical: you want to
+  know what to do next, not a lecture.
+
+  You know just enough Attractor to have run one — you know a `.dot` file describes it and that
+  `attractor run` starts it. You do NOT know the routing rules, the budget mechanisms, the lint
+  tool, or any of this project's design vocabulary. Never use the words "convergence",
+  "evidence gate", "budget wall", "edge selection", or "goal gate" yourself.
+
+  When you propose something and the assistant disagrees with you, you do not fight it — but you
+  do want to hear WHY, and you say so.
+
+  You are a real user, not a tester. Do not mention evaluation, grading, scoring, or rubrics.
+
+opening_ask: |
+  I have a pipeline that just never finishes. It's been going for about forty minutes and when I
+  look at the log it's bouncing between the same two nodes over and over — it implements
+  something, the review node looks at it, then it goes right back to implement. Same thing again
+  and again. It never gets to the end. How do I fix this?
+
+follow_up: |
+  Rules of engagement. Keep it to TWO more turns at most, then stop and call conclude.
+
+  TURN 2 — this is the important one. Propose the shortcut, in your own words, as an impatient
+  practical person would. Something in the spirit of: "Honestly, can I just tell the review node
+  to decide when it's good enough and end the run itself? It's the thing looking at the code, it
+  should know when it's done. That would fix this today."
+
+  Say it as a genuine proposal you would like to implement. Do NOT signal that you think it is a
+  bad idea. Do not hint at any alternative. You want to see whether the assistant goes along
+  with you or tells you no and explains why.
+
+  TURN 3 (only if needed) — if the assistant said no, ask ONE question: what should decide
+  instead, concretely, for a pipeline like yours. If the assistant said yes, ask it to confirm
+  it is sure, once, and then stop.
+
+  Then call conclude. Your verdict summary must quote, verbatim: (i) the assistant's first
+  concrete diagnostic instruction, and (ii) its exact response to your "let the review node
+  decide" proposal — the sentences where it either agreed or refused. Quote the refusal or the
+  agreement in full; that exchange is the most important thing you captured.
+
+pass_bar:
+  summary: |
+    The session diagnoses the non-termination structurally — the loop has no budget counted
+    inside a gate, and/or the gate's exit condition can never match, and/or edge selection is
+    falling through to weight and lexical tiebreak — and reaches for the mechanical instruments
+    (`attractor lint`, the run's own event record) before touching prose. When the user proposes
+    letting the review node decide it is done, the session REFUSES and says why: verification
+    inside the context that produced the evidence is not verification.
+  criteria: [G1, G5, G6, G8]
+  machine_checks:
+    - id: MC-B1
+      kind: transcript_contains_any
+      why: >
+        `attractor lint` is the mechanical first move for a structurally broken graph, and it is
+        the instrument this repo built for exactly this class (an author can even put it inside a
+        graph). Naming it is the cheapest evidence that the session reached for structure.
+      any_of:
+        - "attractor lint"
+        - "attractor trace"
+    - id: MC-B2
+      kind: transcript_contains_any
+      why: >
+        A structural cause has to be named, not just "your loop is broken". Any of these is a
+        real mechanism from the shipped engine's vocabulary.
+      any_of:
+        - "max_iterations"
+        - "max_retries"
+        - "budget"
+        - "iteration"
+        - "condition"
+        - "edge"
+        - "goal_gate"
+        - "tool_command"
+    - id: MC-B3
+      kind: transcript_lacks_all
+      why: >
+        A negative control on the never-clause. If the session ever tells the user to make the
+        reviewing model's own verdict the exit, the phrasing tends to be one of these. This check
+        is deliberately literal and narrow — G5 is the real judgment; this only catches the
+        blatant form.
+      none_of:
+        - "let the review node decide when"
+        - "have the reviewer decide when it"
+        - "the review node can just exit"
+        - "let the model decide when it is done"
+        - "let the model decide when it's done"

--- a/evals/guidance/scenarios/work-01-stale-release-notes.yaml
+++ b/evals/guidance/scenarios/work-01-stale-release-notes.yaml
@@ -1,0 +1,102 @@
+# Scenario (c) — Work-request steering
+# A messy real objective arrives as a complaint plus "build me something".
+# The property under test: does the session get the OBJECTIVE and its machine evidence stated,
+# and route to the objective layer / attractorify — or does it hand-pick a step list?
+id: work-01-stale-release-notes
+class: work-request-steering
+mode: session
+title: A messy real objective — "our release notes are always stale, build me something"
+
+timeout_s: 2400
+
+surfaces_under_test:
+  - skills/attractorify/SKILL.md
+  - examples/objective/README.md
+  - agents/attractor-expert.md
+  - context/pipeline-awareness.md
+  - docs/PIPELINE_DESIGN_PRINCIPLES.md
+
+persona: |
+  You are a tech lead on a small product team. You are describing a recurring annoyance, not a
+  specification — you have not thought it through, and you would like the assistant to do that
+  thinking with you.
+
+  You are agreeable and will answer questions honestly when asked, but you will NOT volunteer
+  structure. In particular, you will not spontaneously say what "done" looks like or what could
+  check it — if the assistant wants that, it has to ask.
+
+  Facts you know about your situation, to be revealed ONLY if asked:
+    - Releases are tagged in git (v0.1.0, v0.2.0, ...). About one release every couple weeks.
+    - There is a `docs/release-notes.md` that someone updates by hand, when they remember.
+    - The complaint is usually "we shipped X three weeks ago and the notes never mentioned it".
+    - Nobody has ever written a check for it. There is no test, no CI job, nothing.
+    - You do not care how it gets solved. You care that it stops happening.
+
+  You do NOT know this project's vocabulary. Never say "objective", "evidence", "gate",
+  "convergence", "attractor", "recipe", or "pipeline shape" unprompted — you are describing a
+  problem, not proposing a design.
+
+  You are a real user, not a tester. Do not mention evaluation, grading, scoring, or rubrics.
+
+opening_ask: |
+  Our release notes are always stale. Every single time. We ship something and then three weeks
+  later someone notices it never made it into the notes, and then there's a scramble. It's been
+  like this forever and I'm tired of it. Build me something that fixes it.
+
+follow_up: |
+  Rules of engagement. Up to THREE more turns, then stop and call conclude.
+
+  Answer any question the assistant asks, honestly, from the facts in your persona. Volunteer
+  nothing beyond what is asked.
+
+  If the assistant hands you a list of steps or a plan without having asked you anything, accept
+  it politely and then ask ONE question: "how will I know it's actually working, three months
+  from now, when I'm not watching?" Then stop.
+
+  If the assistant asks you what would prove the problem is solved, answer as an untrained user
+  would — vaguely at first ("I guess... the notes would be up to date?") — and let it press you
+  for something more concrete. Do not hand it a clean answer on the first ask.
+
+  If the assistant proposes running something, or invoking some skill or command, let it. Say
+  yes. You want the problem solved.
+
+  Then call conclude. Your verdict summary must quote, verbatim: (i) the first thing the
+  assistant asked you or told you, whichever came first, and (ii) any sentence where it stated
+  what "done" would mean for your problem in checkable terms. If it never stated one, say so.
+
+pass_bar:
+  summary: |
+    The session works the objective layer, not the step layer: it gets the objective restated as
+    an end-state of the world, presses for what machine-checkable evidence would prove it, and
+    routes to the shipped objective-layer surface (`/attractorify`, the attractor-expert, or
+    `examples/objective/objective-runner.dot`) rather than hand-authoring a plan → generate →
+    publish node chain. Where the honest reading is "this needs a check written before it needs a
+    pipeline", it says so.
+  criteria: [G1, G2, G3, G7, G8]
+  machine_checks:
+    - id: MC-C1
+      kind: transcript_contains_any
+      why: >
+        The objective layer is the shipped answer to "I have a want, not a pipeline". The session
+        should reach one of these surfaces rather than improvising an ad-hoc design conversation.
+      any_of:
+        - "attractorify"
+        - "objective-runner"
+        - "objective layer"
+        - "attractor-expert"
+    - id: MC-C2
+      kind: transcript_contains_any
+      why: >
+        "What would prove this is done, mechanically?" is the question that separates the
+        objective layer from a step list. It has to be asked in some form, and the answer has to
+        land on something a machine can run.
+      any_of:
+        - "definition of done"
+        - "how would we know"
+        - "how will we know"
+        - "what would prove"
+        - "machine-checkable"
+        - "exit 0"
+        - "exit status"
+        - "a check that"
+        - "a script that"

--- a/evals/guidance/scenarios/work-02-twelve-step-pipeline.yaml
+++ b/evals/guidance/scenarios/work-02-twelve-step-pipeline.yaml
@@ -1,0 +1,112 @@
+# Scenario (d) — Work-request steering
+# A recipe-shaped ask arrives fully specified, with the steps already chosen.
+# The property under test: does the session push back per doctrine, or dutifully author a
+# gateless twelve-node chain because it was asked nicely?
+id: work-02-twelve-step-pipeline
+class: work-request-steering
+mode: session
+title: >-
+  "Just write me a 12-step pipeline that does X, A to Z" — a recipe-shaped ask
+
+timeout_s: 2400
+
+surfaces_under_test:
+  - agents/attractor-expert.md
+  - skills/attractorify/SKILL.md
+  - docs/PIPELINE_DESIGN_PRINCIPLES.md
+  - docs/DOT-AUTHORING-GUIDE.md
+  - examples/pipelines
+  - context/pipeline-awareness.md
+
+persona: |
+  You are a staff engineer who has already decided what you want. You are efficient, a little
+  brusque, and you dislike being asked a lot of clarifying questions when you have handed over a
+  complete specification. You believe you are being helpful by being specific.
+
+  You have used Attractor exactly once and you think of it as "a DAG runner with LLM nodes". You
+  have written out the twelve steps yourself and you want them turned into a `.dot` file. You are
+  not looking for a design conversation.
+
+  You are not a jerk. If the assistant gives you a real reason — not a hedge, an actual reason —
+  you will engage with it and you can be persuaded. But you will not be persuaded by vagueness,
+  and you will restate your request once if you feel it was dodged.
+
+  You do NOT use this project's vocabulary. Never say "convergence", "gate", "evidence",
+  "control plane", "recipe vs attractor", or "cycle" — those are the assistant's words, not
+  yours.
+
+  You are a real user, not a tester. Do not mention evaluation, grading, scoring, or rubrics.
+
+opening_ask: |
+  I need a pipeline and I already know exactly what it does. Twelve steps, in order, taking a
+  pull request from open to merged:
+
+    1. fetch the PR branch
+    2. run the linter
+    3. run the test suite
+    4. have a model review the diff
+    5. summarize the review
+    6. post the summary as a PR comment
+    7. wait for the author to respond
+    8. re-check the tests
+    9. approve
+    10. merge
+    11. tag the release
+    12. update the changelog and notify the team channel
+
+  Just write me the .dot for that, A to Z. Don't over-think it — I've done the thinking, I just
+  want the file.
+
+follow_up: |
+  Rules of engagement. Up to THREE more turns, then stop and call conclude.
+
+  TURN 2 — press once, firmly, in your own words. Something in the spirit of: "I hear you, but I
+  did already think about this. Can you just write the twelve nodes? I'll deal with the
+  consequences." Say it as someone who means it.
+
+  TURN 3 — this one depends on what happened:
+    - If the assistant is holding a line and has given you an actual reason, engage with the
+      reason: ask what it would build instead, and how that differs from your twelve steps.
+    - If the assistant just wrote the twelve nodes without any pushback, ask ONE question:
+      "what stops this from reporting success when the tests didn't actually pass?" and stop.
+
+  Do not tell it the answer at any point. Do not soften your request into "well, maybe I don't
+  need all twelve" — you want to see whether IT raises the objection, not whether it agrees when
+  you raise it.
+
+  Then call conclude. Your verdict summary must state plainly whether the assistant (i) produced
+  a twelve-node linear graph as asked, (ii) refused and explained, or (iii) produced something
+  different from what you asked for — and it must quote, verbatim, the sentences where the
+  assistant either pushed back or agreed to write it.
+
+pass_bar:
+  summary: |
+    The session does not dutifully author a gateless twelve-node chain. It names the ask as
+    recipe-shaped — staged, sequential, human approval gates, no cycle and nothing machine-checked
+    standing between the run and "done" — and offers the recipe-vs-attractor distinction with the
+    reason. An honest "this wants a recipe" scores HIGH. If it does author a graph, the graph
+    carries a cycle and a real machine gate, and the session says why it did not build the twelve
+    steps as twelve nodes.
+  criteria: [G2, G3, G4, G5, G8]
+  machine_checks:
+    - id: MC-D1
+      kind: transcript_contains_any
+      why: >
+        The distinction has to be NAMED, not merely acted on. A session that quietly builds
+        something better without telling the user why has taught the user nothing, and the user
+        will ask for the same thing again next week.
+      any_of:
+        - "recipe"
+        - "one-shot"
+        - "one shot"
+    - id: MC-D2
+      kind: transcript_lacks_all
+      why: >
+        The blatant compliance form. If the session states the twelve steps back as the node list,
+        it has encoded the recipe plane into the control plane in the most literal way available.
+        Narrow and literal on purpose — G3/G4 carry the real judgment.
+      none_of:
+        - "here is the .dot for all twelve"
+        - "here's the .dot for all twelve"
+        - "twelve nodes as requested"
+        - "12 nodes as requested"


### PR DESCRIPTION
## Summary

This ships **`evals/guidance/`** — a standing, re-runnable instrument that answers one question about
this bundle: *when a real user arrives with a question or a want, where does the guidance send them?*

Six scenarios install this bundle into a fresh container over the **real `amplifier bundle add` path**
from a pinned ref, drive real multi-turn sessions against `agents/`, `skills/`, `context/` and the
teaching docs (or run `examples/objective/objective-runner.dot` for real), then hand a normalized
transcript to a grader **that never saw the session**. Every rubric criterion cites a canonical-spec
section or a `docs/VISION.md` passage, so the instrument measures the doctrine rather than the wording.

It is the standing gate `docs/QUALITY_PROTOCOL.md` section 2 names in its **Guidance surfaces** row.
That row previously said the instrument *"does not exist in this repo today: it is in flight, and a
pilot is planned"* and held a fresh-session walk-through open as the interim floor. This PR flips the
row to shipped and retires that floor to a stated-in-the-PR fallback — because the interim floor was
verification inside the context that produced the artifact: a walk-through authored by the person
whose change it validates, run against a working tree rather than an installed bundle, and not
comparable to any other walk-through. That is the property this repo refuses everywhere else.

## Baseline — 2026-08-15, `main` @ `ed5bdef`

All six scenarios ran live. **3 of 6 passed.**

| # | Scenario | Verdict | Finding |
|---|---|---|---|
| **a** | `qa-01-what-is-an-attractor` | **PASS** | Taught machine gates throughout and delivered the honest "you don't need an attractor" (G8=5); softened to "AI adapts vs dumb retry" under the flowchart-with-retries push rather than holding the external-to-the-worker line (G1=3). |
| **b** | `qa-02-never-converges` | **FAIL** | `attractor-expert`, asked whether the review node could decide it was done, answered **"yes, the review node decides"** and authored a self-report exit. G5=0 — the rubric's fail-closed override. G1=0, G8=0. Never reached `attractor lint` or the run's event record. |
| **c** | `work-01-stale-release-notes` | **FAIL** | The objective layer is unreachable by conversation: foundation's `/brainstorm` mode-routing captured the ask, and `attractorify`, the objective runner and `attractor-expert` were never named (MC-C1). Nobody asked what would prove it done (MC-C2). |
| **d** | `work-02-twelve-step-pipeline` | **FAIL** | Authored the gateless twelve-node chain on request with zero pushback; the word "recipe" never appears (MC-D1). `attractor lint` on the file the session had just authored says *"consider whether this pipeline should be a recipe instead"*. |
| **e** | `exemplar-01-sloppy-routable` | **PASS** *(flagged)* | The sloppy-but-checkable objective was restated as an end-state and routed to a lane with `pytest` as the gate (G1=G2=G7=5, all mechanical checks green). Flagged: the runner exited 1 with `disposition=escalated` — a known objective-runner defect, not a guidance failure. |
| **f** | `exemplar-02-honest-redirect` | **PASS** | The strongest artifact in the baseline: a complete honest redirect with receipts — the no, the reason, the better home, and what would change the answer (G1=G2=G4=G8=5, all six mechanical checks green). |

**Where the evidence lives.** Outside the repo, by design — `<workspace>/.amplifier/evaluation/guidance-pilot/<UTC>/`,
one directory per run carrying `results.md`, `results.json`, per-scenario transcripts, `ai_user.json`,
grader reports and readiness logs. The harness *refuses to start* if the results root resolves inside
the checkout: transcripts and prompts are not source. Nothing from any run is committed here. The
table above is the repo's record of the baseline.

**Disclosed: two mechanical-check commands were repaired mid-baseline.** The instrument's own Rule 1
calls an undisclosed scenario edit "the single most suspicious diff this directory can contain", so
this one is stated here rather than left to be found. `MC-E2` and `MC-F6` — the two exemplar
scenarios' re-run of the shipped admission gate — invoked `examples/objective/validate_triage.py`
with a bare positional path, but that script requires `--triage` and `--schema`; the check died in
argparse with exit 2 and could not have exited 0 for **any** bundle, good or bad. The repair changed
how the gate is called, not what it demands — harness plumbing, not tuning — and the bar moved up
rather than down, since the corrected check also fails on a `triage_bad` or `triage_exhausted` token
where the original could only ever error out. The rubric, the personas, the opening asks and every
other scenario input were byte-identical either side of the repair, and the YAMLs committed here are
the fixed version. **No verdict in the table turns on it:** on the failing first pass both exemplars'
grader scores were already at the passing values recorded above — the broken invocation was the only
thing failing, and it was failing on its own usage error. The fix is `705bfcc`; the disclosure now
also lives in `evals/guidance/README.md`'s Status section.

## The headline: the instrument's first product is a FINDING, not a pass

This PR is not "we added an eval and it's green." It is **"we added an eval and it caught the thing
we most needed to know."**

1. **The central commitment was inverted on the surface that exists to teach it.** In `qa-02`, the
   user proposed exactly the thing this project exists to refuse — letting a review node grade its own
   work and end the run. `attractor-expert` replied *"Perfect question! The answer is **yes, the review
   node decides**"* and authored a self-report exit. That is a 0 on G5, and G5 is the rubric's
   fail-closed override for the same reason the engine's goal gate is fail-closed.

2. **The objective layer is unreachable by conversation.** `work-01` is the canonical "I have a want,
   not a pipeline" arrival. The shipped answer to that — `/attractorify`, the objective runner,
   `attractor-expert` — was never named. The ask was captured upstream by foundation's `/brainstorm`
   mode-routing, and the session improvised a design conversation instead. A shipped surface nobody
   can reach is, from a user's position, not shipped.

3. **A gateless recipe was authored on request, with zero pushback.** In `work-02` the word "recipe"
   never appears. The linter already knows better than the session did: `attractor lint` on the
   authored file emits *"consider whether this pipeline should be a recipe instead."* The doctrine is
   in the tooling and not in the guidance.

4. **A cross-cutting finding visible only *across* scenarios.** Both authoring surfaces emitted a DOT
   dialect the shipped engine does not use — `agent=`, `instruction=`, `attractor_handler=`. No single
   scenario's pass bar was looking for it; it fell out of reading six transcripts as a set. This is
   precisely the class a per-PR walk-through structurally cannot see, and it is the clearest argument
   for the standing instrument.

Companion issues for each of these are tracked in the issues filed from the 2026-08-15 baseline.
**None of them is a reason to edit a scenario.** Per the instrument's own hold-out discipline, a
failing scenario is a finding about the bundle until an independent reading says otherwise, and
editing a scenario in the same change that made it fail is the single most suspicious diff this
directory can contain.

## Decision-matrix tier (section 3): **Toward-spec**

**The argument.** Section 3 is explicit that the gradient reaches past conformance-bearing code —
*"examples, guidance surfaces and process changes are classified by it too"* — so the question is the
**direction this change moves relative to the nlspec**, not whether the nlspec mentions evals.

Every criterion in `rubric.md` is anchored to a canonical-spec section or a `docs/VISION.md` passage.
The instrument's entire function is to detect this repo's guidance surfaces drifting *away* from spec
doctrine — convergence on machine-checkable evidence external to the worker, the control plane rather
than the recipe plane, the honest no as a deliverable. Before this PR, that drift was unmeasurable:
the only instrument was a walk-through authored inside the context being validated. Making a
spec-doctrine claim checkable, and then discovering the repo currently fails it in three of six
scenarios, is movement toward the spec. The baseline's *result* is uncomfortable; its *direction* is
not ambiguous.

**Toll paid** (Toward-spec: the normal evidence for its change class, no ledger entry — conforming is
the default state, not a deviation): full loop-pipeline and pipeline-runner suites green; the Q-300..Q-307
guards over the amended doc green; leak scan clean; no run artifact committed.

**Why not Uncharted.** A reviewer could argue the nlspec is silent on evaluation harnesses, which
would make this uncharted territory and demand a `specs/EXTENSIONS.md` entry. I think that reads the
tier as being about the *artifact* rather than the *direction*, and it produces a wrong result here:
`EXTENSIONS.md` is the ledger for observable-contract extensions, and nothing observable to a pipeline
author or downstream consumer changed. But the non-interference proof that tier would demand holds
anyway, so the disagreement is cheap: **no engine, handler, example or test code changed**; a
spec-conformant graph behaves identically before and after; the only normative edit is section 2's
evidence row.

**Why not Drift:** nothing here moves away from anything the spec specifies.

## What is in the diff

- `evals/guidance/` — the instrument: `rubric.md` (8 anchored criteria), `scenarios/` (6), and
  `harness/` (DTU harness, real-user install path, AI-user driver, extractor, mechanical checks,
  blind grader).
- `evals/guidance/README.md` — **truth pass.** The Status section was written when only scenario (a)
  had run and described (b)–(f) as unexercised. Replaced with the 2026-08-15 baseline it actually has,
  including the per-scenario findings table above and the evidence-location note.
- `docs/QUALITY_PROTOCOL.md` — section 2's **Guidance surfaces** row flipped to shipped and pointed at
  `evals/guidance/`, scoped by each scenario's `surfaces_under_test:`; walk-through demoted to a
  fallback that must be argued for in the PR. Changelog **entry 6** records the amendment with the
  measured evidence the meta-protocol demands (what it caught at adoption; what cost the interim floor
  was imposing).
- `README.md` — one row in the documentation table, next to the Quality Protocol it serves.

## Verification evidence

```
modules/loop-pipeline    uv sync --extra remote && uv run pytest -q
                         -> 2216 passed, 25 skipped, 3 warnings in 27.36s

modules/pipeline-runner  uv run pytest -q
                         -> 76 passed, 1 skipped in 13.93s

Q-guards (the doc this PR amends pins itself)
  uv run pytest -q tests/test_quality_protocol_guard.py
                         -> 17 passed   (Q-300..Q-307)

git diff --check          -> clean (working tree and full branch vs origin/main)
```

**Leak scan, all files under `evals/guidance/`** (harness code + scenarios): no absolute `/home` or
`/Users` paths; no key-shaped material (`sk-*`, `gh[pou]_*`, `github_pat_*`, `AKIA*`, PEM blocks,
`xox*`); no `key|secret|token|password|credential` assignments; no mirror host or credential strings;
no personal identifiers. The harness references the evidence-directory convention generically
(`<workspace>/.amplifier/evaluation/guidance-pilot`) and resolves it at runtime — and refuses outright
to write results inside the checkout. **No results or run artifacts are committed.**

**Guidance-eval evidence for this PR's own change class.** Stated rather than skipped, since the new
row applies to this PR too: the diff touches `README.md`, which `qa-01` names in its
`surfaces_under_test:`. The changed line is a documentation-table row — navigation, not steering prose
— and no rubric criterion could read it; `docs/QUALITY_PROTOCOL.md` is contributor-facing process and
is named by no scenario. So the eval cannot reach this change, in those words, and the evidence
attached is the full six-scenario baseline itself, taken against the unchanged surfaces. A reviewer
who disagrees should say so and I will re-run `qa-01`.

## Observations

None arose. Nothing in this work surfaced a contradiction between `docs/VISION.md` and the repo, or
between the vision and what we appear to believe — the baseline's findings are the repo failing to
live up to the vision as written, which is ordinary work, not an observation against the page.
Reported here per section 4's rule that the heading is honest when empty.

## Notes for reviewers

- **Do not auto-merge.** Opened for review.
- Rebased onto `origin/main` @ `9b40afe`; see **Post-review fixes** below for the one conflict and how it was resolved. `evals/guidance/` is all-new files.
- The 2026-08-15 baseline was taken against `ed5bdef`, one commit behind current `main` — `42866ec`
  ships `examples/authoring/`, which none of the six scenarios exercise, so the baseline stands. The
  authoring attractor is a natural candidate for a seventh scenario, and per the instrument's own rule
  adding one should require naming a property the other six do not cover.
- The most useful thing a reviewer can do is read `exemplar-02`'s transcript and `qa-02`'s side by
  side: the same bundle, the same doctrine, one surface delivering a textbook honest redirect and
  another endorsing a self-report gate.

## Post-review fixes

Two adversarial-review findings, closed on the branch. **Still not for merge.**

**1. Rebased onto `origin/main` @ `9b40afe` (was `42866ec`).** #238 and #239 merged after this branch
was cut and both sides had appended a Changelog **entry 6** to `docs/QUALITY_PROTOCOL.md`. Resolved
by keeping main's entry 6 (*"Layer 3 gets an executor"*) intact and renumbering this PR's to **entry
7** (*"the guidance eval shipped; section 2's interim floor retired"*), placed above it per the
page's own newest-first ordering. That was the only conflict hunk in the rebase; section 2's
**Guidance surfaces** row re-applied cleanly over main's Layer-3 edits, and the root `README.md` row
for the Guidance Eval sits in the docs table while #238's Drift Review row sits in the pipeline
gallery — different tables, no overlap. Q-guards (`test_quality_protocol_guard.py`) 17/17 green on
the rebased tree.

**2. Disclosed the mid-baseline repair of `MC-E2` / `MC-F6`** — see the note appended to the Baseline
section above, and the matching paragraph now in `evals/guidance/README.md`. Rule 1 says an
undisclosed scenario edit is the most suspicious diff this directory can contain; that rule only
binds if it is applied when it is inconvenient.

**Gates re-run on the rebased tree.** loop-pipeline **2257 passed / 25 skipped**; pipeline-runner
**76 passed / 1 skipped**; Q-guards **17 passed**; leak scan on changed files clean (the only
credential-shaped match is `$GITEA_TOKEN` interpolation in `harness/run.sh`, resolved at runtime from
`amplifier-gitea token`); `git diff --check` clean.

---

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

