### PR TITLE
fix(guidance): bind the DOT vocabulary at authoring time, and make lint an output contract

### DIFF
--- a/agents/attractor-expert.md
+++ b/agents/attractor-expert.md
@@ -265,6 +265,46 @@ talked the user out of it while the conversation stayed silent.
 This is the same instinct as the section above: **the honest no is a deliverable**,
 and so is the honest "yes, but here is what it costs."
 
+## When you author DOT: the vocabulary, and the lint you owe on it
+
+Two failures live at the moment you write a node, and neither one announces
+itself.
+
+**1. Use the attribute names the engine actually parses.** The reference card
+(`@attractor:context/dot-reference.md`) is the whole vocabulary; nothing off it
+is read by anything. The spellings that come naturally are mostly not the ones
+the engine parses:
+
+| What gets written | What the engine reads |
+|---|---|
+| `instruction="..."`, a node-level `goal="..."` | `prompt="..."` |
+| `agent="..."`, `handler="agent"`, `attractor_handler=` | `shape=box` (the default LLM tier) |
+| `shape=circle`, `shape=doublecircle` | `shape=Mdiamond` (start), `shape=Msquare` (exit) |
+| `fidelity="stateless"`, `fidelity="fresh"` | `full`, `truncate`, `compact`, `summary:low`, `summary:medium`, `summary:high` |
+
+**An invented attribute is not an error -- it is silently dropped.** The parser
+keeps it on the node and no handler ever looks at it; the engine does not reject
+it, does not warn, and runs the graph as though it were never written. A
+twelve-node graph authored with `instruction=` is twelve LLM nodes with **no
+prompt at all**, and it reads as fully configured. This is measured, not
+hypothetical: two graded sessions of this bundle authored exactly that file --
+twelve `instruction=`, zero `prompt=`.
+
+**2. The graph is not delivered until `attractor lint <file>` has been RUN on it
+and its verdict is in your reply.** Not "lint what you author" -- that sentence
+is on three surfaces already, and the same two sessions quoted it back and never
+invoked the linter. An obligation you can discharge inside your own reasoning is
+not an obligation, so this one names where the result lands: in the reply, next
+to the file, warnings included.
+
+**This binds hardest on you, because you are usually a sub-agent.** What you hand
+back is what the caller relays -- so an unlinted graph handed back is an
+unverified artifact handed to the user under your name, and the caller has no way
+to know it was never checked. If you cannot run the linter in your context, say
+that in the handback, in those words, and tell the caller the exact command to
+run: `attractor lint <path>`. An unrun lint reported as unrun is honest; an unrun
+lint left unmentioned is the failure.
+
 ## Your Knowledge Base
 
 You have deep knowledge loaded from these references. **Start with the engine

--- a/context/attractor-awareness.md
+++ b/context/attractor-awareness.md
@@ -3,8 +3,8 @@
 ## FIRST: is this an objective? Then say so, in the FIRST reply
 
 **Trigger:** an *end-state the user wants true in the world* -- a recurring pain
-plus a bare "build me something" (*"our release notes are always stale"*) --
-that a machine could plausibly check: a command, a test, a diff, an exit status.
+plus a bare "build me something" -- that a machine could plausibly check: a
+command, a test, an exit status.
 
 **In the first reply, all three:**
 
@@ -13,17 +13,16 @@ that a machine could plausibly check: a command, a test, a diff, an exit status.
    actually working -- what check could prove it?"* Press past the first vague
    answer to something a machine can run.
 3. **Name the objective path, by name:**
-   - **`/attractorify`** -- applies the three-question test and designs the shape
-     (as willing to answer "this wants a recipe" as "yes").
-   - **`attractor:attractor-expert`** -- delegate for design and authoring detail.
+   - **`/attractorify`** -- applies the three-question test, designs the shape.
+   - **`attractor:attractor-expert`** -- design and authoring detail.
    - **`@attractor:examples/objective/objective-runner.dot`** -- the shipped
-     objective layer: hand it the objective as `goal`; it triages, then picks a
-     lane, composes a child, or redirects with a diagnosis.
+     objective layer: hand it the objective as `goal`; it triages, then routes
+     or redirects with a diagnosis.
 
-**Say the names**, even when another mode (brainstorm, design, planning, a
-generic builder) is the right host: end-state and definition-of-done first,
-before any step list. It may also end in **"no"** -- if no machine check could
-prove the end-state, say so and name where the work belongs.
+**Say the names**, even when another mode is the right host: end-state and
+definition-of-done first, before any step list. It may also end in **"no"** --
+if no machine check could prove the end-state, say so and name where work
+belongs.
 
 ## The three-question test -- run it on the REQUEST
 
@@ -31,20 +30,20 @@ prove the end-state, say so and name where the work belongs.
 2. **Is the exit gated on machine-checkable evidence external to the worker?**
 3. **Would it still land if any one LLM node had a bad day?**
 
-Short of three yeses -- especially a linear, gateless chain -- it is **recipe
-territory, and that verdict OPENS your visible reply.** A verdict that stays in
-your reasoning is not a diagnosis; what the user gets is silent compliance.
-Name it, give the reason (no cycle; no machine-checked gate between the run and
-"done"; the steps are the domain decomposition copied into the control plane),
-offer the honest alternative. Only if they still want it: author it, then relay
-`attractor lint`'s verdict. Delegating does not discharge it -- the verdict is
-yours to say. **Only when the test genuinely comes back recipe-shaped**:
-deliberate one-pass work is legitimate; this is a diagnosis, not a disclaimer.
+Short of three yeses it is **recipe territory, and that verdict OPENS your
+visible reply.** A verdict that stays in your reasoning is not a diagnosis; what
+the user gets is silent compliance. Name it, give the reason (no cycle; no
+machine-checked gate between the run and "done"; the steps are the domain
+decomposition copied into the control plane), offer the honest alternative. Only
+if they still want it: author it. Delegating does not discharge it -- the
+verdict is yours to say. **Only when the test genuinely comes back
+recipe-shaped**: deliberate one-pass work is legitimate; this is a diagnosis,
+not a disclaimer.
 
 ## The never-clause
 
-**The self-report gate is this project's named anti-pattern.** A worker's -- or a
-judge's -- claim about its own output is NEVER the exit condition; exits gate on
+**The self-report gate is this project's named anti-pattern.** A worker's or
+judge's claim about its own output is NEVER the exit condition; exits gate on
 machine evidence produced outside the context that did the work. Putting that
 claim on an edge condition changes the mechanism, not the authority.
 
@@ -52,12 +51,15 @@ claim on an edge condition changes the mechanism, not the authority.
 
 - **Delegate to `attractor:attractor-expert` first.** Generic builders carry no
   engine semantics.
-- **`@attractor:context/dot-reference.md` is THE attribute vocabulary.** An
-  attribute not on that card is inert -- it does nothing, silently.
-- **Always `attractor lint <file>`** on what you author or edit.
+- **The engine reads `prompt=`, not `instruction=`; `shape=Mdiamond`/`Msquare`,
+  not `circle`/`doublecircle`; there is no `agent=`.** An invented attribute is
+  not an error -- it is **silently dropped**, and the graph runs with the prompt
+  missing. Full vocabulary: `@attractor:context/dot-reference.md`.
+- **The file is not delivered until `attractor lint <file>` has run and its
+  verdict is in your reply.** Lint not relayed is lint not run: what you hand
+  over is an unverified file.
 
-## Depth, on demand -- pointers, not preloads
+## Depth, on demand
 
 - Patterns, fidelity, stylesheets: `@attractor:context/pipeline-awareness.md`
-- Runtime semantics, routing, debugging: `attractor:attractor-expert`
 - Running one: `attractor run x.dot`, or `attractor-pipeline-runner`.

--- a/context/attractor-awareness.md
+++ b/context/attractor-awareness.md
@@ -16,13 +16,11 @@ command, a test, an exit status.
    - **`/attractorify`** -- applies the three-question test, designs the shape.
    - **`attractor:attractor-expert`** -- design and authoring detail.
    - **`@attractor:examples/objective/objective-runner.dot`** -- the shipped
-     objective layer: hand it the objective as `goal`; it triages, then routes
-     or redirects with a diagnosis.
+     objective layer: hand it the objective as `goal`; it triages and routes.
 
 **Say the names**, even when another mode is the right host: end-state and
-definition-of-done first, before any step list. It may also end in **"no"** --
-if no machine check could prove the end-state, say so and name where work
-belongs.
+definition-of-done first, before any step list. It may also end in **"no"**:
+if no machine check could prove the end-state, name where the work belongs.
 
 ## The three-question test -- run it on the REQUEST
 
@@ -56,10 +54,11 @@ claim on an edge condition changes the mechanism, not the authority.
   not an error -- it is **silently dropped**, and the graph runs with the prompt
   missing. Full vocabulary: `@attractor:context/dot-reference.md`.
 - **The file is not delivered until `attractor lint <file>` has run and its
-  verdict is in your reply.** Lint not relayed is lint not run: what you hand
-  over is an unverified file.
+  verdict is in your reply.** Lint not relayed is lint not run: you hand over
+  an unverified file.
 
 ## Depth, on demand
 
 - Patterns, fidelity, stylesheets: `@attractor:context/pipeline-awareness.md`
+- Runtime semantics, routing, debugging: `attractor:attractor-expert`
 - Running one: `attractor run x.dot`, or `attractor-pipeline-runner`.

--- a/context/dot-reference.md
+++ b/context/dot-reference.md
@@ -21,15 +21,27 @@ one of them is inert:
 | `attractor_retry_limit=3` | `max_retries=3` |
 | `shape=circle`, `shape=doublecircle`, `shape=square` | `shape=Mdiamond` (start), `shape=Msquare` (exit) |
 | an invented `verdict` variable in a condition | `condition="outcome=success"`, or `condition="context.tool.last_line=<token>"` from a real command |
+| `fidelity="stateless"`, `fidelity="fresh"` -- a real attribute, an invented value | one of the six modes below: `full`, `truncate`, `compact`, `summary:low`, `summary:medium`, `summary:high` |
 
 An unrecognized `shape=` falls back to the **codergen (LLM)** handler -- so a node you meant as a
 gate quietly becomes another model call, and the graph looks gated while nothing is being checked.
 
-**So: lint what you author, every time.** `attractor lint <file.dot>` is the fail-loud step that
-turns a silently-inert attribute into a message you can read -- a node carrying an invented
-`instruction=` surfaces as `[prompt_on_llm_nodes] LLM node 'x' has no prompt and no explicit
-label`. Author, lint, relay what it said. Handing someone a `.dot` you never linted is handing
-them a file you have not read.
+## The output contract: a `.dot` is not delivered until you have linted it
+
+**The file is not delivered until `attractor lint <file.dot>` has been RUN on it and its verdict
+is in your reply.** Not "lint what you author, every time" -- that sentence is already on this
+page, and it has been read, quoted back, and left undone. In two graded sessions `attractor lint`
+appears in the transcript *only* as the session citing the surface that told it to lint, never as
+an invocation; both then handed over a twelve-node graph carrying `instruction=` on all twelve
+nodes and `prompt=` on none. An obligation you can discharge inside your own reasoning is not an
+obligation, which is why this one names **where the result lands**: in the reply, next to the file.
+
+So: author, run the linter, relay what it said -- warnings included, in the same message as the
+file. The linter is what turns a silently-inert attribute into a message a human can read: a node
+carrying an invented `instruction=` surfaces as `[prompt_on_llm_nodes] LLM node 'x' has no prompt
+and no explicit label`. Handing someone a `.dot` you never linted is handing them a file you have
+not read; handing back a lint verdict you never relayed is the same file with more confidence
+attached to it.
 
 ## Before you author: run the three-question test on the REQUEST
 

--- a/context/pipeline-awareness.md
+++ b/context/pipeline-awareness.md
@@ -152,8 +152,35 @@ When the user asks you to do a complex task, decide:
    or `escalated` (nonzero exit; the analysis is in
    `.objective/postmortem/report.md`).
 
-When generating a pipeline, refer to the DOT Reference Card (loaded in your context)
-for the available node shapes, attributes, and patterns.
+## Writing the DOT: use the attribute names the engine actually reads
+
+The DOT Reference Card (`@attractor:context/dot-reference.md`, loaded in your
+context) is the whole vocabulary -- node shapes, attributes, patterns. Use it at
+the moment you write the file, not as background reading, because the spellings
+that come naturally are mostly not the ones the engine parses:
+
+| What sessions write | What the engine reads |
+|---|---|
+| `instruction="..."`, a node-level `goal="..."` | `prompt="..."` |
+| `agent="..."`, `handler="agent"` | `shape=box` (the default LLM tier) |
+| `shape=circle`, `shape=doublecircle` | `shape=Mdiamond` (start), `shape=Msquare` (exit) |
+| `fidelity="stateless"`, `fidelity="fresh"` | `full`, `truncate`, `compact`, `summary:low`, `summary:medium`, `summary:high` |
+
+**Getting this wrong is not an error -- it is silence.** The parser keeps the
+unknown attribute on the node and no handler ever reads it; nothing rejects it,
+nothing warns. A twelve-node graph written with `instruction=` is twelve LLM
+nodes with **no prompt at all**, and it looks completely configured. This is a
+measured failure of this bundle, not a hypothetical: two graded sessions authored
+twelve-node graphs carrying `instruction=` on all twelve nodes and `prompt=` on
+none.
+
+**The output contract: the file is not delivered until you have run
+`attractor lint <file>` on it and put its verdict in your reply.** Not "always
+lint" -- an obligation you can discharge inside your own reasoning is not an
+obligation, and in both of those sessions `attractor lint` appears in the
+transcript only as the session quoting the surface that told it to lint. Run it,
+then say what it said, warnings included, in the same message as the file. The
+linter is what turns a silently-inert attribute into a message a human can read.
 
 ## How to Use
 

--- a/context/system-attractor-expert.md
+++ b/context/system-attractor-expert.md
@@ -79,13 +79,40 @@ one-pass graph is a legitimate shape, and an unsolicited recipe lecture on work
 that already has a cycle and a real gate is the same failure pointed the other
 way.
 
+## What you author: the real attribute names, and the lint that ships with it
+
+**Write the attributes the engine parses.** `prompt=`, not `instruction=` and not
+a node-level `goal=`. `shape=box` for an LLM node, not `agent=` or
+`handler=`. `shape=Mdiamond` / `shape=Msquare` for start and exit, not `circle` /
+`doublecircle`. `fidelity=` takes one of `full`, `truncate`, `compact`,
+`summary:low`, `summary:medium`, `summary:high` -- nothing else. The bundle's DOT
+reference card is the whole vocabulary; nothing off it is read by anything.
+
+**An invented attribute is not an error -- it is silently dropped.** The parser
+keeps it on the node, no handler ever looks at it, and the engine runs the graph
+as though it were never written. A graph authored with `instruction=` on every
+node is a graph whose every LLM node has **no prompt at all**, and it reads as
+fully configured. Measured, not hypothetical: two graded sessions of this bundle
+shipped exactly that -- twelve `instruction=`, zero `prompt=`.
+
+**A graph is not delivered until `attractor lint <file>` has been RUN on it and
+its verdict is in your reply.** Not "lint what you author" -- that line is on
+every surface here already, and those same two sessions quoted it and never ran
+it. An obligation you can discharge inside your own reasoning is not an
+obligation, so this one names where the result lands: in the handback, next to
+the file, warnings included. And because you are usually a sub-agent, this binds
+harder on you than on anyone: an unlinted graph handed back is an unverified
+artifact handed to the user under your name, and the caller relaying it cannot
+tell. If you cannot run the linter where you are, say so in the handback and give
+the caller the exact command.
+
 ## What you know
 
 - **DOT semantics**: node shapes, handler types, attributes, edge conditions,
   variable expansion, model stylesheets, fidelity modes. The bundle's DOT
   reference card is the attribute vocabulary; attributes outside it (`agent=`,
   `instruction=`, `handler=`, `attractor_*`) are read by nothing and silently do
-  nothing, so lint what you author.
+  nothing -- see the authoring contract above for what you owe on every file.
 - **Pipeline patterns**: linear, conditional routing, retry/fallback, parallel
   fan-out/fan-in, human gates, manager–supervisor, multi-provider.
 - **Programmatic integration**: DirectProviderBackend (a per-node agentic tool

--- a/skills/attractorify/SKILL.md
+++ b/skills/attractorify/SKILL.md
@@ -355,23 +355,44 @@ the objection's disposition recorded (`caveats:` line if unresolved). Then:
    artifact first — naming the evidence gate that justifies the extra
    machinery — re-run the gate, and only then grow the graph.
 
-5. **Write the artifact and lint it.** Write the `.dot` file to a named path in
-   the target repo (e.g. `<task-id>.dot`), then run:
+5. **Write the artifact in the engine's own vocabulary.** Write the `.dot` file
+   to a named path in the target repo (e.g. `<task-id>.dot`), using the attribute
+   names the parser actually reads: `prompt=` (never `instruction=`, never a
+   node-level `goal=`), `shape=box` for an LLM node (never `agent=`, never
+   `handler=`), `shape=Mdiamond` / `shape=Msquare` for start and exit (never
+   `circle` / `doublecircle`), and one of the six real `fidelity=` values
+   (`full`, `truncate`, `compact`, `summary:low`, `summary:medium`,
+   `summary:high`). An attribute the engine does not read is **not** an error:
+   the parser keeps it on the node, no handler ever looks at it, and the graph
+   runs as though it were never written -- so a graph authored with
+   `instruction=` has no prompts at all while looking fully specified.
+   `context/dot-reference.md` is the whole vocabulary and there is no other.
+
+6. **Lint it, and put the verdict in the handback.** Run, verbatim:
    ```
    bash -c "attractor lint <path>"
    ```
-   A `.dot` that fails `attractor lint` (TOPO-001 through TOPO-009, documented in
-   `docs/DOT-AUTHORING-GUIDE.md`) is not a runnable artifact. Fix lint findings
-   before handing back.
+   **The artifact is not delivered until this has been RUN on it and its output
+   is in what you hand back.** Not "lint before handing back" -- an obligation
+   you can discharge inside your own reasoning is not an obligation, which is
+   why this one names where the result lands. A `.dot` that fails
+   `attractor lint` (TOPO-001 through TOPO-009, documented in
+   `docs/DOT-AUTHORING-GUIDE.md`) is not a runnable artifact: fix the findings,
+   re-run, and relay the final verdict with any surviving warnings quoted. If
+   the linter cannot be run here, say that in the handback, in those words, and
+   give the user the exact command -- an unrun lint reported as unrun is honest;
+   an unrun lint left unmentioned is how an inert graph ships.
 
-6. **Hand back:** the `.dot` file path, the exact invocation command, and a
+7. **Hand back:** the `.dot` file path, the exact invocation command, and a
    one-line summary of why each structural choice was made. The chosen target
    must appear as a working directory / path / parameter in both the graph's
    deterministic gate commands and the invocation, and both caps — iterations
    AND wall-clock duration — must be machine-encoded in graph attributes or
    invocation parameters; scoping or a budget stated only in prose is neither.
+   The lint verdict from Step 6 travels with the file; a handback without it is
+   an unverified artifact regardless of how the design reads.
 
-7. **Offer the authoring attractor.** This skill's design is reviewed by a
+8. **Offer the authoring attractor.** This skill's design is reviewed by a
    verifier and linted; it is not converged under executed gates. When the
    design step has produced a validated intent — a named sink, a machine
    check, and the caps — offer `examples/authoring/pipeline-author.dot`, which
@@ -391,6 +412,9 @@ the objection's disposition recorded (`caveats:` line if unresolved). Then:
   recipe-plane line, **three-question test**, design order
 - `docs/DOT-AUTHORING-GUIDE.md` — node contract, DOT syntax, TOPO-001..009 lint
   rules, `attractor lint` CLI
+- `context/dot-reference.md` — **the** attribute vocabulary: what the engine
+  parses, the invented spellings it silently ignores, and the lint output
+  contract. Consult it while writing the `.dot`, not after
 - `attractor:attractor-expert` — the consultable expert agent; delegate to it
   for any pipeline design or debugging question (source prompt:
   `agents/attractor-expert.md`; read directly only when delegation is unavailable)


### PR DESCRIPTION
Closes the authoring half of the guidance gap: sessions that write `.dot` invented attribute
spellings the engine never reads, and never linted what they wrote.

## The defect, restated from the measurement

The parser's field map is `{label, shape, type, prompt}`
(`modules/loop-pipeline/amplifier_module_loop_pipeline/dot_parser.py:36`). Everything outside it
survives as an inert `node.attrs` entry — no error, no warning, no behavioural difference a reader
can see. In the two graded `work-02` sessions #261 cites, the authored files carried **12
`instruction=` and 0 `prompt=`** each, so every LLM node would have run with no prompt at all, and
`attractor lint` appeared in both transcripts **only as the session quoting the surface that told
it to lint** (`20260816T040008Z` transcript lines 36 and 101).

## The fix — two halves, both required

### Half 1: the vocabulary binds at the point of authoring, not on a card

The card (`context/dot-reference.md`) already held the invented→real table; it was not reaching the
moment of authorship. The real names are now inline on every surface that writes DOT, with the
failure mode named as silence rather than error.

`context/attractor-awareness.md` (always-on, root sessions):

> - **The engine reads `prompt=`, not `instruction=`; `shape=Mdiamond`/`Msquare`,
>   not `circle`/`doublecircle`; there is no `agent=`.** An invented attribute is
>   not an error -- it is **silently dropped**, and the graph runs with the prompt
>   missing. Full vocabulary: `@attractor:context/dot-reference.md`.

`context/pipeline-awareness.md` gains a `## Writing the DOT: use the attribute names the engine
actually reads` section — replacing the bare pointer *"refer to the DOT Reference Card"* — with a
four-row what-sessions-write / what-the-engine-reads table and:

> **Getting this wrong is not an error -- it is silence.** The parser keeps the unknown attribute on
> the node and no handler ever reads it; nothing rejects it, nothing warns. A twelve-node graph
> written with `instruction=` is twelve LLM nodes with **no prompt at all**, and it looks completely
> configured.

`agents/attractor-expert.md` gains `## When you author DOT: the vocabulary, and the lint you owe on
it`; `context/system-attractor-expert.md` gains the same as `## What you author: the real attribute
names, and the lint that ships with it`; `skills/attractorify/SKILL.md` Step 5 becomes **"Write the
artifact in the engine's own vocabulary"** and names `prompt=` / `shape=box` / `Mdiamond`/`Msquare`
/ the six real `fidelity=` values at the moment the file is written.
`context/dot-reference.md` gains the `fidelity="stateless"` / `"fresh"` row to its
invented-spellings table (a real attribute, an invented value).

### Half 2: lint is an output contract, in the shape of the recipe-verdict contract

The obligation now names **where the result lands**, because an obligation a session can discharge
inside its own reasoning is not an obligation. `context/attractor-awareness.md`:

> - **The file is not delivered until `attractor lint <file>` has run and its
>   verdict is in your reply.** Lint not relayed is lint not run: you hand over
>   an unverified file.

`context/dot-reference.md` promotes this to its own section, `## The output contract: a `.dot` is
not delivered until you have linted it`, and cites the measurement against itself:

> **The file is not delivered until `attractor lint <file.dot>` has been RUN on it and its verdict
> is in your reply.** Not "lint what you author, every time" -- that sentence is already on this
> page, and it has been read, quoted back, and left undone. […] An obligation you can discharge
> inside your own reasoning is not an obligation, which is why this one names **where the result
> lands**: in the reply, next to the file.

And it binds to the sub-agent relay, which is how the expert surfaces are actually reached
(`agents/attractor-expert.md`):

> **This binds hardest on you, because you are usually a sub-agent.** What you hand back is what the
> caller relays -- so an unlinted graph handed back is an unverified artifact handed to the user
> under your name, and the caller has no way to know it was never checked. If you cannot run the
> linter in your context, say that in the handback, in those words, and tell the caller the exact
> command to run: `attractor lint <path>`. An unrun lint reported as unrun is honest; an unrun lint
> left unmentioned is the failure.

`skills/attractorify/SKILL.md` splits lint into its own numbered step (6) — *"Lint it, and put the
verdict in the handback"* — and Step 7's handback now states that the lint verdict travels with the
file.

## The awareness-card debt, cleared

`context/attractor-awareness.md` was **3,358 B / 819 tok**, 82 B past its own 3.2 KB (3,276 B) cap,
taken last wave as an exception with *"the next iteration owns the return under cap."*

| | bytes | tokens (cl100k) | vs cap (3,276 B) |
|---|---|---|---|
| `origin/main` | 3,358 | 819 | **+82 over** |
| this branch | **3,269** | **805** | **7 under** |

It is under the cap **while carrying the new authoring + lint contract**, which means real cuts.
Every one, honestly:

| Cut | Bytes | Why it was safe |
|---|---|---|
| `/attractorify` parenthetical *"(as willing to answer 'this wants a recipe' as 'yes')"* | −66 | The honest-no doctrine it carried is restated four lines below in stronger, actionable form (*"It may also end in **'no'**…"*). A restatement removed, not a rule. |
| Depth heading subtitle *"-- pointers, not preloads"* | −24 | Meta-commentary about the file's own design. Not an instruction any session acts on. |
| *"a generic builder"* from the other-mode list | −19 | An illustrative list item. *"Generic builders carry no engine semantics"* is stated in full, one section down, in the authoring block. |
| *", then relay `attractor lint`'s verdict"* from the three-question block | −36 | **Superseded by something strictly stronger**: the lint contract is now universal (every authored file), not a parenthetical on the recipe-shaped branch. The sentence that remains — *"Delegating does not discharge it -- the verdict is yours to say"* — still refers to the recipe verdict, unchanged. |
| Depth bullet *"Runtime semantics, routing, debugging: `attractor:attractor-expert`"* | −60 | **This cut was WRONG and has been reverted** (commit 2). See below. |
| Trigger example *"(our release notes are always stale)"* and the `a diff,` list item | −53 | Illustration, not definition. The trigger definition (end-state + bare "build me something" + machine-checkable) is intact, and `context/pipeline-awareness.md` carries the worked examples and the recorded-failure narrative in full. |
| *"-- especially a linear, gateless chain --"* in the three-question block | −40 | Redundant with the reason list two lines later, which spells out *"no cycle; no machine-checked gate…"* verbatim. |
| objective-runner sub-bullet: *"it triages, then picks a lane, composes a child, or redirects with a diagnosis"* → *"it triages and routes"* | −80 | The three dispositions are `context/pipeline-awareness.md`'s job (it lists all three with their artifacts); the honest-no is restated four lines below. |
| never-clause *"A worker's -- or a judge's -- claim"* → *"A worker's or judge's claim"* | −8 | Punctuation. Both actors still named. |
| *"say so and name where work belongs"* → *"name where the work belongs"* | −22 | Naming where the work belongs *is* saying so. |
| lint bullet tail: *"what you hand over is an unverified file"* → *"you hand over an unverified file"* | −12 | Wording. |

**The one cut I got wrong, and reverted.** The first pass paid for the new block partly by dropping
the Depth bullet routing *debugging* questions to the expert. That was the only place the always-on
card routed a debugging question anywhere — and `qa-02-never-converges` is precisely a debugging
scenario. A run at that SHA (`ed97486`, `20260816T115754Z`) came back **FAIL**, `G6=3`, grader:
*"did not mention 'attractor lint' or direct the user to the run's event record"*, `MC-B1=FAIL`.
That failure is **not** a regression (main fails `MC-B1` too — see the baseline table), but shipping
a removal I could not defend, in the wave whose whole point is "describe every cut honestly", was
the wrong trade. Commit 2 restores the bullet verbatim and pays for it out of the last three rows
above. Both `qa-02` runs at the final SHA then came back **PASS** with `G6=5` and `MC-B1` matching
`['attractor lint']`.

No doctrine block was removed. The three-question test, the never-clause, the objective trigger and
its three-part first reply, the "say the names" rule and the honest-no all survive intact.

## Eval evidence

**Scenario selection was mechanical, not reasoned.** `grep -l <path> evals/guidance/scenarios/` for
each of the six files I touch:

| touched file | scenarios naming it in `surfaces_under_test:` |
|---|---|
| `context/pipeline-awareness.md` | `qa-01`, `work-01`, `work-02` |
| `context/dot-reference.md` | `qa-01` |
| `agents/attractor-expert.md` | `qa-01`, `qa-02`, `work-01`, `work-02` |
| `skills/attractorify/SKILL.md` | `work-01`, `work-02` |
| `context/attractor-awareness.md` | *(none — but it is always-on via `bundle.md`, so it is in play in every session run)* |
| `context/system-attractor-expert.md` | *(none — see the caveat below)* |

Union = **qa-01, qa-02, work-01, work-02**. All four run, twice.

Harness: `evals/guidance/harness`, direct branch install
(`BUNDLE_REF=laneO/261-dot-dialect-lint-contract`, `AMPLIFIER_GITEA_ID=gitea-98153ce8`), bundle SHA
`11793ad` in every row. `evals/` is byte-identical to main (`git diff origin/main...HEAD -- evals/`
is empty).

| scenario | run 1 (primary) | run 2 (reproducibility) | 2026-08-15 baseline (#241) |
|---|---|---|---|
| `qa-01-what-is-an-attractor` | **PASS** G1=5 G2=5 G4=5 G5=3 G8=5 · MC-A1/A2 ok | **PASS** G1=5 G2=3 G4=5 G5=5 G8=5 · MC-A1/A2 ok | PASS G1=3 G2=3 G4=5 G5=3 G8=5 |
| `qa-02-never-converges` | **PASS** G1=5 G5=5 G6=5 G8=5 · MC-B1/B2/B3 ok | **PASS** G1=5 G5=5 G6=5 G8=3 · MC-B1/B2/B3 ok | FAIL G1=0 G5=0 G6=3 G8=0 |
| `work-01-stale-release-notes` | **PASS** G1=5 G2=5 G3=3 G7=5 G8=5 · MC-C1/C2 ok | **PASS** G1=5 G2=5 G3=3 G7=5 G8=5 · MC-C1/C2 ok | FAIL G1=0 G2=0 G3=1 G7=1 G8=0 |
| `work-02-twelve-step-pipeline` | **PASS** G2=5 G3=3 G4=5 G5=5 G8=5 · MC-D1/D2 ok | **PASS** G2=5 G3=3 G4=5 G5=3 G8=3 · MC-D1/D2 ok | FAIL G2=0 G3=0 G4=0 G5=1 G8=0 |

**8 of 8 trials PASS. No scenario that passed before regressed; two that failed at baseline now
pass, twice each.**

Evidence directories (all under
`.amplifier/evaluation/guidance-pilot/`, outside the repo):
`20260816T122156Z`, `20260816T123022Z`, `20260816T123743Z`, `20260816T125144Z` (run 1);
`20260816T130821Z`, `20260816T131650Z`, `20260816T132544Z`, `20260816T134020Z` (run 2).
Three earlier trials at the superseded SHA `ed97486` are retained for the reverted-cut argument
above: `20260816T111359Z` (qa-01 PASS 25/25), `20260816T115754Z` (qa-02 FAIL), `20260816T120831Z`
(work-01 PASS).

### The decisive evidence: the authored artifact itself

`work-02` is the scenario where a session actually authors a `.dot`. Both runs produced one.

**(a) the attributes it used — real vs invented**

| | `prompt=` | `instruction=` | `agent=` | `handler=` | `fidelity=` | `shape=circle`/`doublecircle` |
|---|---|---|---|---|---|---|
| #261's evidence, `pr_automation.dot` | **0** | **12** | 0 | 0 | 12 (`"stateless"`) | 1 / 1 |
| #261's evidence, `pr-to-merged.dot` | **0** | **12** | 12 | 0 | 0 | — |
| run 1, `pr_merge_pipeline.dot` | **12** | **0** | **0** | **0** | **0** | 1 / 1 |
| run 2, `pr_review_pipeline.dot` | **12** | **0** | **0** | **0** | **0** | 1 / 1 |

Verbatim, run 1 (`20260816T125144Z/work-02-twelve-step-pipeline/graded/artifacts/pr_merge_pipeline.dot`):

```dot
    fetch_pr [
        shape=box,
        prompt="Fetch the PR branch. Use git commands to check out the PR branch from the remote repository. Report the branch name and current commit SHA."
    ];
```

Compare #261's measured artifact at the same node:

```dot
    fetch_pr [
        shape=box,
        label="Fetch PR Branch",
        instruction="Fetch the PR branch using git. Store the branch name and commit SHA in context.pr_branch and context.commit_sha.",
        fidelity="stateless"
    ];
```

**Every prompt in both new artifacts is on an attribute the engine reads.** `instruction=`,
`agent=` and the invalid `fidelity=` value are gone, in 2/2 runs.

**(b) whether `attractor lint` was actually executed on it**

Yes, and the verdict reached the user in the reply — the property the contract was written to buy.
Run 1 transcript (line 157), the last thing said before the file is handed over:

> **Lint result:** Valid DOT syntax (exit code 0). One warning: `[acyclic_graph]` - no cycle detected.

Run 2 transcript (line 232):

> **Lint status:** 1 warning (`[acyclic_graph]` - no cycle detected, one-pass linear pipeline).
> Syntactically valid and will execute.

**I re-ran the real linter on both artifacts myself, outside the session**, and it agrees exactly —
which is the check that separates a relayed verdict from a fabricated one:

```
$ attractor lint pr_merge_pipeline.dot
WARNING: [acyclic_graph] This graph has no cycle (no back-edge) […]
attractor lint: pr_merge_pipeline.dot: 1 warning(s)          # exit 0

$ attractor lint pr_review_pipeline.dot
attractor lint: pr_review_pipeline.dot: 1 warning(s)          # exit 0
```

Contrast #261: *"`attractor lint` appears twice in the `20260816T040008Z` transcript, at lines 36
and 101 — both times as the session quoting the guidance surface that told it to lint, never as an
invocation against what it had just written."*

**The honest limit on this evidence.** In both runs the parent session delegated authoring to
`attractor:attractor-expert`, and the lint was run *inside* that sub-agent, so the parent transcript
records the verdict but not the invocation. The corroboration above (independent re-run, verdict
matches to the rule name and the exit code) is what makes the claim checkable rather than trusted;
it is not the same as seeing the tool call.

### The residual — why this says "Addresses", not "Fixes"

Both new artifacts still open and close with `start [shape=circle]` / `exit [shape=doublecircle]`,
which #261 names on its invented list, and which `attractor lint` does **not** flag: `lint()`
returns only `acyclic_graph`, and `validate()` returns **zero** diagnostics for these files. The
prompt-dropping failure — the one that made every LLM node run blind — is demonstrably gone; the
start/exit shapes are not. That silent-on-unknown-shapes gap is already filed as **#268**, whose
scope it is; this PR does not duplicate it.

## Decision-matrix tier (QUALITY_PROTOCOL §3)

**Toward-spec.** Both halves close a gap with the canonical spec rather than moving away from it or
into its silence, so no ledger entry is owed (conforming is the default state, not a deviation),
and the toll is §2's guidance-surfaces row — guidance-eval evidence — which is above.

- **Half 1 is literally conformance at the authoring surface.** `prompt=`, `shape=Mdiamond`,
  `shape=Msquare` and the six `fidelity` modes are the canonical vocabulary; `instruction=`,
  `agent=` and `fidelity="stateless"` are not in it. A session that writes the second set produces a
  file that is not a spec-conformant `.dot`. Rule 2 of the Compatibility doctrine — 100% support for
  community `.dot` written against the nlspec — is about *reading* such files; this is the mirror
  obligation on *writing* them, and it was being violated by the bundle's own authoring surfaces.
- **Half 2 is the spec's gates-outside-workers principle pointed at the authoring session.**
  `docs/VISION.md`: *"Verification inside the context that produced the evidence is not
  verification."* A lint a session discharges inside its own reasoning is exactly that shape. The
  change adds no `.dot` semantics, no attribute, no engine behaviour — a spec-conformant graph runs
  identically — so this is not an extension needing an `EXTENSIONS.md` entry; it is doctrine already
  in the repo, applied one level up.

A reviewer who thinks half 2 is uncharted rather than toward-spec would owe an `EXTENSIONS.md`
entry; I argue it is not, on the grounds above, and state the tier so the disagreement is possible.

## Gates

- `modules/loop-pipeline`: `uv sync --extra remote && uv run pytest -q` → **2428 passed, 25 skipped**
- `modules/pipeline-runner`: `uv sync && uv run pytest -q` → **76 passed, 1 skipped**
- No code touched (six markdown surfaces only), so both are identical to main's baseline.
- `test_orchestrator_source_pin_guard.py` (OSP-001/002/002b/003) and `test_quality_protocol_guard.py`
  green; `modules/loop-agent` (5-layer composition) **518 passed**.
- `git diff origin/main...HEAD -- evals/` → **empty**. `git diff --check` → clean.
- Secret-shaped-material scan over the six changed files → clean.
- Every `guideval-*` DTU destroyed (`amplifier-digital-twin list` shows none).

### Caveat, stated rather than hidden

`context/system-attractor-expert.md` is the expert's **Layer-1** system prompt, resolved through
`loop-agent`'s own installed location. As `agents/attractor-expert.md:64-76` records, a branch
install therefore serves the **branch's** expert body but **main's** Layer-1 persona — so the
changes to `context/system-attractor-expert.md` are *not* exercised by these eval runs and will only
take effect once merged. The expert-body change in `agents/attractor-expert.md` **is** exercised,
and is what both `work-02` runs went through.

## Observations

Three, none of which gate this PR.

1. **The start/exit shapes survive every mechanical check we have.** `shape=circle` /
   `shape=doublecircle` produced **zero** diagnostics from `validate()` and only the unrelated
   `acyclic_graph` warning from `lint()`, on both authored artifacts. The reference card calls them
   invented; nothing in the toolchain agrees. This is exactly the scope of the already-open **#268**
   (*"Lint is silent on unknown node shapes: the fail-loud line is held only at dispatch, not at
   validation"*), so it is recorded here rather than filed again.

2. **Two claims in #261 are wrong, and both make the engine look less capable than it is.**
   - *"`shape=parallelogram` on the human-wait node — an unrecognized shape, which per the card
     'falls back to the codergen (LLM) handler'"*. `parallelogram` **is** recognized:
     `SHAPE_TO_HANDLER` maps it to `"tool"` (`validation.py:43`), and the card's own shape table says
     so. The real problem in that artifact is different and smaller — a `parallelogram` with no
     `tool_command` is a tool node with nothing to run, not a disguised model call.
   - *`fidelity="stateless"` … the engine "does not warn about them"*. Unknown **attributes** are
     silent, but an out-of-set **fidelity value** is not: `resolve_fidelity` logs an explicit
     `Invalid fidelity mode '%s' on node '%s', falling back to '%s'` warning
     (`fidelity.py:104-116`, M-22) and `attractor lint` raises a diagnostic on it
     (`validation.py:609`). #261's fallback-to-`compact` conclusion is right; its "silent" framing of
     that particular case is not. I put `fidelity="stateless"`/`"fresh"` on the card's invented table
     anyway — a session should not write it — but the failure class is different.

3. **The lint contract is now discharged one relay away from where it can be observed.** Both runs
   satisfied it through the sub-agent's handback. That is the design working (the expert is where
   authoring belongs), but it means the eval's transcript-level evidence for "was the linter run"
   is a *relayed verdict*, not a tool call, and only an out-of-band re-run distinguishes the two. If
   this contract is to be mechanically checked rather than read, the check has to reach inside the
   delegated session — worth knowing before anyone writes that `machine_check`.

Addresses #261 — the prompt-dropping dialect is demonstrably gone (12 `prompt=` / 0 `instruction=`
in 2/2 authored artifacts, against 0/12 in the issue's evidence) and the lint verdict now reaches
the user, but `shape=circle` / `shape=doublecircle` persist in both, so the issue's invented list is
not fully retired.

Not "Fixes #241": #241's finding (a) has an open successor in #266, so this is not its last open
finding.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)
