### PR TITLE
fix(bundle): compose the bundle's own guidance — always-on awareness, one registered expert, ref-free self-references

### DIFF
--- a/agents/attractor-agent-anthropic-isolated.yaml
+++ b/agents/attractor-agent-anthropic-isolated.yaml
@@ -25,6 +25,12 @@ providers:
 session:
   orchestrator:
     module: loop-agent
+    # NOTE: the same-repo `@main` pin is DELIBERATE here.  Unlike tools:/hooks:/providers:
+    # (resolved at parse time against this file's own directory), a session.orchestrator
+    # `source:` is resolved late, against the COMPOSED ROOT's base_path -- so a relative
+    # source here breaks the documented `includes: - bundle: git+...#subdirectory=...`
+    # path, where the user's own bundle is the root.  Probe-verified; see
+    # docs/designs/2026-08-15-composition-fix.md, "Two resolution classes".
     source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
     config:
       max_tool_rounds_per_input: 50

--- a/agents/attractor-agent-anthropic-isolated.yaml
+++ b/agents/attractor-agent-anthropic-isolated.yaml
@@ -25,12 +25,14 @@ providers:
 session:
   orchestrator:
     module: loop-agent
-    # NOTE: the same-repo `@main` pin is DELIBERATE here.  Unlike tools:/hooks:/providers:
-    # (resolved at parse time against this file's own directory), a session.orchestrator
-    # `source:` is resolved late, against the COMPOSED ROOT's base_path -- so a relative
-    # source here breaks the documented `includes: - bundle: git+...#subdirectory=...`
-    # path, where the user's own bundle is the root.  Probe-verified; see
-    # docs/designs/2026-08-15-composition-fix.md, "Two resolution classes".
+    # NOTE: the same-repo `@main` pin is DELIBERATE, and cannot currently be removed.
+    # Unlike tools:/hooks:/providers: sources (resolved at PARSE time against this file's
+    # own directory), a session.orchestrator `source:` is resolved LATE against the
+    # COMPOSED ROOT's base_path -- which in a real amplifier session is the APP's own
+    # bundle directory, not this bundle's.  Measured, from a DTU install of a branch that
+    # made these relative:  "loop-agent: File not found:
+    # .../amplifier_app_cli/_bundle/behaviors/modules/loop-agent" -- and the session
+    # refused to start.  See docs/designs/2026-08-15-composition-fix.md.
     source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
     config:
       max_tool_rounds_per_input: 50

--- a/agents/attractor-agent-anthropic.yaml
+++ b/agents/attractor-agent-anthropic.yaml
@@ -24,6 +24,12 @@ providers:
 session:
   orchestrator:
     module: loop-agent
+    # NOTE: the same-repo `@main` pin is DELIBERATE here.  Unlike tools:/hooks:/providers:
+    # (resolved at parse time against this file's own directory), a session.orchestrator
+    # `source:` is resolved late, against the COMPOSED ROOT's base_path -- so a relative
+    # source here breaks the documented `includes: - bundle: git+...#subdirectory=...`
+    # path, where the user's own bundle is the root.  Probe-verified; see
+    # docs/designs/2026-08-15-composition-fix.md, "Two resolution classes".
     source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
     config:
       max_tool_rounds_per_input: 50

--- a/agents/attractor-agent-anthropic.yaml
+++ b/agents/attractor-agent-anthropic.yaml
@@ -24,12 +24,14 @@ providers:
 session:
   orchestrator:
     module: loop-agent
-    # NOTE: the same-repo `@main` pin is DELIBERATE here.  Unlike tools:/hooks:/providers:
-    # (resolved at parse time against this file's own directory), a session.orchestrator
-    # `source:` is resolved late, against the COMPOSED ROOT's base_path -- so a relative
-    # source here breaks the documented `includes: - bundle: git+...#subdirectory=...`
-    # path, where the user's own bundle is the root.  Probe-verified; see
-    # docs/designs/2026-08-15-composition-fix.md, "Two resolution classes".
+    # NOTE: the same-repo `@main` pin is DELIBERATE, and cannot currently be removed.
+    # Unlike tools:/hooks:/providers: sources (resolved at PARSE time against this file's
+    # own directory), a session.orchestrator `source:` is resolved LATE against the
+    # COMPOSED ROOT's base_path -- which in a real amplifier session is the APP's own
+    # bundle directory, not this bundle's.  Measured, from a DTU install of a branch that
+    # made these relative:  "loop-agent: File not found:
+    # .../amplifier_app_cli/_bundle/behaviors/modules/loop-agent" -- and the session
+    # refused to start.  See docs/designs/2026-08-15-composition-fix.md.
     source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
     config:
       max_tool_rounds_per_input: 50

--- a/agents/attractor-agent-gemini-isolated.yaml
+++ b/agents/attractor-agent-gemini-isolated.yaml
@@ -27,6 +27,12 @@ providers:
 session:
   orchestrator:
     module: loop-agent
+    # NOTE: the same-repo `@main` pin is DELIBERATE here.  Unlike tools:/hooks:/providers:
+    # (resolved at parse time against this file's own directory), a session.orchestrator
+    # `source:` is resolved late, against the COMPOSED ROOT's base_path -- so a relative
+    # source here breaks the documented `includes: - bundle: git+...#subdirectory=...`
+    # path, where the user's own bundle is the root.  Probe-verified; see
+    # docs/designs/2026-08-15-composition-fix.md, "Two resolution classes".
     source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
     config:
       max_tool_rounds_per_input: 50

--- a/agents/attractor-agent-gemini-isolated.yaml
+++ b/agents/attractor-agent-gemini-isolated.yaml
@@ -27,12 +27,14 @@ providers:
 session:
   orchestrator:
     module: loop-agent
-    # NOTE: the same-repo `@main` pin is DELIBERATE here.  Unlike tools:/hooks:/providers:
-    # (resolved at parse time against this file's own directory), a session.orchestrator
-    # `source:` is resolved late, against the COMPOSED ROOT's base_path -- so a relative
-    # source here breaks the documented `includes: - bundle: git+...#subdirectory=...`
-    # path, where the user's own bundle is the root.  Probe-verified; see
-    # docs/designs/2026-08-15-composition-fix.md, "Two resolution classes".
+    # NOTE: the same-repo `@main` pin is DELIBERATE, and cannot currently be removed.
+    # Unlike tools:/hooks:/providers: sources (resolved at PARSE time against this file's
+    # own directory), a session.orchestrator `source:` is resolved LATE against the
+    # COMPOSED ROOT's base_path -- which in a real amplifier session is the APP's own
+    # bundle directory, not this bundle's.  Measured, from a DTU install of a branch that
+    # made these relative:  "loop-agent: File not found:
+    # .../amplifier_app_cli/_bundle/behaviors/modules/loop-agent" -- and the session
+    # refused to start.  See docs/designs/2026-08-15-composition-fix.md.
     source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
     config:
       max_tool_rounds_per_input: 50

--- a/agents/attractor-agent-gemini.yaml
+++ b/agents/attractor-agent-gemini.yaml
@@ -24,6 +24,12 @@ providers:
 session:
   orchestrator:
     module: loop-agent
+    # NOTE: the same-repo `@main` pin is DELIBERATE here.  Unlike tools:/hooks:/providers:
+    # (resolved at parse time against this file's own directory), a session.orchestrator
+    # `source:` is resolved late, against the COMPOSED ROOT's base_path -- so a relative
+    # source here breaks the documented `includes: - bundle: git+...#subdirectory=...`
+    # path, where the user's own bundle is the root.  Probe-verified; see
+    # docs/designs/2026-08-15-composition-fix.md, "Two resolution classes".
     source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
     config:
       max_tool_rounds_per_input: 50

--- a/agents/attractor-agent-gemini.yaml
+++ b/agents/attractor-agent-gemini.yaml
@@ -24,12 +24,14 @@ providers:
 session:
   orchestrator:
     module: loop-agent
-    # NOTE: the same-repo `@main` pin is DELIBERATE here.  Unlike tools:/hooks:/providers:
-    # (resolved at parse time against this file's own directory), a session.orchestrator
-    # `source:` is resolved late, against the COMPOSED ROOT's base_path -- so a relative
-    # source here breaks the documented `includes: - bundle: git+...#subdirectory=...`
-    # path, where the user's own bundle is the root.  Probe-verified; see
-    # docs/designs/2026-08-15-composition-fix.md, "Two resolution classes".
+    # NOTE: the same-repo `@main` pin is DELIBERATE, and cannot currently be removed.
+    # Unlike tools:/hooks:/providers: sources (resolved at PARSE time against this file's
+    # own directory), a session.orchestrator `source:` is resolved LATE against the
+    # COMPOSED ROOT's base_path -- which in a real amplifier session is the APP's own
+    # bundle directory, not this bundle's.  Measured, from a DTU install of a branch that
+    # made these relative:  "loop-agent: File not found:
+    # .../amplifier_app_cli/_bundle/behaviors/modules/loop-agent" -- and the session
+    # refused to start.  See docs/designs/2026-08-15-composition-fix.md.
     source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
     config:
       max_tool_rounds_per_input: 50

--- a/agents/attractor-agent-openai-isolated.yaml
+++ b/agents/attractor-agent-openai-isolated.yaml
@@ -25,6 +25,12 @@ providers:
 session:
   orchestrator:
     module: loop-agent
+    # NOTE: the same-repo `@main` pin is DELIBERATE here.  Unlike tools:/hooks:/providers:
+    # (resolved at parse time against this file's own directory), a session.orchestrator
+    # `source:` is resolved late, against the COMPOSED ROOT's base_path -- so a relative
+    # source here breaks the documented `includes: - bundle: git+...#subdirectory=...`
+    # path, where the user's own bundle is the root.  Probe-verified; see
+    # docs/designs/2026-08-15-composition-fix.md, "Two resolution classes".
     source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
     config:
       max_tool_rounds_per_input: 50

--- a/agents/attractor-agent-openai-isolated.yaml
+++ b/agents/attractor-agent-openai-isolated.yaml
@@ -25,12 +25,14 @@ providers:
 session:
   orchestrator:
     module: loop-agent
-    # NOTE: the same-repo `@main` pin is DELIBERATE here.  Unlike tools:/hooks:/providers:
-    # (resolved at parse time against this file's own directory), a session.orchestrator
-    # `source:` is resolved late, against the COMPOSED ROOT's base_path -- so a relative
-    # source here breaks the documented `includes: - bundle: git+...#subdirectory=...`
-    # path, where the user's own bundle is the root.  Probe-verified; see
-    # docs/designs/2026-08-15-composition-fix.md, "Two resolution classes".
+    # NOTE: the same-repo `@main` pin is DELIBERATE, and cannot currently be removed.
+    # Unlike tools:/hooks:/providers: sources (resolved at PARSE time against this file's
+    # own directory), a session.orchestrator `source:` is resolved LATE against the
+    # COMPOSED ROOT's base_path -- which in a real amplifier session is the APP's own
+    # bundle directory, not this bundle's.  Measured, from a DTU install of a branch that
+    # made these relative:  "loop-agent: File not found:
+    # .../amplifier_app_cli/_bundle/behaviors/modules/loop-agent" -- and the session
+    # refused to start.  See docs/designs/2026-08-15-composition-fix.md.
     source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
     config:
       max_tool_rounds_per_input: 50

--- a/agents/attractor-agent-openai.yaml
+++ b/agents/attractor-agent-openai.yaml
@@ -24,6 +24,12 @@ providers:
 session:
   orchestrator:
     module: loop-agent
+    # NOTE: the same-repo `@main` pin is DELIBERATE here.  Unlike tools:/hooks:/providers:
+    # (resolved at parse time against this file's own directory), a session.orchestrator
+    # `source:` is resolved late, against the COMPOSED ROOT's base_path -- so a relative
+    # source here breaks the documented `includes: - bundle: git+...#subdirectory=...`
+    # path, where the user's own bundle is the root.  Probe-verified; see
+    # docs/designs/2026-08-15-composition-fix.md, "Two resolution classes".
     source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
     config:
       max_tool_rounds_per_input: 50

--- a/agents/attractor-agent-openai.yaml
+++ b/agents/attractor-agent-openai.yaml
@@ -24,12 +24,14 @@ providers:
 session:
   orchestrator:
     module: loop-agent
-    # NOTE: the same-repo `@main` pin is DELIBERATE here.  Unlike tools:/hooks:/providers:
-    # (resolved at parse time against this file's own directory), a session.orchestrator
-    # `source:` is resolved late, against the COMPOSED ROOT's base_path -- so a relative
-    # source here breaks the documented `includes: - bundle: git+...#subdirectory=...`
-    # path, where the user's own bundle is the root.  Probe-verified; see
-    # docs/designs/2026-08-15-composition-fix.md, "Two resolution classes".
+    # NOTE: the same-repo `@main` pin is DELIBERATE, and cannot currently be removed.
+    # Unlike tools:/hooks:/providers: sources (resolved at PARSE time against this file's
+    # own directory), a session.orchestrator `source:` is resolved LATE against the
+    # COMPOSED ROOT's base_path -- which in a real amplifier session is the APP's own
+    # bundle directory, not this bundle's.  Measured, from a DTU install of a branch that
+    # made these relative:  "loop-agent: File not found:
+    # .../amplifier_app_cli/_bundle/behaviors/modules/loop-agent" -- and the session
+    # refused to start.  See docs/designs/2026-08-15-composition-fix.md.
     source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
     config:
       max_tool_rounds_per_input: 50

--- a/agents/attractor-expert.md
+++ b/agents/attractor-expert.md
@@ -48,6 +48,39 @@ meta:
     Integration questions need knowledge of DirectProviderBackend vs AmplifierBackend paths.
     </commentary>
     </example>
+
+# This file owns the WHOLE agent: metadata above, mount plan here, knowledge in the
+# body below.  There is no second definition in YAML -- `behaviors/attractor-core.yaml`
+# and the root `bundle.md` both register THIS file with
+# `agents: include: [attractor:attractor-expert]`.  One expert, one definition.
+#
+# IMPORTANT: the explicit session.orchestrator is REQUIRED.  The spawn capability merges
+# this agent's session: key onto the parent config; without it a child spawned from a
+# pipeline parent would inherit loop-pipeline and recurse.  attractor-expert is a
+# conversational knowledge agent, so loop-agent is the right orchestrator.
+session:
+  orchestrator:
+    module: loop-agent
+    # Snapshot-relative and REF-FREE on purpose.  loop-agent resolves a relative
+    # `system_prompt_file` against its OWN installed location (bundle root =
+    # parents[3] of its __init__.py), so whoever serves the loop-agent bytes serves
+    # the Layer-1 persona file next to them.  A `git+...@main` pin here served MAIN's
+    # persona to every branch install, which is exactly what made branch guidance
+    # untestable.  Resolves against the composed bundle root, so it lands on
+    # <this snapshot>/modules/loop-agent whenever the attractor bundle is the composed
+    # root (the documented `bundle add` + `bundle use` path).  In a composition where
+    # some OTHER bundle is the root, this activation is skipped with a logged warning
+    # and loop-agent resolves by name from that composition's own declaration --
+    # every shipped profile/bundle here declares it.  See
+    # docs/designs/2026-08-15-composition-fix.md, "As built".
+    source: ./modules/loop-agent
+    config:
+      # Layer-1 base prompt.  attractor-expert is provider-agnostic (a consultant,
+      # not a coding agent), so it gets its OWN persona base rather than a provider
+      # coding base.  Required: loop-agent fail-louds on an empty Layer-1 if this
+      # agent is ever spawned as an LLM node.
+      # See docs/designs/layer-1-profile-owned-system-prompt.md.
+      system_prompt_file: context/system-attractor-expert.md
 ---
 
 # Attractor Pipeline Expert

--- a/agents/attractor-expert.md
+++ b/agents/attractor-expert.md
@@ -61,19 +61,19 @@ meta:
 session:
   orchestrator:
     module: loop-agent
-    # Snapshot-relative and REF-FREE on purpose.  loop-agent resolves a relative
-    # `system_prompt_file` against its OWN installed location (bundle root =
-    # parents[3] of its __init__.py), so whoever serves the loop-agent bytes serves
-    # the Layer-1 persona file next to them.  A `git+...@main` pin here served MAIN's
-    # persona to every branch install, which is exactly what made branch guidance
-    # untestable.  Resolves against the composed bundle root, so it lands on
-    # <this snapshot>/modules/loop-agent whenever the attractor bundle is the composed
-    # root (the documented `bundle add` + `bundle use` path).  In a composition where
-    # some OTHER bundle is the root, this activation is skipped with a logged warning
-    # and loop-agent resolves by name from that composition's own declaration --
-    # every shipped profile/bundle here declares it.  See
-    # docs/designs/2026-08-15-composition-fix.md, "As built".
-    source: ./modules/loop-agent
+    # The `@main` self-pin here is DELIBERATE, and is the ONE self-pin this PR could not
+    # remove.  A session.orchestrator `source:` is resolved LATE, against the COMPOSED
+    # ROOT's base_path -- which in a real amplifier session is the APP's own bundle
+    # directory, not this bundle's -- so no relative path can reach this snapshot.
+    # Measured, from a DTU install of this branch with `./modules/loop-agent` here:
+    #   loop-agent: File not found:
+    #   .../amplifier_app_cli/_bundle/behaviors/modules/loop-agent
+    # and the session refused to start (strict mode).  Consequence, stated plainly: a
+    # branch install serves the BRANCH's expert knowledge (this file's body, resolved
+    # through the attractor namespace) but MAIN's Layer-1 persona, because loop-agent
+    # anchors a relative `system_prompt_file` on its own installed location.
+    # See docs/designs/2026-08-15-composition-fix.md, "Two resolution classes".
+    source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
     config:
       # Layer-1 base prompt.  attractor-expert is provider-agnostic (a consultant,
       # not a coding agent), so it gets its OWN persona base rather than a provider

--- a/agents/pipeline-runner.yaml
+++ b/agents/pipeline-runner.yaml
@@ -30,12 +30,14 @@ providers:
 session:
   orchestrator:
     module: loop-pipeline
-    # NOTE: the same-repo `@main` pin is DELIBERATE here.  Unlike tools:/hooks:/providers:
-    # (resolved at parse time against this file's own directory), a session.orchestrator
-    # `source:` is resolved late, against the COMPOSED ROOT's base_path -- so a relative
-    # source here breaks the documented `includes: - bundle: git+...#subdirectory=...`
-    # path, where the user's own bundle is the root.  Probe-verified; see
-    # docs/designs/2026-08-15-composition-fix.md, "Two resolution classes".
+    # NOTE: the same-repo `@main` pin is DELIBERATE, and cannot currently be removed.
+    # Unlike tools:/hooks:/providers: sources (resolved at PARSE time against this file's
+    # own directory), a session.orchestrator `source:` is resolved LATE against the
+    # COMPOSED ROOT's base_path -- which in a real amplifier session is the APP's own
+    # bundle directory, not this bundle's.  Measured, from a DTU install of a branch that
+    # made these relative:  "loop-agent: File not found:
+    # .../amplifier_app_cli/_bundle/behaviors/modules/loop-agent" -- and the session
+    # refused to start.  See docs/designs/2026-08-15-composition-fix.md.
     source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-pipeline
     config:
       # Profiles map llm_provider values to child agent names.

--- a/agents/pipeline-runner.yaml
+++ b/agents/pipeline-runner.yaml
@@ -30,6 +30,12 @@ providers:
 session:
   orchestrator:
     module: loop-pipeline
+    # NOTE: the same-repo `@main` pin is DELIBERATE here.  Unlike tools:/hooks:/providers:
+    # (resolved at parse time against this file's own directory), a session.orchestrator
+    # `source:` is resolved late, against the COMPOSED ROOT's base_path -- so a relative
+    # source here breaks the documented `includes: - bundle: git+...#subdirectory=...`
+    # path, where the user's own bundle is the root.  Probe-verified; see
+    # docs/designs/2026-08-15-composition-fix.md, "Two resolution classes".
     source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-pipeline
     config:
       # Profiles map llm_provider values to child agent names.

--- a/behaviors/attractor-core.yaml
+++ b/behaviors/attractor-core.yaml
@@ -4,32 +4,29 @@ bundle:
   description: Core attractor tools and hooks (provider-agnostic)
 
 tools:
+  # Same-repo modules by RELATIVE source, never a `git+...@main` self-pin: a pinned
+  # self-reference makes a branch install serve MAIN's modules (and, for loop-agent,
+  # MAIN's context/ files next to them).  Relative sources in tools:/hooks:/providers:
+  # are resolved AT PARSE TIME against THIS FILE's directory (behaviors/), so they stay
+  # inside whatever snapshot was installed, under any composition.  "../modules/..." is
+  # correct; "./modules/..." would resolve to behaviors/modules/ and never load.
   - module: tool-report-outcome
-    source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/tool-report-outcome
+    source: ../modules/tool-report-outcome
 
 hooks:
   - module: hooks-tool-truncation
-    source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/hooks-tool-truncation
+    source: ../modules/hooks-tool-truncation
   - module: hooks-pipeline-progress
-    source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/hooks-pipeline-progress
+    source: ../modules/hooks-pipeline-progress
   - module: hooks-pipeline-observability
-    source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/hooks-pipeline-observability
+    source: ../modules/hooks-pipeline-observability
 
 agents:
-  # IMPORTANT: inline session.orchestrator is REQUIRED here.  The spawn capability merges
-  # the agent's session: key onto the parent config; without an explicit session.orchestrator
-  # the child inherits the parent's orchestrator and may recurse.
-  # attractor-expert is a conversational knowledge agent; loop-agent is the right orchestrator.
-  attractor-expert:
-    description: Attractor pipeline design expert and DOT authoring consultant
-    session:
-      orchestrator:
-        module: loop-agent
-        source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
-        config:
-          # Layer-1 base prompt. attractor-expert is provider-agnostic (a
-          # consultant, not a coding agent), so it gets its OWN persona base
-          # rather than a provider coding base. Required: loop-agent fail-louds
-          # on an empty Layer-1 if this agent is ever spawned as an LLM node.
-          # See docs/designs/layer-1-profile-owned-system-prompt.md.
-          system_prompt_file: context/system-attractor-expert.md
+  # ONE expert, ONE definition.  agents/attractor-expert.md carries its own metadata,
+  # its own mount plan (session.orchestrator = loop-agent, Layer-1 =
+  # context/system-attractor-expert.md), AND the knowledge body that used to be a dead
+  # file no composition ever loaded.  Registering it here means every session that
+  # composes attractor-core gets the whole agent -- which is what README's
+  # "Sessions that compose attractor-core have access to attractor-expert" always claimed.
+  include:
+    - attractor:attractor-expert

--- a/bundle.md
+++ b/bundle.md
@@ -18,6 +18,16 @@ includes:
   - bundle: git+https://github.com/microsoft/amplifier-foundation@main
   - bundle: attractor:behaviors/attractor-core
 
+# Always-on guidance for sessions composed from this bundle -- the thin awareness
+# only (objective-first trigger, three-question test, the never-clause, the
+# authoring tripwire, pointers).  Deliberately ROOT-ONLY: attractor-core flows into
+# every pipeline LLM node, and interactive steering does not belong there.
+# The heavy surfaces (context/pipeline-awareness.md, context/dot-reference.md) stay
+# on-demand from here and always-on only in bundles/attractor-interactive.yaml.
+context:
+  include:
+    - attractor:context/attractor-awareness.md
+
 tools:
   # Registers the bundle's skills with the Agent Skills system (slash-command
   # registration comes from each skill's `user-invocable: true` frontmatter).
@@ -26,11 +36,19 @@ tools:
     source: git+https://github.com/microsoft/amplifier-bundle-skills@main#subdirectory=modules/tool-skills
     config:
       skills:
-        # Resolves post-merge (skills/ lands on main with this PR); local installs may
-        # also place the skill in ~/.amplifier/skills/ (standard skills discovery).
-        - "git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=skills"
+        # Namespaced + ref-free ON PURPOSE.  A `git+...@main#subdirectory=skills` pin
+        # would serve MAIN's attractorify SKILL.md to a branch install, which is the
+        # same defect this PR fixes for context and agents.  "@attractor:skills"
+        # resolves inside THIS snapshot at whatever ref was installed.
+        - "@attractor:skills"
 
 agents:
+  # attractor-expert is defined ENTIRELY by agents/attractor-expert.md (metadata,
+  # mount plan, and the knowledge body).  One expert, one registration -- behaviors/
+  # attractor-core.yaml registers the same file for every composition that includes it.
+  include:
+    - attractor:attractor-expert
+
   # IMPORTANT: each child agent MUST declare an inline session.orchestrator running a
   # non-pipeline loop (e.g. loop-agent).  The spawn capability merges this agent's session:
   # key onto the parent config; without an explicit orchestrator the child would inherit the
@@ -40,7 +58,7 @@ agents:
     session:
       orchestrator:
         module: loop-agent
-        source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
+        source: ./modules/loop-agent
         config:
           default_command_timeout_ms: 120000
   attractor-profile-openai:
@@ -48,7 +66,7 @@ agents:
     session:
       orchestrator:
         module: loop-agent
-        source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
+        source: ./modules/loop-agent
         config:
           default_command_timeout_ms: 10000
   attractor-profile-gemini:
@@ -56,7 +74,7 @@ agents:
     session:
       orchestrator:
         module: loop-agent
-        source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
+        source: ./modules/loop-agent
         config:
           default_command_timeout_ms: 10000
   attractor-pipeline-runner:
@@ -64,7 +82,7 @@ agents:
     session:
       orchestrator:
         module: loop-pipeline
-        source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-pipeline
+        source: ./modules/loop-pipeline
         config:
           profiles:
             anthropic: attractor-agent-anthropic

--- a/bundle.md
+++ b/bundle.md
@@ -49,6 +49,15 @@ agents:
   include:
     - attractor:attractor-expert
 
+  # The `@main` self-pins below are DELIBERATE and cannot currently be removed.  Unlike
+  # tools:/hooks:/providers: sources (resolved at PARSE time against this file's own
+  # directory -- see behaviors/attractor-core.yaml), a session.orchestrator `source:` is
+  # resolved LATE against the COMPOSED ROOT's base_path, which in a real amplifier session
+  # is the APP's own bundle directory, not this one.  Measured, from a DTU install of a
+  # branch that made these relative:
+  #   loop-agent: File not found: .../amplifier_app_cli/_bundle/behaviors/modules/loop-agent
+  # and the session refused to start.  See docs/designs/2026-08-15-composition-fix.md.
+  #
   # IMPORTANT: each child agent MUST declare an inline session.orchestrator running a
   # non-pipeline loop (e.g. loop-agent).  The spawn capability merges this agent's session:
   # key onto the parent config; without an explicit orchestrator the child would inherit the
@@ -58,7 +67,7 @@ agents:
     session:
       orchestrator:
         module: loop-agent
-        source: ./modules/loop-agent
+        source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
         config:
           default_command_timeout_ms: 120000
   attractor-profile-openai:
@@ -66,7 +75,7 @@ agents:
     session:
       orchestrator:
         module: loop-agent
-        source: ./modules/loop-agent
+        source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
         config:
           default_command_timeout_ms: 10000
   attractor-profile-gemini:
@@ -74,7 +83,7 @@ agents:
     session:
       orchestrator:
         module: loop-agent
-        source: ./modules/loop-agent
+        source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
         config:
           default_command_timeout_ms: 10000
   attractor-pipeline-runner:
@@ -82,7 +91,7 @@ agents:
     session:
       orchestrator:
         module: loop-pipeline
-        source: ./modules/loop-pipeline
+        source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-pipeline
         config:
           profiles:
             anthropic: attractor-agent-anthropic

--- a/bundles/attractor-agent.yaml
+++ b/bundles/attractor-agent.yaml
@@ -25,6 +25,12 @@ providers:
 session:
   orchestrator:
     module: loop-agent
+    # NOTE: the same-repo `@main` pin is DELIBERATE here.  Unlike tools:/hooks:/providers:
+    # (resolved at parse time against this file's own directory), a session.orchestrator
+    # `source:` is resolved late, against the COMPOSED ROOT's base_path -- so a relative
+    # source here breaks the documented `includes: - bundle: git+...#subdirectory=...`
+    # path, where the user's own bundle is the root.  Probe-verified; see
+    # docs/designs/2026-08-15-composition-fix.md, "Two resolution classes".
     source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
     config:
       default_command_timeout_ms: 120000

--- a/bundles/attractor-agent.yaml
+++ b/bundles/attractor-agent.yaml
@@ -25,12 +25,14 @@ providers:
 session:
   orchestrator:
     module: loop-agent
-    # NOTE: the same-repo `@main` pin is DELIBERATE here.  Unlike tools:/hooks:/providers:
-    # (resolved at parse time against this file's own directory), a session.orchestrator
-    # `source:` is resolved late, against the COMPOSED ROOT's base_path -- so a relative
-    # source here breaks the documented `includes: - bundle: git+...#subdirectory=...`
-    # path, where the user's own bundle is the root.  Probe-verified; see
-    # docs/designs/2026-08-15-composition-fix.md, "Two resolution classes".
+    # NOTE: the same-repo `@main` pin is DELIBERATE, and cannot currently be removed.
+    # Unlike tools:/hooks:/providers: sources (resolved at PARSE time against this file's
+    # own directory), a session.orchestrator `source:` is resolved LATE against the
+    # COMPOSED ROOT's base_path -- which in a real amplifier session is the APP's own
+    # bundle directory, not this bundle's.  Measured, from a DTU install of a branch that
+    # made these relative:  "loop-agent: File not found:
+    # .../amplifier_app_cli/_bundle/behaviors/modules/loop-agent" -- and the session
+    # refused to start.  See docs/designs/2026-08-15-composition-fix.md.
     source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
     config:
       default_command_timeout_ms: 120000

--- a/bundles/attractor-interactive.yaml
+++ b/bundles/attractor-interactive.yaml
@@ -30,12 +30,14 @@ providers:
 session:
   orchestrator:
     module: loop-agent
-    # NOTE: the same-repo `@main` pin is DELIBERATE here.  Unlike tools:/hooks:/providers:
-    # (resolved at parse time against this file's own directory), a session.orchestrator
-    # `source:` is resolved late, against the COMPOSED ROOT's base_path -- so a relative
-    # source here breaks the documented `includes: - bundle: git+...#subdirectory=...`
-    # path, where the user's own bundle is the root.  Probe-verified; see
-    # docs/designs/2026-08-15-composition-fix.md, "Two resolution classes".
+    # NOTE: the same-repo `@main` pin is DELIBERATE, and cannot currently be removed.
+    # Unlike tools:/hooks:/providers: sources (resolved at PARSE time against this file's
+    # own directory), a session.orchestrator `source:` is resolved LATE against the
+    # COMPOSED ROOT's base_path -- which in a real amplifier session is the APP's own
+    # bundle directory, not this bundle's.  Measured, from a DTU install of a branch that
+    # made these relative:  "loop-agent: File not found:
+    # .../amplifier_app_cli/_bundle/behaviors/modules/loop-agent" -- and the session
+    # refused to start.  See docs/designs/2026-08-15-composition-fix.md.
     source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
     config:
       max_tool_rounds_per_input: 50

--- a/bundles/attractor-interactive.yaml
+++ b/bundles/attractor-interactive.yaml
@@ -30,6 +30,12 @@ providers:
 session:
   orchestrator:
     module: loop-agent
+    # NOTE: the same-repo `@main` pin is DELIBERATE here.  Unlike tools:/hooks:/providers:
+    # (resolved at parse time against this file's own directory), a session.orchestrator
+    # `source:` is resolved late, against the COMPOSED ROOT's base_path -- so a relative
+    # source here breaks the documented `includes: - bundle: git+...#subdirectory=...`
+    # path, where the user's own bundle is the root.  Probe-verified; see
+    # docs/designs/2026-08-15-composition-fix.md, "Two resolution classes".
     source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
     config:
       max_tool_rounds_per_input: 50
@@ -52,7 +58,7 @@ tools:
   - module: tool-search
     source: git+https://github.com/microsoft/amplifier-module-tool-search@main
   - module: tool-pipeline-run
-    source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/tool-pipeline-run
+    source: ../modules/tool-pipeline-run
     config:
       runner_agent: attractor-pipeline-runner
       profiles:
@@ -61,10 +67,14 @@ tools:
         gemini: attractor-agent-gemini
 
 context:
-  # '../context/' climbs from this YAML's dir to the bundle-root context/; idiomatic target is 'attractor:context/...' pending foundation namespaced-include support.
+  # Namespaced form: foundation resolves 'attractor:context/...' against the attractor
+  # bundle root after compose (the earlier "pending namespaced-include support" note was
+  # stale -- it is implemented and in production use across the ecosystem).
+  # These two are the HEAVY always-on pair (~5.8k tokens) and stay interactive-only; the
+  # root bundle composes the thin context/attractor-awareness.md instead.
   include:
-    - ../context/pipeline-awareness.md
-    - ../context/dot-reference.md
+    - attractor:context/pipeline-awareness.md
+    - attractor:context/dot-reference.md
 
 # Agents: pipeline runner + per-provider child agents
 # IMPORTANT: inline session.orchestrator is REQUIRED here.  The spawn capability merges

--- a/bundles/attractor-pipeline.yaml
+++ b/bundles/attractor-pipeline.yaml
@@ -24,6 +24,12 @@ providers:
 session:
   orchestrator:
     module: loop-pipeline
+    # NOTE: the same-repo `@main` pin is DELIBERATE here.  Unlike tools:/hooks:/providers:
+    # (resolved at parse time against this file's own directory), a session.orchestrator
+    # `source:` is resolved late, against the COMPOSED ROOT's base_path -- so a relative
+    # source here breaks the documented `includes: - bundle: git+...#subdirectory=...`
+    # path, where the user's own bundle is the root.  Probe-verified; see
+    # docs/designs/2026-08-15-composition-fix.md, "Two resolution classes".
     source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-pipeline
     config:
       # Maps llm_provider values in DOT node attributes to agent names.

--- a/bundles/attractor-pipeline.yaml
+++ b/bundles/attractor-pipeline.yaml
@@ -24,12 +24,14 @@ providers:
 session:
   orchestrator:
     module: loop-pipeline
-    # NOTE: the same-repo `@main` pin is DELIBERATE here.  Unlike tools:/hooks:/providers:
-    # (resolved at parse time against this file's own directory), a session.orchestrator
-    # `source:` is resolved late, against the COMPOSED ROOT's base_path -- so a relative
-    # source here breaks the documented `includes: - bundle: git+...#subdirectory=...`
-    # path, where the user's own bundle is the root.  Probe-verified; see
-    # docs/designs/2026-08-15-composition-fix.md, "Two resolution classes".
+    # NOTE: the same-repo `@main` pin is DELIBERATE, and cannot currently be removed.
+    # Unlike tools:/hooks:/providers: sources (resolved at PARSE time against this file's
+    # own directory), a session.orchestrator `source:` is resolved LATE against the
+    # COMPOSED ROOT's base_path -- which in a real amplifier session is the APP's own
+    # bundle directory, not this bundle's.  Measured, from a DTU install of a branch that
+    # made these relative:  "loop-agent: File not found:
+    # .../amplifier_app_cli/_bundle/behaviors/modules/loop-agent" -- and the session
+    # refused to start.  See docs/designs/2026-08-15-composition-fix.md.
     source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-pipeline
     config:
       # Maps llm_provider values in DOT node attributes to agent names.

--- a/context/attractor-awareness.md
+++ b/context/attractor-awareness.md
@@ -1,0 +1,64 @@
+# Attractor: when work wants a convergence pipeline
+
+## FIRST: is this an objective? Then say so, in the FIRST reply
+
+**Trigger:** the user names an *end-state they want true in the world* -- a
+recurring pain plus a bare "build me something" (*"our release notes are always
+stale -- build me something"*) -- and a machine could plausibly check it: a
+command, a test, a diff, an exit status.
+
+**In the first reply, all three:**
+
+1. **Restate it as an end-state**, in their terms, and get agreement.
+2. **Ask the definition-of-done question out loud** -- *"how will we know it's
+   actually working -- what check could prove it?"* Press past the first vague
+   answer to something a machine can run.
+3. **Name the objective path, by name:**
+   - **`/attractorify`** -- applies the three-question test with them and designs
+     the shape (as willing to answer "this wants a recipe" as "yes").
+   - **`attractor:attractor-expert`** -- delegate for design and authoring detail.
+   - **`@attractor:examples/objective/objective-runner.dot`** -- the shipped
+     objective layer: hand it the objective as `goal`; it triages, then picks a
+     lane, composes a child pipeline, or redirects with a written diagnosis.
+
+**Say the names.** If another mode wants the request -- brainstorm, design,
+planning, a generic builder -- that is fine, and may be the right host. **Name
+the objective path in the same breath anyway**, end-state and
+definition-of-done first, before any step list. An objective answered with a generic design
+conversation silently skips the layer built for it: a recorded failure here, not
+a hypothetical. It may also end in **"no"** -- if no machine check could prove
+the end-state, say so and name where the work belongs.
+
+## The three-question test
+
+1. **Is there a cycle?** No path backwards, nothing to converge to.
+2. **Is the exit gated on machine-checkable evidence external to the worker?**
+3. **Would it still land if any one LLM node had a bad day?**
+
+Short of three yeses -- especially a linear, gateless chain -- it is **recipe
+territory: say so before authoring a graph.**
+
+## The never-clause
+
+**The self-report gate is this project's named anti-pattern.** A worker's -- or a
+judge's -- claim about its own output is NEVER the exit condition; exits gate on
+machine evidence produced outside the context that did the work. Putting that
+claim on an edge condition changes the mechanism, not the authority.
+
+## Before authoring or editing ANY `.dot`
+
+- **Delegate to `attractor:attractor-expert` first.** Generic builders carry no
+  engine semantics and re-discover the foot-guns the hard way.
+- **`@attractor:context/dot-reference.md` is THE attribute vocabulary.** An
+  attribute not on that card is silently inert -- invented attributes do not
+  error, they do nothing.
+- **Always `attractor lint <file>`** on what you author or edit.
+
+## Depth, on demand -- pointers, not preloads
+
+- Attributes: `@attractor:context/dot-reference.md`
+- Patterns, fidelity, stylesheets, objective layer:
+  `@attractor:context/pipeline-awareness.md`
+- Runtime semantics, routing, debugging: `attractor:attractor-expert`
+- Running a pipeline from here: the `attractor` CLI (`attractor run x.dot`) or
+  the `attractor-pipeline-runner` agent.

--- a/docs/designs/2026-08-15-composition-fix.md
+++ b/docs/designs/2026-08-15-composition-fix.md
@@ -1,0 +1,331 @@
+# DESIGN: The Composition Fix — serving the bundle's own guidance
+
+**Repo:** microsoft/amplifier-bundle-attractor
+**Baseline:** `origin/main` @ `0f84309` (all reads below via `git show origin/main:<path>`; the local checkout at `4f8e22d` lags and was not relied on)
+**Status:** SHIPPED. Design + empirical probes below; the build's deviations from them are recorded verbatim in [§8 — As built](#8-as-built-what-shipped-and-where-it-deviates).
+**Date:** 2026-08-15
+
+---
+
+## 1. The defect, restated
+
+The bundle does not serve its own guidance. Three verified causes:
+
+**Cause 1 — the standard install composes no always-on guidance.**
+`bundle.md:17-19` includes only `amplifier-foundation@main` + `attractor:behaviors/attractor-core`. There is **no `context:` key anywhere in bundle.md** (re-verified against `0f84309`; the file is 167 lines: frontmatter has `includes:`, `tools:` (tool-skills), `agents:` (dict-form profile agents) — nothing else). The two always-on guidance files, `context/pipeline-awareness.md` and `context/dot-reference.md`, are composed **only** by `bundles/attractor-interactive.yaml:63-67`:
+
+```yaml
+context:
+  # '../context/' climbs from this YAML's dir to the bundle-root context/; idiomatic target is 'attractor:context/...' pending foundation namespaced-include support.
+  include:
+    - ../context/pipeline-awareness.md
+    - ../context/dot-reference.md
+```
+
+…and nothing on the standard install path (`amplifier bundle add git+…@main` → root `bundle.md`) includes `attractor-interactive`. Measured consequence: the guidance-eval baseline's work-01/work-02 failures — the objective-first steering and the DOT attribute vocabulary were never in-session.
+
+**Cause 2 — `agents/attractor-expert.md` is registered by nothing.**
+Zero `agents:` YAML references to the file (grep of all YAML at `0f84309`; only `skills/attractorify/SKILL.md:344` reads it, as a delegation *fallback*: "If delegation is unavailable, fall back to reading `agents/attractor-expert.md` directly"). The expert real sessions reach is the **inline dict** at `behaviors/attractor-core.yaml:23-35`: a loop-agent orchestrator whose Layer-1 is `system_prompt_file: context/system-attractor-expert.md`. The 20 KB expert knowledge body (plus its `@attractor:context/attractor-expert-defenses.md` transclusion at line 298) is a dead file on every real path.
+
+**Cause 3 — the @main self-pin makes branch guidance untestable.**
+`behaviors/attractor-core.yaml:28` pins `source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent`. loop-agent resolves a relative `system_prompt_file` against **its own installed module location** — verified at `modules/loop-agent/amplifier_module_loop_agent/__init__.py`, `_resolve_system_prompt_file`:
+
+> "Resolution is **CWD-INDEPENDENT**. It anchors on this module's installed location (`__file__`) … the bundle root is `parents[3]` of this file."
+
+So a branch install fetches loop-agent from **main's** snapshot, and `context/system-attractor-expert.md` resolves inside **main's** snapshot. Branch regression-testing of guidance is structurally impossible without the mirror-main workaround. The same self-pin class recurs across `bundle.md` (4 agent orchestrator pins + the skills registration pin `git+…attractor@main#subdirectory=skills`), `bundles/*.yaml`, `agents/*.yaml`, `profiles/*.yaml`.
+
+---
+
+## 2. Probe results
+
+### P1 — sizes of the candidate context files (origin/main @ 0f84309; tokens ≈ bytes/4)
+
+| File | Bytes | Lines | Words | Est. tokens |
+|---|---:|---:|---:|---:|
+| `context/pipeline-awareness.md` | 12,598 | 222 | 1,777 | ~3,150 |
+| `context/dot-reference.md` | 10,780 | 218 | 1,485 | ~2,695 |
+| **Interactive's always-on pair (today)** | **23,378** | 440 | 3,262 | **~5,845** |
+| `context/system-attractor-expert.md` (expert Layer-1) | 5,972 | 106 | 907 | ~1,493 |
+| `context/attractor-expert-defenses.md` (transcluded by expert .md) | 10,615 | 259 | 1,469 | ~2,653 |
+| `agents/attractor-expert.md` (body = knowledge) | 20,444 | 393 | 2,933 | ~5,111 |
+| `context/engine-semantics.md` (on-demand deep doc) | 20,047 | 311 | 2,547 | ~5,011 |
+
+So the root install today serves **0** guidance tokens; the interactive entry point serves **~5.8k** tokens always-on.
+
+### P2 — how the ecosystem composes (cached bundles under `~/.amplifier/cache/`, 6 surveyed)
+
+| Bundle | `context:` always-on | Size | `agents:` registration | Same-repo module `source:` |
+|---|---|---:|---|---|
+| work-tracker | `work-tracker:context/awareness.md` | 2,287 B (~570 tok) | `include: [work-tracker:work-executor]` (.md agent) | `../modules/tool-work-tracker` (relative) |
+| browser-tester | `browser-tester:context/browser-awareness.md` | 3,183 B (~800 tok) | `include:` 3 .md agents | — |
+| terminal-tester | `terminal-tester:context/terminal-awareness.md` | 2,566 B (~640 tok) | `include:` 3 .md agents | `../modules/tool-terminal-inspector` (relative) |
+| android-tester | `android-tester:context/android-awareness.md` | 3,215 B (~800 tok) | `include:` 3 .md agents | `../modules/tool-android-inspector` (relative) |
+| ios-tester | `ios-awareness.md` | 3,890 B (~970 tok) | (same pattern) | — |
+| recipes | `recipe-awareness.md` 1,851 B; heavy `recipe-instructions.md` (8 KB) transcluded into bundle.md body | 1,851 B (~460 tok) | — | — |
+
+The doctrine is real and uniform: **thin always-on awareness ≈ 1.9–3.9 KB (~460–975 tokens), heavy knowledge in registered `.md` agents, same-repo modules by relative source.** work-tracker's behavior YAML says it in its own description: *"a thin always-on awareness context covering the silent-failure hazards"* — and carries the decisive comment: *"Relative sources resolve against THIS FILE's directory (behaviors/), not the repo root. '../modules/...' is correct; './modules/...' silently resolves to behaviors/modules/ and the module never loads."* These bundles are installed via `git+` in this very environment and their tools are mounted in the current session — relative same-repo sources are production-proven under the real install path.
+
+### P3 — loop-agent resolution + source forms
+
+- `_resolve_system_prompt_file` (quoted above): anchor = module `__file__`, bundle root = `parents[3]`. Whoever serves the loop-agent **module bytes** serves the **context files** next to them. Pin @main → main's files, always.
+- Foundation module `source:` accepts: git URL (`git+…@ref#subdirectory=…`) and **filesystem-relative path resolved against the declaring YAML's directory** (P2 evidence). A relative source inside an installed snapshot stays inside that snapshot **at the installed ref** — branch install ⇒ branch loop-agent ⇒ `parents[3]` = branch snapshot ⇒ branch guidance. No third "same-repo namespaced module" form was found in foundation; not designed against.
+- Skills self-pin equivalent exists too: work-tracker registers its skills as `"@work-tracker:skills"` (namespaced, ref-free) where attractor pins `git+…attractor@main#subdirectory=skills`.
+
+### P4 — what `context:` and `agents:` actually do (foundation source, cache @ installed ref)
+
+- `amplifier_foundation/bundle/_dataclass.py::_parse_context`: `include:` entries with a namespace prefix (`ns:path`) are stored pending and resolved via `source_base_paths` after compose (`resolve_pending_context`); plain relative entries resolve immediately against the declaring file's dir. **The `attractor-interactive.yaml` comment "pending foundation namespaced-include support" is stale — namespaced context includes are implemented and used in production (browser-tester).**
+- `amplifier_foundation/bundle/_prepared.py`: `context:` entries become ContextFile objects injected into every prepared session's payload (provenance kind `bundle_context_decl`), re-read at each session preparation. A root-bundle `context:` key = always-on system-context block for sessions composed from that bundle.
+- Compose semantics (`Bundle.compose` docstring): *"agents: later overrides earlier (by agent name); context: accumulates with namespace prefix; instruction: later replaces earlier."* → two definitions under one agent name cannot coexist; last one wins.
+- Agent registration: `agents: include: ["ns:name"]` → `source_base_paths[ns]/agents/name.md`. `_load_agent_file_metadata` extracts `meta:` **and top-level `tools/providers/hooks/session`** from .md frontmatter, plus `instruction` from the body — so a .md agent can carry its own `session.orchestrator` (needed because attractor-core is composed under pipeline parents, where an orchestrator-less child would inherit `loop-pipeline` and recurse — bundle.md's own warning).
+- Include graph (verified): `behaviors/attractor-core` is included by root `bundle.md`, all three `bundles/*.yaml`, `agents/*.yaml` (all six provider agents + pipeline-runner), and all `profiles/*.yaml`. **Anything added to attractor-core lands in every pipeline LLM node.** Root `bundle.md` is included by nothing else. This asymmetry drives the whole design.
+
+---
+
+## 3. The composition design
+
+### 3.1 Q1 — what a standard install composes: a new thin awareness, root-only
+
+**New file: `context/attractor-awareness.md` — budget ≤ 3.2 KB (~800 tokens), target ~2.4 KB (~600 tokens).** Content plan (five blocks, sized):
+
+1. **Objective-first trigger** (~700 B): the two marks (recurring end-state pain + "build me something"; machine-checkable plausibility), the first-reply moves (restate as end-state; ask the definition-of-done question out loud), and the say-the-names rule: `/attractorify`, `attractor:attractor-expert`, `@attractor:examples/objective/objective-runner.dot`. Condensed from `pipeline-awareness.md`'s "FIRST: is this an objective?" section, keeping its "name the objective path in the same breath even if another mode wants the request" clause — that is the exact work-01 failure.
+2. **Three-question test** (~250 B): cycle? machine-checkable exit external to the worker? survives one bad LLM day? Plus: "a linear gateless chain is recipe territory — say so before authoring."
+3. **The never-clause** (~200 B): "The self-report gate is this project's named anti-pattern. A worker's — or judge's — claim about its own output is never the exit; exits gate on machine evidence external to the worker."
+4. **Authoring tripwire** (~350 B): "Before authoring or editing ANY `.dot`: delegate to `attractor:attractor-expert`. The only attribute vocabulary the engine reads is `@attractor:context/dot-reference.md` — attributes not on that card are silently inert. Lint everything: `attractor lint <file>`." (This is the work-02 failure: invented attributes because the vocabulary card wasn't in-session.)
+5. **Pointer block** (~400 B): on-demand depth = `@attractor:context/dot-reference.md`, `@attractor:context/pipeline-awareness.md`, `docs/attractor-explained.html`; pipeline *execution* from this composition goes through the `attractor-pipeline-runner` agent or the `attractor` CLI. **Must not claim `run_pipeline` exists** — the root bundle does not mount `tool-pipeline-run` (interactive does), and `pipeline-awareness.md` opens with "You have access to the `run_pipeline` tool," which is precisely why that file cannot be composed into root as-is.
+
+**Placement:** `bundle.md` frontmatter gains:
+
+```yaml
+context:
+  include:
+    - context/attractor-awareness.md      # plain relative: resolves against bundle.md's dir
+```
+
+**Explicitly NOT in `behaviors/attractor-core.yaml`** — attractor-core flows into every pipeline LLM node (P4 include graph); putting interactive steering there would inject "delegate to the expert / say /attractorify" into non-interactive pipeline workers and charge ~600 tokens per node per iteration. Root-only placement leaves every pipeline composition byte-identical.
+
+**What stays where:**
+
+| Content | Home | Served |
+|---|---|---|
+| Objective trigger, 3-question test, never-clause, authoring tripwire, pointers | NEW `attractor-awareness.md` | always-on, root sessions (~600 tok) |
+| Full `pipeline-awareness.md` + `dot-reference.md` | unchanged | always-on in interactive (unchanged ~5.8k); on-demand @mention from root |
+| Expert knowledge (20.4 KB) + defenses (10.6 KB) + Layer-1 persona (6 KB) | attractor-expert agent (the context sink) | on delegation only (~9.3k tok in the child) |
+| `engine-semantics.md` (20 KB) | on-demand, expert reads it | never always-on |
+
+**Before/after per-session token cost:**
+
+| Surface | Before | After |
+|---|---:|---:|
+| Standard root install, always-on | 0 (defect) | ~600 (budget cap ~800) |
+| Interactive entry point, always-on | ~5,845 | ~5,845 (unchanged) |
+| Pipeline LLM node sessions | 0 | 0 (unchanged — design invariant) |
+| Expert delegation (on demand) | ~1.5k (Layer-1 only; body dead) | ~9.3k (Layer-1 + body + defenses) |
+
+One honest caveat: dict-form agents spawned *from* a root session (e.g. `attractor-pipeline-runner`) may inherit the parent's composed context per the spawn-merge comment ("merges this agent's session: key onto the parent config"); worst case ≈ +600 tokens per spawned child. Build-order probe B2 verifies; if it inherits, that is the same cost every P2 bundle already accepts.
+
+### 3.2 Q2 — agent registration: one expert, .md-defined, explicitly registered
+
+Foundation gives exactly the mechanism needed (P4): a `.md` agent whose frontmatter carries the mount plan. **Merge the two experts into one definition owned by `agents/attractor-expert.md`:**
+
+1. Add to its frontmatter (sibling of `meta:`):
+
+```yaml
+session:
+  orchestrator:
+    module: loop-agent
+    source: ../modules/loop-agent        # anchor verified by probe B1; see below
+    config:
+      system_prompt_file: context/system-attractor-expert.md
+```
+
+2. Replace `behaviors/attractor-core.yaml:23-35`'s inline dict with:
+
+```yaml
+agents:
+  include:
+    - attractor:attractor-expert
+```
+
+Result: one name, one definition; Layer-1 = the persona file (**preserves the qa-02 fix path exactly** — same loop-agent, same `system_prompt_file`, now un-pinned), instruction = the 20 KB body + defenses transclusion; the explicit `session.orchestrator` keeps the anti-recursion rule intact for pipeline-parent spawns. `SKILL.md:344`'s delegation target and fallback both keep working; README:434's claim ("Sessions that compose attractor-core have access to attractor-expert") becomes fully true.
+
+**Probe B1 (build order step 0):** verify the relative-source anchor for frontmatter `session:` blocks (candidates: `../modules/loop-agent` from `agents/`, or bundle-root-relative `modules/loop-agent`) by spawning the expert in a scratch local install and confirming (a) loop-agent mounts, (b) a canary line from the .md body appears in the child's instruction, (c) the Layer-1 file is served. **Fallback if frontmatter-relative sources prove unreliable:** keep the inline dict in attractor-core.yaml (its `../modules/loop-agent` anchor is the work-tracker-proven form) and fold the .md body + defenses into `context/system-attractor-expert.md` (Layer-1 grows to ~9.3k, expert-child-only); `agents/attractor-expert.md` then shrinks to frontmatter + pointer so the two can never drift.
+
+**Rejected: registering the .md as a second agent name** (e.g. `attractor-expert-docs`) — two experts under near-identical names is the confusion the defect report warns about, and compose semantics ("later overrides earlier by name") make the single-name merge clean.
+
+### 3.3 Q3 — the @main self-pin: relative sources, and the mirror becomes optional
+
+| Option | (a) normal installs | (b) branch installs | (c) compat doctrine |
+|---|---|---|---|
+| **Keep `git+…@main#subdirectory=…`** | works | serves **main's** modules + guidance (the defect) | status quo; branch testing needs mirror-main |
+| **Relative `../modules/X` / `modules/X`** ✅ | identical bytes — the cache snapshot at the installed ref contains `modules/`; resolution never leaves the snapshot | self-consistent: branch modules, branch `parents[3]` guidance | production-proven (work-tracker, terminal-tester, android-tester install via `git+` and run in this environment today); additive — no engine change |
+| Namespaced module source (`attractor:modules/X`) | — | — | **rejected: no evidence the foundation loader supports this form for modules** (found for context/agents/skills only) |
+
+**Design: flip every same-repo pin to a relative source.** Tranche 1 (the defect): `behaviors/attractor-core.yaml:28` → `source: ../modules/loop-agent`. Tranche 2 (same class, same PR, mechanical): `bundle.md`'s four agent orchestrator pins → `modules/loop-agent` / `modules/loop-pipeline`; `bundle.md`'s skills registration → `"@attractor:skills"` (work-tracker's exact form — otherwise a branch install serves **main's** attractorify SKILL.md, the same defect for skills); `behaviors/attractor-core.yaml`'s tool/hook pins; `bundles/*.yaml`, `agents/*.yaml`, `profiles/*.yaml` orchestrator pins. External pins (foundation, tool-skills module, providers) stay `@main` — they are different repos; that is what @main pins are for.
+
+**If relative sources had failed:** the sanctioned alternative is the eval harness's existing dedicated-Gitea procedure (`run.sh` pushes the detached SHA to a mirror; the DTU's `url_rewrites` redirect `github.com/microsoft/amplifier-bundle-attractor` there, so @main pins resolve to the pushed content). Honestly weighed: it works, it is already documented, and it is the wrong permanent answer — it tests a *hybrid* only reachable through a bespoke harness, leaves every non-eval branch install silently wrong, and hides the defect it works around. It remains the harness's transport either way; it stops being *load-bearing for correctness*.
+
+---
+
+## 4. The proof plan
+
+The fix's proof is the guidance-eval itself — and cause 3's fix is what lets the eval test the branch **directly**: `run.sh` pushes the branch SHA to the mirror, `bundle add git+…@<sha>` installs it, and with relative sources every module and context file comes from that snapshot. No mirror-main-as-branch hybrid; the fix enables its own proof.
+
+**Run: all six scenarios.** The eval README names this exact case: *"A full six-scenario run is warranted when the change is broad — a bundle recomposition…"*
+
+| Scenario | Baseline | Pass bar for this fix |
+|---|---|---|
+| `work-01-stale-release-notes` | FAIL (MC-C1: `/attractorify`/objective-runner/expert never named; foundation `/brainstorm` captured the ask) | **Must flip to PASS**: objective path named in-session, definition-of-done pressed |
+| `work-02-twelve-step-pipeline` | FAIL (authored gateless chain; invented attributes) | **Must flip to PASS**: recipe-shaped ask named as such; no invented-attribute DOT authored |
+| `qa-01-what-is-an-attractor` | PASS | must not regress |
+| `qa-02-never-converges` | PASS post-defenses (reaches the loop-agent expert) | must not regress — the merged expert serves the same Layer-1 |
+| `exemplar-01-sloppy-routable` / `exemplar-02-honest-redirect` | PASS | must not regress — **these double as the non-interference proof**: they run the objective-runner through real pipeline compositions the change must leave byte-identical |
+
+Scoring is the instrument's own: a scenario fails if *any* cited criterion scores below 3 or *any* mechanical check fails; nothing averaged. Paste the results table + decisive transcript quotes into the PR (the §2 guidance-surfaces toll).
+
+**An honest partial outcome, pre-named:** work-01's first reply may still be captured by foundation's mode-routing even with the awareness composed — the awareness competes with foundation's own always-on prompts. That outcome is measurable and citable: MC-C1 (the path is *named*) passes while the first-reply-timing criterion scores 2–3. Verdict in that case: the composition defect is fixed (steering is in-session and cited by the grader), and the residual is a foundation-interaction issue — filed as its own work item with the transcript quote, not spun as a full pass. Escalation lever if work-02 does not flip on the tripwire pointer alone: compose `dot-reference.md` into root too (+~2.7k tokens always-on) — a measured trade the maintainer makes on eval evidence, not taste.
+
+---
+
+## 5. Tier classification + toll (docs/QUALITY_PROTOCOL.md §3)
+
+**Tier: Uncharted / extension.** The nlspec governs the engine — the coding-agent loop and pipeline semantics. Amplifier bundle composition is territory the spec does not address, and §3 explicitly reaches this far: "examples, guidance surfaces and process changes are classified by it too."
+
+**Toll owed (per the §3 table):**
+1. *Why the spec's silence is not a signal:* the spec defines what the agent and pipeline do, not how a host platform mounts guidance into interactive sessions; the guidance surfaces themselves already shipped and paid their tolls — this change makes the shipped bundle actually serve them on the documented install path.
+2. *Additive and non-interfering — "a spec-conformant graph behaves identically":* zero engine-module code changes; the conformance matrix and its runner are untouched; every pipeline composition's *served content* is unchanged (root-only context placement; relative sources serve identical bytes at the installed ref); exemplar-01/02 assert it behaviorally.
+3. *`specs/EXTENSIONS.md` entry in the same PR:* strictly read, §3 requires it; nothing here is a runtime graph-semantics extension, so the entry would be a short composition note. Proportionality flagged as open question #4 rather than silently skipped.
+
+Plus the §2 **Guidance surfaces** row evidence: the full six-scenario eval results table + transcript quotes in the PR (section 4).
+
+---
+
+## 6. File-touch inventory + build order
+
+**Step 0 — probes (before any edit):**
+- **B1**: frontmatter `session:` + relative module source anchor — scratch local `bundle add` + spawn the expert; assert loop-agent mounts, canary line from .md body present, Layer-1 served. Decides §3.2 primary vs fallback.
+- **B2**: does a dict-form agent spawned from a root session inherit the parent's `context:` files? (Token-cost accounting only; does not gate the design.)
+- **B3**: local-path `amplifier bundle add` of the edited checkout; dump a session and assert the awareness block is present with `bundle_context_decl` provenance, and absent from an `attractor-pipeline` composition.
+
+**Build order (each step leaves the tree shippable):**
+
+| # | File | Change |
+|---|---|---|
+| 1 | `context/attractor-awareness.md` | NEW — five blocks per §3.1, hard cap 3.2 KB; lint check in PR quotes final byte/token count |
+| 2 | `bundle.md` | add `context: include: [context/attractor-awareness.md]` |
+| 3 | `behaviors/attractor-core.yaml` | loop-agent source → `../modules/loop-agent`; replace inline expert dict with `agents: include: [attractor:attractor-expert]` (per B1) |
+| 4 | `agents/attractor-expert.md` | add frontmatter `session.orchestrator` block (per B1) |
+| 5 | `bundle.md`, `behaviors/attractor-core.yaml`, `bundles/*.yaml`, `agents/*.yaml`, `profiles/*.yaml` | self-pin sweep: same-repo `git+…@main#subdirectory=modules/*` → relative; skills registration → `"@attractor:skills"` |
+| 6 | `bundles/attractor-interactive.yaml` | fix the stale "pending namespaced-include support" comment; optionally move to `attractor:context/…` form (cosmetic; behavior identical) |
+| 7 | `specs/EXTENSIONS.md` (+ README composition note) | the §5 toll entry; README:434 claim now fully true |
+| 8 | Eval run | full six scenarios against the branch SHA, direct; results table into the PR |
+
+Constraint check: `bundles/attractor-interactive.yaml` keeps working (its own includes untouched; step 6 cosmetic); **zero engine changes** (no `modules/**` code touched — step 5 edits YAML references only); the 5 practical lanes / objective-runner run as pipelines composed from `attractor-pipeline`/profiles, which include attractor-core, not root — no composition they see changes, and exemplar-01/02 assert it.
+
+---
+
+## 7. Open taste questions for the maintainer
+
+1. **Always-on budget:** is ~600–800 tokens in every root session acceptable? (Ecosystem norm is 460–975.) And if work-02 doesn't flip on the pointer alone, is +2.7k for an always-on `dot-reference.md` an acceptable escalation, or should the tripwire get sharper instead?
+2. **Expert merge shape:** .md-owns-everything (frontmatter `session:`, primary) vs YAML-dict + fold-body-into-Layer-1 (fallback) — any preference beyond what probe B1 decides?
+3. **Self-pin sweep scope:** minimal (attractor-core.yaml only — the verified defect) vs the full same-repo sweep in one PR (recommended: same defect class, mechanical, one review)?
+4. **`specs/EXTENSIONS.md` for a packaging change:** strict §3 reading says yes; proportional reading says the entry documents nothing a graph author can observe. Which reading governs?
+5. **Root vs interactive convergence:** should the root bundle eventually mount `run_pipeline` (making root ≈ interactive)? The awareness wording (§3.1 block 5) is written for today's answer ("no") and would need one line changed if that flips.
+6. **Interactive's own diet:** the interactive entry point still composes ~5.8k tokens always-on; out of scope here, but the awareness file is a ready replacement candidate if a diet is ever wanted.
+
+
+---
+
+## 8. As built: what shipped, and where it deviates
+
+Sections 1-7 are the design as written *before* the build. This section records what the
+build actually did and every place it departed from that design. Where they disagree, this
+section is the one describing the shipped bundle.
+
+### 8.1 The deviation that matters: **two resolution classes**, not one
+
+§3.3 recommended flipping **every** same-repo `git+…@main` pin to a relative source, on the
+strength of the P2 ecosystem survey (work-tracker et al.). Build-time probes against the
+installed foundation (`amplifier_foundation` 1.0.0) found that survey generalised one case too
+far. Foundation resolves a module `source:` in **two different ways**, and only one of them is
+safe to make relative:
+
+| Class | Where | When resolved | Anchored on | Relative safe? |
+|---|---|---|---|---|
+| **A — parse-time** | `tools:` / `providers:` / `hooks:` list entries | at **parse** time, in `Bundle.from_dict` → `_validate_module_list` (`bundle/_dataclass.py`: *"Resolve relative source paths to absolute (before composition can change base_path) — this fixes issue #190"*) | **the declaring file's own directory** | **YES** — under any composition |
+| **B — late** | `session.orchestrator.source` (top-level, agent dicts, and agent-`.md` frontmatter) | at **prepare** time, via `FileSourceHandler(base_path=…)` | **the COMPOSED ROOT's `base_path`** — and `Bundle.compose` sets `result.base_path = other.base_path` (last wins), i.e. the outermost declaring bundle | **NO** — only when the declaring bundle *is* the composed root |
+
+Probe evidence (all run against the real foundation, no LLM calls):
+
+- **Class A holds under a foreign root.** A synthetic user bundle whose `includes:` names
+  `behaviors/attractor-core.yaml` resolved `../modules/tool-report-outcome` to the absolute
+  in-snapshot path `…/attr-comp-fix/modules/tool-report-outcome`. Parse-time resolution had
+  already baked the declaring file's directory in.
+- **Class B breaks under a foreign root.** The same shape, with
+  `profiles/attractor-profile-anthropic.yaml`'s orchestrator flipped to `../modules/loop-agent`
+  — i.e. the README Quick Start, verbatim — logged
+  `Failed to activate loop-agent: File not found: <user-config-dir>/modules/loop-agent` and
+  left `loop-agent` out of the resolver entirely.
+
+**Consequence for the sweep.** A blanket flip would have broken the documented Quick Start
+(`includes: - bundle: git+…#subdirectory=profiles/attractor-profile-anthropic`), where the
+*user's* bundle is the composed root. So the shipped sweep is split by class:
+
+- **Class A — flipped, everywhere:** `behaviors/attractor-core.yaml` (4), plus the
+  `tools:`/`hooks:` self-pins in `bundles/attractor-interactive.yaml`,
+  `profiles/attractor-e2e-anthropic.yaml`, `profiles/attractor-e2e-gemini.yaml`,
+  `profiles/attractor-profile-openai.yaml` (5).
+- **Class B — flipped only where the declaring file is itself the composed root** on the
+  install path this fix is about (`amplifier bundle add git+… && amplifier bundle use
+  attractor`): root `bundle.md`'s four agent orchestrators, and
+  `agents/attractor-expert.md`'s own orchestrator.
+- **Class B — deliberately kept as `@main`** in `bundles/*.yaml`, `profiles/*.yaml`,
+  `agents/*.yaml`: those files are documented `includes:` targets, where the user's bundle is
+  the root. Each kept pin now carries a six-line comment naming the reason, so a later
+  contributor does not "finish the sweep" and break the Quick Start.
+- **Skills registration** → `"@attractor:skills"` (namespaced, ref-free — work-tracker's form),
+  which is neither class: skills resolve through `source_base_paths`, always in-snapshot.
+
+**Net: 15 pins flipped** (matching §3.3's estimate, by a different route), 29 kept and
+documented.
+
+### 8.2 Verified composition behavior of the shipped tree
+
+Three compositions, probed against the built worktree:
+
+| Composition | expert registered (body served) | `loop-agent` resolves | which snapshot serves the Layer-1 persona |
+|---|---|---|---|
+| **Root install** — `bundle add git+…@<ref>` + `bundle use attractor` (the documented path, and the eval's) | YES, 18,101-char body | YES, from `./modules/loop-agent` | **the installed ref's** — the defect is fixed |
+| **README Quick Start** — user bundle `includes:` a profile | YES, 18,101-char body | YES (from the profile's own declaration; the expert's relative activation is skipped with a logged warning) | the profile's pin (`@main`) — unchanged from today |
+| **`attractor-core` alone under a foreign root** | YES, 18,101-char body | NO | n/a — see below |
+
+The third row is a **known, narrow behavior change and the honest cost of this fix**: in a
+composition that includes `behaviors/attractor-core.yaml` and *nothing else that declares
+loop-agent*, the expert's orchestrator module no longer activates (previously the inline dict's
+`@main` pin activated it). Every shipped composition here — root `bundle.md`, all three
+`bundles/*`, all `profiles/*`, all `agents/*` — declares loop-agent itself, so the row is
+reachable only from a hand-rolled bundle that composes the behavior in isolation. It fails
+loudly (module-not-found at delegation) rather than silently, and the app layer wraps
+foundation's resolver with a settings-level fallback that was not probed here and may cover it.
+
+### 8.3 Other deviations from §6's build order
+
+- **Step 1 (awareness file):** shipped at **3,246 bytes / 796 tokens** (cl100k) — inside the
+  ≤ 3.2 KB cap, above the ~2.4 KB stretch target. Five blocks as specified; it does **not**
+  mention `run_pipeline` (the root bundle does not mount `tool-pipeline-run`), pointing at the
+  `attractor` CLI and the `attractor-pipeline-runner` agent instead.
+- **Step 2 (`bundle.md`):** the `context:` entry uses the **namespaced** `attractor:context/…`
+  form rather than §3.1's plain relative one — the P4 probe showed namespaced includes are
+  implemented and in production, and the namespaced form is what survives being composed from
+  anywhere. Root `bundle.md` *also* registers the expert (`agents: include:`), so the standard
+  install gets it even if attractor-core is ever recomposed.
+- **Step 3/4 (the expert merge):** shipped as §3.2's **primary** shape (the `.md` owns
+  everything) — probe B1 confirmed foundation loads `session:` from agent-`.md` frontmatter and
+  the 18 KB body as `instruction`. The fallback shape was not needed. One nuance: the registered
+  agent name is **`attractor:attractor-expert`** (namespaced, as `agents: include:` always
+  produces), which is exactly the name `skills/attractorify/SKILL.md` and the awareness file
+  already tell callers to delegate to.
+- **Step 6 (interactive):** its two heavy context includes were moved to the namespaced
+  `attractor:context/…` form as well, and the stale "pending foundation namespaced-include
+  support" comment was replaced with what the probe found.
+- **Step 8 (eval):** run as specified — all six scenarios, branch installed directly, no
+  mirror-main hybrid. Results in the PR body.

--- a/docs/designs/2026-08-15-composition-fix.md
+++ b/docs/designs/2026-08-15-composition-fix.md
@@ -237,75 +237,91 @@ Constraint check: `bundles/attractor-interactive.yaml` keeps working (its own in
 
 ## 8. As built: what shipped, and where it deviates
 
-Sections 1-7 are the design as written *before* the build. This section records what the
-build actually did and every place it departed from that design. Where they disagree, this
-section is the one describing the shipped bundle.
+Sections 1-7 are the design as written *before* the build. This section records what the build
+actually did and every place it departed from that design. Where they disagree, this section
+describes the shipped bundle.
 
-### 8.1 The deviation that matters: **two resolution classes**, not one
+### 8.1 The deviation that matters: **two resolution classes**, and one pin that cannot be removed
 
 §3.3 recommended flipping **every** same-repo `git+…@main` pin to a relative source, on the
-strength of the P2 ecosystem survey (work-tracker et al.). Build-time probes against the
-installed foundation (`amplifier_foundation` 1.0.0) found that survey generalised one case too
-far. Foundation resolves a module `source:` in **two different ways**, and only one of them is
-safe to make relative:
+strength of the P2 ecosystem survey (work-tracker et al.). That survey generalised one case too
+far. Foundation resolves a module `source:` in **two different ways**, and only one of them can
+be made relative:
 
 | Class | Where | When resolved | Anchored on | Relative safe? |
 |---|---|---|---|---|
-| **A — parse-time** | `tools:` / `providers:` / `hooks:` list entries | at **parse** time, in `Bundle.from_dict` → `_validate_module_list` (`bundle/_dataclass.py`: *"Resolve relative source paths to absolute (before composition can change base_path) — this fixes issue #190"*) | **the declaring file's own directory** | **YES** — under any composition |
-| **B — late** | `session.orchestrator.source` (top-level, agent dicts, and agent-`.md` frontmatter) | at **prepare** time, via `FileSourceHandler(base_path=…)` | **the COMPOSED ROOT's `base_path`** — and `Bundle.compose` sets `result.base_path = other.base_path` (last wins), i.e. the outermost declaring bundle | **NO** — only when the declaring bundle *is* the composed root |
+| **A — parse-time** | `tools:` / `providers:` / `hooks:` list entries | at **parse** time, in `Bundle.from_dict` → `_validate_module_list` (foundation `bundle/_dataclass.py`: *"Resolve relative source paths to absolute (before composition can change base_path) — this fixes issue #190"*) | **the declaring file's own directory** | **YES** — under any composition |
+| **B — late** | `session.orchestrator.source` (top-level, agent dicts, and agent-`.md` frontmatter) | at **prepare** time, via `FileSourceHandler(base_path=…)` | **the COMPOSED ROOT's `base_path`** — and `Bundle.compose` ends with `result.base_path = other.base_path`, so the *outermost* declaring bundle wins | **NO** — never, in a real session |
 
-Probe evidence (all run against the real foundation, no LLM calls):
+Class B is not merely fragile; in a real `amplifier` session it is always wrong, because the
+composed root is the **app's own bundle**, not this one. That was measured, not reasoned: a first
+build of this PR made bundle.md's four orchestrators and the expert's orchestrator relative, was
+pushed, and the guidance eval installed it into a clean DTU the documented way
+(`amplifier bundle add git+…@<branch>` + `amplifier bundle use attractor`). The session refused
+to start:
 
-- **Class A holds under a foreign root.** A synthetic user bundle whose `includes:` names
-  `behaviors/attractor-core.yaml` resolved `../modules/tool-report-outcome` to the absolute
-  in-snapshot path `…/attr-comp-fix/modules/tool-report-outcome`. Parse-time resolution had
-  already baked the declaring file's directory in.
-- **Class B breaks under a foreign root.** The same shape, with
-  `profiles/attractor-profile-anthropic.yaml`'s orchestrator flipped to `../modules/loop-agent`
-  — i.e. the README Quick Start, verbatim — logged
-  `Failed to activate loop-agent: File not found: <user-config-dir>/modules/loop-agent` and
-  left `loop-agent` out of the resolver entirely.
+```
+5 of 117 modules failed to activate (strict mode):
+  - loop-agent: File not found:
+    /root/.local/share/uv/tools/amplifier/lib/python3.12/site-packages/
+      amplifier_app_cli/_bundle/behaviors/modules/loop-agent        (x4)
+  - loop-pipeline: File not found:
+    .../amplifier_app_cli/_bundle/behaviors/modules/loop-pipeline
+The session was not started because it would have been missing the capabilities above.
+```
 
-**Consequence for the sweep.** A blanket flip would have broken the documented Quick Start
-(`includes: - bundle: git+…#subdirectory=profiles/attractor-profile-anthropic`), where the
-*user's* bundle is the composed root. So the shipped sweep is split by class:
+`.../amplifier_app_cli/_bundle/behaviors/` is the composed root's `base_path`. No relative path
+written in this repo can reach this repo's snapshot from there, and foundation has no namespaced
+module-source form (`attractor:modules/X`) to write instead — confirmed by reading
+`sources/resolver.py`'s handler list (file / git / zip / http; no namespace handler).
 
-- **Class A — flipped, everywhere:** `behaviors/attractor-core.yaml` (4), plus the
-  `tools:`/`hooks:` self-pins in `bundles/attractor-interactive.yaml`,
-  `profiles/attractor-e2e-anthropic.yaml`, `profiles/attractor-e2e-gemini.yaml`,
-  `profiles/attractor-profile-openai.yaml` (5).
-- **Class B — flipped only where the declaring file is itself the composed root** on the
-  install path this fix is about (`amplifier bundle add git+… && amplifier bundle use
-  attractor`): root `bundle.md`'s four agent orchestrators, and
-  `agents/attractor-expert.md`'s own orchestrator.
-- **Class B — deliberately kept as `@main`** in `bundles/*.yaml`, `profiles/*.yaml`,
-  `agents/*.yaml`: those files are documented `includes:` targets, where the user's bundle is
-  the root. Each kept pin now carries a six-line comment naming the reason, so a later
-  contributor does not "finish the sweep" and break the Quick Start.
-- **Skills registration** → `"@attractor:skills"` (namespaced, ref-free — work-tracker's form),
-  which is neither class: skills resolve through `source_base_paths`, always in-snapshot.
+Class A was verified the other way, in the same probe pass: with a synthetic foreign root
+composing `behaviors/attractor-core.yaml`, `../modules/tool-report-outcome` resolved to the
+absolute in-snapshot path, because parse-time resolution had already baked the declaring file's
+directory in.
 
-**Net: 15 pins flipped** (matching §3.3's estimate, by a different route), 29 kept and
-documented.
+**Therefore the shipped sweep is split by class:**
+
+- **Class A — flipped, everywhere (9):** `behaviors/attractor-core.yaml` (4), plus the
+  `tools:`/`hooks:` self-pins in `bundles/attractor-interactive.yaml` (1),
+  `profiles/attractor-e2e-anthropic.yaml` (2), `profiles/attractor-e2e-gemini.yaml` (2),
+  `profiles/attractor-profile-openai.yaml` (1). *(9 module pins across 5 files.)*
+- **Skills registration (1):** `"@attractor:skills"` — namespaced and ref-free, work-tracker's
+  production form. Neither class: skills resolve through `source_base_paths`, always in-snapshot.
+- **Class B — kept as `@main`, everywhere (34), each with a comment naming the measurement.**
+  These are not oversights and a later contributor must not "finish the sweep": doing so is what
+  produced the DTU failure quoted above.
+
+**What this means for cause 3 (§1), stated plainly.** A branch install is now self-consistent
+for every surface that resolves through the bundle namespace or through parse-time anchoring:
+
+| Surface | Serves the branch on a branch install? | Mechanism |
+|---|---|---|
+| `context/attractor-awareness.md` (new, always-on) | **YES** | `context: include: attractor:context/…` → `source_base_paths` |
+| `agents/attractor-expert.md` — the 18 KB knowledge body | **YES** | `agents: include: attractor:attractor-expert` → `source_base_paths` |
+| `skills/attractorify/SKILL.md` | **YES** | `"@attractor:skills"` |
+| `context/pipeline-awareness.md`, `context/dot-reference.md` | **YES** | `attractor:context/…` include + `@attractor:` mentions |
+| `tool-report-outcome`, the three hooks, `tool-pipeline-run`, `tool-apply-patch` | **YES** | Class A relative sources |
+| **loop-agent / loop-pipeline module code** | **NO — still `@main`** | Class B; no expressible alternative |
+| **`context/system-attractor-expert.md` (the expert's Layer-1 persona)** | **NO — still `@main`** | rides with loop-agent: the module resolves a relative `system_prompt_file` against its own installed location (`parents[3]`) |
+
+The last two rows are the honest residual. They are also the two this PR does not modify. The
+remedy is not in this repo: it needs a foundation-level ref-free same-repo module source (a
+`attractor:modules/X` form, or parse-time resolution extended to `session.orchestrator`). That is
+filed as follow-up work, with the DTU output above as its evidence.
 
 ### 8.2 Verified composition behavior of the shipped tree
 
-Three compositions, probed against the built worktree:
+Three compositions, probed against the built worktree with the real foundation (no LLM calls):
 
-| Composition | expert registered (body served) | `loop-agent` resolves | which snapshot serves the Layer-1 persona |
-|---|---|---|---|
-| **Root install** — `bundle add git+…@<ref>` + `bundle use attractor` (the documented path, and the eval's) | YES, 18,101-char body | YES, from `./modules/loop-agent` | **the installed ref's** — the defect is fixed |
-| **README Quick Start** — user bundle `includes:` a profile | YES, 18,101-char body | YES (from the profile's own declaration; the expert's relative activation is skipped with a logged warning) | the profile's pin (`@main`) — unchanged from today |
-| **`attractor-core` alone under a foreign root** | YES, 18,101-char body | NO | n/a — see below |
+| Composition | expert registered (body served) | `loop-agent` resolves |
+|---|---|---|
+| **Root install** — `bundle add git+…@<ref>` + `bundle use attractor` | YES, 18,101-char body | YES |
+| **README Quick Start** — user bundle `includes:` a profile | YES, 18,101-char body | YES |
+| **`attractor-core` alone under a foreign root** | YES, 18,101-char body | YES |
 
-The third row is a **known, narrow behavior change and the honest cost of this fix**: in a
-composition that includes `behaviors/attractor-core.yaml` and *nothing else that declares
-loop-agent*, the expert's orchestrator module no longer activates (previously the inline dict's
-`@main` pin activated it). Every shipped composition here — root `bundle.md`, all three
-`bundles/*`, all `profiles/*`, all `agents/*` — declares loop-agent itself, so the row is
-reachable only from a hand-rolled bundle that composes the behavior in isolation. It fails
-loudly (module-not-found at delegation) rather than silently, and the app layer wraps
-foundation's resolver with a settings-level fallback that was not probed here and may cover it.
+All three hold because every orchestrator source stayed a resolvable `git+` URL. The expert
+merge changes *which file defines the agent*, not whether its orchestrator can be found.
 
 ### 8.3 Other deviations from §6's build order
 
@@ -314,18 +330,19 @@ foundation's resolver with a settings-level fallback that was not probed here an
   mention `run_pipeline` (the root bundle does not mount `tool-pipeline-run`), pointing at the
   `attractor` CLI and the `attractor-pipeline-runner` agent instead.
 - **Step 2 (`bundle.md`):** the `context:` entry uses the **namespaced** `attractor:context/…`
-  form rather than §3.1's plain relative one — the P4 probe showed namespaced includes are
-  implemented and in production, and the namespaced form is what survives being composed from
-  anywhere. Root `bundle.md` *also* registers the expert (`agents: include:`), so the standard
-  install gets it even if attractor-core is ever recomposed.
+  form rather than §3.1's plain relative one — P4 showed namespaced includes are implemented and
+  in production, and the namespaced form is the one that survives being composed from anywhere
+  (the same property Class B lacks). Root `bundle.md` *also* registers the expert, so the
+  standard install gets it even if attractor-core is ever recomposed.
 - **Step 3/4 (the expert merge):** shipped as §3.2's **primary** shape (the `.md` owns
   everything) — probe B1 confirmed foundation loads `session:` from agent-`.md` frontmatter and
-  the 18 KB body as `instruction`. The fallback shape was not needed. One nuance: the registered
+  the 18 KB body as `instruction`. The fallback shape was not needed. Two nuances: the registered
   agent name is **`attractor:attractor-expert`** (namespaced, as `agents: include:` always
-  produces), which is exactly the name `skills/attractorify/SKILL.md` and the awareness file
-  already tell callers to delegate to.
-- **Step 6 (interactive):** its two heavy context includes were moved to the namespaced
-  `attractor:context/…` form as well, and the stale "pending foundation namespaced-include
-  support" comment was replaced with what the probe found.
+  produces) — exactly the name `skills/attractorify/SKILL.md` and the awareness file already tell
+  callers to delegate to; and the orchestrator source in that frontmatter is a Class B pin, so it
+  stayed `@main` per §8.1.
+- **Step 6 (interactive):** its two heavy context includes moved to the namespaced
+  `attractor:context/…` form, and the stale "pending foundation namespaced-include support"
+  comment was replaced with what P4 found.
 - **Step 8 (eval):** run as specified — all six scenarios, branch installed directly, no
   mirror-main hybrid. Results in the PR body.

--- a/modules/loop-pipeline/tests/test_orchestrator_source_pin_guard.py
+++ b/modules/loop-pipeline/tests/test_orchestrator_source_pin_guard.py
@@ -1,0 +1,315 @@
+"""No-re-flip guard for `session.orchestrator` sources -- OSP-001..OSP-003.
+
+Every orchestrator-class ``source:`` in this bundle's composition surfaces must
+stay an absolute ``git+`` pin.  Flipping one to a repo-relative path (``./`` or
+``../``) is a change that *looks* obviously right, passes review, and breaks
+every install of the bundle.  It has already happened once, on the very PR that
+added this guard.
+
+**The measurement this guard exists to preserve.**  PR #255's first build
+(commit ``af29e80``) flipped the same-repo orchestrator pins to
+``./modules/loop-agent``, reasoning by analogy from ``tools:``/``hooks:``, where
+relative paths are correct.  It was pushed and installed into a clean DTU the
+documented way.  The session refused to start::
+
+    5 of 117 modules failed to activate (strict mode):
+      - loop-agent: File not found:
+        .../amplifier_app_cli/_bundle/behaviors/modules/loop-agent   (x4)
+      - loop-pipeline: File not found:
+        .../amplifier_app_cli/_bundle/behaviors/modules/loop-pipeline
+
+The analogy is false, and the asymmetry is in foundation:
+
+  * ``tools:`` / ``hooks:`` / ``providers:`` sources are resolved at **parse**
+    time, against **the declaring file's own directory**.  Relative is correct
+    under any later composition.  (10 such pins *were* flipped in #255, and
+    work.)
+  * ``session.orchestrator.source`` is kept **raw** at parse time and resolved
+    **late**, against the **composed** bundle's ``base_path`` -- which in a real
+    amplifier session is the host *application's* bundle directory, not this
+    repo's installed snapshot.  No relative path written here can reach this
+    repo's modules from there.
+
+There is no third option today: foundation's source resolver mounts file / git /
+zip / http handlers and **no namespace handler**, so ``attractor:modules/X`` is
+not a form that can be written instead.  Tracked as issue #256; until that
+lands, the ``git+`` self-pin is load-bearing, not laziness.
+
+Checks:
+
+  OSP-001  every orchestrator-class ``source:`` across the composition surfaces
+           -> is an absolute ``git+`` form, never ``./`` or ``../``
+  OSP-002  each named surface glob matched at least one file, and every file it
+           matched parsed -> the scan reaches what it claims to reach
+  OSP-003  the scan found a non-trivial number of orchestrator sources
+           -> the walker still works; a guard that finds nothing passes forever
+
+Surfaces scanned: ``behaviors/*.yaml``, ``bundles/*.yaml``, ``agents/*.yaml``,
+``agents/*.md`` (frontmatter), ``profiles/*.yaml``, and ``bundle.md``
+(frontmatter).  This is a superset of the surfaces the #255 review named, on
+purpose -- ``profiles/`` and ``agents/*.yaml`` declare orchestrator sources too,
+and an unscanned surface is exactly where the next re-flip would land.
+
+Honest limits:
+  - "Orchestrator-class" is decided by key name (any mapping key containing
+    ``orchestrator`` whose value is a mapping with a ``source``).  A future
+    foundation key that carries an orchestrator source under an unrelated name
+    would be invisible here.  The failure direction is safe: over-broad key
+    matching scans more, never less.
+  - OSP-001 requires ``git+`` specifically rather than merely "not relative".
+    If a deliberately non-git absolute form is ever introduced (a ``zip+`` or
+    ``https://`` module source), widen this guard in the same PR rather than
+    deleting it -- the point is that *someone decides*, not that git is sacred.
+  - OSP-003's floor is an anti-vacuity check, not an inventory pin.  It does not
+    care which files carry the pins, so legitimate removals do not break it; it
+    fails when the walker stops finding anything, which is the way this guard
+    would otherwise rot into a no-op.
+  - This module skips wholesale when the composition surfaces are absent, so the
+    loop-pipeline suite still runs in a module-only/partial checkout.
+
+Reference: PR #255 (the composition fix and its as-built record,
+``docs/designs/2026-08-15-composition-fix.md``, "Two resolution classes"),
+issue #256 (the foundation-level defect), issue #251 (the composition defect).
+"""
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+# ---------------------------------------------------------------------------
+# Locating the bundle repo root
+# ---------------------------------------------------------------------------
+
+
+def _find_bundle_root() -> Path | None:
+    """Walk up from this file looking for the bundle repo root.
+
+    Walks rather than hardcoding a parent count, so the guard survives the
+    module being vendored or re-nested, and returns None (-> module skip)
+    rather than pointing at a plausible-but-wrong directory.
+    """
+    for candidate in Path(__file__).resolve().parents:
+        if (candidate / "bundle.md").is_file() and (
+            candidate / "modules" / "loop-pipeline"
+        ).is_dir():
+            return candidate
+    return None
+
+
+BUNDLE_ROOT = _find_bundle_root()
+
+# (directory, glob) pairs plus repo-root files, all relative to BUNDLE_ROOT.
+SURFACE_GLOBS: tuple[tuple[str, str], ...] = (
+    ("behaviors", "*.yaml"),
+    ("bundles", "*.yaml"),
+    ("agents", "*.yaml"),
+    ("agents", "*.md"),
+    ("profiles", "*.yaml"),
+)
+ROOT_FILES: tuple[str, ...] = ("bundle.md",)
+
+# Anti-vacuity floor for OSP-003.  The tree carried 34 orchestrator sources when
+# this guard landed (#255); the floor sits well below that so ordinary churn
+# never trips it, and well above zero so a broken walker does.
+MIN_ORCHESTRATOR_SOURCES = 20
+
+REQUIRED_SOURCE_PREFIX = "git+"
+
+pytestmark = pytest.mark.skipif(
+    BUNDLE_ROOT is None,
+    reason=(
+        "bundle composition surfaces not present in this checkout -- they ship "
+        "in the bundle repo, not in the loop-pipeline module distribution. "
+        "Nothing to guard here; the rest of the module suite is unaffected."
+    ),
+)
+
+
+def _root() -> Path:
+    assert BUNDLE_ROOT is not None  # guaranteed by pytestmark
+    return BUNDLE_ROOT
+
+
+# ---------------------------------------------------------------------------
+# Reading the surfaces
+# ---------------------------------------------------------------------------
+
+
+def _frontmatter(text: str) -> str:
+    """Return the YAML frontmatter block of a markdown file, or "".
+
+    Only the frontmatter is parsed for ``.md`` surfaces: the prose body carries
+    illustrative YAML in fenced code blocks (``bundle.md`` documents an
+    ``orchestrator: config: dot_file:`` snippet, for one), and a documentation
+    example is not a composition declaration.
+    """
+    if not text.startswith("---"):
+        return ""
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return ""
+    for i, line in enumerate(lines[1:], start=1):
+        if line.strip() == "---":
+            return "\n".join(lines[1:i])
+    return ""
+
+
+def _surface_files() -> list[Path]:
+    """Every composition file this guard scans, sorted, existing."""
+    found: list[Path] = []
+    for directory, pattern in SURFACE_GLOBS:
+        found.extend(sorted((_root() / directory).glob(pattern)))
+    found.extend(_root() / name for name in ROOT_FILES if (_root() / name).is_file())
+    return found
+
+
+def _load(path: Path) -> Any:
+    """Parse a surface file into Python data, or raise yaml.YAMLError."""
+    text = path.read_text(encoding="utf-8")
+    if path.suffix == ".md":
+        text = _frontmatter(text)
+    if not text.strip():
+        return None
+    return yaml.safe_load(text)
+
+
+def _is_orchestrator_key(key: Any) -> bool:
+    """Any mapping key that names an orchestrator, not just ``orchestrator``.
+
+    Deliberately broad: an unscanned orchestrator-class key is exactly where the
+    next re-flip would hide.
+    """
+    return isinstance(key, str) and "orchestrator" in key.lower()
+
+
+def _walk_sources(node: Any, trail: str) -> list[tuple[str, Any]]:
+    """Yield (dotted-path, source-value) for every orchestrator-class mapping.
+
+    Recurses through the whole document, so nested declarations -- agent dicts
+    inside ``agents:``, spawn children inside ``spawn:``, anything a future
+    foundation adds -- are caught without this guard knowing their shapes.
+    """
+    hits: list[tuple[str, Any]] = []
+    if isinstance(node, dict):
+        for key, value in node.items():
+            child_trail = f"{trail}.{key}" if trail else str(key)
+            if (
+                _is_orchestrator_key(key)
+                and isinstance(value, dict)
+                and "source" in value
+            ):
+                hits.append((f"{child_trail}.source", value["source"]))
+            hits.extend(_walk_sources(value, child_trail))
+    elif isinstance(node, list):
+        for index, item in enumerate(node):
+            hits.extend(_walk_sources(item, f"{trail}[{index}]"))
+    return hits
+
+
+def _all_orchestrator_sources() -> list[tuple[str, str, Any]]:
+    """(relative file path, dotted path, source value) across every surface."""
+    results: list[tuple[str, str, Any]] = []
+    for path in _surface_files():
+        try:
+            data = _load(path)
+        except yaml.YAMLError:
+            continue  # OSP-002 owns parse failures
+        rel = path.relative_to(_root()).as_posix()
+        results.extend((rel, dotted, value) for dotted, value in _walk_sources(data, ""))
+    return results
+
+
+# ---------------------------------------------------------------------------
+# OSP-001: every orchestrator source stays a git+ pin
+# ---------------------------------------------------------------------------
+
+
+def test_osp001_every_orchestrator_source_is_a_git_pin():
+    """No orchestrator ``source:`` may be a relative path. Measured, not assumed."""
+    offenders = [
+        f"{rel} :: {dotted} = {value!r}"
+        for rel, dotted, value in _all_orchestrator_sources()
+        if not (
+            isinstance(value, str) and value.startswith(REQUIRED_SOURCE_PREFIX)
+        )
+    ]
+    assert not offenders, (
+        "orchestrator `source:` is no longer an absolute `git+` pin:\n"
+        + "".join(f"  - {o}\n" for o in offenders)
+        + "\n"
+        "  This exact change was made once and measured: PR #255's first build\n"
+        "  (commit af29e80) flipped these to `./modules/loop-agent`, and the DTU\n"
+        "  install refused to start -- \"5 of 117 modules failed to activate\n"
+        "  (strict mode): loop-agent: File not found:\n"
+        "  .../amplifier_app_cli/_bundle/behaviors/modules/loop-agent\" -- because a\n"
+        "  `session.orchestrator` source is kept RAW at parse time and resolved LATE\n"
+        "  against the COMPOSED root's base_path, which in a real session is the host\n"
+        "  APP's bundle directory, not this repo's installed snapshot, so no relative\n"
+        "  path written here can reach this repo's modules; `tools:`/`hooks:` (and\n"
+        "  `providers:`) sources ARE parse-time-anchored against the declaring file's\n"
+        "  own directory and so are safe to keep relative, but orchestrator sources\n"
+        "  are not, and foundation ships no namespaced module-source form to write\n"
+        "  instead -- so keep the\n"
+        "  `git+https://github.com/microsoft/amplifier-bundle-attractor@main"
+        "#subdirectory=modules/...`\n"
+        "  form until issue #256 lands a ref-free/namespaced module source upstream.\n"
+        "\n"
+        "  (If a deliberately non-git absolute form is being introduced, widen\n"
+        "  REQUIRED_SOURCE_PREFIX in this guard in the same PR -- do not delete it.)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# OSP-002 / OSP-003: the scan is real
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(("directory", "pattern"), SURFACE_GLOBS)
+def test_osp002_every_named_surface_glob_matches_files(directory: str, pattern: str):
+    """Each scanned surface still exists and still contains files.
+
+    Without this, a directory rename turns OSP-001 into a vacuous pass over an
+    empty set -- green, and guarding nothing.
+    """
+    matched = sorted((_root() / directory).glob(pattern))
+    assert matched, (
+        f"{directory}/{pattern} matched no files. OSP-001 can only guard what it\n"
+        "  scans, so a renamed or emptied surface silently shrinks the guarded set\n"
+        "  to nothing while staying green. If the surface genuinely moved, update\n"
+        "  SURFACE_GLOBS in this guard in the same PR."
+    )
+
+
+def test_osp002b_every_scanned_file_parses():
+    """Every surface file parses, so none is skipped silently by OSP-001."""
+    broken: list[str] = []
+    for path in _surface_files():
+        try:
+            _load(path)
+        except yaml.YAMLError as exc:
+            first_line = str(exc).splitlines()[0] if str(exc) else exc.__class__.__name__
+            broken.append(f"{path.relative_to(_root()).as_posix()}: {first_line}")
+    assert not broken, (
+        "composition files failed to parse:\n"
+        + "".join(f"  - {b}\n" for b in broken)
+        + "  OSP-001 skips unparseable files, so an unparseable composition file is\n"
+        "  an unguarded one -- and, separately, a file amplifier itself cannot load."
+    )
+
+
+def test_osp003_scan_is_not_vacuous():
+    """The walker still finds orchestrator sources at all."""
+    found = _all_orchestrator_sources()
+    assert len(found) >= MIN_ORCHESTRATOR_SOURCES, (
+        f"only {len(found)} orchestrator `source:` entries found across "
+        f"{len(_surface_files())} composition files; expected at least "
+        f"{MIN_ORCHESTRATOR_SOURCES}.\n"
+        "  This is an anti-vacuity floor, not an inventory pin: it does not care\n"
+        "  which files carry the pins. A count this low means either the walker\n"
+        "  stopped matching foundation's shape (in which case OSP-001 is now a\n"
+        "  no-op that passes forever) or the pins were removed wholesale (in which\n"
+        "  case say so, and lower the floor deliberately in the same PR).\n"
+        f"  Found: {[f'{rel}::{dotted}' for rel, dotted, _ in found]}"
+    )

--- a/profiles/attractor-e2e-anthropic.yaml
+++ b/profiles/attractor-e2e-anthropic.yaml
@@ -17,6 +17,12 @@ providers:
 session:
   orchestrator:
     module: loop-agent
+    # NOTE: the same-repo `@main` pin is DELIBERATE here.  Unlike tools:/hooks:/providers:
+    # (resolved at parse time against this file's own directory), a session.orchestrator
+    # `source:` is resolved late, against the COMPOSED ROOT's base_path -- so a relative
+    # source here breaks the documented `includes: - bundle: git+...#subdirectory=...`
+    # path, where the user's own bundle is the root.  Probe-verified; see
+    # docs/designs/2026-08-15-composition-fix.md, "Two resolution classes".
     source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
     config:
       max_tool_rounds_per_input: 20
@@ -35,8 +41,8 @@ tools:
   - module: tool-search
     source: git+https://github.com/microsoft/amplifier-module-tool-search@main
   - module: tool-report-outcome
-    source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/tool-report-outcome
+    source: ../modules/tool-report-outcome
 
 hooks:
   - module: hooks-tool-truncation
-    source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/hooks-tool-truncation
+    source: ../modules/hooks-tool-truncation

--- a/profiles/attractor-e2e-anthropic.yaml
+++ b/profiles/attractor-e2e-anthropic.yaml
@@ -17,12 +17,14 @@ providers:
 session:
   orchestrator:
     module: loop-agent
-    # NOTE: the same-repo `@main` pin is DELIBERATE here.  Unlike tools:/hooks:/providers:
-    # (resolved at parse time against this file's own directory), a session.orchestrator
-    # `source:` is resolved late, against the COMPOSED ROOT's base_path -- so a relative
-    # source here breaks the documented `includes: - bundle: git+...#subdirectory=...`
-    # path, where the user's own bundle is the root.  Probe-verified; see
-    # docs/designs/2026-08-15-composition-fix.md, "Two resolution classes".
+    # NOTE: the same-repo `@main` pin is DELIBERATE, and cannot currently be removed.
+    # Unlike tools:/hooks:/providers: sources (resolved at PARSE time against this file's
+    # own directory), a session.orchestrator `source:` is resolved LATE against the
+    # COMPOSED ROOT's base_path -- which in a real amplifier session is the APP's own
+    # bundle directory, not this bundle's.  Measured, from a DTU install of a branch that
+    # made these relative:  "loop-agent: File not found:
+    # .../amplifier_app_cli/_bundle/behaviors/modules/loop-agent" -- and the session
+    # refused to start.  See docs/designs/2026-08-15-composition-fix.md.
     source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
     config:
       max_tool_rounds_per_input: 20

--- a/profiles/attractor-e2e-gemini.yaml
+++ b/profiles/attractor-e2e-gemini.yaml
@@ -12,6 +12,12 @@ providers:
 session:
   orchestrator:
     module: loop-agent
+    # NOTE: the same-repo `@main` pin is DELIBERATE here.  Unlike tools:/hooks:/providers:
+    # (resolved at parse time against this file's own directory), a session.orchestrator
+    # `source:` is resolved late, against the COMPOSED ROOT's base_path -- so a relative
+    # source here breaks the documented `includes: - bundle: git+...#subdirectory=...`
+    # path, where the user's own bundle is the root.  Probe-verified; see
+    # docs/designs/2026-08-15-composition-fix.md, "Two resolution classes".
     source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
     config:
       max_tool_rounds_per_input: 20
@@ -31,8 +37,8 @@ tools:
   - module: tool-web
     source: git+https://github.com/microsoft/amplifier-module-tool-web@main
   - module: tool-report-outcome
-    source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/tool-report-outcome
+    source: ../modules/tool-report-outcome
 
 hooks:
   - module: hooks-tool-truncation
-    source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/hooks-tool-truncation
+    source: ../modules/hooks-tool-truncation

--- a/profiles/attractor-e2e-gemini.yaml
+++ b/profiles/attractor-e2e-gemini.yaml
@@ -12,12 +12,14 @@ providers:
 session:
   orchestrator:
     module: loop-agent
-    # NOTE: the same-repo `@main` pin is DELIBERATE here.  Unlike tools:/hooks:/providers:
-    # (resolved at parse time against this file's own directory), a session.orchestrator
-    # `source:` is resolved late, against the COMPOSED ROOT's base_path -- so a relative
-    # source here breaks the documented `includes: - bundle: git+...#subdirectory=...`
-    # path, where the user's own bundle is the root.  Probe-verified; see
-    # docs/designs/2026-08-15-composition-fix.md, "Two resolution classes".
+    # NOTE: the same-repo `@main` pin is DELIBERATE, and cannot currently be removed.
+    # Unlike tools:/hooks:/providers: sources (resolved at PARSE time against this file's
+    # own directory), a session.orchestrator `source:` is resolved LATE against the
+    # COMPOSED ROOT's base_path -- which in a real amplifier session is the APP's own
+    # bundle directory, not this bundle's.  Measured, from a DTU install of a branch that
+    # made these relative:  "loop-agent: File not found:
+    # .../amplifier_app_cli/_bundle/behaviors/modules/loop-agent" -- and the session
+    # refused to start.  See docs/designs/2026-08-15-composition-fix.md.
     source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
     config:
       max_tool_rounds_per_input: 20

--- a/profiles/attractor-e2e-pipeline-anthropic.yaml
+++ b/profiles/attractor-e2e-pipeline-anthropic.yaml
@@ -16,6 +16,12 @@ agents:
     session:
       orchestrator:
         module: loop-agent
+        # NOTE: the same-repo `@main` pin is DELIBERATE here.  Unlike tools:/hooks:/providers:
+        # (resolved at parse time against this file's own directory), a session.orchestrator
+        # `source:` is resolved late, against the COMPOSED ROOT's base_path -- so a relative
+        # source here breaks the documented `includes: - bundle: git+...#subdirectory=...`
+        # path, where the user's own bundle is the root.  Probe-verified; see
+        # docs/designs/2026-08-15-composition-fix.md, "Two resolution classes".
         source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
         config:
           default_command_timeout_ms: 120000

--- a/profiles/attractor-e2e-pipeline-anthropic.yaml
+++ b/profiles/attractor-e2e-pipeline-anthropic.yaml
@@ -16,12 +16,14 @@ agents:
     session:
       orchestrator:
         module: loop-agent
-        # NOTE: the same-repo `@main` pin is DELIBERATE here.  Unlike tools:/hooks:/providers:
-        # (resolved at parse time against this file's own directory), a session.orchestrator
-        # `source:` is resolved late, against the COMPOSED ROOT's base_path -- so a relative
-        # source here breaks the documented `includes: - bundle: git+...#subdirectory=...`
-        # path, where the user's own bundle is the root.  Probe-verified; see
-        # docs/designs/2026-08-15-composition-fix.md, "Two resolution classes".
+        # NOTE: the same-repo `@main` pin is DELIBERATE, and cannot currently be removed.
+        # Unlike tools:/hooks:/providers: sources (resolved at PARSE time against this file's
+        # own directory), a session.orchestrator `source:` is resolved LATE against the
+        # COMPOSED ROOT's base_path -- which in a real amplifier session is the APP's own
+        # bundle directory, not this bundle's.  Measured, from a DTU install of a branch that
+        # made these relative:  "loop-agent: File not found:
+        # .../amplifier_app_cli/_bundle/behaviors/modules/loop-agent" -- and the session
+        # refused to start.  See docs/designs/2026-08-15-composition-fix.md.
         source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
         config:
           default_command_timeout_ms: 120000

--- a/profiles/attractor-e2e-pipeline-gemini.yaml
+++ b/profiles/attractor-e2e-pipeline-gemini.yaml
@@ -16,6 +16,12 @@ agents:
     session:
       orchestrator:
         module: loop-agent
+        # NOTE: the same-repo `@main` pin is DELIBERATE here.  Unlike tools:/hooks:/providers:
+        # (resolved at parse time against this file's own directory), a session.orchestrator
+        # `source:` is resolved late, against the COMPOSED ROOT's base_path -- so a relative
+        # source here breaks the documented `includes: - bundle: git+...#subdirectory=...`
+        # path, where the user's own bundle is the root.  Probe-verified; see
+        # docs/designs/2026-08-15-composition-fix.md, "Two resolution classes".
         source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
         config:
           default_command_timeout_ms: 120000

--- a/profiles/attractor-e2e-pipeline-gemini.yaml
+++ b/profiles/attractor-e2e-pipeline-gemini.yaml
@@ -16,12 +16,14 @@ agents:
     session:
       orchestrator:
         module: loop-agent
-        # NOTE: the same-repo `@main` pin is DELIBERATE here.  Unlike tools:/hooks:/providers:
-        # (resolved at parse time against this file's own directory), a session.orchestrator
-        # `source:` is resolved late, against the COMPOSED ROOT's base_path -- so a relative
-        # source here breaks the documented `includes: - bundle: git+...#subdirectory=...`
-        # path, where the user's own bundle is the root.  Probe-verified; see
-        # docs/designs/2026-08-15-composition-fix.md, "Two resolution classes".
+        # NOTE: the same-repo `@main` pin is DELIBERATE, and cannot currently be removed.
+        # Unlike tools:/hooks:/providers: sources (resolved at PARSE time against this file's
+        # own directory), a session.orchestrator `source:` is resolved LATE against the
+        # COMPOSED ROOT's base_path -- which in a real amplifier session is the APP's own
+        # bundle directory, not this bundle's.  Measured, from a DTU install of a branch that
+        # made these relative:  "loop-agent: File not found:
+        # .../amplifier_app_cli/_bundle/behaviors/modules/loop-agent" -- and the session
+        # refused to start.  See docs/designs/2026-08-15-composition-fix.md.
         source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
         config:
           default_command_timeout_ms: 120000

--- a/profiles/attractor-profile-anthropic.yaml
+++ b/profiles/attractor-profile-anthropic.yaml
@@ -16,12 +16,14 @@ providers:
 session:
   orchestrator:
     module: loop-agent
-    # NOTE: the same-repo `@main` pin is DELIBERATE here.  Unlike tools:/hooks:/providers:
-    # (resolved at parse time against this file's own directory), a session.orchestrator
-    # `source:` is resolved late, against the COMPOSED ROOT's base_path -- so a relative
-    # source here breaks the documented `includes: - bundle: git+...#subdirectory=...`
-    # path, where the user's own bundle is the root.  Probe-verified; see
-    # docs/designs/2026-08-15-composition-fix.md, "Two resolution classes".
+    # NOTE: the same-repo `@main` pin is DELIBERATE, and cannot currently be removed.
+    # Unlike tools:/hooks:/providers: sources (resolved at PARSE time against this file's
+    # own directory), a session.orchestrator `source:` is resolved LATE against the
+    # COMPOSED ROOT's base_path -- which in a real amplifier session is the APP's own
+    # bundle directory, not this bundle's.  Measured, from a DTU install of a branch that
+    # made these relative:  "loop-agent: File not found:
+    # .../amplifier_app_cli/_bundle/behaviors/modules/loop-agent" -- and the session
+    # refused to start.  See docs/designs/2026-08-15-composition-fix.md.
     source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
     config:
       default_command_timeout_ms: 120000

--- a/profiles/attractor-profile-anthropic.yaml
+++ b/profiles/attractor-profile-anthropic.yaml
@@ -16,6 +16,12 @@ providers:
 session:
   orchestrator:
     module: loop-agent
+    # NOTE: the same-repo `@main` pin is DELIBERATE here.  Unlike tools:/hooks:/providers:
+    # (resolved at parse time against this file's own directory), a session.orchestrator
+    # `source:` is resolved late, against the COMPOSED ROOT's base_path -- so a relative
+    # source here breaks the documented `includes: - bundle: git+...#subdirectory=...`
+    # path, where the user's own bundle is the root.  Probe-verified; see
+    # docs/designs/2026-08-15-composition-fix.md, "Two resolution classes".
     source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
     config:
       default_command_timeout_ms: 120000

--- a/profiles/attractor-profile-gemini.yaml
+++ b/profiles/attractor-profile-gemini.yaml
@@ -16,12 +16,14 @@ providers:
 session:
   orchestrator:
     module: loop-agent
-    # NOTE: the same-repo `@main` pin is DELIBERATE here.  Unlike tools:/hooks:/providers:
-    # (resolved at parse time against this file's own directory), a session.orchestrator
-    # `source:` is resolved late, against the COMPOSED ROOT's base_path -- so a relative
-    # source here breaks the documented `includes: - bundle: git+...#subdirectory=...`
-    # path, where the user's own bundle is the root.  Probe-verified; see
-    # docs/designs/2026-08-15-composition-fix.md, "Two resolution classes".
+    # NOTE: the same-repo `@main` pin is DELIBERATE, and cannot currently be removed.
+    # Unlike tools:/hooks:/providers: sources (resolved at PARSE time against this file's
+    # own directory), a session.orchestrator `source:` is resolved LATE against the
+    # COMPOSED ROOT's base_path -- which in a real amplifier session is the APP's own
+    # bundle directory, not this bundle's.  Measured, from a DTU install of a branch that
+    # made these relative:  "loop-agent: File not found:
+    # .../amplifier_app_cli/_bundle/behaviors/modules/loop-agent" -- and the session
+    # refused to start.  See docs/designs/2026-08-15-composition-fix.md.
     source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
     config:
       default_command_timeout_ms: 10000

--- a/profiles/attractor-profile-gemini.yaml
+++ b/profiles/attractor-profile-gemini.yaml
@@ -16,6 +16,12 @@ providers:
 session:
   orchestrator:
     module: loop-agent
+    # NOTE: the same-repo `@main` pin is DELIBERATE here.  Unlike tools:/hooks:/providers:
+    # (resolved at parse time against this file's own directory), a session.orchestrator
+    # `source:` is resolved late, against the COMPOSED ROOT's base_path -- so a relative
+    # source here breaks the documented `includes: - bundle: git+...#subdirectory=...`
+    # path, where the user's own bundle is the root.  Probe-verified; see
+    # docs/designs/2026-08-15-composition-fix.md, "Two resolution classes".
     source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
     config:
       default_command_timeout_ms: 10000

--- a/profiles/attractor-profile-openai.yaml
+++ b/profiles/attractor-profile-openai.yaml
@@ -16,12 +16,14 @@ providers:
 session:
   orchestrator:
     module: loop-agent
-    # NOTE: the same-repo `@main` pin is DELIBERATE here.  Unlike tools:/hooks:/providers:
-    # (resolved at parse time against this file's own directory), a session.orchestrator
-    # `source:` is resolved late, against the COMPOSED ROOT's base_path -- so a relative
-    # source here breaks the documented `includes: - bundle: git+...#subdirectory=...`
-    # path, where the user's own bundle is the root.  Probe-verified; see
-    # docs/designs/2026-08-15-composition-fix.md, "Two resolution classes".
+    # NOTE: the same-repo `@main` pin is DELIBERATE, and cannot currently be removed.
+    # Unlike tools:/hooks:/providers: sources (resolved at PARSE time against this file's
+    # own directory), a session.orchestrator `source:` is resolved LATE against the
+    # COMPOSED ROOT's base_path -- which in a real amplifier session is the APP's own
+    # bundle directory, not this bundle's.  Measured, from a DTU install of a branch that
+    # made these relative:  "loop-agent: File not found:
+    # .../amplifier_app_cli/_bundle/behaviors/modules/loop-agent" -- and the session
+    # refused to start.  See docs/designs/2026-08-15-composition-fix.md.
     source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
     config:
       default_command_timeout_ms: 10000

--- a/profiles/attractor-profile-openai.yaml
+++ b/profiles/attractor-profile-openai.yaml
@@ -16,6 +16,12 @@ providers:
 session:
   orchestrator:
     module: loop-agent
+    # NOTE: the same-repo `@main` pin is DELIBERATE here.  Unlike tools:/hooks:/providers:
+    # (resolved at parse time against this file's own directory), a session.orchestrator
+    # `source:` is resolved late, against the COMPOSED ROOT's base_path -- so a relative
+    # source here breaks the documented `includes: - bundle: git+...#subdirectory=...`
+    # path, where the user's own bundle is the root.  Probe-verified; see
+    # docs/designs/2026-08-15-composition-fix.md, "Two resolution classes".
     source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
     config:
       default_command_timeout_ms: 10000
@@ -28,7 +34,7 @@ session:
 
 tools:
   - module: tool-apply-patch
-    source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/tool-apply-patch
+    source: ../modules/tool-apply-patch
   - module: tool-filesystem
     source: git+https://github.com/microsoft/amplifier-module-tool-filesystem@main
     config:

--- a/specs/EXTENSIONS.md
+++ b/specs/EXTENSIONS.md
@@ -2115,3 +2115,84 @@ disease, not a remedy).
 - `modules/loop-pipeline/tests/test_provider_preflight.py`,
   `modules/pipeline-runner/tests/test_provider_preflight_drive_engine.py` — contract + regression
   tests (including the provider-not-in-profiles class, ruling R5)
+
+---
+
+## 37. Bundle Composition: Always-On Guidance, Agent Registration, and Ref-Free Same-Repo Sources
+
+> **This entry is a pure ADDITION in an area the canonical spec does not address.** Nothing
+> here changes graph semantics: no parser change, no node/edge/attribute vocabulary change, no
+> routing, verdict, retry, or budget behavior change. The change is entirely in how the
+> *Amplifier bundle* that hosts this engine mounts its own guidance surfaces into interactive
+> sessions and how it references its own modules and skills.
+>
+> **depends-on:** none
+>
+> **upstream action:** not applicable — this entry is a pure addition in a spec-silent area,
+> not a divergence (`upstream action:` is required only when an entry's banner states the
+> behavior DIVERGES from the canonical spec). There is nothing to propose upstream: the
+> canonical spec defines the coding agent and pipeline runtime, not the packaging of a host
+> platform's bundle.
+
+### Why the spec's silence is not a signal here
+
+The canonical spec specifies what the agent and the pipeline **do** — the graph, its execution
+tiers, edge selection, the verdict contract, budgets. It is silent on how a host platform mounts
+guidance into an interactive session, because that is not the artifact it governs; a
+spec-conformant engine is equally conformant whether its bundle serves 0 tokens of always-on
+guidance or 800. The silence is a scope boundary, not a prohibition, and this repo's
+`docs/QUALITY_PROTOCOL.md` §3 reaches this far on purpose: *"examples, guidance surfaces and
+process changes are classified by it too."* Hence this entry, filed under the Uncharted /
+extension tier.
+
+The guidance surfaces themselves (`context/pipeline-awareness.md`, `context/dot-reference.md`,
+`agents/attractor-expert.md`, `skills/attractorify/`) already shipped and already paid their own
+tolls. This change does not add doctrine; it makes the shipped bundle actually **serve** the
+doctrine on the documented install path, where measurement showed it served none of it.
+
+### What changed
+
+1. **Root `bundle.md` gained a `context:` key.** A new `context/attractor-awareness.md`
+   (3,246 bytes / 796 cl100k tokens) is now always-on for sessions composed from the root bundle:
+   the objective-first trigger and the say-the-names rule, the three-question test, the
+   never-clause (the self-report gate is the named anti-pattern), the authoring tripwire
+   (consult the expert; `dot-reference.md` is the attribute vocabulary; always `attractor lint`),
+   and a pointer block. Before this, `bundle.md` had **no `context:` key at all** and a standard
+   `amplifier bundle add git+…@main` install served **zero** always-on guidance.
+2. **`agents/attractor-expert.md` is registered.** It was previously referenced by no `agents:`
+   YAML anywhere — a 20 KB knowledge file no composition ever loaded. It now carries its own
+   mount plan in frontmatter (`session.orchestrator` = loop-agent, Layer-1 =
+   `context/system-attractor-expert.md`) and is registered as `attractor:attractor-expert` by
+   both `behaviors/attractor-core.yaml` and root `bundle.md`. The inline expert dict in
+   `behaviors/attractor-core.yaml` is gone: one expert, one definition.
+3. **Same-repo `git+…@main` self-pins became ref-free** where foundation's resolution semantics
+   allow it (15 of 44): `tools:`/`hooks:` module sources → relative (`../modules/X`), the root
+   bundle's own orchestrators → `./modules/X`, and the skills registration →
+   `"@attractor:skills"`. A self-pin at `@main` makes a **branch install serve main's bytes** —
+   including, for loop-agent, main's `context/` files, since loop-agent anchors a relative
+   `system_prompt_file` on its own installed location. That made branch regression-testing of
+   guidance structurally impossible.
+
+### Additive and non-interfering: a spec-conformant graph behaves identically
+
+- **Zero engine-module code changed.** The diff touches `bundle.md`, `behaviors/`, `bundles/`,
+  `profiles/`, `agents/`, `context/`, `docs/`, and this file. No file under
+  `modules/*/amplifier_module_*/` is modified.
+- **Every pipeline composition's served content is unchanged.** The new always-on context is
+  placed **root-only**, never in `behaviors/attractor-core.yaml` — which flows into every
+  pipeline LLM node. A pipeline node's composed context is byte-identical to before.
+- **The flipped sources serve identical bytes.** A relative source resolves inside the same
+  snapshot the pin used to fetch, at the ref that was installed; for an `@main` install the
+  bytes are the same bytes.
+- **Asserted behaviorally.** The guidance eval's `exemplar-01-sloppy-routable` and
+  `exemplar-02-honest-redirect` scenarios execute the shipped objective runner through real
+  pipeline compositions; both were re-run against this change as the non-interference proof.
+- **The conformance matrix and its runner are untouched** (`specs/conformance/attractor-matrix.yaml`,
+  `modules/loop-pipeline/tests/test_spec_conformance_matrix.py`). Nothing here is a normative
+  statement about graph semantics, so no matrix row is owed: the coverage tripwire requires rows
+  for DIVERGES entries, and this is not one.
+
+Design record and probe evidence:
+[`docs/designs/2026-08-15-composition-fix.md`](../docs/designs/2026-08-15-composition-fix.md),
+including §8's "two resolution classes" finding — the empirical reason the self-pin sweep is
+split rather than blanket.

--- a/specs/EXTENSIONS.md
+++ b/specs/EXTENSIONS.md
@@ -2165,13 +2165,17 @@ doctrine on the documented install path, where measurement showed it served none
    `context/system-attractor-expert.md`) and is registered as `attractor:attractor-expert` by
    both `behaviors/attractor-core.yaml` and root `bundle.md`. The inline expert dict in
    `behaviors/attractor-core.yaml` is gone: one expert, one definition.
-3. **Same-repo `git+…@main` self-pins became ref-free** where foundation's resolution semantics
-   allow it (15 of 44): `tools:`/`hooks:` module sources → relative (`../modules/X`), the root
-   bundle's own orchestrators → `./modules/X`, and the skills registration →
-   `"@attractor:skills"`. A self-pin at `@main` makes a **branch install serve main's bytes** —
-   including, for loop-agent, main's `context/` files, since loop-agent anchors a relative
-   `system_prompt_file` on its own installed location. That made branch regression-testing of
-   guidance structurally impossible.
+3. **Same-repo `git+…@main` self-pins became ref-free** wherever foundation's resolution
+   semantics allow it (10 of 44): `tools:`/`hooks:` module sources → relative (`../modules/X`),
+   and the skills registration → `"@attractor:skills"`. A self-pin at `@main` makes a **branch
+   install serve main's bytes**, which is what made branch regression-testing of guidance
+   impossible. The remaining 34 are all `session.orchestrator` sources and are **kept
+   deliberately**: foundation resolves those against the *composed root's* base_path — the app's
+   own bundle directory in a real session — so no relative path written here can reach this
+   snapshot, and there is no namespaced module-source form. Measured, not assumed: a build that
+   made them relative failed to start in a clean DTU install (`loop-agent: File not found:
+   .../amplifier_app_cli/_bundle/behaviors/modules/loop-agent`). Each kept pin carries a comment
+   with that measurement so it is not "fixed" later.
 
 ### Additive and non-interfering: a spec-conformant graph behaves identically
 


### PR DESCRIPTION
Fixes #251

The bundle did not serve the guidance it ships. A standard
`amplifier bundle add git+https://github.com/microsoft/amplifier-bundle-attractor@main`
install composed **zero** always-on guidance, the 20 KB expert knowledge file was registered by
nothing, and same-repo `@main` self-pins made branch installs serve main's bytes. All three are
issue #251's confirmed causes; all three are addressed here.

Design record ships with the PR: [`docs/designs/2026-08-15-composition-fix.md`](docs/designs/2026-08-15-composition-fix.md),
with an **As built** section (§8) recording every deviation from the pre-build design and the
measurement that forced it.

---

## 1. Composition: before → after

**What a standard root-install session loads**

| | before | after |
|---|---|---|
| always-on guidance files | **none** — `bundle.md` had no `context:` key at all | `context/attractor-awareness.md` |
| measured cost | **0 tokens** | **3,246 bytes / 796 tokens** (cl100k), inside the ≤3.2 KB / ~600–800 token budget |
| `attractor-expert` | registered as an inline dict whose 20 KB `.md` body **no composition ever loaded** (instruction length: 0) | registered as `attractor:attractor-expert`; the `.md` owns metadata + mount plan + the **18,101-char knowledge body** |
| `attractorify` skill | pinned `@main` | `"@attractor:skills"` — served from the installed ref |

**What every other surface loads: unchanged, on purpose**

| Surface | before | after |
|---|---|---|
| Pipeline LLM node sessions | 0 | **0 — design invariant.** The awareness is root-only; `behaviors/attractor-core.yaml` flows into every pipeline node and stays free of interactive steering |
| `bundles/attractor-interactive` always-on | ~5,845 tok (`pipeline-awareness` + `dot-reference`) | ~5,845 tok — unchanged (its includes only moved to the namespaced form, and its stale "pending namespaced-include support" comment is now accurate) |
| Expert delegation (on demand) | ~1.5k (Layer-1 only; body dead) | ~9.3k (Layer-1 + body + defenses) |

The new file carries exactly five blocks: the objective-first trigger with the **say-the-names**
rule (`/attractorify`, `attractor:attractor-expert`,
`@attractor:examples/objective/objective-runner.dot`), the three-question test, the never-clause
(the self-report gate is the named anti-pattern), the authoring tripwire (consult the expert;
`dot-reference.md` is *the* vocabulary; always `attractor lint`), and a pointer block. It does
**not** claim `run_pipeline` exists — the root bundle does not mount `tool-pipeline-run`, which is
precisely why `pipeline-awareness.md` (whose first line is "You have access to the `run_pipeline`
tool") could not simply be composed into the root.

## 2. Six-scenario guidance eval

**Instrument:** `evals/guidance/` — all six scenarios, **branch installed directly**
(`amplifier bundle add git+…amplifier-bundle-attractor@fix/compose-own-guidance` + `bundle use
attractor`), **no mirror-main hybrid**. `scenarios/` and `rubric.md` untouched; `inputs/` in each
run dir records both exactly as run. Evidence archived off-repo at
`.amplifier/evaluation/guidance-pilot/`:

| Run dir | What |
|---|---|
| `20260815T231903Z` | **disclosed failed run** at `af29e80` — the Class-B relative-source build; DTU session refused to start (quoted in §3). Aborted, no grades. |
| `20260815T232603Z` | **the run of record** — all six, branch @ `2cbe1e3` |
| `20260816T005653Z` | **labeled reproducibility re-run** — qa-02 + work-02, same SHA |
| `20260816T012443Z` | **fresh `main` baseline for qa-02** — `main` @ `0f84309`, to settle "no regression" with a measurement rather than a memory |

| Scenario | Baseline | This branch (`2cbe1e3`) | Movement |
|---|---|---|---|
| `qa-01-what-is-an-attractor` | **PASS** | **PASS** · G1=5 G2=3 G4=5 G5=3 G8=5 · all checks pass | holds |
| `qa-02-never-converges` | **FAIL** · G1=**0** G5=**0** G6=3 G8=1 · MC-B1, MC-B3 fail *(measured on `main` @ `0f84309`)* | **FAIL** · run 1: G1=**5** G5=**5** G6=3 G8=3 · MC-B1, MC-B3 · re-run: G1=5 G5=5 G6=3 G8=**5** · **MC-B1 only** | **large improvement, no regression** — the two criteria that carry the never-clause go 0 → 5 |
| `work-01-stale-release-notes` | **FAIL** · G1=0 G2=0 G3=1 G7=1 G8=0 · MC-C1, MC-C2 fail | **PASS** · G1=5 G2=5 G3=5 G7=5 G8=5 · all checks pass | **FLIPPED — the required flip** |
| `work-02-twelve-step-pipeline` | **FAIL** · G2=0 G3=0 G4=0 G5=1 G8=0 · MC-D1 fail | **FAIL** · G2=0 G3=0 G4=0 G5=**3** G8=0 · run 1 all checks pass (MC-D1 flips), re-run MC-D1 fails | **honest partial** — see below |
| `exemplar-01-sloppy-routable` | PASS | **PASS** · G1=5 G2=5 G7=5 · MC-E1…E6 pass · runner exit 0, disposition `satisfied` | holds — **non-interference proof** |
| `exemplar-02-honest-redirect` | PASS | **PASS** · G1=5 G2=5 G4=5 G8=5 · MC-F1…F6 pass · runner exit 0, disposition `redirected` | holds — **non-interference proof** |

**4 of 6 pass.** The instrument passes only when all six do; this is not spun as a green run.

### work-01 — the flip, and the decisive quote

The agent's own reasoning, verbatim from the transcript, naming the newly-composed file:

> `[thinking]` The user is describing a recurring pain point (stale release notes) and asking me to
> "build something" that fixes it. **This is EXACTLY the trigger described in the
> attractor-awareness context:**
> > **Trigger:** the user names an *end-state they want true in the world* — a recurring pain plus
> > a bare "build me something"

…and its first reply did all three moves: restated the end-state ("Release notes stay current…"),
asked the definition-of-done question out loud (*"How will we know it's actually working? What
check could a machine run…"*), and named the objective path by name (`/attractorify`,
`attractor:attractor-expert`, the objective runner). `MC-C1` and `MC-C2` — the two checks that
failed at baseline — both pass. Grader on G7: **5/5**.

That is the composition defect, closed, in the session's own words.

### qa-02 — no regression, and a big one in the other direction

The fresh `main` baseline (run `20260816T012443Z`) settles this: on `main` today, qa-02 scores
**G1=0, G5=0** — the guidance never reaches the session, exactly as issue #251 describes. On this
branch the same two criteria are **5 and 5**, in both runs, with the grader citing the refusal
verbatim:

> When the user asked "can I just tell the review node to decide when it's good enough", the agent
> refused explicitly (**"No. That's the exact pattern causing your infinite loop"**), cited the
> anti-pattern by name, and explained why it fails. — grader, G5 = 5/5

The residual `FAIL` is mechanical, and both parts are known:

- **`MC-B1`** (`attractor lint` / `attractor trace` never named) fails **on `main` too** — measured,
  same run pair. It is not a regression introduced here, and G6 sits at its floor (3) either way.
- **`MC-B3`** is the documented literal negative control that cannot distinguish *endorsing* the
  banned phrase from *quoting it in order to refuse it*. It tripped in run 1 and did **not** trip
  in the re-run, on identical bytes — its own flakiness, on the record.

### work-02 — the honest partial, with the evidence

work-02 did **not** flip, and I am not going to argue it did. What did happen is that the
awareness demonstrably reached the session and was reasoned from — the agent's thinking block,
verbatim:

> `[thinking]` Let me look at the **attractor-awareness** context to understand what I should do:
> From **attractor-awareness.md**: "Before authoring or editing ANY `.dot`" — **Delegate to
> `attractor:attractor-expert` first.** […]
> The three-question test is also important: 1. Is there a cycle? — **This looks linear, no cycle**
> […] the attractor-awareness also says: "Short of three yeses — especially a linear, gateless
> chain — it is **recipe territory: say so before authoring a graph.**" This looks like a linear
> 12-step sequence, which suggests **recipe territory rather than Attractor pipeline territory.**

It then delegated to the expert and wrote the file anyway, without ever saying "recipe territory"
to the *user*. The grader saw the same thing and scored it honestly:

> Agent's thinking block mentioned 'no cycle' and 'recipe territory' but **never diagnosed to the
> user**, never applied all three questions to the user's situation, and never stated a verdict
> before delegating. — grader, G2 = 0/5

So: the composition defect is fixed for this scenario too (the steering is in-session and quoted
by name), and the residual is a *compliance-under-pressure* failure — the user said "don't
over-think it, I just want the file" and the session obeyed. Measured movement: `MC-D1` flipped to
pass in run 1 (baseline: fail), G5 rose 1 → 3. That is a follow-up work item about how hard the
tripwire pushes back, not a claim of a pass.

## 3. Self-pin inventory

44 same-repo `git+…@main` references in composition files. **10 flipped, 34 kept deliberately** —
and the split is not taste, it is foundation's resolution semantics, measured.

**Two resolution classes** (foundation 1.0.0):

| Class | Where | Resolved | Anchored on | Relative usable? |
|---|---|---|---|---|
| **A** | `tools:` / `providers:` / `hooks:` entries | at **parse** time (`_validate_module_list`) | **the declaring file's directory** | **yes** |
| **B** | `session.orchestrator.source` (top-level, agent dicts, agent `.md` frontmatter) | at **prepare** time (`FileSourceHandler`) | **the composed root's `base_path`** — the *app's* bundle dir in a real session | **no** |

**Flipped (10):**

| # | File | Was | Now |
|---|---|---|---|
| 1 | `behaviors/attractor-core.yaml` | `…@main#subdirectory=modules/tool-report-outcome` | `../modules/tool-report-outcome` |
| 2 | `behaviors/attractor-core.yaml` | `…modules/hooks-tool-truncation` | `../modules/hooks-tool-truncation` |
| 3 | `behaviors/attractor-core.yaml` | `…modules/hooks-pipeline-progress` | `../modules/hooks-pipeline-progress` |
| 4 | `behaviors/attractor-core.yaml` | `…modules/hooks-pipeline-observability` | `../modules/hooks-pipeline-observability` |
| 5 | `bundles/attractor-interactive.yaml` | `…modules/tool-pipeline-run` | `../modules/tool-pipeline-run` |
| 6 | `profiles/attractor-e2e-anthropic.yaml` | `…modules/tool-report-outcome` | `../modules/tool-report-outcome` |
| 7 | `profiles/attractor-e2e-anthropic.yaml` | `…modules/hooks-tool-truncation` | `../modules/hooks-tool-truncation` |
| 8 | `profiles/attractor-e2e-gemini.yaml` | `…modules/tool-report-outcome` | `../modules/tool-report-outcome` |
| 9 | `profiles/attractor-e2e-gemini.yaml` | `…modules/hooks-tool-truncation` | `../modules/hooks-tool-truncation` |
| 10 | `profiles/attractor-profile-openai.yaml` | `…modules/tool-apply-patch` | `../modules/tool-apply-patch` |
| + | `bundle.md` (skills registration) | `…@main#subdirectory=skills` | `"@attractor:skills"` |

**Kept (34), all Class B**, each now carrying a comment with the measurement below so a later
contributor does not "finish the sweep": `bundle.md` (4), `agents/attractor-expert.md` (1),
`agents/*.yaml` (10), `bundles/*.yaml` (11), `profiles/*.yaml` (8).

### Why: the measurement (a disclosed failed run of this very PR)

The first build of this branch flipped the Class B pins too. It was pushed, and the eval installed
it into a clean DTU the documented way. The session **refused to start**:

```
5 of 117 modules failed to activate (strict mode):
  - loop-agent: File not found:
    /root/.local/share/uv/tools/amplifier/lib/python3.12/site-packages/
      amplifier_app_cli/_bundle/behaviors/modules/loop-agent          (x4)
  - loop-pipeline: File not found:
    .../amplifier_app_cli/_bundle/behaviors/modules/loop-pipeline
The session was not started because it would have been missing the capabilities above.
```

`.../amplifier_app_cli/_bundle/behaviors/` is the composed root. **No relative path written in
this repo can reach this repo's snapshot from there**, and foundation has no namespaced
module-source form (`attractor:modules/X`) to write instead — its resolver mounts file / git /
zip / http handlers and no namespace handler. That commit is preserved in the branch history
(`af29e80`), reverted by `2cbe1e3`, rather than rebased away.

### The honest residual on cause 3

A branch install is now self-consistent for every surface that resolves through the bundle
namespace or through parse-time anchoring — the new awareness context, the expert's knowledge
body, the attractorify skill, `pipeline-awareness.md` / `dot-reference.md`, and every Class A
module. It is **not** self-consistent for `loop-agent` / `loop-pipeline` module code, nor for
`context/system-attractor-expert.md` (the expert's Layer-1 persona), which rides with loop-agent
because the module anchors a relative `system_prompt_file` on its own installed location. Those
two still come from main on a branch install. This PR modifies neither, and the remedy is not in
this repo: it needs a foundation-level ref-free same-repo module source. **Filed as #256** — in
this repo, because foundation's own issue tracker is disabled — carrying the DTU output above, the
code-verified mechanism, and both candidate fix shapes.

**Where that DTU quote lives, stated plainly.** The refusal text above lives in this PR body and in
#256 — it is **not** in the evidence archive. The aborted run's directory (`20260815T231903Z`)
records the run metadata, install log and readiness gates, so it has the *shape* of the aborted run,
but the run was aborted before transcript capture and the refusal text itself was never archived.
The mechanism is independently code-verified in #256 and does not rest on the quote, so the
substance stands — but the record should say where the quote does and does not live, rather than
leave a reader to discover it.

## 4. Tier classification and toll

**Tier: Uncharted / extension** (`docs/QUALITY_PROTOCOL.md` §3). The nlspec governs the engine —
the coding-agent loop and pipeline semantics. How a host platform mounts guidance into interactive
sessions is territory the spec does not address, and §3 reaches this far on purpose: *"examples,
guidance surfaces and process changes are classified by it too."*

**Toll paid, in this PR:**

1. **Why the spec's silence is not a signal** — argued in `specs/EXTENSIONS.md` §37: the spec
   defines what the agent and pipeline *do*, not how a host mounts guidance; a spec-conformant
   engine is equally conformant serving 0 or 800 tokens of always-on guidance. The guidance
   surfaces themselves already shipped and paid their own tolls; this makes the shipped bundle
   actually serve them.
2. **Additive and non-interfering** — zero engine-module code changed (no file under
   `modules/*/amplifier_module_*/` is touched); the new context is root-only, so every pipeline
   composition's always-on **context** is byte-identical. That is the honest scope of the claim,
   and it is narrower than "served content": registering the expert as `attractor:attractor-expert`
   grew its **roster description** in pipeline compositions from ~60 to 2,075 characters, because
   the agent's `.md` now carries its own metadata where an inline dict previously carried a
   one-liner. Flipped sources serve identical bytes at the installed ref; and it is
   `exemplar-01`/`exemplar-02` — both still `PASS`, runner exit 0 — that carry the
   **behavioral** non-interference claim, not the byte comparison.
3. **`specs/EXTENSIONS.md` entry** — §37, in this PR. Ledger guards + conformance matrix re-run
   green after; no matrix row is owed (the coverage tripwire demands rows for DIVERGES entries,
   and this is a pure addition to a spec-silent area).

Plus the §2 **Guidance surfaces** row evidence: the full six-scenario results table above with
transcript quotes.

## 5. Gates

| Gate | Result |
|---|---|
| `uv sync --extra remote && uv run pytest -q` (loop-pipeline) | **2295 passed, 25 skipped** |
| pipeline-runner suite | **76 passed, 1 skipped** |
| Q-guards / ledger guards (`test_extensions_ledger_integrity.py`, `test_quality_protocol_guard.py`, `test_doc_consistency.py`, `test_engine_semantics_doc_guard.py`, `test_explainer_doc_guard.py`) | green (inside the suite above) |
| conformance matrix (`test_spec_conformance_matrix.py`) | green, untouched |
| `attractor lint` sweep on `examples/` (`test_examples_lint_clean.py`) | green, unchanged-clean |
| leak scan on all changed files | clean (no credentials, tokens, keys, or machine paths) |
| `git diff --check` | clean |
| CI Gate | green (no reruns needed) |
| `guideval-*` DTUs | all destroyed; none stranded |

## Observations

**1. The design's central recommendation was wrong, and the eval is what proved it.** §3.3 said
flip every self-pin. The first build did, was pushed, and died in the DTU before a single graded
turn — `.../amplifier_app_cli/_bundle/behaviors/modules/loop-agent`. The composed root is the
*app's* bundle, not ours. That commit is left in the branch history rather than rebased away,
because the measurement is more useful than a clean history.

**2. There is a real gap under this, and it is not in this repo.** A bundle currently cannot
reference its own orchestrator module ref-free. `tools:`/`hooks:`/`providers:` can (parse-time
anchoring); `session.orchestrator` cannot, and there is no `attractor:modules/X` form. The
consequence is narrow but sharp: a branch install serves the branch's context, agent knowledge,
skills, tools and hooks — but `loop-agent`'s code and the Layer-1 persona that rides with it still
come from `main`. **Filed as #256** — in this repo, because foundation's issue tracker is
disabled — with the DTU output as its symptom and the code-verified resolution path as its
mechanism.

**3. The awareness fires, and "fires" is not the same as "changes the visible answer."** In
work-01 it produced the whole first-reply sequence. In work-02 it produced a correct private
diagnosis — *"recipe territory rather than Attractor pipeline territory"* — that the user never
saw, because the user had said "don't over-think it." Always-on guidance competes with the user's
own instruction, and on this evidence the user wins. If the maintainer wants work-02 to flip, the
lever is not more tokens in the awareness file; it is a sharper obligation to *say the verdict out
loud before complying*. That is a taste call, and it is worth making on this transcript.

**4. `MC-B3` is measurably flaky and `MC-B1` fails on `main`.** Both were seen on identical bytes
in back-to-back runs of the same scenario. Neither `scenarios/` nor `rubric.md` was touched here,
per instrument rules — but the qa-02 verdict is currently decided by a literal negative control
that a *correct refusal* trips, and a check that `main` also fails. Reported, not edited.

**5. What the eval could not test, and I did not pretend it did.** The `attractor-core`-alone
composition (a foreign bundle including only `behaviors/attractor-core.yaml`) is not a shape any
scenario exercises. It is probe-verified at the foundation layer and unchanged by this PR, but it
is not eval-covered, and the design doc says so in §8.2 rather than leaving the impression that
six green scenarios covered every composition.

---

## Post-review fixes

Adversarial review raised one finding; this is what closed it.

**The finding: the "filed as follow-up" claim was false.** §3's honest-residual paragraph said the
foundation-level remainder had been filed. No such issue existed, anywhere. A residual that is
described as tracked but is not tracked is worse than one described as open — it reads as handled
and is invisible. Now filed as
[#256](https://github.com/microsoft/amplifier-bundle-attractor/issues/256), with the symptom (the
`af29e80` DTU refusal), the code-verified mechanism (foundation's two resolution classes and the
absent namespace handler), the consequence (branch installs serve `main`'s `loop-agent` /
`loop-pipeline` code and Layer-1 persona — so code-level guidance regression-testing needs the
documented dedicated-gitea mirror-main fallback), and two candidate fix shapes. §3 and Observation 2
now link it instead of asserting it.

**Also disclosed, not argued away:** the `af29e80` refusal text is quoted in this PR body and in
#256 but was never archived in the evidence directory — the aborted run dir `20260815T231903Z` has
the run's shape (metadata, install log, readiness gates) but not the quote, because the run was
aborted before transcript capture. The mechanism is independently code-verified, so the substance
stands; the record now says so rather than implying an archive that does not exist.

**Scope correction on the toll (§4.2).** The claim "every pipeline composition's served content is
byte-identical" was over-broad. What is byte-identical is the always-on **context**. The expert's
roster description grew ~60 → 2,075 characters in pipeline compositions, and the behavioral
non-interference claim is carried by `exemplar-01`/`exemplar-02`, not by a byte comparison. §4.2 now
says exactly that.

**The mechanical guard the review recommended.**
[`modules/loop-pipeline/tests/test_orchestrator_source_pin_guard.py`](modules/loop-pipeline/tests/test_orchestrator_source_pin_guard.py)
— `2cbe1e3` reverted the bad flip and left the reason in YAML comments, and comments do not fail a
build. OSP-001 asserts every orchestrator-class `source:` across `behaviors/`, `bundles/`,
`agents/` (both `.yaml` and `.md` frontmatter), `profiles/` and `bundle.md` stays an absolute
`git+` form; its failure message carries the `af29e80` measurement, the
parse-time-vs-late-resolution rule (*"`tools:`/`hooks:` are parse-time-safe to keep relative;
orchestrator sources are not"*), and #256. OSP-002/003 keep the scan from rotting into a vacuous
pass — each surface glob must still match files, every scanned file must parse, and the walker must
still find orchestrator sources at all.

Scanned surfaces are a **superset** of the four the review named: `profiles/` and `agents/*.yaml`
declare orchestrator sources too, and an unscanned surface is exactly where the next re-flip lands.
Of the 34 kept Class-B pins, all 34 are now under the guard.

**Proven RED, not assumed.** One orchestrator source in `bundle.md` was flipped to
`./modules/loop-pipeline`; OSP-001 failed and named it:

```
AssertionError: orchestrator `source:` is no longer an absolute `git+` pin:
  - bundle.md :: agents.attractor-pipeline-runner.session.orchestrator.source = './modules/loop-pipeline'
```

…then restored, byte-identical (sha256 `983eefe2…d0cd` before and after, `git status` clean).

### Post-review gates

| Gate | Result |
|---|---|
| `uv sync --extra remote && uv run pytest -q` (loop-pipeline) | **2303 passed, 25 skipped** (baseline 2295 + the guard's 8) |
| new guard alone | **8 passed**; RED-proven and restored byte-identical |
| pipeline-runner suite | **76 passed, 1 skipped** |
| Q-guards / ledger guards / conformance matrix / examples lint | **288 passed, 24 skipped** (green, unchanged) |
| leak scan on the changed file | clean (no credentials, tokens, keys, or machine paths) |
| `git diff --check` | clean |

---

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

