### PR TITLE
Decide #234: unknown-shape hard-fail and reasoning_effort unset-passthrough ledgered as DIVERGE-DECIDED (ATX-13/ATX-14, EXTENSIONS §38/§39)

### DIFF
--- a/SPEC_CONFORMANCE.md
+++ b/SPEC_CONFORMANCE.md
@@ -57,7 +57,7 @@ Maintainer ruling, 2026-08-14. The four rules that decide every disposition in t
 |------|----------------|---------------|----------|------|
 | unified-llm | ~35 | 13 | 4 (structured output, all providers) | 9 |
 | coding-agent-loop | ~17 | 9 | 2 (bugs CAL-1, CAL-2) | 7 |
-| attractor | ~30 | 10 | 7 (ATX-1, ATX-2, ATX-4, ATX-5, ATX-10, ATX-11, ATX-12) | 3 (ATX-3, ATX-6, ATX-7) |
+| attractor | ~30 | 12 | 9 (ATX-1, ATX-2, ATX-4, ATX-5, ATX-10, ATX-11, ATX-12, ATX-13, ATX-14) | 3 (ATX-3, ATX-6, ATX-7) |
 
 The engine layer (attractor) is the strongest — substantially a **superset** of the spec. The
 material weaknesses are concentrated in the LLM client's per-provider metadata and a small set
@@ -124,6 +124,8 @@ keys. Do not mark "live" until exercised against real providers (e.g. in a DTU w
 | ATX-10 | Multi-match fan-out: non-component nodes with ≥2 simultaneously-matching conditional edges routed to ALL targets in parallel (unledgered dialect; never in spec §3.3) | `§3.3 :421-458` (`best_by_weight_then_lexical`) | `engine.py` (retired `select_all_matching_edges` gate; now routes through `select_edge()` only) | **DONE** | ALIGN — conformance restored (T0-4) |
 | ATX-11 | Main-loop no-matching-edge hard-fail: a dead end with no matching outgoing edge always terminates the pipeline with `status=FAIL` + `PIPELINE_ERROR error_type=no_matching_edge`, regardless of the last outcome's status | `§3.2 step 6 :388-393` (dead end + non-FAIL outcome ⇒ `Outcome(status=SUCCESS)`) | `engine.py:853-867` (`terminate_pipeline()` + `PIPELINE_ERROR` emission); shipped since the engine's initial commit | **DONE — DECIDED** | DIVERGE (decided; ledgered — `specs/EXTENSIONS.md` §33) |
 | ATX-12 | `loop_restart` is an **in-process reset**, not a terminate-and-relaunch: `$iteration`/`$loop_count` increment, completed nodes are cleared, the run directory is retained (gaining `iteration_N/`), and `context_updates` **survive** | `§2.7 :177` ("terminates the current run and re-launches with a fresh log directory"); `§3.2 step 7 :395-398` (`restart_run(...)` then `RETURN`) | `engine.py` `run()` loop-restart branch; design decision recorded at `docs/plans/2026-02-24-engine-enhancements-design.md:95-102` | **DONE — DECIDED** | DIVERGE (decided; ledgered — `specs/EXTENSIONS.md` §24) |
+| ATX-13 | Unknown node shape hard-fails at dispatch instead of falling back to the default handler: `HandlerRegistry.get()` raises `ValueError` naming the shape, the node, the supported set, and the remedy | `§4.2 :603-607` (resolution order ends "3. Default handler (the codergen/LLM handler)"); `:628-629` (`RETURN default_handler`) | `handlers/__init__.py:116-121`; behavior contract `tests/test_no_silent_fallback.py`; both halves asserted by matrix row `ATX-M-F01` (`specs/conformance/attractor-matrix.yaml`) | **DONE — DECIDED** | DIVERGE (decided; ledgered — `specs/EXTENSIONS.md` §38; closes issue #234 F1) |
+| ATX-14 | `reasoning_effort` unset-passthrough: no engine-injected default anywhere, so Appendix A's `"high"` does not hold — an omitted attribute reaches the provider as no reasoning parameter at all, and node attr / `model_stylesheet` / profile are the only value sources | `§2.6 :162` and Appendix A `:2020` (default `"high"`) | `graph.py:251` (`Node.reasoning_effort = None`), `backend.py:244` + `__init__.py:114` (None passthrough; spawn path omits the key), `transforms.py`/`stylesheet.py` (explicit resolution surface); asserted by matrix row `ATX-M-F04`; authoring-guide claim pinned by `tests/test_doc_consistency.py` D-243 | **DONE — DECIDED** | DIVERGE (decided; ledgered — `specs/EXTENSIONS.md` §39; closes issue #234 F4) |
 
 **Shipped extensions (IMPROVE — fold into `specs/EXTENSIONS.md`):** fail-fast edge routing with
 `runs_on`/`continue_on_fail`; skip-propagation contracts (`requires=`/`outputs=`/`failed_outputs`,
@@ -208,6 +210,36 @@ are the current state; these are the reasoning behind it.
 ---
 
 ## Changelog
+
+### 2026-08-16 — issue #234 decided: ATX-13 + ATX-14 ledgered as divergences (F1/F4 from the matrix build)
+
+- **ATX-13 NEW — DECIDED — DIVERGE** — unknown node shape hard-fails at dispatch
+  (`handlers/__init__.py:116-121`) where canonical §4.2's resolve() falls through to the default
+  codergen handler. First ruling made under the decision matrix (`docs/QUALITY_PROTOCOL.md` §3):
+  drift tier, full toll paid — named safety property (no silent execution-class substitution),
+  measured evidence (PR #19 / `aa44fca`: the spec-literal fallback silently ran `shape=diamond`
+  conditional nodes as full LLM sessions when the shape was missing from the table; plus the
+  in-process demonstration that lint emits 0 ERRORs for a typo'd shape, so dispatch is the only
+  tripwire — spec-literal resolution would run a typo'd tool/human node as an LLM session that
+  reports SUCCESS), loud behavior (the raise names shape, node, valid set, remedy), and
+  `specs/EXTENSIONS.md` §38 + matrix row `ATX-M-F01` flipped OPEN-PINNED → DIVERGE-DECIDED in
+  the same PR. No behavior change — the entry records the decision.
+- **ATX-14 NEW — DECIDED — DIVERGE** — `reasoning_effort` has no engine-injected default;
+  canonical §2.6 `:162` and Appendix A `:2020` say `"high"`. Drift tier, full toll paid — named
+  safety property (no hidden engine default on a provider-mode-switching surface: a baked-in
+  `high` would flip every Anthropic node into extended thinking with `temperature` force-set to
+  1.0 and a 16000-token budget, send `reasoning` params to non-reasoning OpenAI models — live
+  400s for graphs that run clean today — and defeat ULM-7's live-proven "only when explicitly
+  set" wiring from above), honest absence rather than substitution (unset-in is unset-out: the
+  spawn path omits the key; the direct path sends no reasoning field; `Response.raw` shows the
+  request), and `specs/EXTENSIONS.md` §39 + matrix row `ATX-M-F04` flipped OPEN-PINNED →
+  DIVERGE-DECIDED in the same PR. `docs/DOT-AUTHORING-GUIDE.md`'s node-attribute table — which
+  repeated the spec's `high` as if it held here — corrected and pinned two-sided by
+  `tests/test_doc_consistency.py` D-243. No behavior change — the entry records the decision.
+- Both were OPEN-PINNED by the matrix (tranche 1) explicitly so this decision would be
+  deliberate: the rows pinned today's behavior, refused to launder it into DIVERGE-DECIDED, and
+  cited issue #234 as the pending decision. This PR is that decision landing; the issue closes
+  with it.
 
 ### 2026-08-15 — ATX-4 / ATX-5 status cells reconciled with the conformance matrix (PR #235)
 

--- a/docs/DOT-AUTHORING-GUIDE.md
+++ b/docs/DOT-AUTHORING-GUIDE.md
@@ -882,7 +882,7 @@ Every node in a DOT pipeline can have these attributes:
 | `class` | String | `""` | Comma-separated CSS classes for model stylesheet targeting. |
 | `llm_model` | String | inherited | LLM model identifier. Overrides stylesheet. |
 | `llm_provider` | String | auto | Provider key (`anthropic`, `openai`, `gemini`). |
-| `reasoning_effort` | String | `high` | `low`, `medium`, or `high`. |
+| `reasoning_effort` | String | unset (provider default) | `low`, `medium`, or `high`. No engine default is injected: unset means the provider's own default applies. The canonical spec's `high` default deliberately does not hold here — set it per node, via `model_stylesheet`, or in a profile (`specs/EXTENSIONS.md` §39, ledger ATX-14). |
 | `timeout` | Duration | unset | Max execution time (e.g., `900s`, `15m`). |
 | `auto_status` | Boolean | `false` | Auto-generate SUCCESS if handler writes no status. |
 | `allow_partial` | Boolean | `false` | Accept PARTIAL_SUCCESS when retries exhausted. |

--- a/modules/loop-pipeline/tests/test_doc_consistency.py
+++ b/modules/loop-pipeline/tests/test_doc_consistency.py
@@ -1,4 +1,4 @@
-"""Tests for doc/spec internal consistency — D-135, D-137, D-240..D-242.
+"""Tests for doc/spec internal consistency — D-135, D-137, D-240..D-243.
 
 These are regression guards against documentation contradictions.
 
@@ -430,4 +430,95 @@ def test_selfcheck_summary_recount_rejects_the_drifted_row():
     assert _ids_in(cells[3]) != real_resolved_ids, (
         "The drifted summary row would now pass the D-242 check, which means the "
         "check cannot detect the drift it was written for."
+    )
+
+
+# ---------------------------------------------------------------------------
+# D-243: DOT-AUTHORING-GUIDE's reasoning_effort default vs the shipped engine
+# (SPEC_CONFORMANCE.md ATX-14 / specs/EXTENSIONS.md section 39, issue #234 F4)
+# ---------------------------------------------------------------------------
+
+_AUTHORING_GUIDE_REL = "docs/DOT-AUTHORING-GUIDE.md"
+
+
+def _authoring_guide_reasoning_effort_default_cell() -> str:
+    """Extract the Default cell of the guide's `reasoning_effort` table row."""
+    guide = _read(_AUTHORING_GUIDE_REL)
+    m = re.search(
+        r"^\| `reasoning_effort` \| String \| (?P<default>[^|]+) \|",
+        guide,
+        flags=re.MULTILINE,
+    )
+    assert m, (
+        f"{_AUTHORING_GUIDE_REL}: could not find the node-attribute table row for "
+        "`reasoning_effort`. If the row was reworded, re-anchor this guard (D-243) "
+        "in the same PR -- the claim it pins is the attribute's DEFAULT, which the "
+        "canonical spec gives as \"high\" and this engine deliberately does not "
+        "implement (ledger ATX-14, specs/EXTENSIONS.md section 39)."
+    )
+    return m.group("default").strip()
+
+
+def test_authoring_guide_reasoning_effort_default_matches_engine():
+    """The guide's reasoning_effort Default cell must describe the code (D-243).
+
+    Source of truth: ``graph.Node`` -- ``reasoning_effort`` is ``None`` unless
+    the author (node attr), a ``model_stylesheet`` rule, or a profile sets it.
+    The guide shipped Appendix A's ``high`` in that cell as though it held on
+    this engine; it does not, and the divergence is decided and ledgered
+    (SPEC_CONFORMANCE.md ATX-14, specs/EXTENSIONS.md section 39, issue #234 F4).
+
+    Two-sided, D-240 style: asserting the CODE first means introducing an
+    engine default fails here naming the ledger entries that must move with
+    it; asserting the DOC second means restoring the spec's ``high`` to the
+    guide fails here naming the engine truth it would contradict.
+    """
+    from amplifier_module_loop_pipeline.context import PipelineContext
+    from amplifier_module_loop_pipeline.dot_parser import parse_dot
+    from amplifier_module_loop_pipeline.graph import Node
+    from amplifier_module_loop_pipeline.transforms import apply_transforms
+
+    # Code side: no engine-injected default at any resolution layer.
+    assert Node(id="n").reasoning_effort is None, (
+        "Node.reasoning_effort now has a dataclass default of "
+        f"{Node(id='n').reasoning_effort!r}. That is the divergence "
+        "SPEC_CONFORMANCE.md ATX-14 / specs/EXTENSIONS.md section 39 decided "
+        "AGAINST re-introducing (issue #234 F4). If this is a deliberate "
+        "re-decision, move both ledger entries, matrix row ATX-M-F04, and "
+        "docs/DOT-AUTHORING-GUIDE.md's reasoning_effort row in the same PR."
+    )
+    graph = parse_dot(
+        """
+        digraph D243 {
+            start [shape=Mdiamond]
+            exit  [shape=Msquare]
+            work  [prompt="do work"]
+            start -> work -> exit
+        }
+        """
+    )
+    transformed = apply_transforms(graph, PipelineContext())
+    assert transformed.nodes["work"].reasoning_effort is None, (
+        "apply_transforms() resolved reasoning_effort to "
+        f"{transformed.nodes['work'].reasoning_effort!r} for a node that "
+        "omitted it, with no stylesheet rule. The transform pipeline is the "
+        "resolution point EXTENSIONS section 39 says injects NOTHING; see the "
+        "code-side message above for the same-PR checklist."
+    )
+
+    # Doc side: the guide must not re-adopt the spec's "high" as this engine's
+    # default, and must say what actually happens (unset -> provider default).
+    default_cell = _authoring_guide_reasoning_effort_default_cell()
+    assert default_cell != "`high`", (
+        f"{_AUTHORING_GUIDE_REL}: the reasoning_effort Default cell says `high` "
+        "again, but the engine injects no default (Node.reasoning_effort is "
+        "None -- asserted above). That cell taught the canonical spec's "
+        "Appendix A default as though it held here for as long as it shipped; "
+        "the divergence is decided and ledgered (ATX-14, EXTENSIONS section 39)."
+    )
+    assert "unset" in default_cell.lower() and "provider" in default_cell.lower(), (
+        f"{_AUTHORING_GUIDE_REL}: the reasoning_effort Default cell "
+        f"({default_cell!r}) no longer says what an omitted attribute does "
+        "(unset -> the provider's own default). Keep the real behavior in the "
+        "cell or re-anchor this guard (D-243) with the reworded claim."
     )

--- a/modules/loop-pipeline/tests/test_spec_conformance_matrix.py
+++ b/modules/loop-pipeline/tests/test_spec_conformance_matrix.py
@@ -1227,14 +1227,36 @@ def test_row_atx_m_007o():
 
 
 def test_row_atx_m_f01():
-    """F1 (issue #234): an unknown shape hard-errors; it does NOT fall through."""
+    """ATX-13 / EXTENSIONS 38 (decided via issue #234, F1): an unknown shape
+    hard-errors at dispatch; the section 4.2 default-handler fall-through does
+    NOT occur.  Both halves asserted, per the DIVERGE-DECIDED contract."""
     r = row("ATX-M-F01")
     registry = HandlerRegistry(HandlerContext())
 
-    with pytest.raises(ValueError) as exc_info:
-        registry.get(Node(id="broken_gate", shape="trapezium"))
-    message = str(exc_info.value)
+    # Half 1: the spec's behavior does not occur.  Section 4.2's resolve()
+    # would fall through to the default codergen handler; if get() RETURNS
+    # anything for an unknown shape, the engine has silently un-diverged.
+    fell_through: object | None = None
+    message = ""
+    try:
+        fell_through = registry.get(Node(id="broken_gate", shape="trapezium"))
+    except ValueError as exc:
+        message = str(exc)
+    assert fell_through is None, flip(
+        r,
+        observed=(
+            f"an unknown shape fell through to {type(fell_through).__name__} "
+            "instead of raising -- the section 4.2 default-handler fallback is back"
+        ),
+        expected=(
+            "the ledgered refusal: ValueError at dispatch (ATX-13, EXTENSIONS 38). "
+            "A typo'd semantic shape must never silently become an LLM session"
+        ),
+        direction="UN-DIVERGENCE",
+    )
 
+    # Half 2: our ledgered behavior occurs, and is LOUD in the doctrine-rule-4
+    # sense -- names the shape, lists the valid set (remediation, not just refusal).
     assert "trapezium" in message, flip(
         r,
         observed=f"the error does not name the offending shape: {message!r}",
@@ -1256,7 +1278,13 @@ def test_row_atx_m_f01():
 
 
 def test_row_atx_m_f04():
-    """F4 (issue #234): `reasoning_effort` has no built-in default."""
+    """ATX-14 / EXTENSIONS 39 (decided via issue #234, F4): `reasoning_effort`
+    has no engine-injected default -- Appendix A's "high" deliberately does not
+    hold.  Unset stays unset through parse AND transforms (the stylesheet
+    resolution point), so the provider's own default governs.  Any value
+    appearing where the author wrote nothing is a hidden default -- the exact
+    substitution EXTENSIONS 39 rules out -- whether it is the spec's "high" or
+    anything else."""
     r = row("ATX-M-F04")
     graph = parse_dot(
         """
@@ -1273,19 +1301,41 @@ def test_row_atx_m_f04():
         r,
         observed=(
             f"a node omitting reasoning_effort now resolves to "
-            f"{node.reasoning_effort!r}"
+            f"{node.reasoning_effort!r} at parse time"
         ),
         expected=(
-            "today's pinned behavior: the attribute is UNSET, so the provider's own "
-            "default applies -- Appendix A's `\"high\"` does not hold here"
+            "the ledgered behavior (ATX-14, EXTENSIONS 39): the attribute stays "
+            "UNSET so the provider's own default applies -- the engine injects "
+            "no value the author did not write"
         ),
-        direction="UNDECIDED-MOVEMENT",
+        direction="UN-DIVERGENCE",
     )
     assert node.attrs.get("reasoning_effort") is None, flip(
         r,
         observed="node.attrs surfaced a default reasoning_effort",
         expected="the attrs proxy agrees with the first-class field: unset is unset",
-        direction="UNDECIDED-MOVEMENT",
+        direction="UN-DIVERGENCE",
+    )
+
+    # Through the transform pipeline too: apply_transforms() is where the
+    # stylesheet -- the spec's own centralizing surface for this attribute
+    # (section 8) -- resolves values onto nodes.  With no stylesheet rule, the
+    # engine must leave the attribute alone; this is the resolution point a
+    # conforming implementation would have to inject "high" at.
+    from amplifier_module_loop_pipeline.transforms import apply_transforms
+
+    transformed = apply_transforms(graph, PipelineContext())
+    assert transformed.nodes["work"].reasoning_effort is None, flip(
+        r,
+        observed=(
+            "apply_transforms() resolved reasoning_effort to "
+            f"{transformed.nodes['work'].reasoning_effort!r} with no stylesheet rule"
+        ),
+        expected=(
+            "the transform pipeline injects nothing: node attr, model_stylesheet, "
+            "and profile are the ONLY value sources (EXTENSIONS 39)"
+        ),
+        direction="UN-DIVERGENCE",
     )
 
 

--- a/specs/EXTENSIONS.md
+++ b/specs/EXTENSIONS.md
@@ -2213,3 +2213,174 @@ Design record and probe evidence:
 [`docs/designs/2026-08-15-composition-fix.md`](../docs/designs/2026-08-15-composition-fix.md),
 including §8's "two resolution classes" finding — the empirical reason the self-pin sweep is
 split rather than blanket.
+
+---
+
+## 38. Unknown Node Shape Hard-Fails at Dispatch (No Default-Handler Fallback)
+
+> **This extension DIVERGES from canonical spec §4.2.** Canonical spec §4.2 "Handler
+> Registry" (`attractor-spec-canonical.md:603-607`, `:628-629`) resolves a node in three
+> steps — explicit `type`, shape-based resolution (§2.8), then "3. **Default handler** (the
+> codergen/LLM handler)" — so a shape outside §2.8's finite table falls through and runs as a
+> full LLM session. Our engine instead refuses at dispatch: `HandlerRegistry.get()` raises
+> `ValueError` naming the offending shape, the node id, the complete supported-shape list, and
+> the remedy (`shape=box` for an LLM node). See `SPEC_CONFORMANCE.md` ATX-13 for the ledger
+> entry and conformance-matrix row `ATX-M-F01` for the executable assertion.
+>
+> **depends-on:** none
+>
+> **upstream action:** declining, reason: `strongdm/attractor` has had no commits since
+> 2026-03-17, has issues disabled, and its own open community spec-correction PRs (#9, #10)
+> have sat unmerged for 4+ months — filing there would not land. The divergence is tracked
+> here instead.
+
+### The decision
+
+**Keep the raise. A shape selects an execution class; an unrecognized shape must not silently
+select the most powerful one.** (Maintainer's standing doctrine applied — Compatibility
+doctrine rule 4; decision closes issue #234, F1.)
+
+The named safety property: **no silent execution-class substitution.** A node's shape decides
+*who* executes it — a human gate (`hexagon`), a shell command (`parallelogram`), an LLM session
+(`box`), a no-op terminal (`Mdiamond`/`Msquare`). Under the spec-literal fallback, any
+unrecognized shape — in practice a typo'd semantic shape — silently re-classes the node as a
+full LLM session that then reports SUCCESS. The failure is invisible by construction: the run
+goes green while the wrong class of thing executed.
+
+The measured evidence that the spec-literal behavior actually failed:
+
+- **The recorded incident (PR #19, commit `aa44fca`).** `shape=diamond` — a *canonical* §2.8
+  shape — was missing from the engine's table, and the then-spec-literal
+  `SHAPE_TO_HANDLER.get(shape, "codergen")` ran conditional routing points as full codergen
+  LLM sessions, silently, until the optimize_bundle investigation caught it. The fallback did
+  not merely tolerate a typo; it masked a missing canonical handler for the engine's own
+  dispatch table. That commit removed the fallback deliberately ("any unrecognized shape
+  (typo, spec mismatch, future shape) would silently run as a full LLM agent").
+- **Measured on current main (in-process, no LLM).** Lint emits **zero ERROR diagnostics**
+  for a typo'd shape (`deploy [shape=parallelgram, tool_command="./deploy.sh"]` → 0 ERRORs),
+  so dispatch is the only tripwire that can catch it. Under spec-literal resolution, the probe
+  typos `parallelgram`, `hexagonn`, `Mdaimond`, and `trapezium` all land on codergen: a typo'd
+  human-approval gate becomes an unattended LLM node; a typo'd tool node runs an LLM session
+  instead of `./deploy.sh`, with `tool_command` silently ignored and the prompt falling back
+  to the node label. The lint layer's own message for that node — "LLM node 'deploy' has no
+  prompt" — is the reclassification happening live (`validation.py` still classifies with the
+  spec-literal fallback for diagnostic purposes; dispatch does not).
+
+The divergence is loud in exactly the doctrine's sense: the refusal names the shape, the node,
+the full valid set, and the fix. The spec-literal behavior is the quiet resolution toward
+"success" that doctrine rule 4 exists to prevent — same decision shape as §33 (no-matching-edge
+hard-fail) and §36 (no-fallback profile resolution), and the same biography as ATX-11: correct,
+load-bearing, and (until now) undocumented.
+
+**What conforming would cost, stated honestly.** The fallback is not purposeless: it makes
+unmapped decorative shapes (e.g. `shape=ellipse` for a cosmetic LLM node) runnable. A
+canonical-conformant graph doing that is refused here. The cost is bounded: the refusal is
+loud with a one-line fix, and an explicit `type=` attribute still works with *any* shape —
+every decorative rendering remains achievable conformantly (`type=codergen` +
+whatever shape the author likes). Weighed against green runs executing the wrong class of
+node, the bounded loud refusal wins.
+
+**No behavior change in this entry.** The engine has behaved this way since PR #19; this entry
+and ATX-13 record the decision that was made, not a code change.
+
+**Implementation locations:**
+- `modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/__init__.py` —
+  `HandlerRegistry.get()`: the unknown-shape `ValueError` (names shape, node id, supported
+  set, remedy) and the unregistered-handler-type `ValueError` (engine misconfiguration)
+- `modules/loop-pipeline/tests/test_no_silent_fallback.py` — the behavior contract (raise,
+  message contents, and the regression guard that every §2.8 shape still dispatches)
+- `specs/conformance/attractor-matrix.yaml` row `ATX-M-F01` + its probe in
+  `modules/loop-pipeline/tests/test_spec_conformance_matrix.py` — asserts both halves: the
+  refusal occurs AND the spec's fall-through does not, so silently un-diverging fails CI
+  naming this entry
+
+---
+
+## 39. `reasoning_effort` Has No Engine-Injected Default (Appendix A's `"high"` Does Not Hold)
+
+> **This extension DIVERGES from canonical spec §2.6 and Appendix A.** Canonical spec §2.6
+> (`attractor-spec-canonical.md:162`) and Appendix A (`:2020`) both give `reasoning_effort` a
+> default of `"high"`. Our engine injects no default at any layer: a node that omits the
+> attribute (and matches no `model_stylesheet` rule and no profile setting) reaches the
+> provider with **no reasoning parameter at all**, so the provider's own documented default
+> governs. See `SPEC_CONFORMANCE.md` ATX-14 for the ledger entry and conformance-matrix row
+> `ATX-M-F04` for the executable assertion.
+>
+> **depends-on:** none
+>
+> **upstream action:** declining, reason: `strongdm/attractor` has had no commits since
+> 2026-03-17, has issues disabled, and its own open community spec-correction PRs (#9, #10)
+> have sat unmerged for 4+ months — filing there would not land. The divergence is tracked
+> here instead.
+
+### The decision
+
+**Keep unset-as-unset. The engine never injects a cost- and behavior-bearing LLM parameter the
+author did not write; explicit resolution surfaces (node attr → `model_stylesheet` → profile)
+are the only sources of a value.** (Decision closes issue #234, F4.)
+
+The named safety property: **no hidden engine default on a provider-mode-switching surface.**
+On this engine's shipped provider wiring, `reasoning_effort` is not a mild tuning dial — any
+set value switches request *modes*. An engine-injected `"high"` on every node that omitted the
+attribute would mean, measured from the shipped adapters:
+
+- **Anthropic** (`unified_llm/adapters/anthropic.py:449-467`): flips every request into
+  extended-thinking mode — `thinking={enabled, budget_tokens=16000}` — and **force-overrides
+  `temperature` to 1.0** ("Override any caller-specified value; the constraint is absolute"),
+  silently rewriting the sampling behavior of every Anthropic node in every community graph.
+  Where `max_tokens` is small the budget is silently clamped or thinking silently skipped
+  (`max_tokens <= 1024`) — a defaulted "high" that sometimes means "nothing" is a second
+  silent substitution on top of the first.
+- **OpenAI** (`unified_llm/adapters/openai.py:446-447`): forwards `reasoning={"effort": ...}`
+  whenever set — the adapter comments "for o-series models" but nothing gates it by model, so
+  a baked-in default sends reasoning parameters to non-reasoning models on every node: live
+  400s for graphs that run clean today (the same unconditional-request-shape failure class
+  ULM-16 hit live).
+- **Gemini** (`unified_llm/adapters/gemini.py:344-351`): `ThinkingConfig(thinking_budget=16000)`
+  on every call.
+- **Cost**: a 16000-token thinking budget per node call as the *engine's* default, imposed on
+  every existing graph that never asked for it. `ULM-7` shipped effort→budget wiring
+  live-proven and deliberately **"only when explicitly set"** at the client layer; a
+  loop-pipeline default of `"high"` would defeat that decision wholesale from above.
+
+Why the absence is honest rather than a hidden default: a hidden default would be the engine
+*writing a value the author cannot see* into the request. This is the opposite — the engine
+writes **nothing**. The direct-LLM path sends no reasoning field
+(`backend.py`/`__init__.py`: `node.attrs.get("reasoning_effort")` → `None` → adapters send
+nothing), the spawn path *omits the key entirely* ("Omitting a key lets the child orchestrator
+use its own default", `backend.py` orchestrator_config), and the request actually sent is
+inspectable in `Response.raw` (ULM-5). Nothing resolves toward success: no outcome, status,
+routing, or gate decision is affected — the author's request reaches the provider exactly as
+authored. The spec's own design agrees about where this control belongs: §8's
+`model_stylesheet` exists to "centralize model selection so that individual nodes do not need
+to specify `llm_model`, `llm_provider`, and `reasoning_effort` on every node"
+(`:1449`, `:1561`) — and that surface works here (`* { reasoning_effort: low }` resolves onto
+nodes; verified in-process). What does not exist is an unconditional engine constant
+underneath it.
+
+**What conforming would cost, stated honestly.** A community author who read Appendix A and
+*relied* on omitted-means-high gets shallower provider-default reasoning here — a real, silent
+under-delivery relative to the spec's promise. The cure for that author is one stylesheet line
+(`* { reasoning_effort: high }`), which this engine honors on every node. The reverse cure —
+un-breaking every graph that a baked-in "high" would have flipped into extended-thinking /
+temp-1.0 / reasoning-param-400 territory — does not exist. Asymmetric costs; the divergence
+takes the recoverable one.
+
+**No behavior change in this entry.** The engine has behaved this way since the attribute was
+wired; this entry and ATX-14 record the decision, not a code change.
+
+**Implementation locations:**
+- `modules/loop-pipeline/amplifier_module_loop_pipeline/graph.py` — `Node.reasoning_effort:
+  str | None = None` (promoted attr; no parser default)
+- `modules/loop-pipeline/amplifier_module_loop_pipeline/backend.py` +
+  `__init__.py` — `node.attrs.get("reasoning_effort")` passed through as-is on the direct-LLM
+  path; spawn path's orchestrator_config drops `None` keys entirely
+- `modules/loop-pipeline/amplifier_module_loop_pipeline/stylesheet.py` /
+  `transforms.py` — the explicit resolution surface (`model_stylesheet`), which sets the value
+  only when a rule matches
+- `docs/DOT-AUTHORING-GUIDE.md` node-attribute table — documents the real default (none;
+  provider decides) instead of repeating the spec's `high`; pinned two-sided by
+  `modules/loop-pipeline/tests/test_doc_consistency.py` (D-243)
+- `specs/conformance/attractor-matrix.yaml` row `ATX-M-F04` + its probe in
+  `modules/loop-pipeline/tests/test_spec_conformance_matrix.py` — asserts unset stays unset
+  through parse *and* transforms, so a silently-introduced default fails CI naming this entry

--- a/specs/conformance/attractor-matrix.yaml
+++ b/specs/conformance/attractor-matrix.yaml
@@ -68,8 +68,9 @@
 # --------------------------------------------------------------- tranche ----
 #
 # Tranche 1 (this file): every decided divergence, every OPEN ledger item
-# pinned, the two unledgered findings this matrix's construction surfaced
-# (F1 / F4, issue #234), the load-bearing conformances a community `.dot`
+# pinned, the two findings this matrix's construction surfaced (F1 / F4 --
+# born OPEN-PINNED citing issue #234, decided 2026-08-16 as ATX-13/ATX-14),
+# the load-bearing conformances a community `.dot`
 # stakes its correctness on, and the SYNC row. Tranche 2+ (the remaining
 # rows by section) and tranche 3 (ULM/CAL matrices) are named in the
 # design, section 6 and section 12.
@@ -438,11 +439,15 @@ rows:
           - modules/pipeline-runner/amplifier_module_pipeline_runner
 
   # ==========================================================================
-  # D. Findings surfaced by building this matrix -- unledgered today
+  # D. Findings surfaced by building this matrix -- DECIDED (issue #234)
   #
-  # NOT decided divergences. These are behaviors that contradict the canonical
-  # spec with no ledger entry licensing them. Filed as issue #234. The rows pin
-  # actual behavior so that the decision, when it comes, is deliberate.
+  # These two rows were born OPEN-PINNED: behaviors that contradicted the
+  # canonical spec with no ledger entry licensing them, pinned to actual
+  # behavior so the decision would be deliberate rather than accidental.
+  # The decision landed (issue #234, 2026-08-16): both are decided
+  # divergences under the QUALITY_PROTOCOL.md section 3 drift tier, ledgered
+  # as SPEC_CONFORMANCE.md ATX-13/ATX-14 + EXTENSIONS.md sections 38/39.
+  # IDs stay stable per the schema note above; only dispositions moved.
   # ==========================================================================
 
   - id: ATX-M-F01
@@ -458,26 +463,29 @@ rows:
         - section: "4.2"
           quote: |
             3. **Default handler** (the codergen/LLM handler)
-    disposition: OPEN-PINNED
+    disposition: DIVERGE-DECIDED
     ledger:
-      issue: 234
-    justification: >
-      F1. Canonical section 4.2's resolve() pseudocode falls through to the
-      DEFAULT HANDLER when a shape is unrecognized; HandlerRegistry.get() instead
-      raises ValueError naming the bad shape and listing the supported ones. That
-      is the right behavior under doctrine rule 4 (a typo'd shape silently
-      becoming a full LLM session is a real footgun, argued from section 2.8's
-      finite table in test_no_silent_fallback.py's docstring) -- but it is
-      ATX-11's exact biography: correct, load-bearing, and undocumented. No ATX
-      row and no EXTENSIONS entry licenses it today. Pinned here; decision filed
-      as issue #234, whose two resolution shapes are ledger-it-as-DIVERGE or
-      conform to section 4.2.
+      conformance: ATX-13
+      extensions: 38
     assertion:
       kind: probe
       probe: test_row_atx_m_f01
       indexed:
         - modules/loop-pipeline/tests/test_no_silent_fallback.py::test_unknown_shape_raises_value_error
         - modules/loop-pipeline/tests/test_no_silent_fallback.py::test_known_shapes_still_dispatch_correctly
+    notes: >
+      DECIDED 2026-08-16 (issue #234, F1): keep the raise. Named safety
+      property: no silent execution-class substitution -- a shape decides WHO
+      executes a node (human gate / shell tool / LLM), and the spec-literal
+      fall-through re-classes any unrecognized shape as a full LLM session
+      that reports SUCCESS. Measured evidence: PR #19 (aa44fca) -- the
+      spec-literal fallback silently ran shape=diamond conditional nodes as
+      codergen LLM sessions while the shape was missing from the table; and
+      lint emits ZERO ERRORs for a typo'd shape, so dispatch is the only
+      tripwire. The refusal is loud: names the shape, the node, the supported
+      set, and the remedy. Explicit type= still works with any shape, so
+      decorative shapes remain achievable conformantly. Probe asserts both
+      halves: the refusal occurs AND the fall-through does not.
 
   - id: ATX-M-F04
     title: reasoning_effort has no built-in default -- Appendix A's high does not hold
@@ -491,22 +499,28 @@ rows:
         - section: "Appendix A"
           quote: |
             | `reasoning_effort`      | String   | `"high"`      | Reasoning depth: low/medium/high |
-    disposition: OPEN-PINNED
+    disposition: DIVERGE-DECIDED
     ledger:
-      issue: 234
-    justification: >
-      F4, verified empirically rather than assumed. Both the section 2.6
-      attribute table and Appendix A give `reasoning_effort` a default of
-      `"high"`. Parsing a node that omits the attribute yields
-      `Node.reasoning_effort is None`, and None is what reaches the backend -- so
-      the provider's own default applies, not "high". A community graph written
-      to the canonical spec therefore gets a different reasoning depth here than
-      the spec promises. Unledgered; filed together with F1 as issue #234 (same
-      class, same two resolution shapes, one maintainer sitting). Pinned to
-      actual behavior in the meantime.
+      conformance: ATX-14
+      extensions: 39
     assertion:
       kind: probe
       probe: test_row_atx_m_f04
+    notes: >
+      DECIDED 2026-08-16 (issue #234, F4): keep unset-as-unset -- the engine
+      injects no default at any layer; node attr, model_stylesheet, and
+      profile are the only value sources, and an omitted attribute reaches
+      the provider as NO reasoning parameter (spawn path omits the key
+      entirely). Named safety property: no hidden engine default on a
+      provider-mode-switching surface. Measured from the shipped adapters, a
+      baked-in "high" would flip every Anthropic node into extended thinking
+      (16000-token budget) with temperature FORCE-SET to 1.0, send reasoning
+      params to non-reasoning OpenAI models (live 400s for graphs that run
+      clean today), and defeat ULM-7's live-proven only-when-explicitly-set
+      wiring from above. The absence is honest, not hidden: unset-in is
+      unset-out, inspectable in Response.raw. Paired doc guard:
+      test_doc_consistency.py D-243 pins DOT-AUTHORING-GUIDE.md's
+      node-attribute row to the code truth, two-sided.
 
   # ==========================================================================
   # E. Load-bearing conformances


### PR DESCRIPTION
## Summary

First real exercise of the decision matrix (`docs/QUALITY_PROTOCOL.md` §3): issue #234's two unledgered contradictions between the shipped engine and the canonical spec, surfaced by conformance-matrix tranche 1, are **decided**. Both findings were re-verified empirically on current main before ruling (in-process, deterministic, no LLM). Both resolve as **DIVERGE-DECIDED** — the drift tier — with the full toll paid in this PR: named safety property, measured evidence that the spec-literal behavior actually failed, loud behavior, a `SPEC_CONFORMANCE.md` row + `specs/EXTENSIONS.md` entry, and the matrix rows flipped `OPEN-PINNED → DIVERGE-DECIDED` in the same commit. **No engine behavior changes.** The deliverable is the ledger no longer lying by omission.

Fixes #234

---

## F1 — unknown node shape hard-fails at dispatch (canonical §4.2 falls through to the default handler)

**Spec says** (`specs/canonical/attractor-spec-canonical.md:603-607`):

> The handler registry maps type strings to handler instances. Resolution follows this order:
> 1. **Explicit `type` attribute** on the node (e.g., `type="wait.human"`)
> 2. **Shape-based resolution** using the shape-to-handler-type mapping table (Section 2.8)
> 3. **Default handler** (the codergen/LLM handler)

and the `resolve()` pseudocode (`:628-629`): `-- 3. Default` / `RETURN default_handler`.

**Engine does** (re-verified on `9df6c24`, in-process):

```
>>> HandlerRegistry(HandlerContext()).get(Node(id="odd", shape="trapezium"))
ValueError: Unknown node shape 'trapezium' for node 'odd'. Supported shapes:
['Mdiamond', 'Msquare', 'box', 'component', 'diamond', 'folder', 'hexagon',
'house', 'parallelogram', 'tripleoctagon']. To use an LLM-driven node, use
shape=box (codergen handler).
```

**Ruling: DIVERGE-DECIDED (keep the raise).** §3 tier: **Drift** — really hard, and it earns the price:

- **Named safety property:** no silent execution-class substitution. A shape decides *who* executes a node (human gate / shell tool / LLM / no-op terminal). The spec-literal fall-through re-classes any unrecognized shape — in practice a typo'd semantic shape — as a full LLM session that then reports SUCCESS. The failure is invisible by construction.
- **The probe the task asked for — does the fallback actually swallow a typo? Yes, measured:** lint emits **zero ERROR diagnostics** for `deploy [shape=parallelgram, tool_command="./deploy.sh"]` (dispatch is the only tripwire), and under spec-literal resolution all four probe typos (`parallelgram`, `hexagonn`, `Mdaimond`, `trapezium`) land on codergen: a typo'd **human-approval gate becomes an unattended LLM node**; a typo'd **tool node runs an LLM instead of `./deploy.sh`**, `tool_command` silently ignored, prompt falling back to the label. Lint's own warning for that node — "LLM node 'deploy' has no prompt" — is the reclassification happening live.
- **Measured incident, not hypothesis:** PR #19 (`aa44fca`) — `shape=diamond`, a *canonical* §2.8 shape, was missing from the engine's table, and the then-spec-literal `.get(shape, "codergen")` silently ran conditional routing points as full LLM sessions until the optimize_bundle investigation caught it. The fallback masked a missing canonical handler. That commit removed it deliberately.
- **The spec-vs-fail-loud tension, and which governs:** neither wins by reflex. The vision's *"fail loud; never fall back silently"* cannot by itself license drift — that would make "we like loud" a trump card over the spec, the exact reflex §3 exists to prevent. It supplies the **safety property**; the decision matrix supplies the **price** (measured evidence + loudness + double ledger + asserted matrix row). The matrix's drift lane exists so a divergence like this can be *bought*, not asserted — and the evidence affords it. Doctrine rule 4 ("a divergence that resolves quietly toward success is the failure mode this doctrine exists to prevent") describes the spec-literal fallback precisely.
- **Cost stated honestly:** the fallback isn't purposeless — it makes unmapped decorative shapes runnable as LLM nodes. Such a graph is refused here. Bounded: the refusal is loud with a one-line fix, and explicit `type=` works with *any* shape, so decorative rendering stays achievable conformantly.

**Toll paid:** `SPEC_CONFORMANCE.md` **ATX-13** (DONE — DECIDED, DIVERGE) + `specs/EXTENSIONS.md` **§38** (DIVERGES banner, `depends-on`, `upstream action: declining` with the dormancy evidence) + matrix row **ATX-M-F01** flipped, now asserting **both halves** (the refusal occurs AND the fall-through does not) with `UN-DIVERGENCE` flip direction. Scan performed: every shape used by shipped examples is in the §2.8 table (`parallelogram/Msquare/Mdiamond/box/hexagon/folder/tripleoctagon/component/house/diamond`) — nothing shipped depends on the fallback.

## F4 — `reasoning_effort` has no engine-injected default (§2.6 and Appendix A say `"high"`)

**Spec says** — twice, identically. §2.6 (`:162`):

> `| reasoning_effort | String | "high" | LLM reasoning effort: low, medium, high. |`

Appendix A (`:2020`):

> `| reasoning_effort | String | "high" | Reasoning depth: low/medium/high |`

**Engine does** (re-verified on `9df6c24`, in-process):

```
after parse_dot:        node.reasoning_effort = None
                        node.attrs.get('reasoning_effort') = None
after apply_transforms: node.reasoning_effort = None
Node() dataclass default: None
stylesheet '* { reasoning_effort: low }' -> 'low'   (the control surface works)
```

**Ruling: DIVERGE-DECIDED (keep unset-as-unset).** §3 tier: **Drift**, toll paid:

- **Named safety property:** no hidden engine default on a provider-**mode-switching** surface. Measured from the shipped adapters, a baked-in `"high"` is not a tuning dial — it flips request modes: **Anthropic** (`unified_llm/adapters/anthropic.py:449-467`) enters extended thinking with a 16000-token budget and **force-overrides `temperature` to 1.0** ("Override any caller-specified value; the constraint is absolute"), silently rewriting sampling for every Anthropic node in every community graph; **OpenAI** (`openai.py:446-447`) forwards `reasoning={"effort": ...}` ungated by model family, so a default sends reasoning params to non-reasoning models — live 400s for graphs that run clean today (ULM-16's failure class); **Gemini** gets a 16000-token `ThinkingConfig` on every call; and ULM-7's live-proven, ledgered **"only when explicitly set"** wiring would be defeated wholesale from above.
- **Why the absence is honest rather than a hidden default** (the question this lane was asked to answer): a hidden default would be the engine *writing a value the author cannot see* into the request. This is the opposite — the engine writes **nothing**: the direct-LLM path sends no reasoning field, the spawn path *omits the key entirely* (`backend.py`: "Omitting a key lets the child orchestrator use its own default"), and the request actually sent is inspectable in `Response.raw` (ULM-5). Nothing resolves toward success — no outcome, status, routing, or gate decision is touched. Loud-in-the-record (the matrix row + ledger now assert it; movement fails CI naming ATX-14/§39), inert-at-runtime.
- **The spec's own architecture agrees about where this control lives:** §8's `model_stylesheet` exists to "centralize model selection so that individual nodes do not need to specify `llm_model`, `llm_provider`, and `reasoning_effort` on every node" (`:1449`, `:1561`) — and that surface works here (probe above). What doesn't exist is an unconditional engine constant underneath it.
- **Cost stated honestly:** a community author who relied on omitted-means-high gets shallower provider-default reasoning — a real, silent under-delivery vs the spec's promise. The cure is one stylesheet line (`* { reasoning_effort: high }`), honored on every node. The reverse cure — un-breaking every graph a baked-in high would flip into extended-thinking / temp-1.0 / reasoning-param-400 territory — does not exist. Asymmetric costs; the divergence takes the recoverable one.

**Toll paid:** `SPEC_CONFORMANCE.md` **ATX-14** + `specs/EXTENSIONS.md` **§39** + matrix row **ATX-M-F04** flipped, now asserting unset survives parse **and** `apply_transforms()` (the resolution point a conforming implementation would inject at). Plus: `docs/DOT-AUTHORING-GUIDE.md`'s node-attribute table **repeated the spec's `high` as if it held on this engine** — corrected, and pinned two-sided by new doc guard **D-243** (`test_doc_consistency.py`), per the §2 "docs making factual claims" rule.

---

## Matrix rows before → after

| Row | Before | After |
|---|---|---|
| `ATX-M-F01` | `disposition: OPEN-PINNED`, `ledger.issue: 234`, justification "no ATX row and no EXTENSIONS entry licenses it today" | `disposition: DIVERGE-DECIDED`, `ledger: {conformance: ATX-13, extensions: 38}`, probe asserts both halves, `UN-DIVERGENCE` direction, decision recorded in `notes` |
| `ATX-M-F04` | `disposition: OPEN-PINNED`, `ledger.issue: 234`, probe pinned "today's actual behavior" with `UNDECIDED-MOVEMENT` | `disposition: DIVERGE-DECIDED`, `ledger: {conformance: ATX-14, extensions: 39}`, probe extended through `apply_transforms()`, `UN-DIVERGENCE` direction, decision recorded in `notes` |

Neither row still carries `ledger.issue` (legal only on OPEN-PINNED); #234 is no longer cited as a pending decision anywhere in the matrix.

## Assertions proven RED (mutation, then restored byte-identical)

Both flipped rows were proven to have teeth in the direction that now matters (silent un-divergence):

**Mutation A** — restored the spec-literal fallback (`SHAPE_TO_HANDLER.get(node.shape, "codergen")`) in `handlers/__init__.py`:

```
AssertionError: SPEC-CONFORMANCE MATRIX FLIP -- row ATX-M-F01 "unknown node shape hard-errors..."
    disposition: DIVERGE-DECIDED  (ledgered: SPEC_CONFORMANCE.md ATX-13; specs/EXTENSIONS.md section 38)
    direction:   UN-DIVERGENCE -- the engine now matches the spec text the ledger says we deliberately...
4 failed, 2 passed  (probe + all three test_no_silent_fallback contract tests)
```

**Mutation B** — gave `Node.reasoning_effort` the spec's `"high"` dataclass default in `graph.py`:

```
AssertionError: SPEC-CONFORMANCE MATRIX FLIP -- row ATX-M-F04 "reasoning_effort has no built-in default..."
    disposition: DIVERGE-DECIDED  (ledgered: SPEC_CONFORMANCE.md ATX-14; specs/EXTENSIONS.md section 39)
    direction:   UN-DIVERGENCE ...
AssertionError: Node.reasoning_effort now has a dataclass default of 'high'. ... move both ledger
entries, matrix row ATX-M-F04, and docs/DOT-AUTHORING-GUIDE.md's reasoning_effort row in the same PR.
2 failed  (probe + D-243 doc guard)
```

Both mutations restored; `git diff` against the mutated files empty before commit.

## Verification checklist

- [x] Unit tests pass — loop-pipeline (`uv sync --extra remote && uv run pytest -q`): **2429 passed, 25 skipped**; pipeline-runner (plain `uv sync`): **76 passed, 1 skipped**
- [x] Live pipeline run — **N/A with reason:** no `engine.py`/handler/backend code is touched; this PR changes ledgers, the matrix, two matrix probes, one doc cell, and one doc guard. Both rulings keep shipped behavior; the behavior itself is exercised in-process by the matrix probes and `test_no_silent_fallback.py`
- [x] AGENTS.md reviewed; repo-specific gates met (conformance matrix module: **198 passed, 24 skipped in 0.60s**; ledger-integrity + doc guards + examples-lint sweep: **88 passed, 0 ERRORs**; `git diff --check` clean; leak scan of the diff clean)
- [x] Backward-compat path unchanged — no behavior changes at all
- [x] Observable-contract entry: `specs/EXTENSIONS.md` §38 + §39 added (this PR's whole point)
- [x] Doc-claim guard: D-243 pins `DOT-AUTHORING-GUIDE.md`'s corrected `reasoning_effort` default cell to `Node.reasoning_effort`/`apply_transforms()` two-sided
- [x] PR body includes verification evidence (above)
- [ ] CI green before merge — **do not merge**; per lane instructions this PR is left open for the maintainer

## Verification evidence

See "Assertions proven RED" above for the mutation transcripts, and the F1/F4 sections for the in-process re-verification output on `9df6c24`. Suite totals: loop-pipeline 2429 passed / 25 skipped; pipeline-runner 76 passed / 1 skipped; matrix module 198 passed / 24 skipped in 0.60s; guards (ledger-integrity, doc-consistency incl. D-243, examples-lint, quality-protocol, engine-semantics, explainer, no-silent-fallback) 88 passed.

## Observations

- **Filed as #268 (`vision-observation`):** the fail-loud line for unknown shapes is held only at dispatch, not at validation — `validation.py:383` still classifies with the spec-literal `.get(shape, "codergen")`, so a typo'd shape passes `attractor lint` with 0 ERRORs and its warning even mis-describes the typo'd tool node as an "LLM node". Loud-late rather than loud-early. Not touched here: `validation.py` is owned by a parallel lane this wave (a lint rule is landing there), so the observation is recorded for triage after that lands rather than acted on.
- Nothing else arose.

## Notes for reviewers

- This is the first ruling made *under* §3 rather than about it; if the maintainer reads either finding differently, the two rows flip cleanly — each `notes:` field and EXTENSIONS entry records exactly what evidence the decision rests on, and the flip messages name the same-PR checklist in both directions.
- A parallel lane is editing `modules/loop-pipeline/.../validation.py` this wave; this PR deliberately does not touch that file. No overlap expected beyond a possible trivial rebase.
- `#234` should close on merge (Fixes #234 above); observation #268 is non-blocking and independent.
