### PR TITLE
docs(vision): the gates-outside-workers rule binds the assistant too

### DIFF
--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -108,7 +108,9 @@ a ledger row, not a vision. This page does not forge decisions the maintainer ha
   yourself adding `plan -> implement -> test` as graph nodes, stop."*
 - **Gates outside workers.** *"Verification inside the context that produced the evidence is not
   verification."* Bought with a live run where a worker hand-authored its own `convergence.jsonl`
-  and the critics outside its context caught it.
+  and the critics outside its context caught it. The rule binds the sessions and agents this repo
+  composes, not only the graphs they design: what a session authored, it cannot certify -- it
+  relays the machine's verdict as fact and offers the independent path.
 - **Evidence over self-report.** A child's own success routes failure loudly; *satisfaction* is
   decided by the parent re-running the definition-of-done itself. On one live proof a worker had
   genuinely fixed the bug and written "Status: COMPLETE" -- and the run still refused to report
@@ -188,6 +190,23 @@ The vision refines over time, so this page is held to the bar of the protocol th
 ## Changelog
 
 Amendments to this vision, newest first. Each entry names the evidence that justified it.
+
+### 2026-08-16 -- the gates bind the assistant too (entry 3)
+
+- **Changed.** "Gates outside workers" now says the rule binds the sessions and agents this repo
+  composes, not only the graphs they design -- what a session authored, it cannot certify. One
+  sentence, one home: the principle's other statement, "Evidence over self-report," is untouched.
+- **Evidence that justified it: the maintainer read the open question and ruled** (2026-08-16,
+  resolving issue #266). The failure this framing would have caught is on record -- a graded
+  session taught the never-clause correctly, then, asked to vouch for a graph it had just written,
+  certified the absence of self-report gates by self-report. And the cost it retires: the clause
+  was carried only on derived guidance surfaces, which are byte-capped, so a later budget cut there
+  could drop it without becoming drift the review that reads guidance against this page can find.
+  Stated here, that instrument guards it.
+- **Scope: documentation only.** No engine, handler, example or ledger *behavior* changed, and the
+  decision matrix's articulation -- pinned across both pages by `test_quality_protocol_guard.py`'s
+  Q-307 -- is untouched.
+- **Retirement condition.** Unchanged: none.
 
 ### 2026-08-15 -- desired state only, and the matrix in authored prose (entry 2)
 


### PR DESCRIPTION
Fixes #266.

**One sentence and one Changelog entry in `docs/VISION.md`. Nothing else.** `git diff
origin/main...HEAD --stat` is a single file, +20/-1.

---

## The sentence

Added to the **Gates outside workers** bullet under *Operating principles*
([`docs/VISION.md`](https://github.com/microsoft/amplifier-bundle-attractor/blob/docs/266-self-binding-clause/docs/VISION.md#L111-L113),
lines 111-113):

> The rule binds the sessions and agents this repo composes, not only the graphs they design: what
> a session authored, it cannot certify -- it relays the machine's verdict as fact and offers the
> independent path.

The bullet now reads, in full:

> - **Gates outside workers.** *"Verification inside the context that produced the evidence is not
>   verification."* Bought with a live run where a worker hand-authored its own `convergence.jsonl`
>   and the critics outside its context caught it. **The rule binds the sessions and agents this
>   repo composes, not only the graphs they design: what a session authored, it cannot certify --
>   it relays the machine's verdict as fact and offers the independent path.**

## Why there, and only there

**"Gates outside workers" is where the rule is stated in its general form** -- *"verification inside
the context that produced the evidence is not verification"* is a claim about **any** producing
context, and a session that just authored an artifact **is** one. The clause is that sentence
noticing it applies to the reader. "Evidence over self-report" states the same principle as a
*mechanism* (parent re-runs the definition-of-done), which is the pipeline-shaped half; the
self-binding half belongs with the general statement.

**One home, deliberately.** This page avoids one claim with N homes -- that is what Q-307 exists to
police on the one paragraph that legitimately has two. "Evidence over self-report" is untouched.

## The authorization

`docs/VISION.md`'s own *Maintaining this document* section: **"Amendments require the maintainer's
explicit word. This is his vision, captured -- not a consensus document, and not an agent's
inference."**

That word is given. On **2026-08-16** the maintainer answered the open question #266 had been
re-scoped to -- *should `docs/VISION.md` itself gain a one-sentence self-binding clause?* -- with
**"Yes, #1 sounds good do it"**
([the framing and both arguments](https://github.com/microsoft/amplifier-bundle-attractor/issues/266#issuecomment-5309200222)).
The amendment **is** the resolution of the re-scoped observation, hence `Fixes #266`.

The same section requires evidence -- *"a failure this framing would have caught, or a cost it
retires."* Both are on record, and both are in the Changelog entry:

- **The failure.** `work-03` / `work-04`: a graded session taught the never-clause correctly, then
  -- asked to vouch for a graph it had just written -- certified the absence of self-report gates
  *by self-report*.
- **The cost it retires.** PR #271 fixed that on **derived** surfaces only (the always-on awareness
  card, the expert files; `work-03`/`work-04` flipped FAIL->PASS). Those surfaces are hard-capped by
  byte budget. A future budget cut could drop the clause and it would **not** show up as drift --
  the drift-review pipeline audits guidance *against* VISION.md, so a claim that lives only
  downstream of VISION has no normative source to be measured against. Written here, the instrument
  guards it.

## Decision-matrix tier (QUALITY_PROTOCOL §3)

**Toward-spec** -- documentation-only housekeeping of the repo's own governing doc, closing an
inconsistency in which this repo stated the spec's evidence-external-to-the-worker rule while
exempting the actor stating it; no ledger entry (conforming is the default state, not a deviation),
no engine, handler, example or ledger *behavior* changed.

## The Changelog entry

Entry 3, matching entries 1-2's shape (Changed / Evidence / Scope / Retirement condition):

> ### 2026-08-16 -- the gates bind the assistant too (entry 3)
>
> - **Changed.** "Gates outside workers" now says the rule binds the sessions and agents this repo
>   composes, not only the graphs they design -- what a session authored, it cannot certify. One
>   sentence, one home: the principle's other statement, "Evidence over self-report," is untouched.
> - **Evidence that justified it: the maintainer read the open question and ruled** (2026-08-16,
>   resolving issue #266). The failure this framing would have caught is on record -- a graded
>   session taught the never-clause correctly, then, asked to vouch for a graph it had just written,
>   certified the absence of self-report gates by self-report. And the cost it retires: the clause
>   was carried only on derived guidance surfaces, which are byte-capped, so a later budget cut there
>   could drop it without becoming drift the review that reads guidance against this page can find.
>   Stated here, that instrument guards it.
> - **Scope: documentation only.** No engine, handler, example or ledger *behavior* changed, and the
>   decision matrix's articulation -- pinned across both pages by `test_quality_protocol_guard.py`'s
>   Q-307 -- is untouched.
> - **Retirement condition.** Unchanged: none.

## Gates

Machine verdicts, verbatim:

| Gate | Command | Result |
|---|---|---|
| Quality-protocol guard (Q-300..Q-307) | `pytest tests/test_quality_protocol_guard.py -v` | **17 passed** |
| Doc guards + conformance matrix + explainer guard | `pytest test_doc_consistency.py test_engine_semantics_doc_guard.py test_explainer_doc_guard.py test_extensions_ledger_integrity.py test_examples_lint_clean.py test_spec_conformance_matrix.py test_quality_protocol_guard.py -q` | **281 passed, 24 skipped** |
| loop-pipeline, full | `uv sync --extra remote && uv run pytest -q` | **2459 passed, 25 skipped** |
| pipeline-runner | `uv sync && uv run pytest -q` | **76 passed, 1 skipped** |
| Whitespace | `git diff --check` | clean |

**Q-307 specifically: untouched and green.** Its pin is the decision-matrix paragraph in *Our
relationship to the nlspec* (`"Every change here is weighed against the strongdm/attractor
nlspec..."` -> `"That gradient is the steering rule of this project."`), byte-identical with
`QUALITY_PROTOCOL.md` §3. This edit is in *Operating principles* and the Changelog; the diff does
not touch either copy, and no guard needed re-anchoring -- **no test file changed in this PR.**

Leak scan on the diff: no secret-shaped material (it is two prose blocks).

## Observations

None arose. The one candidate considered and rejected: the derived surfaces (awareness card, expert
files) still carry the operational form of this clause, which is correct division of labor --
VISION states the principle, the surfaces state the procedure -- not a one-claim-N-homes violation
of the kind Q-307 guards.

---

**I authored this change and cannot certify it.** What is above is machine verdicts relayed as
facts; what nothing checked is whether this sentence is the *right* sentence for this page -- that
is the maintainer's judgment, and it is the reason this is a PR and not a merge. The independent
path: `git diff origin/main...HEAD` is 20 lines, and #266's comment thread carries the argument
*against* amending at all (VISION is deliberately spare; the clause may already be implied) if a
reviewer wants to re-test the call.

Do **not** merge without the maintainer's word on the wording.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)
