### PR TITLE
feat(lint): flag a goal-gate retry budget that loop_restart structurally kills (TOPO-007)

### DIFF
--- a/docs/DOT-AUTHORING-GUIDE.md
+++ b/docs/DOT-AUTHORING-GUIDE.md
@@ -1437,6 +1437,56 @@ node, and (for the indirect form) the pass-through path.
 
 ---
 
+### TOPO-007 — Goal-gate retry budget dead under `loop_restart`
+
+**What it detects:** A `goal_gate=true` node whose effective retry target
+(node `retry_target` > node `fallback_retry_target` > graph `retry_target` >
+graph `fallback_retry_target`) can only get back to the exit node by crossing
+a `loop_restart` edge — measured on the graph's *success projection*
+(`loop_restart` edges and failure-conditioned edges removed).
+
+**Why it matters:** The engine bounds exit-time goal-gate retries at 50
+(`_MAX_GOAL_GATE_RETRIES`), but every `loop_restart` traversal resets that
+counter to zero — the fresh-attempt semantics ledgered as ATX-12
+(`specs/EXTENSIONS.md` §24).  When every success-path walk from the retry
+target back to the exit crosses a `loop_restart` edge, the budget resets on
+*every* gate-retry cycle: the counter stays pinned at 1 and the loop is
+bounded only by the global step cap (nodes × 50).  Measured on the shipped
+engine (issue #253, 4-node reduction): without `loop_restart` on the retry
+walk the gate executed 51 times and stopped at the budget; with it, 66
+times, ended only by the step cap.  The same shape shipped in
+`objective-runner.dot` until PR #248 dropped the gate's `retry_target`.
+
+```dot
+// WRONG — the gate's retry walk crosses the loop_restart edge every cycle:
+// the 50-retry budget resets each time and can never bind
+gate [shape=parallelogram, tool_command="./dod.sh", goal_gate=true, retry_target="feedback"]
+gate -> feedback [condition="outcome=fail"]
+feedback -> triage [loop_restart=true]   // feedback's only success-path edge
+```
+
+**What is NOT flagged:** the shipped convergence pattern where
+`loop_restart` rides a fail-conditioned or iterate back-edge
+(`examples/patterns/task-runner.dot`, `02-plan-implement-test.dot`, the
+capsule pipelines) — there the forward success walk re-reaches the exit
+without a reset, so the budget stays live for the exit-time retry loop.  The
+iterate cycle also resets the counter when a run keeps choosing it, but that
+cycle is the author's declared iteration protocol, bounded by its own budget
+wall (section 3's doctrine), not the gate-retry loop.  Context-conditioned
+escapes count as live — statically unknowable routing is conservative
+toward silence.
+
+**Severity:** WARNING — the run still terminates (at the step cap), and
+run-time routing is not statically provable.
+
+**Fix:** Point `retry_target` at a node whose success path reaches the exit
+without crossing a `loop_restart` edge; or bound the `loop_restart` cycle
+with an explicit budget wall; or — if the gate's failure cause survives
+retries (an altered pinned check, a missing artifact) — drop the
+`retry_target` and let the failure be terminal, the PR #248 resolution.
+
+---
+
 ### CMD-001 — Pipe-masked exit code
 
 **What it detects:** A `parallelogram` (tool) node whose `tool_command` ends
@@ -1484,7 +1534,7 @@ If you need to see the last N lines, write to a file and read it separately
 from the routing logic.
 
 **Severity:** WARNING — consistent with the WARNING-severity TOPO rules
-(TOPO-002 through TOPO-006; note TOPO-001 is `ERROR`, not this family's
+(TOPO-002 through TOPO-007; note TOPO-001 is `ERROR`, not this family's
 default).  The hazard is real but static analysis cannot prove the command is
 a meaningful gate; conservative analysis may miss complex cases.
 
@@ -1546,7 +1596,7 @@ influence either the exit code or the emitted token?  The hazard shapes
 destroy that influence.  The honest idioms preserve it.
 
 **Severity:** WARNING — consistent with CMD-001 and the WARNING-severity TOPO
-rules (TOPO-002 through TOPO-006; TOPO-001 is `ERROR`).
+rules (TOPO-002 through TOPO-007; TOPO-001 is `ERROR`).
 
 **What this rule does NOT catch:** sentinels inside `$(...)` substitutions,
 sentinels after non-pipe-masked commands (where `&& echo TOKEN` is the honest

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/validation.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/validation.py
@@ -4,7 +4,7 @@ Validates parsed Graph models against the rules defined in
 spec Section 7 (Validation and Linting). Produces Diagnostic objects
 with severity ERROR (blocks execution) or WARNING (informational).
 
-Spec coverage: LINT-001–018.  TOPO-001–006 are topological basin-lint rules
+Spec coverage: LINT-001–018.  TOPO-001–007 are topological basin-lint rules
 implemented here beyond the canonical spec; they are lint-only (exposed via
 ``lint()``, not ``validate()``) and do not change run-time behaviour.
 
@@ -116,8 +116,8 @@ def lint(graph: Graph) -> list[Diagnostic]:
     """Run topological (basin-lint) and command-content rules in addition to structural rules.
 
     This is the entry point for the ``attractor lint`` CLI command.  It runs
-    the full structural ``validate()`` suite plus the six topological rules
-    (TOPO-001–006) that reason about cycle structure, handler semantics, and
+    the full structural ``validate()`` suite plus the seven topological rules
+    (TOPO-001–007) that reason about cycle structure, handler semantics, and
     evidence-routing patterns, plus the two command-content rules (CMD-001–002)
     that inspect ``tool_command`` strings for hazard shapes.
 
@@ -138,6 +138,7 @@ def lint(graph: Graph) -> list[Diagnostic]:
     _check_cycle_no_conditional_exit(graph, diags)
     _check_cycle_no_deterministic_exit(graph, diags)
     _check_fail_routed_to_exit(graph, diags)
+    _check_gate_retry_budget_dead(graph, diags)
     _check_pipe_masked_exit_code(graph, diags)
     _check_always_true_sentinel(graph, diags)
     return diags
@@ -1597,6 +1598,160 @@ def _check_fail_routed_to_exit(graph: Graph, diags: list[Diagnostic]) -> None:
                         ),
                     )
                 )
+
+
+# Documented engine constant, mirrored for the diagnostic message.  The
+# engine's budget lives at ``engine.py::PipelineEngine._MAX_GOAL_GATE_RETRIES``;
+# importing engine here would create a validation -> engine import cycle, so
+# the message cites the mirrored value instead (kept honest by
+# test_topological_lint.py::TestGateRetryBudgetDead::
+# test_documented_budget_matches_engine).
+_GOAL_GATE_RETRY_BUDGET = 50
+
+
+def _effective_gate_retry_target(node: Node, graph: Graph) -> str | None:
+    """Resolve the retry target the exit-time gate check would use.
+
+    Mirrors ``engine.py::_check_goal_gates()`` exactly: first truthy of
+    node ``retry_target`` > node ``fallback_retry_target`` > graph
+    ``retry_target`` > graph ``fallback_retry_target``, counted only if it
+    names a real node (the engine fails instead of retrying otherwise;
+    ``retry_target_exists`` owns reporting that).
+    """
+    target = (
+        node.attrs.get("retry_target")
+        or node.attrs.get("fallback_retry_target")
+        or graph.graph_attrs.get("retry_target")
+        or graph.graph_attrs.get("fallback_retry_target")
+    )
+    if target and target in graph.nodes:
+        return str(target)
+    return None
+
+
+def _check_gate_retry_budget_dead(graph: Graph, diags: list[Diagnostic]) -> None:
+    """TOPO-007: goal-gate retry budget structurally dead under loop_restart.
+
+    The engine bounds exit-time goal-gate retries with a budget
+    (``engine.py::_MAX_GOAL_GATE_RETRIES``, 50) — but every traversal of a
+    ``loop_restart`` edge resets that counter to zero (``run()`` Step 6),
+    which is the fresh-attempt semantics ledgered as ATX-12
+    (``specs/EXTENSIONS.md`` §24: a restart is an in-process stand-in for
+    terminate-and-relaunch, so per-run budgets start over).  The two
+    interact badly in one specific shape: when EVERY success-path walk from
+    the gate's retry target back to the exit crosses a ``loop_restart``
+    edge, the budget resets on every gate-retry cycle and can never bind.
+    The retry loop is then bounded only by the global step cap
+    (nodes × 50), the counter stays pinned at 1, and the author's
+    belt-and-suspenders budget is silently dead (issue #253).
+
+    Measured on the shipped engine (issue #253, 4-node reduction): without
+    ``loop_restart`` on the retry walk the gate executed 51 times and the
+    run stopped at the 50-retry budget ("Unsatisfied goal gates"); with
+    ``loop_restart`` on the retry walk the gate executed 66 times, the
+    retry counter never advanced past 1, and only the step cap (200) ended
+    the run.  The same shape shipped in ``objective-runner.dot`` until
+    PR #248 dropped its ``retry_target`` (its in-file note records 51/50
+    executions measured on a 5-node reduction; #248's review measured 67
+    on an 8-node one).
+
+    Detection is the success projection of the graph: drop ``loop_restart``
+    edges and failure-conditioned edges (``outcome=fail`` /
+    ``outcome=error`` / ``outcome!=success`` — the TOPO-006 classifier,
+    ``_condition_matches_fail``), then ask whether any exit node is
+    reachable from the retry target.  Context-conditioned and
+    success-conditioned edges stay in the projection — statically
+    unknowable routing counts as a live escape (conservative toward
+    silence).  If no exit is reachable AND the projected walk meets at
+    least one ``loop_restart`` edge, the budget is dead: whenever the
+    retried nodes succeed at their jobs, the walk crosses the resetting
+    edge before it can reach the exit's gate check again.
+
+    What this rule deliberately does NOT flag: the shipped convergence
+    pattern where ``loop_restart`` rides a fail-conditioned or iterate
+    back-edge (task-runner, 02-plan-implement-test, the capsule pipelines)
+    — there the forward success walk re-reaches the exit without a reset,
+    so the budget stays live for the exit-time retry loop even though an
+    explicit iterate cycle also exists.  A run that keeps CHOOSING the
+    iterate back-edge also keeps resetting the counter, but that cycle is
+    the author's declared iteration protocol — bounded by its own budget
+    wall per the design doctrine — not the gate-retry loop this budget
+    exists to bound.
+
+    Severity: WARNING — same reasoning as TOPO-006: the hazard is real and
+    was measured on a shipped graph, but run-time routing is not statically
+    provable, and the engine still terminates (at the step cap), so ERROR
+    would hard-fail deliberate designs.
+    """
+    loop_edges = [
+        e for e in graph.edges if resolve_bool_attr(e.loop_restart, "loop_restart")
+    ]
+    if not loop_edges:
+        return
+    exit_ids = {n.id for n in graph.nodes.values() if n.is_exit_node()}
+    if not exit_ids:
+        return
+
+    # Success projection: adjacency over edges that are neither
+    # loop_restart nor failure-conditioned.
+    projected: dict[str, list[str]] = {}
+    for e in graph.edges:
+        if resolve_bool_attr(e.loop_restart, "loop_restart"):
+            continue
+        cond = e.condition.strip() if e.condition else ""
+        if cond and _condition_matches_fail(cond):
+            continue
+        projected.setdefault(e.from_node, []).append(e.to_node)
+
+    for node in graph.nodes.values():
+        if not resolve_bool_attr(node.attrs.get("goal_gate"), "goal_gate"):
+            continue
+        retry_target = _effective_gate_retry_target(node, graph)
+        if retry_target is None:
+            continue
+
+        reachable = {retry_target}
+        stack = [retry_target]
+        while stack:
+            for nxt in projected.get(stack.pop(), []):
+                if nxt not in reachable:
+                    reachable.add(nxt)
+                    stack.append(nxt)
+
+        if reachable & exit_ids:
+            continue  # a reset-free success walk back to the exit exists
+
+        crossing = [e for e in loop_edges if e.from_node in reachable]
+        if not crossing:
+            continue  # projected retry walk never meets a resetting edge
+
+        edge = crossing[0]
+        diags.append(
+            Diagnostic(
+                rule="gate_retry_budget_dead",
+                severity="WARNING",
+                message=(
+                    f"Node '{node.id}' (goal_gate=true) retries from "
+                    f"'{retry_target}', but every success-path walk from "
+                    f"'{retry_target}' back to the exit crosses a "
+                    f"loop_restart edge ({edge.from_node} -> {edge.to_node}), "
+                    f"and loop_restart resets the goal-gate retry counter. "
+                    f"The {_GOAL_GATE_RETRY_BUDGET}-retry budget can never "
+                    f"bind: the retry loop is bounded only by the global "
+                    f"step cap (nodes × {_GOAL_GATE_RETRY_BUDGET}) "
+                    f"(TOPO-007)."
+                ),
+                node_id=node.id,
+                edge=(edge.from_node, edge.to_node),
+                fix=(
+                    "Point retry_target at a node whose success path reaches "
+                    "the exit without crossing a loop_restart edge, bound the "
+                    "loop_restart cycle with an explicit budget wall, or drop "
+                    "the retry_target if the gate's failure cause survives "
+                    "retries (the PR #248 resolution)"
+                ),
+            )
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/modules/loop-pipeline/tests/test_topological_lint.py
+++ b/modules/loop-pipeline/tests/test_topological_lint.py
@@ -1333,3 +1333,367 @@ class TestFailRoutedToExit:
             ],
         )
         assert not _diag(lint(g), "fail_routed_to_exit")
+
+
+# ---------------------------------------------------------------------------
+# TOPO-007: gate_retry_budget_dead
+# ---------------------------------------------------------------------------
+
+
+class TestGateRetryBudgetDead:
+    """TOPO-007: goal-gate retry budget structurally dead under loop_restart.
+
+    Issue #253.  ``loop_restart`` resets ``goal_gate_retries`` (engine.py,
+    run() Step 6) -- correct for ATX-12's fresh-attempt semantics, but when
+    EVERY success-path walk from the gate's retry target back to the exit
+    crosses a loop_restart edge, the budget resets on every gate-retry cycle
+    and can never bind: the loop is bounded only by the global step cap.
+
+    Measured on the shipped engine (4-node reduction): without loop_restart
+    the gate ran 51 times and stopped at the 50-retry budget; with
+    loop_restart on the retry walk it ran 66 times, the counter pinned at 1,
+    and only the step cap (nodes x 50 = 200) ended the run.
+    """
+
+    # -- hazard probes -------------------------------------------------------
+
+    def test_minimal_hazard_fires(self):
+        """Hazard probe: retry walk crosses a loop_restart edge -> fires,
+        names gate, retry target, and the resetting edge."""
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "work": _box("work", prompt="w"),
+                "gate": _box(
+                    "gate",
+                    prompt="g",
+                    attrs={"goal_gate": True, "retry_target": "work"},
+                ),
+                "done": _msquare("done"),
+            },
+            edges=[
+                Edge("start", "work"),
+                Edge("work", "gate", loop_restart=True),
+                Edge("gate", "done", condition="outcome=fail"),
+            ],
+        )
+        diags = _diag(lint(g), "gate_retry_budget_dead")
+        assert diags, "Expected gate_retry_budget_dead diagnostic"
+        d = diags[0]
+        assert d.severity == "WARNING"
+        assert d.node_id == "gate"
+        assert "work" in d.message
+        assert "loop_restart" in d.message
+        assert "step cap" in d.message
+
+    def test_objective_runner_reduction_fires(self):
+        """Hazard probe: the pre-#248 objective-runner shape.  The retry
+        target's only success-path edge is the loop_restart edge; a
+        fail-conditioned escape to the exit exists but does not keep the
+        budget alive.  Measured shape: evidence gate executed 67 times in an
+        8-node reduction (its retry target 66) before the step cap."""
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "triage": _tool("triage"),
+                "evidence_gate": Node(
+                    id="evidence_gate",
+                    shape="parallelogram",
+                    attrs={
+                        "tool_command": "./dod.sh",
+                        "goal_gate": True,
+                        "retry_target": "feedback",
+                    },
+                ),
+                "feedback": _box("feedback", prompt="teach the next attempt"),
+                "postmortem": _box("postmortem", prompt="salvage"),
+                "done": _msquare("done"),
+            },
+            edges=[
+                Edge("start", "triage"),
+                Edge("triage", "evidence_gate"),
+                Edge("evidence_gate", "done", condition="outcome=success"),
+                Edge("evidence_gate", "feedback", condition="outcome=fail"),
+                # iteration protocol: fresh attempt re-enters through triage
+                Edge("feedback", "triage", loop_restart=True),
+                # hard-failure escape reaches the exit WITHOUT loop_restart,
+                # but only on feedback's own failure -- the success walk
+                # still crosses the resetting edge every cycle.
+                Edge("feedback", "postmortem", condition="outcome=fail"),
+                Edge("postmortem", "done"),
+            ],
+        )
+        diags = _diag(lint(g), "gate_retry_budget_dead")
+        assert diags, "Expected gate_retry_budget_dead on the objective-runner shape"
+        assert diags[0].node_id == "evidence_gate"
+        assert "feedback" in diags[0].message
+
+    def test_graph_level_retry_target_fires(self):
+        """The engine resolves graph-level retry_target for gate retries
+        (node > node fallback > graph > graph fallback); a dead walk from a
+        graph-level target fires too."""
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "work": _box("work", prompt="w"),
+                "gate": _box("gate", prompt="g", attrs={"goal_gate": True}),
+                "done": _msquare("done"),
+            },
+            edges=[
+                Edge("start", "work"),
+                Edge("work", "gate", loop_restart=True),
+                Edge("gate", "done", condition="outcome=fail"),
+            ],
+            graph_attrs={"retry_target": "work"},
+        )
+        diags = _diag(lint(g), "gate_retry_budget_dead")
+        assert diags and diags[0].node_id == "gate"
+
+    def test_fallback_retry_target_fires(self):
+        """node fallback_retry_target is consulted when retry_target absent."""
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "work": _box("work", prompt="w"),
+                "gate": _box(
+                    "gate",
+                    prompt="g",
+                    attrs={"goal_gate": True, "fallback_retry_target": "work"},
+                ),
+                "done": _msquare("done"),
+            },
+            edges=[
+                Edge("start", "work"),
+                Edge("work", "gate", loop_restart=True),
+                Edge("gate", "done", condition="outcome=fail"),
+            ],
+        )
+        assert _diag(lint(g), "gate_retry_budget_dead")
+
+    # -- benign probes (the shipped-graph shapes) ----------------------------
+
+    def test_fail_backedge_silent(self):
+        """02-plan-implement-test shape: loop_restart rides the gate's own
+        fail-conditioned back-edge; the success walk implement -> gate ->
+        exit never crosses it.  The budget stays live -- silent."""
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "implement": _box("implement", prompt="i"),
+                "test_gate": Node(
+                    id="test_gate",
+                    shape="parallelogram",
+                    attrs={
+                        "tool_command": "pytest",
+                        "goal_gate": True,
+                        "retry_target": "implement",
+                    },
+                ),
+                "done": _msquare("done"),
+            },
+            edges=[
+                Edge("start", "implement"),
+                Edge("implement", "test_gate"),
+                Edge("test_gate", "done", condition="outcome=success"),
+                Edge(
+                    "test_gate",
+                    "implement",
+                    condition="outcome=fail",
+                    loop_restart=True,
+                ),
+            ],
+        )
+        assert not _diag(lint(g), "gate_retry_budget_dead")
+
+    def test_iterate_backedge_silent(self):
+        """task-runner shape: the loop_restart back-edge is the iteration
+        protocol (feedback -> attempt); the forward success walk attempt ->
+        gate -> exit is loop_restart-free -- silent."""
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "attempt": _box("attempt", prompt="a"),
+                "gate": Node(
+                    id="gate",
+                    shape="parallelogram",
+                    attrs={
+                        "tool_command": "check",
+                        "goal_gate": True,
+                        "retry_target": "attempt",
+                    },
+                ),
+                "feedback": _box("feedback", prompt="f"),
+                "done": _msquare("done"),
+            },
+            edges=[
+                Edge("start", "attempt"),
+                Edge("attempt", "gate"),
+                Edge("gate", "done", condition="outcome=success"),
+                Edge("gate", "feedback", condition="outcome=fail"),
+                Edge("feedback", "attempt", loop_restart=True),
+            ],
+        )
+        assert not _diag(lint(g), "gate_retry_budget_dead")
+
+    def test_no_loop_restart_silent(self):
+        """Same hazard topology minus loop_restart: the budget binds (measured
+        51 executions, then 'Unsatisfied goal gates') -- silent."""
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "work": _box("work", prompt="w"),
+                "gate": _box(
+                    "gate",
+                    prompt="g",
+                    attrs={"goal_gate": True, "retry_target": "work"},
+                ),
+                "done": _msquare("done"),
+            },
+            edges=[
+                Edge("start", "work"),
+                Edge("work", "gate"),
+                Edge("gate", "done", condition="outcome=fail"),
+            ],
+        )
+        assert not _diag(lint(g), "gate_retry_budget_dead")
+
+    def test_no_retry_target_silent(self):
+        """A gate with no effective retry target has no budget to kill --
+        silent here (goal_gate_has_retry owns that report)."""
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "work": _box("work", prompt="w"),
+                "gate": _box("gate", prompt="g", attrs={"goal_gate": True}),
+                "done": _msquare("done"),
+            },
+            edges=[
+                Edge("start", "work"),
+                Edge("work", "gate", loop_restart=True),
+                Edge("gate", "done", condition="outcome=fail"),
+            ],
+        )
+        assert not _diag(lint(g), "gate_retry_budget_dead")
+
+    def test_nonexistent_retry_target_silent(self):
+        """A retry target that is not a node is a different defect
+        (retry_target_exists owns it) -- silent here."""
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "work": _box("work", prompt="w"),
+                "gate": _box(
+                    "gate",
+                    prompt="g",
+                    attrs={"goal_gate": True, "retry_target": "ghost"},
+                ),
+                "done": _msquare("done"),
+            },
+            edges=[
+                Edge("start", "work"),
+                Edge("work", "gate", loop_restart=True),
+                Edge("gate", "done", condition="outcome=fail"),
+            ],
+        )
+        assert not _diag(lint(g), "gate_retry_budget_dead")
+
+    def test_context_conditioned_escape_silent(self):
+        """A context-conditioned escape (statically unknowable) counts as a
+        live walk to the exit -- conservative toward silence."""
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "work": _box("work", prompt="w"),
+                "router": _tool("router"),
+                "gate": _box(
+                    "gate",
+                    prompt="g",
+                    attrs={"goal_gate": True, "retry_target": "work"},
+                ),
+                "done": _msquare("done"),
+            },
+            edges=[
+                Edge("start", "work"),
+                Edge("work", "router"),
+                Edge("router", "gate", loop_restart=True),
+                Edge(
+                    "router",
+                    "done",
+                    condition="context.tool.last_line=exhausted",
+                ),
+                Edge("gate", "done", condition="outcome=fail"),
+            ],
+        )
+        assert not _diag(lint(g), "gate_retry_budget_dead")
+
+    def test_retry_target_dead_end_silent(self):
+        """If the projected retry walk never meets a loop_restart edge, this
+        rule has nothing to say (reachability/other rules own dead ends)."""
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "work": _box("work", prompt="w"),
+                "sink": _box("sink", prompt="s"),
+                "gate": _box(
+                    "gate",
+                    prompt="g",
+                    attrs={"goal_gate": True, "retry_target": "sink"},
+                ),
+                "done": _msquare("done"),
+            },
+            edges=[
+                Edge("start", "work"),
+                Edge("work", "gate", loop_restart=True),
+                Edge("gate", "done", condition="outcome=fail"),
+                Edge("sink", "sink2", condition="outcome=fail"),
+            ],
+        )
+        # sink's only edge is fail-conditioned; the projected walk from sink
+        # meets no loop_restart edge -> silent.
+        assert not _diag(lint(g), "gate_retry_budget_dead")
+
+    # -- enforcement ---------------------------------------------------------
+
+    def test_documented_budget_matches_engine(self):
+        """The diagnostic message mirrors the engine's budget constant
+        (importing engine from validation would create an import cycle);
+        this pin keeps the mirror honest."""
+        from amplifier_module_loop_pipeline.engine import PipelineEngine
+        from amplifier_module_loop_pipeline.validation import (
+            _GOAL_GATE_RETRY_BUDGET,
+        )
+
+        assert _GOAL_GATE_RETRY_BUDGET == PipelineEngine._MAX_GOAL_GATE_RETRIES
+
+    def test_calibration_zero_findings_on_shipped_graphs(self):
+        """Calibration: TOPO-007 is silent on every shipped graph.
+
+        The shipped corpus deliberately pairs goal_gate + retry_target with
+        loop_restart iterate back-edges (task-runner, the capsule pipelines,
+        02-plan-implement-test, 04-retry-with-fallback) -- a naive
+        coexistence rule would fire on all of them.  This sweep pins the
+        calibrated predicate: zero findings across examples/ and
+        .github/capsule-pipeline/.  Skips gracefully on installed-package
+        runs where the corpus is not present (the test_examples_lint_clean
+        precedent).
+        """
+        from pathlib import Path as _Path
+
+        import pytest as _pytest
+
+        from amplifier_module_loop_pipeline.dot_parser import parse_dot as _parse
+
+        repo_root = _Path(__file__).resolve().parents[3]
+        sweep_dirs = [repo_root / "examples", repo_root / ".github" / "capsule-pipeline"]
+        dot_files = [p for d in sweep_dirs if d.is_dir() for p in sorted(d.rglob("*.dot"))]
+        if not dot_files:
+            _pytest.skip("shipped corpus not present (installed-package run)")
+        fired: list[str] = []
+        for dot_path in dot_files:
+            graph = _parse(dot_path.read_text(encoding="utf-8"))
+            for d in _diag(lint(graph), "gate_retry_budget_dead"):
+                fired.append(f"{dot_path.relative_to(repo_root)}: {d.message}")
+        assert not fired, (
+            "TOPO-007 fired on shipped graphs (calibration regression):\n"
+            + "\n".join(fired)
+        )

--- a/modules/pipeline-runner/amplifier_module_pipeline_runner/cli.py
+++ b/modules/pipeline-runner/amplifier_module_pipeline_runner/cli.py
@@ -549,7 +549,7 @@ def cmd_lint(args: argparse.Namespace) -> int:
     """Static topological lint of a .dot pipeline file.
 
     Parses the DOT file and runs the full basin-lint rule set:
-    structural rules (LINT-001–018), topological rules (TOPO-001–006),
+    structural rules (LINT-001–018), topological rules (TOPO-001–007),
     and command-content rules (CMD-001–002, which inspect tool_command
     strings for pipe-masked exit codes and always-true sentinels).
 

--- a/skills/attractorify/SKILL.md
+++ b/skills/attractorify/SKILL.md
@@ -360,7 +360,7 @@ the objection's disposition recorded (`caveats:` line if unresolved). Then:
    ```
    bash -c "attractor lint <path>"
    ```
-   A `.dot` that fails `attractor lint` (TOPO-001 through TOPO-006, documented in
+   A `.dot` that fails `attractor lint` (TOPO-001 through TOPO-007, documented in
    `docs/DOT-AUTHORING-GUIDE.md`) is not a runnable artifact. Fix lint findings
    before handing back.
 
@@ -389,7 +389,7 @@ the objection's disposition recorded (`caveats:` line if unresolved). Then:
 
 - `docs/PIPELINE_DESIGN_PRINCIPLES.md` §0 — one-sentence rule, control-plane vs
   recipe-plane line, **three-question test**, design order
-- `docs/DOT-AUTHORING-GUIDE.md` — node contract, DOT syntax, TOPO-001..005 lint
+- `docs/DOT-AUTHORING-GUIDE.md` — node contract, DOT syntax, TOPO-001..007 lint
   rules, `attractor lint` CLI
 - `attractor:attractor-expert` — the consultable expert agent; delegate to it
   for any pipeline design or debugging question (source prompt:

--- a/specs/EXTENSIONS.md
+++ b/specs/EXTENSIONS.md
@@ -1724,6 +1724,15 @@ rules that reason about cycle structure and handler semantics rather than per-at
 - **TOPO-005** (`WARNING`) — a cycle whose continuation/exit rests solely on LLM say-so, with no
   deterministic (tool or human-gate) evidence gate on the cycle.
 
+*Addendum (2026-08-15): the family has since grown on the same advisory entry point —
+**TOPO-006** (`WARNING`, issue #173: failure outcome routed into the terminal success node) and
+**TOPO-007** (`WARNING`, issue #253: goal-gate retry budget structurally dead when every
+success-path walk from the gate's retry target back to the exit crosses a `loop_restart` edge,
+whose traversal resets the budget — the ATX-12 fresh-attempt semantics — leaving the loop bounded
+only by the step cap). Listed here so this entry stays the complete catalog of the `lint()`-only
+rule family; per this entry's own discriminator (the **entry point**, not the rule count), neither
+owed a new ledger entry. Both are documented in `docs/DOT-AUTHORING-GUIDE.md` with fix examples.*
+
 **Why a separate entry point, not folded into `validate()`:** the five TOPO rules are
 judgment calls about pipeline *design quality* (is this graph shaped like a converging
 attractor?), not about whether the graph is *executable*. `validate_or_raise()` — the


### PR DESCRIPTION
Fixes #253

## Probe: reproduction on the shipped engine (in-process, no LLM)

Minimal 4-node graph — `gate [goal_gate=true, retry_target=work]`, `gate -> done [condition="outcome=fail"]`, and the retry walk `work -> gate` optionally carrying `loop_restart=true`. Explicit-FAIL gate verdicts, so every cycle reaches the exit and takes the exit-time goal-gate retry path (`engine.py:690/:708`), the exact counter the issue names:

| variant | gate executions | goal-gate retry jumps | counter values seen | run ended by |
|---|---|---|---|---|
| control (no `loop_restart`) | **51** | 50 | 1..50 | the 50-retry budget: `Unsatisfied goal gates: ['gate']` |
| hazard (`loop_restart` on the retry walk) | **66** | 66 | **pinned at 1** | step cap only: `Pipeline exceeded 200 steps (safety bound): 4 nodes × 50` |

The counter never advancing past 1 is the smoking gun of the `engine.py:1302` reset. This independently confirms #248's review measurement (67 executions in an 8-node reduction, cap 400) and `objective-runner.dot`'s in-file note (51/50 on a 5-node reduction, where the budget and the cap coincide at 250). A second repro through the fail-closed §25 path (plain-text gate output → RETRY → failure routing) showed the sibling counter `failure_routing_retries` (`engine.py:1303`) equally affected: 99 gate executions vs 51 control.

## The spec's position (quoted)

- Canonical §3.2 step 1 retries an unsatisfied gate with **no counter at all**: `IF retry_target exists: current_node = graph.nodes[retry_target]; CONTINUE`. The 50-retry budget is already this engine's own safety addition beyond the spec.
- Canonical §2.7:177 defines the semantics the reset rides on: `loop_restart` — *"When `true`, terminates the current run and re-launches with a fresh log directory."* §3.2 step 7: `restart_run(...)` then `RETURN`. A relaunched run trivially has fresh per-run budgets.
- The spec says **nothing about retry-counter lifetime across a restart** — there is no counter in the spec to have a lifetime. That silence puts any change here in **Uncharted** territory under `docs/QUALITY_PROTOCOL.md` §3.
- ATX-12 (`SPEC_CONFORMANCE.md`, DECIDED — DIVERGE, ledgered at `specs/EXTENSIONS.md` §24) already records our `loop_restart` as an in-process stand-in for terminate-and-relaunch: completed nodes cleared, `$iteration` incremented, `context_updates` surviving. Resetting per-run budgets is the faithful shadow of the relaunch model the divergence deliberately mimics.

## The three-way decision

**(a) Engine fix (preserve `goal_gate_retries` across `loop_restart`) — ruled out on evidence.**
- Direction: it would diverge *further* from the spec's relaunch model (Drift tier — measured-safety toll, matrix row, loudness), for a hazard the step cap already bounds (both measured runaways were stopped by it).
- Shipped dependence: seven shipped graphs deliberately pair `goal_gate` + `retry_target` with `loop_restart` iterate back-edges (`.github/capsule-pipeline/capsule.dot` ×5 gates, `feature-capsule.dot`, `task-runner.dot` ×2 instances, `pipeline-author.dot`, `02-plan-implement-test.dot`, `04-retry-with-fallback.dot` ×2 — the latter documents the pairing as "belt-and-suspenders" in-file). A cumulative, never-refreshed budget of 50 kills any legitimate run whose author-bounded iteration protocol spends gate retries across >50 iterations — the fresh-attempt contract (EXTENSIONS §24: feedback accumulation, `$iteration` continuity, preserved context) is load-bearing for exactly those graphs.
- No test in the suite depends on the reset by name, but the semantics do: a restart **is** a fresh attempt.

**(b) Lint warning — yes, but calibrated.** The issue's literal candidate ("warn on `retry_target` + `loop_restart` coexistence") fires on all 7 shipped pairings above — over-broad, would train authors to ignore it. The measured hazard has a sharper structural signature: **the budget is dead** — every success-path walk from the gate's retry target back to the exit crosses a `loop_restart` edge, so the counter resets every cycle and can never bind. That predicate (success projection: drop `loop_restart` edges and `outcome=fail`-conditioned edges — TOPO-006's classifier — then test exit reachability from the retry target) fires on the measured hazard AND on the pre-#248 `objective-runner` shape (`retry_target="feedback"` restored: `feedback`'s only success-path edge is the `loop_restart` back-edge), and on **zero** shipped graphs.

**(c) Document — yes.** The interaction, the measured numbers, and the fix idioms now live in `docs/DOT-AUTHORING-GUIDE.md` (TOPO-007 section); `specs/EXTENSIONS.md` §32 gains a dated addendum keeping the `lint()`-family catalog complete.

**Decision: (b)+(c).** The engine's reset stands as the ATX-12-consistent fresh-attempt semantics; the hazard is an authoring shape, caught at authoring time.

## What shipped

- `validation.py`: `gate_retry_budget_dead` (**TOPO-007**, WARNING, `lint()`-only — `validate()`/`validate_or_raise()` untouched). Mirrors the engine's retry-target resolution (`_check_goal_gates`: node > node fallback > graph > graph fallback, real-node check) and reuses `_condition_matches_fail`. Context-conditioned escapes count as live — conservative toward silence.
- `tests/test_topological_lint.py`: 13 new tests — 4 hazard probes (RED before the rule existed: minimal shape, objective-runner reduction incl. the fail-conditioned escape that must NOT silence it, graph-level and fallback target resolution), 7 benign probes (the shipped shapes: fail back-edge, iterate back-edge, no-loop_restart, no-target, nonexistent-target, context-conditioned escape, dead-end walk), a budget-constant pin against `PipelineEngine._MAX_GOAL_GATE_RETRIES`, and a calibration sweep asserting zero findings across `examples/` + `.github/capsule-pipeline/`.
- Docs: `DOT-AUTHORING-GUIDE.md` TOPO-007 section + rule-range bumps (`cli.py`, `SKILL.md`, including one stale `TOPO-001..005` mention); `EXTENSIONS.md` §32 addendum.

## Calibration results

- Fires: synthetic hazard (measured 66-executions shape) → `('gate', 'work')`; pre-#248 `objective-runner.dot` with `retry_target="feedback"` restored → `('evidence_gate', 'feedback')`.
- Silent: **every** `.dot` in the repo (22 graphs with `loop_restart` edges and/or gated retry targets across `examples/`, `.github/capsule-pipeline/`, `tests/fixtures/`, `skills/`) — enforced by the new sweep test.
- End-to-end: `attractor lint` prints the WARNING with edge + fix, exits 0 (warning-only contract preserved).

## Tier classification (QUALITY_PROTOCOL §3) + toll

**Uncharted / extension.** Toll paid:
- *Why silence is not a signal:* the spec's gate-retry loop has no counter to interact with `loop_restart` (its restart is a process relaunch), so it cannot have an opinion on a budget×reset interaction that only exists in this engine's decided ATX-12 divergence — the hazard is native to our extension surface, and canonical §7.4 explicitly invites additional lint rules on that surface.
- *Additive and non-interfering:* `lint()`-only WARNING; zero engine behavior change; a spec-conformant graph behaves identically (proved by the full suite: loop-pipeline 2316 passed / 25 skipped, pipeline-runner 76 passed / 1 skipped, and the zero-findings sweep).
- *Ledger:* the advisory `lint()` entry point is already ledgered as `specs/EXTENSIONS.md` §32; per that entry's own recorded discriminator (the **entry point**, not the rule count — the TOPO-006 precedent), no new entry is owed. §32's catalog is updated in this PR so the ledger stays complete.

No conformance-matrix row: no DIVERGE disposition and no engine behavior change (the matrix's ATX-12 row continues to assert the reset semantics this PR deliberately leaves intact).

## Gates

- `modules/loop-pipeline`: `uv sync --extra remote && uv run pytest -q` → **2316 passed, 25 skipped**
- `modules/pipeline-runner`: **76 passed, 1 skipped**
- Conformance matrix, extensions-ledger integrity, engine-semantics doc guard, doc consistency, quality-protocol guard, examples-lint sweep: green
- `git diff --check` clean; leak scan of added lines clean

## Observations

- The parser's `_NodeAttrsProxy.get()` resolves promoted attrs (e.g. `retry_target`) to first-class fields, but `attrs.items()` does not include them — code iterating `attrs` directly (rather than `.get()`) silently misses promoted attributes. Everything engine/validation-side uses `.get()` today, so no defect to file, but it is a trap for future rules; noted here for the record.
- `skills/attractorify/SKILL.md` carried a stale `TOPO-001..005` range from before TOPO-006; bumped in passing.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)
