### PR TITLE
fix(examples): route the four exemplars' loud terminals to their exit node

### DIFF
--- a/examples/authoring/check_authored_pipeline.py
+++ b/examples/authoring/check_authored_pipeline.py
@@ -428,6 +428,65 @@ def _is_failure_condition(condition: str) -> bool:
     return bool(_IS_FAIL_RE.search(condition) or _NOT_SUCCESS_RE.search(condition))
 
 
+#: The last statement of a command that ends the process nonzero, deliberately.
+#: Anchored at the end because what matters is the EXIT STATUS THE NODE LEAVES
+#: WITH -- an `exit 1` on some interior branch says nothing about the others.
+_TERMINAL_NONZERO_EXIT_RE = re.compile(r"(?:^|;|&&|\|\||\n)\s*exit\s+[1-9][0-9]*\s*;?\s*$")
+
+
+def _is_loud_terminal(graph: DotGraph, node_id: str) -> bool:
+    """Is this node a DESIGNED LOUD TERMINAL, whose own FAIL becomes the status?
+
+    A8's hazard is a failure being CONVERTED into a successful run -- classically
+    by putting one succeeding bookkeeping step (a recorder, a notifier, a
+    cleanup) between the failed gate and the exit, so the run's final status
+    comes from that step and not from the failure.  There is exactly one shape
+    where routing a failure into the exit does NOT do that, and the engine
+    settles it: at the exit node, with every goal gate satisfied,
+    ``_check_goal_gates()`` returns ``node_outcomes[completed_nodes[-1]]`` -- the
+    LAST COMPLETED node's outcome.  So if the node that routes into the exit is
+    itself the last thing that runs and it exits nonzero, the run's status IS
+    that failure: ``status=fail``, CLI exit 1.  That is the convergence-factory
+    idiom -- "a budget-exhaustion exit that deliberately ends at the single exit
+    node with a genuine FAIL outcome" (docs/DOT-AUTHORING-GUIDE.md, TOPO-006),
+    shipped in ``examples/patterns/convergence-factory.dot`` and adopted by
+    ``examples/objective/objective-runner.dot`` in #248 -- and it is the ONLY
+    way a deliberately loud terminal can exist on this engine at all, because
+    the main loop has no designed-terminus concept: a terminal that dead-ends
+    is reported as PIPELINE_ERROR ``error_type=no_matching_edge`` (issue #252).
+
+    Blocking it was therefore not strictness, it was a miscalibration: A8
+    rejected the repo's own merged flagship.  A gate that rejects
+    ``objective-runner.dot`` is a wrong gate, not a strict one -- the same rule
+    this contract's calibration suite applies to ``task-runner.dot``.
+
+    The exemption is deliberately narrow, so it cannot be worn as a costume by
+    the shape A8 exists to catch.  ALL FOUR must hold:
+
+    1. It is a TOOL node.  A worker's "failure" is a provider verdict, not a
+       process exit status; only a shell command can guarantee the exit code.
+    2. Its command's LAST statement exits NONZERO -- so it fails on EVERY path,
+       not just some branch.  A node that can exit 0 could hand the exit a
+       SUCCESS and turn the escalation green: precisely the A8 hazard.
+    3. ``max_retries=0``.  The failure is the point, not a flake to retry.
+    4. The edge into the exit is its ONLY outgoing edge.  A node with somewhere
+       else to go is a step on a path, and a step on a path is the bookkeeping
+       intermediary A8 is looking for.
+
+    A recorder that exits 0, a notifier with a second route, or an LLM node all
+    still block -- see the mutation tests in ``test_authoring_layer_gates.py``.
+    """
+    if not _is_tool(graph, node_id):
+        return False
+    command = graph.attr(graph_node_id := node_id, "tool_command")
+    if not command or not _TERMINAL_NONZERO_EXIT_RE.search(command.strip()):
+        return False
+    if graph.attr(graph_node_id, "max_retries").strip().strip('"') != "0":
+        return False
+    outgoing = graph.outgoing(node_id)
+    return len(outgoing) == 1 and _is_exit(graph, outgoing[0].dst)
+
+
 def _is_truthy(value: str) -> bool:
     return value.strip().strip('"').lower() in ("true", "1", "yes", "on")
 
@@ -726,7 +785,18 @@ def run_checks(graph: DotGraph, companion: Path | None) -> list[CheckResult]:
     # and that path is the one a bad day will find.
     if len(exits) == 1 and starts:
         exit_id = exits[0]
-        bypass = exit_id in _reachable(graph, starts, blocked=set(gates))
+        # Designed loud terminals are blocked alongside the gates. A4 asks
+        # whether the run can FINISH WITHOUT EVIDENCE; a loud terminal cannot
+        # finish at all in the sense A4 means -- it is the last node to
+        # complete, it exits nonzero, and the exit therefore returns its FAIL
+        # (status=fail, CLI exit 1). Counting that as a "bypass" would mean
+        # the only shape in which a deliberately red terminal can exist on this
+        # engine (see _is_loud_terminal) is also the shape A4 forbids, which
+        # would leave an author with no legal way to fail loudly at all.
+        # The green door is unchanged: every path that ends SUCCESSFULLY still
+        # has to pass a gate, which is the whole of what A4 was protecting.
+        loud = {n for n in graph.nodes if _is_loud_terminal(graph, n)}
+        bypass = exit_id in _reachable(graph, starts, blocked=set(gates) | loud)
         results.append(
             CheckResult(
                 "A4",
@@ -842,7 +912,9 @@ def run_checks(graph: DotGraph, companion: Path | None) -> list[CheckResult]:
     fail_to_exit = sorted(
         f"{e.src} -> {e.dst} [condition={e.attrs.get('condition', '')!r}]"
         for e in graph.edges
-        if _is_exit(graph, e.dst) and _is_failure_condition(e.attrs.get("condition", ""))
+        if _is_exit(graph, e.dst)
+        and _is_failure_condition(e.attrs.get("condition", ""))
+        and not _is_loud_terminal(graph, e.src)
     )
     results.append(
         CheckResult(
@@ -855,7 +927,13 @@ def run_checks(graph: DotGraph, companion: Path | None) -> list[CheckResult]:
                 if not fail_to_exit
                 else " -- this converts a failure into a successful run. A failure belongs on a "
                 "salvage path (postmortem, escalation) that ends LOUD, not through the success "
-                "door. The engine's own lint calls this TOPO-006 and warns; here it blocks"
+                "door. The engine's own lint calls this TOPO-006 and warns; here it blocks. "
+                "The ONE exemption is a designed loud terminal: a tool node with max_retries=0 "
+                "whose command's last statement exits nonzero and whose only outgoing edge is "
+                "this one. It is then the last node to complete, so the exit returns ITS fail "
+                "and the run ends status=fail / exit 1 -- the convergence-factory idiom, and "
+                "the only way a loud terminal can exist on an engine whose main loop reports a "
+                "dead end as no_matching_edge"
             ),
         )
     )

--- a/examples/authoring/check_authored_pipeline.py
+++ b/examples/authoring/check_authored_pipeline.py
@@ -461,7 +461,7 @@ def _is_loud_terminal(graph: DotGraph, node_id: str) -> bool:
     this contract's calibration suite applies to ``task-runner.dot``.
 
     The exemption is deliberately narrow, so it cannot be worn as a costume by
-    the shape A8 exists to catch.  ALL FOUR must hold:
+    the shape A8 exists to catch.  ALL FIVE must hold:
 
     1. It is a TOOL node.  A worker's "failure" is a provider verdict, not a
        process exit status; only a shell command can guarantee the exit code.
@@ -472,9 +472,22 @@ def _is_loud_terminal(graph: DotGraph, node_id: str) -> bool:
     4. The edge into the exit is its ONLY outgoing edge.  A node with somewhere
        else to go is a step on a path, and a step on a path is the bookkeeping
        intermediary A8 is looking for.
+    5. That edge carries a FAILURE CONDITION (``outcome=fail`` /
+       ``outcome!=success``).  Clauses 1-4 are read off the TEXT of the graph,
+       and clause 2 is the weakest of them: the regex matches the *shape* of a
+       terminal ``exit 1``, which a command like ``rm -f scratch.tmp || exit 1``
+       wears while exiting 0 at runtime.  Wired to the exit UNCONDITIONALLY,
+       such a node is not a loud terminal at all -- it is an ungated fast path
+       to a GREEN finish, and blocking it in A4 would launder exactly the
+       evidence-free finish A4 exists to catch.  The condition is what makes
+       this exemption RUNTIME-SOUND rather than textual: an edge that only
+       fires on ``outcome=fail`` can never carry a SUCCESS into the exit,
+       whatever the command turns out to do.  Every shipped exemplar terminal
+       and ``objective-runner.dot`` already route on ``condition="outcome=fail"``.
 
-    A recorder that exits 0, a notifier with a second route, or an LLM node all
-    still block -- see the mutation tests in ``test_authoring_layer_gates.py``.
+    A recorder that exits 0, a notifier with a second route, an LLM node, or a
+    node whose edge into the exit is unconditional all still block -- see the
+    mutation tests in ``test_authoring_layer_gates.py``.
     """
     if not _is_tool(graph, node_id):
         return False
@@ -484,7 +497,11 @@ def _is_loud_terminal(graph: DotGraph, node_id: str) -> bool:
     if graph.attr(graph_node_id, "max_retries").strip().strip('"') != "0":
         return False
     outgoing = graph.outgoing(node_id)
-    return len(outgoing) == 1 and _is_exit(graph, outgoing[0].dst)
+    return (
+        len(outgoing) == 1
+        and _is_exit(graph, outgoing[0].dst)
+        and _is_failure_condition(outgoing[0].attrs.get("condition", ""))
+    )
 
 
 def _is_truthy(value: str) -> bool:

--- a/examples/authoring/pipeline-author.dot
+++ b/examples/authoring/pipeline-author.dot
@@ -79,13 +79,51 @@
 //     goal and run id only. It never sees the author's reasoning about why the
 //     graph was right; it sees the artifact and the two gate reports. That
 //     isolation is the property being purchased, not an optimisation.
-//   - ONE GREEN EXIT. `validate_or_raise` requires exactly one exit node, so the
-//     two honest terminals are `done` (Msquare, reachable only through
-//     `finalize`, which refuses to open without a disposition artifact) and
-//     `escalated` (a tool node that exits 1 with max_retries=0 and no
-//     fail-route -- the bug-fix.dot idiom, a LOUD red).
+//   - ONE EXIT NODE, TWO HONEST TERMINALS. `validate_or_raise` requires exactly
+//     one exit node, so BOTH terminals reach it: `done` opens GREEN only
+//     through `finalize` (which refuses to open without a disposition
+//     artifact), and RED only through `escalated`, whose own nonzero exit
+//     becomes the run's status. That is the convergence-factory.dot idiom --
+//     "a budget-exhaustion exit that deliberately ends at the single exit node
+//     with a genuine FAIL outcome" (docs/DOT-AUTHORING-GUIDE.md, TOPO-006) --
+//     and it is why this file consciously carries ONE TOPO-006 WARNING, for the
+//     same reason and in the same way examples/objective/objective-runner.dot
+//     and examples/patterns/convergence-factory.dot do. Letting `escalated`
+//     dead-end instead does NOT work: see the engine semantics below.
 //
 // VERIFIED ENGINE SEMANTICS THIS FILE DEPENDS ON:
+//   - THE MAIN LOOP HAS NO DESIGNED-TERMINUS CONCEPT. `run_subgraph()`
+//     distinguishes "no outgoing edges at all" (a designed terminus) from a
+//     conditional-mismatch dead end; `run()` does NOT. Any node the main loop
+//     finishes with no matching outgoing edge -- WHATEVER its exit status --
+//     terminates through `terminate_pipeline()` and emits PIPELINE_ERROR
+//     `error_type=no_matching_edge`. Measured on the shipped CLI against this
+//     very file before the `escalated -> done` edge below existed: a blocked
+//     preflight produced `[PIPELINE] X Error at escalated (no_matching_edge)`
+//     and `notes: No matching edge from node 'escalated'` -- the graph's most
+//     important honest outcome reported in the vocabulary of an authoring bug
+//     (issue #252; issue #243 defect (a), fixed in objective-runner.dot by
+//     #248).
+//   - AT THE EXIT NODE, WITH EVERY GOAL GATE SATISFIED, THE RUN'S STATUS IS THE
+//     LAST COMPLETED NODE'S OUTCOME (`engine.py::_check_goal_gates` ->
+//     `node_outcomes[completed_nodes[-1]]`). That is the whole mechanism behind
+//     `escalated -> done [outcome=fail]`: `escalated`'s own nonzero exit becomes
+//     the run's status=fail / CLI exit 1, with no routing error.
+//   - GOAL-GATE COROLLARY, AND THE REASON `verdict_gate` CARRIES NO
+//     `retry_target`: `retry_target` on a goal gate is consulted in exactly one
+//     place -- `_check_goal_gates()` AT THE EXIT NODE. While `escalated`
+//     dead-ended, the exit was unreachable with `verdict_gate` red, so the
+//     attribute was dead. Routing `escalated` to `done` makes it reachable,
+//     which turns the attribute live and wrong: an escalation that already
+//     wrote its postmortem and its handoff would be sent back to `author` for
+//     another paid iteration, with `completed_nodes` cleared. Measured on the
+//     shipped engine with a faithful reduction of this shape: with the
+//     attribute present the retry target, the gate and the loud terminal each
+//     executed 51 times before the step cap; with it removed, once each.
+//     `verdict_gate`'s teeth are unchanged -- an unsatisfied goal gate at the
+//     exit is still a hard FAIL, and its `loop_restart` back-edge to `author`
+//     is still the corrective loop (which is also why `goal_gate_has_retry`
+//     stays quiet here).
 //   - STALE-LABEL RULE: a tool node that exits nonzero does NOT refresh
 //     tool.last_line, so a stale label can match at the same time as an
 //     outcome=fail edge. Every last_line edge below whose source also carries a
@@ -259,9 +297,21 @@ digraph PipelineAuthor {
     // deliberately so goal_gate=true has real teeth here rather than being a
     // declaration: a red verdict is a genuine FAIL the engine's exit-time check
     // can see.
+    // ON THE ABSENCE OF retry_target, HONESTLY: the corrective loop for a red
+    // verdict is the `loop_restart` back-edge to `author` below -- that is what
+    // actually iterates, and it is what keeps `goal_gate_has_retry` satisfied.
+    // `retry_target` is a DIFFERENT mechanism: it is consulted only by
+    // `_check_goal_gates()` at the exit node, and it means "if this gate is
+    // unsatisfied when the run tries to leave, go back to X instead." While
+    // `escalated` dead-ended, the exit was unreachable with this gate red, so
+    // the attribute was dead. `escalated -> done` makes it reachable, which
+    // turns it live and wrong -- an escalation that has already written its
+    // postmortem and its handoff would be sent back to `author` to be paid for
+    // again, with `completed_nodes` cleared. See the goal-gate corollary in the
+    // engine-semantics list at the top of this file for the measurement.
     verdict_gate [
         shape=parallelogram, class="gate", label="Ship or Iterate?", max_retries=0,
-        goal_gate=true, retry_target="author",
+        goal_gate=true,
         tool_command="n=$(cat .authoring/iter 2>/dev/null || echo 0); v=noverdict; if [ -s .authoring/critique.md ]; then tail -n 1 .authoring/critique.md > .authoring/verdict-line.txt; if grep -qix 'VERDICT: SHIP' .authoring/verdict-line.txt; then v=ship; elif grep -qix 'VERDICT: ITERATE' .authoring/verdict-line.txt; then v=iterate; fi; fi; printf '{\"iteration\": %s, \"gate\": \"critique\", \"verdict\": \"%s\"}\\n' \"$n\" \"$v\" >> .authoring/convergence.jsonl; if [ \"$v\" = ship ]; then printf ship; else echo \"critique verdict: $v -- another iteration\" >&2; printf %s \"$v\"; exit 1; fi"
     ]
 
@@ -297,8 +347,11 @@ digraph PipelineAuthor {
     ]
 
     // Deterministic salvage terminal. Writes a handoff even when the postmortem
-    // node itself failed, then exits 1 DELIBERATELY: max_retries=0 and no
-    // fail-route, so the engine hard-fails LOUD (run status=fail, CLI exit 1).
+    // node itself failed, then exits 1 DELIBERATELY (max_retries=0), and ROUTES
+    // that nonzero exit to the single exit node -- see the last edge in this
+    // file. It does NOT dead-end: the main loop has no designed-terminus
+    // concept, so a dead-ended terminal is reported as PIPELINE_ERROR
+    // `no_matching_edge`, not as the loud red it is.
     escalated [
         shape=parallelogram, class="glue", label="Escalated", max_retries=0,
         tool_command="mkdir -p .authoring/postmortem; if [ -s .authoring/postmortem/report.md ]; then echo 'Read .authoring/postmortem/report.md and .authoring/convergence.jsonl, then choose: change the brief, raise the budget, redirect instead, or take it to a human.' > .authoring/postmortem/escalation.md; else echo 'Postmortem could not be produced. Preserve the run logs and escalate to a human.' > .authoring/postmortem/escalation.md; fi; echo escalated > .authoring/disposition; printf escalated; exit 1"
@@ -356,4 +409,26 @@ digraph PipelineAuthor {
 
     postmortem -> escalated [condition="outcome=fail", label="postmortem failed"]
     postmortem -> escalated [label="escalate"]
+
+    // ...and then the loud terminal ROUTES to the single exit node CARRYING its
+    // nonzero exit. Without this edge `escalated` dead-ends, and the main loop
+    // -- which has no designed-terminus concept -- reports this graph's most
+    // important honest outcome in the vocabulary of an authoring bug:
+    // `[PIPELINE] X Error at escalated (no_matching_edge)`, with the run's
+    // machine-readable `notes` reading "No matching edge from node
+    // 'escalated'". With it, `_check_goal_gates` returns the LAST COMPLETED
+    // node's outcome -- `escalated`'s own FAIL -- so the run ends status=fail /
+    // CLI exit 1 with no routing error, and `.authoring/disposition` =
+    // escalated says which terminal it was. `escalated` exits nonzero on EVERY
+    // path, so `outcome=fail` is the total case, not a partial one.
+    // THE ONE TOPO-006 WARNING THIS FILE CARRIES IS THIS EDGE, ON PURPOSE: "a
+    // budget-exhaustion exit that deliberately ends at the single exit node
+    // with a genuine FAIL outcome" is the named, sanctioned deliberate design
+    // (docs/DOT-AUTHORING-GUIDE.md, TOPO-006), and objective-runner.dot and
+    // convergence-factory.dot carry the identical diagnostic for the identical
+    // reason. The hazard the rule guards -- a failure leaving through the
+    // success door as `status: success`, exit 0 -- cannot happen here:
+    // `escalated` is the last node to complete and its FAIL is what the exit
+    // returns.
+    escalated -> done [condition="outcome=fail", label="loud exit -- status is escalated's own nonzero exit"]
 }

--- a/examples/drift-review/drift-review.dot
+++ b/examples/drift-review/drift-review.dot
@@ -65,9 +65,14 @@
 //     repairs unshaped findings ($max_revisions); consolidate <-> report_gate
 //     repairs a report that dropped an admitted finding ($max_reports). Both
 //     counters are files owned by the gates, so they survive every re-entry.
-//   - ONE GREEN EXIT. `done` is reachable only through `report_gate`, which
-//     re-derives the finding ids from findings.json and refuses to open if the
-//     report is missing any of them.
+//   - ONE EXIT NODE, TWO HONEST TERMINALS. `done` opens GREEN only through
+//     `report_gate`, which re-derives the finding ids from findings.json and
+//     refuses to open if the report is missing any of them. It opens RED only
+//     through `escalated`, whose own nonzero exit becomes the run's status --
+//     the convergence-factory.dot idiom, "a budget-exhaustion exit that
+//     deliberately ends at the single exit node with a genuine FAIL outcome"
+//     (docs/DOT-AUTHORING-GUIDE.md, TOPO-006). Letting `escalated` dead-end
+//     instead does NOT work: see the engine semantics below.
 //
 // WHY THE BACK-EDGES DO NOT CARRY loop_restart: both cycles re-enter a GATE to
 // re-judge an artifact that was just repaired, not a fresh attempt at the whole
@@ -91,6 +96,35 @@
 //     The shell variables here (rd, f, c, t, n, B, mr, mv, id, fc, miss) are
 //     safe only because no param shares their name. Never add a param named
 //     like a shell var.
+//   - THE MAIN LOOP HAS NO DESIGNED-TERMINUS CONCEPT. `run_subgraph()`
+//     distinguishes "no outgoing edges at all" (a designed terminus) from a
+//     conditional-mismatch dead end; `run()` does NOT. Any node the main loop
+//     finishes with no matching outgoing edge -- WHATEVER its exit status --
+//     terminates through `terminate_pipeline()` and emits PIPELINE_ERROR
+//     `error_type=no_matching_edge`. Measured on the shipped CLI against this
+//     very file before the `escalated -> done` edge existed: a blocked
+//     preflight produced `[PIPELINE] X Error at escalated (no_matching_edge)`
+//     and `notes: No matching edge from node 'escalated'` -- this graph's most
+//     important honest outcome reported in the vocabulary of an authoring bug
+//     (issue #252; issue #243 defect (a), fixed in objective-runner.dot by
+//     #248).
+//   - AT THE EXIT NODE, WITH EVERY GOAL GATE SATISFIED, THE RUN'S STATUS IS THE
+//     LAST COMPLETED NODE'S OUTCOME (`engine.py::_check_goal_gates` ->
+//     `node_outcomes[completed_nodes[-1]]`). That is the whole mechanism behind
+//     `escalated -> done [outcome=fail]`: `escalated`'s own nonzero exit becomes
+//     the run's status=fail / CLI exit 1, with no routing error.
+//   - GOAL-GATE COROLLARY, AND THE REASON `report_gate` CARRIES NO
+//     `retry_target`: `retry_target` on a goal gate is consulted in exactly one
+//     place -- `_check_goal_gates()` AT THE EXIT NODE. While `escalated`
+//     dead-ended, the exit was unreachable with `report_gate` unsatisfied, so
+//     the attribute was dead. Routing `escalated` to `done` makes it reachable
+//     -- `report_gate -> escalated [outcome=fail]` is the shortest path in this
+//     graph -- which turns the attribute live and wrong. Measured on the
+//     shipped engine with a faithful reduction of exactly that shape: with
+//     retry_target="consolidate" the `no_corpus` path executed `consolidate`,
+//     `report_gate` and `escalated` 51 times each before the step cap; with the
+//     attribute removed, once each. `no_corpus` means the findings gate never
+//     admitted a corpus -- a cause no number of re-consolidations can change.
 // ============================================================================
 
 digraph DriftReview {
@@ -260,9 +294,18 @@ digraph DriftReview {
     // examples/objective/objective-runner.dot records about its evidence_gate.
     // The enforcement that really holds is structural: `done` has exactly one
     // incoming edge and it is this node's report_ok.
+    // ON THE ABSENCE OF retry_target, HONESTLY: the corrective loop for a report
+    // that dropped a finding is the `report_bad` edge back to `consolidate`
+    // below -- that is what actually iterates, and its wall is $max_reports.
+    // `retry_target` is a DIFFERENT mechanism, consulted only by
+    // `_check_goal_gates()` at the exit node; see the goal-gate corollary at
+    // the top of this file for why it is now a hazard rather than a spare tyre.
+    // Consequence, stated plainly: this node carries a deliberate
+    // `goal_gate_has_retry` WARNING, exactly as objective-runner.dot's
+    // evidence_gate does, for the same reason.
     report_gate [
         shape=parallelogram, label="Report Complete?", max_retries=0,
-        goal_gate=true, retry_target="consolidate",
+        goal_gate=true,
         tool_command="mr=$max_reports; B=${mr:-2}; n=$(($(cat .drift-review/report-iter 2>/dev/null || echo 0)+1)); echo $n > .drift-review/report-iter; if [ ! -s .drift-review/findings.json ]; then echo 'FATAL: .drift-review/findings.json is absent -- the findings gate never admitted a corpus, so there is nothing to report on' >&2; printf no_corpus; exit 1; fi; if [ ! -s .drift-review/coverage.txt ]; then echo 'FATAL: .drift-review/coverage.txt is absent -- the findings gate writes it beside findings.json on admission, and without it this gate cannot check that report.md carries the coverage that was measured' >&2; printf no_corpus; exit 1; fi; fc=$(grep -o '\"finding_count\": [0-9]*' .drift-review/findings.json | head -1 | tr -cd '0-9'); if [ \"${fc:-0}\" -gt 0 ]; then echo findings > .drift-review/disposition; else echo clean > .drift-review/disposition; fi; : > .drift-review/report-gate.txt; miss=0; if [ ! -s .drift-review/report.md ]; then echo 'report.md is missing or empty' >> .drift-review/report-gate.txt; miss=1; else for id in $(grep -o '\"id\": \"[^\"]*\"' .drift-review/findings.json | cut -d'\"' -f4); do grep -qF \"$id\" .drift-review/report.md || { echo \"admitted finding $id never appears in report.md\" >> .drift-review/report-gate.txt; miss=1; }; done; for c in core-docs examples guidance ledgers; do grep -qF \"$c\" .drift-review/report.md || { echo \"report.md never names the swept surface class $c\" >> .drift-review/report-gate.txt; miss=1; }; done; while IFS= read -r cl; do [ -n \"$cl\" ] || continue; grep -qF \"$cl\" .drift-review/report.md || { echo \"report.md never carries the measured coverage line: $cl -- the swept number in the deliverable must be the one check_findings.py reconciled against the inventory\" >> .drift-review/report-gate.txt; miss=1; }; done < .drift-review/coverage.txt; fi; if [ \"$miss\" -eq 0 ]; then printf report_ok; elif [ \"$n\" -gt \"$B\" ]; then printf report_exhausted; else printf report_bad; fi"
     ]
 
@@ -273,10 +316,12 @@ digraph DriftReview {
         prompt="This Layer-3 review reached a decision point without producing a report: $goal\n\nRead .drift-review/findings-report.txt, .drift-review/report-gate.txt (if it exists), .drift-review/inventory/summary.txt, and whatever is in .drift-review/raw/. Write .drift-review/postmortem/report.md: which stage stalled, what each round attempted, and -- specifically -- whether the failure was in the REVIEWERS (could not cite what they claimed), in the CONTRACT (the shape rules reject findings that are actually sound), in the MACHINERY (a gate or the inventory), or in the SCOPE (the classes are too large for one pass). Then state the options: relax nothing, but say whether to re-run, re-scope, raise a budget, or take it to a human.\n\nBe honest, and be specific about what was salvageable: if some classes produced admitted findings and one did not, say which, because a partial sweep is worth more to a human than a discarded run. This report is the value salvaged from a non-converging review."
     ]
 
-    // Escalation is a deterministic non-terminal handoff, not a second
-    // successful exit. It writes a handoff even if the postmortem LLM itself
-    // failed, then exits 1 DELIBERATELY: max_retries=0 and no fail-route, so
-    // the engine hard-fails LOUD (run status=fail, CLI exit 1).
+    // Escalation is a deterministic handoff, not a second successful exit. It
+    // writes a handoff even if the postmortem LLM itself failed, then exits 1
+    // DELIBERATELY (max_retries=0), and ROUTES that nonzero exit to the single
+    // exit node -- see the last edge in this file. It does NOT dead-end: the
+    // main loop has no designed-terminus concept, so a dead-ended terminal is
+    // reported as PIPELINE_ERROR `no_matching_edge`, not as the loud red it is.
     escalated [
         shape=parallelogram, label="Escalated", max_retries=0,
         tool_command="mkdir -p .drift-review/postmortem; if [ -s .drift-review/postmortem/report.md ]; then echo 'Read .drift-review/postmortem/report.md and .drift-review/findings-report.txt, then choose: re-run, re-scope the classes, raise a budget, or review by hand.' > .drift-review/postmortem/escalation.md; else echo 'The Layer-3 review could not run. Preserve .drift-review/ and escalate to a human.' > .drift-review/postmortem/escalation.md; fi; echo escalated > .drift-review/disposition; printf escalated; exit 1"
@@ -322,4 +367,22 @@ digraph DriftReview {
 
     postmortem -> escalated [condition="outcome=fail", label="postmortem failed"]
     postmortem -> escalated [label="escalate"]
+
+    // ...and then the loud terminal ROUTES to the single exit node CARRYING its
+    // nonzero exit. Without this edge `escalated` dead-ends and the main loop
+    // reports `[PIPELINE] X Error at escalated (no_matching_edge)`, with the
+    // run's machine-readable `notes` reading "No matching edge from node
+    // 'escalated'" -- an authoring-bug vocabulary for the review's most
+    // important honest outcome. With it, the run ends status=fail / CLI exit 1
+    // with no routing error, and `.drift-review/disposition` = escalated says
+    // which terminal it was. `escalated` exits nonzero on EVERY path, so
+    // `outcome=fail` is the total case, not a partial one.
+    // THE ONE TOPO-006 WARNING THIS FILE CARRIES IS THIS EDGE, ON PURPOSE: "a
+    // budget-exhaustion exit that deliberately ends at the single exit node
+    // with a genuine FAIL outcome" is the named, sanctioned deliberate design
+    // (docs/DOT-AUTHORING-GUIDE.md, TOPO-006). The hazard the rule guards -- a
+    // failure leaving through the success door as `status: success`, exit 0 --
+    // cannot happen here: `escalated` is the last node to complete and its FAIL
+    // is what the exit returns.
+    escalated -> done [condition="outcome=fail", label="loud exit -- status is escalated's own nonzero exit"]
 }

--- a/examples/patterns/task-runner.dot
+++ b/examples/patterns/task-runner.dot
@@ -45,6 +45,13 @@
 //     No diamond+outcome= routing (dead-edge trap). Cheap gate (DoD script)
 //     before expensive gate (LLM critique). goal_gate on both gates makes
 //     the exit unearnable without evidence.
+//   - ONE EXIT NODE, THREE HONEST TERMINALS. `done` opens GREEN only through
+//     ship_check, and RED through `bad_input` (the run was never given a
+//     runnable task) or `abandon` (the human gate chose to stop). All three
+//     ROUTE to the single exit node; the two red ones carry their own nonzero
+//     exit, which becomes the run's status. That is the convergence-factory
+//     idiom, and the reason this file consciously carries TWO TOPO-006
+//     warnings (see the last edges in this file).
 //
 // VERIFIED ENGINE SEMANTICS THIS FILE DEPENDS ON (see task-runner.md):
 //   - STALE-LABEL RULE: a failing tool node does NOT refresh tool.last_line
@@ -74,6 +81,63 @@
 //   - On a human-gate timeout/auto-approve, the FIRST edge is chosen:
 //     Abandon is listed first so unattended runs fail safe (honest FAIL +
 //     postmortem) instead of looping on budget bumps.
+//   - THE MAIN LOOP HAS NO DESIGNED-TERMINUS CONCEPT. `run_subgraph()`
+//     distinguishes "no outgoing edges at all" (a designed terminus) from a
+//     conditional-mismatch dead end; `run()` does NOT. Any node the main
+//     loop finishes with no matching outgoing edge — WHATEVER its exit
+//     status — terminates through `terminate_pipeline()` and emits
+//     PIPELINE_ERROR `error_type=no_matching_edge`. Measured on the shipped
+//     CLI against this very file before the terminal edges below existed: a
+//     missing task_file produced `[PIPELINE] X Error at bad_input
+//     (no_matching_edge)` and `notes: No matching edge from node
+//     'bad_input'` — a plain "you did not give me a task" reported in the
+//     vocabulary of an authoring bug (issue #252; issue #243 defect (a),
+//     fixed in objective-runner.dot by #248).
+//   - AT THE EXIT NODE, WITH EVERY GOAL GATE SATISFIED, THE RUN'S STATUS IS
+//     THE LAST COMPLETED NODE'S OUTCOME (`engine.py::_check_goal_gates` ->
+//     `node_outcomes[completed_nodes[-1]]`). That is the whole mechanism
+//     behind `bad_input -> done` and `abandon -> done`: each terminal's own
+//     nonzero exit becomes the run's status=fail / CLI exit 1, with no
+//     routing error.
+//   - GOAL-GATE COROLLARY — WHY NEITHER GATE CARRIES retry_target ANY MORE,
+//     AND WHY THE GRAPH-LEVEL ONE NOW POINTS AT `abandon`. `retry_target` on
+//     a goal gate is consulted in exactly ONE place — `_check_goal_gates()`
+//     AT THE EXIT NODE — and the graph-level attribute is that same
+//     mechanism's fallback (spec §3.4). It is deliberately NOT consulted on
+//     per-node failure (spec §3.7,
+//     `engine.py::_resolve_failure_retry_target`), so it never was a
+//     corrective loop; the corrective loops here are and always were the
+//     graph's own edges (triage -> attempt, feedback -> attempt with
+//     loop_restart). The one question it actually answers is: "the run is
+//     trying to LEAVE with a goal gate unsatisfied — where does it go
+//     instead?"
+//     While `abandon` dead-ended, the exit was unreachable with a gate
+//     unsatisfied, so the answer never mattered. Routing `abandon` to `done`
+//     makes it matter, and `attempt` became the WRONG answer: `abandon` is
+//     reached with `verify` red (verify -> triage -> postmortem) or with
+//     `verdict` red (verdict -> feedback -> ...), so an abandonment a HUMAN
+//     had just chosen would be overruled and sent back to the maker for more
+//     paid iterations, with `completed_nodes` cleared. Measured on the
+//     shipped engine with a faithful reduction of this shape:
+//       retry_target="attempt"  -> attempt/verify/postmortem/abandon each
+//                                  executed 51 times before the step cap
+//       retry_target="abandon"  -> 1 / 1 / 1 / 2
+//     The right answer to "where does a run go when it tries to leave with
+//     an unsatisfied gate" is the abandonment terminal, which is where it
+//     already was. `abandon` runs a second time (an echo and `exit 1`,
+//     idempotent), the exit-time check then finds no unsatisfied gate — a
+//     goal-gate retry clears `node_outcomes` — and the run ends on
+//     `abandon`'s own FAIL. The node-level `retry_target="attempt"` on
+//     `verify` and `verdict` is gone because a node-level value would take
+//     precedence and re-open the 51-lap hazard.
+//     HONEST NOTE ON WHAT THIS ATTRIBUTE DOES *NOT* BUY: it is not a failure
+//     route for the box nodes. `orient`, `attempt`, `diagnose` and
+//     `postmortem` still have no per-node failure route, because the engine
+//     does not consult the graph-level attribute there. That is a separate,
+//     pre-existing question (and `check_authored_pipeline.py`'s A6 counts
+//     this attribute as if it were such a route, which is a false negative in
+//     the checker, not a property of this graph). Recorded here rather than
+//     quietly fixed under an unrelated issue.
 //   - SHIP-PATH TRANSIENT RECOVERY + BUDGET WALL AT VERIFY: critique/
 //     feedback/package carry outcome=fail edges back to verify (see the
 //     edge block below). verify increments .ai/iter FIRST and checks the
@@ -110,7 +174,7 @@ digraph TaskRunner {
         default_max_retries=2,
         default_fidelity="compact",
         max_pipeline_duration="14400s",
-        retry_target="attempt"
+        retry_target="abandon"
     ]
 
     start [shape=Mdiamond]
@@ -120,6 +184,12 @@ digraph TaskRunner {
     setup [shape=parallelogram, class="glue", max_retries=0,
         tool_command="rm -rf .ai && mkdir -p .ai/feedback .ai/postmortem && B=$max_iterations; echo ${B:-6} > .ai/budget && VF=\"$task_file\"; VF=\"${VF%.md}.verify.sh\"; [ -f \"$task_file\" ] && [ -f \"$VF\" ] && printf ok || printf missing"]
 
+    // Loud refusal terminal: the run was never given a runnable task. Exits 1
+    // DELIBERATELY (max_retries=0) and ROUTES that nonzero exit to the single
+    // exit node — see the terminal edges at the end of this file. It does NOT
+    // dead-end: the main loop has no designed-terminus concept, so a dead-ended
+    // terminal is reported as PIPELINE_ERROR `no_matching_edge` rather than as
+    // the plain refusal it is.
     bad_input [shape=parallelogram, class="glue", max_retries=0,
         tool_command="echo 'FATAL: task_file or its sibling .verify.sh not found' >&2; exit 1"]
 
@@ -133,7 +203,7 @@ digraph TaskRunner {
 
     // ---------- verify: CHEAP deterministic gate (the task's own DoD) ----------
     verify [shape=parallelogram, class="gate", max_retries=0,
-        goal_gate=true, retry_target="attempt",
+        goal_gate=true,
         tool_command="n=$(grep -c '"gate": "verify"' .ai/convergence.jsonl 2>/dev/null); n=$((${n:-0}+1)); echo $n > .ai/iter; B=$(cat .ai/budget 2>/dev/null); B=${B:-6}; if [ \"$n\" -gt \"$B\" ]; then printf '{\"iteration\": %s, \"gate\": \"verify\", \"budget\": \"exhausted\"}\n' \"$n\" >> .ai/convergence.jsonl; printf exhausted; else VF=\"$task_file\"; VF=\"${VF%.md}.verify.sh\"; timeout 1800 bash \"$VF\" > .ai/verify.log 2>&1; rc=$?; [ $rc -eq 124 ] && echo 'VERIFY TIMEOUT after 1800s' >> .ai/verify.log; printf '{\"iteration\": %s, \"gate\": \"verify\", \"pass\": %s}\n' \"$n\" \"$([ $rc -eq 0 ] && echo true || echo false)\" >> .ai/convergence.jsonl; [ $rc -eq 0 ] && printf green || { printf red; exit 1; }; fi"]
 
     // ---------- triage: root-cause wall + budget check (deterministic) ----------
@@ -167,7 +237,7 @@ digraph TaskRunner {
     // finding something new each cycle. After 3 total refusals the verdict
     // routes to postmortem->human: budget-as-decision-point on the OUTER loop.
     verdict [shape=parallelogram, class="gate", max_retries=0,
-        goal_gate=true, retry_target="attempt",
+        goal_gate=true,
         tool_command="n=$(cat .ai/iter 2>/dev/null || echo 0); grep -E '^VERDICT:' .ai/critique.md | tail -1 | grep -q 'SHIP'; ok=$?; printf '{\"iteration\": %s, \"gate\": \"critique\", \"ship\": %s}\n' \"$n\" \"$([ $ok -eq 0 ] && echo true || echo false)\" >> .ai/convergence.jsonl; [ $ok -eq 0 ] && printf ship || { sc=$(($(cat .ai/stall-count 2>/dev/null || echo 0)+1)); echo $sc > .ai/stall-count; if [ \"$sc\" -ge 3 ]; then printf stall; else printf iterate; exit 1; fi; }"]
 
     // ---------- feedback: accumulate critique -> descent, not re-flip ----------
@@ -201,6 +271,11 @@ digraph TaskRunner {
     bump_budget [shape=parallelogram, class="glue", max_retries=0,
         tool_command="B=$(cat .ai/budget 2>/dev/null); B=${B:-6}; N=$((B+3)); [ $N -gt 15 ] && N=15; echo $N > .ai/budget; rm -f .ai/last-fail-sig; printf continue"]
 
+    // Loud abandonment terminal: a human (or an unattended fail-safe) chose to
+    // stop, and the postmortem is the salvage. Exits 1 DELIBERATELY
+    // (max_retries=0) and ROUTES that nonzero exit to the single exit node —
+    // see the terminal edges at the end of this file. Same reason as bad_input:
+    // a dead-end here is reported as an authoring bug, not as an abandonment.
     abandon [shape=parallelogram, class="glue", max_retries=0,
         tool_command="echo 'ABANDONED: see .ai/postmortem/report.md and .ai/convergence.jsonl' >&2; exit 1"]
 
@@ -269,4 +344,28 @@ digraph TaskRunner {
     escalate -> abandon     [label="[A] Abandon — keep the postmortem"]
     escalate -> bump_budget [label="[C] Continue — raise the budget"]
     bump_budget -> attempt
+
+    // ---------- the two loud terminals ROUTE, they do not dead-end ----------
+    // Each carries its own nonzero exit into the single exit node. Without
+    // these edges the main loop — which has no designed-terminus concept —
+    // reports this graph's two honest red outcomes in the vocabulary of an
+    // authoring bug: `[PIPELINE] X Error at bad_input (no_matching_edge)` /
+    // `... at abandon (no_matching_edge)`, with the run's machine-readable
+    // `notes` reading "No matching edge from node '<terminal>'". With them,
+    // `_check_goal_gates` returns the LAST COMPLETED node's outcome — the
+    // terminal's own FAIL — so the run ends status=fail / CLI exit 1 with no
+    // routing error and the postmortem still on disk. Both terminals exit
+    // nonzero on EVERY path, so `outcome=fail` is the total case, not a
+    // partial one.
+    // THE TWO TOPO-006 WARNINGS THIS FILE CARRIES ARE THESE EDGES, ON PURPOSE:
+    // "a budget-exhaustion exit that deliberately ends at the single exit node
+    // with a genuine FAIL outcome" is the named, sanctioned deliberate design
+    // (docs/DOT-AUTHORING-GUIDE.md, TOPO-006), and objective-runner.dot and
+    // convergence-factory.dot carry the identical diagnostic for the identical
+    // reason. The hazard the rule guards — a failure leaving through the
+    // success door as `status: success`, exit 0 — cannot happen here: the
+    // terminal is the last node to complete and its FAIL is what the exit
+    // returns.
+    bad_input -> done [condition="outcome=fail", label="loud exit — status is bad_input's own nonzero exit"]
+    abandon   -> done [condition="outcome=fail", label="loud exit — status is abandon's own nonzero exit"]
 }

--- a/examples/pipelines/practical/bug-fix.dot
+++ b/examples/pipelines/practical/bug-fix.dot
@@ -22,8 +22,31 @@
 //     max_pipeline_duration is a safety ceiling that terminates the engine
 //     directly (bare FAIL, no graph traversal); it is NOT a postmortem trigger.
 //     default_max_retries bounds only implement_fix hard failures.
+//   BROKEN INSTRUMENT as a decision point: test_gate -[no_target]-> postmortem
+//     A gate that collects no tests can never go green. That is not a red the
+//     fixer can patch, so it does not re-enter the fix loop; it goes where
+//     budget exhaustion goes. See test_gate below.
+//   ONE EXIT NODE, TWO HONEST TERMINALS: `done` opens GREEN only through
+//     verdict_gate's ship verdict, and RED only through `escalated`, whose own
+//     nonzero exit becomes the run's status. Both reach the single exit node --
+//     the convergence-factory.dot idiom, and the reason this file consciously
+//     carries ONE TOPO-006 warning (see the last edge in this file).
 //
 // VERIFIED ENGINE SEMANTICS THIS FILE DEPENDS ON:
+//   THE MAIN LOOP HAS NO DESIGNED-TERMINUS CONCEPT. `run_subgraph()`
+//   distinguishes "no outgoing edges at all" (a designed terminus) from a
+//   conditional-mismatch dead end; `run()` does NOT. Any node the main loop
+//   finishes with no matching outgoing edge -- WHATEVER its exit status --
+//   terminates through `terminate_pipeline()` and emits PIPELINE_ERROR
+//   `error_type=no_matching_edge`. A deliberate loud terminal must therefore
+//   ROUTE somewhere; it cannot dead-end (issue #252; issue #243 defect (a),
+//   fixed in objective-runner.dot by #248).
+//   AT THE EXIT NODE, WITH EVERY GOAL GATE SATISFIED, THE RUN'S STATUS IS THE
+//   LAST COMPLETED NODE'S OUTCOME (`engine.py::_check_goal_gates` ->
+//   `node_outcomes[completed_nodes[-1]]`). That is the whole mechanism behind
+//   `escalated -> done [outcome=fail]`: escalated's own nonzero exit becomes the
+//   run's status=fail / CLI exit 1, with no routing error. This graph declares
+//   no goal_gate, so nothing else is consulted at the exit.
 //   STALE-LABEL RULE (general case): a tool node that exits nonzero does NOT
 //   refresh tool.last_line. On a second visit after a failure, a stale label
 //   can simultaneously match a last_line edge AND an outcome=fail edge.
@@ -49,14 +72,19 @@ digraph BugFix {
 
     start     [shape=Mdiamond, label="Start"]
     done      [shape=Msquare,  label="Done"]
-    // Escalation is a deterministic non-terminal handoff, not a second
-    // successful pipeline exit. It writes a minimal fallback handoff even if
-    // the postmortem LLM itself failed, so every LLM-node hard failure is
-    // absorbed before the run reports failure. It then exits 1 DELIBERATELY:
-    // the run's failure is carried by the node's own exit code, portable
-    // under either dead-end semantics (the canonical spec treats a no-edge
-    // dead-end as SUCCESS; this engine hard-fails). max_retries=0 because
-    // the failure is the point, not a flake to retry.
+    // Escalation is a deterministic handoff, not a second successful pipeline
+    // exit. It writes a minimal fallback handoff even if the postmortem LLM
+    // itself failed, so every LLM-node hard failure is absorbed before the run
+    // reports failure. It then exits 1 DELIBERATELY (max_retries=0, because the
+    // failure is the point, not a flake to retry) and ROUTES that nonzero exit
+    // to the single exit node -- see the last edge in this file.
+    // The comment that used to sit here claimed the failure was "portable under
+    // either dead-end semantics (the canonical spec treats a no-edge dead-end as
+    // SUCCESS; this engine hard-fails)". That was wrong about the engine that
+    // actually ships: a dead-ended node is reported as PIPELINE_ERROR
+    // `error_type=no_matching_edge`, which is the vocabulary of an AUTHORING
+    // BUG, not of a loud red. Portability across dead-end semantics is not
+    // achievable by dead-ending; it is achieved by routing.
     escalated [
         shape=parallelogram,
         label="Escalated",
@@ -93,17 +121,54 @@ digraph BugFix {
     // shape=parallelogram runs the tool_command directly (not via LLM).
     // Increments .ai/iter on every entry (inner loop + outer loop). When the
     // count exceeds .ai/budget (default 5), emits "exhausted" and routes to
-    // postmortem -- a decision point, not a bare FAIL. Otherwise runs pytest
-    // and saves output to .ai/test.log for the triage node's signature check.
-    // All three branches end with printf (exit 0), so tool.last_line is always
-    // fresh. The `&& outcome=success` on pass/exhausted edges is general-case
-    // discipline (STALE-LABEL RULE): if the tool ever exits nonzero, a stale
-    // last_line could be the deterministic pick on a FAIL visit. Edges condition
-    // on context.tool.last_line.
+    // postmortem -- a decision point, not a bare FAIL.
+    //
+    // WHERE THE TESTS ACTUALLY ARE (issue #252, issue #243's live failure).
+    // This gate used to run a bare `pytest -q` from the workspace root. For any
+    // workspace whose package sits one level down -- its own pyproject/conftest,
+    // its own rootdir, often its own environment -- that command collects
+    // nothing or dies on import, and pytest's "no tests collected" is exit 5,
+    // which the old `[ $? -eq 0 ] && pass || fail` reported as an ordinary RED.
+    // The fixer was then sent to patch code against a gate that could not go
+    // green under any patch; it oscillated to its own budget wall. That is not
+    // a hypothetical -- it is what the 2026-08-15 exemplar-01 lane child did.
+    // Three changes, in order of how much they matter:
+    //   1. THE TARGET IS DISCOVERED, NOT ASSUMED. With no `test_command` param,
+    //      the gate asks pytest itself where the tests are: it tries the
+    //      workspace root first, then each directory within two levels that
+    //      owns a `tests/` dir (lexically ordered, so the choice is
+    //      deterministic), and takes the first that actually COLLECTS. Flat and
+    //      nested layouts both work with no configuration.
+    //   2. "NOTHING TO RUN" IS NOT "RED". Exit 5, and a discovery sweep that
+    //      finds no collecting target at all, both emit `no_target`, which
+    //      routes to `postmortem` -- a decision point about a broken
+    //      instrument, never another lap of the fix loop. A gate that cannot
+    //      go green must say so, not fail quietly forever.
+    //   3. THE ESCAPE HATCH IS A PARAM, AND IT IS RUN AS GIVEN. `--param
+    //      test_command=<...>` is handed to `bash -c` verbatim, so a compound
+    //      command (`cd pkg && uv run pytest -q`, an env prefix, an `&&` chain)
+    //      runs exactly as passed. It stays an EVIDENCE gate, not a recipe:
+    //      the graph still decides what the result MEANS, and the node still
+    //      runs outside the fixer's context.
+    // The chosen target is cached in .ai/test-target (discovery is paid once)
+    // and .ai/test.log opens with `RAN: <command>` -- so "the gate tested
+    // something other than what you think" is visible on iteration 1 instead of
+    // being reconstructed from a postmortem at budget exhaustion.
+    //
+    // All four branches end with printf (exit 0), so tool.last_line is always
+    // fresh. The `&& outcome=success` on pass/exhausted/no_target edges is
+    // general-case discipline (STALE-LABEL RULE): if the tool ever exits
+    // nonzero, a stale last_line could be the deterministic pick on a FAIL
+    // visit. Edges condition on context.tool.last_line.
+    // PARAM NAMESPACE: substitution rewrites $name/${name} for any context key
+    // and leaves absent keys as literals, which the shell then expands to
+    // empty -- that is exactly how `test_command` gets its honest default. The
+    // shell variables here (n, B, tc, d, rc, sig, prev) are safe only because
+    // no param shares their name. Never add a param named like a shell var.
     test_gate [
         shape=parallelogram,
         label="Tests Pass?",
-        tool_command="mkdir -p .ai; n=$(($(cat .ai/iter 2>/dev/null || echo 0)+1)); echo $n > .ai/iter; B=$(cat .ai/budget 2>/dev/null || echo 5); if [ \"$n\" -gt \"$B\" ]; then printf exhausted; else pytest -q > .ai/test.log 2>&1; [ $? -eq 0 ] && printf pass || printf fail; fi"
+        tool_command="mkdir -p .ai; n=$(($(cat .ai/iter 2>/dev/null || echo 0)+1)); echo $n > .ai/iter; B=$(cat .ai/budget 2>/dev/null || echo 5); if [ \"$n\" -gt \"$B\" ]; then printf exhausted; else tc=\"$test_command\"; [ -z \"$tc\" ] && [ -s .ai/test-target ] && tc=$(cat .ai/test-target); if [ -z \"$tc\" ]; then for d in . $(find . -maxdepth 2 -type d -name tests -not -path './.*' 2>/dev/null | sed 's|/tests$||' | LC_ALL=C sort); do (cd \"$d\" && pytest -q --collect-only) >/dev/null 2>&1 || continue; if [ \"$d\" = . ]; then tc='pytest -q'; else tc=\"cd '$d' && pytest -q\"; fi; break; done; fi; if [ -z \"$tc\" ]; then echo 'FATAL: no pytest target collects a single test -- not here, and not in any tests/ directory within two levels. This gate can never go green, so the fixer must not be sent to grind against it. Re-run with --param test_command=<how this project actually runs its tests>, e.g. --param \"test_command=cd mypkg && uv run pytest -q\".' >&2; printf no_target; else echo \"$tc\" > .ai/test-target; { echo \"RAN: $tc\"; echo; bash -c \"$tc\"; } > .ai/test.log 2>&1; rc=$?; if [ $rc -eq 0 ]; then printf pass; elif [ $rc -eq 5 ]; then printf no_target; else printf fail; fi; fi; fi"
     ]
 
     // Triage: deterministic root-cause wall.
@@ -142,12 +207,13 @@ digraph BugFix {
         prompt="Read .ai/critique.md. Distill the single highest-leverage change for the next iteration into a new file in .ai/feedback/ (name it by iteration, e.g. 1-next.md). Format: Key finding (1 sentence) / What to change (3-5 bullets) / Why it matters. Be precise -- this is the descent signal the next attempt will read."
     ]
 
-    // Postmortem: budget exhaustion or a single LLM-node hard failure produces
-    // a decision point, not a bare FAIL. A deterministic fallback path below
-    // still reaches escalated if this LLM cannot write the detailed report.
+    // Postmortem: budget exhaustion, a test gate with no target, or a single
+    // LLM-node hard failure produces a decision point, not a bare FAIL. A
+    // deterministic fallback path below still reaches escalated if this LLM
+    // cannot write the detailed report.
     postmortem [
         label="Postmortem",
-        prompt="The fix loop has exhausted its budget without converging. Read .ai/feedback/, .ai/critique.md (if it exists), .ai/test.log, and the current state of the code. Write .ai/postmortem/report.md: what was attempted each iteration, whether the loop was descending or oscillating, your best hypothesis for why it has not converged, and the options (change approach / split the task / escalate to a human). Be honest -- this report is the value salvaged from a non-converging run."
+        prompt="The fix loop reached a decision point without converging -- either the iteration budget is spent, or the test gate reported that it has no target to run (read the first line of .ai/test.log and .ai/test-target: if the gate found nothing to collect, the instrument is wrong, not the fix, and no further patching can turn it green). Read .ai/feedback/, .ai/critique.md (if it exists), .ai/test.log, .ai/test-target, and the current state of the code. Write .ai/postmortem/report.md: what was attempted each iteration, whether the loop was descending or oscillating, WHICH of the two decision points was reached and on what evidence, your best hypothesis for why it has not converged, and the options (name the right test command / change approach / split the task / escalate to a human). Be honest -- this report is the value salvaged from a non-converging run."
     ]
 
     // ===== edges =====
@@ -159,6 +225,12 @@ digraph BugFix {
     // exhausted-path intent explicit and prevents a stale "exhausted" from being
     // the deterministic pick on a FAIL visit).
     test_gate -> postmortem [label="budget exhausted", condition="context.tool.last_line=exhausted && outcome=success"]
+
+    // Broken-instrument wall: the gate found nothing to run. This is NOT a red
+    // test and must never re-enter the fix loop -- no patch can make a
+    // non-existent or uncollectable test suite go green. It is a decision point
+    // about the gate itself, so it goes where budget exhaustion goes.
+    test_gate -> postmortem [label="no test target -- the gate cannot go green", condition="context.tool.last_line=no_target && outcome=success"]
 
     // Inner loop: red enters triage for root-cause classification.
     // `&& outcome=success` on the pass edge: general-case STALE-LABEL discipline.
@@ -195,4 +267,23 @@ digraph BugFix {
     feedback      -> postmortem [condition="outcome=fail", label="hard failure"]
     postmortem   -> escalated  [condition="outcome=fail", label="postmortem failed"]
     postmortem   -> escalated  [label="escalate"]
+
+    // ...and then the loud terminal ROUTES to the single exit node CARRYING its
+    // nonzero exit. Without this edge `escalated` dead-ends, and the main loop
+    // -- which has no designed-terminus concept -- reports this pipeline's most
+    // important honest outcome in the vocabulary of an authoring bug:
+    // `[PIPELINE] X Error at escalated (no_matching_edge)`, with the run's
+    // machine-readable `notes` reading "No matching edge from node 'escalated'".
+    // With it, `_check_goal_gates` returns the LAST COMPLETED node's outcome --
+    // escalated's own FAIL -- so the run ends status=fail / CLI exit 1 with no
+    // routing error and the escalation handoff on disk. `escalated` exits
+    // nonzero on EVERY path, so `outcome=fail` is the total case.
+    // THE ONE TOPO-006 WARNING THIS FILE CARRIES IS THIS EDGE, ON PURPOSE: "a
+    // budget-exhaustion exit that deliberately ends at the single exit node with
+    // a genuine FAIL outcome" is the named, sanctioned deliberate design
+    // (docs/DOT-AUTHORING-GUIDE.md, TOPO-006). The hazard the rule guards -- a
+    // failure leaving through the success door as `status: success`, exit 0 --
+    // cannot happen here: `escalated` is the last node to complete and its FAIL
+    // is what the exit returns.
+    escalated -> done [condition="outcome=fail", label="loud exit -- status is escalated's own nonzero exit"]
 }

--- a/modules/loop-pipeline/tests/test_authoring_layer_gates.py
+++ b/modules/loop-pipeline/tests/test_authoring_layer_gates.py
@@ -1177,6 +1177,71 @@ def test_a4_is_not_bypassed_by_a_path_that_can_only_end_red(checker, tmp_path, c
     assert "[PASS] A4" in text, text
 
 
+#: The reviewer's laundering shape (PR #259 adversarial review): a node whose
+#: command only TEXTUALLY ends in `exit 1` -- `rm -f scratch.tmp || exit 1` exits
+#: 0 whenever the `rm` succeeds, which is almost always -- wired to the exit off
+#: an ungated fast path.  Clauses 1-4 all match it on the text of the graph, so
+#: without clause 5 A4 blocks it as a "loud terminal" and reports the exit as
+#: unreachable-without-evidence.  The reviewer ran this shape on the live engine:
+#: it finished `status=success`, CLI exit 0 -- an evidence-free GREEN finish that
+#: main's A4 catches and the un-hardened exemption laundered.
+_LAUNDERING_SNEAK = (
+    '    escalated [shape=parallelogram, max_retries=0, tool_command="printf escalated; exit 1"]',
+    (
+        '    escalated [shape=parallelogram, max_retries=0, tool_command="printf escalated; exit 1"]\n'
+        '    sneak [shape=parallelogram, max_retries=0, tool_command="rm -f scratch.tmp || exit 1"]'
+    ),
+)
+
+
+def _sneak_wired(edge: str) -> tuple[str, str]:
+    """Put `sneak` on the ungated fast path, reaching the exit via `edge`."""
+    return ("    work -> dod_gate", f"    work -> dod_gate\n    work -> sneak\n{edge}")
+
+
+@pytest.mark.parametrize(
+    ("edge", "verdict", "a4", "why"),
+    [
+        pytest.param(
+            "    sneak -> done",
+            "doctrine_bad",
+            "[FAIL] A4",
+            "an UNCONDITIONAL edge into the exit can carry the node's SUCCESS -- "
+            "`rm -f scratch.tmp || exit 1` exits 0, so this is an evidence-free green finish",
+            id="unconditional-edge-is-laundering",
+        ),
+        pytest.param(
+            '    sneak -> done [condition="outcome=fail"]',
+            "doctrine_ok",
+            "[PASS] A4",
+            "an outcome=fail edge can never carry a SUCCESS into the exit, whatever "
+            "the command does -- this is the shipped exemplars' own shape",
+            id="outcome-fail-edge-stays-exempt",
+        ),
+    ],
+)
+def test_a4_exempts_a_loud_terminal_only_when_its_edge_is_conditioned_on_failure(
+    checker, tmp_path, capsys, edge, verdict, a4, why
+):
+    """Clause 5: the exemption is RUNTIME-sound, not merely textual.
+
+    These two cases differ in exactly ONE character sequence -- the condition on
+    `sneak -> done`.  The node, its command, its `max_retries=0` and its single
+    outgoing edge are identical, and clauses 1-4 therefore cannot tell them
+    apart: clause 2's regex matches `|| exit 1` on the text while the command
+    exits 0 at runtime.  Only the edge's condition distinguishes a terminal
+    whose FAIL becomes the run's status from a fast path that quietly finishes
+    green without ever touching a gate.
+    """
+    dot = _with_loud_terminal(_LAUNDERING_SNEAK, _sneak_wired(edge))
+    pipeline, companion = _write_draft(tmp_path, dot)
+    rc, text = _run_checker(checker, pipeline, companion, tmp_path / "report.txt")
+
+    assert rc == 0
+    assert capsys.readouterr().out == verdict, (why, text)
+    assert a4 in text, (why, text)
+
+
 def test_a8_admits_the_shape_248_merged_into_the_objective_runner(checker, tmp_path, capsys):
     """Calibration, stated against the real file rather than a fixture.
 

--- a/modules/loop-pipeline/tests/test_authoring_layer_gates.py
+++ b/modules/loop-pipeline/tests/test_authoring_layer_gates.py
@@ -969,3 +969,238 @@ def test_real_preflight_refuses_an_unsafe_publish_name(tmp_path):
     assert good.returncode == 0
     assert good.stdout == "ready"
     assert (workspace / ".authoring" / "name").read_text(encoding="utf-8").strip() == "doc-claims-verified"
+
+
+# ---------------------------------------------------------------------------
+# Issue #252 -- the dead-end designed terminal, and its goal-gate corollary
+#
+# The engine's MAIN loop has no designed-terminus concept.  `run_subgraph()`
+# distinguishes "no outgoing edges at all" (a designed terminus) from a
+# conditional-mismatch dead end; `run()` does NOT -- it reports
+# `error_type=no_matching_edge` as a PIPELINE_ERROR whatever the exit status.
+# So `escalated` -- a tool node that exits 1 on purpose -- was reported as an
+# authoring bug when it was reached.  Measured on the shipped CLI against this
+# very file, with a blocked preflight:
+#
+#     [PIPELINE] X Error at escalated (no_matching_edge): Command exited with
+#     code 1: escalated
+#     notes: No matching edge from node 'escalated'
+#
+# These read the shipped graph through the engine's own parser, not a
+# paraphrase of it.
+# ---------------------------------------------------------------------------
+
+
+def _author_graph():
+    from amplifier_module_loop_pipeline.dot_parser import parse_dot
+
+    return parse_dot((_AUTHORING_DIR / "pipeline-author.dot").read_text(encoding="utf-8"))
+
+
+def test_escalated_routes_to_the_exit_instead_of_dead_ending():
+    """A loud terminal must ROUTE; the main loop has no designed terminus.
+
+    One edge -- `escalated -> done [outcome=fail]` -- is the convergence-factory
+    idiom proven in #248.  `_check_goal_gates` then returns the LAST COMPLETED
+    node's outcome, so `escalated`'s own nonzero exit becomes the run's
+    status=fail / CLI exit 1, with no routing error.
+    """
+    graph = _author_graph()
+    exits = [n.id for n in graph.nodes.values() if n.is_exit_node()]
+    assert exits == ["done"], exits
+
+    outgoing = graph.outgoing_edges("escalated")
+    assert outgoing, (
+        "`escalated` has no outgoing edge, so the engine reports the designed "
+        "escalation as PIPELINE_ERROR error_type=no_matching_edge (issue #252)"
+    )
+    assert [e.to_node for e in outgoing] == ["done"]
+    assert "outcome=fail" in (outgoing[0].condition or ""), outgoing[0].condition
+
+
+def test_escalated_still_exits_nonzero_so_the_exit_it_reaches_is_red():
+    """The routing fix must not turn the loud terminal into a quiet one.
+
+    An `escalated` that exited 0 would convert the escalation into a green run
+    -- the exact hazard TOPO-006 names -- because the exit returns the last
+    completed node's outcome.
+    """
+    node = _author_graph().nodes["escalated"]
+    command = str(node.attrs["tool_command"])
+    assert command.rstrip().endswith("exit 1"), command
+    assert str(node.attrs.get("max_retries")) == "0"
+    assert ".authoring/disposition" in command, "the terminal must say which terminal it was"
+
+
+def test_no_node_in_the_authoring_graph_dead_ends():
+    """The whole-graph form of the rule, so a future terminal cannot regress."""
+    graph = _author_graph()
+    exits = {n.id for n in graph.nodes.values() if n.is_exit_node()}
+    dead_ends = [n for n in graph.nodes if n not in exits and not graph.outgoing_edges(n)]
+    assert dead_ends == [], dead_ends
+
+
+def test_the_goal_gate_carries_no_retry_target():
+    """#252's corollary, which #252 does not mention and #248 discovered.
+
+    `retry_target` on a goal gate is consulted in exactly one place --
+    `_check_goal_gates()` at the exit node.  While `escalated` dead-ended, the
+    exit was unreachable with `verdict_gate` red, so the attribute was dead;
+    `escalated -> done` makes it reachable, which turns it live and wrong -- an
+    escalation that has already written its postmortem and its handoff would be
+    sent back to `author` to be paid for again, with `completed_nodes` cleared.
+    Measured on the shipped engine with a faithful reduction of this shape: 51
+    executions of the retry target before the step cap, versus one without.
+
+    The corrective loop is untouched: it is the `loop_restart` back-edge to
+    `author`, which is also what keeps `goal_gate_has_retry` satisfied.
+    """
+    graph = _author_graph()
+    gate = graph.nodes["verdict_gate"]
+    assert str(gate.attrs.get("goal_gate", "")).lower() == "true"
+    assert not gate.attrs.get("retry_target"), gate.attrs.get("retry_target")
+    assert not gate.attrs.get("fallback_retry_target")
+    assert "retry_target" not in graph.graph_attrs
+
+    restarts = [
+        e
+        for e in graph.outgoing_edges("verdict_gate")
+        if str(e.loop_restart).lower() == "true" and e.to_node == "author"
+    ]
+    assert restarts, "the corrective loop must survive removing the exit-time retry"
+
+
+# ---------------------------------------------------------------------------
+# A8's one exemption: a DESIGNED LOUD TERMINAL (issue #252)
+#
+# A8 blocked `escalated -> done [outcome=fail]` -- the shape #248 merged into
+# `examples/objective/objective-runner.dot`, and the ONLY shape in which a
+# deliberately red terminal can exist on this engine at all (the main loop has
+# no designed-terminus concept, so a dead-ended terminal is reported as
+# PIPELINE_ERROR error_type=no_matching_edge, not as a loud red).  A gate that
+# rejects the repo's own merged flagship is a wrong gate, not a strict one --
+# the same calibration rule this file already applies to `task-runner.dot`.
+#
+# The exemption is narrow on purpose, and every clause below is held RED by a
+# mutation: a recorder that exits 0, a node with somewhere else to go, a
+# retried node, and an LLM worker all still block.
+# ---------------------------------------------------------------------------
+
+#: Route the fixture's existing loud terminal into the exit -- the #248 shape.
+_LOUD_TERMINAL_TO_EXIT = (
+    '    postmortem -> escalated [condition="outcome=fail"]',
+    (
+        '    postmortem -> escalated [condition="outcome=fail"]\n'
+        '    escalated -> done [condition="outcome=fail"]'
+    ),
+)
+
+
+def _with_loud_terminal(*more: tuple[str, str]) -> str:
+    text = _GOOD_PIPELINE.replace(*_LOUD_TERMINAL_TO_EXIT, 1)
+    for old, new in more:
+        assert old in text, f"mutation anchor drifted: {old!r}"
+        text = text.replace(old, new, 1)
+    return text
+
+
+def test_a8_admits_a_designed_loud_terminal(checker, tmp_path, capsys):
+    """The whole point: routing a terminal's own FAIL into the exit is legal.
+
+    At the exit node, with every goal gate satisfied, `_check_goal_gates()`
+    returns `node_outcomes[completed_nodes[-1]]` -- the LAST COMPLETED node's
+    outcome.  `escalated` is that node and it exits 1, so the run ends
+    status=fail / CLI exit 1.  Nothing is converted into a successful run,
+    which is the only thing A8 was ever protecting.
+    """
+    pipeline, companion = _write_draft(tmp_path, _with_loud_terminal())
+    rc, text = _run_checker(checker, pipeline, companion, tmp_path / "report.txt")
+
+    assert rc == 0
+    assert capsys.readouterr().out == "doctrine_ok", text
+
+
+@pytest.mark.parametrize(
+    ("mutation", "why"),
+    [
+        pytest.param(
+            ('escalated [shape=parallelogram, max_retries=0, tool_command="printf escalated; exit 1"]',
+             'escalated [shape=parallelogram, max_retries=0, tool_command="printf escalated"]'),
+            "a terminal that can exit 0 hands the exit a SUCCESS -- the escalation goes green",
+            id="terminal-that-exits-zero",
+        ),
+        pytest.param(
+            ('    escalated -> done [condition="outcome=fail"]',
+             '    escalated -> done [condition="outcome=fail"]\n    escalated -> work [condition="outcome=success"]'),
+            "a node with somewhere else to go is a step on a path, not a terminal",
+            id="terminal-with-a-second-route",
+        ),
+        pytest.param(
+            ('escalated [shape=parallelogram, max_retries=0, tool_command="printf escalated; exit 1"]',
+             'escalated [shape=parallelogram, max_retries=2, tool_command="printf escalated; exit 1"]'),
+            "the failure is the point, not a flake to retry",
+            id="terminal-that-is-retried",
+        ),
+        pytest.param(
+            ('escalated [shape=parallelogram, max_retries=0, tool_command="printf escalated; exit 1"]',
+             'escalated [shape=box, max_retries=0, prompt="Escalate this to a human, loudly."]'),
+            "a worker's failure is a provider verdict, not a guaranteed process exit",
+            id="terminal-that-is-an-llm-worker",
+        ),
+    ],
+)
+def test_a8_still_blocks_everything_that_is_not_one(checker, tmp_path, capsys, mutation, why):
+    """The exemption must not be wearable as a costume by the A8 hazard itself."""
+    pipeline, companion = _write_draft(tmp_path, _with_loud_terminal(mutation))
+    rc, text = _run_checker(checker, pipeline, companion, tmp_path / "report.txt")
+
+    assert rc == 0
+    assert capsys.readouterr().out == "doctrine_bad", why
+    assert "[FAIL] A8" in text, (why, text)
+
+
+def test_a4_is_not_bypassed_by_a_path_that_can_only_end_red(checker, tmp_path, capsys):
+    """A4's companion correction: a loud terminal is not an evidence-free finish.
+
+    A4 asks whether the run can FINISH WITHOUT EVIDENCE.  A path that reaches
+    the exit only through a node that exits nonzero cannot finish at all in
+    that sense -- it fails, loudly.  Counting it as a bypass would leave an
+    author no legal way to fail loudly: the only shape A8 admits would be the
+    shape A4 forbids.  The green door is untouched, which is asserted by the
+    A4 mutation in the table above still going red.
+    """
+    pipeline, companion = _write_draft(tmp_path, _with_loud_terminal())
+    rc, text = _run_checker(checker, pipeline, companion, tmp_path / "report.txt")
+
+    assert rc == 0
+    assert capsys.readouterr().out == "doctrine_ok", text
+    assert "[PASS] A4" in text, text
+
+
+def test_a8_admits_the_shape_248_merged_into_the_objective_runner(checker, tmp_path, capsys):
+    """Calibration, stated against the real file rather than a fixture.
+
+    `objective-runner.dot` is the repo's own merged, reviewed exemplar of this
+    idiom.  A8 rejected it -- so A8 was mis-calibrated, and this is the
+    assertion that keeps it calibrated.  (A9 is evaluated separately for that
+    file; this test is about A8 alone.)
+    """
+    dot_path = _REPO_ROOT / "examples" / "objective" / "objective-runner.dot"
+    if not dot_path.is_file():
+        pytest.skip("examples/objective/ not present")
+
+    report = tmp_path / "report.txt"
+    checker.main(
+        [
+            "--pipeline",
+            str(dot_path),
+            "--companion",
+            str(dot_path.with_suffix(".md")),
+            "--report",
+            str(report),
+        ]
+    )
+    capsys.readouterr()
+    text = report.read_text(encoding="utf-8")
+    assert "[PASS] A8" in text, text
+    assert "[PASS] A4" in text, text

--- a/modules/loop-pipeline/tests/test_drift_review_gate.py
+++ b/modules/loop-pipeline/tests/test_drift_review_gate.py
@@ -877,11 +877,16 @@ def test_the_shipped_graph_keeps_its_layer_three_contract():
     # Zero ERROR diagnostics -- the bar every shipped example is held to.
     assert [d for d in lint(graph) if d.severity == "ERROR"] == []
 
-    # Exactly one exit, and it is reachable only through the report gate.
+    # Exactly one exit node, with exactly two doors into it: the report gate is
+    # the only GREEN one, and `escalated` is the only RED one (issue #252 -- a
+    # designed loud terminal has to route, because the main loop has no
+    # designed-terminus concept).
     exits = [n for n in graph.nodes.values() if n.is_exit_node()]
     assert len(exits) == 1
     into_exit = graph.incoming_edges(exits[0].id)
-    assert [e.from_node for e in into_exit] == ["report_gate"]
+    assert sorted(e.from_node for e in into_exit) == ["escalated", "report_gate"]
+    green = [e for e in into_exit if e.from_node == "report_gate"]
+    assert all("outcome=success" in str(e.condition or "") for e in green), green
 
     # The verdict is owned by a code-tier node, never by a worker.
     gates = [
@@ -920,7 +925,118 @@ def test_the_shipped_graph_keeps_its_layer_three_contract():
         node_id = "review_" + cls.replace("-", "_")
         assert graph.nodes[node_id].attrs.get("must_write") == f".drift-review/raw/{cls}.json"
 
-    # No outcome=fail edge may reach the exit: a machinery failure leaves loudly.
-    for edge in graph.edges:
-        if edge.to_node == exits[0].id:
-            assert "outcome=fail" not in str(edge.condition or "")
+    # Exactly ONE outcome=fail edge reaches the exit, and it is the loud
+    # terminal's own (issue #252).  Before that edge existed the invariant here
+    # was "no failure edge may reach the exit" -- which read as a safety
+    # property but was actually the bug: `escalated` dead-ended, and the main
+    # loop, which has no designed-terminus concept, reported the review's most
+    # important honest outcome as PIPELINE_ERROR error_type=no_matching_edge.
+    # The property that actually matters is preserved and asserted below: the
+    # failure that reaches the exit is the LAST node to complete and exits
+    # nonzero, so `_check_goal_gates` returns ITS fail -- status=fail, exit 1 --
+    # rather than a machinery failure leaving through the success door green.
+    fail_into_exit = [
+        edge
+        for edge in graph.edges
+        if edge.to_node == exits[0].id and "outcome=fail" in str(edge.condition or "")
+    ]
+    assert [e.from_node for e in fail_into_exit] == ["escalated"], fail_into_exit
+    escalated_command = str(graph.nodes["escalated"].attrs["tool_command"])
+    assert escalated_command.rstrip().endswith("exit 1"), escalated_command
+    assert graph.outgoing_edges("escalated") == fail_into_exit, (
+        "the loud terminal must have nowhere else to go -- a node with another "
+        "route is a step on a path, not a terminal"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Issue #252 -- the dead-end designed terminal, and its goal-gate corollary
+#
+# The engine's MAIN loop has no designed-terminus concept.  `run_subgraph()`
+# distinguishes "no outgoing edges at all" (a designed terminus) from a
+# conditional-mismatch dead end; `run()` does NOT -- it reports
+# `error_type=no_matching_edge` as a PIPELINE_ERROR whatever the exit status.
+# So `escalated` -- a tool node that exits 1 on purpose, having just written the
+# handoff -- was reported as an authoring bug when it was reached.  Measured on
+# the shipped CLI against this very file, with a blocked preflight:
+#
+#     [PIPELINE] X Error at escalated (no_matching_edge): Command exited with
+#     code 1: escalated
+#     notes: No matching edge from node 'escalated'
+#
+# Read through the engine's own parser, not a paraphrase of the file.
+# ---------------------------------------------------------------------------
+
+
+def _drift_graph():
+    from amplifier_module_loop_pipeline.dot_parser import parse_dot
+
+    return parse_dot(_DOT_PATH.read_text(encoding="utf-8"))
+
+
+def test_escalated_routes_to_the_exit_instead_of_dead_ending():
+    """A loud terminal must ROUTE; the main loop has no designed terminus.
+
+    One edge -- `escalated -> done [outcome=fail]` -- is the convergence-factory
+    idiom proven in #248.  `_check_goal_gates` then returns the LAST COMPLETED
+    node's outcome, so `escalated`'s own nonzero exit becomes the run's
+    status=fail / CLI exit 1, with no routing error, and
+    `.drift-review/disposition` still says which terminal it was.
+    """
+    graph = _drift_graph()
+    exits = [n.id for n in graph.nodes.values() if n.is_exit_node()]
+    assert exits == ["done"], exits
+
+    outgoing = graph.outgoing_edges("escalated")
+    assert outgoing, (
+        "`escalated` has no outgoing edge, so the engine reports the designed "
+        "escalation as PIPELINE_ERROR error_type=no_matching_edge (issue #252)"
+    )
+    assert [e.to_node for e in outgoing] == ["done"]
+    assert "outcome=fail" in (outgoing[0].condition or ""), outgoing[0].condition
+
+
+def test_escalated_still_exits_nonzero_so_the_exit_it_reaches_is_red():
+    """The routing fix must not turn the loud terminal into a quiet one."""
+    node = _drift_graph().nodes["escalated"]
+    command = str(node.attrs["tool_command"])
+    assert command.rstrip().endswith("exit 1"), command
+    assert str(node.attrs.get("max_retries")) == "0"
+    assert ".drift-review/disposition" in command
+
+
+def test_no_node_in_the_drift_review_graph_dead_ends():
+    """The whole-graph form of the rule, so a future terminal cannot regress."""
+    graph = _drift_graph()
+    exits = {n.id for n in graph.nodes.values() if n.is_exit_node()}
+    dead_ends = [n for n in graph.nodes if n not in exits and not graph.outgoing_edges(n)]
+    assert dead_ends == [], dead_ends
+
+
+def test_the_report_gate_carries_no_retry_target():
+    """#252's corollary, which #252 does not mention and #248 discovered.
+
+    `retry_target` on a goal gate is consulted in exactly one place --
+    `_check_goal_gates()` at the exit node.  While `escalated` dead-ended, the
+    exit was unreachable with `report_gate` unsatisfied, so the attribute was
+    dead.  `escalated -> done` makes it reachable -- and in THIS graph
+    `report_gate -> escalated [outcome=fail]` is the shortest path there, so the
+    attribute becomes live on the very route it must not fire on.  Measured on
+    the shipped engine with a faithful reduction of exactly that shape:
+    `consolidate`, `report_gate` and `escalated` executed 51 times each before
+    the step cap with `retry_target="consolidate"`, and once each without it.
+    `no_corpus` means the findings gate never admitted a corpus -- a cause no
+    number of re-consolidations can change.
+
+    The corrective cycle is untouched: it is the `report_bad` edge back to
+    `consolidate`, walled by $max_reports.
+    """
+    graph = _drift_graph()
+    gate = graph.nodes["report_gate"]
+    assert str(gate.attrs.get("goal_gate", "")).lower() == "true"
+    assert not gate.attrs.get("retry_target"), gate.attrs.get("retry_target")
+    assert not gate.attrs.get("fallback_retry_target")
+    assert "retry_target" not in graph.graph_attrs
+
+    pairs = {(e.from_node, e.to_node) for e in graph.edges}
+    assert ("report_gate", "consolidate") in pairs

--- a/modules/loop-pipeline/tests/test_exemplar_terminals.py
+++ b/modules/loop-pipeline/tests/test_exemplar_terminals.py
@@ -1,0 +1,410 @@
+"""Guards for the two exemplars whose loud terminals had no test home.
+
+``examples/pipelines/practical/bug-fix.dot`` and
+``examples/patterns/task-runner.dot`` are shipped, copy-me exemplars, and both
+carried the dead-end designed-terminal shape that #248 removed from
+``examples/objective/objective-runner.dot``:
+
+  * ``bug-fix.dot``   -- ``escalated``
+  * ``task-runner.dot`` -- ``bad_input`` AND ``abandon``
+
+The engine's MAIN loop has no designed-terminus concept.  ``run_subgraph()``
+distinguishes "no outgoing edges at all" (a designed terminus) from a
+conditional-mismatch dead end; ``run()`` does NOT -- it reports
+``no_matching_edge`` as a PIPELINE_ERROR whatever the node's exit status.  So
+each of these deliberately-loud terminals *errored as unroutable* when it was
+reached, and the author's intent ("exit red, loudly, having salvaged a
+postmortem") was delivered to the operator as "the pipeline is broken".
+Measured on the shipped CLI before the fix::
+
+    [PIPELINE] X Error at bad_input (no_matching_edge): ...
+    notes: No matching edge from node 'bad_input'
+
+The second half of this file holds ``bug-fix.dot``'s ``test_gate`` -- which
+used to run a bare workspace-root ``pytest -q`` -- to the bar an evidence gate
+has to clear: it must find the tests in a nested-package workspace, and it must
+not report "there is nothing here to run" as an ordinary RED that the fixer is
+then sent to grind against.  That grind is what actually failed in the #243
+incident.
+
+Every structural assertion reads the shipped graph through the ENGINE'S OWN
+PARSER, and every behavioural assertion drives the graph's REAL ``tool_command``
+text -- not a paraphrase of either.  A property that only holds in a
+hand-written approximation of the gate is not a property of the pipeline.
+
+The examples tree lives at the repository root, outside the installed package,
+so these tests run against a source checkout and skip gracefully when the
+examples directory is absent (e.g. an installed-package test run) -- the same
+pattern as ``test_examples_lint_clean.py`` and ``test_objective_layer_gates.py``.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from amplifier_module_loop_pipeline.dot_parser import parse_dot
+from amplifier_module_loop_pipeline.graph import Graph
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_EXAMPLES = _REPO_ROOT / "examples"
+_BUG_FIX = _EXAMPLES / "pipelines" / "practical" / "bug-fix.dot"
+_TASK_RUNNER = _EXAMPLES / "patterns" / "task-runner.dot"
+
+pytestmark = pytest.mark.skipif(
+    not _EXAMPLES.is_dir(),
+    reason="examples/ not present (installed-package run)",
+)
+
+
+def _graph(path: Path) -> Graph:
+    return parse_dot(path.read_text(encoding="utf-8"))
+
+
+def _exit_id(graph: Graph) -> str:
+    exits = [n.id for n in graph.nodes.values() if n.is_exit_node()]
+    assert len(exits) == 1, f"validate_or_raise requires exactly one exit node, got {exits}"
+    return exits[0]
+
+
+# ---------------------------------------------------------------------------
+# The routing fix: a designed loud terminal must ROUTE, it cannot dead-end.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("dot_path", "terminal"),
+    [
+        (_BUG_FIX, "escalated"),
+        (_TASK_RUNNER, "bad_input"),
+        (_TASK_RUNNER, "abandon"),
+    ],
+    ids=["bug-fix:escalated", "task-runner:bad_input", "task-runner:abandon"],
+)
+def test_the_loud_terminal_routes_to_the_exit_instead_of_dead_ending(dot_path, terminal):
+    """Issue #252: the main loop has no designed-terminus concept.
+
+    ``run_subgraph()`` gives the subgraph path an explicit "no outgoing edges at
+    all is a designed terminus" branch; ``run()`` has no such branch and reports
+    ``error_type=no_matching_edge`` regardless of exit status.  A dead-ended
+    terminal therefore surfaces the graph's most important honest outcome in the
+    vocabulary of an authoring bug.  One edge per terminal --
+    ``<terminal> -> <exit> [outcome=fail]`` -- is the convergence-factory idiom
+    proven in #248.
+    """
+    graph = _graph(dot_path)
+    exit_id = _exit_id(graph)
+
+    outgoing = graph.outgoing_edges(terminal)
+    assert outgoing, (
+        f"'{terminal}' has no outgoing edge, so the engine reports the designed "
+        f"terminal as PIPELINE_ERROR error_type=no_matching_edge (issue #252)"
+    )
+    assert [e.to_node for e in outgoing] == [exit_id]
+    assert "outcome=fail" in (outgoing[0].condition or ""), outgoing[0].condition
+
+
+@pytest.mark.parametrize(
+    ("dot_path", "terminal"),
+    [
+        (_BUG_FIX, "escalated"),
+        (_TASK_RUNNER, "bad_input"),
+        (_TASK_RUNNER, "abandon"),
+    ],
+    ids=["bug-fix:escalated", "task-runner:bad_input", "task-runner:abandon"],
+)
+def test_the_routed_terminal_is_still_red(dot_path, terminal):
+    """The routing fix must not turn a loud terminal into a quiet one.
+
+    ``<terminal> -> <exit> [outcome=fail]`` is only honest because the
+    terminal's own FAIL is what ``_check_goal_gates`` returns from the exit.  A
+    terminal that exited 0 would convert the escalation into a GREEN run -- the
+    exact hazard TOPO-006 names -- and ``max_retries`` above 0 would let the
+    engine re-run a node whose failure is the point.
+    """
+    node = _graph(dot_path).nodes[terminal]
+    command = str(node.attrs["tool_command"])
+    assert command.rstrip().endswith("exit 1"), command
+    assert str(node.attrs.get("max_retries")) == "0", node.attrs.get("max_retries")
+
+
+@pytest.mark.parametrize(
+    "dot_path",
+    [_BUG_FIX, _TASK_RUNNER],
+    ids=["bug-fix", "task-runner"],
+)
+def test_no_node_in_these_graphs_dead_ends(dot_path):
+    """The whole-graph form of the same rule -- a future terminal cannot regress.
+
+    Anything that is not the exit node and has no outgoing edge is, on this
+    engine, an unroutable node waiting to be reached.
+    """
+    graph = _graph(dot_path)
+    exit_id = _exit_id(graph)
+    dead_ends = [
+        node_id
+        for node_id in graph.nodes
+        if node_id != exit_id and not graph.outgoing_edges(node_id)
+    ]
+    assert dead_ends == [], (
+        f"{dot_path.name}: nodes with no outgoing edge report no_matching_edge "
+        f"when reached: {dead_ends}"
+    )
+
+
+def test_task_runners_exit_time_retry_can_no_longer_overrule_an_abandonment():
+    """#252's corollary, which #252 itself does not mention (#248 found it).
+
+    ``retry_target`` on a goal gate is consulted in exactly ONE place --
+    ``_check_goal_gates()`` at the exit node -- and the graph-level attribute is
+    that same mechanism's fallback (spec 3.4; it is deliberately NOT consulted
+    on per-node failure, spec 3.7, ``_resolve_failure_retry_target``).  It never
+    was a corrective loop.  The one question it answers is "the run is trying to
+    LEAVE with a goal gate unsatisfied -- where does it go instead?"
+
+    While ``abandon`` dead-ended, the exit was unreachable with a gate
+    unsatisfied, so the answer never mattered.  ``abandon -> done`` makes it
+    matter, and ``attempt`` became the WRONG answer: ``abandon`` is reached with
+    ``verify`` red (verify -> triage -> postmortem) or ``verdict`` red, so an
+    abandonment a HUMAN had just chosen would be overruled and the maker paid
+    for again, with ``completed_nodes`` cleared.  Measured on the shipped engine
+    with a faithful reduction of this shape::
+
+        retry_target="attempt"  -> attempt/verify/postmortem/abandon x51 each
+        retry_target="abandon"  -> 1 / 1 / 1 / 2
+
+    So: no node-level value (it would take precedence and re-open the hazard),
+    and the graph-level answer is the abandonment terminal.
+    """
+    graph = _graph(_TASK_RUNNER)
+
+    gates = [n for n in graph.nodes.values() if str(n.attrs.get("goal_gate", "")).lower() == "true"]
+    assert {n.id for n in gates} == {"verify", "verdict"}, [n.id for n in gates]
+    for gate in gates:
+        assert not gate.attrs.get("retry_target"), gate.id
+        assert not gate.attrs.get("fallback_retry_target"), gate.id
+
+    # Whatever the graph-level answer is, it must not be a maker: a run that a
+    # human has just abandoned may not be sent back to do more work.
+    exit_time_retry = graph.graph_attrs.get("retry_target") or graph.graph_attrs.get(
+        "fallback_retry_target"
+    )
+    assert exit_time_retry in (None, "abandon"), exit_time_retry
+    if exit_time_retry is not None:
+        target = graph.nodes[exit_time_retry]
+        assert str(target.attrs["tool_command"]).rstrip().endswith("exit 1"), target.id
+
+    # The corrective loops are unchanged -- they are the graph's own edges,
+    # which is where iteration was always actually happening.
+    pairs = {(e.from_node, e.to_node) for e in graph.edges}
+    assert ("triage", "attempt") in pairs
+    assert ("feedback", "attempt") in pairs
+
+
+# ---------------------------------------------------------------------------
+# bug-fix.dot's test_gate: find the tests, and never grind against a gate that
+# cannot go green.  These drive the REAL tool_command text.
+# ---------------------------------------------------------------------------
+
+_SHELL_GATE = pytest.mark.skipif(
+    not (shutil.which("bash") and shutil.which("pytest")),
+    reason="the shipped test_gate command needs bash and pytest on PATH",
+)
+
+_NESTED_PYPROJECT = """[project]
+name = "mypkg"
+version = "0.1.0"
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+"""
+
+_PASSING_TEST = "def test_ok():\n    assert True\n"
+_IMPORTING_TEST = "from mypkg import VALUE\n\n\ndef test_value():\n    assert VALUE == 42\n"
+
+
+def _test_gate_command() -> str:
+    """The verbatim test_gate tool_command, read through the engine's parser."""
+    return str(_graph(_BUG_FIX).nodes["test_gate"].attrs["tool_command"])
+
+
+def _run_test_gate(workspace: Path, **env_overrides: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        _test_gate_command(),
+        shell=True,
+        cwd=workspace,
+        env={**os.environ, **env_overrides},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _flat_workspace(root: Path) -> Path:
+    (root / "tests").mkdir(parents=True, exist_ok=True)
+    (root / "tests" / "test_flat.py").write_text(_PASSING_TEST, encoding="utf-8")
+    return root
+
+
+def _nested_workspace(root: Path) -> Path:
+    """A package one level down, with its own pytest rootdir -- the #243 shape.
+
+    ``pytest -q`` from ``root`` collects ``mypkg/tests/test_value.py`` and then
+    dies importing ``mypkg``, because the ini options that make the import work
+    live in ``mypkg/pyproject.toml`` and a root-level run never reads them.
+    """
+    pkg = root / "mypkg"
+    (pkg / "src" / "mypkg").mkdir(parents=True, exist_ok=True)
+    (pkg / "tests").mkdir(parents=True, exist_ok=True)
+    (pkg / "pyproject.toml").write_text(_NESTED_PYPROJECT, encoding="utf-8")
+    (pkg / "src" / "mypkg" / "__init__.py").write_text("VALUE = 42\n", encoding="utf-8")
+    (pkg / "tests" / "test_value.py").write_text(_IMPORTING_TEST, encoding="utf-8")
+    return root
+
+
+@_SHELL_GATE
+def test_the_old_hardcoded_gate_could_not_pass_a_nested_workspace(tmp_path):
+    """The defect itself, held in place so the fix cannot be undone silently.
+
+    This is the shipped-before command, verbatim.  It is not "strict" -- it is
+    UNPASSABLE for this layout, and the branch it lands in reports the same
+    token as a genuinely failing test, which is what sent the #243 lane child
+    to its budget wall.
+    """
+    workspace = _nested_workspace(tmp_path)
+    before = subprocess.run(
+        "mkdir -p .ai; pytest -q > .ai/test.log 2>&1; [ $? -eq 0 ] && printf pass || printf fail",
+        shell=True,
+        cwd=workspace,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert before.stdout == "fail", before.stdout
+
+
+@_SHELL_GATE
+def test_the_gate_finds_the_tests_in_a_flat_workspace(tmp_path):
+    """Discovery must not regress the ordinary case: root wins when root works."""
+    workspace = _flat_workspace(tmp_path)
+
+    result = _run_test_gate(workspace)
+
+    assert result.stdout == "pass", (result.stdout, result.stderr)
+    assert result.returncode == 0
+    assert (workspace / ".ai" / "test-target").read_text(encoding="utf-8").strip() == "pytest -q"
+
+
+@_SHELL_GATE
+def test_the_gate_finds_the_tests_in_a_nested_workspace(tmp_path):
+    """Issue #252 / #243: the workspace-root assumption is what actually broke.
+
+    The gate now asks pytest itself where the tests are, so the same graph that
+    could never go green on this layout goes green on the first entry.
+    """
+    workspace = _nested_workspace(tmp_path)
+
+    result = _run_test_gate(workspace)
+
+    assert result.stdout == "pass", (result.stdout, result.stderr)
+    target = (workspace / ".ai" / "test-target").read_text(encoding="utf-8").strip()
+    assert "mypkg" in target, target
+    # The receipt: the log opens by naming what was actually run, so "the gate
+    # tested something other than what you think" is visible on iteration 1.
+    assert (workspace / ".ai" / "test.log").read_text(encoding="utf-8").startswith(f"RAN: {target}")
+
+
+@_SHELL_GATE
+def test_a_gate_with_nothing_to_run_is_not_reported_as_a_red_test(tmp_path):
+    """"Nothing collected" is a broken instrument, not a fixable failure.
+
+    pytest exits 5 for "no tests collected".  The old gate folded that into
+    ``fail`` and sent the fixer round the loop again; no patch can make a
+    non-existent suite green, so the run burned its whole budget.  The gate now
+    says ``no_target`` and the graph routes that to the decision point.
+    """
+    workspace = tmp_path
+    (workspace / "src.py").write_text("VALUE = 1\n", encoding="utf-8")
+
+    result = _run_test_gate(workspace)
+
+    assert result.stdout == "no_target", (result.stdout, result.stderr)
+    assert result.returncode == 0, "the token carries the verdict; the gate itself ran fine"
+    # The refusal has to be actionable, not just loud.
+    assert "test_command" in result.stderr
+    assert not (workspace / ".ai" / "test-target").exists()
+
+
+@_SHELL_GATE
+def test_an_explicit_test_command_is_run_as_given(tmp_path):
+    """The escape hatch has to survive being a COMPOUND command.
+
+    ``bash -c "$tc"`` hands the parameter to a shell verbatim, so ``cd <pkg> &&
+    ...``, an env prefix, or an ``&&`` chain runs exactly as passed.  A gate
+    that silently rewrote the operator's command would be a worse bug than the
+    one being fixed.
+    """
+    workspace = _nested_workspace(tmp_path)
+
+    result = _run_test_gate(workspace, test_command="cd mypkg && pytest -q tests/test_value.py")
+
+    assert result.stdout == "pass", (result.stdout, result.stderr)
+    log = (workspace / ".ai" / "test.log").read_text(encoding="utf-8")
+    assert log.startswith("RAN: cd mypkg && pytest -q tests/test_value.py"), log[:200]
+
+
+@_SHELL_GATE
+def test_a_genuinely_failing_suite_is_still_an_ordinary_red(tmp_path):
+    """The distinction only means something if a real red still routes to triage."""
+    workspace = _flat_workspace(tmp_path)
+    (workspace / "tests" / "test_flat.py").write_text("def test_bad():\n    assert False\n", encoding="utf-8")
+
+    result = _run_test_gate(workspace)
+
+    assert result.stdout == "fail", (result.stdout, result.stderr)
+
+
+@_SHELL_GATE
+def test_the_budget_wall_still_fires_before_any_discovery(tmp_path):
+    """Exhaustion is checked first, so a spent budget never pays for a pytest run."""
+    workspace = _flat_workspace(tmp_path)
+    (workspace / ".ai").mkdir(exist_ok=True)
+    (workspace / ".ai" / "iter").write_text("5\n", encoding="utf-8")
+    (workspace / ".ai" / "budget").write_text("5\n", encoding="utf-8")
+
+    result = _run_test_gate(workspace)
+
+    assert result.stdout == "exhausted", (result.stdout, result.stderr)
+    assert not (workspace / ".ai" / "test.log").exists()
+
+
+def test_no_target_routes_to_the_decision_point_not_back_into_the_fix_loop():
+    """The token is only half the fix; the routing is the other half."""
+    graph = _graph(_BUG_FIX)
+    targets = {
+        e.to_node
+        for e in graph.outgoing_edges("test_gate")
+        if "no_target" in str(e.condition or "")
+    }
+    assert targets == {"postmortem"}, targets
+
+    # ...and the fix loop is still reachable for an ordinary red.
+    fail_targets = {
+        e.to_node
+        for e in graph.outgoing_edges("test_gate")
+        if "last_line=fail" in str(e.condition or "")
+    }
+    assert fail_targets == {"triage"}, fail_targets
+
+
+def test_the_gate_no_longer_hardcodes_a_workspace_root_pytest():
+    """The shipped text itself, so a revert cannot pass the behavioural tests by luck."""
+    command = _test_gate_command()
+    assert "$test_command" in command, "the honest escape hatch is a param"
+    assert "--collect-only" in command, "the default target is discovered, not assumed"
+    assert "no_target" in command
+    assert "; pytest -q > .ai/test.log" not in command, "the bare workspace-root run is back"


### PR DESCRIPTION
The engine's **main loop has no designed-terminus concept**. `run_subgraph()` distinguishes "no outgoing edges at all" (a designed terminus) from a conditional-mismatch dead end; `run()` does **not** — it terminates through `terminate_pipeline()` and emits `PIPELINE_ERROR error_type=no_matching_edge` **regardless of exit status**. So five deliberately-loud terminals across four shipped exemplars reported their graph's most important honest outcome in the vocabulary of an authoring bug. Measured on the shipped CLI against the pre-fix files:

```
[PIPELINE] ✗ Error at bad_input (no_matching_edge): Command exited with code 1: FATAL: task_file or its sibling .verify.sh not found
notes: No matching edge from node 'bad_input'

[PIPELINE] ✗ Error at escalated (no_matching_edge): Command exited with code 1: escalated
notes: No matching edge from node 'escalated'
```

Fix shape is #248's, followed exactly: one edge per terminal.

## Terminal inventory

| File | Terminal | Exit node | Edge added |
|---|---|---|---|
| `examples/authoring/pipeline-author.dot` | `escalated` | `done` | `escalated -> done [condition="outcome=fail", label="loud exit -- status is escalated's own nonzero exit"]` |
| `examples/drift-review/drift-review.dot` | `escalated` | `done` | `escalated -> done [condition="outcome=fail", label="loud exit -- status is escalated's own nonzero exit"]` |
| `examples/pipelines/practical/bug-fix.dot` | `escalated` | `done` | `escalated -> done [condition="outcome=fail", label="loud exit -- status is escalated's own nonzero exit"]` |
| `examples/patterns/task-runner.dot` | `bad_input` | `done` | `bad_input -> done [condition="outcome=fail", label="loud exit — status is bad_input's own nonzero exit"]` |
| `examples/patterns/task-runner.dot` | `abandon` | `done` | `abandon -> done [condition="outcome=fail", label="loud exit — status is abandon's own nonzero exit"]` |

Each graph's own exit-node name was read through the engine's parser (all four are `done`), the one-exit rule still holds, and `attractor lint` reports **zero ERRORs** on all four. Every graph now has **zero** non-exit nodes with no outgoing edge (asserted per graph, not just per terminal).

## The corollary #252 does not mention — and it is load-bearing

Routing a terminal to the exit makes each graph's goal-gate `retry_target` **reachable**, and therefore live and wrong. `retry_target` on a goal gate is consulted in exactly one place — `_check_goal_gates()` **at the exit node** — and the graph-level attribute is that same mechanism's fallback (spec §3.4; deliberately *not* consulted on per-node failure, spec §3.7). While the terminal dead-ended, the exit was unreachable with a gate unsatisfied, so the attribute was dead. #248 found this for `objective-runner.dot` and removed the attribute; #252 does not carry it forward, and for three of these five terminals it is reachable — `report_gate -> escalated [outcome=fail]` is a *direct* edge.

Measured on the shipped engine with faithful reductions (evidence below):

| Reduction | `retry_target` | Executions before the step cap |
|---|---|---|
| drift-review `report_gate`(no_corpus) → `escalated` → `done` | `"consolidate"` | consolidate **51**, report_gate **51**, escalated **51** |
| same | *(removed)* | **1 / 1 / 1** |
| task-runner `verify`(red) → … → `abandon` → `done` | `"attempt"` | attempt **51**, verify **51**, postmortem **51**, abandon **51** |
| same | `"abandon"` | **1 / 1 / 1 / 2** |
| same | *(removed)* | **1 / 1 / 1 / 1** |

So an escalation that had already written its postmortem — or an abandonment a **human had just chosen** — would be overruled and the maker paid for another 50 laps, with `completed_nodes` cleared.

- `pipeline-author.dot` — `verdict_gate` loses `retry_target`. Its real corrective loop is the `loop_restart` back-edge to `author`, untouched (which is also why `goal_gate_has_retry` stays quiet).
- `drift-review.dot` — `report_gate` loses `retry_target`. Its corrective cycle is the `report_bad` edge to `consolidate`, untouched. Carries a deliberate `goal_gate_has_retry` WARNING, exactly as `objective-runner.dot`'s `evidence_gate` does.
- `task-runner.dot` — node-level values gone; the **graph-level** one now names `abandon` rather than `attempt`. Deleting it outright would have silently re-opened an unrelated question (`check_authored_pipeline.py`'s A6 counts a graph-level `retry_target` as a per-node failure route, which the engine does not — four box nodes there have no real failure route today). That is a separate defect; it is now **written into the file** rather than quietly fixed or quietly widened here.
- `bug-fix.dot` declares no goal gate, so nothing is consulted at its exit.

## The `bug-fix.dot` gate fix, and why this mechanism

`test_gate` ran a bare workspace-root `pytest -q`. For a package nested one level down — its own `pyproject`, its own rootdir, often its own environment — that collects nothing or dies on import, and pytest's *"no tests collected"* is **exit 5**, which `[ $? -eq 0 ] && printf pass || printf fail` reported as an ordinary RED. The fixer was then sent to patch code against a gate that could not go green under any patch. That is the #243 incident's actual failure: a lane child exhausting its budget against a gate that could never go green.

Three changes, in the order they matter:

1. **The target is discovered, not assumed.** With no param, the gate asks pytest itself where the tests are: the workspace root first, then each directory within two levels owning a `tests/` dir (lexically ordered → deterministic), taking the first that actually **collects** (`pytest -q --collect-only`). Flat and nested layouts both work with no configuration.
2. **"Nothing to run" is not "red."** Exit 5, and a discovery sweep that finds no collecting target at all, both emit a distinct **`no_target`** verdict routed to `postmortem` — a decision point about a broken instrument — never back into the fix loop.
3. **The escape hatch is a param, run as given.** `--param test_command=<...>` is handed to `bash -c` verbatim, so `cd pkg && uv run pytest -q`, an env prefix, or an `&&` chain runs exactly as passed.

**Why this and not one of the two alternatives.** A param *alone* (default `pytest -q`) only helps callers who already know about the wall — the naive invocation still hits it, which is precisely the population #243 was drawn from. Discovery *alone* has no answer for `uv run pytest`, `make test`, or a monorepo with two suites. And neither alone fixes the deeper half: even a perfect default can be wrong somewhere, so the gate must be able to say **"I have nothing to run"** in a vocabulary the graph can route on. That third piece is what converts a silent forever-red into a bounded, loud decision point.

**It stays an evidence gate, not a recipe.** It runs a command and emits a token; the *graph* decides what the token means; the node runs outside the fixer's context; nothing about *how to fix the bug* moved into the gate. The chosen target is cached in `.ai/test-target` (discovery is paid once) and `.ai/test.log` opens with `RAN: <command>` — so "the gate tested something other than what you think" is visible on iteration 1 instead of being reconstructed from a postmortem at budget exhaustion.

## Authoring-contract recalibration (a pre-existing conflict this surfaced)

`examples/authoring/check_authored_pipeline.py`'s **A8** blocks *any* failure-conditioned edge into the exit — including the shape #248 merged. **On `origin/main` today, A8 already rejects `objective-runner.dot`.** It is simply not in A8's calibration list, so nobody noticed. **A4** has the sibling problem: it counts a path that can only end **red** as an "evidence-free finish."

By this contract's own calibration doctrine — *"a gate that rejects `task-runner.dot` is a wrong gate, not a strict one"* — A8 was mis-calibrated. Both checks now recognise a **designed loud terminal**, defined narrowly enough that the hazard they exist to catch cannot wear it as a costume. All five must hold:

1. a **tool** node (a worker's "failure" is a provider verdict, not a process exit status);
2. its command's **last** statement exits **nonzero** (so it fails on *every* path — a node that can exit 0 could hand the exit a SUCCESS);
3. `max_retries=0` (the failure is the point);
4. the edge into the exit is its **only** outgoing edge (a node with somewhere else to go is the bookkeeping intermediary A8 is looking for);
5. **that edge carries a failure condition** (`outcome=fail` / `outcome!=success`) — added post-review, see *Post-review fixes* below. Clauses 1–4 are all read off the **text** of the graph and clause 2 is the weakest of them; the condition is what makes the exemption sound at **runtime**.

Each clause is held RED by a mutation test; the original A8 mutation (`critique -> done [outcome=fail]`) still fires unchanged. Scope note, plainly: this file is not in this lane's declared file set. It is the doctrine gate *for* `pipeline-author.dot` and its test file is in scope, and without this the mandated fix shape cannot ship green in three of four files — so it is here, surgical (one helper, two call sites), and called out rather than slipped in.

## Deterministic RED → GREEN

Revert **only** the four `.dot` files to `origin/main` and 19 of the new/updated tests fail; restore the fix and all pass. Evidence: `deterministic/RED-against-pre-fix-dots.txt`.

```
FAILED test_exemplar_terminals.py::test_the_loud_terminal_routes_to_the_exit_instead_of_dead_ending[bug-fix:escalated]
E  AssertionError: 'escalated' has no outgoing edge, so the engine reports the designed terminal as
   PIPELINE_ERROR error_type=no_matching_edge (issue #252)
E  assert []

FAILED test_exemplar_terminals.py::test_the_loud_terminal_routes_to_the_exit_instead_of_dead_ending[task-runner:bad_input]
E  AssertionError: 'bad_input' has no outgoing edge, ...        E  assert []

FAILED test_exemplar_terminals.py::test_the_loud_terminal_routes_to_the_exit_instead_of_dead_ending[task-runner:abandon]
E  AssertionError: 'abandon' has no outgoing edge, ...          E  assert []

FAILED test_authoring_layer_gates.py::test_escalated_routes_to_the_exit_instead_of_dead_ending
E  AssertionError: `escalated` has no outgoing edge, so the engine reports the designed escalation as
   PIPELINE_ERROR error_type=no_matching_edge (issue #252)

FAILED test_drift_review_gate.py::test_escalated_routes_to_the_exit_instead_of_dead_ending
E  AssertionError: `escalated` has no outgoing edge, ...

... plus test_no_node_in_{these_graphs,the_authoring_graph,the_drift_review_graph}_dead_ends,
    the three goal-gate/retry-target corollary tests
    (authoring test_the_goal_gate_carries_no_retry_target, drift-review
     test_the_report_gate_carries_no_retry_target and
     test_the_shipped_graph_keeps_its_layer_three_contract),
    test_task_runners_exit_time_retry_can_no_longer_overrule_an_abandonment,
    and 6 test_gate tests
    (flat / nested / no_target / explicit test_command / routing / shipped-text).
19 failed, 127 passed   ->   after the fix: 146 passed
```

Tests read the shipped graphs through the **engine's own parser** and drive the **real `tool_command` text**, per the repo's gate-test pattern. New file `modules/loop-pipeline/tests/test_exemplar_terminals.py` is the home for `bug-fix.dot` and `task-runner.dot`, which had none; `pipeline-author` and `drift-review` terminals went into their existing files.

## Live proof — all five terminals, real `attractor` CLI

Evidence: `.amplifier/evaluation/exemplar-terminals/20260816T034322Z/` (`SUMMARY.md`, `live/`, `red-baseline/`, `goal-gate-retry-measurement/`, `deterministic/`). Terminal reached is taken from each run's own `<logs>/<terminal>/status.json` and `trace.jsonl` — not inferred.

| Terminal | How it was driven (cheapest reachable path) | `trace.jsonl` tail | `status.json` | CLI exit | `no_matching_edge` | Artifacts |
|---|---|---|---|---|---|---|
| task-runner `bad_input` | `task_file` that does not exist — **no LLM at all** | `start, setup, bad_input` | `{"node_id":"bad_input","status":"fail","outcome":"fail"}` | **1** | **0** | `.ai/{budget,feedback,postmortem}` |
| pipeline-author `escalated` | `authoring_dir` missing `check_authored_pipeline.py` → `preflight` refuses — **no LLM** | `start, preflight, escalated` | `{"node_id":"escalated","status":"fail","outcome":"fail"}` | **1** | **0** | `.authoring/disposition=escalated`, `postmortem/escalation.md` (81B) |
| drift-review `escalated` | cwd is not the repo under review → `preflight` refuses — **no LLM** | `start, preflight, escalated` | `{"node_id":"escalated","status":"fail","outcome":"fail"}` | **1** | **0** | `.drift-review/disposition=escalated`, `postmortem/escalation.md` (83B) |
| bug-fix `escalated` | invalid `ANTHROPIC_API_KEY` → `reproduce` fails → `postmortem` fails → `escalated` | `start, reproduce, postmortem, escalated` | `{"node_id":"escalated","status":"fail","outcome":"fail"}` | **1** | **0** | `.ai/postmortem/escalation.md` |
| task-runner `abandon` | one-file probe task, `--param max_iterations=0`, `--on-human-gate auto-approve` (Abandon is the first edge, by design) | `triage, postmortem, pm_gate, escalate, abandon, abandon` | `{"node_id":"abandon","status":"fail","outcome":"fail"}` | **1** | **0** | `.ai/postmortem/report.md` |

Every run: `attractor: status=fail`, exit **1**, terminal artifacts on disk, and **zero** occurrences of `no_matching_edge` in the log. Pre-fix baselines for three of them are in `red-baseline/` with the `[PIPELINE] ✗ Error at <terminal> (no_matching_edge)` line.

`abandon` appearing **twice** in that trace is the measured, documented behaviour of `retry_target="abandon"`: the exit-time check finds `verify` red, jumps once to the abandonment terminal, and the second exit-check (a goal-gate retry clears `node_outcomes`) returns `abandon`'s own FAIL. The live run confirms the reduction's `1/1/1/2` exactly.

## Tier classification (QUALITY_PROTOCOL §3)

**Toward-spec.** No conformance-bearing code changed — four example graphs, an example-tree gate script, and tests — so no ledger entry is owed. On direction: canonical §3.2 step 6 reads a dead end as *successful completion*; this engine deliberately diverges (ATX-11 / `specs/EXTENSIONS.md` §33, `terminate_pipeline` + `no_matching_edge`). Pre-fix, all five terminals **depended on that divergence** to be loud at all — under spec-literal semantics these files would have exited **green** on their escalation paths. Post-fix each terminal's status is carried by an explicit edge and the node's own exit code, so every graph behaves identically under **either** dead-end rule. That closes a gap with the canonical spec rather than widening one, and asks the engine to move not at all. The `check_authored_pipeline.py` change is a calibration correction to an example-tree gate — it admits a shape already merged in this repo and rejects strictly more than it did before on everything else — not a spec movement.

## Gates

| Gate | Result |
|---|---|
| `modules/loop-pipeline`: `uv sync --extra remote && uv run pytest -q` | **2351 passed, 25 skipped** |
| `modules/pipeline-runner`: `uv sync && uv run pytest -q` | **76 passed, 1 skipped** |
| examples-lint sweep (`attractor lint`, 33 `.dot` files) | **0 ERRORs** |
| `attractor lint` on the four changed files | pipeline-author 1 warn · drift-review 2 warns · bug-fix 1 warn · task-runner 2 warns — every one deliberate and documented in place (TOPO-006 `fail_routed_to_exit`, and drift-review's `goal_gate_has_retry`) |
| `git diff --check` | clean |
| Leak scan over the diff | 0 hits |
| Run artifacts committed | none (evidence lives under `.amplifier/evaluation/`, outside the repo) |
| New ruff findings | none (the pre-existing `EXE001`/`RUF007`/format findings in `check_authored_pipeline.py` are unchanged from `origin/main`) |

## Post-review fixes

**Adversarial review verdict: MERGE-AFTER-FIX — one exact fix, reviewer-reproduced.** Applied in `88bcaa4`.

**The finding.** The widened A4/A8 exemption could be laundered into an evidence-free **green** finish. The reviewer built the shape and ran it green on the live engine:

```dot
sneak [shape=parallelogram, max_retries=0, tool_command="rm -f scratch.tmp || exit 1"]
work  -> sneak          // ungated fast path
sneak -> done           // UNCONDITIONAL
```

Clauses 1–4 all matched it — on the **text** of the graph. Clause 2's regex (`check_authored_pipeline.py:434`) sees `|| exit 1` and reads a terminal nonzero exit; the command actually exits **0** whenever the `rm` succeeds. Clause 4 checked that the exit edge was the node's *only* edge but never looked at its **condition**. So A4 blocked `sneak` alongside the evidence gates, found `done` unreachable without them, and passed the graph. Live run: `status=success`, CLI exit **0**. `origin/main`'s A4 catches this shape; the un-hardened branch did not.

**The fix.** The hole was that all four clauses were read off the graph text, and the weakest of them was carrying the runtime claim. Clause 5 moves that claim onto something the text cannot fake — the single outgoing edge must carry a failure condition:

```python
    outgoing = graph.outgoing(node_id)
    return (
        len(outgoing) == 1
        and _is_exit(graph, outgoing[0].dst)
        and _is_failure_condition(outgoing[0].attrs.get("condition", ""))
    )
```

`_is_failure_condition` is the file's existing helper (`outcome=fail` / `outcome!=success`) — no new vocabulary. An edge that only fires on `outcome=fail` can never carry a SUCCESS into the exit, **whatever the command turns out to do**, so the exemption is sound at runtime rather than by inspection.

**Recalibration — nothing else moved.** All five shipped exemplar terminals and `objective-runner.dot` already route on `condition="outcome=fail"`, so they stay exempt. Running the checker over **all 33 shipped `.dot` files** before and after the fix produces **byte-identical** PASS/FAIL results across all 330 check outcomes — **zero new rejections**.

**The pin.** One new parametrized mutation test, `test_a4_exempts_a_loud_terminal_only_when_its_edge_is_conditioned_on_failure`. Both cases use the same node, command, `max_retries=0` and single outgoing edge; they differ in exactly one character sequence — the edge's condition:

| `sneak -> done` edge | verdict | A4 |
|---|---|---|
| *(unconditional)* — the reviewer's laundering shape | `doctrine_bad` | **`[FAIL] A4`** |
| `[condition="outcome=fail"]` — the shipped exemplars' shape | `doctrine_ok` | **`[PASS] A4`** |

**Clause-level mutation of the checker itself** (disable one clause, expect the suite to go RED) confirms every behavioural clause is independently load-bearing:

```
[RED (killed)]  clause 2 (last statement exits NONZERO)  -> terminal-that-exits-zero
[RED (killed)]  clause 3 (max_retries=0)                 -> terminal-that-is-retried
[RED (killed)]  clause 4 (the exit edge is its ONLY edge)-> terminal-with-a-second-route
[RED (killed)]  clause 5 (edge carries a FAILURE COND.)  -> unconditional-edge-is-laundering
```

The PR's four original clause mutations all still hold RED, unchanged.

**One honest note, not fixed here.** Clause 1 (`_is_tool`) is *not* independently load-bearing: `_is_tool()` returns true for any node carrying a `tool_command`, and clause 2 already requires a non-empty `tool_command` — so clause 1 can never reject anything clause 2 would not. It is harmless (it can only ever agree) and it documents intent for a reader, so it is left in place rather than churned; the `terminal-that-is-an-llm-worker` mutation still goes RED, just via clause 2. Recorded because the mutation harness found it, not because it is a defect.


## Observations

- **#252's fix prescription is incomplete, and the missing half is the dangerous one.** The issue says "one edge each" and stops. #248's merged diff also removed the goal gate's `retry_target`, and #252 does not carry that forward. Applied literally, #252's instruction would have converted a `no_matching_edge` error into **50 laps of an LLM maker** on three of the five terminals — strictly worse than the bug it fixes. Measured, not reasoned: 51 executions vs 1.
- **#252's file table has a path error.** It lists `examples/patterns/task-runner.dot` in the table (correct) but the fix shape section and the lane brief both say `patterns/task-runner.dot`. The file is at `examples/patterns/task-runner.dot`. Cosmetic, noted for the record.
- **The rest of #252 checks out exactly.** All four files, all five terminals, and the declared line numbers (`pipeline-author:302`, `drift-review:280`, `bug-fix:60`, `task-runner:123`/`:204`) match `origin/main` @ `8c05b2f`, verified through the engine's parser. The `bug-fix.dot` gate hazard is real and reproduces.
- **`objective-runner.dot` fails its own repo's authoring contract on `main` today** (A8), and has since #248 merged. The contract's calibration suite covers `pipeline-author`/`task-runner`/`bug-fix` for A1–A9 but only A10 for `objective-runner`, so the flagship was never held to the rule it violates. Fixed here for A8/A4; `objective-runner.dot` still fails **A9** (companion coverage), which is untouched and out of scope for this lane.
- **A6 in `check_authored_pipeline.py` has a false negative** that is not fixed here: `_has_fail_route()` counts a *graph-level* `retry_target` as a per-node failure route, but the engine explicitly does not (`_resolve_failure_retry_target`: *"Graph-level retry_target is goal-gate-exit only (spec §3.4); it is intentionally NOT consulted on per-node failure (spec §3.7)"*). Consequence for `task-runner.dot`: `orient`, `attempt`, `diagnose` and `postmortem` have **no** failure route on the shipped engine — one transient provider error at any of them ends the run — and A6 is quiet about it. Fixing that means either adding fail routes to nodes the file documents as deliberately fail-fast, or changing what A6 counts, and both are real design decisions that belong to their own issue (this smells adjacent to #220). Recorded in `task-runner.dot` in place, deliberately not fixed under an unrelated issue number.
- **The old `bug-fix.dot` comment about dead-end portability was simply wrong** and is now corrected in place. It claimed the terminal's failure was *"portable under either dead-end semantics (the canonical spec treats a no-edge dead-end as SUCCESS; this engine hard-fails)."* On the engine that ships, a dead end is reported as an **authoring bug**, not a loud red. Portability across dead-end rules is not achieved by dead-ending; it is achieved by routing — which is exactly what this PR does.
- **`convergence-factory.dot` still fails A8** and is deliberately left alone: its `budget_check` has a second outgoing edge and can exit 0, so it is not a loud terminal by the definition above. It failed A8 before this PR too, and is in no calibration list. Widening the exemption to cover it would weaken it to the point of uselessness; the honest move is to leave the finding visible.

Fixes #252

