### PR TITLE
fix(objective): route the loud terminal to the exit, and stop letting a lane's red bypass the parent's own gate

### DIFF
--- a/examples/objective/objective-runner.dot
+++ b/examples/objective/objective-runner.dot
@@ -41,12 +41,13 @@
 //     triage-schema.json and prints the routing token. The first routing
 //     decision of the run is therefore evidence outside the worker's context --
 //     the same rule every gate in this repo obeys.
-//   - THE PARENT NEVER TRUSTS THE CHILD'S SELF-REPORT. A child pipeline's
-//     terminal outcome is used for LOUD FAIL ROUTING ONLY. Satisfaction is
-//     decided by `evidence_gate`, which RE-RUNS the definition-of-done command
-//     itself and additionally asserts a durable workspace delta since the
-//     anchor recorded at `preflight`. A no-op child cannot pass on a stale
-//     green.
+//   - THE PARENT NEVER TRUSTS THE CHILD'S SELF-REPORT -- IN EITHER DIRECTION.
+//     Satisfaction is decided by `evidence_gate`, which RE-RUNS the
+//     definition-of-done command itself and additionally asserts a durable
+//     workspace delta since the anchor recorded at `preflight`. A no-op child
+//     cannot pass on a stale green -- and a child that gave up cannot fail the
+//     objective on its own say-so either: a child's terminal FAIL routes INTO
+//     `evidence_gate`, never around it (see the lane fail edges below).
 //   - THE COMPOSER'S OUTPUT IS GATED BEFORE IT RUNS. `compose` writes a child
 //     graph; `lint_gate` (the engine's own linter -- ERRORs block, warnings are
 //     recorded) and `contract_gate` (check_child_contract.py) both sit OUTSIDE
@@ -54,11 +55,25 @@
 //   - BUDGET AS A DECISION POINT. evidence_gate spends an iteration on EVERY
 //     entry (green and red alike) and routes exhaustion to postmortem ->
 //     escalated, never to a bare FAIL.
-//   - ONE GREEN EXIT. `validate_or_raise` requires exactly one exit node, so the
-//     two honest terminals are expressed as: `done` (Msquare, reached only
-//     through `finalize`, which refuses to open without a disposition artifact)
-//     and `escalated` (a tool node that exits 1 with max_retries=0 and no
-//     fail-route -- the bug-fix.dot idiom, a LOUD red).
+//   - ONE EXIT NODE, TWO HONEST TERMINALS. `validate_or_raise` requires
+//     exactly one exit node, so both terminals reach it: `done` opens GREEN
+//     only through `finalize` (which refuses to open without a disposition
+//     artifact), and RED only through `escalated`, whose own nonzero exit
+//     becomes the run's status. That is the convergence-factory.dot idiom --
+//     "a budget-exhaustion exit that deliberately ends at the single exit node
+//     with a genuine FAIL outcome" (docs/DOT-AUTHORING-GUIDE.md, TOPO-006) --
+//     and it is why this file consciously carries ONE TOPO-006 WARNING, for
+//     the same reason and in the same way examples/patterns/
+//     convergence-factory.dot does. Letting `escalated` dead-end instead does
+//     NOT work: see the engine semantics below.
+//   - TWO LINT WARNINGS, BOTH DELIBERATE (`attractor lint` reports zero
+//     ERRORs): `fail_routed_to_exit` on `escalated -> done` (above), and
+//     `goal_gate_has_retry` on `evidence_gate`. The second is a true
+//     observation about the wrong hop: this graph's corrective loop for a red
+//     gate is `evidence_gate -> feedback -> triage_gate [loop_restart]`, one
+//     hop further downstream than the rule can see. A `retry_target` on the
+//     gate itself is not merely redundant here, it is a hazard -- see the
+//     goal-gate corollary in the engine-semantics list below.
 //
 // VERIFIED ENGINE SEMANTICS THIS FILE DEPENDS ON:
 //   - STALE-LABEL RULE: a tool node that exits nonzero does NOT refresh
@@ -73,10 +88,29 @@
 //   - A sub-pipeline is a fresh session boundary (section 11): each lane and the
 //     generated child run with their own context. Files are the only channel
 //     this graph trusts across that boundary.
+//   - THE MAIN LOOP HAS NO DESIGNED-TERMINUS CONCEPT. `run_subgraph()`
+//     distinguishes "no outgoing edges at all" (a designed terminus) from a
+//     conditional-mismatch dead end; `run()` does NOT (specs/EXTENSIONS.md
+//     section 33; context/engine-semantics.md section 3). Any node the main
+//     loop finishes with no matching outgoing edge -- WHATEVER its exit
+//     status -- terminates through `terminate_pipeline()` and emits
+//     PIPELINE_ERROR `error_type=no_matching_edge`. Probed on the shipped
+//     CLI: a dead-ended tool node reports `no_matching_edge` on `exit 1` AND
+//     on `exit 0`. A deliberate loud terminal must therefore ROUTE somewhere;
+//     it cannot dead-end.
+//   - AT THE EXIT NODE, WITH EVERY GOAL GATE SATISFIED, THE RUN'S STATUS IS
+//     THE LAST COMPLETED NODE'S OUTCOME (`engine.py::_check_goal_gates` ->
+//     `node_outcomes[completed_nodes[-1]]`). That is the whole mechanism
+//     behind `escalated -> done [outcome=fail]`: `escalated`'s own nonzero
+//     exit becomes the run's status=fail / CLI exit 1, with no routing error.
+//     Corollary, and the reason `evidence_gate` carries NO `retry_target`:
+//     an UNSATISFIED goal gate at that moment is retried from its
+//     `retry_target` instead, which on the escalation path would buy a run
+//     that refused to evaluate (`tampered`) another whole lane iteration.
 //   - PARAM NAMESPACE: substitution rewrites $name/${name} for any context key.
-//     The shell variables here (rd, mi, mc, mf, n, B, w, ev, rc, res, now, base,
-//     delta) are safe only because no param shares their name. Never add a param
-//     named like a shell var.
+//     The shell variables here (rd, mi, mc, mf, n, B, w, ev, evsha, rc, res,
+//     now, base, delta) are safe only because no param shares their name.
+//     Never add a param named like a shell var.
 // ============================================================================
 
 digraph ObjectiveRunner {
@@ -106,7 +140,7 @@ digraph ObjectiveRunner {
     // works in a workspace whose child pipelines do not commit.
     preflight [
         shape=parallelogram, label="Preflight", max_retries=0,
-        tool_command="mkdir -p .objective/postmortem .objective/gen .objective/feedback || { printf blocked; exit 1; }; rd=\"$runner_dir\"; for f in sha256sum md5sum find; do command -v \"$f\" >/dev/null 2>&1 || { echo \"FATAL: '$f' is not on PATH; the anchor digest and the DoD sha-pin both need it\" >&2; printf blocked; exit 1; }; done; for f in validate_triage.py check_child_contract.py triage-schema.json compose-contract.md; do [ -f \"$rd/$f\" ] || { echo \"FATAL: --param runner_dir must name the examples/objective directory; missing $f under '$rd'\" >&2; printf blocked; exit 1; }; done; case \"$target_dir\" in /*) ;; *) echo \"FATAL: --param target_dir must be an absolute path (got '$target_dir')\" >&2; printf blocked; exit 1;; esac; find . -name .git -prune -o -name .objective -prune -o -name .ai -prune -o -name __pycache__ -prune -o -name .pytest_cache -prune -o -name .ruff_cache -prune -o -name node_modules -prune -o -name .venv -prune -o -type f -exec md5sum {} + 2>/dev/null | LC_ALL=C sort | md5sum | cut -d' ' -f1 > .objective/anchor; [ -s .objective/anchor ] && printf ready || { printf blocked; exit 1; }"
+        tool_command="mkdir -p .objective/postmortem .objective/gen .objective/feedback || { printf blocked; exit 1; }; rd=\"$runner_dir\"; for f in bash sha256sum md5sum find; do command -v \"$f\" >/dev/null 2>&1 || { echo \"FATAL: '$f' is not on PATH; the anchor digest, the DoD sha-pin, and evidence_gate's 'bash -c' re-run of the admitted evidence command all need it\" >&2; printf blocked; exit 1; }; done; for f in validate_triage.py check_child_contract.py triage-schema.json compose-contract.md; do [ -f \"$rd/$f\" ] || { echo \"FATAL: --param runner_dir must name the examples/objective directory; missing $f under '$rd'\" >&2; printf blocked; exit 1; }; done; case \"$target_dir\" in /*) ;; *) echo \"FATAL: --param target_dir must be an absolute path (got '$target_dir')\" >&2; printf blocked; exit 1;; esac; find . -name .git -prune -o -name .objective -prune -o -name .ai -prune -o -name __pycache__ -prune -o -name .pytest_cache -prune -o -name .ruff_cache -prune -o -name node_modules -prune -o -name .venv -prune -o -type f -exec md5sum {} + 2>/dev/null | LC_ALL=C sort | md5sum | cut -d' ' -f1 > .objective/anchor; [ -s .objective/anchor ] && printf ready || { printf blocked; exit 1; }"
     ]
 
     // ---------- frame: diagnose the objective; do NOT do the work ------------
@@ -254,6 +288,15 @@ digraph ObjectiveRunner {
     // CAPABILITIES the admitted evidence_command; the workspace digest.
     // EVIDENCE     .objective/evidence-N.log, .objective/convergence.jsonl,
     //              .objective/evidence-pass
+    // THE COMMAND IS RUN AS ADMITTED, AND THE RECORD SAYS SO. `bash -c "$ev"`
+    // hands the admitted string to a shell verbatim, so a compound command --
+    // `cd <subdir> && ...`, an env prefix, an `&&` chain -- runs exactly as
+    // triage_gate admitted it (regression-tested against this node's real
+    // command text). What was missing was the receipt: the log now opens with
+    // `RAN AS ADMITTED: <command>` and convergence.jsonl carries
+    // `evidence_command_sha`, so "the gate tested something other than what
+    // was admitted" is visible on iteration 1 instead of being reconstructed
+    // from a postmortem at budget exhaustion (issue #243, defect b).
     // EXIT         evidence_ok | evidence_bad | exhausted
     // The delta assertion is the second half of the gate: a green DoD with an
     // UNCHANGED workspace means nothing happened and the check was already
@@ -265,6 +308,19 @@ digraph ObjectiveRunner {
     // and exits 1. Nonzero means tool.last_line is NOT refreshed, so every
     // `&& outcome=success` edge below is dead and only outcome=fail can match:
     // postmortem -> escalated, CLI exit 1.
+    // ON THE ABSENCE OF retry_target, HONESTLY: `retry_target` on a goal gate
+    // is consulted in exactly one place -- `_check_goal_gates()` at the exit
+    // node -- and it means "if this gate is unsatisfied when the run tries to
+    // leave, go back to X instead." Before `escalated -> done` existed the
+    // exit was unreachable with this gate unsatisfied, so the attribute was
+    // dead. It is now reachable, which turns it live and wrong: the only way
+    // this gate is unsatisfied at the exit is the `tampered` refusal, whose
+    // cause (an altered, pinned check) survives any number of retries.
+    // Measured on the shipped engine with a faithful 5-node reduction of this
+    // graph: with retry_target="feedback" the tampered path executed
+    // evidence_gate 51 times and feedback 50 times before the step cap; with
+    // the attribute removed, once each. `tampered` means terminal, and the
+    // file already said so.
     // ON goal_gate=true, HONESTLY: this node uses Idiom A (always exit 0), and a
     // tool node's exit 0 is an explicit SUCCESS verdict (handlers/tool.py), so
     // the engine's exit-time gate check can never actually fail here -- even an
@@ -275,8 +331,8 @@ digraph ObjectiveRunner {
     // `finalize`, which refuses to open without a disposition artifact.
     evidence_gate [
         shape=parallelogram, label="Objective Satisfied?", max_retries=0,
-        goal_gate=true, retry_target="feedback",
-        tool_command="if [ -f .objective/evidence-command.sha256 ] && [ \"$(sha256sum .objective/evidence-command 2>/dev/null | cut -d' ' -f1)\" != \"$(cat .objective/evidence-command.sha256)\" ]; then echo 'FATAL: .objective/evidence-command was altered after triage_gate admitted it -- refusing to re-run a definition of done this run never approved' >&2; printf tampered; exit 1; fi; if [ -f .objective/dod.sha256 ] && [ \"$(sha256sum .objective/gen/dod.sh 2>/dev/null | cut -d' ' -f1)\" != \"$(cat .objective/dod.sha256)\" ]; then echo 'FATAL: .objective/gen/dod.sh was altered after contract_gate admitted it -- refusing to re-run a definition of done this run never approved' >&2; printf tampered; exit 1; fi; mi=$max_iterations; B=${mi:-3}; n=$(($(cat .objective/iter 2>/dev/null || echo 0)+1)); echo $n > .objective/iter; if [ \"$n\" -gt \"$B\" ]; then printf '{\"iteration\": %s, \"gate\": \"evidence\", \"budget\": \"exhausted\"}\n' \"$n\" >> .objective/convergence.jsonl; printf exhausted; else ev=$(cat .objective/evidence-command 2>/dev/null); now=$(find . -name .git -prune -o -name .objective -prune -o -name .ai -prune -o -name __pycache__ -prune -o -name .pytest_cache -prune -o -name .ruff_cache -prune -o -name node_modules -prune -o -name .venv -prune -o -type f -exec md5sum {} + 2>/dev/null | LC_ALL=C sort | md5sum | cut -d' ' -f1); base=$(cat .objective/anchor 2>/dev/null); [ \"$now\" != \"$base\" ] && delta=changed || delta=unchanged; if [ -z \"$ev\" ]; then rc=99; else bash -c \"$ev\" > .objective/evidence-$n.log 2>&1; rc=$?; fi; printf '{\"iteration\": %s, \"gate\": \"evidence\", \"dod_exit\": %s, \"delta\": \"%s\"}\n' \"$n\" \"$rc\" \"$delta\" >> .objective/convergence.jsonl; if [ $rc -eq 0 ] && [ \"$delta\" = changed ]; then : > .objective/evidence-pass; printf evidence_ok; else rm -f .objective/evidence-pass; printf evidence_bad; fi; fi"
+        goal_gate=true,
+        tool_command="if [ -f .objective/evidence-command.sha256 ] && [ \"$(sha256sum .objective/evidence-command 2>/dev/null | cut -d' ' -f1)\" != \"$(cat .objective/evidence-command.sha256)\" ]; then echo 'FATAL: .objective/evidence-command was altered after triage_gate admitted it -- refusing to re-run a definition of done this run never approved' >&2; printf tampered; exit 1; fi; if [ -f .objective/dod.sha256 ] && [ \"$(sha256sum .objective/gen/dod.sh 2>/dev/null | cut -d' ' -f1)\" != \"$(cat .objective/dod.sha256)\" ]; then echo 'FATAL: .objective/gen/dod.sh was altered after contract_gate admitted it -- refusing to re-run a definition of done this run never approved' >&2; printf tampered; exit 1; fi; mi=$max_iterations; B=${mi:-3}; n=$(($(cat .objective/iter 2>/dev/null || echo 0)+1)); echo $n > .objective/iter; if [ \"$n\" -gt \"$B\" ]; then printf '{\"iteration\": %s, \"gate\": \"evidence\", \"budget\": \"exhausted\"}\n' \"$n\" >> .objective/convergence.jsonl; printf exhausted; else ev=$(cat .objective/evidence-command 2>/dev/null); now=$(find . -name .git -prune -o -name .objective -prune -o -name .ai -prune -o -name __pycache__ -prune -o -name .pytest_cache -prune -o -name .ruff_cache -prune -o -name node_modules -prune -o -name .venv -prune -o -type f -exec md5sum {} + 2>/dev/null | LC_ALL=C sort | md5sum | cut -d' ' -f1); base=$(cat .objective/anchor 2>/dev/null); [ \"$now\" != \"$base\" ] && delta=changed || delta=unchanged; if [ -z \"$ev\" ]; then rc=99; evsha=none; else evsha=$(printf %s \"$ev\" | sha256sum | cut -c1-12); { printf 'RAN AS ADMITTED: %s\n\n' \"$ev\"; bash -c \"$ev\"; } > .objective/evidence-$n.log 2>&1; rc=$?; fi; printf '{\"iteration\": %s, \"gate\": \"evidence\", \"dod_exit\": %s, \"delta\": \"%s\", \"evidence_command_sha\": \"%s\"}\n' \"$n\" \"$rc\" \"$delta\" \"$evsha\" >> .objective/convergence.jsonl; if [ $rc -eq 0 ] && [ \"$delta\" = changed ]; then : > .objective/evidence-pass; printf evidence_ok; else rm -f .objective/evidence-pass; printf evidence_bad; fi; fi"
     ]
 
     // ---------- feedback: teach the NEXT attempt ----------------------------
@@ -360,11 +416,27 @@ digraph ObjectiveRunner {
     lane_refactor -> evidence_gate
     lane_testgen  -> evidence_gate
     lane_review   -> evidence_gate
-    lane_bugfix   -> postmortem [condition="outcome=fail", label="child could not converge"]
-    lane_feature  -> postmortem [condition="outcome=fail", label="child could not converge"]
-    lane_refactor -> postmortem [condition="outcome=fail", label="child could not converge"]
-    lane_testgen  -> postmortem [condition="outcome=fail", label="child could not converge"]
-    lane_review   -> postmortem [condition="outcome=fail", label="child could not converge"]
+    // A CHILD'S RED IS A SELF-REPORT TOO. These edges used to run straight to
+    // `postmortem`, which made a lane's own terminal outcome the parent's
+    // verdict -- the exact trust this graph refuses to extend to a child's
+    // GREEN. The 2026-08-15 exemplar-01 run is what that costs: the shipped
+    // bug-fix lane's `test_gate` runs a hardcoded `pytest -q` from the
+    // workspace root, which can never pass for a package nested one level
+    // down; it oscillated to its own budget wall (.ai/iter=6, a byte-stable
+    // .ai/last-fail-sig) and reported FAIL. The objective was ALREADY
+    // satisfied -- the admitted `cd <pkg> && python3 -m pytest tests/ -v`
+    // exits 0 -- but `evidence_gate` never ran even once (the salvaged run
+    // wrote no .objective/evidence-*.log and no .objective/convergence.jsonl),
+    // so the parent escalated an objective it had never checked. A child's
+    // FAIL now enters `evidence_gate` like every other route: the parent's own
+    // re-run of the ADMITTED command decides, and `postmortem` is reached
+    // through the budget wall (`exhausted`), which is where the decision to
+    // give up belongs.
+    lane_bugfix   -> evidence_gate [condition="outcome=fail", label="child gave up -- the parent still runs its own check"]
+    lane_feature  -> evidence_gate [condition="outcome=fail", label="child gave up -- the parent still runs its own check"]
+    lane_refactor -> evidence_gate [condition="outcome=fail", label="child gave up -- the parent still runs its own check"]
+    lane_testgen  -> evidence_gate [condition="outcome=fail", label="child gave up -- the parent still runs its own check"]
+    lane_review   -> evidence_gate [condition="outcome=fail", label="child gave up -- the parent still runs its own check"]
 
     // Compose path: write -> lint -> contract -> run. Both gates can send it back.
     compose -> lint_gate
@@ -380,7 +452,7 @@ digraph ObjectiveRunner {
     contract_gate -> postmortem [condition="outcome=fail", label="contract gate could not run"]
 
     run_child -> evidence_gate
-    run_child -> postmortem [condition="outcome=fail", label="generated child could not converge"]
+    run_child -> evidence_gate [condition="outcome=fail", label="generated child gave up -- the parent still runs its own check"]
 
     // The honest no reaches the single green exit through finalize.
     redirect_report -> finalize
@@ -406,10 +478,32 @@ digraph ObjectiveRunner {
     finalize -> done       [condition="context.tool.last_line=finalized && outcome=success", label="disposition recorded"]
     finalize -> postmortem [condition="outcome=fail",                                        label="no disposition -- refuse to exit green"]
 
-    // Escalation is a deterministic non-terminal handoff, not a second
-    // successful exit. It writes a fallback handoff even if the postmortem LLM
-    // itself failed, then exits 1 DELIBERATELY: max_retries=0 and no fail-route,
-    // so the engine hard-fails LOUD (run status=fail, CLI exit 1).
+    // Escalation is a deterministic handoff, not a second successful exit. It
+    // writes a fallback handoff even if the postmortem LLM itself failed, then
+    // exits 1 DELIBERATELY (max_retries=0).
     postmortem -> escalated [condition="outcome=fail", label="postmortem failed"]
     postmortem -> escalated [label="escalate"]
+
+    // ...and then it ROUTES to the single exit node carrying that nonzero exit.
+    // This edge is the whole of issue #243 defect (a). Without it `escalated`
+    // dead-ends, and the main loop -- which has no designed-terminus concept --
+    // reports the graph's most important honest outcome in the vocabulary of an
+    // authoring bug: `[PIPELINE] X Error at escalated (no_matching_edge)`, with
+    // the run's machine-readable `notes` field reading "No matching edge from
+    // node 'escalated'". With it, `_check_goal_gates` finds every goal gate
+    // satisfied and returns the LAST COMPLETED node's outcome -- `escalated`'s
+    // own FAIL -- so the run ends status=fail / CLI exit 1 with no routing
+    // error, and `.objective/disposition` = escalated says which terminal it
+    // was. `escalated` exits nonzero on EVERY path, so the `outcome=fail`
+    // condition is the total case, not a partial one.
+    // THE ONE TOPO-006 WARNING THIS FILE CARRIES IS THIS EDGE, ON PURPOSE:
+    // "a budget-exhaustion exit that deliberately ends at the single exit node
+    // with a genuine FAIL outcome" is the named, sanctioned deliberate design
+    // (docs/DOT-AUTHORING-GUIDE.md, TOPO-006), and
+    // examples/patterns/convergence-factory.dot carries the identical
+    // diagnostic for the identical reason. The hazard the rule guards -- a
+    // failure leaving through the success door as `status: success`, exit 0 --
+    // cannot happen here: `escalated` is the last node to complete and its
+    // FAIL is what the exit returns.
+    escalated -> done [condition="outcome=fail", label="loud exit -- status is escalated's own nonzero exit"]
 }

--- a/modules/loop-pipeline/tests/test_objective_layer_gates.py
+++ b/modules/loop-pipeline/tests/test_objective_layer_gates.py
@@ -710,3 +710,266 @@ def test_triage_cannot_run_is_distinct_from_a_bad_record(triage, tmp_path, capsy
     )
     assert rc != 0
     assert capsys.readouterr().out == ""
+
+
+# ---------------------------------------------------------------------------
+# Issue #243 -- the two defects two independent live runs found
+#
+# (a) The designed loud terminal dead-ended, so the engine reported the run's
+#     most important honest outcome as an authoring bug:
+#     `[PIPELINE] X Error at escalated (no_matching_edge)`.
+# (b) The objective was ALREADY satisfied and the run escalated anyway: the
+#     lane's own hardcoded gate could not pass, and its self-reported FAIL
+#     routed straight past `evidence_gate` -- so the admitted evidence command
+#     was never re-run by the parent even once.
+#
+# These read the shipped graph through the engine's own parser and drive the
+# engine and the real command text, not a paraphrase of either.
+# ---------------------------------------------------------------------------
+
+
+def _graph():
+    from amplifier_module_loop_pipeline.dot_parser import parse_dot
+
+    return parse_dot((_OBJECTIVE_DIR / "objective-runner.dot").read_text(encoding="utf-8"))
+
+
+def test_escalated_routes_to_the_exit_instead_of_dead_ending():
+    """243(a): a loud terminal must ROUTE; the main loop has no designed terminus.
+
+    `run_subgraph()` distinguishes "no outgoing edges at all" from a
+    conditional-mismatch dead end; `run()` does not.  A dead-ended `escalated`
+    therefore terminates through `terminate_pipeline()` with
+    `error_type=no_matching_edge` -- the same class a genuinely mis-authored
+    graph produces -- whatever its exit status.
+    """
+    graph = _graph()
+    exits = [n.id for n in graph.nodes.values() if n.is_exit_node()]
+    assert exits == ["done"], exits
+
+    outgoing = graph.outgoing_edges("escalated")
+    assert outgoing, (
+        "`escalated` has no outgoing edge, so the engine reports the designed "
+        "escalation as PIPELINE_ERROR error_type=no_matching_edge (issue #243a)"
+    )
+    assert [e.to_node for e in outgoing] == ["done"]
+    assert "outcome=fail" in (outgoing[0].condition or ""), outgoing[0].condition
+
+
+def test_escalated_still_exits_nonzero_so_the_exit_it_reaches_is_red():
+    """The routing fix must not turn the loud terminal into a quiet one.
+
+    `escalated -> done` is only honest because `escalated`'s own FAIL is what
+    `_check_goal_gates` returns from the exit.  An `escalated` that exited 0
+    would convert the escalation into a green run -- the exact hazard TOPO-006
+    names.
+    """
+    command = _graph().nodes["escalated"].attrs["tool_command"]
+    assert command.rstrip().endswith("exit 1"), command
+    assert "> .objective/disposition" in command or "echo escalated > .objective/disposition" in command
+
+
+def test_the_goal_gate_carries_no_retry_target():
+    """243(a), corollary: a retry_target on the goal gate is now reachable.
+
+    `retry_target` on a goal gate is consulted in exactly one place --
+    `_check_goal_gates()` at the exit node.  Before `escalated -> done` the
+    exit was unreachable with the gate unsatisfied, so the attribute was dead;
+    with it, the only way the gate is unsatisfied there is the `tampered`
+    refusal, whose cause survives every retry.  Measured on the shipped engine
+    with a faithful reduction of this graph: 51 gate executions before the step
+    cap, versus one with the attribute gone.
+    """
+    graph = _graph()
+    gate = graph.nodes["evidence_gate"]
+    assert gate.attrs.get("goal_gate") in (True, "true"), gate.attrs.get("goal_gate")
+    assert not gate.attrs.get("retry_target"), gate.attrs.get("retry_target")
+    assert not gate.attrs.get("fallback_retry_target")
+    assert not graph.graph_attrs.get("retry_target")
+    assert not graph.graph_attrs.get("fallback_retry_target")
+
+
+@pytest.mark.parametrize(
+    "child",
+    ["lane_bugfix", "lane_feature", "lane_refactor", "lane_testgen", "lane_review", "run_child"],
+)
+def test_a_childs_terminal_fail_is_re_verified_not_believed(child):
+    """243(b): the parent does not trust a child's self-report in EITHER direction.
+
+    These edges used to run straight to `postmortem`, which made a lane's own
+    terminal outcome the parent's verdict.  In the 2026-08-15 exemplar-01 runs
+    the shipped bug-fix lane's `test_gate` runs a hardcoded `pytest -q` from the
+    workspace root, which cannot pass for a package nested one level down; it
+    exhausted its own budget and reported FAIL.  The objective was satisfied --
+    the admitted `cd <pkg> && python3 -m pytest tests/ -v` exits 0 -- but
+    `evidence_gate` never ran once, so the parent escalated an objective it had
+    never checked.
+    """
+    graph = _graph()
+    fail_edges = [
+        e
+        for e in graph.outgoing_edges(child)
+        if e.condition and "outcome=fail" in e.condition
+    ]
+    assert fail_edges, f"{child} has no failure route at all"
+    assert [e.to_node for e in fail_edges] == ["evidence_gate"], (
+        f"{child}'s FAIL must enter the parent's own gate, not bypass it; "
+        f"got {[e.to_node for e in fail_edges]}"
+    )
+    # postmortem stays reachable -- through the budget wall, where giving up belongs.
+    assert any(
+        e.to_node == "postmortem" and "exhausted" in (e.condition or "")
+        for e in graph.outgoing_edges("evidence_gate")
+    )
+
+
+def test_escalation_terminates_the_run_without_a_routing_error(tmp_path):
+    """243(a), end to end on the SHIPPED graph, with no LLM node executed.
+
+    `preflight -> escalated [outcome=fail]` is a tool-to-tool route, so a bad
+    `runner_dir` walks the real file from `start` to the real `escalated` and
+    out through the real exit.  Pre-fix this returned FAIL carrying
+    `PIPELINE_ERROR error_type=no_matching_edge` and notes "No matching edge
+    from node 'escalated'"; post-fix the FAIL is `escalated`'s own exit code.
+    """
+    import asyncio
+
+    from amplifier_module_loop_pipeline.context import PipelineContext
+    from amplifier_module_loop_pipeline.engine import PipelineEngine
+    from amplifier_module_loop_pipeline.handlers import HandlerRegistry
+    from amplifier_module_loop_pipeline.handlers.context import HandlerContext
+    from amplifier_module_loop_pipeline.outcome import StageStatus
+    from amplifier_module_loop_pipeline.pipeline_events import PIPELINE_ERROR
+
+    class _Hooks:
+        def __init__(self):
+            self.events = []
+
+        async def emit(self, name, data):
+            self.events.append((name, data))
+
+    context = PipelineContext()
+    context.set("context.target_dir", str(tmp_path))
+    context.set("runner_dir", str(tmp_path / "not-the-objective-dir"))
+    context.set("target_dir", str(tmp_path))
+
+    hooks = _Hooks()
+    engine = PipelineEngine(
+        graph=_graph(),
+        context=context,
+        handler_registry=HandlerRegistry(HandlerContext(backend=None)),
+        logs_root=str(tmp_path / "logs"),
+        hooks=hooks,
+    )
+    outcome = asyncio.run(engine.run())
+
+    routing_errors = [
+        d for n, d in hooks.events
+        if n == PIPELINE_ERROR and d.get("error_type") == "no_matching_edge"
+    ]
+    assert not routing_errors, (
+        "the designed escalation is being reported as an authoring bug: "
+        f"{routing_errors}"
+    )
+    assert outcome.status is StageStatus.FAIL, "escalation must stay LOUD (CLI exit 1)"
+    assert "No matching edge" not in ((outcome.notes or "") + (outcome.failure_reason or ""))
+    assert (tmp_path / ".objective" / "disposition").read_text(encoding="utf-8").strip() == "escalated"
+    assert (tmp_path / ".objective" / "postmortem" / "escalation.md").is_file()
+
+
+@_SHELL_GATES
+def test_evidence_gate_runs_a_cd_carrying_command_exactly_as_admitted(tmp_path):
+    """243(b): the shipped gate command, on the exemplar-01 workspace shape.
+
+    The run's postmortem reconstructed this as "the pipeline evaluated the
+    evidence command from the wrong working directory... rather than
+    `cd /workspace/notesvc && python3 -m pytest tests/ -v`".  Driven against the
+    real `tool_command`, that reconstruction does not hold: `bash -c "$ev"`
+    hands the admitted string to a shell verbatim and the `cd` is honoured.
+    What was missing is the receipt -- nothing recorded WHAT the gate ran, so a
+    divergence could only ever be inferred from a postmortem at budget
+    exhaustion.  This pins both halves.
+    """
+    workspace = tmp_path
+    state = workspace / ".objective"
+    state.mkdir()
+    pkg = workspace / "notesvc" / "notesvc"
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    (pkg / "users.py").write_text("def user_slug(u):\n    return u.lower()\n", encoding="utf-8")
+    tests = workspace / "notesvc" / "tests"
+    tests.mkdir()
+    (tests / "test_users.py").write_text(
+        "from notesvc.users import user_slug\n\n\ndef test_slug():\n    assert user_slug('AB') == 'ab'\n",
+        encoding="utf-8",
+    )
+    # A stale anchor stands in for preflight's pre-work digest, so delta=changed.
+    (state / "anchor").write_text("0" * 32 + "\n", encoding="utf-8")
+
+    admitted = f"cd {workspace}/notesvc && python3 -m pytest tests/ -q"
+    (state / "evidence-command").write_text(admitted + "\n", encoding="utf-8")
+    (state / "evidence-command.sha256").write_text(
+        hashlib.sha256((state / "evidence-command").read_bytes()).hexdigest() + "\n",
+        encoding="utf-8",
+    )
+
+    result = _run_gate("evidence_gate", workspace)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "evidence_ok", (
+        "a cd-carrying admitted command must run as admitted: "
+        f"{(state / 'evidence-1.log').read_text(encoding='utf-8')}"
+    )
+    record = json.loads((state / "convergence.jsonl").read_text(encoding="utf-8").splitlines()[-1])
+    assert record["dod_exit"] == 0 and record["delta"] == "changed", record
+
+    # The receipt: what ran, recorded next to what was admitted.
+    log = (state / "evidence-1.log").read_text(encoding="utf-8")
+    assert log.splitlines()[0] == f"RAN AS ADMITTED: {admitted}", log.splitlines()[:1]
+    assert record["evidence_command_sha"] == hashlib.sha256(
+        admitted.encode()
+    ).hexdigest()[:12], record
+
+
+@_SHELL_GATES
+def test_preflight_refuses_when_the_shell_the_gate_uses_is_absent(tmp_path):
+    """243(b), the same class one layer earlier.
+
+    `evidence_gate` executes the admitted command with `bash -c`.  Preflight
+    verified `sha256sum`, `md5sum` and `find` but not `bash`, so a workspace
+    without bash would have returned `ready` and then failed EVERY evidence
+    iteration for a reason no code change could affect -- a gate that could
+    never go green, which is exactly the shape #243(b) reports.
+    """
+    stub_bin = tmp_path / "bin"
+    stub_bin.mkdir()
+    # Everything preflight itself needs, and deliberately NOT bash.
+    for tool in ("mkdir", "sha256sum", "md5sum", "find", "sort", "cut"):
+        real = shutil.which(tool)
+        if real is None:
+            pytest.skip(f"{tool} is not available to build a bash-free PATH")
+        (stub_bin / tool).symlink_to(real)
+    assert shutil.which("bash", path=str(stub_bin)) is None
+
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    result = subprocess.run(
+        _tool_command("preflight"),
+        shell=True,
+        cwd=workspace,
+        env={
+            "PATH": str(stub_bin),
+            "runner_dir": str(_OBJECTIVE_DIR),
+            "target_dir": str(workspace),
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.stdout == "blocked", (
+        "preflight admitted a workspace whose shell the evidence gate cannot use; "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    assert result.returncode != 0
+    assert "bash" in result.stderr, result.stderr


### PR DESCRIPTION
Fixes #243

Two defects in `examples/objective/objective-runner.dot`, both reproduced identically in two independent DTU runs of `exemplar-01-sloppy-routable`. Both were probed before being fixed, and **on both, the probe contradicted the issue's reconstruction.**

## Root cause (a) — the escalation terminal

**The issue's reconstruction:** something about *this file's* `escalated` node made the engine report the designed escalation as `no_matching_edge`.

**What the probe found:** nothing about this file differed. The idiom is byte-identical across `examples/authoring/pipeline-author.dot`, `examples/drift-review/drift-review.dot`, `examples/pipelines/practical/bug-fix.dot` and this file — a `parallelogram` with `max_retries=0`, a `printf …; exit 1` command, and **no outgoing edge at all**. The engine's main loop simply has no designed-terminus concept:

```python
# engine.py::run_subgraph — knows the difference
# (a) Conditional-mismatch dead end: outgoing edges exist but none matched … hard failure
# (b) No outgoing edges at all: a designed terminus. Return the last outcome unchanged
```
```python
# engine.py::run — does not. Any unmatched node, whatever its exit status:
fail_outcome = self.terminate_pipeline(..., termination_reason=self._no_matching_edge_reason(...))
await self._emit(PIPELINE_ERROR, {"error_type": "no_matching_edge", ...})
```

Probed on the shipped CLI with a minimal graph, the dead-end reports `no_matching_edge` **on `exit 0` too** — the exit status is irrelevant:

```
# tool node exits 1, dead-ends
[PIPELINE] ✗ Error at escalated (no_matching_edge): Command exited with code 1: escalated
{"status": "fail", "notes": "No matching edge from node 'escalated'", ...}

# same node exits 0, dead-ends
[PIPELINE] ✗ Error at escalated (no_matching_edge): No matching edge from node 'escalated'
```

So a deliberate loud terminal **must route**; it cannot dead-end. The repo already names the idiom for exactly this case, in `docs/DOT-AUTHORING-GUIDE.md` (TOPO-006):

> deliberate finish-through-`done` designs exist (e.g. **a budget-exhaustion exit that deliberately ends at the single exit node with a genuine FAIL outcome, as in `examples/patterns/convergence-factory.dot`, which consciously carries this diagnostic**)

The mechanism that makes it clean is `_check_goal_gates`: with every goal gate satisfied it returns `node_outcomes[completed_nodes[-1]]` — i.e. `escalated`'s own FAIL — so the run ends `status=fail` / CLI exit 1 with **no** routing error.

**Corollary found while probing the fix (this is why `retry_target` is removed):** `retry_target` on a goal gate is consulted in exactly one place, `_check_goal_gates()` at the exit node. Before `escalated -> done` the exit was unreachable with the gate unsatisfied, so `evidence_gate`'s `retry_target="feedback"` was dead. Adding the edge makes it live — and wrong, because the only way this gate is unsatisfied at the exit is the `tampered` refusal, whose cause survives every retry. Measured on the shipped engine with a faithful 5-node reduction:

```
with retry_target="feedback":  node visits {'evidence_gate': 51, 'postmortem': 51, 'escalated': 51, 'feedback': 50}
without it:                    node visits {'evidence_gate': 1,  'postmortem': 1,  'escalated': 1}
```

## Root cause (b) — the evidence gate

**The issue's reconstruction** (quoting the run's own postmortem):

> The pipeline evaluated the evidence command from the wrong working directory … Ensure the pipeline evaluates `evidence_command` by executing it as a shell command (i.e. via `sh -c` or equivalent that honours `cd`), not by naively splitting on whitespace

**What the probe found: the gate honours `cd` perfectly — it never ran.** Driving the real `tool_command` (extracted verbatim by the engine's parser) against the exemplar-01 workspace shape, with the admitted `cd <ws>/notesvc && python3 -m pytest tests/ -q`:

```
--- evidence_gate (real tool_command, cwd=workspace):
   returncode: 0
   stdout token: 'evidence_ok'
   convergence.jsonl: {"iteration": 1, "gate": "evidence", "dod_exit": 0, "delta": "changed"}
```

`bash -c "$ev"` hands the admitted string to a shell verbatim. The failure was one layer up. The `ModuleNotFoundError` the issue quotes came from **`.ai/test.log`** — the `.ai/` namespace belongs to the *lane child*, `bug-fix.dot`, whose gate is hardcoded:

```dot
test_gate [ … tool_command="… else pytest -q > .ai/test.log 2>&1; …" ]
```

`pytest -q` from the workspace root cannot pass for a package nested one level down. Reproduced locally on the same fixture: `exit=2`, `ERROR notesvc/tests/test_users.py … 1 error during collection`. The lane oscillated to **its own** budget wall — the postmortem's own numbers are all the child's (`/workspace/.ai/iter = 6`, a byte-stable `.ai/last-fail-sig`) — reported FAIL, and that FAIL routed **straight past** `evidence_gate` to `postmortem`.

The decisive artifact evidence that the parent's gate never ran once: `evidence_gate` writes `.objective/evidence-$n.log`, `.objective/convergence.jsonl` and `.objective/iter` on **every** entry, and the salvaged run has **none of them** — only `disposition`, `objective.md`, `postmortem/report.md`, `triage.json`. The run's own postmortem lists the durable artifacts and every one is `.ai/`.

So the parent escalated an objective it had never checked — and the objective was already satisfied. That is the graph trusting a child's **self-reported red**, which is the same trust it explicitly refuses to extend to a child's green:

> THE PARENT NEVER TRUSTS THE CHILD'S SELF-REPORT. … Satisfaction is decided by `evidence_gate`, which RE-RUNS the definition-of-done command itself

## Fixes

| # | Defect | Change | Why |
|---|---|---|---|
| 1 | (a) | `escalated -> done [condition="outcome=fail"]` | The loud terminal routes to the single exit node carrying its own nonzero exit — the `convergence-factory.dot` idiom the authoring guide names. No `no_matching_edge`. |
| 2 | (a) | `retry_target="feedback"` removed from `evidence_gate` | Dead before fix 1; a 51-iteration hazard on the `tampered` path after it. `tampered` means terminal, and the file already said so. |
| 3 | (b) | 5 `lane_* -> postmortem [outcome=fail]` + `run_child -> postmortem [outcome=fail]` retargeted to `evidence_gate` | The parent does not trust a child's self-report in **either** direction. `postmortem` stays reachable through the budget wall (`exhausted`), where the decision to give up belongs. |
| 4 | (b) | `preflight` now requires `bash` on PATH | `evidence_gate` executes the admitted command with `bash -c`. Preflight checked `sha256sum`/`md5sum`/`find` but not the interpreter the gate itself uses — a bash-less workspace returned `ready` and then failed every iteration for a reason no code change could affect. |
| 5 | (b) | The gate records what it ran: `RAN AS ADMITTED: <command>` opens each evidence log, and `evidence_command_sha` joins `convergence.jsonl` | The issue's own suggested follow-up. A divergence between admitted and executed is now visible on iteration 1 instead of reconstructed from a postmortem at budget exhaustion. |

**Node/edge count:** 21 nodes → 21 nodes; 50 edges → 51 edges (5 lane fail edges and 1 `run_child` fail edge retargeted, +1 for `escalated -> done`).

**Comments updated to match**, including the two engine facts the terminal contract now depends on, and both lint diagnostics this file now carries on purpose.

## Deterministic proof — RED → GREEN

12 regression cases added to `modules/loop-pipeline/tests/test_objective_layer_gates.py`, all reading the shipped graph through the engine's own parser and driving the real command text (never a paraphrase). Pre-fix, with the new tests present and `objective-runner.dot` reverted to `origin/main`:

```
11 failed, 39 passed in 1.78s
```

```
E  AssertionError: `escalated` has no outgoing edge, so the engine reports the designed escalation as PIPELINE_ERROR error_type=no_matching_edge (issue #243a)
E  assert []

E  AssertionError: lane_bugfix's FAIL must enter the parent's own gate, not bypass it; got ['postmortem']
E  assert ['postmortem'] == ['evidence_gate']

E  AssertionError: feedback
E  assert not 'feedback'
E   +  where 'feedback' = get('retry_target')

E  AssertionError: preflight admitted a workspace whose shell the evidence gate cannot use; stdout='ready' stderr=''
E  assert 'ready' == 'blocked'
```

The end-to-end case walks the **shipped** graph from `start` to the real `escalated` and out through the real exit with no LLM node executed (`preflight -> escalated` is tool-to-tool), and the cd-carrying case fails pre-fix on the missing receipt.

Post-fix, same file:

```
50 passed in 2.70s
```

(38 pre-existing cases + 12 new; the pre-existing 38 are untouched and green.)

## Live proof

Evidence on the host at `.amplifier/evaluation/objective-layer/20260815T190918Z/` (`EVIDENCE.md`, plus `run.log` / `exit-code.txt` / `workspace/` per run).

| Run | What it drives | Result |
|---|---|---|
| `run-a1-escalation-preflight` | **Post-fix**, shipped graph, real CLI, bad `runner_dir` → `preflight` exits 1 → `escalated` → `done`. No LLM node. | exit **1**, `status=fail`, **0** `no_matching_edge`, `disposition=escalated`, `postmortem/escalation.md` written |
| `run-a2-escalation-postmortem` | **Post-fix, real LLM run**, shipped graph, unreadable `triage-schema.json` → `triage_gate` nonzero → `postmortem` (LLM) → `escalated` → `done`. | exit **1**, `status=fail`, **0** `no_matching_edge`, `disposition=escalated`, `postmortem/report.md` **and** `escalation.md` written |
| `run-b0-prefix-baseline` | **PRE-FIX baseline.** Reduction built from `git show HEAD:…/objective-runner.dot`, node blocks copied verbatim; lane gives up nonzero exactly as exemplar-01's did. | exit 1, **1** `no_matching_edge`, `notes="No matching edge from node 'escalated'"`, `disposition=escalated` — and **no** `.objective/evidence-*.log`, **no** `.objective/convergence.jsonl`: both defects, one run |
| `run-b1-evidence-gate-cd` | **Post-fix.** Same reduction and workspace, post-fix node blocks + edges, admitted command `cd <ws>/notesvc && python3 -m pytest tests/ -v`. | exit **0**, `status=success`, **0** `no_matching_edge`, `disposition=`**`satisfied`**, `dod_exit: 0`, `delta: changed` |

`run-b1`'s log records the receipt and the divergence it exists to catch:

```
$ python3 -m pytest -q            # the lane's hardcoded gate, from the workspace root
ERROR notesvc/tests/test_users.py
!!!!!!!! Interrupted: 1 error during collection !!!!!!!!

# .objective/evidence-1.log, first line
RAN AS ADMITTED: cd …/run-b1-evidence-gate-cd/workspace/notesvc && python3 -m pytest tests/ -v
# .objective/convergence.jsonl
{"iteration": 1, "gate": "evidence", "dod_exit": 0, "delta": "changed", "evidence_command_sha": "eae19b8fc054"}
```

**Which live proofs were done, precisely:** (a) got two full CLI runs of the shipped graph — one deterministic, one with real LLM nodes reaching `postmortem -> escalated`. (b) got the gate-level live proof — the real engine executing the real `evidence_gate` node text through the real CLI — paired with a pre-fix baseline of the identical reduction. A full shipped-lane run (`bug-fix.dot` end to end) was **not** done: it is many LLM nodes × iterations, and the reduction isolates exactly the routing and gate behaviour under test.

## Lint

`attractor lint examples/objective/objective-runner.dot`: **0 errors**, 2 warnings, both deliberate and both documented in the file's header:

- `fail_routed_to_exit` (TOPO-006) on `escalated -> done` — the sanctioned deliberate design; `examples/patterns/convergence-factory.dot` carries the identical diagnostic for the identical reason. The hazard the rule guards (a failure leaving as `status: success`, exit 0) cannot happen here: `escalated` is the last node to complete and its FAIL is what the exit returns.
- `goal_gate_has_retry` on `evidence_gate` — a true observation about the wrong hop. The corrective loop for a red gate is `evidence_gate -> feedback -> triage_gate [loop_restart]`, one hop further downstream than the rule can see. Satisfying it would mean restoring the 51-iteration hazard above.

The whole `examples/` corpus still lints ERROR-free (`test_examples_lint_clean.py` green).

## Tier classification (QUALITY_PROTOCOL §3)

**Toward-spec.** No conformance-bearing code changed — this is an example graph plus its test file, so no ledger entry is owed. On direction: canonical §3.2 step 6 reads a dead end as successful completion; this engine deliberately diverges (ATX-11 / `specs/EXTENSIONS.md` §33, `terminate_pipeline` + `no_matching_edge`). Pre-fix, this exemplar's terminal *depended* on that divergence to be loud at all — the same file under spec-literal semantics would have exited **green**. Post-fix the terminal status is carried by an explicit edge and the node's own exit code, so the graph behaves identically under either dead-end rule. That closes a gap with the canonical spec rather than widening one, and it does so without asking the engine to move.

## Gates

| Gate | Result |
|---|---|
| `modules/loop-pipeline` (`uv sync --extra remote && uv run pytest -q`) | 2269 passed, 25 skipped |
| `modules/pipeline-runner` | 76 passed, 1 skipped |
| `test_objective_layer_gates.py` | 50 passed (38 pre-existing + 12 new) |
| `attractor lint` on the corpus | 0 ERRORs |
| `git diff --check` | clean |
| Leak scan (secrets / absolute paths / host names in the diff) | clean |
| Run artifacts committed | none — 2 files changed, evidence lives outside the repo |

## Observations

- **The escalation defect is not this file's.** `pipeline-author.dot`, `drift-review.dot` and `bug-fix.dot` all carry the identical dead-ending `escalated`, and `examples/patterns/task-runner.dot` carries two more (`bad_input`, `abandon`). Every one of them will report its designed loud terminal as `no_matching_edge`. This PR fixes only `examples/objective/` (its lane's scope); the other four are the same one-edge change and are worth a follow-up. `bug-fix.dot`'s own comment even anticipates the ambiguity — *"portable under either dead-end semantics (the canonical spec treats a no-edge dead-end as SUCCESS; this engine hard-fails)"* — which is exactly the portability the routing edge now makes real rather than assumed.
- **The lane's hardcoded gate is untouched and still a live hazard.** `bug-fix.dot`'s `test_gate` runs `pytest -q` from the workspace root and never learns the objective's admitted evidence command, so for any nested-package objective the lane cannot converge on its own. This PR stops that from *deciding the objective* (the parent now checks), but the lane still burns its full budget first. Making a lane consume the admitted command is a change to `examples/pipelines/practical/`, outside this lane's file scope.
- **The duplicate `[PIPELINE] ✗ Error at escalated` emission the issue notes did not reproduce.** Every probe run here emitted it exactly once. The two occurrences in both transcripts are 14 log lines apart, so they are not a print-twice; the likeliest explanation is the harness's own log capture, not the engine. Not chased further — the emission disappears entirely with the fix.
- **`_MAX_GOAL_GATE_RETRIES` is 50, not a small number.** It is also reused as the `max_steps` multiplier (`len(nodes) × 50`). Worth knowing before adding any `retry_target` to a goal gate whose exit is reachable while unsatisfied: the ceiling is high enough that "bounded" and "cheap" are very different claims.
- **`goal_gate_has_retry` fires on a correct graph here.** The rule looks for a `retry_target` or a `loop_restart` edge *on the gate node*; a corrective loop that goes gate → writer → router with the `loop_restart` on the last hop is invisible to it. Not worth changing the rule for one example, but it is a false-positive shape that will recur in any graph whose loop re-enters through a router.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)
