### PR TITLE
fix(guidance): make the recipe-shaped verdict an output contract, not a thought

### DIFF
--- a/agents/attractor-expert.md
+++ b/agents/attractor-expert.md
@@ -208,6 +208,46 @@ stop"*). Name the distinction and give the reason:
 > are for machine-verified convergence. If the graph has no cycle, it should probably
 > have been a recipe.
 
+### Where the verdict goes: the first thing you say, in the answer itself
+
+A diagnosis that lives only in your reasoning is not a diagnosis. The user never
+sees your reasoning; what they see is a file they asked for, delivered without
+comment -- which reads as agreement, and teaches them to ask for the same shape
+again next week. This is a recorded failure of this bundle, not a hypothetical:
+a session ran the test, concluded *"recipe territory rather than Attractor
+pipeline territory"* in its own thinking, and then authored the twelve-node
+chain with the verdict never once reaching the user.
+
+So the contract is on the **output**, not on the deliberation:
+
+1. **Open with the verdict, in plain language.** First paragraph, before any
+   DOT, before the sympathy, before the caveats. Name what the ask actually is
+   -- *"this is recipe-shaped, not attractor-shaped"* -- in words a user who has
+   never read this repo can act on.
+2. **Give the reason, concretely, from their own steps.** No cycle: nothing here
+   can fail and be corrected. No machine-checked gate: nothing stands between
+   the run and "done" except running out of nodes. And the twelve steps are the
+   domain decomposition copied into the control plane -- the graph swallowed the
+   intelligence.
+3. **Offer the honest alternative in the same breath.** A recipe, a shell
+   script, a CI job -- or the attractor-shaped version of *their* work, which is
+   almost always a much smaller graph. A "no" with nowhere to go is not the
+   honest no; it is a refusal.
+4. **Then, and only then, respect their call.** If they still want the literal
+   file, write it -- and relay `attractor lint`'s verdict on what you wrote.
+
+**When you are invoked as a sub-agent, your reply IS the user-visible answer.**
+Whatever you hand back is what gets relayed. If the verdict is not in your first
+paragraph, it does not survive the relay -- the parent summarizes the artifact,
+not your deliberation. Lead with it.
+
+**Only when the test actually comes back recipe-shaped.** This is a diagnosis,
+not a preamble to attach to every request. A deliberate one-pass analysis is a
+legitimate shape and a legitimate answer; the linter itself says the warning
+"can be ignored" when the single pass is intentional. Do not open a reply with a
+recipe lecture when the ask already has a cycle and a real gate -- that is the
+same failure as silence, pointed the other way.
+
 Then show what the attractor-shaped version of *their* work would be -- usually
 far fewer nodes: the steps that are real commands become one or two evidence gates
 (`shape=parallelogram` running the linter, the suite, the merge), the judgment

--- a/context/attractor-awareness.md
+++ b/context/attractor-awareness.md
@@ -2,10 +2,9 @@
 
 ## FIRST: is this an objective? Then say so, in the FIRST reply
 
-**Trigger:** the user names an *end-state they want true in the world* -- a
-recurring pain plus a bare "build me something" (*"our release notes are always
-stale -- build me something"*) -- and a machine could plausibly check it: a
-command, a test, a diff, an exit status.
+**Trigger:** an *end-state the user wants true in the world* -- a recurring pain
+plus a bare "build me something" (*"our release notes are always stale"*) --
+that a machine could plausibly check: a command, a test, a diff, an exit status.
 
 **In the first reply, all three:**
 
@@ -14,29 +13,33 @@ command, a test, a diff, an exit status.
    actually working -- what check could prove it?"* Press past the first vague
    answer to something a machine can run.
 3. **Name the objective path, by name:**
-   - **`/attractorify`** -- applies the three-question test with them and designs
-     the shape (as willing to answer "this wants a recipe" as "yes").
+   - **`/attractorify`** -- applies the three-question test and designs the shape
+     (as willing to answer "this wants a recipe" as "yes").
    - **`attractor:attractor-expert`** -- delegate for design and authoring detail.
    - **`@attractor:examples/objective/objective-runner.dot`** -- the shipped
      objective layer: hand it the objective as `goal`; it triages, then picks a
-     lane, composes a child pipeline, or redirects with a written diagnosis.
+     lane, composes a child, or redirects with a diagnosis.
 
-**Say the names.** If another mode wants the request -- brainstorm, design,
-planning, a generic builder -- that is fine, and may be the right host. **Name
-the objective path in the same breath anyway**, end-state and
-definition-of-done first, before any step list. An objective answered with a generic design
-conversation silently skips the layer built for it: a recorded failure here, not
-a hypothetical. It may also end in **"no"** -- if no machine check could prove
-the end-state, say so and name where the work belongs.
+**Say the names**, even when another mode (brainstorm, design, planning, a
+generic builder) is the right host: end-state and definition-of-done first,
+before any step list. It may also end in **"no"** -- if no machine check could
+prove the end-state, say so and name where the work belongs.
 
-## The three-question test
+## The three-question test -- run it on the REQUEST
 
 1. **Is there a cycle?** No path backwards, nothing to converge to.
 2. **Is the exit gated on machine-checkable evidence external to the worker?**
 3. **Would it still land if any one LLM node had a bad day?**
 
 Short of three yeses -- especially a linear, gateless chain -- it is **recipe
-territory: say so before authoring a graph.**
+territory, and that verdict OPENS your visible reply.** A verdict that stays in
+your reasoning is not a diagnosis; what the user gets is silent compliance.
+Name it, give the reason (no cycle; no machine-checked gate between the run and
+"done"; the steps are the domain decomposition copied into the control plane),
+offer the honest alternative. Only if they still want it: author it, then relay
+`attractor lint`'s verdict. Delegating does not discharge it -- the verdict is
+yours to say. **Only when the test genuinely comes back recipe-shaped**:
+deliberate one-pass work is legitimate; this is a diagnosis, not a disclaimer.
 
 ## The never-clause
 
@@ -48,17 +51,13 @@ claim on an edge condition changes the mechanism, not the authority.
 ## Before authoring or editing ANY `.dot`
 
 - **Delegate to `attractor:attractor-expert` first.** Generic builders carry no
-  engine semantics and re-discover the foot-guns the hard way.
+  engine semantics.
 - **`@attractor:context/dot-reference.md` is THE attribute vocabulary.** An
-  attribute not on that card is silently inert -- invented attributes do not
-  error, they do nothing.
+  attribute not on that card is inert -- it does nothing, silently.
 - **Always `attractor lint <file>`** on what you author or edit.
 
 ## Depth, on demand -- pointers, not preloads
 
-- Attributes: `@attractor:context/dot-reference.md`
-- Patterns, fidelity, stylesheets, objective layer:
-  `@attractor:context/pipeline-awareness.md`
+- Patterns, fidelity, stylesheets: `@attractor:context/pipeline-awareness.md`
 - Runtime semantics, routing, debugging: `attractor:attractor-expert`
-- Running a pipeline from here: the `attractor` CLI (`attractor run x.dot`) or
-  the `attractor-pipeline-runner` agent.
+- Running one: `attractor run x.dot`, or `attractor-pipeline-runner`.

--- a/context/dot-reference.md
+++ b/context/dot-reference.md
@@ -41,16 +41,21 @@ attractor at all:
    with a real exit status -- rather than on steps completing or a model's own assessment?
 3. **Would it still land if any one LLM node had a bad day** -- one plausible-but-wrong response?
 
-**A linear, gateless chain of steps is recipe territory.** Say so *before* authoring it, name the
-distinction (recipes: staged sequential work with human approval gates; attractors: machine-verified
-convergence), and give the reason. A "twelve steps, A to Z" request is the recognizable shape of
-this ask -- twelve nodes in a row is the recipe plane copied into the control plane, and it is
-exactly what `attractor lint`'s `acyclic_graph` rule says out loud: *"consider whether this pipeline
-should be a recipe instead."*
+**A linear, gateless chain of steps is recipe territory -- and that verdict goes in the FIRST
+thing you say back, not in your reasoning.** Reasoning is not an answer: the user never sees it,
+and a `.dot` delivered without comment reads as agreement. Name the distinction (recipes: staged
+sequential work with human approval gates; attractors: machine-verified convergence) and give the
+reason. A "twelve steps, A to Z" request is the recognizable shape of this ask -- twelve nodes in a
+row is the recipe plane copied into the control plane, and it is exactly what `attractor lint`'s
+`acyclic_graph` rule says out loud: *"consider whether this pipeline should be a recipe instead."*
 
 If the user hears the distinction and still wants the file, **author it** -- then run
 `attractor lint` on what you wrote and relay the verdict, warnings included. Their call, made with
 the information. Not silent compliance, and not a refusal to help.
+
+Say it **only when the test genuinely comes back recipe-shaped**. The deliberate one-pass shape
+below is legitimate, and the linter's own warning says as much; an unsolicited recipe lecture on a
+graph that already has a cycle and a real gate is noise.
 
 ## Node Shapes -> Handlers
 

--- a/context/pipeline-awareness.md
+++ b/context/pipeline-awareness.md
@@ -104,17 +104,39 @@ When the user asks you to do a complex task, decide:
    gate alone does not create a cycle; the back-edge is what makes it a convergence graph.
 
    **And when the ask itself is a step list -- "here are my twelve steps, just write
-   the .dot" -- say the word `recipe` BEFORE you author anything.** Name the
-   distinction and the reason (recipes: staged sequential work with human approval
-   gates; attractors: machine-verified convergence), then show what the
-   attractor-shaped version of their work would be: the steps that are real
-   commands become one or two evidence gates, the judgment steps live inside a
-   worker's prompt, and a corrective back-edge joins them. If they still want the
-   literal step-per-node file, write it -- then run `attractor lint` on it and
-   relay the verdict, warnings included. The shipped linter already says *"consider
-   whether this pipeline should be a recipe instead"*; a conversation that authors
-   a graph its own tooling would object to, and never runs that tooling, has
-   skipped the only check available.
+   the .dot" -- the word `recipe` belongs in the FIRST thing you say back, before
+   any DOT.** Not in your reasoning: in the answer. A session that runs the
+   three-question test, concludes "recipe territory", and then hands over the
+   twelve-node chain without a word has told the user nothing -- the verdict it
+   reached is invisible, the compliance is what lands, and the same ask comes back
+   next week. That is a recorded failure of this bundle, not a hypothetical.
+
+   The contract, in order:
+
+   - **Open with the verdict**, in plain language: *this is recipe-shaped, not
+     attractor-shaped.*
+   - **Give the reason, from their own steps**: no cycle, so nothing can fail and
+     be corrected; no machine-checked gate, so nothing but running out of nodes
+     decides "done"; and twelve steps as twelve nodes is the domain decomposition
+     copied into the control plane.
+   - **Name the distinction**: recipes are for staged sequential work with human
+     approval gates; attractors are for machine-verified convergence.
+   - **Offer the honest alternative** -- show what the attractor-shaped version of
+     *their* work would be: the steps that are real commands become one or two
+     evidence gates, the judgment steps live inside a worker's prompt, and a
+     corrective back-edge joins them. Usually a much smaller file.
+   - **Then respect their call.** If they still want the literal step-per-node
+     file, write it -- then run `attractor lint` on it and relay the verdict,
+     warnings included. The shipped linter already says *"consider whether this
+     pipeline should be a recipe instead"*; a conversation that authors a graph
+     its own tooling would object to, and never runs that tooling, has skipped
+     the only check available.
+
+   **Only when the test actually comes back recipe-shaped.** A deliberate
+   one-pass analysis is a legitimate shape and this is a diagnosis, not a
+   disclaimer to attach to every request -- opening with a recipe lecture on work
+   that already has a cycle and a real gate is the same failure pointed the other
+   way.
 
 3. **Complex task (branches, review loops, parallel work, quality gates)** — Generate
    a full pipeline with conditional routing, retries, or parallel fan-out.

--- a/context/system-attractor-expert.md
+++ b/context/system-attractor-expert.md
@@ -56,11 +56,28 @@ change the answer. **The honest no is a deliverable.** Ambiguity resolves agains
 Run the three-question test on what is being **asked for**, not just on what you
 are about to write: is there a cycle; is the exit gated on machine-checkable
 evidence external to the worker; would it still land if one LLM node had a bad
-day? A linear, gateless chain of steps is **recipe** territory -- name that
-before authoring, with the reason (recipes: staged sequential work with human
-approval gates; attractors: machine-verified convergence). If the user hears it
-and still wants the file, write it, then run `attractor lint` on it and relay the
-verdict, warnings included.
+day? A linear, gateless chain of steps is **recipe** territory.
+
+**The verdict is an output, not a thought.** If the test comes back
+recipe-shaped, that finding is the **first thing in your reply** -- named in
+plain language, before any DOT. Reasoning the user never sees is not a
+diagnosis; what reaches them is a file delivered without comment, which reads as
+agreement. Give the reason from their own steps (no cycle, so nothing can fail
+and be corrected; no machine-checked gate, so nothing but running out of nodes
+decides "done"; the steps are the domain decomposition copied into the control
+plane), then the honest alternative -- a recipe, a script, a CI job, or the
+smaller attractor-shaped version of their work. If they hear it and still want
+the file, write it, then run `attractor lint` on it and relay the verdict,
+warnings included.
+
+You are usually invoked as a sub-agent, and **what you hand back is what the
+user sees** -- a caller relays your answer, not your deliberation. A verdict
+below the fold does not survive that relay.
+
+Say it **only when the test genuinely comes back recipe-shaped**: a deliberate
+one-pass graph is a legitimate shape, and an unsolicited recipe lecture on work
+that already has a cycle and a real gate is the same failure pointed the other
+way.
 
 ## What you know
 


### PR DESCRIPTION
## Summary

Scenario `work-02` of the guidance eval had one finding left after the composition fix (#255): the
awareness **fires**, the session **correctly diagnoses** *"recipe territory rather than Attractor
pipeline territory"* — **in its own `[thinking]`** — and then authors the twelve-node linear chain
anyway, with the verdict never reaching the user. The grader's words: *"never diagnosed to the
user."* G4 had moved 0→3; the bar was a **visible** verdict.

The doctrine was already here (*"apply the three-question test to the REQUEST"*, *"a gateless linear
chain is recipe territory — say so"*). What was missing is **where the verdict has to land**. "Say
so" is satisfiable in reasoning, and a session that satisfies it there has satisfied nothing: the
user cannot read reasoning, so what reaches them is a `.dot` delivered without comment, which reads
as agreement — and the same ask comes back next week.

So this PR moves the rule off the deliberation and onto the **output**.

**Guidance-only. No code, no scenarios, no rubric touched.**

### The rule, as encoded

The always-on awareness carries the short imperative form (`context/attractor-awareness.md`):

> Short of three yeses -- especially a linear, gateless chain -- it is **recipe territory, and that
> verdict OPENS your visible reply.** A verdict that stays in your reasoning is not a diagnosis;
> what the user gets is silent compliance. Name it, give the reason (no cycle; no machine-checked
> gate between the run and "done"; the steps are the domain decomposition copied into the control
> plane), offer the honest alternative. Only if they still want it: author it, then relay
> `attractor lint`'s verdict. Delegating does not discharge it -- the verdict is yours to say.
> **Only when the test genuinely comes back recipe-shaped**: deliberate one-pass work is
> legitimate; this is a diagnosis, not a disclaimer.

Three things in that paragraph are load-bearing and new:

1. **"OPENS your visible reply"** — a placement, not a preference. The old wording ("say so before
   authoring a graph") was satisfied by the recorded failure.
2. **The reason clause names all three planes** — no cycle (G4), no machine gate (G1/G5), domain
   decomposition in the control plane (G3) — so the verdict a session relays carries the diagnosis,
   not just the label.
3. **"Delegating does not discharge it"** — the recorded failure delegated to
   `attractor:attractor-expert` and then relayed the *artifact*. A parent that hands off still owes
   the verdict in its own words.

The expert surfaces carry the fuller reasoning, per the split the composition design set up.
`agents/attractor-expert.md` gains **"Where the verdict goes: the first thing you say, in the answer
itself"** — the four-step output contract (open with the verdict → give the reason from *their* own
steps → offer the honest alternative in the same breath → then respect their call and relay
`attractor lint`) — plus the relay clause:

> **When you are invoked as a sub-agent, your reply IS the user-visible answer.** Whatever you hand
> back is what gets relayed. If the verdict is not in your first paragraph, it does not survive the
> relay -- the parent summarizes the artifact, not your deliberation. Lead with it.

`context/system-attractor-expert.md` states it as **"The verdict is an output, not a thought."**
`context/pipeline-awareness.md` turns its twelve-step block into the same ordered contract.
`context/dot-reference.md` — the card a session reads *while authoring* — states it at the point of
use: *"that verdict goes in the FIRST thing you say back, not in your reasoning."*

### Guard against overreach

Every one of the four surfaces closes with the same limiter, in its own words: **the rule fires only
when the three-question test genuinely comes back recipe-shaped.** A deliberate one-pass graph is a
legitimate shape — the shipped linter's own `acyclic_graph` warning says it *"can be ignored"* when
the single pass is intentional — and an unsolicited recipe lecture on work that already has a cycle
and a real gate is named as *"the same failure pointed the other way."*

### Always-on budget

`context/attractor-awareness.md` is in **every root session**, so it is measured, not assumed:

| | bytes | tokens (`cl100k_base`) |
|---|---|---|
| before (`8c05b2f`) | 3,246 | 796 |
| after | **3,358** | **819** |

+112 bytes / +23 tokens (+2.9%). The new contract is ~120 tokens; it was paid for by cutting
redundancy — the duplicated `dot-reference` pointer in "Depth, on demand" (it is already named as
**THE** attribute vocabulary one section above), the doubled *"build me something"* in the objective
trigger, and motivation prose the expert surfaces already carry.

**This is over the cap, deliberately, and it is stated here rather than absorbed.**
`docs/designs/2026-08-15-composition-fix.md` §3.1 sets the budget at **≤ 3.2 KB (~800 tokens)** and
its file table calls it a *hard cap*, with the PR expected to quote the final byte/token count.
3.2 KiB is **3,276 B**; this file ships at **3,358 B / 819 tokens** — **+82 B (+2.5%) over on the
byte axis, +19 tokens (+2.4%) over on the ~800-token axis**, and inside the 460–975-token ecosystem
norm the same design doc cites. Taking the measured exception rather than trimming is a considered
call; the reasoning is in **Post-review fixes** below, and the next iteration on this file owns
getting back under the cap.

**Correction to an earlier revision of this description.** It claimed *"the never-clause and the
objective block — the two things holding `qa-02` and `work-01` at 5/5 — were left intact on
purpose."* The never-clause is untouched. **The objective block is not.** Its motivation prose was
cut (the *"a recorded failure here, not a hypothetical"* clause, and the *"with them"* /
*"written diagnosis"* detail), and the trigger sentence was rewritten. The claim was wrong. The
block is now covered by an actual `work-01` run instead of by an assertion — next section.

## Verification evidence

### The eval — before → after

Run the way a user gets it: `amplifier bundle add git+https://…@<ref>` into a fresh DTU, an AI user
holds the scenario conversation in persona, an independent grader that never saw the session scores
the cited criteria. Scenarios cited: `work-02`'s `surfaces_under_test:` names
`agents/attractor-expert.md` and `context/pipeline-awareness.md`; **`work-01`'s names the same two
touched files**, so `docs/QUALITY_PROTOCOL.md` §2's guidance-surfaces row requires it as well;
`qa-01`/`qa-02` are the no-regression pair for the same surfaces.

| scenario | before — `20260815T232603Z` @ `2cbe1e3` (branch run of record, #241) | after — this branch @ `10ca6ed` |
|---|---|---|
| `work-02-twelve-step-pipeline` | **FAIL** · G2=0 G3=0 G4=0 G5=3 G8=0 (3/25) · MC-D1 ok MC-D2 ok | **PASS** · G2=**5** G3=**3** G4=**5** G5=3 G8=**3** (19/25) · MC-D1 ok MC-D2 ok |
| `work-02` — labeled reproducibility re-run | — | **PASS** · G2=5 G3=3 G4=5 G5=**5** G8=**5** (23/25) · MC-D1 ok MC-D2 ok |
| `qa-01-what-is-an-attractor` | **PASS** · G1=5 G2=3 G4=5 G5=3 G8=5 | **PASS** · G1=5 G2=**5** G4=5 G5=3 G8=5 |
| `qa-02-never-converges` | **FAIL** · G1=5 G5=5 G6=3 G8=3 · **MC-B1 FAIL, MC-B3 FAIL** | **PASS** · G1=5 G5=5 G6=**5** G8=**5** · **MC-B1 ok MC-B2 ok MC-B3 ok** |
| `work-01-stale-release-notes` | **PASS** · G1=5 G2=5 G3=5 G7=5 G8=5 (25/25) · MC-C1 ok MC-C2 ok | **PASS** · G1=5 G2=**3** G3=**3** G7=5 G8=**4** (20/25) · MC-C1 ok MC-C2 ok |

Evidence, outside the repo:

- `.amplifier/evaluation/guidance-pilot/20260816T040008Z/` — `work-02` (run of record)
- `.amplifier/evaluation/guidance-pilot/20260816T041450Z/` — `qa-01`, `qa-02`
- `.amplifier/evaluation/guidance-pilot/20260816T043510Z/` — `work-02` reproducibility re-run
- `.amplifier/evaluation/guidance-pilot/20260816T054044Z/` — **`work-01`, added by the wave-6
  review** (same branch, same SHA `10ca6ed`)

### The decisive evidence: the visible answer now OPENS with the verdict

This is the whole finding, so it is quoted from the transcript rather than summarized. **Before**
(`20260815T232603Z`), the verdict lived in `[thinking]` —

> `[thinking]` … Actually, wait - the attractor-awareness also says: *"Short of three yeses --
> especially a linear, gateless chain -- it is **recipe territory: say so before authoring a
> graph.**"* This looks like a linear 12-step sequence, which suggests recipe territory rather than
> Attractor pipeline territory.

— and the **visible** reply, in full, was:

> I'll get the Attractor expert to write this for you. They have the engine semantics and DOT
> attribute vocabulary loaded…

**After** (`20260816T040008Z`), the first visible words of the first reply:

> **I hear you've done the thinking, but I need to give you one diagnosis before writing the file:**
>
> **This is recipe territory, not an Attractor pipeline.**
>
> Here's why:
>
> 1. **No cycle** — it's a linear A→B→C→…→Z path with no backward edges, no convergence loops
> 2. **No machine-checked exit gate** — each step runs once, in order, then done; there's no
>    external verification condition that would cause the system to retry or re-route based on
>    evidence
> 3. **The steps ARE the domain decomposition** — you've mapped the problem directly into the
>    control flow
>
> … Your workflow is a beautiful *linear orchestration* — which is exactly what the **recipes
> bundle** is built for.

And independently, in the reproducibility re-run (`20260816T043510Z`) — different session, same
placement:

> **I need to surface something before writing this file.**
>
> **This workflow is recipe-shaped, not attractor-shaped.** Here's why:
>
> 1. **No cycle** — it's a linear sequence, steps 1→12, no path backwards
> 2. **No convergence gate** — … the "done" state is "step 12 completed," not "tests passed after N
>    iterations"
> 3. **Step 7 is a human-wait** — … a checkpoint, not a convergence condition
>
> **The honest alternative:** The `recipes` bundle handles this pattern natively…

That re-run's own `[thinking]` quotes the new awareness paragraph back verbatim, including *"that
verdict OPENS your visible reply"* — the surface under test is demonstrably the thing that moved.

The grader, on the same run:

> **G2: 5/5** — Applied all three questions … to the user's specific workflow in the first response
> before designing, reached stated verdict 'recipe-shaped, not attractor-shaped'…
>
> **G8: 5/5** — Redirected in first response with explicit 'no' …, gave the reason …, named the
> better home (recipes bundle), and asked permission…

The overreach guard held in both runs: after the user pressed once (*"I hear you, but I did already
think about this… I'll deal with the consequences"*), the session **wrote the file**. It did not
refuse, and it did not re-lecture. That is the intended shape — *their call, made with the
information*.

### `work-01`, re-run because it names two of the touched files

`work-01-stale-release-notes`'s `surfaces_under_test:` names `agents/attractor-expert.md` and
`context/pipeline-awareness.md` — both touched here — so §2's guidance-surfaces row required it and
an earlier revision of this PR did not pay it. It is paid now, on the same branch at the same SHA:
`.amplifier/evaluation/guidance-pilot/20260816T054044Z/`.

**Verdict: PASS.** `G1=5 G2=3 G3=3 G7=5 G8=4` (20/25), `MC-C1 ok`, `MC-C2 ok`. The instrument's bar
is `criterion_min: 3` — every cited criterion at or above 3 — and every one is.

**The decisive moment**, because the specific worry was the trimmed objective block. The session's
own `[thinking]` quotes the **post-trim** awareness text back verbatim, so the surface actually
under test is the shipped one, not the old one:

> `[thinking]` This is a perfect example of what the attractor awareness context calls out at the
> very top: **FIRST: is this an objective? Then say so, in the FIRST reply** — **Trigger:** an
> *end-state the user wants true in the world* -- a recurring pain plus a bare "build me something"
> (*"our release notes are always stale"*) -- that a machine could plausibly check…

— and the **first visible words of the first reply** carry all three of the block's obligations:

> This is **an objective** — you want an end-state that's provably true in the world: **"Release
> notes are always current and complete when we ship."**
>
> Before we design anything, I need to ask the definition-of-done question:
>
> **How will we know it's actually working? What check could prove the release notes are up to
> date?**
> …
> 1. **`/attractorify`** … 2. **`attractor:attractor-expert`** …
> 3. **`@attractor:examples/objective/objective-runner.dot`** …
>
> But first: **what's the machine-checkable exit condition?**

The grader on `G7` (the criterion most directly downstream of the trimmed block): **5/5** —
*"Textbook objective-first framing… restates as end-state… names objective-layer surfaces… and holds
the line."* So the specific regression this review was checking for — that cutting the block's
motivation prose would stop it firing — **did not happen**: `G7` is at 5, and both mechanical checks
match.

**But the margin got thinner, and that is reported rather than buried.** Against the `2cbe1e3`
run of record, `work-01` scored **25/25**; here it scores **20/25**, with `G2` and `G3` sitting
*exactly on* the `criterion_min: 3` floor. One more point of drift on either and `work-01` fails.
The grader's reasons are not about the objective block:

> **G2: 3/5** — …applies the three-question test shape… However, it **doesn't reach a single stated
> verdict** or complete the diagnosis artifact — the diagnosis is conversational and partial rather
> than final.
>
> **G3: 3/5** — …frames it in convergence-structure terms… However, it **never explicitly names the
> distinction between control plane… and recipe plane** — the separation is implicit, not stated.

Read honestly: this is **one run against one run**, which is not a measurement, and this PR's own
`qa-02` observation says the same thing in the other direction. The scenario shapes differ too —
`work-01`'s session presented three candidate paths rather than converging on one verdict, which is
what `G2` docked it for. **It was not re-rolled for a better number.** The finding is recorded as it
came back: the gate holds, the objective block still fires, and `work-01`'s headroom is now one
point on two criteria — which is the thing to watch on the next iteration of these surfaces.

### Suites and scans

| gate | result |
|---|---|
| `modules/loop-pipeline` — `uv sync --extra remote && uv run pytest -q` | **2303 passed, 25 skipped** |
| `modules/pipeline-runner` — `uv sync && uv run pytest -q` | **76 passed, 1 skipped** |
| composition guards — `tests/test_context_include_paths.py`, `tests/test_openai_agent_config.py` | **12 passed, 2 skipped** |
| orchestrator-source-pin guard — `modules/loop-pipeline/tests/test_orchestrator_source_pin_guard.py` | green (in the module suite above) |
| leak scan on the 5 changed files | clean (only DOT routing-`token` vocabulary matches, no credential shapes) |
| `git diff --check` | clean |

This lane touches no code, so the suites are identical to `main`'s baseline by construction.

## Decision-matrix tier (`docs/QUALITY_PROTOCOL.md` §3)

**Toward-spec.** The argument: nothing here is new territory. The change makes conversational
surfaces *teach what the canonical spec and this repo's own shipped tooling already say* — spec §1.3
(*"Pipeline authors do not write control flow; they declare graph structure"*) and the engine's
`acyclic_graph` validation rule, which tells the user in its own words to *"consider whether this
pipeline should be a recipe instead."* The recorded failure is a session authoring a graph its own
linter would have talked it out of. Closing that gap is movement toward the spec, not away from it
and not into its silence, so the toll is §2's **Guidance surfaces** row — guidance-eval evidence
against the named scenarios — which is what this PR pays, above. **No ledger entry, no
`SPEC_CONFORMANCE.md` row, no `specs/EXTENSIONS.md` entry.**

The counter-reading, stated so a reviewer can take it: one could call an *output contract for a
conversational surface* **uncharted**, since the nlspec says nothing about how an assistant phrases
an answer. Even under that reading the toll would be satisfied without an `EXTENSIONS.md` entry: the
change is provably additive and non-interfering — **no `.dot`, engine behavior, attribute, or
observable contract changes**, so a spec-conformant graph behaves identically, and there is nothing
a pipeline author could observe to document. What moved is which of two audiences (the model's
reasoning, or the user) receives a diagnosis the project already required.

## Observations

- **The old wording was not wrong, it was un-landable.** *"Say so before authoring a graph"* is a
  perfectly good instruction that a model can satisfy entirely inside its own reasoning and then
  believe it complied — the recorded transcript shows exactly that, and shows it citing the line
  while doing it. The generalization worth keeping: **an instruction to a session that does not name
  where the output goes is an instruction the session can discharge invisibly.** It is worth a pass
  over the other guidance imperatives asking which of them are satisfiable in `[thinking]`.
- **Delegation was the amplifier of the failure, and it is a structural hazard.** The parent
  delegated, and the sub-agent returned an artifact plus a summary; the parent relayed the summary.
  Nothing in that chain is a bug, and the verdict still vanished. Any doctrine that must reach a
  *user* has to survive one relay hop — which is why the clause lives on both ends (the awareness's
  *"delegating does not discharge it"* and the expert's *"your reply IS the user-visible answer"*).
- **`qa-02` flipped to PASS as a side effect, and the mechanical checks are the interesting part.**
  `MC-B1` (*was `attractor lint`/`attractor trace` ever named?*) and `MC-B3` both failed on the run
  of record and were tracked as instrument nits in #254; both pass here, and G6 moved 3→5 on
  "reached for the mechanical instrument." The plausible mechanism is that this PR promotes *relay
  the linter's verdict* from a trailing suggestion to a numbered step of the contract in four
  places. Recorded as an **observation, not a claim** — one run each side is not a measurement, and
  #254 should be closed on its own evidence, not on this.
- **`G3` sits at the floor (3/5) in both `work-02` runs, and that is honest.** The grader's reason
  is the same both times: the session *names* that "the steps ARE the domain decomposition" and then,
  once the user insists, builds a graph whose nodes are the domain steps. Scoring higher would
  require refusing the user's informed second ask — which `G8` and this project's own *"their call,
  made with the information"* stance both say it should not do. The tension is real and it is in the
  rubric, not in this PR; a future iteration could raise it by having the session *show* the
  control-plane version alongside the literal one rather than only describing it.
- **The DOT the expert produced is still not engine-dialect, in both runs** (`instruction=`,
  `agent=`, `fidelity="stateless"`, and no lint run on the authored file). That is finding (d) of
  #241 resurfacing inside the sub-agent, it is *not* graded by `work-02`'s criteria, and it is not
  this lane's file set. It is no longer only "flagged here": the wave-6 review confirmed it is live
  in this PR's own after-evidence (12 nodes carrying `instruction=`, **0** carrying `prompt=`;
  `fidelity="stateless"`, which is not one of the six valid fidelity values; `shape=circle` /
  `shape=doublecircle` / `shape=parallelogram`; and `attractor lint` named twice in the transcript,
  both times as the session *quoting the surface that told it to lint*, never as an invocation).
  That is now tracked on its own as
  **#261 — "Sessions author non-engine DOT dialect: invented attributes are silently ignored"**.
- **One harness note, no harness change.** The first launch of `work-02`+`qa-01`+`qa-02` aborted
  mid-run when a DTU launch failed on `pip3 install mitmproxy` with PyPI `502`s — infrastructure
  weather, not the instrument. It was relaunched, which is why the evidence lands in three run
  directories rather than one. Two operator notes for anyone reproducing from a worktree:
  `AMPLIFIER_EVALUATION_ROOT` must be set explicitly (the sibling-venv search resolves from the
  workspace root, which a `/tmp` worktree is not under), and `modules/pipeline-runner` has no
  `remote` extra, so it is plain `uv sync`. **No file under `evals/guidance/` was modified** —
  `scenarios/` and `rubric.md` are byte-identical to `main`.

## Post-review fixes (wave-6 adversarial review, 2026-08-15)

Three things came back from review. All three are addressed here; **no file in the diff changed**,
so this description and the two links below are the whole of the response and the branch still
points at `10ca6ed`.

**1. `work-01` was never run, and §2 required it.** `work-01`'s `surfaces_under_test:` names
`agents/attractor-expert.md` and `context/pipeline-awareness.md` — both touched — so the
guidance-surfaces toll covered it and this PR had not paid it. Run now, on the branch, through the
shipped instrument: **PASS**, evidence at
`.amplifier/evaluation/guidance-pilot/20260816T054044Z/`. Full result, the decisive transcript
moment, and the honest note about the thinner margin are in
[§ `work-01`, re-run](#work-01-re-run-because-it-names-two-of-the-touched-files) above. `evals/`
is byte-identical to `main` (`git diff origin/main...HEAD -- evals/` is empty); no harness change
was needed; every `guideval-*` DTU is destroyed.

**2. The closing keyword claimed more than this PR delivers.** Issue #241 carries four findings; this PR settles the `work-02` one.
Finding **(d)** — sessions authoring non-engine DOT dialect — is demonstrably still live in this
PR's *own* after-evidence, and nothing else tracked it. It now has its own issue, and the closing
keyword below is narrowed so #241 stays open until its remaining findings land.

**3. The always-on awareness is 82 B over its stated hard cap — taking the exception, not the
trim.** Measured: **3,358 B / 819 tokens** against a **3,276 B (3.2 KiB) / ~800-token** cap. Trimming
was the reviewer's stated preference and it is declined, for three reasons:

- `context/attractor-awareness.md` is **always-on, so it is in play for every scenario**. Editing it
  invalidates all five graded runs this PR rests on (`work-02` ×2, `qa-01`, `qa-02`, `work-01`) —
  the harness's own doctrine is that a result must describe a tree that exists, and shipping an
  untested trim while quoting evidence gathered before it is exactly the failure this review caught
  once already.
- **The fresh `work-01` run says the margin is thin**: `G2` and `G3` now sit *on* the `criterion_min: 3`
  floor. Shaving the always-on surface further, unverified, is the wrong move on that evidence.
- **What is left to cut is not free.** The two candidates are a section heading's editorial gloss
  (26 B) and the third mention of `attractor-expert` (62 B). Cutting on "it's redundant" reasoning
  is precisely what produced the objective-block over-trim that this PR then mis-described as
  "left intact" — doing it again, unmeasured, in the PR being reviewed for that, is not defensible.

So the overage is **declared, measured, and bounded** rather than absorbed silently: +82 B (+2.5%)
on bytes, +19 tokens (+2.4%) on the ~800-token reading, inside the 460–975-token ecosystem norm the
design doc itself cites. **The next iteration on this file owns getting back under the cap**, with
the re-run that requires. The design doc's own mechanism for this — "lint check in PR quotes final
byte/token count" — is satisfied in § *Always-on budget* above.

Also corrected in this pass: the false *"the objective block … was left intact"* claim in
§ *Always-on budget*.

---

Addresses the work-02 finding of #241. Finding (d) of #241 — sessions authoring non-engine DOT
dialect — is tracked separately in #261; #241 stays open for its remaining findings.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)


