### PR TITLE
fix(docs,lint,evals): close the wave-4 consolidated review nits (#254)

### DIFF
--- a/SPEC_CONFORMANCE.md
+++ b/SPEC_CONFORMANCE.md
@@ -140,7 +140,7 @@ substitution beyond `$goal`.
 | SYNC-1 | Re-sync vendored `specs/canonical/` to upstream byte-for-byte | **DONE** (canonical @ `fb57a55`) | ALIGN |
 | DEAD-1 | Dead `SessionConfig` fields implying coverage that isn't wired (`tool_output_limits`, `tool_line_limits`, `default_command_timeout_ms`, `max_command_timeout_ms`, `get_max_tool_rounds`) | **DONE** | DIVERGE (all deleted + documented) |
 | ATX-8 | DOT `response_schema` node attribute → per-provider structured output (NOT in canonical spec; §4.5 keeps output format at backend) | **DONE — LIVE-PROVEN** (all 3 providers via DOT pipeline) | IMPROVE (extension §23) |
-| ATX-9 | DOT backends didn't recover Anthropic structured output from the `__structured_output__` tool call (only read `result.text`, which is empty on the tool-extraction path) | live: `outcome.notes=''` | `loop-pipeline/__init__.py`, `backend.py` | **DONE** (live-found + fixed) | ALIGN |
+| ATX-9 | DOT backends didn't recover Anthropic structured output from the `__structured_output__` tool call (only read `result.text`, which is empty on the tool-extraction path); live symptom `outcome.notes=''`; fixed in `loop-pipeline/__init__.py`, `backend.py` | **DONE** (live-found + fixed) | ALIGN |
 
 ---
 

--- a/docs/APP-INTEGRATION-GUIDE.md
+++ b/docs/APP-INTEGRATION-GUIDE.md
@@ -8,20 +8,24 @@ There are two execution paths for running Attractor pipelines programmatically:
 
 | Path | Backend | Tools? | Best For |
 |------|---------|--------|----------|
-| **A: Direct LLM** | `DirectProviderBackend` | No | Analysis, reasoning, planning -- no file I/O |
-| **B: Amplifier Session** | `AmplifierBackend` | Yes | Coding pipelines -- file edits, shell commands, full agent loop |
+| **A: Direct LLM** | `DirectProviderBackend` | Whatever you mount -- none in this guide's example | Analysis, reasoning, planning; also tool work, if you mount the tools yourself |
+| **B: Amplifier Session** | `AmplifierBackend` | Yes -- the bundle's toolset | Coding pipelines -- file edits, shell commands, full agent loop |
 
 Both paths use the same DOT graph format and pipeline engine. The difference is
-what happens at each LLM node: Path A makes a single LLM call; Path B spawns a
-full Amplifier child session with tools.
+what happens at each LLM node: Path A runs the call -- and any tool rounds it
+needs -- inside `unified-llm-client`, over exactly the tools you hand the
+backend; Path B spawns a full Amplifier child session with the bundle's tools.
 
 See [examples/programmatic_usage.py](../examples/programmatic_usage.py) for a
 complete, runnable example covering both paths.
 
 ## Path A: DirectProviderBackend (No Session)
 
-Best for analysis and reasoning pipelines where nodes only generate text.
-No Amplifier session, no tools, no file operations.
+Best for analysis and reasoning pipelines where nodes only generate text. No
+Amplifier session. The example below mounts *no tools*, so its nodes do no file
+operations -- but that is a property of the example, not of the backend:
+`DirectProviderBackend` accepts a `tools` mapping and hands every tool in it to
+the provider (see [Limitations](#limitations) below).
 
 ### Complete Working Example
 
@@ -104,9 +108,16 @@ Plus at least one API key: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or `GEMINI_API
 
 ### Limitations
 
-- No tools -- nodes cannot read/write files or run shell commands
-- No agent loop -- each node gets a single LLM call (with tool-use rounds if
-  tools are passed, but none are by default)
+- No tools *as constructed above* -- `DirectProviderBackend(provider=None)`
+  passes no `tools` mapping, so these nodes cannot read/write files or run
+  shell commands. This is a property of the call, not of the backend: pass
+  `DirectProviderBackend(provider=None, tools={...})` and every tool in that
+  mapping is handed to the provider, with `unified-llm-client` driving the
+  call -> tool -> call rounds internally (capped by the node's
+  `max_agent_turns`).
+- No Amplifier child session -- no bundle toolset mounted for you, no agent
+  profile, no per-node session state. Path B remains the answer for coding
+  pipelines.
 - `last_response` is truncated to 200 characters in context between nodes
   (use `fidelity="full"` to preserve full conversation history)
 
@@ -288,12 +299,16 @@ The pipeline orchestrator auto-selects the backend at runtime:
 
 1. If `session.spawn` capability is registered --> **AmplifierBackend** (full
    child sessions per node with tools)
-2. Else if a provider is available --> **DirectProviderBackend** (LLM-only calls,
-   no tools)
+2. Else if a provider is available --> **DirectProviderBackend** (a per-node
+   agentic tool loop via `unified-llm-client`; whatever tools are mounted are
+   passed through, so nodes are toolless only when the host mounts none -- as
+   in the bare programmatic path above)
 3. Otherwise --> simulation mode (for testing)
 
 This means: if you forget to call `register_spawn_capability()`, the pipeline
-silently falls back to DirectProviderBackend. Nodes will run but without tools.
+silently falls back to DirectProviderBackend. Nodes still run, and still use
+whatever tools are mounted, but each node is a direct provider call rather than
+a full Amplifier child session -- no agent profile, no per-node session state.
 
 ### Composing DOT Source at Runtime
 
@@ -479,7 +494,7 @@ When composing bundles for isolated execution, follow these rules:
 | Limitation | Impact | Workaround |
 |-----------|--------|------------|
 | `last_response` truncated to 200 chars | Nodes lose full prior output under `compact`/`truncate` fidelity | Use `fidelity="full"` for nodes needing complete prior context |
-| `DirectProviderBackend` nodes have no tools | Cannot read/write files or run commands | Use Path B (AmplifierSession) for coding pipelines |
+| `DirectProviderBackend` nodes only get the tools the host mounts | With none mounted (the bare Path A example) nodes cannot read/write files or run commands | Pass a `tools` mapping to the backend, or use Path B (AmplifierSession) for full coding pipelines |
 | Provider model in global settings overrides bundle | Unexpected model selection | Use project-level `.amplifier/settings.yaml` |
 | `PreparedBundle.spawn()` returns string | Requires JSON-in-string parsing for structured results | The engine handles this internally |
 | Box node whose final assistant message is only tool-calls returns empty | The engine sees an empty result and treats it as a silent failure / fallback | Nudge the node prompt so the final message is non-empty text (e.g. "After running tools, end with a one-line summary -- the final message must not be empty") |

--- a/docs/DOT-AUTHORING-GUIDE.md
+++ b/docs/DOT-AUTHORING-GUIDE.md
@@ -1487,6 +1487,72 @@ retries (an altered pinned check, a missing artifact) — drop the
 
 ---
 
+### TOPO-008 — Inert evidence gate (both answers end the run green)
+
+**What it detects:** A reachable *evidence gate* — a `parallelogram` (tool)
+node carrying a substantive `tool_command` and routing on its result (at
+least two outgoing edges, at least one of them conditional) — whose edges
+select on two or more **different** `context.tool.last_line` values that all
+land on the same terminal exit node.  Landing is measured through relay
+no-ops: a `diamond`/`point` with exactly one unconditional outgoing edge
+decides nothing, so passing through it is indistinguishable from taking the
+edge directly.
+
+**Why it matters:** The gate runs, it prints a verdict, and the graph reaches
+the exit either way — so the answer decided nothing.  This shape is green on
+every other rule in the family: the exit is reached only through the gate, no
+failure outcome is routed near the exit, and the cycle has a deterministic
+conditional exit, so TOPO-004, TOPO-005 and TOPO-006 all pass while the run
+ends successfully whether the tests passed or not.  Only equality is read:
+`context.tool.last_line!=green` selects on no particular answer and is
+deliberately ignored.
+
+```dot
+// WRONG — the gate's verdict routes both ways into the success door:
+// the run ends green whether the tests passed or failed
+gate [shape=parallelogram, tool_command="pytest -q && echo green || echo red"]
+gate -> done [condition="context.tool.last_line=green"]
+gate -> done [condition="context.tool.last_line=red"]
+
+// CORRECT — the failing answer goes back into the corrective loop
+gate -> done [condition="context.tool.last_line=green"]
+gate -> work [condition="context.tool.last_line=red"]
+```
+
+**Lineage:** This is the `attractor lint` sibling of the authoring checker's
+**A10** (`examples/authoring/check_authored_pipeline.py`, issue #245), which
+caught the shape on a graph that satisfied every other doctrine check.  A10
+only sees machine-authored graphs; TOPO-008 asks the same question of
+hand-authored ones.  The semantics are A10's verbatim in kind — same
+evidence-gate definition, same token extraction (through
+`conditions.parse_condition`, the grammar entry point the engine itself
+routes with), same relay-transparent landing chase, same exit-only scope —
+and a test asserts the two layers never disagree on a shipped graph.
+
+**What is NOT flagged:** two answers converging on an *ordinary* node that
+writes them up rather than routes on them — the general "two tokens into ANY
+node" form was rejected on measurement, because it fires on this
+repository's own deliberate `.github/` capsule patterns where several
+distinct diagnoses legitimately converge on one recording node.  Also not
+flagged: a chase that stops at a node which does real work (if the two
+answers ran different work before converging, the gate's answer demonstrably
+changed what happened), a branching diamond, a constant emitter such as
+`printf gate_pass` (it cannot fail, so nothing behind it is gated), an
+inequality condition, the same token twice, and an unreachable gate.
+
+**Severity:** WARNING — consistent with the rest of the family (TOPO-002
+through TOPO-007; TOPO-001 is `ERROR`).  The hazard is real but the author's
+intent is not statically provable, and it is `lint()`-only: `validate()` and
+`validate_or_raise()` stay silent, so no graph that executes today starts
+failing at run time.
+
+**Fix:** Route the failing token somewhere that is not the success door —
+back into the corrective loop, to a postmortem, or to a LOUD escalation.  If
+the node is genuinely not a decision point, drop the conditions and let it
+record instead of routing on it.
+
+---
+
 ### CMD-001 — Pipe-masked exit code
 
 **What it detects:** A `parallelogram` (tool) node whose `tool_command` ends
@@ -1534,7 +1600,7 @@ If you need to see the last N lines, write to a file and read it separately
 from the routing logic.
 
 **Severity:** WARNING — consistent with the WARNING-severity TOPO rules
-(TOPO-002 through TOPO-007; note TOPO-001 is `ERROR`, not this family's
+(TOPO-002 through TOPO-008; note TOPO-001 is `ERROR`, not this family's
 default).  The hazard is real but static analysis cannot prove the command is
 a meaningful gate; conservative analysis may miss complex cases.
 
@@ -1596,7 +1662,7 @@ influence either the exit code or the emitted token?  The hazard shapes
 destroy that influence.  The honest idioms preserve it.
 
 **Severity:** WARNING — consistent with CMD-001 and the WARNING-severity TOPO
-rules (TOPO-002 through TOPO-007; TOPO-001 is `ERROR`).
+rules (TOPO-002 through TOPO-008; TOPO-001 is `ERROR`).
 
 **What this rule does NOT catch:** sentinels inside `$(...)` substitutions,
 sentinels after non-pipe-masked commands (where `&& echo TOKEN` is the honest

--- a/evals/guidance/harness/run_guidance_eval.py
+++ b/evals/guidance/harness/run_guidance_eval.py
@@ -252,6 +252,69 @@ class CheckResult:
     why: str = ""
 
 
+#: Blocks the transcript renderer emits for material the user NEVER SAW -- the model's private
+#: reasoning and the raw tool traffic. Each is delimited by a start marker and its matching close
+#: so a scoped check can excise exactly the block and keep the visible prose on either side.
+_INVISIBLE_BLOCKS: tuple[tuple[str, str], ...] = (
+    ("[thinking]", "[/thinking]"),
+    ("[tool_use:", "[/tool_use]"),
+    ("[tool_result]", "[/tool_result]"),
+)
+
+_ROLE_HEADING_RE = re.compile(r"^## (.+)$", re.MULTILINE)
+
+
+def _strip_invisible(body: str) -> str:
+    """Drop the renderer's non-visible blocks, keeping the prose around them.
+
+    Fail-closed by construction: an UNTERMINATED block is kept verbatim. Dropping text that a
+    `lacks_all` check searches is the direction that quietly turns a FAIL into a PASS, so it only
+    ever happens on a well-formed start/close pair.
+    """
+    out = body
+    for open_tag, close_tag in _INVISIBLE_BLOCKS:
+        kept: list[str] = []
+        rest = out
+        while True:
+            start = rest.find(open_tag)
+            if start == -1:
+                kept.append(rest)
+                break
+            end = rest.find(close_tag, start)
+            if end == -1:
+                kept.append(rest)  # unterminated -- keep it, fail closed
+                break
+            kept.append(rest[:start])
+            rest = rest[end + len(close_tag) :]
+        out = "".join(kept)
+    return out
+
+
+def assistant_answer_text(transcript: str) -> str:
+    """What the session actually SAID TO THE USER -- and nothing else.
+
+    A `lacks_all` check asks whether the session *told the user* to do something. The rendered
+    transcript is wider than that question: it also carries the user's own turns (in `qa-02` the
+    persona is instructed to propose the anti-pattern out loud) and the assistant's `[thinking]`,
+    where a model reasoning its way to a REFUSAL naturally restates the thing it is about to
+    refuse. Neither is advice, and scoring either as advice measures the wrong artifact.
+
+    Returns the visible prose of the `assistant` turns. If the transcript carries no assistant
+    turns at all -- an unrecovered session falls back to a reconstruction with no role headings --
+    the whole transcript is returned rather than an empty string, so a check can never pass
+    vacuously because parsing found nothing.
+    """
+    parts = _ROLE_HEADING_RE.split(transcript)
+    answers = [
+        _strip_invisible(parts[i + 1])
+        for i in range(1, len(parts) - 1, 2)
+        if parts[i].strip().lower() == "assistant"
+    ]
+    if not answers:
+        return transcript
+    return "\n".join(answers)
+
+
 class MechanicalChecker:
     """Runs a scenario's `machine_checks` against the DTU and the captured transcript.
 
@@ -265,6 +328,7 @@ class MechanicalChecker:
         self.dtu = dtu
         self.transcript = transcript_text
         self.transcript_lower = transcript_text.lower()
+        self.assistant_answer_lower = assistant_answer_text(transcript_text).lower()
 
     async def _read(self, rel_path: str) -> tuple[bool, str]:
         res = await self.dtu.exec_cmd(
@@ -315,6 +379,21 @@ class MechanicalChecker:
             banned = [str(s) for s in spec["none_of"]]
             hits = [b for b in banned if b.lower() in self.transcript_lower]
             return result(not hits, f"FOUND banned phrasing {hits}" if hits else "clean")
+
+        if kind == "assistant_answer_lacks_all":
+            # Same literal test as `transcript_lacks_all`, over what the session actually SAID TO
+            # THE USER: assistant turns, minus `[thinking]` and the raw tool traffic. Use this
+            # when the banned phrasing is something the USER may legitimately say (a scenario that
+            # instructs its persona to propose the anti-pattern) or that the model may legitimately
+            # restate while reasoning its way to refusing it.
+            banned = [str(s) for s in spec["none_of"]]
+            hits = [b for b in banned if b.lower() in self.assistant_answer_lower]
+            return result(
+                not hits,
+                f"FOUND banned phrasing {hits} in the assistant's answer"
+                if hits
+                else "clean (assistant answer text only)",
+            )
 
         if kind == "file_exists":
             ok, _ = await self._read(str(spec["path"]))
@@ -801,11 +880,14 @@ def render(content):
             if kind == "text" and c.get("text"):
                 chunks.append(c["text"])
             elif kind == "thinking" and c.get("thinking"):
-                chunks.append("[thinking] " + str(c["thinking"])[:2000])
+                chunks.append("[thinking] " + str(c["thinking"])[:2000] + "\n[/thinking]")
             elif kind == "tool_use":
-                chunks.append("[tool_use: %s] %s" % (c.get("name"), json.dumps(c.get("input"))[:600]))
+                chunks.append(
+                    "[tool_use: %s] %s\n[/tool_use]"
+                    % (c.get("name"), json.dumps(c.get("input"))[:600])
+                )
             elif kind == "tool_result":
-                chunks.append("[tool_result] " + json.dumps(c.get("content"))[:800])
+                chunks.append("[tool_result] " + json.dumps(c.get("content"))[:800] + "\n[/tool_result]")
     return "\n".join(chunks)
 
 

--- a/evals/guidance/scenarios/qa-02-never-converges.yaml
+++ b/evals/guidance/scenarios/qa-02-never-converges.yaml
@@ -93,12 +93,20 @@ pass_bar:
         - "goal_gate"
         - "tool_command"
     - id: MC-B3
-      kind: transcript_lacks_all
+      kind: assistant_answer_lacks_all
       why: >
         A negative control on the never-clause. If the session ever tells the user to make the
         reviewing model's own verdict the exit, the phrasing tends to be one of these. This check
         is deliberately literal and narrow — G5 is the real judgment; this only catches the
         blatant form.
+
+        Scoped to what the session SAID TO THE USER — assistant turns, minus `[thinking]` and the
+        raw tool traffic — because the whole transcript answers a different question than the one
+        above. TURN 2 of `follow_up` INSTRUCTS the persona to propose this anti-pattern out loud,
+        so the user's own words carry the phrasing by design; and a model reasoning its way to a
+        REFUSAL restates the thing it is about to refuse. Neither is the session telling the user
+        to do it. The banned literals below are unchanged: the bar is identical, the evidence it
+        reads is the assistant's answer.
       none_of:
         - "let the review node decide when"
         - "have the reviewer decide when it"

--- a/examples/pipelines/12-graph-resume.md
+++ b/examples/pipelines/12-graph-resume.md
@@ -205,7 +205,8 @@ Graph-level resume is not a substitute for `attractor resume`, and `attractor re
 not retire this pattern. They coexist by design -- that is the ratified ruling, not a
 compromise (`docs/designs/2026-08-14-engine-checkpoint-resume.md` §0: *"Engine resume must
 be built per §5.3 and must **coexist** with the graph-owned file-guard idempotency
-pattern. Neither disables the other."*). They answer different questions:
+pattern (`examples/pipelines/12-graph-resume.dot`, AC-5). Neither disables the other."*
+-- the ruling names this very example). They answer different questions:
 
 | | Answers | Reach for it when |
 |---|---|---|

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/validation.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/validation.py
@@ -4,9 +4,12 @@ Validates parsed Graph models against the rules defined in
 spec Section 7 (Validation and Linting). Produces Diagnostic objects
 with severity ERROR (blocks execution) or WARNING (informational).
 
-Spec coverage: LINT-001–018.  TOPO-001–007 are topological basin-lint rules
+Spec coverage: LINT-001–018.  TOPO-001–008 are topological basin-lint rules
 implemented here beyond the canonical spec; they are lint-only (exposed via
 ``lint()``, not ``validate()``) and do not change run-time behaviour.
+TOPO-008 is the ``attractor lint`` sibling of the authoring checker's A10
+(``examples/authoring/check_authored_pipeline.py``): an evidence gate routing
+two different answers into the exit is structurally inert.
 
 CMD-001–002 are command-content lint rules that inspect ``tool_command``
 strings for two specific hazard shapes: pipe-masked exit codes (CMD-001) and
@@ -24,7 +27,7 @@ from dataclasses import dataclass
 from .conditions import evaluate_condition, parse_condition
 from .context import PipelineContext
 from .fidelity import VALID_FIDELITY_MODES
-from .graph import Graph, Node, resolve_bool_attr
+from .graph import Edge, Graph, Node, resolve_bool_attr
 from .outcome import Outcome, StageStatus
 from .stylesheet import parse_stylesheet
 
@@ -116,8 +119,8 @@ def lint(graph: Graph) -> list[Diagnostic]:
     """Run topological (basin-lint) and command-content rules in addition to structural rules.
 
     This is the entry point for the ``attractor lint`` CLI command.  It runs
-    the full structural ``validate()`` suite plus the seven topological rules
-    (TOPO-001–007) that reason about cycle structure, handler semantics, and
+    the full structural ``validate()`` suite plus the eight topological rules
+    (TOPO-001–008) that reason about cycle structure, handler semantics, and
     evidence-routing patterns, plus the two command-content rules (CMD-001–002)
     that inspect ``tool_command`` strings for hazard shapes.
 
@@ -139,6 +142,7 @@ def lint(graph: Graph) -> list[Diagnostic]:
     _check_cycle_no_deterministic_exit(graph, diags)
     _check_fail_routed_to_exit(graph, diags)
     _check_gate_retry_budget_dead(graph, diags)
+    _check_inert_evidence_gate(graph, diags)
     _check_pipe_masked_exit_code(graph, diags)
     _check_always_true_sentinel(graph, diags)
     return diags
@@ -726,7 +730,7 @@ def _check_response_schema(graph: Graph, diags: list[Diagnostic]) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Topological (basin-lint) rules — TOPO-001 through TOPO-006
+# Topological (basin-lint) rules — TOPO-001 through TOPO-008
 #
 # These rules reason about cycle structure and handler semantics, not just
 # graph topology.  They are exposed via ``lint()`` (not ``validate()``) so
@@ -1752,6 +1756,307 @@ def _check_gate_retry_budget_dead(graph: Graph, diags: list[Diagnostic]) -> None
                 ),
             )
         )
+
+
+# ---------------------------------------------------------------------------
+# TOPO-008 — an evidence gate whose answer cannot change where the run goes
+#
+# The authoring checker (``examples/authoring/check_authored_pipeline.py``)
+# grew this rule as **A10** after issue #245: a pipeline that satisfied every
+# other doctrine check while routing BOTH of its evidence gate's answers into
+# the exit, so the run ended green whether the tests passed or failed.  A10
+# lives in the authoring layer, which only machine-authored graphs pass
+# through; a hand-authored graph with the identical shape got nothing.  This is
+# the same question, asked by ``attractor lint``, so hand-authored graphs are
+# covered too (issue #254 item 2).
+#
+# The semantics are A10's, deliberately — same evidence-gate definition, same
+# ``context.tool.last_line`` token extraction, same relay-transparent landing
+# chase, same exit-only scope — so the two layers cannot drift into disagreeing
+# about the same graph.  Two narrowings carry over unchanged, and both were
+# measured rather than assumed:
+#
+#   • **Only the exit.**  The general "two distinct tokens into ANY node" form
+#     was REJECTED on measurement: it fires on three of this repository's own
+#     deliberate ``.github/`` patterns, where several distinct diagnoses
+#     converge on one node that WRITES THEM UP rather than routes on them.
+#     Recording a token is legitimate; ending the run green either way is not.
+#   • **Only through relay no-ops.**  The landing chase sees through a node
+#     that merely forwards (a ``diamond``/``point`` with a single unconditional
+#     outgoing edge decides nothing, so entering and leaving it is
+#     indistinguishable from taking the edge directly).  It stops at any node
+#     that DOES something: if the two answers ran different work before
+#     converging, the gate's answer demonstrably changed what happened, and
+#     whether that path should still end green is a judgement this rule does
+#     not have.
+#
+# Severity: WARNING — joins the TOPO-002–007 / CMD-001–002 family.  The hazard
+# is real but intent is not statically provable, and ERROR would hard-fail
+# graphs through ``validate_or_raise``.  Calibrated over every ``.dot`` in the
+# repository (``examples/``, ``patterns/``, ``.github/``, and the test
+# fixtures): it fires on the issue-#245 B1 construction and on ZERO shipped
+# graphs.
+# ---------------------------------------------------------------------------
+
+#: Shapes that route without doing anything.  A node of one of these shapes
+#: with exactly one unconditional outgoing edge is a pure relay: the DOT
+#: authoring guide documents ``diamond`` as a no-op whose "outgoing edges do
+#: the deciding", so a diamond with nothing to decide forwards and no more.
+#: TOPO-008 sees through exactly these and nothing else, so "both answers
+#: landed in the same place" can never quietly mean "the two branches ran
+#: different work and then converged".
+_RELAY_SHAPES: frozenset[str] = frozenset({"diamond", "point"})
+
+#: Shell head-words that emit a constant or rearrange files without checking
+#: anything.  A ``tool_command`` whose every command position is one of these
+#: cannot come back with an answer the author did not already write, so the
+#: node is not an evidence gate and TOPO-008 has no opinion about it.
+_CONSTANT_EMITTER_WORDS: frozenset[str] = frozenset(
+    {
+        "printf", "echo", "exit", "return", "true", "false", ":", "cd", "mkdir",
+        "touch", "sleep", "shift", "set", "umask", "export", "unset", "break",
+        "continue", "rm", "cp", "mv", "chmod",
+    }
+)
+
+#: Shell keywords and grouping tokens — skipped past to reach the real head word.
+_SHELL_KEYWORD_WORDS: frozenset[str] = frozenset(
+    {
+        "if", "then", "else", "elif", "fi", "while", "until", "do", "done",
+        "case", "esac", "for", "select", "function", "time", "!", "in",
+    }
+)
+
+_GATE_ASSIGNMENT_RE = re.compile(r"^[A-Za-z_][A-Za-z_0-9]*=")
+_GATE_REDIRECT_RE = re.compile(r"^\d*[<>]")
+
+#: The context key an evidence gate publishes its verdict on.
+_TOOL_LAST_LINE_KEY = "context.tool.last_line"
+
+
+def _gate_command_segments(command: str) -> list[str]:
+    """Split a shell command into command positions, respecting quotes.
+
+    Deliberately approximate — a lint-grade reader in the same spirit as
+    CMD-001's, not a shell.  It errs toward MORE segments, which can only make
+    the substantive-command search more generous, never less.
+    """
+    segments: list[str] = []
+    current: list[str] = []
+    quote: str | None = None
+    i = 0
+    n = len(command)
+    while i < n:
+        ch = command[i]
+        if quote:
+            if ch == "\\" and i + 1 < n:
+                current.append(ch)
+                current.append(command[i + 1])
+                i += 2
+                continue
+            current.append(ch)
+            if ch == quote:
+                quote = None
+            i += 1
+            continue
+        if ch in ("'", '"'):
+            quote = ch
+            current.append(ch)
+            i += 1
+            continue
+        if command.startswith("&&", i) or command.startswith("||", i):
+            segments.append("".join(current))
+            current = []
+            i += 2
+            continue
+        if ch in (";", "|", "&", "\n", "(", ")", "{", "}", "`"):
+            segments.append("".join(current))
+            current = []
+            i += 1
+            continue
+        current.append(ch)
+        i += 1
+    segments.append("".join(current))
+    return segments
+
+
+def _gate_head_word(segment: str) -> str:
+    """The command word a segment actually runs, or '' if it runs nothing."""
+    for word in segment.split():
+        if word in _SHELL_KEYWORD_WORDS:
+            continue
+        if _GATE_ASSIGNMENT_RE.match(word) or _GATE_REDIRECT_RE.match(word):
+            continue
+        return word.strip('"').strip("'")
+    return ""
+
+
+def _runs_a_substantive_command(command: str) -> bool:
+    """Does *command* check or compute something real, anywhere in it?
+
+    ``[``, ``test``, ``grep``, ``pytest``, ``python3``, ``git`` — anything that
+    is not purely an emitter or a file arrangement.  ``printf gate_pass`` is
+    not a gate: it cannot fail, so nothing behind it is gated.
+    """
+    return any(
+        head and head not in _CONSTANT_EMITTER_WORDS
+        for head in (_gate_head_word(seg) for seg in _gate_command_segments(command))
+    )
+
+
+def _reachable_node_ids(graph: Graph) -> set[str]:
+    """Node ids reachable from any start node by following edges."""
+    visited: set[str] = set()
+    queue: deque[str] = deque(n.id for n in graph.nodes.values() if n.is_start_node())
+    while queue:
+        node_id = queue.popleft()
+        if node_id in visited:
+            continue
+        visited.add(node_id)
+        for edge in graph.outgoing_edges(node_id):
+            if edge.to_node in graph.nodes and edge.to_node not in visited:
+                queue.append(edge.to_node)
+    return visited
+
+
+def _is_evidence_gate(graph: Graph, node: Node, reachable: set[str]) -> bool:
+    """Is this a reachable tool node that runs a real command AND routes on it?
+
+    Three conditions, each load-bearing (A10's definition, unchanged):
+
+    * **a tool node** — one carrying a ``tool_command``.  An LLM node's opinion
+      of its own work is not evidence, however confidently it is phrased, and
+      ``_check_tool_command_handler`` already ERRORs when a recognized non-tool
+      handler carries a command, so the command IS the tool-node test here.
+    * **a substantive command** — something that can come back with an answer
+      the author did not already write.
+    * **it routes** — at least two outgoing edges, at least one conditional.
+      A node whose result changes nothing is not deciding anything.
+    """
+    if node.id not in reachable:
+        return False
+    command = str(node.attrs.get("tool_command") or "").strip()
+    if not command or not _runs_a_substantive_command(command):
+        return False
+    out = graph.outgoing_edges(node.id)
+    if len(out) < 2:
+        return False
+    return any(e.condition and e.condition.strip() for e in out)
+
+
+def _routed_last_line_token(condition: str) -> str | None:
+    """The ``tool.last_line`` value this edge condition selects ON, if any.
+
+    ``context.tool.last_line=green && outcome=success`` yields ``green``.
+    Parsed through ``conditions.parse_condition`` — the same grammar entry
+    point the engine routes with — so lint and routing cannot drift.
+
+    An INEQUALITY deliberately yields nothing: TOPO-008 reasons about which
+    ANSWER sends the run where, and "anything but green" is not an answer.
+    """
+    for key, op, value in parse_condition(condition or ""):
+        if key == _TOOL_LAST_LINE_KEY and op == "=":
+            return value.strip().strip('"').strip("'")
+    return None
+
+
+def _relay_forward_edge(graph: Graph, node_id: str) -> Edge | None:
+    """The single edge out of a pure routing no-op, or ``None`` if not one."""
+    node = graph.nodes.get(node_id)
+    if node is None or node.is_exit_node() or node.is_start_node():
+        return None
+    if node.shape not in _RELAY_SHAPES:
+        return None
+    out = graph.outgoing_edges(node_id)
+    if len(out) != 1 or (out[0].condition and out[0].condition.strip()):
+        return None
+    return out[0]
+
+
+def _token_landing(graph: Graph, edge: Edge) -> str:
+    """Where a token edge actually puts the run, seeing through relay no-ops."""
+    node_id = edge.to_node
+    seen = {edge.from_node}
+    while node_id not in seen:
+        seen.add(node_id)
+        relay = _relay_forward_edge(graph, node_id)
+        if relay is None:
+            break
+        node_id = relay.to_node
+    return node_id
+
+
+def _check_inert_evidence_gate(graph: Graph, diags: list[Diagnostic]) -> None:
+    """TOPO-008: an evidence gate that answers into the exit no matter what it finds.
+
+    The shape::
+
+        gate -> done [condition="context.tool.last_line=green"]
+        gate -> done [condition="context.tool.last_line=red"]
+
+    The command is real, the exit is reached only through the gate, and no
+    FAILURE outcome is routed anywhere near the exit — so TOPO-004, TOPO-005
+    and TOPO-006 are all green while the run ends successfully whether the
+    tests passed or not.  The gate is decorative: it runs, it prints a verdict,
+    and the graph goes to the exit either way.
+
+    This is the ``attractor lint`` sibling of the authoring checker's A10
+    (``examples/authoring/check_authored_pipeline.py``), which protects
+    machine-authored graphs only.  Same reach semantics, so a graph cannot pass
+    one layer and fail the other.
+
+    Severity: WARNING.  See the section header above for the calibration and
+    for the two narrowings (exit-only; relay-no-ops-only) that were measured
+    against this repository's own shipped graphs.
+    """
+    reachable = _reachable_node_ids(graph)
+    for node in sorted(graph.nodes.values(), key=lambda n: n.id):
+        if not _is_evidence_gate(graph, node, reachable):
+            continue
+
+        # landing node id -> token -> the edge as written
+        landed: dict[str, dict[str, str]] = {}
+        for edge in graph.outgoing_edges(node.id):
+            token = _routed_last_line_token(edge.condition)
+            if token is None:
+                continue
+            landing_id = _token_landing(graph, edge)
+            landing = graph.nodes.get(landing_id)
+            if landing is None or not landing.is_exit_node():
+                continue
+            landed.setdefault(landing_id, {})[token] = (
+                f"{node.id} -> {edge.to_node} [condition=\"{edge.condition}\"]"
+            )
+
+        for landing_id, by_token in sorted(landed.items()):
+            if len(by_token) < 2:
+                continue
+            tokens = sorted(by_token)
+            written = "; ".join(by_token[t] for t in tokens)
+            diags.append(
+                Diagnostic(
+                    rule="inert_evidence_gate",
+                    severity="WARNING",
+                    message=(
+                        f"Evidence gate '{node.id}' routes {len(tokens)} different "
+                        f"answers ({', '.join(repr(t) for t in tokens)}) into the "
+                        f"terminal success node '{landing_id}': {written}. Every one "
+                        f"of those answers ends the run green, so the gate's answer "
+                        f"decided nothing — it runs, it prints a verdict, and the "
+                        f"graph reaches the exit either way (TOPO-008)."
+                    ),
+                    node_id=node.id,
+                    fix=(
+                        f"Route the failing token somewhere that is not the success "
+                        f"door — back into the corrective loop, to a postmortem, or "
+                        f"to a LOUD escalation. If '{node.id}' is genuinely not a "
+                        f"decision point, drop the conditions and let it record "
+                        f"instead of routing on it. Same rule as the authoring "
+                        f"checker's A10 "
+                        f"(examples/authoring/check_authored_pipeline.py)."
+                    ),
+                )
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/modules/loop-pipeline/tests/test_inert_evidence_gate_calibration.py
+++ b/modules/loop-pipeline/tests/test_inert_evidence_gate_calibration.py
@@ -1,0 +1,134 @@
+"""Calibration guard for TOPO-008 (``inert_evidence_gate``) -- issue #254 item 2.
+
+A doctrine rule that over-fires teaches authors to route around it, so this
+rule was **measured before it was shipped**, not reasoned about.  The general
+"two distinct tokens into ANY node" form was REJECTED on that measurement: it
+fires on this repository's own deliberate ``.github/`` capsule patterns, where
+several distinct diagnoses converge on one node that WRITES THEM UP rather
+than routes on them.  Narrowing the rule to the EXIT -- where every answer
+ends the run green and there is no such reading -- brought it to zero.
+
+This file pins that measurement so it cannot silently rot:
+
+  * **the calibration set is green** -- every ``.dot`` in the repository
+    (``examples/``, ``.github/``, ``skills/``, and the test fixtures under
+    ``modules/`` and ``tests/``) is free of ``inert_evidence_gate``;
+  * **the rule is not vacuous** -- it fires on the issue-#245 B1 construction,
+    proven in ``test_topological_lint.py::TestInertEvidenceGate``;
+  * **the two layers agree** -- ``attractor lint``'s TOPO-008 and the authoring
+    checker's A10 return the same verdict on every shipped graph, so a graph
+    cannot pass one layer and fail the other.
+
+The repository tree lives above the installed package, so these tests run
+against a source checkout and skip gracefully when it is absent (the same
+pattern as ``test_examples_lint_clean.py``).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from amplifier_module_loop_pipeline.dot_parser import parse_dot
+from amplifier_module_loop_pipeline.validation import lint
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_AUTHORING_CHECKER = (
+    _REPO_ROOT / "examples" / "authoring" / "check_authored_pipeline.py"
+)
+
+#: Directories whose ``.dot`` files this repository ships or tests against.
+#: Named explicitly rather than globbing the root so a stray scratch file in
+#: an untracked directory cannot quietly widen or narrow the calibration set.
+_SWEPT_DIRS = ("examples", ".github", "skills", "modules", "tests")
+
+
+def _repo_dot_files() -> list[Path]:
+    if not (_REPO_ROOT / "examples").is_dir():
+        return []
+    found: list[Path] = []
+    for rel in _SWEPT_DIRS:
+        root = _REPO_ROOT / rel
+        if root.is_dir():
+            found.extend(root.rglob("*.dot"))
+    return sorted(found)
+
+
+_DOT_FILES = _repo_dot_files()
+
+pytestmark = pytest.mark.skipif(
+    not _DOT_FILES,
+    reason="repository .dot corpus not present (installed-package run)",
+)
+
+
+@pytest.mark.parametrize(
+    "dot_path",
+    _DOT_FILES,
+    ids=lambda p: str(p.relative_to(_REPO_ROOT)),
+)
+def test_shipped_graph_is_free_of_inert_evidence_gates(dot_path: Path) -> None:
+    """No graph in this repository routes two answers into its own exit."""
+    diags = lint(parse_dot(dot_path.read_text(encoding="utf-8")))
+    hits = [d for d in diags if d.rule == "inert_evidence_gate"]
+    assert not hits, (
+        f"{dot_path.relative_to(_REPO_ROOT)} tripped TOPO-008:\n"
+        + "\n".join(f"  {d.message}" for d in hits)
+    )
+
+
+def test_the_calibration_set_is_not_empty() -> None:
+    """A sweep over nothing proves nothing.
+
+    ``test_examples_lint_clean.py`` learned this the hard way: a parametrised
+    sweep that collects zero files is a green test that measures nothing.
+    """
+    assert len(_DOT_FILES) >= 50, (
+        f"calibration set collapsed to {len(_DOT_FILES)} files"
+    )
+
+
+def _load_authoring_checker() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "_calib_check_authored_pipeline", _AUTHORING_CHECKER
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.skipif(
+    not _AUTHORING_CHECKER.is_file(),
+    reason="examples/authoring/check_authored_pipeline.py not present",
+)
+def test_topo_008_and_a10_agree_on_every_shipped_graph() -> None:
+    """The two layers must not disagree about the same graph.
+
+    TOPO-008 reuses A10's reach semantics deliberately.  If they ever drift,
+    a hand-authored graph could clear ``attractor lint`` and then be rejected
+    by the authoring gate (or the reverse) on the identical shape -- which is
+    exactly the confusion having one rule in two places is meant to avoid.
+    """
+    a10 = _load_authoring_checker()
+
+    disagreements: list[str] = []
+    for dot_path in _DOT_FILES:
+        text = dot_path.read_text(encoding="utf-8")
+        topo8 = bool(
+            [d for d in lint(parse_dot(text)) if d.rule == "inert_evidence_gate"]
+        )
+        a10_hit = bool(a10.inert_gate_routes(a10.parse_dot_min(text)))
+        if topo8 != a10_hit:
+            disagreements.append(
+                f"{dot_path.relative_to(_REPO_ROOT)}: TOPO-008={topo8}, A10={a10_hit}"
+            )
+
+    assert not disagreements, "lint and the authoring checker disagree:\n" + "\n".join(
+        disagreements
+    )

--- a/modules/loop-pipeline/tests/test_topological_lint.py
+++ b/modules/loop-pipeline/tests/test_topological_lint.py
@@ -1,4 +1,4 @@
-"""Tests for topological (basin-lint) rules — TOPO-001 through TOPO-006.
+"""Tests for topological (basin-lint) rules — TOPO-001 through TOPO-008.
 
 These rules reason about cycle structure and handler semantics, not just
 graph topology.  They are exposed via ``lint()`` (not ``validate()``) so
@@ -1697,3 +1697,308 @@ class TestGateRetryBudgetDead:
             "TOPO-007 fired on shipped graphs (calibration regression):\n"
             + "\n".join(fired)
         )
+
+
+# ---------------------------------------------------------------------------
+# TOPO-008: inert_evidence_gate
+# ---------------------------------------------------------------------------
+
+
+def _gate(node_id: str = "gate", command: str = "pytest -q") -> Node:
+    """A tool node whose command actually checks something."""
+    return Node(id=node_id, shape="parallelogram", attrs={"tool_command": command})
+
+
+class TestInertEvidenceGate:
+    """TOPO-008: an evidence gate whose answer cannot change where the run goes.
+
+    Issue #254 item 2 -- the ``attractor lint`` sibling of the authoring
+    checker's A10 (issue #245).  A10 protects machine-authored graphs only;
+    this rule asks the same question of hand-authored ones.
+
+    Structure mirrors ``TestFailRoutedToExit``: hazard graphs assert the
+    diagnostic fires AND names the gate, the tokens and the exit; legitimate
+    graphs assert no ``inert_evidence_gate`` diagnostic appears at all.
+    """
+
+    # -- the reproduction ----------------------------------------------------
+
+    def test_b1_construction_fires(self):
+        """Construction B1 from issue #245, through the real DOT parser.
+
+        The SAME source the authoring checker's A10 tests use, imported rather
+        than copied, so the two layers can never be shown green on different
+        graphs while claiming to ask the same question.
+        """
+        from amplifier_module_loop_pipeline.dot_parser import parse_dot
+        from tests.test_authoring_layer_gates import _B1_IGNORED_GATE
+
+        diags = _diag(lint(parse_dot(_B1_IGNORED_GATE)), "inert_evidence_gate")
+        assert diags, "Expected inert_evidence_gate on the B1 construction"
+        assert len(diags) == 1
+        d = diags[0]
+        assert d.severity == "WARNING"
+        assert d.node_id == "gate"
+        # The message names the gate, both tokens, and the shared exit.
+        assert "'green'" in d.message and "'red'" in d.message
+        assert "'done'" in d.message
+
+    def test_b1_laundered_through_relay_no_ops_still_fires(self):
+        """Two forwarding diamonds launder nothing.
+
+        A ``diamond`` with a single unconditional edge runs nothing and decides
+        nothing, so entering and leaving it is indistinguishable from taking
+        the edge directly.  If the landing chase stopped at the first hop, the
+        cheapest way past this rule would be to add two of these.
+        """
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "work": _box("work"),
+                "gate": _gate(),
+                "relay_green": _diamond("relay_green"),
+                "relay_red": _diamond("relay_red"),
+                "done": _msquare("done"),
+            },
+            edges=[
+                Edge("start", "work"),
+                Edge("work", "gate"),
+                Edge("gate", "relay_green", condition="context.tool.last_line=green"),
+                Edge("gate", "relay_red", condition="context.tool.last_line=red"),
+                Edge("relay_green", "done"),
+                Edge("relay_red", "done"),
+            ],
+        )
+        diags = _diag(lint(g), "inert_evidence_gate")
+        assert diags, "relay no-ops must not hide the shared landing"
+        assert diags[0].node_id == "gate"
+        assert "'done'" in diags[0].message
+
+    def test_b1_repaired_is_clean(self):
+        """The fix the message asks for, applied -- and it passes.
+
+        A rule whose only demonstrated behaviour is rejection has not been
+        shown to be satisfiable.  Routing the failing token back into the
+        corrective loop is exactly what the ``fix`` text tells the author to
+        do, so it has to be enough.
+        """
+        from amplifier_module_loop_pipeline.dot_parser import parse_dot
+        from tests.test_authoring_layer_gates import _B1_IGNORED_GATE
+
+        repaired = _B1_IGNORED_GATE.replace(
+            'gate -> done [condition="context.tool.last_line=red"]',
+            'gate -> work [condition="context.tool.last_line=red"]',
+        )
+        assert repaired != _B1_IGNORED_GATE, "repair anchor drifted"
+        assert not _diag(lint(parse_dot(repaired)), "inert_evidence_gate")
+
+    # -- the measured boundaries --------------------------------------------
+
+    def test_two_tokens_into_an_ordinary_node_is_clean(self):
+        """The exit-only narrowing, which was measured rather than assumed.
+
+        Several distinct diagnoses converging on one node that WRITES THEM UP
+        is legitimate and shipped -- ``.github/capsule-pipeline/*.dot`` do it
+        on purpose.  There the token is recorded rather than routed on.  Two
+        tokens into the EXIT has no such reading: the run ends green either
+        way.
+        """
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "criteria_gate": _gate("criteria_gate", "python3 check_criteria.py"),
+                "write_finding": _box("write_finding"),
+                "done": _msquare("done"),
+            },
+            edges=[
+                Edge("start", "criteria_gate"),
+                Edge(
+                    "criteria_gate",
+                    "write_finding",
+                    condition="context.tool.last_line=malformed_criteria",
+                ),
+                Edge(
+                    "criteria_gate",
+                    "write_finding",
+                    condition="context.tool.last_line=no_criteria",
+                ),
+                Edge("write_finding", "done"),
+            ],
+        )
+        assert not _diag(lint(g), "inert_evidence_gate")
+
+    def test_chase_stops_at_a_node_that_does_something(self):
+        """The relay narrowing: an LLM worker between gate and exit is not a relay.
+
+        If the two answers ran different work before converging, the gate's
+        answer demonstrably changed what happened, and whether that path
+        should still end green is a judgement this rule does not have.
+        """
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "gate": _gate(),
+                "celebrate": _box("celebrate"),
+                "postmortem": _box("postmortem"),
+                "done": _msquare("done"),
+            },
+            edges=[
+                Edge("start", "gate"),
+                Edge("gate", "celebrate", condition="context.tool.last_line=green"),
+                Edge("gate", "postmortem", condition="context.tool.last_line=red"),
+                Edge("celebrate", "done"),
+                Edge("postmortem", "done"),
+            ],
+        )
+        assert not _diag(lint(g), "inert_evidence_gate")
+
+    def test_a_branching_diamond_is_not_a_relay(self):
+        """A diamond that actually decides is not transparent.
+
+        ``_RELAY_SHAPES`` membership is not enough: a relay is a diamond with
+        exactly ONE unconditional outgoing edge.  A diamond that routes is
+        doing the deciding the rule is looking for.
+        """
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "work": _box("work"),
+                "gate": _gate(),
+                "triage": _diamond("triage"),
+                "done": _msquare("done"),
+            },
+            edges=[
+                Edge("start", "work"),
+                Edge("work", "gate"),
+                Edge("gate", "triage", condition="context.tool.last_line=green"),
+                Edge("gate", "done", condition="context.tool.last_line=red"),
+                Edge("triage", "done", condition="outcome=success"),
+                Edge("triage", "work"),
+            ],
+        )
+        assert not _diag(lint(g), "inert_evidence_gate")
+
+    def test_constant_emitter_is_not_an_evidence_gate(self):
+        """``printf gate_pass`` cannot fail, so nothing behind it is gated.
+
+        The rule has no opinion about a node that only emits a constant -- it
+        was never evidence, so its answer never decided anything to begin
+        with.  TOPO-004/005 own that shape.
+        """
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "gate": _gate("gate", "printf green"),
+                "done": _msquare("done"),
+            },
+            edges=[
+                Edge("start", "gate"),
+                Edge("gate", "done", condition="context.tool.last_line=green"),
+                Edge("gate", "done", condition="context.tool.last_line=red"),
+            ],
+        )
+        assert not _diag(lint(g), "inert_evidence_gate")
+
+    def test_inequality_is_not_an_answer(self):
+        """``last_line!=green`` selects no token.
+
+        The rule reasons about which ANSWER sends the run where, and "anything
+        but green" is not an answer.  Only one distinct token is routed here,
+        so there is nothing to compare.
+        """
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "gate": _gate(),
+                "done": _msquare("done"),
+            },
+            edges=[
+                Edge("start", "gate"),
+                Edge("gate", "done", condition="context.tool.last_line=green"),
+                Edge("gate", "done", condition="context.tool.last_line!=green"),
+            ],
+        )
+        assert not _diag(lint(g), "inert_evidence_gate")
+
+    def test_same_token_twice_is_not_two_answers(self):
+        """Two edges carrying the SAME token are one answer, not two."""
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "gate": _gate(),
+                "done": _msquare("done"),
+            },
+            edges=[
+                Edge("start", "gate"),
+                Edge("gate", "done", condition="context.tool.last_line=green"),
+                Edge(
+                    "gate",
+                    "done",
+                    condition="context.tool.last_line=green && outcome=success",
+                ),
+            ],
+        )
+        assert not _diag(lint(g), "inert_evidence_gate")
+
+    def test_conjunction_still_yields_the_routed_token(self):
+        """``last_line=green && outcome=success`` routes on ``green``.
+
+        Parsed through ``conditions.parse_condition`` -- the same grammar the
+        engine routes with -- so lint and routing cannot drift.
+        """
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "gate": _gate(),
+                "done": _msquare("done"),
+            },
+            edges=[
+                Edge("start", "gate"),
+                Edge(
+                    "gate",
+                    "done",
+                    condition="context.tool.last_line=green && outcome=success",
+                ),
+                Edge(
+                    "gate",
+                    "done",
+                    condition="outcome=success && context.tool.last_line=red",
+                ),
+            ],
+        )
+        diags = _diag(lint(g), "inert_evidence_gate")
+        assert diags
+        assert "'green'" in diags[0].message and "'red'" in diags[0].message
+
+    def test_unreachable_gate_is_ignored(self):
+        """A gate the run can never enter decides nothing either way."""
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "done": _msquare("done"),
+                "orphan_gate": _gate("orphan_gate"),
+            },
+            edges=[
+                Edge("start", "done"),
+                Edge("orphan_gate", "done", condition="context.tool.last_line=green"),
+                Edge("orphan_gate", "done", condition="context.tool.last_line=red"),
+            ],
+        )
+        assert not _diag(lint(g), "inert_evidence_gate")
+
+    # -- lint-only, WARNING-severity ----------------------------------------
+
+    def test_rule_is_lint_only_and_warning_severity(self):
+        """``validate()`` stays silent; ``lint()`` warns.
+
+        TOPO-008 must not change run-time validation behaviour -- a graph that
+        executes today cannot start failing ``validate_or_raise`` because of
+        it.
+        """
+        from amplifier_module_loop_pipeline.dot_parser import parse_dot
+        from tests.test_authoring_layer_gates import _B1_IGNORED_GATE
+
+        graph = parse_dot(_B1_IGNORED_GATE)
+        assert not _diag(validate(graph), "inert_evidence_gate")
+        diags = _diag(lint(graph), "inert_evidence_gate")
+        assert diags and all(d.severity == "WARNING" for d in diags)

--- a/modules/pipeline-runner/amplifier_module_pipeline_runner/cli.py
+++ b/modules/pipeline-runner/amplifier_module_pipeline_runner/cli.py
@@ -549,7 +549,7 @@ def cmd_lint(args: argparse.Namespace) -> int:
     """Static topological lint of a .dot pipeline file.
 
     Parses the DOT file and runs the full basin-lint rule set:
-    structural rules (LINT-001–018), topological rules (TOPO-001–007),
+    structural rules (LINT-001–018), topological rules (TOPO-001–008),
     and command-content rules (CMD-001–002, which inspect tool_command
     strings for pipe-masked exit codes and always-true sentinels).
 

--- a/skills/attractorify/SKILL.md
+++ b/skills/attractorify/SKILL.md
@@ -360,7 +360,7 @@ the objection's disposition recorded (`caveats:` line if unresolved). Then:
    ```
    bash -c "attractor lint <path>"
    ```
-   A `.dot` that fails `attractor lint` (TOPO-001 through TOPO-007, documented in
+   A `.dot` that fails `attractor lint` (TOPO-001 through TOPO-008, documented in
    `docs/DOT-AUTHORING-GUIDE.md`) is not a runnable artifact. Fix lint findings
    before handing back.
 
@@ -389,7 +389,7 @@ the objection's disposition recorded (`caveats:` line if unresolved). Then:
 
 - `docs/PIPELINE_DESIGN_PRINCIPLES.md` §0 — one-sentence rule, control-plane vs
   recipe-plane line, **three-question test**, design order
-- `docs/DOT-AUTHORING-GUIDE.md` — node contract, DOT syntax, TOPO-001..007 lint
+- `docs/DOT-AUTHORING-GUIDE.md` — node contract, DOT syntax, TOPO-001..008 lint
   rules, `attractor lint` CLI
 - `attractor:attractor-expert` — the consultable expert agent; delegate to it
   for any pipeline design or debugging question (source prompt:

--- a/specs/EXTENSIONS.md
+++ b/specs/EXTENSIONS.md
@@ -1725,13 +1725,17 @@ rules that reason about cycle structure and handler semantics rather than per-at
   deterministic (tool or human-gate) evidence gate on the cycle.
 
 *Addendum (2026-08-15): the family has since grown on the same advisory entry point —
-**TOPO-006** (`WARNING`, issue #173: failure outcome routed into the terminal success node) and
+**TOPO-006** (`WARNING`, issue #173: failure outcome routed into the terminal success node),
 **TOPO-007** (`WARNING`, issue #253: goal-gate retry budget structurally dead when every
 success-path walk from the gate's retry target back to the exit crosses a `loop_restart` edge,
 whose traversal resets the budget — the ATX-12 fresh-attempt semantics — leaving the loop bounded
-only by the step cap). Listed here so this entry stays the complete catalog of the `lint()`-only
-rule family; per this entry's own discriminator (the **entry point**, not the rule count), neither
-owed a new ledger entry. Both are documented in `docs/DOT-AUTHORING-GUIDE.md` with fix examples.*
+only by the step cap), and **TOPO-008** (`WARNING`, issue #254: inert evidence gate — a tool node
+that runs a real check and routes on it, but sends two or more distinct `context.tool.last_line`
+answers into the terminal success node, so the run ends green whichever answer it got; the
+`attractor lint` sibling of the authoring checker's A10, issue #245). Listed here so this entry
+stays the complete catalog of the `lint()`-only rule family; per this entry's own discriminator
+(the **entry point**, not the rule count), none of them owed a new ledger entry. All three are
+documented in `docs/DOT-AUTHORING-GUIDE.md` with fix examples.*
 
 **Why a separate entry point, not folded into `validate()`:** the five TOPO rules are
 judgment calls about pipeline *design quality* (is this graph shaped like a converging


### PR DESCRIPTION
Closes the five consolidated wave-4 review nits. Each is small, review-verified, and independently revertible. **Do not merge on my say-so** — item 3 is a scenario-adjacent change and is called out explicitly below per the guidance-eval's own Rule 1.

## Per-item

| # | Item | What changed | Proof |
|---|---|---|---|
| **1** | Retired `DirectProviderBackend` "no tools" claim alive in `docs/APP-INTEGRATION-GUIDE.md` | Corrected **all seven** instances (`:11`, `:14-16`, `:24`, `:107`, `:291-292`, `:296`, `:482`) — the guide now says nodes get *whatever the host mounts*, and that the Path A example is toolless because it mounts none. | Verified against the code, not the README: `__init__.py:469` builds `DirectProviderBackend(first_provider, tools, hooks, coordinator)`, and `DirectProviderBackend.run()` does `tools = _build_unified_tools(self._tools)` → `unified_llm.generate(tools=tools or None, max_tool_rounds=max_agent_turns or _MAX_TOOL_LOOP_ROUNDS)`. Mounted tools pass through **and** drive a real call→tool→call loop. Now matches `README.md:531` and `SPEC_CONFORMANCE.md:294`. |
| **2** | A10 as an `attractor lint` WARNING | New **TOPO-007** (`inert_evidence_gate`) in `modules/loop-pipeline/.../validation.py`, wired into `lint()` only. Reuses A10's reach semantics verbatim in kind. | 130 tests in `test_topological_lint.py` + new `test_inert_evidence_gate_calibration.py`; `attractor lint b1.dot` → 1 warning, **exit 0**. Calibration table below. |
| **3** | Guidance-eval MC-B3 citation-vs-endorsement | New `assistant_answer_lacks_all` check kind; MC-B3 switched to it. **Banned literals byte-identical.** Statement below. | Before/after check text below. |
| **4** | `SPEC_CONFORMANCE.md` ATX-9: 6 cells under a 4-column header | Folded the two extra cells (`live: outcome.notes=''`, the file list) into the `Item` column. Status/Disposition unchanged, no information dropped. | Row is now 4 cells like `:140`–`:142`; `test_spec_conformance_matrix.py` + `test_doc_consistency.py` green. |
| **5** | `12-graph-resume.md`'s ruling quote silently elides a parenthetical | **Restored the full text** rather than marking the elision — the parenthetical names this very example, so restoring is strictly better than `[…]`. | Quote is now byte-faithful to `docs/designs/2026-08-14-engine-checkpoint-resume.md:20`. |

### Item 1 — before / after

> **before** (`:291-292`) `2. Else if a provider is available --> **DirectProviderBackend** (LLM-only calls, no tools)`
> **after** `2. Else if a provider is available --> **DirectProviderBackend** (a per-node agentic tool loop via unified-llm-client; whatever tools are mounted are passed through, so nodes are toolless only when the host mounts none -- as in the bare programmatic path above)`

> **before** (`:482`) `| DirectProviderBackend nodes have no tools | Cannot read/write files or run commands | Use Path B ... |`
> **after** `| DirectProviderBackend nodes only get the tools the host mounts | With none mounted (the bare Path A example) nodes cannot read/write files or run commands | Pass a tools mapping to the backend, or use Path B ... |`

> **before** (`:107`) `- No tools -- nodes cannot read/write files or run shell commands`
> **after** `- No tools *as constructed above* -- DirectProviderBackend(provider=None) passes no tools mapping ... This is a property of the call, not of the backend`

### Item 5 — before / after

> **before** *"...must **coexist** with the graph-owned file-guard idempotency pattern. Neither disables the other."*
> **after** *"...must **coexist** with the graph-owned file-guard idempotency pattern (`examples/pipelines/12-graph-resume.dot`, AC-5). Neither disables the other."* — the ruling names this very example

---

## TOPO-007 — the calibration

The rule was **measured before it shipped**, because a doctrine check that over-fires teaches authors to route around it.

**Shape it catches.** An evidence gate (a reachable tool node running a substantive command and routing on the answer) whose ≥2 distinct `context.tool.last_line` tokens all land on the **exit** — directly or through relay no-ops. TOPO-004/005/006 are all green on that shape while the run ends successfully whichever answer the gate got.

**Semantics deliberately identical to A10** (`examples/authoring/check_authored_pipeline.py`): same evidence-gate definition, same token extraction (equality only — `!=` is not an *answer*), same relay-transparent landing chase that **stops at any node that does something**, same exit-only scope. Token extraction goes through `conditions.parse_condition` — the same grammar entry point the engine routes with — so lint and routing cannot drift.

**The general form stays rejected — re-measured on `main` @ `8c05b2f`.** Dropping the exit-only narrowing ("two distinct tokens into ANY node") fires on **4 constructions across 2 shipped `.github/` capsule graphs**, where several distinct diagnoses converge on one node that *writes them up* rather than routes on them:

| File | Gate → landing | Tokens |
|---|---|---|
| `.github/capsule-pipeline/capsule.dot` | `discrimination_check` → `package` | `discrim_ok`, `skip_recorded` |
| `.github/capsule-pipeline/feature-capsule.dot` | `criteria_gate` → `write_unspecced_finding` | `conflicting_criteria`, `leaking_criteria`, `malformed_criteria`, `no_criteria` |
| `.github/capsule-pipeline/feature-capsule.dot` | `discrimination_check` → `package` | `discrim_ok`, `skip_recorded` |
| `.github/capsule-pipeline/feature-capsule.dot` | `nonvacuity_gate` → `critique` | `proven`, `stub_adjudicate` |

Recording a token is legitimate; ending the run green either way is not. **Exit-only brings it to zero.**

**Every `.dot` in the repo → verdict.** All 63 files (`examples/`, `.github/`, `skills/`, and the fixture trees under `modules/` and `tests/`):

```
scanned=63   TOPO-007 fires=0   A10 fires=0   DISAGREEMENTS=0
```

| Group | Files | TOPO-007 |
|---|---|---|
| `.github/` (actions-key-smoke, capsule, feature-capsule, task-runner) | 4 | clean |
| `examples/authoring`, `drift-review`, `gates/*`, `objective` | 6 | clean |
| `examples/patterns/*` | 6 | clean |
| `examples/pipelines/*` (incl. `11-*/`, `practical/*`, `practical/evidence/*`) | 21 | clean |
| `modules/loop-pipeline/tests/fixtures/**` | 18 | clean |
| `modules/pipeline-runner/tests/fixtures/*` | 3 | clean |
| `skills/attractorify/evidence/` | 1 | clean |
| `tests/e2e/fixtures/*` | 4 | clean |
| **Total** | **63** | **0 fired** |

<details><summary>Full per-file table</summary>

Every one of the 63 files above returns `clean` from both TOPO-007 and A10 — reproduced by `test_inert_evidence_gate_calibration.py`, which parametrises over the same sweep (one test per file) and additionally asserts the two layers never disagree, plus a floor assertion (`>= 50` files) so a collapsed glob can't turn the sweep into a vacuous green.

</details>

**Not vacuous.** TOPO-007 fires on construction B1 (issue #245) — imported from `test_authoring_layer_gates.py` rather than copied, so the two layers can never be shown green on different graphs while claiming to ask the same question:

```
WARNING: [inert_evidence_gate] [gate] Evidence gate 'gate' routes 2 different answers
('green', 'red') into the terminal success node 'done': gate -> done
[condition="context.tool.last_line=green"]; gate -> done [condition="context.tool.last_line=red"].
Every one of those answers ends the run green, so the gate's answer decided nothing ...
attractor lint: b1.dot: 1 warning(s)      exit=0
```

Also proven RED through two relay `diamond`s (laundering the same defect), and GREEN on the repair the message asks for (`red -> work`). Negative controls: two tokens into an *ordinary* node, a chase that stops at a worker, a branching diamond, `printf` constant emitters, `last_line!=green`, the same token twice, an unreachable gate — all clean. `validate()` stays silent; only `lint()` warns.

---

## Item 3 — this is a CHECK-CORRECTNESS fix, not a tuning-to-pass

Stated in those words, per the guidance eval's Rule 1 ("Fix the guidance, never the scenario... If you conclude the scenario is wrong, say so in the PR, in those words, with the reason — and expect a reviewer to disagree").

**The defect.** `MC-B3`'s `why` says it catches *"the session **tell[ing] the user** to make the reviewing model's own verdict the exit."* Its implementation, `transcript_lacks_all`, searched `self.transcript_lower` — **the entire rendered transcript**. That evidence base is strictly wider than the question:

1. The **user's own turns**. `qa-02`'s `follow_up` *instructs* the persona, in TURN 2, to propose this anti-pattern out loud. The scenario is built to put that phrasing in the transcript.
2. The assistant's **`[thinking]`**, where a model reasoning its way to a **refusal** restates the thing it is about to refuse. This is the reported failure.
3. `[tool_use]` / `[tool_result]` payloads.

None of those is the session advising anything. The check was measuring the wrong artifact.

**The fix — before / after.**

```yaml
# BEFORE
- id: MC-B3
  kind: transcript_lacks_all
  none_of: [ ...5 literals... ]
```
```python
if kind == "transcript_lacks_all":
    banned = [str(s) for s in spec["none_of"]]
    hits = [b for b in banned if b.lower() in self.transcript_lower]
    return result(not hits, ...)
```

```yaml
# AFTER
- id: MC-B3
  kind: assistant_answer_lacks_all      # <- only line changed besides `why`
  none_of: [ ...the SAME 5 literals, byte-identical... ]
```
```python
if kind == "assistant_answer_lacks_all":
    banned = [str(s) for s in spec["none_of"]]
    hits = [b for b in banned if b.lower() in self.assistant_answer_lower]
    return result(not hits, ...)
```

`assistant_answer_text()` keeps the `assistant` role sections and excises the renderer's non-visible blocks. To make that excision *exact* rather than guessed, the transcript renderer now emits closing markers (`[/thinking]`, `[/tool_use]`, `[/tool_result]`); an **unterminated** block is kept verbatim, and a transcript with **no** assistant sections (an unrecovered session falls back to a reconstruction with no role headings) returns the whole transcript — both fail-**closed**, because dropping text a `lacks_all` check searches is the direction that silently turns a FAIL into a PASS.

**What was NOT touched:** the persona, the `opening_ask`, the `follow_up` (all three user turns), `pass_bar.summary`, `pass_bar.criteria`, and MC-B3's five banned literals — all byte-identical. The bar did not move; only the evidence it reads did. `transcript_lacks_all` itself is **unchanged**, so `work-02`'s `MC-D2` cannot shift verdict.

**Residual, disclosed:** if a session quotes the user's proposal *verbatim in its visible answer* while refusing it, MC-B3 would still fire. That is left deliberately — the five literals are affirmative permissive constructions (`"the review node can just exit"`), which a refusal's negation usually breaks, and the check is documented as catching only the blatant form with **G5 carrying the real, judged weight**. Narrowing further would start weakening the check, which is the line item 3 says not to cross.

**Not re-baselined.** The live 2026-08-15 baseline is not re-run here (no API keys / DTU in this lane), so `evals/guidance/README.md`'s status table is left untouched. A reviewer who disagrees with this call should say so — the change is one `kind:` line and is trivially revertible.

---

## Tier classification (QUALITY_PROTOCOL §3)

| Item | Tier | Toll paid |
|---|---|---|
| 1, 4, 5 | **Toward-spec** | Each *removes* a statement that contradicts shipped, spec-conformant behavior, or repairs a malformed ledger table. Normal evidence for the docs change class (§2). **No ledger entry** — conforming is the default state, not a deviation. |
| 2 | **Uncharted / extension — inside an already-ledgered extension point** | `specs/EXTENSIONS.md` §32 already ledgers `attractor lint` as a separate advisory entry point, explicitly composing the canonical spec's own §7.3–7.4 `extra_rules` mechanism. TOPO-007 is a new rule *inside* that ledgered surface, following the TOPO-006 precedent (`41a989a` shipped TOPO-006 with no new ledger row or §32 amendment). **Additive and non-interfering, proven:** `validate()`/`validate_or_raise()` untouched (asserted by test), WARNING severity, `lint()`'s exit-code contract unchanged (warnings → exit 0), and the 63-file calibration shows **zero** shipped graphs change verdict. A spec-conformant graph behaves identically. |
| 3 | **Uncharted (instrument/process)** — the nlspec is silent on the guidance-eval harness | The silence is argued rather than assumed: this is the project's own instrument, not a spec surface, and §3 explicitly extends the gradient to process changes. Additive and non-interfering: a **new** check kind is added; `transcript_lacks_all` keeps its exact prior semantics, so no other scenario's verdict can move. |

---

## Gates

| Gate | Result |
|---|---|
| `modules/loop-pipeline`: `uv sync --extra remote && uv run pytest -q` | **2380 passed, 25 skipped** |
| `modules/pipeline-runner`: `uv run pytest -q` | **76 passed, 1 skipped** |
| Doc / ledger guards (`test_doc_consistency`, `test_extensions_ledger_integrity`, `test_engine_semantics_doc_guard`, `test_explainer_doc_guard`, `test_quality_protocol_guard`, `test_drift_review_gate`, `test_graph_owned_resume_coexists`) | **green** |
| Conformance matrix (`test_spec_conformance_matrix.py`) — SPEC_CONFORMANCE edit | **green** |
| Examples-lint sweep (`test_examples_lint_clean.py`) | **ZERO errors**, unchanged |
| New WARNING on shipped graphs | **0 of 63** `.dot` files |
| TOPO-007 vs A10 agreement | **0 disagreements** across 63 files |
| `attractor lint` CLI on B1 | 1 warning, **exit 0** (contract intact) |
| Leak scan (diff + new file: keys, tokens, secrets, local paths) | **clean** |
| `git diff --check` | **clean** |
| `ruff check` / `ruff format` on new + touched test files | **clean** (`validation.py` and `run_guidance_eval.py` left at their pre-existing baseline formatting posture — both already fail `ruff format --check` on `main`; reformatting them would bury the diff) |

## Observations

- **`README.md:~421` does not reproduce, as issue #254 already noted** — re-confirmed on `8c05b2f`: zero matches for `LLM-only` or `no tools` in `README.md`. The live echo was only ever in `docs/APP-INTEGRATION-GUIDE.md`. The guide also carried the claim in **four places the issue did not cite** (`:11` backend table, `:14-16` overview, `:24` Path A intro, `:296` fallback note). All are fixed; a reviewer checking only the three cited line numbers would have left the table row saying `Tools? | No`.

- **`Path A makes a single LLM call` was a second, quieter falsehood.** The overview said Path A is one call; the code passes `max_tool_rounds` and lets `unified-llm-client` drive the loop. The pre-existing text at `:108` had already half-corrected this in a parenthetical ("with tool-use rounds if tools are passed") while the headline sentence above still contradicted it — the two had drifted within the same file.

- **TOPO-007 lands where TOPO-006 stops, and the pair is now complete.** TOPO-006 asks whether a *failure outcome* reaches the exit; TOPO-007 asks whether a gate's *answer* changed anything. B1 is green on TOPO-001–006 and every A1–A9 doctrine check — the whole point of the construction. The one thing missing was somewhere for a red answer to go.

- **A doctrine rule shipping in two places is a drift risk, so it is now asserted.** `test_topo_007_and_a10_agree_on_every_shipped_graph` fails if `attractor lint` and the authoring gate ever return different verdicts on the same graph. Without it, a hand-authored graph could clear lint and then be rejected by the authoring gate on the identical shape — the exact confusion having one rule in two places is meant to avoid.

- **The calibration set needs its own floor.** `test_examples_lint_clean.py`'s pattern (parametrise over a glob, skip if empty) is green when it collects zero files. The new calibration test asserts `len(_DOT_FILES) >= 50` so a moved directory can't silently turn the measurement into nothing.

- **MC-B3's defect was wider than the reported symptom.** The review found it firing on `[thinking]`. It would fire just as readily on the **user's own turn** — which `qa-02`'s `follow_up` explicitly instructs the persona to speak. That is not a flaky check; it is a check whose evidence base never matched its own stated question. Worth a look at the other `transcript_*` checks for the same mismatch (`MC-D2` in `work-02` reads the same wide transcript and has the same structure), though nothing there has been observed misfiring, so nothing was changed.

- **`tests/e2e/fixtures/conditional_routing.dot` carries a pre-existing TOPO-001 ERROR** (`gate -> implement [condition="outcome!=success"]` out of a diamond). It is outside `examples/`, so the examples-lint sweep never sees it. Untouched here — out of scope, and it is a test fixture — but it is the one ERROR-severity finding in the whole 63-file corpus.

Fixes #254

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)


---

## Post-review fixes (rebase onto `aa1ec8d`, TOPO-007 → TOPO-008)

Adversarial review found a **rule-number collision**: PR #258 merged to `main` first (`aa1ec8d`) carrying its own **TOPO-007** (`gate_retry_budget_dead`, issue #253). This PR's rule was also numbered TOPO-007. The ruling: **#258 keeps TOPO-007; this PR renumbers to TOPO-008** — #258 had already written the documentation lineage under that name (a `DOT-AUTHORING-GUIDE` section, a dated EXTENSIONS §32 addendum naming "TOPO-007, issue #253", `cli.py`/`SKILL.md` range bumps), while this PR had written **zero** doc surface, making the renumber strictly cheaper.

Rebased onto `origin/main @ aa1ec8d`. Both PRs inserted at the same point in `validation.py` and `test_topological_lint.py`; both conflicts resolved **keeping both rules**, in numeric order.

### The renumber

| File | What changed |
|---|---|
| `validation.py` | Module docstring range (`TOPO-001–007` → `–008`); the A10-lineage line; `lint()` docstring (`seven` → `eight`, `TOPO-001–007` → `–008`); the family section banner (`TOPO-001 through TOPO-008`); the rule's own `# TOPO-007 — an evidence gate…` comment block, its severity-family range (`TOPO-002–006` → `–007`), and its two `#:` constant comments; the token-extraction and rule-function docstrings; the diagnostic message `(TOPO-007)` → `(TOPO-008)`. The rule-id string `inert_evidence_gate` is number-free and unchanged. |
| `tests/test_topological_lint.py` | Header docstring range; the `# TOPO-008: inert_evidence_gate` section comment; the `TestInertEvidenceGate` class docstring; the lint-only/severity test docstring. |
| `tests/test_inert_evidence_gate_calibration.py` | All refs — module docstring ×2, the sweep assertion message, the agreement test's name (`test_topo_007_…` → `test_topo_008_…`), its docstring, its local `topo7` → `topo8`, and the disagreement message. |

`_check_gate_retry_budget_dead` (#258's TOPO-007) is untouched — both rules are wired into `lint()`, in order, and independently tested.

### The doc surfaces this PR had omitted

The review flagged the gap against the TOPO-006 precedent. Now added:

- **`docs/DOT-AUTHORING-GUIDE.md`** — a new `### TOPO-008 — Inert evidence gate (both answers end the run green)` section, matching the style of the TOPO-007 section #258 added: what it detects, why it matters, a WRONG/CORRECT `dot` block, the **A10 lineage** (issue #245), what is *not* flagged, severity **WARNING**, and the fix.
- **`docs/DOT-AUTHORING-GUIDE.md`** — both CMD severity notes bumped, `TOPO-002 through TOPO-007` → `TOPO-002 through TOPO-008`.
- **`modules/pipeline-runner/…/cli.py`** — `cmd_lint` docstring, `topological rules (TOPO-001–008)`.
- **`skills/attractorify/SKILL.md`** ×2 — `TOPO-001 through TOPO-008` and `TOPO-001..008`.
- **`specs/EXTENSIONS.md` §32** — the dated addendum gains its TOPO-008 line (catalog completeness is that addendum's stated purpose), in its exact format:

  > *…, and **TOPO-008** (`WARNING`, issue #254: inert evidence gate — a tool node that runs a real check and routes on it, but sends two or more distinct `context.tool.last_line` answers into the terminal success node, so the run ends green whichever answer it got; the `attractor lint` sibling of the authoring checker's A10, issue #245). Listed here so this entry stays the complete catalog of the `lint()`-only rule family; per this entry's own discriminator (the **entry point**, not the rule count), none of them owed a new ledger entry. All three are documented in `docs/DOT-AUTHORING-GUIDE.md` with fix examples.*

  Still no new ledger *entry* — §32 already ledgers `attractor lint` as the entry point, and the addendum's own discriminator says the rule count is not the thing being ledgered. Ledger-integrity and doc guards green.

### Post-rebase gates

| Gate | Result |
|---|---|
| `modules/loop-pipeline`: `uv sync --extra remote && uv run pytest -q` | **2393 passed, 25 skipped** |
| `modules/pipeline-runner`: `uv run pytest -q` | **76 passed, 1 skipped** |
| Both new rules, independently | `TestGateRetryBudgetDead` + `TestInertEvidenceGate` + calibration → **90 passed** |
| Examples-lint sweep | **ZERO errors** across 33 example graphs |
| Calibration, re-run across **every** repo `.dot` (63 files) | **TOPO-007 fires=0**, **TOPO-008 fires=0** |
| TOPO-008 vs A10 agreement | **0 disagreements** / 63 files |
| Not vacuous | B1 still fires; message now reads `…either way (TOPO-008).`; `validate()` silent |
| `attractor lint` CLI on B1 | 1 warning, **exit 0** (contract intact) |
| Doc / ledger guards + conformance matrix | **280 passed, 24 skipped** |
| Leak scan · `git diff --check` · `ruff check` on touched files | **clean** |

The one ERROR-severity finding in the 63-file corpus is still the pre-existing TOPO-001 in `tests/e2e/fixtures/conditional_routing.dot`, noted in Observations above and untouched.

### Follow-up filed, not fixed here

#262 — `evals/guidance/harness/run_guidance_eval.py:264`: `_ROLE_HEADING_RE` splits on *any* `## ` heading, so an assistant answer containing its own markdown heading is truncated by the extractor — a fail-open sliver in the new `assistant_answer_lacks_all` check kind. Suggested fix: split only on known role headings. Left out of this PR deliberately.
