### PR TITLE
docs: close the Layer-3 drift findings outside the guidance surfaces (#240 partial, #236, #229)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ cited as prior-art inspiration where useful.
 | [DOT Syntax Reference](docs/DOT-SYNTAX.md) | Quick reference tables and copy-paste patterns |
 | [Routing Reference](docs/ROUTING-REFERENCE.md) | Edge selection algorithm, `report_outcome` tool, condition expressions, common pitfalls |
 | [App Integration Guide](docs/APP-INTEGRATION-GUIDE.md) | Using pipelines from Python applications (DirectProvider vs AmplifierSession) |
-| [Pipeline Design Principles](docs/PIPELINE_DESIGN_PRINCIPLES.md) | Six framework-agnostic design principles: tier discipline, validation patterns, loop convergence, LLM output protocols, parameterization, verdict-bearing nodes |
+| [Pipeline Design Principles](docs/PIPELINE_DESIGN_PRINCIPLES.md) | Eight framework-agnostic design principles, opening with **the control-plane vs recipe-plane line** -- the three-question test for whether the work wants a pipeline at all -- then tier discipline, validation patterns, loop convergence, LLM output protocols, parameterization, verdict-bearing nodes, and delta-assertion / shared-checkout discipline |
 | [Issue Pipeline](docs/ISSUE_PIPELINE.md) | What happens after a maintainer labels an issue `ready:spec` (defects) or `ready:feature-spec` (features) -- the autonomous specify/implement pipelines, their human review gates, what makes a good defect report, and how a maintainer supplies binding acceptance criteria for a feature |
 | [Quality Protocol](docs/QUALITY_PROTOCOL.md) | How work gets proven here -- the design -> build -> live-proof -> adversarial-review -> maintainer's-word arc, the evidence each class of change owes before merge, the five-layer drift defense against the upstream nlspec, and the meta-protocol for amending and retiring all of it |
 | [Guidance Eval](evals/guidance/README.md) | The standing instrument behind the Quality Protocol's **Guidance surfaces** row -- six scenarios that install this bundle the way a user does, drive real sessions against `agents/`, `skills/`, `context/` and the teaching docs, and grade them blind against criteria anchored in the canonical spec and the vision |
@@ -418,7 +418,12 @@ asyncio.run(main())
 
 The key difference: with `session.spawn` registered, the `AmplifierBackend` kicks
 in and each pipeline node gets a full child session with tools (filesystem, bash,
-search). Without it, you get `DirectProviderBackend` (LLM-only, no tools).
+search). Without it, you get `DirectProviderBackend`, which runs a per-node agentic
+tool loop and passes through whatever tools the host has mounted -- so a node is
+tool-free only when the host mounts none, which is the case in the bare
+programmatic path above. See [Backend Selection](#backend-selection) for the full
+contract (`DirectProviderBackend` also requires an explicit `llm_model` on every
+node; there is no default).
 
 See [`amplifier-foundation/examples/07_full_workflow.py`](https://github.com/microsoft/amplifier-foundation/blob/main/examples/07_full_workflow.py) for the reference
 `register_spawn_capability()` implementation. For a comprehensive guide,
@@ -447,12 +452,16 @@ default; see `SPEC_CONFORMANCE.md` ATX-11 for the rationale).
 Development velocity is high and behavior can change between commits. If you depend on this
 engine, **pin a commit SHA** rather than tracking `@main`.
 
-**Known caveat:** `Outcome.suggested_next_ids` entries must be strings that exactly match a
-target node's `id`. Non-string or mismatched entries currently fail to match during edge
-selection (`edge_selection.py`), silently falling through to the next selection step rather
-than the intended target. If an outcome report seems to route unexpectedly, check the types
-and exact spelling of `suggested_next_ids` first. This is a known issue being addressed; no
-version cutover is implied by that work landing.
+**`suggested_next_ids` typing:** node IDs are strings, and an `Outcome.suggested_next_ids`
+entry must match a target node's `id` exactly. Edge selection coerces the one type slip an
+LLM actually makes -- a bare number, `[3]` instead of `["3"]` -- to its string form before
+comparing (`edge_selection._coerce_suggested_id()`); any other shape (`bool`, `float`,
+`dict`, `list`, `None`) is rejected as malformed, logged with the value and its type, and
+skipped so one bad entry does not sink the rest of the list. A suggestion that survives
+coercion but names no real node falls through to the next selection step, and the resulting
+`no_matching_edge` failure names both the suggested IDs and the outgoing edge targets that
+existed. So if an outcome report routes unexpectedly, check the exact spelling first --
+the types are handled. See [`specs/EXTENSIONS.md`](specs/EXTENSIONS.md) §34.
 
 ## Architecture
 

--- a/SPEC_CONFORMANCE.md
+++ b/SPEC_CONFORMANCE.md
@@ -57,7 +57,7 @@ Maintainer ruling, 2026-08-14. The four rules that decide every disposition in t
 |------|----------------|---------------|----------|------|
 | unified-llm | ~35 | 13 | 4 (structured output, all providers) | 9 |
 | coding-agent-loop | ~17 | 9 | 2 (bugs CAL-1, CAL-2) | 7 |
-| attractor | ~30 | 8 | 3 (ATX-1, ATX-2, ATX-10) | 3 (ATX-3, ATX-6, ATX-7) |
+| attractor | ~30 | 10 | 7 (ATX-1, ATX-2, ATX-4, ATX-5, ATX-10, ATX-11, ATX-12) | 3 (ATX-3, ATX-6, ATX-7) |
 
 The engine layer (attractor) is the strongest — substantially a **superset** of the spec. The
 material weaknesses are concentrated in the LLM client's per-provider metadata and a small set
@@ -147,7 +147,10 @@ substitution beyond `$goal`.
 ## DECIDE items — context for a future decision
 
 Deferred by owner; not decided yet. Captured context so the future call is well-informed.
-Each is currently **OPEN** with disposition pending (ALIGN vs DIVERGE).
+Each is **OPEN** with disposition pending (ALIGN vs DIVERGE) unless its heading says otherwise:
+an item that has since been decided keeps its subsection here as the record of *why* the call
+went the way it did, with its heading and **Status** line carrying the outcome. The tables above
+are the current state; these are the reasoning behind it.
 
 ### CAL-3 — ExecutionEnvironment abstraction (coding-agent-loop §4)
 - **Spec wants:** a swappable `read_file/write_file/exec_command/grep/glob/list_directory` seam with
@@ -163,12 +166,13 @@ Each is currently **OPEN** with disposition pending (ALIGN vs DIVERGE).
   different layer (DTU), which may make a loop-level ExecutionEnvironment redundant.
 - **Cost if ALIGN:** new abstraction crossing the tool boundary; touches every tool's call contract.
 
-### ATX-2 — Checkpoint-based resume (attractor §5.3) — **DECIDED 2026-08-14: ALIGN (build it)**
+### ATX-2 — Checkpoint-based resume (attractor §5.3) — **DECIDED 2026-08-14: ALIGN (build it) — SHIPPED**
 - **Spec wants:** load `checkpoint.json` → restore context/completed-nodes/retry counters → continue
   from the node after `current_node`; degrade `full`→`summary:high` one hop on resume.
-- **Reality now:** engine always restarts from the start node; `checkpoint.py` is an observability
-  record (explicitly "not a resume marker"); `load_checkpoint()` is never used to rehydrate.
-  Idempotency is **graph-owned**: handlers skip already-done work (see `examples/pipelines/12-graph-resume`).
+- **Reality when this was written (pre-ship, superseded):** engine always restarted from the start
+  node; `checkpoint.py` was an observability record (explicitly "not a resume marker");
+  `load_checkpoint()` was never used to rehydrate. Idempotency was **graph-owned** only: handlers
+  skip already-done work (see `examples/pipelines/12-graph-resume`).
 - **Ruling (maintainer, 2026-08-14):** the missing engine-level resume is a **bug in our design**, not
   a defensible divergence. The spec's Definition of Done mandates it outright —
   `specs/canonical/attractor-spec-canonical.md:1857`: *"Resume from checkpoint: load checkpoint ->
@@ -179,9 +183,16 @@ Each is currently **OPEN** with disposition pending (ALIGN vs DIVERGE).
   The `examples/pipelines/12-graph-resume` pattern stays supported and documented — handler-level
   "don't redo finished work" remains the right tool for expensive idempotent steps; engine resume
   covers the different problem of restoring accumulated *context* after a crash mid-pipeline.
-- **Status:** implementation in flight via the repo's feature pipeline as **issue #224**.
+- **Status: SHIPPED** (issue #224). Engine resume landed per §5.3 and the ATX-2 row above is
+  **DONE — PROVEN ON A REALLY-KILLED RUN**: `attractor resume <run_dir>` /
+  `resume_pipeline()` / `PipelineEngine.resume()`, opt-in only — a fresh `run()` has no code
+  path to a checkpoint loader (`modules/loop-pipeline/tests/test_no_implicit_resume.py`).
+  The coexistence condition held: the graph-owned pattern still parses, lints and executes its
+  documented guard-skip semantics (`modules/loop-pipeline/tests/test_graph_owned_resume_coexists.py`).
+  Design record: `docs/designs/2026-08-14-engine-checkpoint-resume.md`. See the 2026-08-14
+  Changelog entry below for the full evidence.
 - **Cost:** real state-serialization + rehydration surface; the `full`→`summary:high` degrade rule;
-  correctness testing across partial-completion states. Accepted.
+  correctness testing across partial-completion states. Accepted, and paid.
 
 ### ATX-3 — Tool-call hooks (attractor §9.7)
 - **Spec wants:** `tool_hooks.pre` / `tool_hooks.post` shell commands wrapping every LLM tool call;
@@ -244,9 +255,11 @@ Each is currently **OPEN** with disposition pending (ALIGN vs DIVERGE).
     evaluated only inside the explicit resume ladder. (2) "No matching edge from resumed node":
     there is no fast-forward replay — the checkpoint records the last COMPLETED node and its real
     outcome, and resume runs edge selection exactly ONCE from those recorded inputs.
-  - **Coexistence held (the ALIGN condition):** `examples/pipelines/12-graph-resume.{dot,md}` are
-    byte-unchanged and still parse, lint and execute their documented guard-skip semantics
-    (`modules/loop-pipeline/tests/test_graph_owned_resume_coexists.py`). Engine resume answers
+  - **Coexistence held (the ALIGN condition):** `examples/pipelines/12-graph-resume.{dot,md}` were
+    left byte-unchanged by this PR and still parse, lint and execute their documented guard-skip
+    semantics (`modules/loop-pipeline/tests/test_graph_owned_resume_coexists.py`). *(Later: the
+    `.md`'s closing prose was reconciled to this coexistence ruling on 2026-08-15 — issue #229 —
+    which the byte-pin had deliberately deferred. The `.dot` remains untouched.)* Engine resume answers
     "this process died mid-graph"; graph-owned skip-through answers "this work is already done on
     disk". Neither disables the other.
   - Design record: `docs/designs/2026-08-14-engine-checkpoint-resume.md`. Issue #224.

--- a/docs/PIPELINE_DESIGN_PRINCIPLES.md
+++ b/docs/PIPELINE_DESIGN_PRINCIPLES.md
@@ -189,7 +189,7 @@ Check   -> Done    [condition="context.tool.last_line=done"];
 node behavior.
 
 ```dot
-graph [default_max_retry=4]
+graph [default_max_retries=4]
 
 Iterate [shape=box, goal_gate=true, retry_target=Iterate,
          prompt="Attempt to complete $goal. Signal success when done."]
@@ -322,7 +322,7 @@ value. This allows experimentation and tuning without forking the pipeline.
 
 **What to surface as parameters:**
 
-- Iteration counts and retry ceilings (`default_max_retry`, per-node `max_retries`)
+- Iteration counts and retry ceilings (`default_max_retries`, per-node `max_retries`)
 - Sample sizes or batch limits for pipelines that process sets of items
 - Quality thresholds for verdict or gate nodes
 - Model selection per node class when the pipeline is intended to run across providers
@@ -338,7 +338,7 @@ digraph {
     graph [
         goal="$goal",
         params="goal, max_rounds, quality_threshold",
-        default_max_retry=3
+        default_max_retries=3
     ]
 
     start    [shape=Mdiamond]
@@ -355,7 +355,7 @@ digraph {
 ```
 
 Operators pass `max_rounds` and `quality_threshold` to tune behavior; the pipeline
-handles the common case without them via `default_max_retry`.
+handles the common case without them via `default_max_retries`.
 
 ---
 

--- a/examples/pipelines/05-parallel-fan-out.md
+++ b/examples/pipelines/05-parallel-fan-out.md
@@ -59,14 +59,30 @@ start -> plan -> parallel +--> test_trig --------+--> collect_results -> summari
 
 ### Join Policy Variations
 
+The canonical spec defines exactly two join policies (§4.8,
+[`specs/canonical/attractor-spec-canonical.md`](../../specs/canonical/attractor-spec-canonical.md)):
+
 | Policy | Behavior |
 |--------|----------|
 | `wait_all` | All branches complete. SUCCESS if none failed, PARTIAL_SUCCESS otherwise |
 | `first_success` | Returns as soon as one branch succeeds. Others may be cancelled |
+
+This engine also accepts two **non-canonical extensions**. Upstream removed both from
+the spec at `fb57a55`, and no shipped graph in this repo uses either -- they are recorded
+as subtraction candidates in [`specs/EXTENSIONS.md`](../../specs/EXTENSIONS.md) §18. They
+still work; reach for them only when the two canonical policies genuinely cannot express
+the join, and expect a `.dot` that uses them to be non-portable to a spec-only runtime:
+
+| Policy (extension) | Behavior |
+|--------|----------|
 | `k_of_n` | At least `min_success` branches must succeed (set via node attribute) |
 | `quorum` | At least `quorum_fraction` (e.g., 0.5) of branches must succeed |
 
 ### Error Policy Variations
+
+`error_policy` is likewise a non-canonical extension (removed upstream at `fb57a55`;
+`specs/EXTENSIONS.md` §18) -- but unlike `k_of_n`/`quorum` it is in live use across this
+repo's own graphs, including the one above:
 
 | Policy | Behavior |
 |--------|----------|

--- a/examples/pipelines/12-graph-resume.md
+++ b/examples/pipelines/12-graph-resume.md
@@ -8,8 +8,10 @@
 
 ## What This Exercises
 
-- **Graph-level resume**: The correct way to make a pipeline resumable. The engine always
-  runs from Start; resume happens at the graph level via file-state self-skip.
+- **Graph-level resume**: Making a pipeline resumable from the graph itself, with no engine
+  resume involved. The engine always runs from Start; resume happens at the graph level via
+  file-state self-skip. (Engine-level `attractor resume` is a separate, complementary
+  mechanism -- see the closing section for when to reach for which.)
 - **`shape=parallelogram` guard nodes**: Each check_* node runs a shell command that tests
   for an artifact file and prints a routing token (`done` or `todo`).
 - **`context.tool.last_line` routing**: Guard nodes route via
@@ -197,19 +199,35 @@ The resume artifacts (`.ai/`) are written under `--cwd`.
 - **`STATE.json` evolution**: starts as `{"tests_passed": false}` after `implement_refactor`,
   updates to `{"tests_passed": true}` after a passing `run_tests`.
 
-## Key Insight: Why This Is Better Than Engine-Level Resume
+## Key Insight: This and Engine-Level Resume Answer Different Questions
 
-Engine-level resume (fast-forward replay from a checkpoint) has two failure modes:
+Graph-level resume is not a substitute for `attractor resume`, and `attractor resume` did
+not retire this pattern. They coexist by design -- that is the ratified ruling, not a
+compromise (`docs/designs/2026-08-14-engine-checkpoint-resume.md` §0: *"Engine resume must
+be built per §5.3 and must **coexist** with the graph-owned file-guard idempotency
+pattern. Neither disables the other."*). They answer different questions:
 
-1. **Edge-structure mismatch**: If the graph's edge conditions do not match the saved routing
-   path (e.g. after editing the graph, or when resuming a different graph at the same
-   checkpoint path), the engine fails with "No matching edge from resumed node."
+| | Answers | Reach for it when |
+|---|---|---|
+| **Graph-owned file guards** (this example) | "is this work already done *on disk*?" | Stages are expensive and idempotent, the graph may be edited between runs, or you want per-artifact rewind |
+| **Engine `resume`** (§5.3) | "did this *process* die mid-graph?" | A crash, kill or lost machine left in-flight engine state -- retry counters, `$iteration`, accumulated context -- that no filesystem artifact can reconstruct |
 
-2. **Graph drift**: Engine resume bakes in routing decisions from the previous run. If the
-   graph changed between runs, the engine blindly replays stale decisions.
+What this pattern buys you, and the engine cannot:
 
-Graph-level resume has neither problem:
-- The engine always evaluates edges fresh from Start.
-- Guard nodes re-evaluate the real filesystem state on every run.
-- Editing the graph and re-running works correctly -- guards adapt to the current graph.
-- Deleting an artifact file is a surgical rewind; no engine state to reset.
+- Guards re-evaluate the real filesystem on every run, so the state they read is the truth
+  on disk rather than a record of what a previous run believed.
+- Editing the graph and re-running works: the engine evaluates edges fresh from Start, and
+  guards adapt to whatever graph is in front of them.
+- Deleting one artifact file is a surgical rewind of exactly one stage, with no engine
+  state to reset and no run directory to find.
+- It needs no engine support at all, so it works identically on any conformant runtime.
+
+What engine resume buys you, and this pattern cannot: the accumulated in-memory state of a
+run that died. A file guard can tell you `implement_refactor` finished; it cannot tell you
+how many retries `run_tests` had already spent, or restore the context the earlier nodes
+accumulated. Resume is explicit opt-in -- a plain `attractor run` never reads a checkpoint
+-- so adding it changes nothing about how this graph behaves.
+
+For the mechanism and its guarantees see the design record above and
+[`docs/DOT-AUTHORING-GUIDE.md`](../../docs/DOT-AUTHORING-GUIDE.md); the conformance
+position is `SPEC_CONFORMANCE.md` ATX-2.

--- a/modules/loop-pipeline/tests/test_doc_consistency.py
+++ b/modules/loop-pipeline/tests/test_doc_consistency.py
@@ -1,6 +1,30 @@
-"""Tests for doc/spec internal consistency — D-135, D-137.
+"""Tests for doc/spec internal consistency — D-135, D-137, D-240..D-242.
 
 These are regression guards against documentation contradictions.
+
+D-240..D-242 were added closing the 2026-08-15 Layer-3 drift review (issue
+#240). Each pins a claim that had already drifted once, against the thing the
+claim is *about* rather than against itself:
+
+  D-240  ``README.md``'s ``suggested_next_ids`` note
+         <- ``edge_selection._coerce_suggested_id``'s real behavior.
+         The README taught the pre-fix bug as current for the life of
+         ``specs/EXTENSIONS.md`` §34 (DR-CORE-001). Two-sided: revert the
+         coercion in code and this fails, naming the README paragraph that
+         would need its caveat back.
+  D-241  ``README.md``'s section count for ``docs/PIPELINE_DESIGN_PRINCIPLES.md``
+         <- that file's actual numbered ``## N.`` headings.
+         The row said "Six" while the file carried eight sections; §0 and §7
+         shipped and the summary was never revisited (issue #236).
+  D-242  ``SPEC_CONFORMANCE.md``'s Summary row for the attractor spec
+         <- the §3 attractor table it summarizes.
+         The summary claimed 3 resolved / 3 open while four more rows had been
+         decided (DR-LEDGER-002). Recomputes the arithmetic from the table.
+
+Honest limit shared by all three: extracting a claim from prose is
+regex-over-prose. Rewording the sentence a claim lives in fails the guard with
+"claim not found" — the intended failure, not a false alarm. A reworded claim
+needs a re-anchored guard.
 """
 
 import re
@@ -153,4 +177,257 @@ def test_house_llm_classification_is_indirect():
     )
     assert "Indirect" in syntax_val, (
         f"DOT-SYNTAX.md house LLM field should contain 'Indirect', got: '{syntax_val}' (D-137)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# D-240: README's suggested_next_ids note vs the shipped coercion (DR-CORE-001)
+# ---------------------------------------------------------------------------
+
+# The exact phrases the README used while it still taught the pre-§34 bug as
+# current. Kept verbatim so the guard fails loudly if that paragraph is ever
+# restored without the code regressing to match it.
+_RETIRED_SUGGESTED_ID_CAVEAT_PHRASES = (
+    "This is a known issue being addressed",
+    "Non-string or mismatched entries currently fail to match",
+)
+
+
+def test_readme_suggested_next_ids_note_matches_the_shipped_coercion():
+    """README's `suggested_next_ids` note must describe the code as it is (D-240).
+
+    Source of truth: ``edge_selection._coerce_suggested_id``. The README carried
+    a "Known caveat" teaching the pre-fix behavior (non-string entries silently
+    fail to match, "known issue being addressed") for the whole life of the
+    shipped fix -- ``specs/EXTENSIONS.md`` §34, drift finding DR-CORE-001.
+
+    This asserts the *code's* behavior first, so reverting the coercion fails
+    here and names the README paragraph that would then need its caveat back.
+    """
+    from amplifier_module_loop_pipeline import edge_selection
+
+    coerce = getattr(edge_selection, "_coerce_suggested_id", None)
+    assert coerce is not None, (
+        "edge_selection._coerce_suggested_id is gone. README.md's "
+        "'`suggested_next_ids` typing' paragraph (Stability & Compatibility) "
+        "documents that int entries are coerced and malformed shapes are "
+        "skipped, and specs/EXTENSIONS.md §34 records that as shipped. If the "
+        "coercion was deliberately removed, restore the README's caveat and "
+        "re-anchor this guard in the same PR."
+    )
+
+    # The contract §34 records, and the README now describes.
+    assert coerce("review") == "review", "str entries must pass through unchanged"
+    assert coerce(3) == "3", (
+        'int entries must coerce to their string form (§34: `[3]` -> `["3"]`). '
+        "README.md now tells readers the type slip is handled; if this stops "
+        "being true the README is lying again (DR-CORE-001)."
+    )
+    for malformed in (True, 3.0, {"a": 1}, ["x"], None):
+        assert coerce(malformed) is None, (
+            f"{malformed!r} must be rejected, not coerced -- README.md and "
+            "specs/EXTENSIONS.md §34 both say only int is coerced and every "
+            "other shape is skipped."
+        )
+
+    readme = _read("README.md")
+    for phrase in _RETIRED_SUGGESTED_ID_CAVEAT_PHRASES:
+        assert phrase not in readme, (
+            f"README.md still carries the retired pre-§34 caveat phrase "
+            f"{phrase!r}, but the coercion above is shipped and passing. That "
+            "combination teaches readers to work around a closed bug (DR-CORE-001)."
+        )
+
+
+# ---------------------------------------------------------------------------
+# D-241: README's principle count vs PIPELINE_DESIGN_PRINCIPLES.md (issue #236)
+# ---------------------------------------------------------------------------
+
+_PRINCIPLES_REL = "docs/PIPELINE_DESIGN_PRINCIPLES.md"
+_NUMBER_WORDS = {
+    "One": 1,
+    "Two": 2,
+    "Three": 3,
+    "Four": 4,
+    "Five": 5,
+    "Six": 6,
+    "Seven": 7,
+    "Eight": 8,
+    "Nine": 9,
+    "Ten": 10,
+    "Eleven": 11,
+    "Twelve": 12,
+}
+
+
+def test_readme_principle_count_matches_the_principles_file():
+    """README's doc-table row must count the sections the file actually has (D-241).
+
+    The row said "Six framework-agnostic design principles" while the file
+    carried eight numbered sections: §0 (the control-plane vs recipe-plane line,
+    the most vision-load-bearing section in the repo) and §7 shipped later and
+    the summary was never revisited -- issue #236.
+
+    Source of truth: the ``## N.`` headings in the principles file itself. Add a
+    ``## 8.`` and this fails, which is the recurrence this guard exists to stop.
+    """
+    principles = _read(_PRINCIPLES_REL)
+    sections = re.findall(r"^##\s+(\d+)\.", principles, re.MULTILINE)
+    assert sections, (
+        f"{_PRINCIPLES_REL}: no numbered `## N.` section headings found. Either "
+        "the file's heading style changed -- re-anchor this pattern -- or the "
+        "numbered sections are gone, which would make README.md's count "
+        "meaningless rather than merely wrong."
+    )
+    actual = len(sections)
+
+    readme = _read("README.md")
+    match = re.search(
+        r"\|\s*\[Pipeline Design Principles\]\([^)]*\)\s*\|\s*(\w+)\s+framework-agnostic",
+        readme,
+    )
+    assert match is not None, (
+        "README.md: could not find the Pipeline Design Principles row's "
+        "'<count> framework-agnostic design principles' claim. If the row was "
+        "reworded, re-anchor this guard in the same PR (issue #236)."
+    )
+    word = match.group(1)
+    claimed = _NUMBER_WORDS.get(word)
+    assert claimed is not None, (
+        f"README.md claims '{word} framework-agnostic design principles', which "
+        f"is not a number word this guard knows. Known: {sorted(_NUMBER_WORDS)}."
+    )
+    assert claimed == actual, (
+        f"README.md's documentation table claims {word} ({claimed}) principles in "
+        f"{_PRINCIPLES_REL}, but that file carries {actual} numbered sections "
+        f"(§{', §'.join(sections)}). A section shipped and the summary was not "
+        "revisited -- exactly the drift issue #236 recorded. Update the README "
+        "row (and name the new section in it) in the PR that adds the section."
+    )
+
+
+# ---------------------------------------------------------------------------
+# D-242: SPEC_CONFORMANCE's Summary row vs the table it summarizes (DR-LEDGER-002)
+# ---------------------------------------------------------------------------
+
+_LEDGER_REL = "SPEC_CONFORMANCE.md"
+
+
+def _attractor_table_rows(ledger: str) -> dict[str, str]:
+    """Map ``ATX-n`` -> its Status cell, read from the section-3 table."""
+    section = re.split(r"^##\s+3\.\s+attractor-spec", ledger, flags=re.MULTILINE)
+    assert len(section) == 2, (
+        f"{_LEDGER_REL}: the '## 3. attractor-spec ...' heading this guard "
+        "anchors on was not found exactly once. Re-anchor if the heading was "
+        "reworded (DR-LEDGER-002)."
+    )
+    body = re.split(r"^##\s+", section[1], flags=re.MULTILINE)[0]
+
+    rows: dict[str, str] = {}
+    for line in body.splitlines():
+        if not re.match(r"^\|\s*ATX-\d+\s*\|", line):
+            continue
+        cells = [c.strip() for c in line.strip().strip("|").split("|")]
+        assert len(cells) == 6, (
+            f"{_LEDGER_REL}: attractor table row has {len(cells)} cells, "
+            f"expected 6 (ID|Area|Spec|Impl|Status|Disposition):\n    {line}\n"
+            "  Re-anchor this guard if the table's shape changed."
+        )
+        rows[cells[0]] = cells[4]
+    assert rows, f"{_LEDGER_REL}: no ATX-* rows found in the section-3 table."
+    return rows
+
+
+def _summary_attractor_cells(ledger: str) -> list[str]:
+    matches = [
+        line for line in ledger.splitlines() if re.match(r"^\|\s*attractor\s*\|", line)
+    ]
+    assert len(matches) == 1, (
+        f"{_LEDGER_REL}: expected exactly one Summary row starting `| attractor |`, "
+        f"found {len(matches)}. Re-anchor this guard if the Summary table changed."
+    )
+    return [c.strip() for c in matches[0].strip().strip("|").split("|")]
+
+
+def _ids_in(cell: str) -> set[str]:
+    return set(re.findall(r"ATX-\d+", cell))
+
+
+def _count_in(cell: str) -> int:
+    match = re.match(r"^(\d+)", cell)
+    assert match is not None, (
+        f"{_LEDGER_REL}: Summary cell {cell!r} does not start with a count."
+    )
+    return int(match.group(1))
+
+
+def test_ledger_summary_row_matches_the_attractor_table():
+    """The Summary row's arithmetic must be re-derivable from the table (D-242).
+
+    The summary read "8 gaps | 3 resolved (ATX-1, ATX-2, ATX-10) | 3 open" while
+    ATX-4, ATX-5, ATX-11 and ATX-12 had all been decided in the table below it --
+    drift finding DR-LEDGER-002. The summary is a derived view; this recomputes
+    it, so deciding a row without updating the summary fails here.
+
+    Classification rule, matching the Status legend: a Status cell containing
+    ``OPEN`` is open; everything else (DONE / WONTFIX, decided either way) is
+    resolved.
+    """
+    ledger = _read(_LEDGER_REL)
+    rows = _attractor_table_rows(ledger)
+
+    open_ids = {rid for rid, status in rows.items() if "OPEN" in status.upper()}
+    resolved_ids = set(rows) - open_ids
+
+    cells = _summary_attractor_cells(ledger)
+    assert len(cells) == 5, (
+        f"{_LEDGER_REL}: Summary row has {len(cells)} cells, expected 5 "
+        f"(Spec|Areas reviewed|Off-spec gaps|Resolved|Open):\n    {cells}"
+    )
+    _, _, gaps_cell, resolved_cell, open_cell = cells
+
+    def _sorted(ids: set[str]) -> list[str]:
+        return sorted(ids, key=lambda i: int(i.split("-")[1]))
+
+    assert _count_in(gaps_cell) == len(rows), (
+        f"{_LEDGER_REL} Summary: attractor 'Off-spec gaps' says "
+        f"{_count_in(gaps_cell)}, but the section-3 table carries {len(rows)} "
+        f"ATX rows ({', '.join(_sorted(set(rows)))}). Adding a row to the table "
+        "means updating the summary in the same PR (DR-LEDGER-002)."
+    )
+    assert _ids_in(resolved_cell) == resolved_ids, (
+        f"{_LEDGER_REL} Summary: 'Resolved' names {_sorted(_ids_in(resolved_cell))}, "
+        f"but the table's non-OPEN rows are {_sorted(resolved_ids)}. The summary "
+        "is a derived view of the table; re-derive it."
+    )
+    assert _count_in(resolved_cell) == len(resolved_ids), (
+        f"{_LEDGER_REL} Summary: 'Resolved' count is {_count_in(resolved_cell)} "
+        f"but names/derives {len(resolved_ids)} rows ({_sorted(resolved_ids)})."
+    )
+    assert _ids_in(open_cell) == open_ids, (
+        f"{_LEDGER_REL} Summary: 'Open' names {_sorted(_ids_in(open_cell))}, but "
+        f"the table's OPEN rows are {_sorted(open_ids)}."
+    )
+    assert _count_in(open_cell) == len(open_ids), (
+        f"{_LEDGER_REL} Summary: 'Open' count is {_count_in(open_cell)} but "
+        f"names/derives {len(open_ids)} rows ({_sorted(open_ids)})."
+    )
+
+
+def test_selfcheck_summary_recount_rejects_the_drifted_row():
+    """The D-242 checker must actually fail on the shape DR-LEDGER-002 found."""
+    drifted = (
+        "| attractor | ~30 | 8 | 3 (ATX-1, ATX-2, ATX-10) | 3 (ATX-3, ATX-6, ATX-7) |"
+    )
+    cells = [c.strip() for c in drifted.strip().strip("|").split("|")]
+    assert _count_in(cells[2]) == 8
+    assert _ids_in(cells[3]) == {"ATX-1", "ATX-2", "ATX-10"}
+    # The real table resolves seven; the drifted row named three.
+    real_resolved = _attractor_table_rows(_read(_LEDGER_REL))
+    real_resolved_ids = {
+        rid for rid, status in real_resolved.items() if "OPEN" not in status.upper()
+    }
+    assert _ids_in(cells[3]) != real_resolved_ids, (
+        "The drifted summary row would now pass the D-242 check, which means the "
+        "check cannot detect the drift it was written for."
     )


### PR DESCRIPTION
## Summary

Closes the verified Layer-3 drift findings from issue #240 that live **outside the guidance
surfaces**, plus the two issues that overlap them: the README vision-observation (#236) and the
`12-graph-resume` prose reconciliation (#229). Every fix is the same shape — a doc asserting
something the tree stopped supporting — so this PR changes no behavior, only claims.

`agents/`, `context/` and `skills/` are deliberately untouched; `DR-GUIDE-001/002/003` are owned by
a parallel lane.

## Per-finding fix table

| Finding | File:line (@`ed5bdef`) | Before | After |
|---|---|---|---|
| `DR-CORE-001` | `README.md:447` | "**Known caveat:** ... Non-string or mismatched entries **currently fail to match** during edge selection ... This is a **known issue being addressed**" | "**`suggested_next_ids` typing:** ... Edge selection **coerces** the one type slip an LLM actually makes -- a bare number, `[3]` instead of `["3"]` ... any other shape ... is rejected as malformed, logged ... and skipped ... See `specs/EXTENSIONS.md` §34." |
| `DR-CORE-002` | `README.md:418` | "Without it, you get `DirectProviderBackend` (**LLM-only, no tools**)." | "you get `DirectProviderBackend`, which **runs a per-node agentic tool loop and passes through whatever tools the host has mounted** -- so a node is tool-free only when the host mounts none, which is the case in the bare programmatic path above." |
| #236 | `README.md:36` | "**Six** framework-agnostic design principles: tier discipline, ... verdict-bearing nodes" | "**Eight** framework-agnostic design principles, **opening with the control-plane vs recipe-plane line** -- the three-question test for whether the work wants a pipeline at all -- then tier discipline, ... verdict-bearing nodes, **and delta-assertion / shared-checkout discipline**" |
| `DR-EX-001` | `examples/pipelines/05-parallel-fan-out.md:62-67` | One flat table listing `wait_all`, `first_success`, `k_of_n`, `quorum` **as peers** | Split: "**The canonical spec defines exactly two join policies (§4.8)**" + "This engine **also accepts two non-canonical extensions**. Upstream removed both from the spec at `fb57a55`, and no shipped graph in this repo uses either -- ... `specs/EXTENSIONS.md` §18." (`error_policy` labelled the same way, noted as **in live use**) |
| `DR-EX-002` / #229 | `examples/pipelines/12-graph-resume.md:200-215` | "## Key Insight: **Why This Is Better Than Engine-Level Resume** / Engine-level resume (fast-forward replay from a checkpoint) has two failure modes: 1. Edge-structure mismatch ... 2. Graph drift ..." | "## Key Insight: **This and Engine-Level Resume Answer Different Questions** / ... **They coexist by design -- that is the ratified ruling, not a compromise**" + a when-to-reach-for-which table + what each buys that the other cannot + a pointer to `docs/designs/2026-08-14-engine-checkpoint-resume.md` §0. Also `:11` "**The correct way** to make a pipeline resumable" -> "Making a pipeline resumable **from the graph itself**, with no engine resume involved" |
| `DR-EX-003` | `docs/PIPELINE_DESIGN_PRINCIPLES.md:192,325,341,358` | `graph [default_max_retry=4]` · "retry ceilings (`default_max_retry`, ...)" · `default_max_retry=3` · "without them via `default_max_retry`" | canonical plural `default_max_retries` in all four (the finding named three; `:341` is the same alias in the same file's second code example -- fixing three of four would have left the doc self-inconsistent) |
| `DR-LEDGER-001` | `SPEC_CONFORMANCE.md:166-184` | "**Reality now:** engine always restarts from the start node" · "**Status:** implementation in flight via the repo's feature pipeline as **issue #224**." | "**Reality when this was written (pre-ship, superseded):** engine always restart**ed** ..." · "**Status: SHIPPED** (issue #224). Engine resume landed per §5.3 and the ATX-2 row above is **DONE -- PROVEN ON A REALLY-KILLED RUN** ..." (heading gains "-- SHIPPED"; DECIDE preamble now says a decided item keeps its subsection as the record of *why*) |
| `DR-LEDGER-002` | `SPEC_CONFORMANCE.md:60` | `\| attractor \| ~30 \| 8 \| 3 (ATX-1, ATX-2, ATX-10) \| 3 (ATX-3, ATX-6, ATX-7) \|` | `\| attractor \| ~30 \| 10 \| 7 (ATX-1, ATX-2, ATX-4, ATX-5, ATX-10, ATX-11, ATX-12) \| 3 (ATX-3, ATX-6, ATX-7) \|` |

Counting rule used for `DR-LEDGER-002`, now enforced by **D-242**: the §3 attractor table is the
source of truth; a Status cell containing `OPEN` is open, everything else (DONE / WONTFIX, decided
either way) is resolved. That yields 10 rows / 7 resolved / 3 open. The `8` also had to move —
7 + 3 ≠ 8, and leaving it would have replaced one contradiction with another.

One echo-sweep beyond the finding list: `SPEC_CONFORMANCE.md:247` claimed
`12-graph-resume.{dot,md}` "**are** byte-unchanged". That is a record of what PR #228 did, so it now
reads "**were** left byte-unchanged **by this PR**", with a dated parenthetical noting the `.md`
prose was reconciled here. The `.dot` remains untouched. Not sweeping it would have made this PR the
author of a new contradiction — the exact failure mode #240's closing observation names.

## The `12-graph-resume` byte-pin: checked, and it is not in force

#229 warned that #224's **AC-5** byte-pinned `examples/pipelines/12-graph-resume.{dot,md}`, and that
this reconciliation "must land *after* #228 merges, since AC-5's byte-pin is only in force while that
PR is open." Verified before editing:

- **The pin was PR-scoped, not committed.** `docs/designs/2026-08-14-engine-checkpoint-resume.md:293`
  defines AC-5 as "byte-equality check on `examples/pipelines/12-graph-resume.dot` **in the PR diff**"
  — a `git diff origin/main..HEAD` assertion. #228 has merged (ATX-2 is DONE), so nothing is holding it.
- **The surviving guard reads the `.dot`, never the `.md`.**
  `modules/loop-pipeline/tests/test_graph_owned_resume_coexists.py` parses, lints and *executes*
  `12-graph-resume.dot`; it compares no bytes and never opens the `.md`.
- **Repo-wide sweep for a pin:** `read_bytes` / `sha256` / "byte-identical" across `modules/`,
  `tests/`, `.github/` returns no reference to either file. The only `sha256` pin in the tree is the
  canonical-spec pin (`test_spec_conformance_matrix.py`).

**Conclusion: no pin to update.** The `.dot` is byte-identical on this branch
(`git diff` touches only the `.md`), so AC-5's substance — engine resume did not disturb the
graph-owned pattern — still holds and its guard still passes.

## Guards added (QUALITY_PROTOCOL §2)

All three in `modules/loop-pipeline/tests/test_doc_consistency.py`, following its existing
D-135/D-137 conventions:

| ID | Pins | Against | Fails when |
|---|---|---|---|
| **D-240** | README's `suggested_next_ids` note | `edge_selection._coerce_suggested_id`'s **real behavior** (`str` passes through, `int` -> `str`, `bool`/`float`/`dict`/`list`/`None` rejected) | the coercion is reverted in code — the message names the README paragraph that would then need its caveat back. Also asserts the two retired pre-§34 phrases are gone. |
| **D-241** | README's principle **count** for `PIPELINE_DESIGN_PRINCIPLES.md` | that file's actual `## N.` headings | a §8 ships and the README row is not revisited — precisely the recurrence #236 recorded (§0 and §7 shipped, summary never updated) |
| **D-242** | `SPEC_CONFORMANCE.md` Summary row's gaps/resolved/open **arithmetic and ID lists** | the §3 attractor table it summarizes | a row is decided (or added) without re-deriving the summary. Ships a self-check proving the checker rejects the exact drifted row `DR-LEDGER-002` found. |

**Deliberately not pinned, and why:**

- **`DR-CORE-002`** (DirectProviderBackend / tools). Same claim lives on three surfaces; two of them
  (`context/system-attractor-expert.md`, `agents/attractor-expert.md` — `DR-GUIDE-001`) belong to the
  parallel lane. A README-only half-guard now would collide with theirs, and the honest source of
  truth is the agentic loop in `unified-llm-client`, not a greppable constant. **A single
  three-surface sweep guard belongs in the guidance lane's PR, not split across two.**
- **`DR-EX-002` / #229** (resume coexistence). Already pinned, and better than prose could be:
  `test_graph_owned_resume_coexists.py` proves the pattern still executes and
  `test_no_implicit_resume.py` proves a fresh `run()` has no path to a checkpoint. The doc claim is a
  framing claim; the property under it is asserted.
- **`DR-LEDGER-001`** (ATX-2 DECIDE prose). ATX-2's shipped status is already asserted by matrix rows
  `ATX-M-120`/`ATX-M-121` and `test_resume_e2e.py`. A guard on the DECIDE narrative would be
  page-only — tautological by §2's own definition.
- **`DR-EX-003`** (`default_max_retry` alias). `test_doc_consistency.py::test_spec_default_max_retry_table_is_zero`
  deliberately accepts *both* spellings so it stays anchored on the value, not the name. A guard
  forbidding the legacy alias would fire on eight other files (`10-full-attractor.dot`,
  `04-retry-with-fallback.dot`, `practical/*.dot`, fixtures) that this lane does not own and that are
  not wrong — the alias is supported. **That sweep is its own change, with its own blast radius.**
- **`DR-EX-001`** (join policies). Considered pinning the canonical §4.8 table to the doc's canonical
  half. Left out: Layer 2's conformance matrix is the right home for "what does canonical say", and
  adding a second, divergent reader of the same table is how the two drift apart later.

## Tier classification (QUALITY_PROTOCOL §3)

**Toward-spec**, for all eight. Each edit moves a surface back onto something authoritative — the
canonical spec (`DR-EX-001`, `DR-EX-003`), the shipped engine (`DR-CORE-001`, `DR-CORE-002`,
`DR-EX-002`), or the ledger/file it summarizes (#236, `DR-LEDGER-001`, `DR-LEDGER-002`). No behavior
changes, nothing new enters uncharted territory, and nothing moves away from the spec — so **no
`specs/EXTENSIONS.md` entry and no conformance-matrix row are owed**. The `k_of_n`/`quorum`
extensions are now *labelled* as extensions, which is the ledger's existing §18 position stated on
the surface that teaches them, not a new one.

## Verification checklist

- [x] Unit tests pass (`pytest modules/loop-pipeline/`)
- [x] Live pipeline run exercising changed code path — **N/A, stated deliberately**: no engine,
      handler or dispatch code is touched. The only `.py` change is a test file. The automated
      live-graph gate still runs in CI.
- [x] AGENTS.md reviewed; repo-specific gates met
- [x] Backward-compat path unchanged (docs only; `12-graph-resume.dot` byte-identical)
- [x] Observable contract — **no change**: doc claims only, no dispatch/event/validation behavior
      moves, so no `specs/EXTENSIONS.md` entry is owed.
- [x] Doc claims about code behavior ship guards — **D-240, D-241, D-242** above, plus the explicit
      not-pinned list with reasons.
- [x] PR body includes verification evidence
- [ ] CI is green before merge — **do not merge this PR**; see "Notes for reviewers".

## Verification evidence

```
$ cd modules/loop-pipeline && uv sync --extra remote && uv run pytest -q
2261 passed, 25 skipped, 3 warnings in 27.86s

$ cd modules/pipeline-runner && uv sync && uv run pytest -q
76 passed, 1 skipped in 12.36s

$ cd modules/loop-pipeline && uv run pytest -q \
    tests/test_doc_consistency.py tests/test_spec_conformance_matrix.py \
    tests/test_quality_protocol_guard.py tests/test_extensions_ledger_integrity.py \
    tests/test_explainer_doc_guard.py tests/test_graph_owned_resume_coexists.py \
    tests/test_no_implicit_resume.py tests/test_examples_lint_clean.py
283 passed, 24 skipped in 0.54s
```

Q-guards, the conformance matrix's structural readers of `SPEC_CONFORMANCE.md`, the EXTENSIONS
ledger-integrity guard, the examples lint gate and both resume coexistence guards are all green
**after** the ledger edits — which is the case that mattered, since D-242 and the matrix now both
read that file.

`ruff format` + `ruff check` clean on the changed test module. `git diff --check` clean. Leak scan
over the full diff (api key / secret / token / bearer / `sk-` / `ghp_` / `AKIA` / PEM header
patterns): one hit, `"prints a routing token"` — prose, not a credential.

**Negative controls for the new guards** (run against perturbed copies, not committed):

- D-241 with the README reverted to "Six": claimed=6, actual=8 -> **fails**, as designed.
- D-242 self-check `test_selfcheck_summary_recount_rejects_the_drifted_row` is committed and proves
  the checker rejects the pre-fix row rather than passing it.
- D-240 asserts the coercion contract directly (`coerce(3) == "3"`, `coerce(3.0) is None`,
  `coerce(True) is None`), so a revert of `_coerce_suggested_id` fails it.

## Observations

- **#240's closing observation reproduced itself while this PR was being written.** The changelog at
  `SPEC_CONFORMANCE.md:247` asserted the `12-graph-resume` files "are byte-unchanged" — true when
  written, and made false by the very edit #229 asked for. "A correction has no mechanism for finding
  its own echoes" is not a metaphor; it is a property of prose that names other files. **D-242 is a
  partial answer for the ledger** (the summary can no longer drift from its table), but nothing yet
  catches a *narrative* claim about another file's contents.
- **Two of the eight findings are the same bug: a count drifting from the thing counted.** #236 (six
  vs eight sections) and `DR-LEDGER-002` (three vs seven resolved) are structurally identical, in
  different files, found by different reviewers. D-241 and D-242 are the same guard written twice. If
  a third instance appears, that argues for a general "summary of a countable thing" check rather
  than a third bespoke one.
- **`DR-EX-001` resolved toward honesty, not deletion.** `k_of_n`/`quorum` are still live code
  (`handlers/parallel.py:472,490`), so removing them from the doc would have made the doc wrong in the
  other direction. §18 already calls them subtraction candidates with zero shipped usage; the guide
  now says exactly that, which is the information a reader needs to *not reach for them*. **The
  subtraction itself is still an open call**, and this PR does not make it.
- **The DECIDE section is now two things at once.** It is titled "context for a future decision" but
  holds one item (ATX-2) that is decided *and shipped*. Rewriting the preamble was the minimum
  honest fix; the larger question — whether decided items should graduate out of DECIDE into their
  own "decision records" section — is a maintainer call, not a drift fix, so it is left alone.
- **The finding list under-counted `DR-EX-003` by one.** `:341` carries the same legacy alias in the
  same file and was not in the citation. Line-anchored review finds *instances*; it does not find
  *all* instances. Worth knowing when reading the drift pipeline's output as a completeness claim —
  it is a detection claim.

## Notes for reviewers

- **Do not merge.** Per the standing instruction on this lane and `AGENTS.md`'s "no merge without the
  maintainer's explicit word."
- **Issue closure is deliberately partial.** The commit closes **#236** and **#229** (both fully
  satisfied from this lane's files) and only *addresses* **#240** — `DR-GUIDE-001`, `DR-GUIDE-002`
  and `DR-GUIDE-003` live in `context/` and `agents/`, which a parallel lane owns. #240 should stay
  open until that lane lands.
- **The `README.md` line-36 wording is a judgment call.** #236 offered three resolution paths; this
  takes path 1 (correct the count, lead with §0). If the table was meant as a deliberate partial
  teaser (path 3), say so and I will revert to a count-only fix.
- Expect a small overlap with the guidance lane in `README.md` only if they also touch the
  `DirectProviderBackend` prose — they should not; that surface is listed as this lane's.

Closes #236, closes #229. Addresses #240 except `DR-GUIDE-001/002/003`.
