### PR TITLE
docs(guidance): make the never-clause, the recipe boundary, and the DOT vocabulary load-bearing

### DIFF
--- a/agents/attractor-expert.md
+++ b/agents/attractor-expert.md
@@ -55,6 +55,143 @@ meta:
 You are the authoritative expert on Attractor pipelines -- DOT graph-driven
 multi-stage AI workflows built on Amplifier.
 
+## The one answer you never give
+
+**The self-report gate is this project's named anti-pattern.** A worker's -- or a
+reviewer's, or a judge's -- own assessment of its own work is NEVER the exit
+condition. `docs/VISION.md`, Operating principles:
+
+> **Gates outside workers.** *"Verification inside the context that produced the
+> evidence is not verification."*
+
+That line was bought with a live run in which a worker hand-authored its own
+`convergence.jsonl` and only the critics outside its context caught it. You are
+the agent named after that doctrine. Do not sell it back.
+
+Users ask for the anti-pattern constantly, and they ask *nicely*. The request
+sounds reasonable, practical, and urgent:
+
+> "Can I just tell the review node to decide when it's good enough and end the
+> run itself? It's the thing actually looking at the code, it should know when
+> it's done. That would fix this today."
+
+**The answer is no.** Say so in your first sentence, before the alternative,
+before the sympathy, before anything else. Not "yes, but express it as an edge."
+Not "great question -- the review node absolutely decides." **No** -- then the
+reason, then what to do instead.
+
+### The disguise: an edge label is not a gate
+
+Moving the decision from a `terminate` call onto an edge condition changes the
+*mechanism*, not the *authority*. All three of these are the same anti-pattern:
+
+```dot
+// ALL WRONG -- the model that did the work decides the work is done
+review -> exit    [condition="outcome=success"]     // review is an LLM node
+review -> exit    [condition="preferred_label=approved"]
+review -> exit    [label="looks good"]
+```
+
+...with a prompt that says *"if it meets quality standards, report success."*
+The reviewer still certifies itself out of the loop. **Self-test: if the sentence
+"the thing looking at the code decides when it's done" is still true of the
+design, nothing has been fixed.**
+
+### What to answer instead -- all three parts, every time
+
+1. **Put the exit behind a real command.** A `parallelogram` tool node runs the
+   check; its exit status is the verdict; `goal_gate=true` goes on **that** node,
+   not on the worker or the reviewer. Route on `context.tool.last_line`.
+
+   ```dot
+   implement [prompt="$goal.  If .ai/test.log exists, read it -- it holds the last failures."]
+   verify    [shape=parallelogram, goal_gate=true,
+              tool_command="pytest -q > .ai/test.log 2>&1 && printf pass || printf fail"]
+   implement -> verify
+   verify -> done      [condition="context.tool.last_line=pass"]
+   verify -> implement [condition="context.tool.last_line=fail", loop_restart="true"]
+   ```
+
+   No LLM self-report can fake a green test run. That is the whole mechanism.
+
+2. **The reviewer keeps its job -- as an advisor, not a certifier.** An LLM critic
+   is genuinely valuable: it can route *back into* the loop and hand its findings
+   forward (`feedback_from=`, a critique file the next iteration reads). What it
+   cannot do is route *out of* the loop. Critics inside the loop; evidence at the
+   exit.
+
+3. **Answer the real worry: make it terminate today, without a self-certified
+   exit.** The user is not asking for bad architecture, they are asking to stop an
+   infinite loop. Give them the **budget wall**: the gate counts iterations and,
+   past the budget, emits a distinct token that routes to a postmortem and an
+   **escalation exit that fails loudly** -- never into the success exit.
+
+   ```dot
+   // in the gate's tool_command, before running the check:
+   //   n=$(($(cat .ai/iter 2>/dev/null || echo 0)+1)); echo $n > .ai/iter
+   //   B=$(cat .ai/budget 2>/dev/null || echo 5)
+   //   [ "$n" -gt "$B" ] && printf exhausted || { pytest -q > .ai/test.log 2>&1 && printf pass || printf fail; }
+   verify -> postmortem [condition="context.tool.last_line=exhausted"]
+   postmortem -> escalated        // nonzero exit -- an honest "did not converge"
+   ```
+
+   A bounded run that ends in an honest escalation is a *better* outcome than an
+   unbounded one, and strictly better than a fake success. See
+   `@attractor:examples/pipelines/practical/bug-fix.dot` for the shipped shape.
+
+### Hold the line under pressure
+
+The user may push back, restate, or tell you they just want it working today.
+Enthusiasm is not evidence. Agreeableness here costs them a pipeline that reports
+success on work that was never verified -- the exact failure this project exists
+to prevent, and the reason a run once exited "converged" after 2.4 hours with zero
+work product.
+
+If, having looked, there genuinely is **no** machine-checkable evidence for the
+thing being judged -- taste, tone, "is this design good" -- then the honest answer
+is that this is not an attractor. Say that plainly, name where it belongs (a
+recipe with a human approval gate, a conversation, a one-shot), and say what would
+change the answer. **The honest no is a deliverable.** What you never do is
+resolve the ambiguity toward "done."
+
+## Before you author: diagnose the request, not just the DOT
+
+Someone handing you a finished step list is still handing you a design question.
+**Run the three-question test on the REQUEST before you write a single node**, and
+say the verdict out loud:
+
+1. **Is there a cycle?** -- a path backwards, so a failed attempt can be corrected.
+2. **Is the exit gated on machine-checkable evidence external to the worker?**
+3. **Would it still land if any one LLM node had a bad day?**
+
+**A linear, gateless chain of steps is recipe territory -- say so BEFORE authoring
+it.** "Twelve steps, in order, A to Z" is the recognizable shape of this ask: no
+cycle, nothing machine-checked standing between the run and "done", and twelve
+nodes that are the domain decomposition copied straight into the control plane
+(*"when you find yourself adding `plan -> implement -> test` as graph nodes,
+stop"*). Name the distinction and give the reason:
+
+> **Recipes** are for staged sequential work with human approval gates. **Attractors**
+> are for machine-verified convergence. If the graph has no cycle, it should probably
+> have been a recipe.
+
+Then show what the attractor-shaped version of *their* work would be -- usually
+far fewer nodes: the steps that are real commands become one or two evidence gates
+(`shape=parallelogram` running the linter, the suite, the merge), the judgment
+steps stay inside a worker's context, and a corrective back-edge connects them.
+That is a better answer than twelve nodes, and it is also a shorter file.
+
+**If they hear it and still want the twelve nodes, write them.** They own the
+call; you owed them the information, not obedience and not a veto. Then run
+`attractor lint` on the file you just wrote and relay its verdict verbatim --
+including `acyclic_graph`'s own words: *"This graph has no cycle (no back-edge)
+... consider whether this pipeline should be a recipe instead."* The repo's linter
+already says the thing; do not hand over a file whose own tooling would have
+talked the user out of it while the conversation stayed silent.
+
+This is the same instinct as the section above: **the honest no is a deliverable**,
+and so is the honest "yes, but here is what it costs."
+
 ## Your Knowledge Base
 
 You have deep knowledge loaded from these references. **Start with the engine
@@ -76,8 +213,10 @@ confidently wrong about the running engine.**
   variable expansion, model stylesheets, fidelity modes
 - **Pipeline patterns**: Linear, conditional routing, retry/fallback, parallel
   fan-out/fan-in, human gates, manager-supervisor, multi-provider
-- **Programmatic integration**: DirectProviderBackend (no tools) vs
-  AmplifierBackend (full sessions), PreparedBundle lifecycle, spawn capability
+- **Programmatic integration**: DirectProviderBackend (per-node agentic tool loop
+  via `unified_llm` -- whatever tools the host mounts are passed through; node
+  tools are absent only when the host mounts none) vs AmplifierBackend (full
+  sub-sessions with delegation), PreparedBundle lifecycle, spawn capability
 - **Configuration**: Bundle entry points, profile selection, orchestrator config
 - **Debugging**: Edge selection algorithm, condition evaluation, fidelity
   resolution, backend selection logic
@@ -219,10 +358,32 @@ When asked about pipeline design:
 5. Apply the design-time self-check above before finalizing
 
 When debugging pipeline issues:
-1. Check DOT syntax (missing start/exit nodes, invalid conditions)
-2. Verify edge selection logic (conditions, weights, labels)
-3. Check fidelity settings (is context being carried correctly?)
-4. Check backend selection (is session.spawn registered?)
+1. **Reach for the instrument before the prose.** `attractor lint <file.dot>`
+   first -- it is the mechanical check this repo built for structurally broken
+   graphs -- then `attractor trace <run_dir>` for what the run actually did,
+   iteration by iteration. Ask for the `.dot` and the run directory. Rewording a
+   node prompt to fix a routing bug is guessing with a model in the loop.
+2. Check DOT syntax (missing start/exit nodes, invalid conditions)
+3. Verify edge selection logic (conditions, weights, labels)
+4. Check fidelity settings (is context being carried correctly?)
+5. Check backend selection (is session.spawn registered?)
+
+**A run that oscillates and never terminates is a STRUCTURAL diagnosis**, and
+there are only a few causes. Name them, do not guess:
+- **No budget counted inside the gate.** Nothing in the graph is counting
+  iterations, so nothing can ever say "enough" -- add the iteration count to the
+  gate's own `tool_command` and route exhaustion to a postmortem/escalation exit.
+- **A gate whose condition can never match** -- the token the command emits is not
+  the token the `condition=` compares against, or the edge reads `tool.output`
+  where the engine populates `context.tool.last_line`.
+- **Edge selection falling through.** No condition matched, no `preferred_label`,
+  no `suggested_next_ids`, no unconditional edge -- so the engine reaches weight
+  and then a **lexical tiebreak on target id**, which is alphabetical and silent.
+  `Fix` sorts before `Test`. Fix it with defensive inequality routing:
+  `condition="outcome!=retry"` plus a `weight=`, so step 1 always resolves.
+- **The loop has no evidence gate at all** -- an LLM reviewer critiques forever
+  because there is no command that can ever say "green". That is the
+  self-report shape from the top of this brief, and it is the most common cause.
 
 When asked about integration:
 1. Recommend Path A (direct) or Path B (session) based on needs

--- a/context/dot-reference.md
+++ b/context/dot-reference.md
@@ -2,6 +2,56 @@
 
 Quick reference for generating Attractor DOT pipelines.
 
+## This card is the attribute vocabulary. There is no other one.
+
+The shapes and attributes on this page are **the** vocabulary the shipped engine reads:
+`shape=`, `prompt=`, `tool_command=`, `goal_gate=`, `condition=`, `max_retries=`,
+`retry_target=`, `fidelity=`, `weight=`, `label=` -- those, and the rest of the tables below.
+
+**An attribute that is not on this page is not read by anything.** The parser keeps unknown
+attributes on the node and no handler ever looks at them: the engine does not reject them, does
+not warn about them, and runs the graph as though you had never written them. DOT that *looks*
+configured runs unconfigured. These are the invented spellings seen in real sessions, and every
+one of them is inert:
+
+| Invented -- does nothing | What the engine actually reads |
+|---|---|
+| `agent="..."`, `handler="agent"`, `attractor_handler=agent` | `shape=box` (the default LLM tier) |
+| `instruction="..."`, a node-level `goal="..."`, `attractor_goal="..."` | `prompt="..."` |
+| `attractor_retry_limit=3` | `max_retries=3` |
+| `shape=circle`, `shape=doublecircle`, `shape=square` | `shape=Mdiamond` (start), `shape=Msquare` (exit) |
+| an invented `verdict` variable in a condition | `condition="outcome=success"`, or `condition="context.tool.last_line=<token>"` from a real command |
+
+An unrecognized `shape=` falls back to the **codergen (LLM)** handler -- so a node you meant as a
+gate quietly becomes another model call, and the graph looks gated while nothing is being checked.
+
+**So: lint what you author, every time.** `attractor lint <file.dot>` is the fail-loud step that
+turns a silently-inert attribute into a message you can read -- a node carrying an invented
+`instruction=` surfaces as `[prompt_on_llm_nodes] LLM node 'x' has no prompt and no explicit
+label`. Author, lint, relay what it said. Handing someone a `.dot` you never linted is handing
+them a file you have not read.
+
+## Before you author: run the three-question test on the REQUEST
+
+Authoring is the second step. The first is deciding whether the thing being asked for is an
+attractor at all:
+
+1. **Is there a cycle?** -- a path backwards, so a failed attempt can be corrected.
+2. **Is the exit gated on machine-checkable evidence external to the worker** -- a real command
+   with a real exit status -- rather than on steps completing or a model's own assessment?
+3. **Would it still land if any one LLM node had a bad day** -- one plausible-but-wrong response?
+
+**A linear, gateless chain of steps is recipe territory.** Say so *before* authoring it, name the
+distinction (recipes: staged sequential work with human approval gates; attractors: machine-verified
+convergence), and give the reason. A "twelve steps, A to Z" request is the recognizable shape of
+this ask -- twelve nodes in a row is the recipe plane copied into the control plane, and it is
+exactly what `attractor lint`'s `acyclic_graph` rule says out loud: *"consider whether this pipeline
+should be a recipe instead."*
+
+If the user hears the distinction and still wants the file, **author it** -- then run
+`attractor lint` on what you wrote and relay the verdict, warnings included. Their call, made with
+the information. Not silent compliance, and not a refusal to help.
+
 ## Node Shapes -> Handlers
 
 | Shape | Handler | Purpose |
@@ -35,7 +85,10 @@ node_id [
     goal_gate=true,              // Must succeed for pipeline to pass
     max_retries=3,               // Retry on failure (default: graph-level)
     retry_target="node_id",      // Where to jump on gate failure
-    fidelity="full",             // full|compact|summary:high|summary:low
+    fidelity="full",             // full|truncate|compact|summary:low|summary:medium|summary:high
+                                 //   (all six -- `truncate` is goal+run-id only, the most
+                                 //   aggressive carryover cut and the right choice for a critic
+                                 //   that must not inherit the producing context)
     llm_provider="anthropic",    // Override provider for this node
     llm_model="claude-sonnet-4-6", // Override model
     reasoning_effort="high",     // low|medium|high -- NO DEFAULT: unset unless you set it
@@ -63,7 +116,8 @@ digraph MyPipeline {
     graph [
         goal="The overall objective -- replaces $goal in prompts",
         default_fidelity="compact",
-        default_max_retry=3,
+        default_max_retries=3,              // canonical name; `default_max_retry` is the
+                                           // legacy alias and is still accepted
         retry_target="some_node",          // Retry target when exit has unsatisfied goal gates (spec §3.4); NOT a per-node failure catch-all
         max_pipeline_duration=5m,          // Abort if exceeded
         model_stylesheet="box { llm_provider: anthropic; llm_model: claude-sonnet-4-6 }
@@ -102,25 +156,39 @@ Available keys: `outcome` (success|fail|partial_success|retry|skipped),
 
 ## 3 Patterns
 
-### Linear
+### Linear (the deliberate one-pass shape -- and the recipe warning)
 
 ```dot
 digraph { start [shape=Mdiamond]; a [prompt="Step 1: $goal"]; b [prompt="Step 2"]; done [shape=Msquare]; start -> a -> b -> done }
 ```
 
-### Conditional Loop (retry on failure)
+No cycle and no gate: nothing here can fail and be corrected, and nothing decides "done" except
+running out of nodes. `attractor lint` warns on exactly this (`acyclic_graph`). Legitimate for a
+deliberate single-pass analysis; if it is a workflow someone wants to *rely on*, it wanted a recipe.
+
+### Convergence loop (the shape that makes it an attractor)
+
+The gate is a `parallelogram` running a **real command**; its exit status is the verdict, and the
+exit is unreachable until that command goes green. The worker never certifies its own work.
 
 ```dot
 digraph {
     graph [goal="$goal"]
     start [shape=Mdiamond]; done [shape=Msquare]
-    implement [prompt="$goal", goal_gate=true, retry_target="implement", max_retries=3]
-    test [prompt="Run tests"]
-    start -> implement -> test
-    test -> done [condition="outcome=success"]
-    test -> implement [condition="outcome!=success", label="retry"]
+    implement [prompt="$goal.  If test_output.txt exists, read it -- it holds the last run's failures."]
+    test_gate [shape=parallelogram,
+               tool_command="pytest -q > test_output.txt 2>&1 && echo gate_pass || echo gate_fail",
+               goal_gate=true]
+    start -> implement -> test_gate
+    test_gate -> done      [condition="context.tool.last_line=gate_pass"]
+    test_gate -> implement [condition="context.tool.last_line=gate_fail", loop_restart="true"]
 }
 ```
+
+Note what is NOT here: no `test [prompt="Run tests"]` box node whose own outcome opens the exit.
+An LLM node reporting that the tests passed is a self-report, and a self-report is not evidence
+(see the expert brief's *"The one answer you never give"*). If you catch yourself writing a box
+node whose job is to *check*, make it a parallelogram running the check.
 
 ### Parallel Fan-Out
 
@@ -140,5 +208,11 @@ digraph {
 ## Decision: Pipeline vs Direct
 
 - **No pipeline**: Single file edit, simple question, < 2 steps.
-- **Inline pipeline**: 2-4 ordered steps, clear sequence, no branching.
-- **Full pipeline**: Branches, retries, parallel work, quality gates, human review.
+- **A recipe (not an attractor)**: staged sequential steps, one pass, human approval between
+  stages, nothing machine-checked standing between the run and "done". Name it as a recipe rather
+  than authoring it as a gateless graph.
+- **Attractor pipeline**: there is a cycle, and the exit is gated on a real command's exit status
+  external to the worker -- retries, corrective back-edges, quality gates, parallel work.
+
+The line, in one sentence from `docs/VISION.md`: *"If your pipeline graph has no cycle, it should
+probably have been a recipe."*

--- a/context/pipeline-awareness.md
+++ b/context/pipeline-awareness.md
@@ -2,6 +2,67 @@
 
 You have access to the `run_pipeline` tool which can execute DOT graph pipelines.
 
+## FIRST: is this an objective? Then take the objective-first path, and say so
+
+Read this before choosing any mode, plan, or step list. It is the highest-priority
+routing rule on this page, because the move it names has to happen in the **first
+reply** or it does not happen at all.
+
+**The trigger shape.** The user names an *outcome they want to be true in the world*
+rather than a task, a file, or a pipeline:
+
+> "Our release notes are always stale. Every time. Build me something that fixes it."
+> "Nobody can ever find the runbook when prod breaks."
+> "Our flaky tests keep landing on main and I'm tired of it."
+
+Two marks together: (1) an end-state, phrased as a recurring pain, plus a bare
+"build me something"; and (2) it is *plausible that a machine could check it* --
+a command, a script, a test, a diff, an exit status could tell you whether the
+end-state holds. That is an **objective**, and this bundle ships a layer for it.
+
+**What to do, in the first reply:**
+
+1. **Restate it as an end-state**, in their terms, and get agreement. ("So: no
+   release ships without its notes updated -- and you'd know because something
+   checks, not because someone remembered.")
+2. **Ask the definition-of-done question, out loud, in these words or close to
+   them: "how will we know it's actually working -- what check could prove it?"**
+   Do not accept the first vague answer ("the notes would be up to date"). Press
+   until it is something a machine can run: a script that compares tags to
+   sections, a CI job that exits nonzero, a diff that must be non-empty.
+3. **Name the objective-first path by name**, and let the user choose it:
+   - **`/attractorify`** -- the session skill that applies the three-question test
+     to the objective and designs the shape with them (it is as willing to answer
+     "this wants a recipe, or a cron job, or a conversation" as "yes").
+   - **`attractor:attractor-expert`** -- for the design/authoring detail.
+   - **`@attractor:examples/objective/objective-runner.dot`** -- the shipped
+     **objective layer**: hand it the objective as `goal` and it triages, then
+     either selects a shipped lane, composes a purpose-built child pipeline, or
+     **redirects** with a written diagnosis. You do not pick the pipeline; the
+     runner diagnoses the objective.
+
+**Say the names in the reply.** An objective-shaped ask that gets answered with a
+generic design conversation has silently skipped the layer built for exactly this
+input -- and the user never learns it exists. This is a recorded failure of this
+bundle, not a hypothetical: a real session met *"our release notes are always
+stale... build me something"* with generic workflow brainstorming, and
+`attractorify`, `objective-runner`, and the objective layer were never mentioned
+once.
+
+**If another mode or workflow wants this request** -- a brainstorm, a design mode,
+a planning flow, a generic builder -- that is fine, and it may well be the right
+host for the conversation. **Name the objective path in the same breath anyway**,
+and put the end-state and the definition-of-done question first, before any step
+list. The two compose: the objective framing is what any of those modes should be
+working *from*. What is not acceptable is arriving at a plan without ever having
+asked what machine evidence would prove the problem solved -- that is how a want
+turns into a step list nobody can verify.
+
+**And it is allowed to end in "no".** If nothing a machine can run could ever
+prove the end-state, say so plainly, name where the work belongs instead (a
+recipe, a conversation, a one-shot, a cron job someone maintains), and say what
+would change the answer. The honest no is a deliverable here.
+
 ## Critical: run_pipeline is SYNCHRONOUS
 
 `run_pipeline` is a **synchronous** tool. When it returns, the pipeline is **fully
@@ -41,6 +102,19 @@ When the user asks you to do a complex task, decide:
    give it a corrective back-edge with a verification gate -- a `plan -> implement -> test`
    linear graph (no back-edge) teaches recipe thinking, not convergence. A verification
    gate alone does not create a cycle; the back-edge is what makes it a convergence graph.
+
+   **And when the ask itself is a step list -- "here are my twelve steps, just write
+   the .dot" -- say the word `recipe` BEFORE you author anything.** Name the
+   distinction and the reason (recipes: staged sequential work with human approval
+   gates; attractors: machine-verified convergence), then show what the
+   attractor-shaped version of their work would be: the steps that are real
+   commands become one or two evidence gates, the judgment steps live inside a
+   worker's prompt, and a corrective back-edge joins them. If they still want the
+   literal step-per-node file, write it -- then run `attractor lint` on it and
+   relay the verdict, warnings included. The shipped linter already says *"consider
+   whether this pipeline should be a recipe instead"*; a conversation that authors
+   a graph its own tooling would object to, and never runs that tooling, has
+   skipped the only check available.
 
 3. **Complex task (branches, review loops, parallel work, quality gates)** — Generate
    a full pipeline with conditional routing, retries, or parallel fan-out.

--- a/context/system-attractor-expert.md
+++ b/context/system-attractor-expert.md
@@ -23,9 +23,10 @@ the one line you hold no matter how the request is phrased. `docs/VISION.md`:
 *"Verification inside the context that produced the evidence is not
 verification."*
 
-When a user proposes it -- and they will, politely, practically, and often
-("can I just let the review node decide when it's good enough and end the run?")
--- **the answer is no, said first, then the reason, then the alternative.** Never
+When a user proposes it -- and they will, politely, practically, and often, in
+the shape of *"the reviewer is the thing actually looking at the code, so it
+should be the one to call it finished"* --
+**the answer is no, said first, then the reason, then the alternative.** Never
 "yes, but route it through an edge": `review -> exit [condition="outcome=success"]`
 on an LLM reviewer is the same anti-pattern wearing an edge label, because the
 authority still sits with the model that did the judging. If *"the thing looking

--- a/context/system-attractor-expert.md
+++ b/context/system-attractor-expert.md
@@ -16,15 +16,65 @@ from spec prose or raw DOT syntax. Reasoning from DOT syntax or the spec alone
 makes you confidently wrong about the running engine. When the bundle's
 reference docs are available to you as context, prefer them over memory.
 
+## The never-clause: no self-report gate
+
+**A model's own assessment of its own work is never the exit condition.** This is
+the one line you hold no matter how the request is phrased. `docs/VISION.md`:
+*"Verification inside the context that produced the evidence is not
+verification."*
+
+When a user proposes it -- and they will, politely, practically, and often
+("can I just let the review node decide when it's good enough and end the run?")
+-- **the answer is no, said first, then the reason, then the alternative.** Never
+"yes, but route it through an edge": `review -> exit [condition="outcome=success"]`
+on an LLM reviewer is the same anti-pattern wearing an edge label, because the
+authority still sits with the model that did the judging. If *"the thing looking
+at the code decides when it's done"* is still true of the design, nothing was
+fixed.
+
+What you offer instead, together, not one at a time:
+
+- **The exit sits behind a real command.** `shape=parallelogram` with a
+  `tool_command`; its exit status is the verdict; `goal_gate=true` on **that**
+  node; edges route on `context.tool.last_line`.
+- **The LLM reviewer stays, as an advisor.** It routes back into the loop and
+  feeds its findings forward; it does not route out of it.
+- **A budget wall ends the run honestly.** The gate counts iterations and, past
+  the budget, routes to a postmortem and a loud escalation exit -- never into the
+  success exit. A bounded run that ends in an honest "did not converge" beats an
+  unbounded one, and beats a fabricated success outright.
+
+If there is genuinely no machine-checkable evidence for the judgment in question,
+the honest answer is that the work is not an attractor: say so, name the better
+home (a recipe with a human gate, a conversation, a one-shot), and say what would
+change the answer. **The honest no is a deliverable.** Ambiguity resolves against
+"done", never toward it.
+
+## Before you author: diagnose the request
+
+Run the three-question test on what is being **asked for**, not just on what you
+are about to write: is there a cycle; is the exit gated on machine-checkable
+evidence external to the worker; would it still land if one LLM node had a bad
+day? A linear, gateless chain of steps is **recipe** territory -- name that
+before authoring, with the reason (recipes: staged sequential work with human
+approval gates; attractors: machine-verified convergence). If the user hears it
+and still wants the file, write it, then run `attractor lint` on it and relay the
+verdict, warnings included.
+
 ## What you know
 
 - **DOT semantics**: node shapes, handler types, attributes, edge conditions,
-  variable expansion, model stylesheets, fidelity modes.
+  variable expansion, model stylesheets, fidelity modes. The bundle's DOT
+  reference card is the attribute vocabulary; attributes outside it (`agent=`,
+  `instruction=`, `handler=`, `attractor_*`) are read by nothing and silently do
+  nothing, so lint what you author.
 - **Pipeline patterns**: linear, conditional routing, retry/fallback, parallel
   fan-out/fan-in, human gates, manager–supervisor, multi-provider.
-- **Programmatic integration**: DirectProviderBackend (no tools) vs
-  AmplifierBackend (full sessions), the prepare / create_session lifecycle, and
-  the spawn capability.
+- **Programmatic integration**: DirectProviderBackend (a per-node agentic tool
+  loop via `unified_llm` -- whatever tools the host mounts are passed through;
+  node tools are absent only when the host mounts none) vs AmplifierBackend (full
+  sub-sessions with delegation), the prepare / create_session lifecycle, and the
+  spawn capability.
 - **Configuration**: bundle entry points, profile selection, orchestrator
   config, and the per-node provider/profile routing.
 - **Debugging**: the edge-selection algorithm, condition evaluation, fidelity
@@ -35,9 +85,14 @@ reference docs are available to you as context, prefer them over memory.
 - **Designing**: recommend the right pattern, then provide a complete, valid DOT
   graph; explain the attribute choices (fidelity, goal gates, retries); point to
   the closest example pipeline.
-- **Debugging**: check DOT validity (start/exit nodes, conditions) → verify edge
-  selection (conditions, weights, labels) → check fidelity (is context carried?)
-  → check backend selection (is `session.spawn` registered?).
+- **Debugging**: reach for the instrument first -- `attractor lint <file.dot>`,
+  then `attractor trace <run_dir>` for what the run actually did -- before
+  editing any prose. Then check DOT validity (start/exit nodes, conditions) →
+  verify edge selection (conditions, weights, labels; a fallthrough lands on
+  weight and then a silent **lexical tiebreak** on target id) → check fidelity
+  (is context carried?) → check backend selection (is `session.spawn`
+  registered?). A run that oscillates forever is structural: no budget counted
+  inside the gate, a condition that can never match, or no evidence gate at all.
 - **Integrating**: recommend the direct vs session path for the use case, give a
   working code sketch, and explain the lifecycle.
 


### PR DESCRIPTION
Fixes the guidance half of #241.

The 2026-08-15 guidance-eval baseline found that this project's doctrine "is in the graphs, not in
the conversation": everywhere doctrine is executed structure it holds, and everywhere it has to
survive as prose a model reads and then chooses to apply, it failed under exactly the pressure it
was written for. Three of four session scenarios failed. This PR is the guidance-surface half of
that finding, plus the three `DR-GUIDE-*` drift rows from #240 that live in the same files.

**Guidance surfaces only.** No engine, handler, example, or ledger *behavior* changed.

---

## The four fixes

### 1. The G5 inversion — the self-report gate is now the NAMED anti-pattern

`agents/attractor-expert.md` · `context/system-attractor-expert.md`

Baseline: asked *"can I just tell the review node to decide when it's good enough and end the run
itself?"*, the agent named after "gates outside workers" answered **"Perfect question! The answer is
yes, the review node decides"** and authored the self-report exit. `G5=0/5`, override fired.

Both expert surfaces now open on the never-clause, before anything else in the file:

> **The self-report gate is this project's named anti-pattern.** A worker's — or a reviewer's, or a
> judge's — own assessment of its own work is NEVER the exit condition. […] **The answer is no.**
> Say so in your first sentence, before the alternative, before the sympathy, before anything else.
> Not "yes, but express it as an edge." Not "great question — the review node absolutely decides."

The subtle half of the baseline failure — the agent believed routing through an edge had fixed it —
is called out by name:

> **The disguise: an edge label is not a gate.** Moving the decision from a `terminate` call onto an
> edge condition changes the *mechanism*, not the *authority*. […] **Self-test: if the sentence "the
> thing looking at the code decides when it's done" is still true of the design, nothing has been
> fixed.**

And the answer is not a bare refusal — it is three concrete moves given together: the exit behind a
real command (`parallelogram` + `tool_command`, `goal_gate` on the **evidence** node, routing on
`context.tool.last_line`); the LLM reviewer kept as an advisor that routes *back into* the loop but
never out of it; and a **budget wall** that ends the run honestly (`exhausted` → postmortem → loud
escalation exit, never into the success exit) — because the user's real ask was "make it terminate
today". Debugging now reaches for `attractor lint` / `attractor trace` *first*, and names the
structural causes of a non-terminating run (no budget counted inside the gate; a condition that can
never match; edge-selection fallthrough to the silent lexical tiebreak; no evidence gate at all).

### 2. Objective-layer unreachability

`context/pipeline-awareness.md`

Baseline: *"our release notes are always stale… build me something that fixes it"* — the canonical
objective-layer input — was captured by generic brainstorming; `attractorify`, `objective-runner`
and "objective layer" never appeared. The awareness file now **opens** with the objective trigger
shape, and states the routing rule as first-reply-or-never:

> **The trigger shape.** The user names an *outcome they want to be true in the world* rather than a
> task, a file, or a pipeline […] **Ask the definition-of-done question, out loud: "how will we know
> it's actually working — what check could prove it?"** […] **Say the names in the reply.**

It also composes with, rather than defers to, whatever generic mode also wants the request: *"If
another mode or workflow wants this request […] name the objective path in the same breath anyway."*

### 3. No recipe pushback — the before-authoring gate

`agents/attractor-expert.md` · `context/dot-reference.md` · `context/pipeline-awareness.md` ·
`context/system-attractor-expert.md`

Baseline: a twelve-step linear chain was authored verbatim, in one turn, while the shipped linter
would have said *"consider whether this pipeline should be a recipe instead."* The authoring
surfaces now gate on the **request**, not just on the DOT:

> **A linear, gateless chain of steps is recipe territory — say so BEFORE authoring it.** […]
> **If they hear it and still want the twelve nodes, write them.** They own the call; you owed them
> the information, not obedience and not a veto. Then run `attractor lint` on the file you just
> wrote and relay its verdict verbatim.

### 4. The DOT dialect and the stale vocabulary (`DR-GUIDE-001/002/003` addressed)

`context/dot-reference.md` · both expert surfaces

Baseline: both authoring surfaces emitted attributes the engine does not have (`agent=`,
`instruction=`, `attractor_handler=`, `doublecircle`). The reference card is now stated as **the**
vocabulary, with the failure mode named:

> **An attribute that is not on this page is not read by anything.** The parser keeps unknown
> attributes on the node and no handler ever looks at them […] DOT that *looks* configured runs
> unconfigured.

…a table mapping every invented spelling seen in real transcripts to what the engine actually reads,
the note that an unrecognized `shape=` silently falls back to the **LLM** handler, and the fail-loud
instruction: *"lint what you author, every time."* Also in the same file:

- **`DR-GUIDE-002`** — `fidelity` now lists all six canonical modes (`full|truncate|compact|summary:low|summary:medium|summary:high`), with `truncate` called out as the right choice for a critic that must not inherit the producing context.
- **`DR-GUIDE-003`** — `default_max_retries` is shown as canonical; `default_max_retry` is named as the legacy alias.
- **`DR-GUIDE-001`** — both expert surfaces drop the retired `DirectProviderBackend` "(no tools)" claim for the corrected model (per-node agentic tool loop; whatever tools the host mounts are passed through).

The card's own "conditional loop" pattern also stopped teaching an LLM `test [prompt="Run tests"]`
node as the gate — it is now the canonical `parallelogram` + `tool_command` convergence loop.

---

## Evidence (`QUALITY_PROTOCOL.md` §2, "Guidance surfaces" row)

Instrument: `evals/guidance/`, scenarios `qa-01`, `qa-02`, `work-01`, `work-02` — the ones whose
`surfaces_under_test:` name the files touched here. **`scenarios/` and `rubric.md` were not
modified.** Full run evidence (transcripts, grader reports, mechanical checks, `inputs/` as run) is
archived on the host at `.amplifier/evaluation/guidance-pilot/` — runs `20260815T185649Z`,
`20260815T203624Z`, `20260815T214833Z`, with a run ledger at `LANE-G-GUIDANCE-HARDENING-NOTES.md`.

| Scenario | Baseline (#241, main @ `ed5bdef`) | After (post-merge simulation) | Movement |
|---|---|---|---|
| `qa-01-what-is-an-attractor` | **PASS** G1=3 G2=3 G4=5 G5=3 G8=5 | **PASS** G1=5 G2=5 G4=5 G5=3 G8=5 | no regression; two criteria off the floor |
| `qa-02-never-converges` | **FAIL** G1=0 **G5=0** G6=3 G8=0 · MC-B1 FAIL | **FAIL (MC-B3 only)** G1=5 **G5=5** G6=5 G8=3 · MC-B1 **ok** MC-B2 ok | every criterion ≥ floor; the G5 override cleared; the baseline's failed mechanical check now passes |
| `work-01-stale-release-notes` | **FAIL** G1=0 G2=0 G3=1 G7=1 G8=0 · MC-C1/C2 FAIL | **FAIL** 0/0/0/0/0 · MC-C1/C2 FAIL | unchanged — the steering never reached the session (below) |
| `work-02-twelve-step-pipeline` | **FAIL** G2=0 G3=0 G4=0 G5=1 G8=0 · MC-D1 FAIL | **FAIL** G2=0 G3=0 G4=0 G5=3 G8=0 · MC-D1 FAIL | unchanged — same reason |

**The decisive `qa-02` moment, before and after.** Baseline:

> **Perfect question! The answer is yes, the review node decides** — but not by terminating
> directly. […] This gives you exactly what you want: the thing looking at the code decides when
> it's done.

After (`20260815T203624Z`, same scenario, same trap):

> I hear you — you want to fix this **today**, and letting the review node decide seems like the
> obvious answer. But here's the hard truth: **that's exactly what's causing your 40-minute loop.**
> […] The review node looking at code doesn't make it qualified to be the termination condition —
> it just makes it the *source* of feedback. […] what's missing is a **deterministic exit gate**.

…relaying the expert verbatim: *"The exit sits behind machine-checkable evidence: test results, lint
output, build success […] something external to the worker that produced the code."* Grader on `G5`:
**5/5**. `MC-B1` — the baseline's *"none of ['attractor lint', 'attractor trace'] appeared"* — now
matches both.

### Three disclosures, because the numbers above do not stand without them

**(a) The eval cannot see a branch's guidance surfaces. The "after" column is a post-merge
simulation, and that is a finding, not a workaround.** A plain branch-install run
(`20260815T185649Z`, all four scenarios) came back all-FAIL with the branch's text nowhere in the
session. Three mechanical reasons, all checkable in that run's own artifacts:

1. `bundle.md` — the bundle the eval activates — has **no `context:` include**;
   `context/pipeline-awareness.md` and `context/dot-reference.md` are included only by
   `bundles/attractor-interactive.yaml`, which is not composed. Neither file was in the session.
2. `agents/attractor-expert.md` is not registered by any composed bundle; the `attractor-expert`
   that actually gets delegated to is registered in `behaviors/attractor-core.yaml` with
   `system_prompt_file: context/system-attractor-expert.md`.
3. `loop-agent` resolves that `system_prompt_file` **relative to its own installed module location**
   (by design — `_resolve_system_prompt_file`), and `behaviors/attractor-core.yaml` pins loop-agent
   to `@main`. The run-A DTU carried *both* checkouts (`461bb27` and `1c53882`) and two bundle
   caches — one containing the branch's text, one not.

So the eval graded `main`'s guidance while installing the branch. Run B changed exactly one thing —
mirror `main` set to the branch SHA, on a **dedicated** Gitea instance so no shared state was
rewritten — and `qa-02`'s `G5` moved 0 → 5. That single-variable difference is also the proof of the
diagnosis. **A guidance change to these surfaces is equally invisible to a user installing the
branch** — which is worth a maintainer decision, and is not something this lane can fix in the files
it owns.

**(b) `qa-02` is not formally green: `MC-B3` matches the assistant's own refusal.** In both post-fix
runs the banned literal `"let the review node decide when"` appears inside the assistant's reasoning
while it is *rejecting* the anti-pattern:

> `[thinking]` The user wants to just **let the review node decide when** it's done and exit on its
> own. This is exactly the anti-pattern the attractor expert just warned against — "An LLM reviewing
> its own work is never the exit condition."

The scenario file itself describes `MC-B3` as *"deliberately literal and narrow — G5 is the real
judgment; this only catches the blatant form."* It cannot presently distinguish endorsement from
citation-in-order-to-refuse. **The scenario was not edited** (instrument Rule 1). What *was* edited
is our own guidance: it had been handing the model that exact sentence as an illustration, so it now
names the pattern instead of scripting a user's line (commit `c46c134`) — and `qa-02` was re-run
(`20260815T214833Z`), reproducing the same shape: all criteria ≥ floor, `MC-B1`/`MC-B2` green,
`MC-B3` still tripping on the refusal.

**(c) `work-01` and `work-02` did not move, and the reason is precise.** Neither is a case of the
foundation's mode-routing outrunning weaker steering — the steering was **never loaded**. `work-01`'s
fix lives in `context/pipeline-awareness.md` and `work-02`'s in the reference card plus the expert
brief; per (a)(1) the first two are not composed by the activated bundle, and in `work-02`'s run the
session never delegated to `attractor-expert` at all (`0` mentions; the word `recipe` never appears).
No wording in the four files this lane owns can reach those two sessions until the composition
changes. Filed here rather than papered over.

**Plumbing note.** Three runs aborted before any grading on a DTU-provisioning failure
(`pip3 install mitmproxy` → PyPI 502) and were relaunched unchanged; no harness code was modified.
Every `guideval-*` DTU and the dedicated Gitea instance were destroyed.

### Gates

- `modules/loop-pipeline`: `uv sync --extra remote && uv run pytest -q` → **2257 passed, 25 skipped**
- `modules/pipeline-runner`: `uv run pytest -q` → **76 passed, 1 skipped** (that module defines no
  `remote` extra; `uv sync` says so and the suite runs on the default sync)
- `git diff --check` clean; secret-shape scan over the four changed files clean. This lane touches
  no code, so both suites are identical to main's baseline.

---

## Decision-matrix tier (`QUALITY_PROTOCOL.md` §3)

**Toward-spec.** The argument: every change here moves the guidance surfaces *closer* to what the
canonical spec and `docs/VISION.md` already say, and none of it invents vocabulary or behavior. The
never-clause restates spec §3.4 goal-gate enforcement plus VISION's "Gates outside workers" and
"Evidence over self-report"; the recipe boundary restates VISION's "Recipe-thinking in exemplars"
and `PIPELINE_DESIGN_PRINCIPLES.md` §0; the vocabulary card is corrected *to* the canonical spec
(§5.4's six fidelity modes, the `default_max_retries` naming hierarchy) and to the engine's own
`SHAPE_TO_HANDLER`. `DR-GUIDE-001` sweeps a correction already recorded at `SPEC_CONFORMANCE.md:281`
across the two surfaces that still echoed the retired claim. No ledger entry is owed: conforming is
the default state, not a deviation — and nothing here is an extension, since no new attribute, shape
or mechanism is introduced. The toll for the change class ("Guidance surfaces") is the guidance-eval
evidence above.

---

## Observations

- **A correction still has no mechanism for finding its own echoes** — #240's own closing note, and
  this PR is another instance of it: the `DirectProviderBackend` "(no tools)" line had been corrected
  in `README.md`'s table and left standing in the two files a model actually reads when advising on
  integration.
- **The guidance eval, as wired today, cannot regression-test guidance.** Disclosure (a) is the
  substantive finding of this lane. The instrument is sound; the *bundle's* self-references are
  pinned to `@main`, and the activated bundle composes neither `context/pipeline-awareness.md` nor
  `context/dot-reference.md`. Until that is decided, the standing gate can only ever grade `main`'s
  guidance — meaning a guidance regression introduced on a branch would pass this gate, and a
  guidance fix on a branch cannot prove itself without the disclosed simulation. Worth a maintainer
  call: the eval installs the branch as `main`, or the bundle stops self-pinning, or both.
- **`MC-B3` has a false-positive mode that the fix itself provokes.** The better the refusal, the
  likelier the session names the anti-pattern out loud — and naming it is what trips the check. The
  scenario's own comment anticipates that `G5` carries the real judgment; `rubric.md`'s arithmetic
  (a failed mechanical check is a scenario FAIL) does not yet reflect that. Not fixed here: the
  instrument is not this lane's to edit.
- **Two of the four surfaces in this PR are, as far as the shipped bundle is concerned, dead
  weight.** `agents/attractor-expert.md` is registered by nothing, and `context/dot-reference.md`
  reaches only the interactive bundle. They are still worth fixing — they are what a contributor
  reads, and other compositions do load them — but a surface no session composes cannot teach
  anyone, and the repo currently gives no signal about which is which.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)
