### PR TITLE
fix(fixtures): route the goal-gated e2e fixtures; feat(lint): TOPO-009 outcome=/preferred_label shadowing hint

### DIFF
--- a/docs/DOT-AUTHORING-GUIDE.md
+++ b/docs/DOT-AUTHORING-GUIDE.md
@@ -1541,7 +1541,7 @@ changed what happened), a branching diamond, a constant emitter such as
 inequality condition, the same token twice, and an unreachable gate.
 
 **Severity:** WARNING — consistent with the rest of the family (TOPO-002
-through TOPO-007; TOPO-001 is `ERROR`).  The hazard is real but the author's
+through TOPO-009; TOPO-001 is `ERROR`).  The hazard is real but the author's
 intent is not statically provable, and it is `lint()`-only: `validate()` and
 `validate_or_raise()` stay silent, so no graph that executes today starts
 failing at run time.
@@ -1550,6 +1550,72 @@ failing at run time.
 back into the corrective loop, to a postmortem, or to a LOUD escalation.  If
 the node is genuinely not a decision point, drop the conditions and let it
 record instead of routing on it.
+
+---
+
+### TOPO-009 — `outcome=` shadowed by a status-word label
+
+**What it detects:** One node carrying **both** halves of a vocabulary
+collision: an outgoing edge whose condition routes on the `outcome` key
+against a status word (`success`, `fail`, `partial_success`, `retry`,
+`skipped` — via `=` or `!=`), **and** an outgoing *unconditional, labelled*
+edge whose label is one of those same words.
+
+**Why it matters:** `outcome=` does not mean here what canonical §10.4 says it
+means.  Canonical defines it as `outcome.status` only; this engine resolves it
+to **`preferred_label` first**, falling back to `status` only when no label is
+set.  That divergence is deliberate and ledgered — `specs/EXTENSIONS.md` §22,
+`SPEC_CONFORMANCE.md` ATX-5 (disposition DIVERGE, decided) — because it is how
+a node steers its own routing through `report_outcome`.  The trap is that
+`preferred_label` is free-form and the status words are exactly the words an
+author reaches for as a label.  When they overlap, the label silently wins:
+
+```dot
+// WRONG — `review` steers by label AND is routed on `outcome=retry`
+review -> fix    [condition="outcome=retry"]   // author means the STATUS
+review -> rework [label="retry"]               // node steers by LABEL
+
+// A node reporting status="success", preferred_label="retry" takes the edge
+// to `fix` anyway — its status is SUCCESS.
+// A node reporting status="retry", preferred_label="needs_work" does not take
+// it at all — its status is RETRY.  Neither case is logged.
+
+// CORRECT — say which key you mean; both are exact
+review -> fix    [condition="status=retry"]           // the status
+review -> fix    [condition="preferred_label=retry"]  // ...or the label
+```
+
+**Calibration:** measured over every `.dot` in this repository (63 files:
+`examples/`, `.github/`, `skills/`, and every test fixture).  Flagging *any*
+`outcome=<status word>` edge — the shape issue #226 first proposed — fires on
+**23 of 63** shipped graphs; routing on `outcome=success` in a graph whose
+nodes never emit labels is ordinary and correct.  Adding "…and a status-word
+`label=` anywhere in the graph" still fires on **6**.  What ships — the
+collision scoped to one node's own out-edges, and to the edges
+`preferred_label` can actually select — fires on **zero** shipped graphs.
+
+**What is NOT flagged:** an `outcome=` condition on a node with no labelled
+edges (the common, correct case); a status word on a *conditional* edge —
+spec §3.3 Step 2 considers only unconditional edges when matching
+`preferred_label`, so such a label is documentation the label matcher can
+never select, and it is this repository's own shipped convention
+(`gate -> fix [condition="context.tool.last_line=fail", label="fail"]`); a
+label outside the status vocabulary (`label="needs_work"`); a labelled edge
+belonging to a *different* node (`select_edge` resolves a node's outcome
+against that node's own out-edges); and conditions on any other key
+(`context.tool.last_line=fail` never goes through the overloaded key).  A node
+that emits a colliding `preferred_label` with no labelled edge to reveal it is
+not statically visible and is not detected.
+
+**Severity:** WARNING — the pattern is legal and sometimes exactly what the
+author wants, so this is advisory and `lint()`-only; `validate()` and
+`validate_or_raise()` stay silent and no graph that runs today starts failing.
+
+**Fix:** Use the unambiguous key.  `status=<word>` matches the status and
+nothing else; `preferred_label=<word>` matches the label and nothing else.  If
+the node is not meant to steer itself by label, take the status word off its
+labelled edge instead.  Background: `docs/ROUTING-REFERENCE.md` §3 ("Engine
+delta: `outcome` resolves `preferred_label` first").
 
 ---
 
@@ -1600,7 +1666,7 @@ If you need to see the last N lines, write to a file and read it separately
 from the routing logic.
 
 **Severity:** WARNING — consistent with the WARNING-severity TOPO rules
-(TOPO-002 through TOPO-008; note TOPO-001 is `ERROR`, not this family's
+(TOPO-002 through TOPO-009; note TOPO-001 is `ERROR`, not this family's
 default).  The hazard is real but static analysis cannot prove the command is
 a meaningful gate; conservative analysis may miss complex cases.
 
@@ -1662,7 +1728,7 @@ influence either the exit code or the emitted token?  The hazard shapes
 destroy that influence.  The honest idioms preserve it.
 
 **Severity:** WARNING — consistent with CMD-001 and the WARNING-severity TOPO
-rules (TOPO-002 through TOPO-008; TOPO-001 is `ERROR`).
+rules (TOPO-002 through TOPO-009; TOPO-001 is `ERROR`).
 
 **What this rule does NOT catch:** sentinels inside `$(...)` substitutions,
 sentinels after non-pipe-masked commands (where `&& echo TOKEN` is the honest

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/validation.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/validation.py
@@ -4,9 +4,12 @@ Validates parsed Graph models against the rules defined in
 spec Section 7 (Validation and Linting). Produces Diagnostic objects
 with severity ERROR (blocks execution) or WARNING (informational).
 
-Spec coverage: LINT-001–018.  TOPO-001–008 are topological basin-lint rules
+Spec coverage: LINT-001–018.  TOPO-001–009 are topological basin-lint rules
 implemented here beyond the canonical spec; they are lint-only (exposed via
 ``lint()``, not ``validate()``) and do not change run-time behaviour.
+TOPO-009 warns when an ``outcome=<status word>`` edge condition shares a
+vocabulary with a ``preferred_label`` the same node can emit -- ``outcome``
+resolves the label BEFORE the status here (EXTENSIONS.md §22 / ATX-5).
 TOPO-008 is the ``attractor lint`` sibling of the authoring checker's A10
 (``examples/authoring/check_authored_pipeline.py``): an evidence gate routing
 two different answers into the exit is structurally inert.
@@ -26,6 +29,11 @@ from dataclasses import dataclass
 
 from .conditions import evaluate_condition, parse_condition
 from .context import PipelineContext
+
+# `_normalize_label` is edge_selection's own label normaliser -- imported (not
+# reimplemented) so TOPO-009 asks "is this label a status word?" exactly the
+# way spec §3.3 Step 2 asks it at run time, and the two cannot drift.
+from .edge_selection import _normalize_label
 from .fidelity import VALID_FIDELITY_MODES
 from .graph import Edge, Graph, Node, resolve_bool_attr
 from .outcome import Outcome, StageStatus
@@ -119,9 +127,10 @@ def lint(graph: Graph) -> list[Diagnostic]:
     """Run topological (basin-lint) and command-content rules in addition to structural rules.
 
     This is the entry point for the ``attractor lint`` CLI command.  It runs
-    the full structural ``validate()`` suite plus the eight topological rules
-    (TOPO-001–008) that reason about cycle structure, handler semantics, and
-    evidence-routing patterns, plus the two command-content rules (CMD-001–002)
+    the full structural ``validate()`` suite plus the nine topological rules
+    (TOPO-001–009) that reason about cycle structure, handler semantics,
+    evidence-routing patterns and condition-key hazards, plus the two
+    command-content rules (CMD-001–002)
     that inspect ``tool_command`` strings for hazard shapes.
 
     All lint-only rules do not change run-time validation behaviour.  Existing
@@ -143,6 +152,7 @@ def lint(graph: Graph) -> list[Diagnostic]:
     _check_fail_routed_to_exit(graph, diags)
     _check_gate_retry_budget_dead(graph, diags)
     _check_inert_evidence_gate(graph, diags)
+    _check_outcome_label_shadowing(graph, diags)
     _check_pipe_masked_exit_code(graph, diags)
     _check_always_true_sentinel(graph, diags)
     return diags
@@ -730,7 +740,7 @@ def _check_response_schema(graph: Graph, diags: list[Diagnostic]) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Topological (basin-lint) rules — TOPO-001 through TOPO-008
+# Topological (basin-lint) rules — TOPO-001 through TOPO-009
 #
 # These rules reason about cycle structure and handler semantics, not just
 # graph topology.  They are exposed via ``lint()`` (not ``validate()``) so
@@ -2057,6 +2067,216 @@ def _check_inert_evidence_gate(graph: Graph, diags: list[Diagnostic]) -> None:
                     ),
                 )
             )
+
+
+# ---------------------------------------------------------------------------
+# TOPO-009 — an `outcome=` condition whose word the node can also emit as a label
+#
+# `outcome=` does not mean what canonical §10.4 says it means here.  Canonical
+# defines it as `outcome.status` only; this engine resolves it to
+# `preferred_label` FIRST and falls back to `status.value` only when no label
+# is set (`conditions.py::_resolve_key`).  That divergence is deliberate,
+# load-bearing (it is how a node steers its own routing through
+# `report_outcome`) and ledgered — `specs/EXTENSIONS.md` §22, `SPEC_CONFORMANCE`
+# ATX-5 (disposition DIVERGE, decided).  The ledger is explicit that it is not
+# behaviour-neutral.  What it has never had is a way for an author to find out
+# they walked into it (issue #226).
+#
+# The hazard is a vocabulary overlap.  `preferred_label` is free-form, and the
+# status words are exactly the words an author reaches for as a label, so on a
+# node that emits labels an `outcome=<status word>` edge answers a question the
+# author did not ask:
+#
+#   * a node reporting `status="success", preferred_label="retry"` MATCHES
+#     `condition="outcome=retry"` — its status is SUCCESS; and
+#   * a node reporting `status="retry", preferred_label="needs_work"` does NOT
+#     match it — its status is RETRY.
+#
+# Nothing is logged either way.  The condition is well-formed, the graph lints
+# clean, and the route is simply not the one on the page.
+#
+# **Calibration — the narrowing is measured, not asserted.**  Run over every
+# `.dot` in this repository (63 files: `examples/`, `.github/`, `skills/`, and
+# every test fixture), scoring the shapes the issue proposed:
+#
+#   * the issue's condition (1) alone — *any* `outcome=<status word>` edge —
+#     fires on **23 of 63** shipped graphs.  `outcome=success` is the ordinary,
+#     correct way to route a graph whose nodes never emit labels; flagging it
+#     is wolf-crying.
+#   * the issue's own suggested conservative form — condition (1) plus *any*
+#     status-word edge `label=` anywhere in the graph — still fires on **6**.
+#     Shipped graphs put status words on CONDITIONAL edges as documentation
+#     (`gate -> fix [condition="context.tool.last_line=fail", label="fail"]`),
+#     where `preferred_label` matching cannot reach them at all.
+#   * what ships below — the collision scoped to ONE node's own out-edges, and
+#     to the edges `preferred_label` can actually select — fires on **ZERO**
+#     shipped graphs, and on the issue's constructed hazard.
+#
+# The scoping is not a fudge to reach zero; it is the routing semantics.
+# `select_edge` resolves a node's outcome against THAT node's out-edges, and
+# its Step 2 (`preferred_label` match) considers only UNCONDITIONAL labelled
+# edges.  So an unconditional labelled edge out of a node is the documented,
+# statically-visible evidence that the node is steered by `preferred_label`;
+# a label on a conditional edge is inert decoration that no label can select.
+# The sweep test `test_topological_lint.py::TestOutcomeLabelShadowing::
+# test_silent_on_every_shipped_dot` pins the zero.
+#
+# Severity: WARNING — joins the TOPO-002–008 / CMD-001–002 family.  The pattern
+# is legal and sometimes exactly what the author wants; ERROR would hard-fail
+# deliberate graphs through `validate_or_raise`.  `lint()`-only.
+# ---------------------------------------------------------------------------
+
+#: The status vocabulary `outcome=` falls back to, derived from `StageStatus`
+#: itself (not a hand-copied list) so a new status value cannot silently leave
+#: this rule behind.  Normalised through the engine's own label normaliser so
+#: "what counts as a status word" is asked exactly once, the same way routing
+#: asks it.
+_STATUS_WORDS: frozenset[str] = frozenset(
+    _normalize_label(s.value) for s in StageStatus
+)
+
+
+def _outcome_status_words(condition: str) -> set[str]:
+    """Status words this condition routes on via the `outcome` key.
+
+    Parsed through ``conditions.parse_condition`` — the same grammar entry
+    point the engine routes with — so lint and routing cannot drift.  Both
+    ``=`` and ``!=`` count: an inequality resolves the same overloaded key and
+    is shadowed by a label just as silently.
+    """
+    words: set[str] = set()
+    for key, op, value in parse_condition(condition or ""):
+        if key != "outcome" or op not in ("=", "!="):
+            continue
+        word = _normalize_label(value.strip().strip('"').strip("'"))
+        if word in _STATUS_WORDS:
+            words.add(word)
+    return words
+
+
+def _label_selectable_edges(graph: Graph, node_id: str) -> list[Edge]:
+    """Out-edges ``preferred_label`` can actually select — spec §3.3 Step 2.
+
+    Step 2 considers only UNCONDITIONAL labelled edges: a conditional edge
+    whose condition failed in Step 1 must not then be picked by label.  A
+    status word on a conditional edge is therefore documentation, not a
+    routing target, and is deliberately not evidence here.
+    """
+    return [
+        e
+        for e in graph.outgoing_edges(node_id)
+        if not (e.condition or "").strip() and (e.label or "").strip()
+    ]
+
+
+def _check_outcome_label_shadowing(graph: Graph, diags: list[Diagnostic]) -> None:
+    """TOPO-009: an `outcome=<status word>` edge on a node that also routes by label.
+
+    The shape::
+
+        review -> fix    [condition="outcome=retry"]   // author means STATUS
+        review -> rework [label="retry"]               // node steers by LABEL
+
+    Both edges leave the same node, and `outcome=` reads `preferred_label`
+    before `status` (EXTENSIONS §22 / ATX-5).  So `review` emitting
+    ``preferred_label="retry"`` takes the *condition* edge to `fix` whatever
+    its status was — Step 1 runs before Step 2 — and `review` emitting
+    ``status="retry"`` with any other label does not take it at all.
+
+    Fires only when one node carries both halves, and only when the label is
+    on an edge ``preferred_label`` can actually select.  See the section
+    header above for the measurement behind that scoping.
+
+    Severity: WARNING, ``lint()``-only.  Routing on ``outcome=success`` in a
+    graph whose nodes never emit labels is normal and correct; this rule has
+    no opinion about it.
+    """
+    for node in sorted(graph.nodes.values(), key=lambda n: n.id):
+        condition_edges: list[tuple[Edge, set[str]]] = []
+        for edge in graph.outgoing_edges(node.id):
+            words = _outcome_status_words(edge.condition)
+            if words:
+                condition_edges.append((edge, words))
+        if not condition_edges:
+            continue
+
+        label_edges = [
+            e
+            for e in _label_selectable_edges(graph, node.id)
+            if _normalize_label(e.label) in _STATUS_WORDS
+        ]
+        if not label_edges:
+            continue
+
+        labels = sorted({_normalize_label(e.label) for e in label_edges})
+        label_written = "; ".join(
+            f'{node.id} -> {e.to_node} [label="{e.label}"]'
+            for e in sorted(label_edges, key=lambda e: (e.to_node, e.label))
+        )
+        condition_written = "; ".join(
+            f'{node.id} -> {e.to_node} [condition="{e.condition}"]'
+            for e, _ in sorted(condition_edges, key=lambda pair: pair[0].to_node)
+        )
+        all_words = sorted(set().union(*(w for _, w in condition_edges)))
+        collisions = sorted(set(all_words).intersection(labels))
+
+        # Report against the edge that actually collides when one does; that is
+        # the edge whose route the label decides.  Otherwise the first by
+        # target id, so the diagnostic is always pinpointed at a real edge.
+        by_target = sorted(condition_edges, key=lambda pair: pair[0].to_node)
+        primary = next(
+            (e for e, w in by_target if w.intersection(labels)),
+            by_target[0][0],
+        )
+        word = (collisions or all_words)[0]
+
+        if collisions:
+            overlap = (
+                f"'{word}' is in both vocabularies at once, so "
+                f"'{node.id}' reporting status=success with "
+                f"preferred_label=\"{word}\" matches "
+                f"'{node.id}' -> '{primary.to_node}' anyway, while "
+                f"'{node.id}' reporting status={word} under any other label "
+                f"does not match it at all."
+            )
+        else:
+            overlap = (
+                f"The label vocabulary here ({', '.join(repr(x) for x in labels)}) "
+                f"is drawn from the status vocabulary, so any label "
+                f"'{node.id}' emits is what these conditions compare against - "
+                f"'{node.id}' reporting status={word} under one of those labels "
+                f"does not match '{node.id}' -> '{primary.to_node}' at all."
+            )
+
+        diags.append(
+            Diagnostic(
+                rule="outcome_label_shadowing",
+                severity="WARNING",
+                message=(
+                    f"Node '{node.id}' routes on the 'outcome' key against "
+                    f"status words ({condition_written}) while also steering "
+                    f"itself by label ({label_written}). 'outcome' resolves "
+                    f"preferred_label BEFORE status (EXTENSIONS.md §22 / "
+                    f"SPEC_CONFORMANCE ATX-5) - not status alone, as canonical "
+                    f"§10.4 defines it. {overlap} Neither case is logged: the "
+                    f"condition is well-formed and the graph is otherwise clean "
+                    f"(TOPO-009)."
+                ),
+                node_id=node.id,
+                edge=(primary.from_node, primary.to_node),
+                fix=(
+                    f"Say which one you mean - both keys are exact and "
+                    f"unambiguous. For the status, write "
+                    f'condition="status={word}" on '
+                    f"'{node.id}' -> '{primary.to_node}'; for the label, write "
+                    f'condition="preferred_label={word}". If \'{node.id}\' is '
+                    f"not meant to steer itself by label, take the status word "
+                    f"off its labelled edge instead. See "
+                    f"DOT-AUTHORING-GUIDE.md (TOPO-009) and "
+                    f"docs/ROUTING-REFERENCE.md §3."
+                ),
+            )
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/modules/loop-pipeline/tests/test_e2e_fixture_routes.py
+++ b/modules/loop-pipeline/tests/test_e2e_fixture_routes.py
@@ -1,0 +1,242 @@
+"""Every ``tests/e2e/fixtures/*.dot`` must be able to reach its own exit.
+
+Issue #250: ``simple_file_creation.dot`` never routed past ``implement``.  The
+filed suspicion was that "a goal-gated node requires labelled/conditional
+outgoing edges ... the gate would have nothing to match".  That is not the
+mechanism.  The bare ``implement -> done`` edge resolves perfectly well; what
+actually happens is a four-step chain that only ends at edge selection:
+
+1. ``implement`` carries ``goal_gate=true``, so EXTENSIONS.md §25's fail-closed
+   contract requires an ASSERTED verdict (``report_outcome`` / JSON).
+2. The fixture's prompt never asked for one, so a real agent answers in prose.
+   ``_parse_outcome`` maps prose on a gated node to ``RETRY``/``is_explicit=
+   False`` -- deliberately, so a defaulted response cannot satisfy a gate.
+3. The retry budget is spent and the node's recorded outcome becomes ``FAIL``.
+4. Only now does routing fail: spec §3.7 fail-fast refuses to traverse an
+   UNCONDITIONAL edge on a ``FAIL`` outcome when the target is a default
+   ``runs_on=success`` node -- so ``select_edge`` returns ``None`` and the run
+   hard-fails with ``"No matching edge from node 'implement'"`` (§33).
+
+The fix is therefore in the prompt, not in the topology: a gated node's prompt
+must ask for the verdict its own gate demands.  These tests pin that, through
+the real engine rather than by reading the DOT text, so a future edit that
+drops the instruction turns the suite red instead of shipping a fixture that
+proves nothing.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from amplifier_module_loop_pipeline.backend import _parse_outcome
+from amplifier_module_loop_pipeline.context import PipelineContext
+from amplifier_module_loop_pipeline.dot_parser import parse_dot
+from amplifier_module_loop_pipeline.edge_selection import select_edge
+from amplifier_module_loop_pipeline.engine import PipelineEngine
+from amplifier_module_loop_pipeline.graph import Graph, Node, resolve_bool_attr
+from amplifier_module_loop_pipeline.handlers import HandlerRegistry
+from amplifier_module_loop_pipeline.handlers.context import HandlerContext
+from amplifier_module_loop_pipeline.outcome import Outcome, StageStatus
+from amplifier_module_loop_pipeline.validation import validate_or_raise
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_E2E_FIXTURE_DIR = _REPO_ROOT / "tests" / "e2e" / "fixtures"
+
+#: The prose a real agent produces when nothing asked it for a verdict.  This
+#: is the shape issue #250 was filed against -- the agent DID the work ("
+#: nodes_completed: 2 means node bodies do execute") and then said so in
+#: English.
+_PROSE_ANSWER = "Done -- I created the file and it prints Hello World."
+
+#: An asserted verdict, in the pure-JSON shape ``_parse_outcome`` recognises as
+#: explicit (the same disposition a ``report_outcome`` tool call produces).
+_ASSERTED_VERDICT = '{"status": "success", "notes": "work complete"}'
+
+#: A prompt "asks for the verdict" when it names the tool that produces one.
+#: The engine's own contract surface is ``report_outcome``; nothing else in a
+#: prompt makes an agent assert a status.
+_ASKS_FOR_VERDICT_RE = re.compile(r"report_outcome", re.IGNORECASE)
+
+
+def _e2e_fixture_files() -> list[Path]:
+    if not _E2E_FIXTURE_DIR.is_dir():
+        return []
+    return sorted(_E2E_FIXTURE_DIR.rglob("*.dot"))
+
+
+_FIXTURES = _e2e_fixture_files()
+
+_needs_fixtures = pytest.mark.skipif(
+    not _FIXTURES,
+    reason="tests/e2e/fixtures not present (installed-package run)",
+)
+
+
+def _goal_gate_nodes(graph: Graph) -> list[Node]:
+    return [
+        n
+        for n in graph.nodes.values()
+        if resolve_bool_attr(n.attrs.get("goal_gate"), "goal_gate")
+    ]
+
+
+class ContractFollowingBackend:
+    """An agent that does exactly what each node's own prompt tells it to.
+
+    If the prompt asks for a ``report_outcome`` verdict, it asserts one.  If the
+    prompt does NOT ask, it answers in prose -- which is what a real agent does,
+    and what issue #250 observed.  Nothing here is stubbed past the backend
+    boundary: ``_parse_outcome``, the goal-gate check, the retry ladder and
+    ``select_edge`` all run for real, so the assertion below is about routing,
+    not about DOT text.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    async def run(self, node, prompt, context, incoming_edge=None, graph=None):
+        self.calls.append(node.id)
+        if _ASKS_FOR_VERDICT_RE.search(prompt or ""):
+            return _ASSERTED_VERDICT
+        return _PROSE_ANSWER
+
+
+@_needs_fixtures
+@pytest.mark.parametrize(
+    "dot_path", _FIXTURES, ids=lambda p: p.name
+)
+def test_fixture_parses_and_validates(dot_path: Path) -> None:
+    """A fixture that cannot even be admitted proves nothing."""
+    graph = parse_dot(dot_path.read_text(encoding="utf-8"))
+    validate_or_raise(graph)
+
+
+@_needs_fixtures
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "dot_path", _FIXTURES, ids=lambda p: p.name
+)
+async def test_fixture_reaches_its_exit(dot_path: Path, tmp_path) -> None:
+    """Issue #250: every e2e fixture must route to completion, not dead-end.
+
+    Driven by an agent that obeys each node's prompt.  A gated node whose prompt
+    forgot to ask for a verdict makes this go red with the exact #250 symptom.
+    """
+    graph = parse_dot(dot_path.read_text(encoding="utf-8"))
+    backend = ContractFollowingBackend()
+    engine = PipelineEngine(
+        graph=graph,
+        context=PipelineContext(),
+        handler_registry=HandlerRegistry(HandlerContext(backend=backend)),
+        logs_root=str(tmp_path),
+    )
+    outcome = await engine.run()
+
+    detail = (
+        f"{dot_path.name}: status={outcome.status.value} "
+        f"notes={outcome.notes!r} failure_reason={outcome.failure_reason!r} "
+        f"completed={engine.completed_nodes}"
+    )
+    assert "No matching edge" not in (outcome.notes or ""), detail
+    assert "No matching edge" not in (outcome.failure_reason or ""), detail
+    assert outcome.is_success, detail
+
+
+@_needs_fixtures
+@pytest.mark.parametrize(
+    "dot_path", _FIXTURES, ids=lambda p: p.name
+)
+def test_goal_gate_prompts_ask_for_the_verdict_they_require(dot_path: Path) -> None:
+    """A ``goal_gate=true`` node's prompt must ask for an explicit verdict.
+
+    Grounded in the engine, not in the wording: for each gated node this asserts
+    through the REAL ``_parse_outcome`` that (a) prose does not satisfy the gate
+    and (b) an asserted verdict does -- so the textual check below is pinned to
+    the contract that makes it necessary, rather than standing on its own.
+    """
+    graph = parse_dot(dot_path.read_text(encoding="utf-8"))
+    for node in _goal_gate_nodes(graph):
+        prose = _parse_outcome(_PROSE_ANSWER, node=node)
+        assert not (prose.is_success and prose.is_explicit), (
+            f"{dot_path.name}:{node.id}: prose unexpectedly satisfies the gate "
+            f"(status={prose.status.value}, is_explicit={prose.is_explicit}) -- "
+            f"EXTENSIONS.md §25 fail-closed contract changed?"
+        )
+        asserted = _parse_outcome(_ASSERTED_VERDICT, node=node)
+        assert asserted.is_success and asserted.is_explicit, (
+            f"{dot_path.name}:{node.id}: an asserted verdict does not satisfy "
+            f"the gate (status={asserted.status.value}, "
+            f"is_explicit={asserted.is_explicit})"
+        )
+        assert _ASKS_FOR_VERDICT_RE.search(node.prompt or ""), (
+            f"{dot_path.name}:{node.id} has goal_gate=true but its prompt never "
+            f"asks for a report_outcome verdict. Prose resolves to "
+            f"{prose.status.value}/is_explicit={prose.is_explicit}, the retry "
+            f"budget is then spent into FAIL, and §3.7 fail-fast refuses the "
+            f"node's plain outgoing edge -- the run dead-ends with 'No matching "
+            f"edge' (issue #250)."
+        )
+
+
+@_needs_fixtures
+@pytest.mark.asyncio
+async def test_prose_only_answer_is_what_dead_ended_the_gate(tmp_path) -> None:
+    """Characterisation of the #250 mechanism -- the reason the prompt matters.
+
+    This pins the chain the probe found, on a graph shaped exactly like the
+    pre-fix fixture, so nobody "fixes" #250 by deleting the verdict instruction
+    and papering over the symptom somewhere else.
+    """
+    dot = """
+    digraph mechanism {
+        graph [goal="probe"]
+        start     [shape=Mdiamond]
+        implement [shape=box, prompt="do the work", goal_gate=true]
+        done      [shape=Msquare]
+        start -> implement -> done
+    }
+    """
+    graph = parse_dot(dot)
+    gate = graph.nodes["implement"]
+
+    # Step 2: prose on a gated node is RETRY, never an explicit success.
+    prose = _parse_outcome(_PROSE_ANSWER, node=gate)
+    assert prose.status is StageStatus.RETRY
+    assert prose.is_explicit is False
+
+    # Step 4: the plain edge is fine for every status EXCEPT FAIL.
+    ctx = PipelineContext()
+    for status in (
+        StageStatus.SUCCESS,
+        StageStatus.PARTIAL_SUCCESS,
+        StageStatus.RETRY,
+    ):
+        edge = select_edge(
+            "implement", Outcome(status=status, is_explicit=True), ctx, graph
+        )
+        assert edge is not None and edge.to_node == "done", (
+            f"the bare implement -> done edge should resolve on {status.value}; "
+            f"the filed suspicion that a goal gate needs labelled edges is wrong"
+        )
+    assert (
+        select_edge(
+            "implement", Outcome(status=StageStatus.FAIL, is_explicit=True), ctx, graph
+        )
+        is None
+    ), "spec §3.7 fail-fast: a FAIL must not traverse a plain edge to a runs_on=success target"
+
+    # End to end: a prose-answering agent reproduces the filed symptom exactly.
+    backend = ContractFollowingBackend()
+    engine = PipelineEngine(
+        graph=parse_dot(dot),
+        context=PipelineContext(),
+        handler_registry=HandlerRegistry(HandlerContext(backend=backend)),
+        logs_root=str(tmp_path),
+    )
+    outcome = await engine.run()
+    assert outcome.status is StageStatus.FAIL
+    assert "No matching edge from node 'implement'" in (outcome.notes or "")
+    assert engine.completed_nodes == ["start", "implement"]

--- a/modules/loop-pipeline/tests/test_topological_lint.py
+++ b/modules/loop-pipeline/tests/test_topological_lint.py
@@ -1,4 +1,4 @@
-"""Tests for topological (basin-lint) rules — TOPO-001 through TOPO-008.
+"""Tests for topological (basin-lint) rules — TOPO-001 through TOPO-009.
 
 These rules reason about cycle structure and handler semantics, not just
 graph topology.  They are exposed via ``lint()`` (not ``validate()``) so
@@ -2002,3 +2002,333 @@ class TestInertEvidenceGate:
         assert not _diag(validate(graph), "inert_evidence_gate")
         diags = _diag(lint(graph), "inert_evidence_gate")
         assert diags and all(d.severity == "WARNING" for d in diags)
+
+
+# ---------------------------------------------------------------------------
+# TOPO-009: outcome_label_shadowing (issue #226)
+# ---------------------------------------------------------------------------
+
+
+def _hazard_graph() -> Graph:
+    """The issue-#226 shape: an `outcome=retry` edge on a label-steered node."""
+    return _graph(
+        nodes={
+            "start": _mdiamond(),
+            "review": _box("review", prompt="review it"),
+            "fix": _box("fix", prompt="fix it"),
+            "rework": _box("rework", prompt="rework it"),
+            "done": _msquare("done"),
+        },
+        edges=[
+            Edge("start", "review"),
+            Edge("review", "fix", condition="outcome=retry"),
+            Edge("review", "rework", label="retry"),
+            Edge("review", "done", condition="outcome=success"),
+            Edge("fix", "review"),
+            Edge("rework", "review"),
+        ],
+    )
+
+
+class TestOutcomeLabelShadowing:
+    """TOPO-009 -- `outcome=` reads preferred_label before status (EXTENSIONS §22)."""
+
+    # -- fires ---------------------------------------------------------------
+
+    def test_fires_on_the_constructed_hazard(self):
+        diags = _diag(lint(_hazard_graph()), "outcome_label_shadowing")
+        assert len(diags) == 1
+        d = diags[0]
+        assert d.node_id == "review"
+        assert d.edge == ("review", "fix")
+
+    def test_message_names_the_rule_the_ledger_and_both_edges(self):
+        d = _diag(lint(_hazard_graph()), "outcome_label_shadowing")[0]
+        assert "TOPO-009" in d.message
+        assert "EXTENSIONS.md §22" in d.message
+        assert "ATX-5" in d.message
+        assert 'review -> fix [condition="outcome=retry"]' in d.message
+        assert 'review -> rework [label="retry"]' in d.message
+
+    def test_fix_offers_both_unambiguous_keys(self):
+        d = _diag(lint(_hazard_graph()), "outcome_label_shadowing")[0]
+        assert 'condition="status=retry"' in d.fix
+        assert 'condition="preferred_label=retry"' in d.fix
+
+    def test_one_diagnostic_per_node_not_per_edge(self):
+        """`review` carries two `outcome=` edges; the node is warned about once."""
+        assert len(_diag(lint(_hazard_graph()), "outcome_label_shadowing")) == 1
+
+    def test_inequality_counts_too(self):
+        """`outcome!=success` resolves the same overloaded key."""
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "review": _box("review", prompt="r"),
+                "fix": _box("fix", prompt="f"),
+                "done": _msquare("done"),
+            },
+            edges=[
+                Edge("start", "review"),
+                Edge("review", "fix", condition="outcome!=success"),
+                Edge("review", "done", label="success"),
+                Edge("fix", "review"),
+            ],
+        )
+        assert _diag(lint(g), "outcome_label_shadowing")
+
+    def test_accelerator_stripped_label_still_collides(self):
+        """The engine strips accelerators before matching; so does this rule."""
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "review": _box("review", prompt="r"),
+                "fix": _box("fix", prompt="f"),
+                "done": _msquare("done"),
+            },
+            edges=[
+                Edge("start", "review"),
+                Edge("review", "fix", condition="outcome=retry"),
+                Edge("review", "done", label="[R] Retry"),
+                Edge("fix", "review"),
+            ],
+        )
+        assert _diag(lint(g), "outcome_label_shadowing")
+
+    # -- the narrowings, each load-bearing -----------------------------------
+
+    def test_silent_on_an_outcome_condition_with_no_labelled_edge(self):
+        """Routing on `outcome=success` in a label-free graph is normal and correct.
+
+        This is the shape the issue's condition (1) would have flagged; it is
+        23 of this repository's 63 shipped graphs.
+        """
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "review": _box("review", prompt="r"),
+                "fix": _box("fix", prompt="f"),
+                "done": _msquare("done"),
+            },
+            edges=[
+                Edge("start", "review"),
+                Edge("review", "done", condition="outcome=success"),
+                Edge("review", "fix", condition="outcome=fail"),
+                Edge("fix", "review"),
+            ],
+        )
+        assert not _diag(lint(g), "outcome_label_shadowing")
+
+    def test_silent_when_the_status_word_label_is_on_a_conditional_edge(self):
+        """Spec §3.3 Step 2 skips conditional edges, so such a label is inert.
+
+        This is the shipped convention -- `gate -> fix
+        [condition="context.tool.last_line=fail", label="fail"]` -- and is why
+        the issue's own suggested conservative form still fires on 6 graphs.
+        """
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "review": _box("review", prompt="r"),
+                "fix": _box("fix", prompt="f"),
+                "done": _msquare("done"),
+            },
+            edges=[
+                Edge("start", "review"),
+                Edge("review", "done", condition="outcome=success"),
+                Edge("review", "fix", condition="outcome=fail", label="fail"),
+                Edge("fix", "review"),
+            ],
+        )
+        assert not _diag(lint(g), "outcome_label_shadowing")
+
+    def test_silent_when_the_label_is_outside_the_status_vocabulary(self):
+        """`label="needs_work"` cannot be confused with a status value."""
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "review": _box("review", prompt="r"),
+                "fix": _box("fix", prompt="f"),
+                "done": _msquare("done"),
+            },
+            edges=[
+                Edge("start", "review"),
+                Edge("review", "done", condition="outcome=success"),
+                Edge("review", "fix", label="needs_work"),
+                Edge("fix", "review"),
+            ],
+        )
+        assert not _diag(lint(g), "outcome_label_shadowing")
+
+    def test_silent_when_the_label_edge_belongs_to_a_different_node(self):
+        """`select_edge` resolves a node's outcome against THAT node's out-edges."""
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "review": _box("review", prompt="r"),
+                "other": _box("other", prompt="o"),
+                "fix": _box("fix", prompt="f"),
+                "done": _msquare("done"),
+            },
+            edges=[
+                Edge("start", "review"),
+                Edge("review", "done", condition="outcome=retry"),
+                Edge("review", "other"),
+                Edge("other", "fix", label="retry"),
+                Edge("fix", "review"),
+            ],
+        )
+        assert not _diag(lint(g), "outcome_label_shadowing")
+
+    def test_silent_on_a_non_outcome_condition_key(self):
+        """`context.tool.last_line=fail` does not go through the overloaded key."""
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "gate": _gate("gate"),
+                "fix": _box("fix", prompt="f"),
+                "done": _msquare("done"),
+            },
+            edges=[
+                Edge("start", "gate"),
+                Edge("gate", "done", condition="context.tool.last_line=green"),
+                Edge("gate", "fix", label="fail"),
+                Edge("fix", "gate"),
+            ],
+        )
+        assert not _diag(lint(g), "outcome_label_shadowing")
+
+    def test_silent_on_an_unlabelled_unconditional_edge(self):
+        """An unconditional edge with no label is not evidence of label steering."""
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "review": _box("review", prompt="r"),
+                "fix": _box("fix", prompt="f"),
+                "done": _msquare("done"),
+            },
+            edges=[
+                Edge("start", "review"),
+                Edge("review", "done", condition="outcome=success"),
+                Edge("review", "fix"),
+                Edge("fix", "review"),
+            ],
+        )
+        assert not _diag(lint(g), "outcome_label_shadowing")
+
+    # -- lint-only, WARNING severity ----------------------------------------
+
+    def test_rule_is_lint_only_and_warning_severity(self):
+        """`validate()` stays silent; `lint()` warns. No graph starts failing at run time."""
+        g = _hazard_graph()
+        assert not _diag(validate(g), "outcome_label_shadowing")
+        diags = _diag(lint(g), "outcome_label_shadowing")
+        assert diags and all(d.severity == "WARNING" for d in diags)
+
+    # -- vocabulary is derived, not hand-copied ------------------------------
+
+    def test_status_vocabulary_tracks_stage_status(self):
+        """A new StageStatus value cannot silently leave TOPO-009 behind."""
+        from amplifier_module_loop_pipeline.edge_selection import _normalize_label
+        from amplifier_module_loop_pipeline.outcome import StageStatus
+        from amplifier_module_loop_pipeline.validation import _STATUS_WORDS
+
+        assert _STATUS_WORDS == {_normalize_label(s.value) for s in StageStatus}
+
+
+class TestOutcomeLabelShadowingCalibration:
+    """TOPO-009 must be silent on every graph this repository ships.
+
+    A lint rule that fires on shipped, correct graphs is wolf-crying: authors
+    learn to ignore it and it stops protecting anything.  This sweep pins the
+    measurement the rule's narrowing was derived from, over EVERY `.dot` in the
+    repository -- `examples/`, `.github/`, `skills/`, and every test fixture --
+    not just the `examples/` corpus `test_examples_lint_clean.py` covers.
+    """
+
+    @staticmethod
+    def _repo_dots() -> list:
+        from pathlib import Path
+
+        root = Path(__file__).resolve().parents[3]
+        if not (root / "examples").is_dir():
+            return []
+        return sorted(p for p in root.rglob("*.dot") if ".git/" not in str(p))
+
+    def test_silent_on_every_shipped_dot(self):
+        import pytest
+
+        from amplifier_module_loop_pipeline.dot_parser import parse_dot
+
+        dots = self._repo_dots()
+        if not dots:
+            pytest.skip("repository .dot corpus not present (installed-package run)")
+
+        fired = []
+        for path in dots:
+            graph = parse_dot(path.read_text(encoding="utf-8"))
+            for d in _diag(lint(graph), "outcome_label_shadowing"):
+                fired.append(f"{path}: {d.message}")
+
+        assert not fired, (
+            f"TOPO-009 fired on {len(fired)} of {len(dots)} shipped graphs -- it is "
+            f"wolf-crying and must be narrowed until it is silent on all of them:\n"
+            + "\n".join(fired)
+        )
+
+    def test_the_corpus_is_actually_large_enough_to_mean_something(self):
+        """Guard the guard: a sweep over an empty corpus proves nothing."""
+        import pytest
+
+        dots = self._repo_dots()
+        if not dots:
+            pytest.skip("repository .dot corpus not present (installed-package run)")
+        assert len(dots) >= 60, f"only {len(dots)} .dot files found; corpus shrank?"
+
+    def test_the_rejected_broader_shapes_really_do_fire_on_shipped_graphs(self):
+        """Why the narrowing exists, measured rather than asserted.
+
+        The issue proposed keying on an `outcome=<status word>` condition plus a
+        status-word edge `label=` anywhere in the graph.  Both of those broader
+        forms are demonstrably noisy on this repository's own corpus -- that
+        measurement is what moved the rule to per-node, Step-2-eligible label
+        edges.  If a future change ever makes the broad forms silent too, this
+        test goes red and the narrowing should be revisited.
+        """
+        import pytest
+
+        from amplifier_module_loop_pipeline.conditions import parse_condition
+        from amplifier_module_loop_pipeline.dot_parser import parse_dot
+        from amplifier_module_loop_pipeline.edge_selection import _normalize_label
+        from amplifier_module_loop_pipeline.validation import _STATUS_WORDS
+
+        dots = self._repo_dots()
+        if not dots:
+            pytest.skip("repository .dot corpus not present (installed-package run)")
+
+        condition_only = 0
+        plus_any_status_label = 0
+        for path in dots:
+            graph = parse_dot(path.read_text(encoding="utf-8"))
+            has_cond = any(
+                key == "outcome"
+                and op in ("=", "!=")
+                and _normalize_label(val) in _STATUS_WORDS
+                for e in graph.edges
+                for key, op, val in parse_condition(e.condition or "")
+            )
+            has_label = any(
+                e.label and _normalize_label(e.label) in _STATUS_WORDS
+                for e in graph.edges
+            )
+            condition_only += 1 if has_cond else 0
+            plus_any_status_label += 1 if (has_cond and has_label) else 0
+
+        assert condition_only >= 20, (
+            f"the issue's condition (1) alone fires on only {condition_only} graphs now "
+            f"(was 23 of 63) -- recheck whether TOPO-009 still needs narrowing"
+        )
+        assert plus_any_status_label >= 5, (
+            f"the issue's suggested conservative form fires on only "
+            f"{plus_any_status_label} graphs now (was 6 of 63) -- recheck the narrowing"
+        )

--- a/modules/pipeline-runner/amplifier_module_pipeline_runner/cli.py
+++ b/modules/pipeline-runner/amplifier_module_pipeline_runner/cli.py
@@ -549,7 +549,7 @@ def cmd_lint(args: argparse.Namespace) -> int:
     """Static topological lint of a .dot pipeline file.
 
     Parses the DOT file and runs the full basin-lint rule set:
-    structural rules (LINT-001–018), topological rules (TOPO-001–008),
+    structural rules (LINT-001–018), topological rules (TOPO-001–009),
     and command-content rules (CMD-001–002, which inspect tool_command
     strings for pipe-masked exit codes and always-true sentinels).
 

--- a/skills/attractorify/SKILL.md
+++ b/skills/attractorify/SKILL.md
@@ -360,7 +360,7 @@ the objection's disposition recorded (`caveats:` line if unresolved). Then:
    ```
    bash -c "attractor lint <path>"
    ```
-   A `.dot` that fails `attractor lint` (TOPO-001 through TOPO-008, documented in
+   A `.dot` that fails `attractor lint` (TOPO-001 through TOPO-009, documented in
    `docs/DOT-AUTHORING-GUIDE.md`) is not a runnable artifact. Fix lint findings
    before handing back.
 
@@ -389,7 +389,7 @@ the objection's disposition recorded (`caveats:` line if unresolved). Then:
 
 - `docs/PIPELINE_DESIGN_PRINCIPLES.md` §0 — one-sentence rule, control-plane vs
   recipe-plane line, **three-question test**, design order
-- `docs/DOT-AUTHORING-GUIDE.md` — node contract, DOT syntax, TOPO-001..008 lint
+- `docs/DOT-AUTHORING-GUIDE.md` — node contract, DOT syntax, TOPO-001..009 lint
   rules, `attractor lint` CLI
 - `attractor:attractor-expert` — the consultable expert agent; delegate to it
   for any pipeline design or debugging question (source prompt:

--- a/specs/EXTENSIONS.md
+++ b/specs/EXTENSIONS.md
@@ -1732,10 +1732,23 @@ whose traversal resets the budget — the ATX-12 fresh-attempt semantics — lea
 only by the step cap), and **TOPO-008** (`WARNING`, issue #254: inert evidence gate — a tool node
 that runs a real check and routes on it, but sends two or more distinct `context.tool.last_line`
 answers into the terminal success node, so the run ends green whichever answer it got; the
-`attractor lint` sibling of the authoring checker's A10, issue #245). Listed here so this entry
+`attractor lint` sibling of the authoring checker's A10, issue #245), and **TOPO-009**
+(`WARNING`, issue #226: an `outcome=<status word>` edge condition on a node that also steers
+itself by an unconditional status-word `label=` — `outcome` resolves `preferred_label` before
+`status` here, the §22 divergence above, so the label silently decides a route the author read
+as a status). Listed here so this entry
 stays the complete catalog of the `lint()`-only rule family; per this entry's own discriminator
-(the **entry point**, not the rule count), none of them owed a new ledger entry. All three are
-documented in `docs/DOT-AUTHORING-GUIDE.md` with fix examples.*
+(the **entry point**, not the rule count), none of them owed a new ledger entry. All four are
+documented in `docs/DOT-AUTHORING-GUIDE.md` with fix examples.
+
+TOPO-009 is the first rule in the family whose whole subject is a ledgered divergence rather than
+a topology defect: §22 / ATX-5 is deliberate and load-bearing, and the rule does not argue with
+it — it makes the choice visible to an author who never read the ledger. Its scope was set by
+measurement, not by taste: the shape issue #226 first proposed fires on 23 of this repository's
+63 shipped `.dot` graphs and the issue's own suggested conservative form on 6, while the shipped
+form (the collision scoped to one node's out-edges, and to the unconditional labelled edges spec
+§3.3 Step 2 can actually select) fires on zero. That zero is pinned by
+`test_topological_lint.py::TestOutcomeLabelShadowingCalibration`.*
 
 **Why a separate entry point, not folded into `validate()`:** the five TOPO rules are
 judgment calls about pipeline *design quality* (is this graph shaped like a converging

--- a/tests/e2e/fixtures/plan_implement_review.dot
+++ b/tests/e2e/fixtures/plan_implement_review.dot
@@ -1,11 +1,16 @@
 digraph plan_implement_review {
     graph [goal="Create and validate a Python script"]
-    
+
+    // `implement` carries goal_gate=true and therefore owes an ASSERTED
+    // verdict (EXTENSIONS.md §25).  Without the report_outcome instruction
+    // below, a prose answer resolves to RETRY -> FAIL and the plain
+    // `implement -> validate` edge is refused by §3.7 fail-fast, so the run
+    // dead-ends at `implement` -- the same defect as issue #250.
     start     [shape=Mdiamond]
     plan      [shape=box, prompt="List the steps needed to create a Python script that defines an add(a,b) function and tests it. Be brief - just list 2-3 steps."]
-    implement [shape=box, prompt="Create test_math.py with a function add(a,b) that returns a+b, and a main block that asserts add(1,2)==3 and prints 'Tests passed'", goal_gate=true]
+    implement [shape=box, prompt="Create test_math.py with a function add(a,b) that returns a+b, and a main block that asserts add(1,2)==3 and prints 'Tests passed'. Then call the report_outcome tool to assert your verdict: status=success once test_math.py exists, or status=fail with a failure_reason if you could not create it. This node is a goal gate -- a plain-text answer is not a verdict and will not satisfy it.", goal_gate=true]
     validate  [shape=box, prompt="Run 'python3 test_math.py' and report whether it passed or failed"]
     done      [shape=Msquare]
-    
+
     start -> plan -> implement -> validate -> done
 }

--- a/tests/e2e/fixtures/simple_file_creation.dot
+++ b/tests/e2e/fixtures/simple_file_creation.dot
@@ -1,9 +1,18 @@
 digraph simple_test {
     graph [goal="Create a hello world Python script"]
-    
+
+    // `implement` carries goal_gate=true, so EXTENSIONS.md §25's fail-closed
+    // contract requires it to ASSERT a verdict (report_outcome / JSON).  A
+    // plain-prose answer resolves to RETRY with is_explicit=false; the retry
+    // budget is then spent and the node's outcome becomes FAIL -- at which
+    // point spec §3.7 fail-fast refuses to traverse the plain
+    // `implement -> done` edge (`done` is a default runs_on=success target)
+    // and the run dies with "No matching edge from node 'implement'"
+    // (issue #250).  The edge is fine; the prompt has to ask for the verdict
+    // the gate demands.
     start     [shape=Mdiamond]
-    implement [shape=box, prompt="Create a file called hello.py that prints 'Hello World'. Use only the tools available to you.", goal_gate=true]
+    implement [shape=box, prompt="Create a file called hello.py that prints 'Hello World'. Use only the tools available to you. Then call the report_outcome tool to assert your verdict: status=success once hello.py exists, or status=fail with a failure_reason if you could not create it. This node is a goal gate -- a plain-text answer is not a verdict and will not satisfy it.", goal_gate=true]
     done      [shape=Msquare]
-    
+
     start -> implement -> done
 }

--- a/tests/e2e/fixtures/simple_file_creation_gemini.dot
+++ b/tests/e2e/fixtures/simple_file_creation_gemini.dot
@@ -1,9 +1,12 @@
 digraph simple_gemini_test {
     graph [goal="Create a hello world Python script"]
-    
+
+    // Gemini-provider twin of simple_file_creation.dot.  Same goal_gate=true
+    // contract, same reason the prompt must ask for an explicit verdict --
+    // see that fixture's comment and issue #250.
     start     [shape=Mdiamond]
-    implement [shape=box, prompt="Create a file called hello.py that prints 'Hello World'. Use only the tools available to you.", llm_provider="gemini", goal_gate=true]
+    implement [shape=box, prompt="Create a file called hello.py that prints 'Hello World'. Use only the tools available to you. Then call the report_outcome tool to assert your verdict: status=success once hello.py exists, or status=fail with a failure_reason if you could not create it. This node is a goal gate -- a plain-text answer is not a verdict and will not satisfy it.", llm_provider="gemini", goal_gate=true]
     done      [shape=Msquare]
-    
+
     start -> implement -> done
 }


### PR DESCRIPTION
Closes two small standing issues: an e2e fixture that could never reach its own exit, and a missing lint hint for the `outcome=` / `preferred_label` vocabulary collision.

**Decision-matrix tier (QUALITY_PROTOCOL §3): TOWARD-SPEC, both halves.** Stated explicitly so it can be disagreed with.
- #250 corrects a test fixture so it obeys the engine's own already-ledgered contract (EXTENSIONS §25). Nothing moves relative to the nlspec; no ledger entry owed.
- #226 adds a rule on the advisory `lint()` entry point, which canonical §7.4 explicitly permits as an extension point and which EXTENSIONS §32 already ledgers as a family. `validate()` / `validate_or_raise()` are untouched, so no graph that runs today starts failing — additive and non-interfering. Per §32's own discriminator (**the entry point, not the rule count**) no new ledger entry is owed; the §32 catalog addendum is updated instead. TOPO-009's *subject* is a DIVERGE (ATX-5), but the rule does not argue with it — it steers authors toward the spec-literal `status=` key, which is toward-spec.

---

## #250 — the e2e fixture that never routes past `implement`

### The issue's claimed mechanism was wrong

> **Suspicion, not verified:** `implement` carries `goal_gate=true`. If a goal-gated node requires labelled/conditional outgoing edges (e.g. a pass/fail branch) and this fixture supplies only a bare edge, the gate would have nothing to match.

Probed against the real engine before changing anything. The bare edge is fine — the gate does not consume edges at all:

```
select_edge('implement', <status>) over tests/e2e/fixtures/simple_file_creation.dot
    status=success          -> implement->done
    status=retry            -> implement->done
    status=partial_success  -> implement->done
    status=fail             -> None  <-- "No matching edge"
    node 'done' runs_on attr = None (default 'success')
```

### The true mechanism — four steps, and only the last one is routing

1. `implement` carries `goal_gate=true`, so **EXTENSIONS §25**'s fail-closed contract requires an *asserted* verdict (`report_outcome` / JSON).
2. The fixture's prompt never asked for one, so a real agent answers in prose. `_parse_outcome` maps prose on a gated node to **RETRY / `is_explicit=False`** — deliberately, so a defaulted response cannot satisfy a gate:
   ```
   _parse_outcome(plain prose, node=implement[goal_gate=true])
     status=StageStatus.RETRY  is_explicit=False
     failure_reason='goal_gate node requires an explicit verdict (report_outcome / JSON)'
   ```
3. The retry budget is spent and the node's recorded outcome becomes **FAIL**.
4. *Now* routing fails: spec **§3.7 fail-fast** refuses to traverse an unconditional edge on FAIL when the target is a default `runs_on=success` node → `select_edge` returns `None` → hard-fail per **§33**.

Full engine run reproduces the filed symptom exactly, including `nodes_completed: 2`:

```
--- A. plain prose (real-agent shape, as in the issue)
    backend calls  : ['implement']  (n=1)
    completed      : ['start', 'implement']
    final          : fail  notes="No matching edge from node 'implement'" fail='Max retries exceeded'
--- B. explicit JSON verdict (report_outcome-equivalent)
    final          : success  notes='wrote hello.py' fail=None
```

So the defect is **in the prompt, not the topology** — and it is not confined to the fixture the issue named. Sweeping all four e2e fixtures through the real engine with a prose-answering agent:

| fixture | goal_gate node | result with a prose-answering agent |
|---|---|---|
| `conditional_routing.dot` | — | `status=success` |
| `plan_implement_review.dot` | `implement` | `status=fail` — `No matching edge from node 'implement'` |
| `simple_file_creation.dot` | `implement` | `status=fail` — `No matching edge from node 'implement'` |
| `simple_file_creation_gemini.dot` | `implement` | `status=fail` — `No matching edge from node 'implement'` |

### The fix

All three gated fixtures now instruct their gated node to call `report_outcome`, plus a comment recording the four-step chain so the next author does not delete it back out.

Topology is deliberately **untouched**: hard-failing a genuine FAIL is the designed §3.7 / §33 contract, and absorbing it with a second `Msquare` terminal would route a failure out the success door — the exact TOPO-006 hazard.

### The pinning assertion

`modules/loop-pipeline/tests/test_e2e_fixture_routes.py` (new, 13 tests) pins the route **through the engine**, not by reading DOT text:

- `ContractFollowingBackend` does exactly what each node's own prompt tells it to — asserts a verdict if the prompt asks, answers in prose if it does not. Nothing is stubbed past the backend boundary: `_parse_outcome`, the goal-gate check, the retry ladder and `select_edge` all run for real.
- `test_fixture_reaches_its_exit` — every fixture must complete without `No matching edge`. Deleting a verdict instruction from a prompt turns this red.
- `test_goal_gate_prompts_ask_for_the_verdict_they_require` — grounds the textual half in the engine: asserts through the real `_parse_outcome` that prose does **not** satisfy the gate and an asserted verdict **does**, so the check stands on the contract that makes it necessary.
- `test_prose_only_answer_is_what_dead_ended_the_gate` — characterises the four-step mechanism itself, so the symptom cannot be papered over elsewhere.

**RED-proven against the pre-fix tree** (fixtures reverted to `9df6c24`, tests unchanged):

```
### PRE-FIX TREE  → 6 failed, 7 passed
FAILED test_fixture_reaches_its_exit[plan_implement_review.dot]
FAILED test_fixture_reaches_its_exit[simple_file_creation.dot]
FAILED test_fixture_reaches_its_exit[simple_file_creation_gemini.dot]
FAILED test_goal_gate_prompts_ask_for_the_verdict_they_require[plan_implement_review.dot]
FAILED test_goal_gate_prompts_ask_for_the_verdict_they_require[simple_file_creation.dot]
FAILED test_goal_gate_prompts_ask_for_the_verdict_they_require[simple_file_creation_gemini.dot]

### POST-FIX TREE → 13 passed
```

---

## #226 — the `outcome=` lint hint → TOPO-009

### Rule number

Verified `TOPO-009` free before naming it: `grep -rn "TOPO-009\|TOPO-09" .` returned nothing repo-wide, and the family's highest existing number is **TOPO-008** (`_check_inert_evidence_gate`, issue #254) across `validation.py`, `DOT-AUTHORING-GUIDE.md`, `EXTENSIONS.md`, `cli.py` and `SKILL.md`.

### What it detects

`outcome=` resolves `preferred_label` **first** and falls back to `status.value` only when no label is set (`conditions.py::_resolve_key`) — a decided, ledgered divergence from canonical §10.4 (**EXTENSIONS §22**, **SPEC_CONFORMANCE ATX-5**, disposition DIVERGE). The ledger is explicit that it is *not* behaviour-neutral; what it never had was a way for an author to find out.

**TOPO-009** (`outcome_label_shadowing`, **WARNING**, `lint()`-only) fires when **one node** carries both halves:

1. an out-edge routing on `outcome=<status word>` (`=` or `!=`), **and**
2. an out-edge that is **unconditional and labelled** with a status word — the only edges spec §3.3 Step 2 can actually select by `preferred_label`.

The vocabulary is derived from `StageStatus` itself and normalised through `edge_selection._normalize_label`, so lint asks "is this a status word?" exactly the way routing asks it and the two cannot drift. A test pins that derivation.

### Diagnostic message

> Node `'review'` routes on the `'outcome'` key against status words (`review -> done [condition="outcome=success"]`; `review -> fix [condition="outcome=retry"]`) while also steering itself by label (`review -> rework [label="retry"]`). `'outcome'` resolves preferred_label BEFORE status (EXTENSIONS.md §22 / SPEC_CONFORMANCE ATX-5) - not status alone, as canonical §10.4 defines it. `'retry'` is in both vocabularies at once, so `'review'` reporting status=success with preferred_label="retry" matches `'review' -> 'fix'` anyway, while `'review'` reporting status=retry under any other label does not match it at all. Neither case is logged: the condition is well-formed and the graph is otherwise clean (TOPO-009).

**fix:** > Say which one you mean - both keys are exact and unambiguous. For the status, write `condition="status=retry"` on `'review' -> 'fix'`; for the label, write `condition="preferred_label=retry"`. If `'review'` is not meant to steer itself by label, take the status word off its labelled edge instead. See DOT-AUTHORING-GUIDE.md (TOPO-009) and docs/ROUTING-REFERENCE.md §3.

### Calibration table — the hard part

Every `.dot` in the repository was scanned: **63 files** across `examples/` (33), `modules/` test fixtures (21), `.github/` (4), `tests/e2e/fixtures/` (4), `skills/` (1). Each candidate shape was measured, not assumed:

| candidate rule shape | graphs scanned | fires on shipped graphs | verdict |
|---|---|---|---|
| **C1** — the issue's condition (1) alone: any `outcome=<status word>` edge | 63 | **23** | wolf-crying — `outcome=success` is the ordinary correct way to route a label-free graph |
| **C2** — the issue's own suggested conservative form: C1 + any status-word edge `label=` anywhere in the graph | 63 | **6** | still wolf-crying |
| **C3** — node-scoped + **any** unconditional labelled out-edge | 63 | **8** | still wolf-crying |
| **SHIPPED** — node-scoped + unconditional out-edge labelled with a **status word** (Step-2-eligible) | 63 | **0** | ✅ silent on every shipped graph, fires on the constructed hazard |

Per-tree, for the shipped shape:

| tree | graphs | TOPO-009 fires |
|---|---|---|
| `examples/` | 33 | 0 |
| `modules/` (test fixtures) | 21 | 0 |
| `.github/` | 4 | 0 |
| `tests/` | 4 | 0 |
| `skills/` | 1 | 0 |
| **total** | **63** | **0** |

Confirmed through the CLI entry point too (`attractor lint` over all 63 files): `TOPO-009 fires=0`.

**The narrowing is the routing semantics, not a fudge to reach zero.** `select_edge` resolves a node's outcome against *that node's* out-edges, and its Step 2 (`preferred_label` match) considers only **unconditional** labelled edges. A status word on a *conditional* edge is documentation the label matcher can never select — and that is this repository's own shipped convention (`gate -> fix [condition="context.tool.last_line=fail", label="fail"]`, 7 occurrences), which is precisely why C2 misfires.

The rule fires on the issue's constructed hazard:

```dot
review -> fix    [condition="outcome=retry"]   // author means the STATUS
review -> rework [label="retry"]               // node steers by LABEL
```

`TestOutcomeLabelShadowingCalibration` pins all of it: the zero across the whole corpus, a guard that the corpus is still ≥60 files (a sweep over an empty corpus proves nothing), and an assertion that the **rejected broader shapes really do still fire** — so if the narrowing ever stops being necessary, the suite says so instead of the reasoning quietly rotting.

**RED-proven against `9df6c24`** (`validation.py` reverted, tests unchanged): 9 failed / 8 passed → 17 passed after. The 8 that passed pre-fix are the negative "must stay silent" cases, which trivially hold when the rule does not exist; every positive/firing test was red.

### Doc surfaces added

| surface | change |
|---|---|
| `docs/DOT-AUTHORING-GUIDE.md` | new `### TOPO-009` section matching the family structure (what it detects / why it matters / wrong+correct DOT / calibration / what is NOT flagged / severity / fix) |
| `docs/DOT-AUTHORING-GUIDE.md` | 3 severity-range notes: `TOPO-002 through TOPO-008` → `…TOPO-009` (TOPO-008, CMD-001, CMD-002) |
| `modules/pipeline-runner/…/cli.py` | `topological rules (TOPO-001–008)` → `–009` |
| `skills/attractorify/SKILL.md` | both rule ranges (`TOPO-001 through TOPO-008`, `TOPO-001..008`) |
| `specs/EXTENSIONS.md` §32 | catalog addendum extended to TOPO-009 with the calibration numbers and why no new ledger entry is owed |
| `validation.py` | module docstring, `lint()` docstring, family section header |

---

## Gates

| gate | result |
|---|---|
| loop-pipeline suite (`uv sync --extra remote && uv run pytest -q`) | **2458 passed, 25 skipped** |
| pipeline-runner suite (plain `uv sync`) | **76 passed, 1 skipped** |
| examples-lint sweep (`examples/` + `.github/` + `skills/`, 38 graphs) | **0 errors** |
| TOPO-009 silent on shipped graphs | **0 / 63** (module sweep + `attractor lint` CLI) |
| doc/ledger guards + conformance matrix (`test_extensions_ledger_integrity`, `test_spec_conformance_matrix`, `test_spec_conformance_batch`, `test_doc_consistency`, `test_quality_protocol_guard`, `test_examples_lint_clean`) | **276 passed, 24 skipped** |
| `ruff check` (module config) on changed files | clean (5 pre-existing `F401`s elsewhere in `tests/`, unchanged) |
| leak scan (secret-shaped material, absolute paths, lane scratch) | clean |
| `git diff --check` | clean |

## Observations

1. **The issue's stated mechanism for #250 was wrong in the detail that matters.** It suspected the goal gate needed labelled/conditional edges. It does not — the bare edge resolves for SUCCESS, RETRY and PARTIAL_SUCCESS. The gate never touches edge selection; it is the §25 fail-closed contract turning prose into RETRY, then retry exhaustion into FAIL, that hands §3.7 an outcome it will not route. Filed under "verify, don't assume."

2. **The defect was wider than the issue's title.** `plan_implement_review.dot` has the identical shape and dead-ends identically; `simple_file_creation_gemini.dot` is a verbatim twin. All three are fixed. Nothing but the goal-gated fixtures is affected.

3. **The issue's own proposed lint shape for #226 was noisy on this corpus** — 23/63 for its condition (1), 6/63 for the conservative form it suggested. That measurement, not taste, is what moved the rule to per-node, Step-2-eligible label edges. Recording it because "we tried the obvious thing and measured it" is the part that decays fastest.

4. **`tests/e2e/fixtures/conditional_routing.dot` carries a pre-existing TOPO-001 ERROR** (`dead_conditional_edge`): `gate` is a `diamond`, `ConditionalHandler` always returns SUCCESS, so `gate -> implement [condition="outcome!=success", label="Retry"]` can never fire — the fixture's retry branch is provably dead. It is **not** fixed here: the fixture *does* route to completion (so it is not a #250 defect), the file predates both issues, and its exact topology is transcribed in `tests/e2e/MANUAL_E2E.md` §"E2E Test 6", which is outside this lane's file ownership — fixing the graph without the doc would desync them. Flagged for a follow-up that owns both.

5. **`test_examples_lint_clean.py` only sweeps `examples/`.** Observation 4 exists because nothing sweeps `tests/e2e/fixtures/`, `modules/**/fixtures/`, `.github/` or `skills/`. TOPO-009's calibration test now sweeps all 63 for *this rule*; a general all-trees ERROR sweep would have caught #4 years ago and is worth someone's next PR.

6. **Not statically detectable, documented as such:** a node that emits a colliding `preferred_label` with no labelled edge to reveal it. The issue floated keying on `prompt=` text for this; that is guessing at prose, and it was left out deliberately.

Fixes #250, fixes #226
