### PR TITLE
implement: fix for #197 (topo006-conditional-plain-edge-false-negative)

### DIFF
--- a/docs/DOT-AUTHORING-GUIDE.md
+++ b/docs/DOT-AUTHORING-GUIDE.md
@@ -1371,8 +1371,8 @@ through a silent pass-through path.  Two forms:
    to mark.
 2. **Indirect:** the failure edge's receiving path reaches the exit with
    every hop unconditional and no re-gating in between, through at least one
-   *unmarked* intermediary (default `runs_on`, only unconditional outgoing
-   edges).
+   *unmarked* intermediary (default `runs_on`, with a plain outgoing edge the
+   flow can follow).
 
 **Why it matters:** This is the graph-topology sibling of the CMD-001/CMD-002
 hazard class — a gate whose failure is structurally converted into a
@@ -1401,9 +1401,23 @@ semantics — `engine.py::_get_runs_on` and `edge_selection.py::select_edge`):
   record_failure [shape=parallelogram, tool_command="echo recorded", runs_on=always]
   ```
 
-- **A re-gating intermediary.**  A node with at least one condition-bearing
-  outgoing edge makes a fresh routing decision (retry-vs-escalate and the
-  like) — corrective routing, not a silent pass-through.
+- **A re-gating intermediary.**  A node whose outgoing edges are **all**
+  condition-bearing makes a fresh routing decision (retry-vs-escalate and the
+  like) — corrective routing, not a silent pass-through.  One conditional
+  edge is not enough: a node that *also* carries a plain (unconditional)
+  outgoing edge does **not** re-gate, because the failure can still take that
+  plain escape to the exit.  To re-gate, make **every** outgoing edge
+  condition-bearing — remove or condition the plain escape:
+
+  ```dot
+  // NOT a re-gate — the plain triage -> done edge is the silent escape
+  triage -> work [condition="context.tool.last_line=retry"]
+  triage -> done
+
+  // A re-gate — every outgoing edge of triage is condition-bearing
+  triage -> work     [condition="context.tool.last_line=retry"]
+  triage -> escalate [condition="context.tool.last_line=escalate"]
+  ```
 
 - **A human-gate intermediary.**  A `hexagon` (`wait.human`) node on the
   failure path is external human judgment — the failure cannot exit green
@@ -1431,9 +1445,11 @@ fix -> verify
 
 Or, if finishing after a handled failure is deliberate, declare it: mark
 every intermediary on the path with `runs_on="always"` or
-`runs_on="failure"`, or re-gate the flow with a condition-bearing edge on an
-intermediary.  The diagnostic names the failure-conditioned edge, its source
-node, and (for the indirect form) the pass-through path.
+`runs_on="failure"`, or genuinely re-gate the flow by making **every**
+outgoing edge of an intermediary condition-bearing (remove or condition its
+plain escape — a node with any plain outgoing edge does not re-gate).  The
+diagnostic names the failure-conditioned edge, its source node, and (for the
+indirect form) the pass-through path.
 
 ---
 

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/validation.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/validation.py
@@ -1400,11 +1400,14 @@ def _condition_matches_fail(cond: str) -> bool:
 def _node_regates(graph: Graph, node_id: str) -> bool:
     """Return True if the node re-gates the flow.
 
-    A node with at least one condition-bearing outgoing edge makes a fresh
-    routing decision (retry-vs-escalate and the like) — flow through it is
-    corrective routing, not a silent pass-through.
+    A node truly re-gates only when ALL its outgoing edges are conditional.
+    If the node has any plain (unconditional) outgoing edge — whether to an
+    exit node directly or to a non-exit intermediary — that plain edge is a
+    potential silent escape route: BFS must be allowed to follow it and
+    evaluate the continuation on its own merits.  Such a node does NOT
+    re-gate, even if other outgoing edges are conditional.
 
-    A human-gate (hexagon / wait.human) node also re-gates: routing beyond
+    A human-gate (hexagon / wait.human) node always re-gates: routing beyond
     it passes through external human judgment, so a failure cannot exit the
     pipeline green without a human seeing it.  This follows the TOPO-004/
     TOPO-005 precedent (a labeled human-gate exit is an explicit gate; a
@@ -1415,9 +1418,15 @@ def _node_regates(graph: Graph, node_id: str) -> bool:
     node = graph.nodes.get(node_id)
     if node is not None and _is_human_gate(node):
         return True
-    return any(
-        e.condition and e.condition.strip() for e in graph.outgoing_edges(node_id)
+    outgoing = list(graph.outgoing_edges(node_id))
+    has_any_conditional = any(e.condition and e.condition.strip() for e in outgoing)
+    if not has_any_conditional:
+        return False
+    has_plain_escape = any(
+        not (e.condition and e.condition.strip())
+        for e in outgoing
     )
+    return not has_plain_escape
 
 
 def _unmarked_passthrough_path_to_exit(
@@ -1457,7 +1466,7 @@ def _unmarked_passthrough_path_to_exit(
             continue
         for edge in graph.outgoing_edges(node_id):
             if edge.condition and edge.condition.strip():
-                continue  # unreachable given the re-gate check; kept for clarity
+                continue  # skip conditional edges — BFS follows only plain edges
             if edge.to_node in exit_ids:
                 if has_unmarked:
                     return path + [edge.to_node]

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/validation.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/validation.py
@@ -1522,14 +1522,17 @@ def _check_fail_routed_to_exit(graph: Graph, diags: list[Diagnostic]) -> None:
     and the exit carries ``runs_on="always"`` or ``runs_on="failure"`` is a
     deliberately declared handled-failure termination (e.g. a
     ``runs_on=always`` recorder before ``done``) and is NOT flagged.
-    Likewise, an intermediary with at least one condition-bearing outgoing
-    edge re-gates the flow (retry-vs-escalate routing) — corrective
-    routing, not flagged.  A human-gate (hexagon / wait.human) intermediary
-    likewise re-gates — external human judgment on the failure path, per
-    the TOPO-004/TOPO-005 human-gate precedent.  An UNMARKED pass-through
-    intermediary (default
-    ``runs_on``, only unconditional outgoing edges, exit reachable) is
-    exactly the accident class this rule catches: flagged.
+    Likewise, an intermediary whose outgoing edges are ALL condition-bearing
+    re-gates the flow (retry-vs-escalate routing) — corrective routing, not
+    flagged.  One conditional edge is not enough: a node that ALSO has a
+    plain (unconditional) outgoing edge does NOT re-gate (``_node_regates``)
+    — the plain edge is a silent escape the failure can still take, so such
+    a node stays flagged.  A human-gate (hexagon / wait.human) intermediary
+    always re-gates — external human judgment on the failure path, per the
+    TOPO-004/TOPO-005 human-gate precedent.  An UNMARKED pass-through
+    intermediary (default ``runs_on``, a plain outgoing edge the flow can
+    follow, exit reachable) is exactly the accident class this rule catches:
+    flagged.
 
     The rule fires regardless of the source node's shape.  On a diamond
     source, TOPO-001 (ERROR — the edge is provably dead) additionally
@@ -1609,11 +1612,13 @@ def _check_fail_routed_to_exit(graph: Graph, diags: list[Diagnostic]) -> None:
                         edge=(edge.from_node, edge.to_node),
                         fix=(
                             f"Either route the failure to a corrective target "
-                            f"with a back-edge to retry, add a "
-                            f"condition-bearing edge on an intermediary so the "
-                            f"flow is re-gated, or — if this handled-failure "
-                            f"termination is deliberate — mark every "
-                            f"intermediary on the path ({path_str}) with "
+                            f"with a back-edge to retry; make EVERY outgoing "
+                            f"edge of an intermediary condition-bearing "
+                            f"(remove or condition its plain escape) so the "
+                            f"flow is re-gated — a node with any plain "
+                            f"outgoing edge does not re-gate; or — if this "
+                            f"handled-failure termination is deliberate — "
+                            f"mark every intermediary on the path ({path_str}) with "
                             f'runs_on="always" or runs_on="failure" (the '
                             f"engine's failure-routing opt-in) so the intent "
                             f"is declared. See DOT-AUTHORING-GUIDE.md "

--- a/modules/loop-pipeline/tests/test_topological_lint.py
+++ b/modules/loop-pipeline/tests/test_topological_lint.py
@@ -1168,9 +1168,9 @@ class TestFailRoutedToExit:
         g = self._recorder_graph(recorder_runs_on="sometimes")
         assert _diag(lint(g), "fail_routed_to_exit")
 
-    def test_indirect_regating_intermediary_not_flagged(self):
-        """An intermediary with a condition-bearing outgoing edge re-gates the
-        flow (retry-vs-escalate routing) — corrective, not flagged."""
+    def test_indirect_regating_intermediary_with_plain_exit_flagged(self):
+        """An intermediary with a conditional edge plus a plain edge to the exit
+        is the hazard shape: the plain edge is a silent escape route — flagged."""
         g = _graph(
             nodes={
                 "start": _mdiamond(),
@@ -1188,7 +1188,61 @@ class TestFailRoutedToExit:
                 Edge("triage", "done"),
             ],
         )
+        # triage has a plain edge to done (exit) -- this IS the hazard shape.
+        assert _diag(lint(g), "fail_routed_to_exit")
+
+    def test_indirect_true_regate_all_conditional_not_flagged(self):
+        """An intermediary whose ALL outgoing edges are conditional (no plain
+        escape to exit or anywhere) truly re-gates the flow -- not flagged."""
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "work": _box("work", prompt="do it"),
+                "verify": _tool("verify"),
+                "triage": _tool("triage"),
+                "done": _msquare("done"),
+            },
+            edges=[
+                Edge("start", "work"),
+                Edge("work", "verify"),
+                Edge("verify", "done", condition="outcome=success"),
+                Edge("verify", "triage", condition="outcome=fail"),
+                Edge("triage", "work", condition="context.tool.last_line=retry"),
+                Edge("triage", "done", condition="context.tool.last_line=escalate"),
+            ],
+        )
+        # triage has ONLY conditional outgoing edges — a true re-gate, not flagged.
         assert not _diag(lint(g), "fail_routed_to_exit")
+
+    def test_indirect_plain_escape_via_nonexit_intermediary_flagged(self):
+        """An intermediary with a plain edge to a non-exit node whose downstream
+        path reaches the exit without a re-gate is still the hazard shape — flagged.
+
+        triage -> record (plain) -> done (plain): the plain escape is one hop
+        away from exit but the silent path still exists.
+        """
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "work": _box("work", prompt="do it"),
+                "verify": _tool("verify"),
+                "triage": _tool("triage"),
+                "record": _tool("record"),
+                "done": _msquare("done"),
+            },
+            edges=[
+                Edge("start", "work"),
+                Edge("work", "verify"),
+                Edge("verify", "done", condition="outcome=success"),
+                Edge("verify", "triage", condition="outcome=fail"),
+                Edge("triage", "work", condition="context.tool.last_line=retry"),
+                Edge("triage", "record"),
+                Edge("record", "done"),
+            ],
+        )
+        # triage has a plain edge to record (non-exit), which continues plainly
+        # to done.  The silent exit path exists; must be flagged.
+        assert _diag(lint(g), "fail_routed_to_exit")
 
     def test_indirect_multihop_one_unmarked_flagged(self):
         """Multi-hop path with one unmarked intermediary among marked ones


### PR DESCRIPTION
Fix for #197, produced by the implement stage (task-runner.dot) against the reviewed + hardened capsule gate merged in PR #273.

**Provenance:** implement run [31981137533](https://github.com/microsoft/amplifier-bundle-attractor/actions/runs/31981137533). The run CONVERGED and pushed this branch — the workflow's own `gh pr create` then failed with `GraphQL: Resource not accessible by personal access token (createPullRequest)`: the regenerated `CAPSULE_PR_TOKEN` authenticates but cannot create PRs (likely missing the Pull-requests write permission or pending org approval — escalated to the maintainer). This PR is the manual open of the pipeline's own pushed branch; precedent #143/#273–#275.

**Acceptance:** the reviewed capsule gate (`.github/capsule-pipeline/proposals/issue-197/topo006-conditional-plain-edge-false-negative.verify.sh`) is the DoD — RED at base, must be GREEN at this head. An independent adversarial review will verify before merge is recommended.

Fixes #197.

---

## Post-review fixes

The independent adversarial review verified the behavior fix end to end (capsule gate RED at base / GREEN at head, generality beyond the reported repro, zero `attractor lint` examples-sweep delta, mutation kills) and returned **MERGE-AFTER-FIX** on a single finding: three doc surfaces still described the OLD, buggy re-gating rule — and one of them is emitted to authors by the diagnostic itself. Fixed in 460b837 — docs-only, no behavior change.

The rule as shipped: a node re-gates only when **every** outgoing edge is condition-bearing; a node with any plain (unconditional) outgoing edge does **not** re-gate, because that plain edge is a silent escape the failure can still take.

**1. `validation.py` — `_check_fail_routed_to_exit` docstring** (precise semantics)

> **Before:** "Likewise, an intermediary with at least one condition-bearing outgoing edge re-gates the flow (retry-vs-escalate routing) — corrective routing, not flagged. … An UNMARKED pass-through intermediary (default `runs_on`, only unconditional outgoing edges, exit reachable) is exactly the accident class this rule catches: flagged."

> **After:** "Likewise, an intermediary whose outgoing edges are ALL condition-bearing re-gates the flow (retry-vs-escalate routing) — corrective routing, not flagged. One conditional edge is not enough: a node that ALSO has a plain (unconditional) outgoing edge does NOT re-gate (`_node_regates`) — the plain edge is a silent escape the failure can still take, so such a node stays flagged. … An UNMARKED pass-through intermediary (default `runs_on`, a plain outgoing edge the flow can follow, exit reachable) is exactly the accident class this rule catches: flagged."

The companion parenthetical was reworded for the same reason: "only unconditional outgoing edges" described the flagged class too narrowly — it excluded the exact conditional+plain shape #197 is about.

**2. `validation.py` — the diagnostic's emitted `fix` text** (short, actionable, and it actually clears)

> **Before:** "… add a condition-bearing edge on an intermediary so the flow is re-gated …"

> **After:** "… make EVERY outgoing edge of an intermediary condition-bearing (remove or condition its plain escape) so the flow is re-gated — a node with any plain outgoing edge does not re-gate …"

Verified by rendering the diagnostic on the #197 hazard shape: following the **new** advice literally (condition every outgoing edge of `triage`) clears the warning, 1 → 0 findings; following the **old** advice (add a conditional edge, keep the plain escape) leaves it at 1. The linter no longer trains authors to ignore its own rule.

**3. `docs/DOT-AUTHORING-GUIDE.md` — TOPO-006 "What is NOT flagged" + Fix paragraph** (teaches the rule)

> **Before:** "**A re-gating intermediary.** A node with at least one condition-bearing outgoing edge makes a fresh routing decision (retry-vs-escalate and the like) — corrective routing, not a silent pass-through."

> **After:** "**A re-gating intermediary.** A node whose outgoing edges are **all** condition-bearing makes a fresh routing decision (retry-vs-escalate and the like) — corrective routing, not a silent pass-through. One conditional edge is not enough: a node that *also* carries a plain (unconditional) outgoing edge does **not** re-gate, because the failure can still take that plain escape to the exit. To re-gate, make **every** outgoing edge condition-bearing — remove or condition the plain escape:" — followed by a WRONG/CORRECT `dot` pair.

Also reworded: the "Indirect" form's description of the unmarked intermediary ("only unconditional outgoing edges" → "with a plain outgoing edge the flow can follow"), and the closing **Fix** paragraph's re-gate advice. The genuinely unchanged exemptions — `runs_on="always"`/`runs_on="failure"` marked paths and the `hexagon` / `wait.human` human gate — are untouched.

**Test updates:** none required. No test pinned any of the reworded phrases — `condition-bearing`, `Either route the failure`, and `flow is re-gated` appear nowhere in the suite or its fixtures; the `re-gate` mentions in `test_topological_lint.py` are docstrings/comments describing graph shapes, not assertions on emitted text.

**Gates re-run at 460b837**

| Gate | Result |
| --- | --- |
| Capsule gate `.github/capsule-pipeline/proposals/issue-197/topo006-conditional-plain-edge-false-negative.verify.sh` | **rc=0 — GREEN**; behavioral probes pass, `TestFailRoutedToExit` 18/18 |
| loop-pipeline (`uv sync --extra remote && uv run pytest -q`) | **2461 passed, 25 skipped** |
| pipeline-runner (`uv sync && uv run pytest -q`) | **76 passed, 1 skipped** |
| Doc guards (`test_doc_consistency`, explainer + engine-semantics guards) | green, within the above |
| `attractor lint` examples sweep | **byte-identical** to base, fix text included — 22 findings over 33 `.dot` files (the corpus's 7 TOPO-006 findings are all the *direct* form, whose fix text is unchanged and still accurate) |
| `git diff --check` + leak scan | clean |
