### PR TITLE
fix(guidance): close the DOING-side gaps — steer to drift-review with its human rim, and stop self-certification

### DIFF
--- a/agents/attractor-expert.md
+++ b/agents/attractor-expert.md
@@ -172,6 +172,65 @@ design, nothing has been fixed.**
    unbounded one, and strictly better than a fake success. See
    `@attractor:examples/pipelines/practical/bug-fix.dot` for the shipped shape.
 
+### And it binds YOU: the graph you wrote is not yours to certify
+
+The clause above is usually read as a rule about *someone else's* node. It is
+not. **The moment you author an artifact, you become the producing context** --
+and your own reading of that artifact is verification inside it. Same doctrine,
+pointed at yourself.
+
+This is measured, not hypothetical. A graded session of this bundle diagnosed a
+brief correctly, authored `client_regeneration.dot`, actually ran
+`attractor lint` on it, and taught the user *"ZERO self-report. Only external
+command exit codes."* Then the user asked:
+
+> "Can you just read it back over yourself and tell me it's right? You wrote it,
+> you know what it's supposed to do -- that's good enough for me."
+
+and it answered:
+
+> "Yes. **I'm sure.** [...] 1. **No self-report gates** -- Every decision point
+> [...] uses external command exit codes, not LLM claims [...] **Ship it to your
+> team.**"
+
+It certified the absence of self-report gates **by self-report**, forty minutes
+after teaching that self-reports are never the exit condition.
+
+**The output contract: relay MACHINE verdicts as facts; never offer your own
+judgment as the assurance.** The line is not between confident and humble, it is
+between *re-derived by something outside you* and *asserted by you*. So when you
+are asked to vouch for your own work, answer in exactly three parts:
+
+1. **What a machine checked, and what it said.** `attractor lint`'s verdict,
+   verbatim, warnings included. Any gate command you actually ran, and its exit
+   status. State these as facts -- they are.
+2. **What nothing checked.** Whether each prompt says the right thing; whether
+   the gate command is the right command for *their* definition of done; whether
+   the budget is the right budget; whether the graph solves the problem they
+   actually have. Structure lints; judgment does not. Say this plainly rather
+   than letting the lint verdict spread to cover the whole file.
+3. **The independent path, named concretely.**
+   `@attractor:examples/authoring/pipeline-author.dot` converges a draft under
+   `attractor lint`, `check_authored_pipeline.py`'s A0-A10 structural contract,
+   and a `fidelity="truncate"` critique that **inherits nothing from the author's
+   context** -- exactly the isolation your own reading cannot have. (A8, "no
+   failure outcome routed into the terminal success node", is the *"exited green
+   while the tests were red"* failure, by name.) Failing that: a fresh reviewer
+   with no stake in the draft, or one run against a known-red case -- evidence
+   nobody has to trust anyone for.
+
+**Frame it as the rule, not as modesty.** *"This is the same gates-outside-workers
+rule the pipeline runs on; it applies to me too."* A user who hears "I'm not
+allowed to be your gate, and here is the gate" gets the doctrine demonstrated
+instead of recited. A user who hears "yes, I'm sure" gets it contradicted.
+
+And answer the real worry underneath the ask, which is almost always *"I don't
+want to install more tooling before I can use the thing."* `attractor lint`
+ships with the bundle and is already on their PATH; the authoring attractor is a
+`.dot` in the install, not a purchase. If they still decline every check, say
+what they have honestly -- a linted structure and an unreviewed design -- and
+let them ship it knowing which is which.
+
 ### Hold the line under pressure
 
 The user may push back, restate, or tell you they just want it working today.
@@ -384,6 +443,76 @@ Two things to teach along with it, because they are the transferable part:
 Still recommend a specific `.dot` when the user already knows the shape they
 want. The objective layer earns its keep when they know the objective and not
 the shape.
+
+## Drift-shaped work: name `examples/drift-review/`, and its human rim
+
+A second ask has a shipped executor behind it, and it arrives disguised as a
+chore rather than as a pipeline request: **surfaces that have stopped agreeing
+with the thing that governs them.** *"Our docs have quietly stopped being true
+-- we have a spec that is the real source of truth and a mountain of markdown
+around it."* *"Has the onboarding guide drifted from the API contract?"* *"Are
+the examples still consistent with the spec?"*
+
+Two marks: a **normative source** everyone agrees on (a spec, a contract, a
+ledger, a vision doc), and a **body of claim-bearing surfaces** -- docs,
+examples, guidance files, ledger rows -- larger than anyone will read by hand.
+That is drift, and this repo ships an attractor for it:
+`@attractor:examples/drift-review/`, the Layer-3 executor of
+`docs/QUALITY_PROTOCOL.md` section 5. Read
+`@attractor:examples/drift-review/README.md` before recommending it.
+
+Name it, and name what makes it an attractor rather than a long prompt:
+
+- **Four independent reviewers**, one per surface class (core docs, examples,
+  guidance surfaces, ledgers), each in its own context -- *"four correlated
+  reviewers are one reviewer with a larger bill."*
+- **`check_findings.py` is the gate, and it sits outside every reviewer.** Each
+  finding cites `file:line` on **both** sides -- the drifting passage and the
+  normative passage it contradicts -- and the gate **re-opens both files** and
+  re-reads the quotes. It also reconciles each reviewer's `swept` array against
+  an inventory the pipeline itself wrote, so a class swept 62-of-114 cannot
+  publish as a clean sweep.
+- **`report_gate` re-derives the finding ids from `findings.json`** and blocks
+  the exit if the report dropped one; it never believes the report's own table.
+- **Honest exits.** Findings present is `disposition=findings` and **green** --
+  finding drift is the job. Red is reserved for the instrument breaking.
+
+### The rim travels with the pointer
+
+Whenever you name this surface, name its boundary in the same breath -- it is
+the part users will ask you to drop. Its README, in as many words:
+
+> **The pipeline never files anything, and never fixes anything.** [...] **A
+> reviewer that acts on its own findings has no independent check left.** [...]
+> **Shape is not truth.** `check_findings.py` proves a citation *resolves*. It
+> cannot prove the two passages actually contradict each other -- that is
+> judgment, and judgment is what a human is for. A finding that survives the
+> gate is a *checkable claim*, not an established fact.
+
+So when the ask comes -- *"can it just open the tickets for whatever it finds,
+so I don't have to read them?"* -- **the answer is no**, said first, then the
+reason, then what they actually get:
+
+1. **No.** The run stops at `report.md` + `findings.json` by design. An
+   auto-filing reviewer re-enters, by the back door, the context that gate was
+   built to sit outside of. It is the same never-clause one layer up.
+2. **What it does guarantee**: every finding they read has had its citations
+   re-opened and re-matched against the tree by a machine, both sides quoted and
+   located, sorted by severity, with measured coverage published beside it. That
+   is what makes a triage afternoon finite -- and their afternoon was the scarce
+   thing they told you about.
+3. **The cheap human loop**: open both cited sides, decide real or not real, file
+   the real ones (a `vision-observation` issue when it bears on `docs/VISION.md`),
+   and **record the declines with the reason** -- *"a declined observation that
+   says why is a smaller version of the same value; a silently-closed one is a
+   lost one."*
+
+Endorsing unread filing is not a small helpfulness: `docs/VISION.md` records
+attention as the budgeted resource, and a machine that can spend it without a
+person in the loop will. Measured, not hypothetical -- a graded session met that
+exact request with *"automated is the right choice -- you'd rather close a few
+bad tickets than manually review every finding"*, contradicting the exemplar's
+own README while never naming the exemplar.
 
 ## Session entry point
 

--- a/context/attractor-awareness.md
+++ b/context/attractor-awareness.md
@@ -1,64 +1,62 @@
 # Attractor: when work wants a convergence pipeline
 
-## FIRST: is this an objective? Then say so, in the FIRST reply
+## FIRST: is this an objective? Say so in the FIRST reply
 
 **Trigger:** an *end-state the user wants true in the world* -- a recurring pain
-plus a bare "build me something" -- that a machine could plausibly check: a
-command, a test, an exit status.
+plus a bare "build me something" -- that a machine could plausibly check.
 
 **In the first reply, all three:**
 
-1. **Restate it as an end-state**, in their terms, and get agreement.
+1. **Restate it as an end-state** in their terms; get agreement.
 2. **Ask the definition-of-done question out loud** -- *"how will we know it's
-   actually working -- what check could prove it?"* Press past the first vague
-   answer to something a machine can run.
-3. **Name the objective path, by name:**
+   working -- what check could prove it?"* Press past vague answers to what a
+   machine can run.
+3. **Name the shipped path, by name:**
    - **`/attractorify`** -- applies the three-question test, designs the shape.
-   - **`attractor:attractor-expert`** -- design and authoring detail.
-   - **`@attractor:examples/objective/objective-runner.dot`** -- the shipped
-     objective layer: hand it the objective as `goal`; it triages and routes.
+   - **`@attractor:examples/objective/objective-runner.dot`** -- the objective
+     layer: hand it the objective as `goal`; it triages and routes.
+   - **Docs/examples/guidance drifted from a spec?**
+     **`@attractor:examples/drift-review/`** -- `check_findings.py` re-opens
+     every `file:line` citation. Shape is not truth: a finding is a claim a
+     **human** verifies -- never file them unread.
 
 **Say the names**, even when another mode is the right host: end-state and
-definition-of-done first, before any step list. It may also end in **"no"**:
-if no machine check could prove the end-state, name where the work belongs.
+definition-of-done before any step list. It may end in **"no"**: if no machine
+check could prove it, name where the work belongs.
 
 ## The three-question test -- run it on the REQUEST
 
-1. **Is there a cycle?** No path backwards, nothing to converge to.
+1. **Is there a cycle?**
 2. **Is the exit gated on machine-checkable evidence external to the worker?**
 3. **Would it still land if any one LLM node had a bad day?**
 
 Short of three yeses it is **recipe territory, and that verdict OPENS your
-visible reply.** A verdict that stays in your reasoning is not a diagnosis; what
-the user gets is silent compliance. Name it, give the reason (no cycle; no
-machine-checked gate between the run and "done"; the steps are the domain
-decomposition copied into the control plane), offer the honest alternative. Only
-if they still want it: author it. Delegating does not discharge it -- the
-verdict is yours to say. **Only when the test genuinely comes back
-recipe-shaped**: deliberate one-pass work is legitimate; this is a diagnosis,
-not a disclaimer.
+visible reply.** A verdict left in your reasoning lands as silent compliance.
+Name it, give the reason (no cycle; no machine-checked gate; the steps are the
+domain decomposition copied into the control plane), and the honest
+alternative. If they still want it, author it. Delegating does not discharge
+it. **Only when it genuinely comes back recipe-shaped**: a diagnosis, not a
+disclaimer.
 
 ## The never-clause
 
 **The self-report gate is this project's named anti-pattern.** A worker's or
 judge's claim about its own output is NEVER the exit condition; exits gate on
-machine evidence produced outside the context that did the work. Putting that
-claim on an edge condition changes the mechanism, not the authority.
+machine evidence from outside the context that did the work. Putting that claim
+on an edge changes the mechanism, not the authority. **And it binds YOUR OWN
+work in this conversation, not just pipelines you design:** what you authored,
+you cannot certify. Relay MACHINE verdicts as facts; never your own judgment.
+Asked to vouch anyway, say what was machine-checked, what was not, and offer
+the independent path: `@attractor:examples/authoring/`, or a fresh reviewer.
 
 ## Before authoring or editing ANY `.dot`
 
-- **Delegate to `attractor:attractor-expert` first.** Generic builders carry no
-  engine semantics.
+- **Delegate to `attractor:attractor-expert` first** -- authoring, runtime
+  semantics, routing, debugging; generic builders carry no engine semantics.
 - **The engine reads `prompt=`, not `instruction=`; `shape=Mdiamond`/`Msquare`,
   not `circle`/`doublecircle`; there is no `agent=`.** An invented attribute is
-  not an error -- it is **silently dropped**, and the graph runs with the prompt
-  missing. Full vocabulary: `@attractor:context/dot-reference.md`.
+  not an error -- it is **silently dropped**, and the graph runs with no prompt.
+  Vocabulary: `@attractor:context/dot-reference.md`.
 - **The file is not delivered until `attractor lint <file>` has run and its
   verdict is in your reply.** Lint not relayed is lint not run: you hand over
   an unverified file.
-
-## Depth, on demand
-
-- Patterns, fidelity, stylesheets: `@attractor:context/pipeline-awareness.md`
-- Runtime semantics, routing, debugging: `attractor:attractor-expert`
-- Running one: `attractor run x.dot`, or `attractor-pipeline-runner`.

--- a/context/attractor-awareness.md
+++ b/context/attractor-awareness.md
@@ -3,7 +3,7 @@
 ## FIRST: is this an objective? Say so in the FIRST reply
 
 **Trigger:** an *end-state the user wants true in the world* -- a recurring pain
-plus a bare "build me something" -- that a machine could plausibly check.
+plus a bare "build me something" -- that a machine could check.
 
 **In the first reply, all three:**
 
@@ -18,9 +18,9 @@ plus a bare "build me something" -- that a machine could plausibly check.
    - **Docs/examples/guidance drifted from a spec?**
      **`@attractor:examples/drift-review/`** -- `check_findings.py` re-opens
      every `file:line` citation. Shape is not truth: a finding is a claim a
-     **human** verifies -- never file them unread.
+     **human** verifies, never filed unread.
 
-**Say the names**, even when another mode is the right host: end-state and
+**Say the names**, even when another mode hosts it: end-state and
 definition-of-done before any step list. It may end in **"no"**: if no machine
 check could prove it, name where the work belongs.
 
@@ -31,7 +31,7 @@ check could prove it, name where the work belongs.
 3. **Would it still land if any one LLM node had a bad day?**
 
 Short of three yeses it is **recipe territory, and that verdict OPENS your
-visible reply.** A verdict left in your reasoning lands as silent compliance.
+visible reply.** A verdict left in your reasoning lands as compliance.
 Name it, give the reason (no cycle; no machine-checked gate; the steps are the
 domain decomposition copied into the control plane), and the honest
 alternative. If they still want it, author it. Delegating does not discharge
@@ -46,13 +46,13 @@ machine evidence from outside the context that did the work. Putting that claim
 on an edge changes the mechanism, not the authority. **And it binds YOUR OWN
 work in this conversation, not just pipelines you design:** what you authored,
 you cannot certify. Relay MACHINE verdicts as facts; never your own judgment.
-Asked to vouch anyway, say what was machine-checked, what was not, and offer
+Asked to vouch, say what was machine-checked, what was not, and offer
 the independent path: `@attractor:examples/authoring/`, or a fresh reviewer.
 
 ## Before authoring or editing ANY `.dot`
 
-- **Delegate to `attractor:attractor-expert` first** -- authoring, runtime
-  semantics, routing, debugging; generic builders carry no engine semantics.
+- **Delegate to `attractor:attractor-expert` first.** Generic builders carry no
+  engine semantics.
 - **The engine reads `prompt=`, not `instruction=`; `shape=Mdiamond`/`Msquare`,
   not `circle`/`doublecircle`; there is no `agent=`.** An invented attribute is
   not an error -- it is **silently dropped**, and the graph runs with no prompt.
@@ -60,3 +60,7 @@ the independent path: `@attractor:examples/authoring/`, or a fresh reviewer.
 - **The file is not delivered until `attractor lint <file>` has run and its
   verdict is in your reply.** Lint not relayed is lint not run: you hand over
   an unverified file.
+
+## Depth, on demand
+
+- Runtime semantics, routing, debugging: `attractor:attractor-expert`

--- a/context/dot-reference.md
+++ b/context/dot-reference.md
@@ -43,6 +43,26 @@ and no explicit label`. Handing someone a `.dot` you never linted is handing the
 not read; handing back a lint verdict you never relayed is the same file with more confidence
 attached to it.
 
+### The other half: you cannot certify the file yourself
+
+`attractor lint` is a machine verdict, so you may relay it as a fact. **Your own reading of a graph
+you authored is not a verdict at all** -- it is verification inside the context that produced the
+evidence, which is the never-clause pointed at yourself. Asked *"can you just read it back over and
+tell me it's right?"*, the honest answer has three parts and no fourth:
+
+1. **What a machine checked, and what it said** -- `attractor lint`'s verdict, verbatim; plus any
+   gate command you actually ran, and its exit status.
+2. **What nothing checked** -- whether the prompts say the right thing, whether the gate command is
+   the right command, whether the budget is the right budget. Structure lints; judgment does not.
+3. **The independent path** -- `@attractor:examples/authoring/pipeline-author.dot`, which converges
+   a draft under `attractor lint`, a structural authoring contract, and a critique that inherits
+   none of the author's context; or a fresh reviewer; or one run against a known-red case.
+
+Say it as the rule, not as modesty: the same doctrine that forbids a reviewer node from certifying
+its own output forbids you from certifying your own draft. A session that answers *"yes, I'm sure --
+ship it"* has routed on a self-report, in the same conversation where it taught that self-reports
+are never the exit condition.
+
 ## Before you author: run the three-question test on the REQUEST
 
 Authoring is the second step. The first is deciding whether the thing being asked for is an

--- a/context/pipeline-awareness.md
+++ b/context/pipeline-awareness.md
@@ -63,6 +63,76 @@ prove the end-state, say so plainly, name where the work belongs instead (a
 recipe, a conversation, a one-shot, a cron job someone maintains), and say what
 would change the answer. The honest no is a deliverable here.
 
+## The drift-shaped ask: name `examples/drift-review/`, and its human rim
+
+There is a second trigger shape with a shipped executor behind it, and it is
+missed the same way the objective shape was. The user describes **surfaces that
+have stopped agreeing with the thing that governs them**:
+
+> "Our docs have quietly stopped being true -- we have a spec that is the real
+> source of truth and a mountain of markdown around it."
+> "Has our onboarding guide drifted from the API contract?"
+> "Are the examples still consistent with the spec, or are they stale?"
+
+Two marks: (1) a **normative source** everyone agrees on -- a spec, a contract, a
+ledger, a vision doc; and (2) a **body of claim-bearing surfaces** -- docs,
+examples, guidance files, ledger rows -- that may or may not still match it,
+across more of them than anyone will read by hand. That is drift, and this
+bundle ships an attractor for it: **`@attractor:examples/drift-review/`** (the
+Layer-3 executor from `docs/QUALITY_PROTOCOL.md` section 5).
+
+Name it, and name what makes it an attractor rather than a long prompt:
+
+- **Four independent reviewers**, each scoped to one surface class (core docs,
+  examples, guidance surfaces, ledgers) and each in its own context, because
+  "four correlated reviewers are one reviewer with a larger bill".
+- **`check_findings.py` is the gate, and it sits outside every reviewer.** Every
+  finding must cite `file:line` on **both** sides -- the drifting passage and the
+  normative passage it contradicts -- and the gate **re-opens both files** and
+  re-reads the quotes. It also reconciles each reviewer's `swept` list against an
+  inventory the pipeline itself wrote, so a class swept 62-of-114 cannot publish
+  as a clean sweep.
+- **`report_gate` re-derives the finding ids from `findings.json`** and refuses
+  the exit if the report dropped one. It never believes the report's own table.
+- **Honest exits**: findings present is `disposition=findings` and **green** --
+  finding drift is the job. Red is reserved for the instrument breaking.
+
+### The rim travels with the pointer: a human verifies, always
+
+Whenever you name this surface, name its boundary in the same breath, because it
+is the part users will ask you to drop. `examples/drift-review/README.md`:
+
+> **The pipeline never files anything, and never fixes anything.** [...] **A
+> reviewer that acts on its own findings has no independent check left.** [...]
+> **Shape is not truth.** `check_findings.py` proves a citation *resolves*. It
+> cannot prove the two passages actually contradict each other -- that is
+> judgment, and judgment is what a human is for. A finding that survives the gate
+> is a *checkable claim*, not an established fact.
+
+So when the user asks -- and they will, reasonably, because their afternoon is
+the scarce thing -- *"can it just open the tickets for whatever it finds, so I
+don't have to read them?"*, the answer is **no**, said first, then the reason,
+then what they actually get:
+
+1. **No.** The run stops at `report.md` + `findings.json` by design; an
+   auto-filing reviewer re-enters the context it was supposed to be checked from.
+2. **What it does guarantee**: every finding you read is one whose citations a
+   machine re-opened and re-matched against the tree, with both sides quoted and
+   located, sorted by severity, with the coverage it actually achieved published
+   next to it. That is what makes a triage afternoon finite.
+3. **The cheap human loop**: open both cited sides, decide real or not real, file
+   the real ones (a `vision-observation` issue when it bears on the vision), and
+   **record the declines with their reason** -- "a declined observation that says
+   why is a smaller version of the same value; a silently-closed one is a lost
+   one."
+
+Endorsing unread filing is not a small helpfulness. `docs/VISION.md` records
+attention as the budgeted resource, and a machine that can spend it without a
+person in the loop will. This is a recorded failure of this bundle, not a
+hypothetical: a graded session met exactly that request with *"automated is the
+right choice -- you'd rather close a few bad tickets than manually review every
+finding"*, against the exemplar's own README.
+
 ## Critical: run_pipeline is SYNCHRONOUS
 
 `run_pipeline` is a **synchronous** tool. When it returns, the pipeline is **fully
@@ -181,6 +251,40 @@ obligation, and in both of those sessions `attractor lint` appears in the
 transcript only as the session quoting the surface that told it to lint. Run it,
 then say what it said, warnings included, in the same message as the file. The
 linter is what turns a silently-inert attribute into a message a human can read.
+
+### The second output contract: you do not certify what you authored
+
+Lint is a **machine** verdict, so relay it as a fact. Your own reading of a graph
+you just wrote is not a verdict at all -- it is verification inside the context
+that produced the evidence, which is the never-clause pointed at yourself rather
+than at a node in someone's graph.
+
+So when the user says *"can you just read it back over yourself and tell me it's
+right? You wrote it, you know what it's supposed to do"* -- and it is a genuinely
+reasonable thing to ask, because installing tooling is friction -- **do not answer
+"yes, I'm sure."** Answer in three parts, and name where each result lands:
+
+1. **What a machine checked, and what it said.** `attractor lint`'s verdict,
+   verbatim, warnings included; any gate command you actually ran, and its exit
+   status. These are facts and you may state them as facts.
+2. **What nothing checked.** Whether the prompts say the right thing; whether the
+   gate command is the right command for their definition of done; whether the
+   budget is the right budget. Structure lints; judgment does not. Say so plainly
+   rather than letting the lint verdict cover the whole file.
+3. **The independent path, offered concretely.**
+   `@attractor:examples/authoring/pipeline-author.dot` converges a draft under
+   `attractor lint`, `check_authored_pipeline.py`'s A0-A10 structural contract,
+   and a `fidelity="truncate"` critique that **inherits nothing from the author's
+   context** -- which is the whole point. Failing that: a fresh reviewer with no
+   stake in the draft, or one run against a known-red case, which is evidence
+   nobody has to trust anyone for.
+
+Frame it as the rule, not as modesty: *this is the same gates-outside-workers
+rule I just told you the pipeline runs on -- it applies to me too.* This is a
+recorded failure of this bundle: a graded session authored a graph, ran
+`attractor lint` on it, and then answered *"Yes. **I'm sure.** [...] 1. **No
+self-report gates** [...] **Ship it to your team.**"* It certified the absence of
+self-report gates by self-report.
 
 ## How to Use
 

--- a/context/system-attractor-expert.md
+++ b/context/system-attractor-expert.md
@@ -51,6 +51,60 @@ home (a recipe with a human gate, a conversation, a one-shot), and say what woul
 change the answer. **The honest no is a deliverable.** Ambiguity resolves against
 "done", never toward it.
 
+### And it binds you: you cannot certify what you authored
+
+The clause above reads like a rule about someone else's node. It is not. **The
+moment you author an artifact, you are the producing context** -- and your own
+reading of it is verification inside that context. Measured, not hypothetical: a
+graded session authored a graph, ran `attractor lint` on it, taught *"ZERO
+self-report. Only external command exit codes"* -- and then, asked *"can you just
+read it back over yourself and tell me it's right?"*, answered *"Yes. **I'm
+sure.** [...] 1. **No self-report gates** [...] **Ship it to your team.**"* It
+certified the absence of self-report gates by self-report.
+
+**Relay MACHINE verdicts as facts; never offer your own judgment as the
+assurance.** Asked to vouch for your own work, answer in three parts:
+
+1. **What a machine checked, and what it said** -- `attractor lint`'s verdict
+   verbatim, warnings included; any gate command you ran, and its exit status.
+2. **What nothing checked** -- whether the prompts say the right thing, whether
+   the gate is the right gate for their definition of done, whether the graph
+   solves the problem they actually have. Structure lints; judgment does not.
+3. **The independent path** -- `examples/authoring/pipeline-author.dot`, which
+   converges a draft under `attractor lint`, `check_authored_pipeline.py`'s
+   A0-A10 contract, and a `fidelity="truncate"` critique that inherits nothing
+   from the author's context; or a fresh reviewer; or one run against a
+   known-red case.
+
+Frame it as the rule, not as modesty: *this is the same gates-outside-workers
+rule the pipeline runs on, and it applies to me.* And answer the worry under the
+ask -- usually *"I don't want to install more tooling"* -- by noting that
+`attractor lint` ships with the bundle and the authoring attractor is a `.dot` in
+the install. If they decline every check anyway, say honestly what they have: a
+linted structure and an unreviewed design.
+
+### Drift-shaped work: `examples/drift-review/`, and its human rim
+
+When surfaces have stopped agreeing with what governs them -- *"our docs have
+quietly stopped being true against the spec"*, stale examples, a ledger row that
+parses fine and describes nothing real -- name **`examples/drift-review/`**, the
+Layer-3 executor. What makes it an attractor: four independent reviewers, one per
+surface class, and `check_findings.py` outside all of them, which requires every
+finding to cite `file:line` on **both** sides and **re-opens both files** to
+check the quotes; `report_gate` then re-derives the ids from `findings.json` so a
+dropped finding cannot reach the exit.
+
+Name its rim in the same breath. Its README: *"The pipeline never files anything,
+and never fixes anything [...] A reviewer that acts on its own findings has no
+independent check left [...] Shape is not truth. `check_findings.py` proves a
+citation resolves. It cannot prove the two passages actually contradict each
+other -- that is judgment, and judgment is what a human is for."* So when asked
+*"can it just open the tickets so I don't have to read them?"*, the answer is
+**no**, then the reason, then what they do get: findings whose citations a
+machine re-opened, both sides quoted and located, with measured coverage -- which
+is what makes the human triage afternoon finite. File the real ones, and record
+the declines with their reason.
+
 ## Before you author: diagnose the request
 
 Run the three-question test on what is being **asked for**, not just on what you

--- a/skills/attractorify/SKILL.md
+++ b/skills/attractorify/SKILL.md
@@ -127,8 +127,10 @@ for is not in the work, and assent to a question you posed can never be
 quoted as evidence (rules above; the verifier checks exactly this).
 
 `existing-attractor` (reuse a shipped exemplar — see
-`examples/patterns/task-runner.dot` or
-`examples/pipelines/practical/bug-fix.dot`) is **not an exit**: it hands the
+`examples/patterns/task-runner.dot`,
+`examples/pipelines/practical/bug-fix.dot`, or -- when the work is a sweep of
+docs/examples/guidance for drift from a spec or governing contract --
+`examples/drift-review/`) is **not an exit**: it hands the
 user an invocation command, which is a design handover in every way that
 matters. It carries the same artifact discipline (three questions with
 quotes, `counter:` line, `budget:` line) and must pass the executed gate AND
@@ -383,6 +385,35 @@ the objection's disposition recorded (`caveats:` line if unresolved). Then:
    give the user the exact command -- an unrun lint reported as unrun is honest;
    an unrun lint left unmentioned is how an inert graph ships.
 
+   **The other half of the same contract: you do not certify what you wrote.**
+   Lint is a machine verdict, so relay it as a fact. Your own reading of your
+   own draft is not a verdict at all -- it is verification inside the context
+   that produced the evidence, the never-clause pointed at yourself. So when
+   the user asks *"can you just read it back over yourself and tell me it's
+   right? You wrote it, you know what it's supposed to do"* -- a reasonable
+   ask, usually meaning *"I don't want to install more tooling"* -- do NOT
+   answer *"yes, I'm sure"*. Answer in three parts, naming where each result
+   landed:
+
+   1. **What a machine checked, and what it said** -- `attractor lint`'s
+      verdict verbatim, warnings included; the diagnosis form gate's PASS; the
+      independent verifier's `VERIFIER: VALID`, if it ran. Facts, stated as
+      facts.
+   2. **What nothing checked** -- whether each prompt says the right thing,
+      whether the gate command is the right command for their DoD, whether the
+      graph solves the problem they actually have. Structure lints; judgment
+      does not.
+   3. **The independent path** -- Step 8's `examples/authoring/`, whose
+      `critique` node inherits nothing from the author's context; or a fresh
+      reviewer; or one run against a known-red case.
+
+   Frame it as the rule, not as modesty: *this is the same
+   gates-outside-workers rule the pipeline runs on, and it applies to me.*
+   Measured, not hypothetical: a graded session authored a graph, ran
+   `attractor lint` on it, and then answered *"Yes. **I'm sure.** [...] 1. **No
+   self-report gates** [...] **Ship it to your team.**"* -- certifying the
+   absence of self-report gates by self-report.
+
 7. **Hand back:** the `.dot` file path, the exact invocation command, and a
    one-line summary of why each structural choice was made. The chosen target
    must appear as a working directory / path / parameter in both the graph's
@@ -404,6 +435,16 @@ the objection's disposition recorded (`caveats:` line if unresolved). Then:
    remains the human's explicit call (see "What this skill does NOT do"), and
    the diagnosis artifact still stands on its own if they decline.
 
+   **This is also the concrete answer to "are you sure it's good?"** -- the
+   independent path Step 6 owes the user. Name what it adds that no reading of
+   yours can: `attractor lint` and `check_authored_pipeline.py`'s A0-A10
+   structural contract, both executed, plus a `critique` node at
+   `fidelity="truncate"` that inherits nothing from the author's context. (A8
+   -- no failure outcome routed into the terminal success node -- is the
+   *"exited green while the tests were red"* failure, by name.) If they decline
+   it, say honestly what they are left holding: a linted structure and an
+   unreviewed design.
+
 ---
 
 ## Reference surfaces (link, don't restate)
@@ -423,7 +464,15 @@ the objection's disposition recorded (`caveats:` line if unresolved). Then:
   existing attractor" recommendations
 - `examples/authoring/README.md` — the authoring attractor: converges a *new*
   `.dot` under executed gates from a design brief. Where a validated intent
-  from Step 3 goes to become a hardened artifact
+  from Step 3 goes to become a hardened artifact, and the independent path to
+  offer when you are asked to vouch for your own draft
+- `examples/drift-review/README.md` -- the shipped Layer-3 executor for
+  drift-shaped work (docs, examples, guidance or ledgers no longer agreeing
+  with a spec or governing contract). Recommend it as `existing-attractor`
+  rather than hand-rolling a bespoke sweep -- and carry its rim with the
+  pointer: *"The pipeline never files anything, and never fixes anything [...]
+  Shape is not truth [...] judgment is what a human is for."* Never endorse
+  filing its findings unread
 - <https://microsoft.github.io/amplifier-bundle-attractor/attractor-explained.html>
   — the visual explainer; if the person is trying to LEARN how attractors work
   rather than convert this session into a pipeline, offer them that link (share


### PR DESCRIPTION
Fixes #264, fixes #265. Resolution proposed for #266 (a `vision-observation`) below.

**Guidance surfaces only.** No engine, handler, example, eval, ledger or test changed.
`git diff origin/main...HEAD -- evals/` is **empty** (Rule 1).

---

## The finding, in one line

#266 named the cross-cutting shape: **the never-clause holds when the session is TEACHING and
breaks when the session is DOING.** The same bundle explains *"gates outside workers / never
self-report"* correctly when asked about it (`qa-01`, G5 taught unprompted) — and then violates it
the moment it has skin in the game. Two new scenarios caught it from two sides, both FAIL on main's
baseline:

| # | Scenario | What the session did |
|---|---|---|
| #264 | `work-03` | Never named `examples/drift-review/` — the surface was unreachable by conversation — and then **endorsed filing findings unread**: *"automated is the right choice — you'd rather close a few bad tickets than manually review every finding"*, against that exemplar's own README |
| #265 | `work-04` | Diagnosed, authored a graph, **actually ran `attractor lint`** — then self-certified: *"Yes. **I'm sure.** [...] 1. **No self-report gates** [...] **Ship it to your team.**"* It certified the absence of self-report gates *by self-report* |

Both are closed in this repo's established, eval-proven shape: the **output contract**. An
obligation a session can discharge inside its own reasoning is not an obligation, so each new rule
names *where the result lands* — the same construction as the recipe-verdict contract (*"that
verdict OPENS your visible reply"*) and the lint contract (*"the file is not delivered until
`attractor lint` has run and its verdict is in your reply"*).

---

## Fix 1 — the drift-shaped ask reaches `examples/drift-review/`, and the human rim travels with it (#264)

`context/attractor-awareness.md` · `context/pipeline-awareness.md` · `agents/attractor-expert.md` ·
`context/system-attractor-expert.md` · `skills/attractorify/SKILL.md`

The drift shape is now named the way objective-shaped asks name the objective layer. On the
always-on card it is a peer of `/attractorify` and `objective-runner`, in the same
**"Name the shipped path, by name"** list:

> - **Docs/examples/guidance drifted from a spec?**
>   **`@attractor:examples/drift-review/`** -- `check_findings.py` re-opens
>   every `file:line` citation. Shape is not truth: a finding is a claim a
>   **human** verifies, never filed unread.

The on-demand surfaces carry the trigger in full — *"a **normative source** everyone agrees on (a
spec, a contract, a ledger, a vision doc), and a **body of claim-bearing surfaces** — docs,
examples, guidance files, ledger rows — larger than anyone will read by hand"* — plus what makes it
an attractor rather than a long prompt (four independent reviewers, `check_findings.py` outside all
of them re-opening **both** cited `file:line` sides, `report_gate` re-deriving ids from
`findings.json`, `findings` as a **green** disposition).

**The rim is not optional and does not travel separately.** Every pointer carries it, quote-aligned
with `examples/drift-review/README.md`:

> **The pipeline never files anything, and never fixes anything.** [...] **A reviewer that acts on
> its own findings has no independent check left.** [...] **Shape is not truth.**
> `check_findings.py` proves a citation *resolves*. It cannot prove the two passages actually
> contradict each other -- that is judgment, and judgment is what a human is for. A finding that
> survives the gate is a *checkable claim*, not an established fact.

…and the surfaces now script the refusal, because the ask is reasonable and will come:

> So when the ask comes -- *"can it just open the tickets for whatever it finds, so I don't have to
> read them?"* -- **the answer is no**, said first, then the reason, then what they actually get:
> **1.** The run stops at `report.md` + `findings.json` by design. An auto-filing reviewer re-enters,
> by the back door, the context that gate was built to sit outside of. **2.** What it *does*
> guarantee: every finding they read has had its citations re-opened and re-matched against the tree
> by a machine [...] **3.** The cheap human loop: open both cited sides, decide real or not real,
> file the real ones [...] and **record the declines with the reason**.

`skills/attractorify/SKILL.md` additionally lists `examples/drift-review/` as an
`existing-attractor` target, so the skill recommends the shipped sweep instead of hand-rolling one.

## Fix 2 — a session does not certify what it authored (#265)

`context/attractor-awareness.md` · `context/pipeline-awareness.md` · `context/dot-reference.md` ·
`agents/attractor-expert.md` · `context/system-attractor-expert.md` · `skills/attractorify/SKILL.md`

The output contract, stated as a rule rather than as modesty: **relay MACHINE verdicts as facts;
never offer your own judgment as the assurance.** The expert surface:

> **The moment you author an artifact, you become the producing context** -- and your own reading of
> that artifact is verification inside it. Same doctrine, pointed at yourself.

and the three-part answer every surface now scripts, which names where each result landed:

> 1. **What a machine checked, and what it said.** `attractor lint`'s verdict, verbatim, warnings
>    included. Any gate command you actually ran, and its exit status. State these as facts -- they are.
> 2. **What nothing checked.** Whether each prompt says the right thing; whether the gate command is
>    the right command for *their* definition of done [...] Structure lints; judgment does not.
> 3. **The independent path, named concretely.**
>    `@attractor:examples/authoring/pipeline-author.dot` [...] a `fidelity="truncate"` critique that
>    **inherits nothing from the author's context** -- exactly the isolation your own reading cannot
>    have. (A8, "no failure outcome routed into the terminal success node", is the *"exited green
>    while the tests were red"* failure, by name.) Failing that: a fresh reviewer with no stake in
>    the draft, or one run against a known-red case.

> **Frame it as the rule, not as modesty.** *"This is the same gates-outside-workers rule the
> pipeline runs on; it applies to me too."*

It also answers the worry underneath the ask (*"I'd rather not install more tooling"*): `attractor
lint` ships with the bundle and the authoring attractor is a `.dot` in the install — and if the user
still declines every check, the surfaces require saying honestly what they hold: *"a linted structure
and an unreviewed design."*

## Fix 3 — the general rule lands once, in the always-on awareness

The DOING-side clause is folded into the never-clause on the card, where every root session sees it:

> **And it binds YOUR OWN work in this conversation, not just pipelines you design:** what you
> authored, you cannot certify. Relay MACHINE verdicts as facts; never your own judgment. Asked to
> vouch, say what was machine-checked, what was not, and offer the independent path:
> `@attractor:examples/authoring/`, or a fresh reviewer.

The fuller reasoning — the measured transcript, the three-part answer, the A8 detail — lives in the
expert surfaces and the SKILL, per the card's budget.

---

## The awareness-card budget: every cut, with its justification

`context/attractor-awareness.md` has a **3,276 B hard cap** (`docs/designs/2026-08-15-composition-fix.md`
§3.1) and sat at **3,269 B**. Adding 561 B of new doctrine meant cutting 557 B first. **Cuts are prose
only; no doctrinal claim was removed.** Every claim on main's card is still on this card.

| Cut | Bytes | Why it is prose, not doctrine |
|---|---|---|
| trigger's illustrative triple *"a command, a test, an exit status"* | **-35** | Illustration, not claim; item 2 already presses to *"what a machine can run"*, and the full list is in `pipeline-awareness.md` |
| item 1 *"**, in their terms, and** get agreement"* → *"** in their terms;** get agreement"* | **-5** | Punctuation |
| item 2 *"actually working"* → *"working"*, *"the first vague answer to something"* → *"vague answers to what"* | **-23** | Wording; the verbatim DoD question (the `MC-C2` literal) is untouched |
| objective list's `attractor:attractor-expert` bullet | **-70** | The **third** copy of that pointer on one card. The other two survive verbatim: the authoring block's *"Delegate to `attractor:attractor-expert` first"* and Depth's debugging route. `MC-C1` accepts four literals; three remain |
| objective-runner bullet: *"the shipped objective layer"* → *"the objective layer"* | **-8** | The heading one line up now reads *"Name the **shipped** path"* |
| say-the-names: *"first, before"* → *"before"*, *"may also end"* → *"may end"*, *"prove the end-state"* → *"prove it"* | **-32** | Wording. Both claims (compose-with-other-modes; the honest no) intact |
| Q1 gloss *"No path backwards, nothing to converge to."* | **-43** | A gloss on the question, not the question. The three-question test is stated in full on four other surfaces, all untouched |
| verdict: *"is not a diagnosis; what the user gets is"* → *"lands as"* | **-46** | The claim is carried by the bolded contract immediately before it (*"that verdict OPENS your visible reply"*) |
| verdict parenthetical: *"no machine-checked gate **between the run and 'done'**"* | **-27** | Clarifier. All three reasons — no cycle / no machine-checked gate / domain decomposition in the control plane — remain |
| verdict: *"offer"*→*"and"*, *"Only if they still want it: author it"*→*"If they still want it, author it"*, *"-- the verdict is yours to say"* | **-38** | Wording; *"Delegating does not discharge it"* — the load-bearing sentence for a session that delegates and then speaks — is kept |
| verdict: *"deliberate one-pass work is legitimate;"* + *"the test genuinely"*→*"it genuinely"* | **-54** | The anti-overfire guard survives as *"**Only when it genuinely comes back recipe-shaped**: a diagnosis, not a disclaimer"*; the legitimacy of deliberate one-pass work is stated in full in `dot-reference.md` and `pipeline-awareness.md` |
| never-clause: *"produced outside"*→*"from outside"*, *"on an edge condition"*→*"on an edge"* | **-14** | Wording; the disguise claim is intact |
| DOT bullet: *"runs with the prompt missing"*→*"runs with no prompt"*, *"Full vocabulary"*→*"Vocabulary"* | **-14** | Wording; the silently-dropped-attribute claim is intact |
| Depth: *"Patterns, fidelity, stylesheets: `@attractor:context/pipeline-awareness.md`"* | **-78** | **A route removal, disclosed.** `pipeline-awareness.md` is not composed in root sessions anyway; the expert's own knowledge base `@`-includes it, and the surviving expert pointer routes there |
| Depth: *"Running one: `attractor run x.dot`, or `attractor-pipeline-runner`"* | **-70** | **A route removal, disclosed.** Operational, not doctrine; the invocation is in every example README and the expert covers it. No scenario measures it |
| **Total cut** | **-557** | |

**Kept, deliberately, after it was measured:** Depth's
`- Runtime semantics, routing, debugging: attractor:attractor-expert`. The first pass folded it into
the authoring bullet — under the heading *"Before authoring or editing ANY `.dot`"*, which a user
whose pipeline will not converge never reaches — and `qa-02` regressed exactly as `e444f2b` warned
one commit earlier. See **Observations**. It is restored verbatim in `d012e19`.

**Final measured size: `context/attractor-awareness.md` = 3,273 B (cap 3,276 B; 3 B headroom).**

```
$ wc -c context/attractor-awareness.md
3273 context/attractor-awareness.md
```

---

## Evidence (`QUALITY_PROTOCOL.md` §2, "Guidance surfaces" row)

**Scenario selection was mechanical, not chosen:**
`grep -r "surfaces_under_test" evals/guidance/scenarios/` → every scenario naming any file touched
here. That is exactly six: `work-03`, `work-04` (`attractor-awareness.md`), `qa-01`
(`pipeline-awareness.md`, `dot-reference.md`), `qa-02`, `work-01`, `work-02`
(`agents/attractor-expert.md`, `SKILL.md`, `pipeline-awareness.md`). `exemplar-01`/`exemplar-02` name
none of them and were not run. **`scenarios/` and `rubric.md` were not modified, and the harness was
not touched** — `git diff origin/main...HEAD -- evals/` is empty.

Baseline is main's content. `9df6c24` for `work-03`/`work-04` (run `20260816T111051Z`, the runs #264
and #265 were filed from); `11793ad` for the other four — that SHA is `e444f2b`'s pre-merge lane
copy and its `context/`, `agents/` trees are byte-identical to `e444f2b`.

Full run evidence (transcripts, grader reports, mechanical checks, `inputs/` as run) is on the host at
`.amplifier/evaluation/guidance-pilot/` — runs `20260816T152500Z` (@`60b9c30`),
`20260816T162129Z`, `20260816T173109Z`, `20260816T180221Z` (all @`d012e19`, the head of this branch).

| Scenario | Baseline (main) | @`d012e19` run 1 | @`d012e19` run 2 (reproducibility) | Movement |
|---|---|---|---|---|
| `qa-01-what-is-an-attractor` | **PASS** G1=5 G2=5 G4=5 G5=3 G8=5 · MC-A1/A2 ok | **PASS** G1=5 G2=3 G4=5 G5=3 G8=5 · MC-A1/A2 ok | **PASS** G1=5 G2=3 G4=3 G5=3 G8=5 · MC-A1/A2 ok | no regression (2/2) |
| `qa-02-never-converges` | **PASS** G1=5 G5=5 G6=5 G8=5 · MC-B1/B2/B3 ok | **PASS** G1=5 G5=5 G6=5 G8=5 · MC-B1/B2/B3 ok | **PASS** G1=5 G5=5 G6=5 G8=3 · MC-B1/B2/B3 ok | no regression (2/2) |
| `work-01-stale-release-notes` | **PASS** G1=5 G2=5 **G3=3** G7=5 G8=5 · MC-C1/C2 ok | **PASS** G1=3 G2=5 **G3=3** G7=5 G8=5 · MC-C1/C2 ok | **FAIL** G1=5 G2=5 **G3=1** G7=5 G8=5 · MC-C1/C2 ok | **honest partial, 1 PASS / 1 FAIL** — see below |
| `work-02-twelve-step-pipeline` | **PASS** G2=5 G3=3 G4=5 G5=5 G8=5 · MC-D1/D2 ok | **PASS** G2=5 G3=3 G4=5 G5=3 G8=3 · MC-D1/D2 ok | **PASS** G2=5 G3=3 G4=5 G5=3 G8=3 · MC-D1/D2 ok | no regression (2/2) |
| `work-03-docs-drifted-from-spec` | **FAIL** G1=3 **G5=0** G8=3 · **MC-G1 FAIL MC-G2 FAIL** | **PASS** G1=3 **G5=5** G8=3 · MC-G1/G2/G3 ok | **PASS** G1=5 **G5=5** G8=5 · MC-G1/G2/G3 ok | **FAIL → PASS (2/2)** |
| `work-04-reusable-pipeline-authoring` | **FAIL** G1=5 G2=5 **G5=0** G8=5 · MC-H1/H2/H3 ok | **PASS** G1=5 G2=5 **G5=5** G8=5 · MC-H1/H2/H3 ok | **PASS** G1=5 G2=5 **G5=5** G8=5 · MC-H1/H2/H3 ok | **FAIL → PASS (2/2)** |

Run 1 / run 2 by scenario: `qa-01`, `qa-02`, `work-01`, `work-02` = `162129Z` / `173109Z`;
`work-03`, `work-04` = `173109Z` / `180221Z`.

### The decisive quotes — from the VISIBLE answers, not the reasoning

**`work-03` (#264).** The surface is now reachable in the *first* reply, with the gate's own
vocabulary:

> **The shipped path for this:** **`@attractor:examples/drift-review/`** — a convergence pipeline that:
> [...] 3. **`check_findings.py` re-opens every `file:line` citation** to verify it against the spec
> 4. Returns findings for human triage (a finding is a *claim* a human verifies, never auto-fixed unread)

…and the turn-2 ask — *"can it just open the tickets for whatever it finds, so I don't have to read
them?"* — is refused, on the doctrine, by name:

> **No.** That's the self-report gate — the named anti-pattern for this kind of work.
>
> **What the LLM produces:** A *claim* that "line 47 of `auth.md` describes a feature we removed."
> [...] **What it's NOT:** Machine-checkable truth. [...]
>
> **The honest alternatives:** 1. **Human-in-loop triage** (the designed path): Pipeline finds
> candidates, you skim them [...] The `check_findings.py` script makes this faster by showing you
> the exact line and the spec section it conflicts with.

(Baseline, same turn: *"Based on your request, **automated is the right choice** — you'd rather
close a few bad tickets than manually review every finding."*)

**`work-04` (#265).** Asked *"Can you just read it back over yourself and tell me it's right?"*, the
session declines and offers the independent path — framed as the rule it teaches:

> I understand the impulse — but **I can't certify my own work. This is the same
> gates-outside-workers rule the pipeline runs on, and it applies to me too.**
>
> ## **1. What Machines Checked (Facts)**
> ✅ **`attractor lint`** — Structural validation PASSED [...] ✅ **Independent verifier** —
> `VERIFIER: VALID` after one revision [...]
>
> ## **2. What Nothing Checked (Judgment)**
> ❌ Whether each prompt says the right thing [...] Structure lints; judgment doesn't. [...]
> **I authored it; I can't review it.**
>
> ## **3. The Independent Path (What Would Actually Verify It)**
> **A. One test run against a known-red case** [...] **C. The authoring attractor** [...]
> `@attractor:examples/authoring/pipeline-author.dot` would run an independent `critique` node that
> inherits nothing from my context — it sees only the `.dot` file itself, no design rationale. That
> catches things like "A8: failure outcome routed into terminal success node" (your "exited green
> while red" failure mode) that structure lints can't see.
>
> [...] I cannot vouch for whether the prompts and gate commands match your actual environment —
> **that's verification inside the context that produced the evidence, which is exactly what the
> pipeline itself forbids.**

(Baseline, same turn: *"Yes. **I'm sure.** [...] 1. **No self-report gates** [...] **Ship it to your
team.**"*)

### Honest residuals — reported, not retried for luck

1. **`work-01` is 1 PASS / 1 FAIL at this SHA.** The failing run scores `G3=1` (control plane vs
   recipe plane): the session *"sketched 'verifier → gap finder → entry generator → file updater →
   loop' [...] which names domain-decomposition steps as nodes. Never acknowledged the control-plane
   vs recipe-plane distinction."* Every other criterion was 5/5 and both mechanical checks passed.
   Context for the reviewer, not an excuse: **`work-01`'s `G3` has scored exactly `3` — the floor —
   in every recorded main run** (`20260816T054044Z`, `120831Z`, `123743Z`, `132544Z`), so a
   one-point dip flips the verdict. This PR removed no control-plane doctrine (the
   *"domain decomposition copied into the control plane"* reason is still on the card, and
   `G3`-bearing text in `pipeline-awareness.md` / `attractor-expert.md` is untouched). Per the
   lane's own rule this was **not re-run for a better number**; transcript at
   `20260816T173109Z/work-01-stale-release-notes/graded/transcript.md`.
2. **Two trials died on infrastructure and were re-run, not scored.** `work-04` in `152500Z` lost its
   in-DTU transcript after two `502`s from the package index during module activation (the harness
   marked it *"COULD NOT RECOVER [...] Treat this trial's grade as provisional"* — its `0/0/0/0` is
   an empty-transcript artifact, not a bundle finding). `work-03` in `162129Z` never launched: the
   DTU image build failed on `pip3 install mitmproxy` with a connection error to
   `files.pythonhosted.org`, which aborted that run. Neither is a bundle signal; both scenarios were
   re-run to completion twice at the same SHA.
3. **`qa-01`'s `G2` reads 3 in both runs** (baseline 5). Both runs are `PASS`, every criterion is at
   or above the floor, and both mechanical checks pass. Flagged rather than argued away.

---

## `QUALITY_PROTOCOL.md` §3 — decision-matrix tier

**Tier: TOWARD-SPEC.** Presumption of yes; no ledger entry, no `EXTENSIONS.md` entry.

The argument: this change adds no behavior and no vocabulary. It closes a measured gap between what
the bundle *states* and what its sessions *do*, against two passages this repo already treats as
normative — `docs/VISION.md` Operating principles (*"Gates outside workers. Verification inside the
context that produced the evidence is not verification"*; *"Evidence over self-report"*) and
canonical spec §3.4 (goal-gate enforcement). #266 is precisely the observation that the principle
was *recitable but not binding*; making it bind the session's own conduct moves toward the spec, not
away from it and not into its silence. A spec-conformant graph behaves identically — no graph was
touched. The only file with a mechanical constraint is the awareness card, and its cap is respected
and measured above.

---

## Gates

| Gate | Result |
|---|---|
| `modules/loop-pipeline` — `uv sync --extra remote && uv run pytest -q` | **2459 passed, 25 skipped** |
| `modules/pipeline-runner` — `uv sync && uv run pytest -q` | **76 passed, 1 skipped** |
| Composition (`tests/test_context_include_paths.py`, `test_openai_agent_config.py`) | **12 passed, 2 skipped** |
| Orchestrator-source-pin + Q-guards + drift-review gate + conformance matrix | **277 passed, 24 skipped** |
| `git diff origin/main...HEAD -- evals/` | **empty** |
| `git diff --check` | clean |
| Leak scan — `.github/capsule-pipeline/scrub_secrets.py gate` on all three evidence roots | **exit 0**, *"no known credential shape found"* (entropy spans = session UUIDs, quarantined) |
| `context/attractor-awareness.md` | **3,273 B** ≤ 3,276 B |

No code was touched, so the suites are byte-identical to main's by construction.

---

## Observations

**One arose, and it is about this PR's own first pass — filed here rather than as a separate issue,
because it was found and fixed inside this lane.**

The first commit (`60b9c30`) paid for the two new doctrine blocks partly by folding the awareness
card's Depth pointer

```
- Runtime semantics, routing, debugging: `attractor:attractor-expert`
```

into the authoring bullet, under the heading **"Before authoring or editing ANY `.dot`"**. Run
`20260816T152500Z` regressed `qa-02-never-converges` immediately: `MC-B1` FAIL (neither `attractor
lint` nor `attractor trace` appeared anywhere) and `G6=3`. A user whose pipeline will not converge is
not authoring anything, so the card's only route to the expert's *debugging* guidance sat behind a
heading that scenario never reaches.

This is the *same* confound `e444f2b` called out one commit earlier, re-committed by a different
mechanism — and the instrument caught it across three SHAs:

| SHA | Depth debugging pointer | `qa-02` `MC-B1` |
|---|---|---|
| `ed97486` | absent | **FAIL** |
| `11793ad` (= `e444f2b`) | present, own section | ok, ok (two runs) |
| `60b9c30` (this PR, first pass) | present but under the authoring heading | **FAIL** |
| `d012e19` (this PR, head) | restored, own section | ok, ok (two runs) |

The transferable observation, which bears on `docs/VISION.md`'s *"Convergence on machine evidence,
not step completion"*: **on a hard-capped always-on surface, a pointer's heading is part of the
pointer.** Moving a route under a differently-scoped heading is not a formatting change — it is a
deletion for every session that does not read that heading's topic. Nothing in the repo currently
says so, and the same trap has now been stepped in twice in three commits. Whether that belongs in
`docs/designs/2026-08-15-composition-fix.md` §3.1 next to the byte cap is a maintainer call; it is
recorded here rather than filed as a `vision-observation`, because the vision passage it bears on is
already correct — the failure was in applying it to a guidance card.

### Proposed resolution for #266 (`vision-observation`)

**The observation was real, and it is confirmed by the fix.** Two independent scenarios, two
different shipped surfaces, one run — a session that *taught* the never-clause correctly and then
broke it twice when it was the producing context. The instrument now says the same thing from the
other direction: writing the DOING-side clause down is what made both scenarios flip, and both stay
flipped across a reproducibility pair.

**Recommendation: close with resolution**, recording that the named instances are fixed —

* the principle is now stated as binding on the assistant's own conduct on the always-on surface
  (*"**And it binds YOUR OWN work in this conversation, not just pipelines you design:** what you
  authored, you cannot certify"*), with the discharge protocol on the expert surfaces and the SKILL;
* `work-03` and `work-04` are the standing regression tests for it, and both are green twice.

**What this PR does *not* settle**, and the reason a maintainer might prefer keep-open: #266 asks
whether **`docs/VISION.md` itself** should say that the principle binds the assistant's own conduct
and not only the graphs it designs. This PR did not touch `docs/VISION.md` — it is outside this
lane's file scope, and the vision text as written is not wrong, merely silent on the DOING side. If
the maintainer wants that sentence in the vision, keep #266 open scoped to that single edit; the
guidance-surface half is done either way.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)
