### PR TITLE
fix(preflight): refuse when a profile names an unresolvable adapter; extract one shared profile resolver (#195, #279)

### DIFF
--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/__init__.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/__init__.py
@@ -17,6 +17,7 @@ import logging
 import os
 import re
 import tempfile
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
@@ -391,6 +392,100 @@ class DirectProviderBackend:
         return None
 
 
+def _spawn_capability(coordinator: Any | None) -> Any | None:
+    """Resolve ``session.spawn`` off a coordinator, tolerating stand-ins.
+
+    One home for the capability gate both profile-resolution call sites use
+    (``_build_backend`` and ``execute()``'s preflight step 5b).  Bare test
+    stubs may not expose ``get_capability`` at all, and a coordinator is free
+    to raise for an unknown capability name; both mean "no spawn backend".
+    """
+    if coordinator is None or not hasattr(coordinator, "get_capability"):
+        return None
+    try:
+        return coordinator.get_capability("session.spawn")
+    except Exception:
+        return None
+
+
+def _resolve_profiles(
+    config: dict[str, Any] | None,
+    coordinator: Any | None,
+) -> dict[str, str]:
+    """THE single home for provider -> agent-profile resolution (issue #279).
+
+    Consumed by BOTH homes that need it -- ``_build_backend()`` (which hands
+    the result to ``AmplifierBackend``) and ``PipelineOrchestrator.execute()``
+    step 5b (which hands the same result to the startup provider preflight).
+    They previously carried two independent copies of this logic with no test
+    pinning them to each other, so a solo edit to either could drift silently;
+    ``tests/test_profile_resolver_parity.py`` now pins both call sites here.
+
+    Resolution order (either/or, by truthiness -- an explicit but EMPTY
+    ``profiles`` mapping therefore falls through to auto-discovery, in both
+    homes, exactly as before):
+
+    1. Explicit ``config["profiles"]`` mapping, e.g.
+       ``{"anthropic": "attractor-anthropic"}``.
+    2. Auto-discovery from ``coordinator.config["agents"]`` -- each dict-valued
+       agent entry maps as ``agent_name -> agent_name``.  Gated on the
+       ``session.spawn`` capability, because auto-discovered profiles are only
+       ever consumed by the spawn backend.
+
+    Raises whatever a malformed coordinator config raises (e.g. a non-mapping
+    ``agents``).  ``_build_backend`` lets that propagate, as it always has;
+    the preflight call site catches it and proceeds with FEWER profiles, so a
+    discovery crash can only ever produce a refusal, never a false accept.
+    """
+    profiles: dict[str, str] = {}
+    cfg = config or {}
+
+    # Source 1: Explicit profiles mapping in orchestrator config
+    explicit_profiles = cfg.get("profiles")
+    if isinstance(explicit_profiles, dict):
+        profiles.update(explicit_profiles)
+
+    # Source 2: Auto-discover from coordinator.config["agents"]
+    if not profiles and _spawn_capability(coordinator) is not None:
+        coordinator_config = getattr(coordinator, "config", None) or {}
+        agents = coordinator_config.get("agents", {})
+        for agent_name, agent_cfg in agents.items():
+            if isinstance(agent_cfg, dict):
+                profiles[agent_name] = agent_name
+
+    return profiles
+
+
+def _spawn_resolvable_agents(coordinator: Any | None) -> frozenset[str] | None:
+    """Profile names the spawn backend can actually resolve (issue #195).
+
+    A profile is a STRING naming an agent.  ``AmplifierBackend._run_with_spawn``
+    resolves it in exactly one place -- ``coordinator.config["agents"]`` -- and
+    refuses an entry it cannot find there.  A profile naming an absent agent is
+    therefore unserviceable no matter how many credentials are set, and every
+    visit to a node declaring that provider fails, draining the budget (the
+    residual #155 crash loop reported in #195).  The keys of that same mapping
+    are the statically knowable answer, read with no spawn and no live call.
+
+    Returns ``None`` -- meaning "not knowable here; do not police it" -- when:
+
+    - there is no ``session.spawn`` capability (the spawn backend is not the
+      one that will run, so profiles are never consumed at all); or
+    - ``coordinator.config`` / its ``agents`` entry is not a mapping we can
+      inspect statically (a stub or proxy coordinator).  The runtime guard in
+      ``backend.py`` still covers those.
+    """
+    if _spawn_capability(coordinator) is None:
+        return None
+    coordinator_config = getattr(coordinator, "config", None)
+    if not isinstance(coordinator_config, Mapping):
+        return None
+    agents = coordinator_config.get("agents", {})
+    if not isinstance(agents, Mapping):
+        return None
+    return frozenset(str(name) for name in agents)
+
+
 def _build_backend(
     providers: dict[str, Any],
     tools: dict[str, Any],
@@ -414,33 +509,18 @@ def _build_backend(
 
     # Try the full spawn-based backend first
     if coordinator is not None:
-        spawn_fn = None
-        if hasattr(coordinator, "get_capability"):
-            try:
-                spawn_fn = coordinator.get_capability("session.spawn")
-            except Exception:
-                pass
+        spawn_fn = _spawn_capability(coordinator)
         if spawn_fn is not None:
             from .backend import AmplifierBackend
 
-            # Resolve profiles: explicit config > auto-discovery from agents
-            cfg = orchestrator_config or {}
-            profiles: dict[str, str] = {}
-
-            # Source 1: Explicit profiles mapping in orchestrator config
-            # e.g. config.profiles = {"anthropic": "attractor-anthropic"}
-            explicit_profiles = cfg.get("profiles")
-            if isinstance(explicit_profiles, dict):
-                profiles.update(explicit_profiles)
-
-            # Source 2: Auto-discover from coordinator.config["agents"]
-            # Each agent entry is mapped as agent_name -> agent_name.
-            if not profiles:
-                coordinator_config = getattr(coordinator, "config", None) or {}
-                agents = coordinator_config.get("agents", {})
-                for agent_name, agent_cfg in agents.items():
-                    if isinstance(agent_cfg, dict):
-                        profiles[agent_name] = agent_name
+            # Resolve profiles: explicit config > auto-discovery from agents.
+            # ONE home for that rule -- _resolve_profiles() (issue #279); the
+            # startup preflight in execute() step 5b consumes the SAME
+            # function, and tests/test_profile_resolver_parity.py pins both
+            # call sites to it so the two can no longer drift apart.
+            profiles: dict[str, str] = _resolve_profiles(
+                orchestrator_config, coordinator
+            )
 
             if profiles:
                 logger.info(
@@ -564,46 +644,40 @@ class PipelineOrchestrator:
             # claims).  The auto-constructed backend path (production) is
             # always checked.
             if kwargs.get("backend") is None:
-                # Resolve profiles for the preflight using the same two-source
-                # priority as _build_backend(): explicit config first, then
-                # auto-discovery from coordinator.config["agents"].  Without
-                # this the preflight only sees source 1 and raises a false
-                # ProviderPreflightError when the only profiles come from
-                # auto-discovery (issue #196).
-                preflight_profiles: dict[str, str] | None = None
-                explicit_profiles = self.config.get("profiles")
-                if isinstance(explicit_profiles, dict):
-                    # Source 1: explicit profiles mapping in orchestrator config
-                    preflight_profiles = dict(explicit_profiles)
-                if not preflight_profiles:
-                    # Source 2: auto-discover from coordinator.config["agents"]
-                    # (mirrors _build_backend() lines 438-443 exactly)
-                    _coordinator = kwargs.get("coordinator")
-                    if _coordinator is not None:
-                        try:
-                            _coord_cfg = getattr(_coordinator, "config", None) or {}
-                            _agents = _coord_cfg.get("agents", {})
-                            _spawn_fn = None
-                            if hasattr(_coordinator, "get_capability"):
-                                try:
-                                    _spawn_fn = _coordinator.get_capability(
-                                        "session.spawn"
-                                    )
-                                except Exception:
-                                    pass
-                            if _spawn_fn is not None:
-                                _discovered: dict[str, str] = {}
-                                for _agent_name, _agent_cfg in _agents.items():
-                                    if isinstance(_agent_cfg, dict):
-                                        _discovered[_agent_name] = _agent_name
-                                if _discovered:
-                                    preflight_profiles = _discovered
-                        except Exception:
-                            pass
+                _coordinator = kwargs.get("coordinator")
+                # Resolve profiles for the preflight through the SAME function
+                # _build_backend() uses -- _resolve_profiles() (issue #279).
+                # Before the extraction this call site carried its own copy of
+                # the two-source rule (explicit config first, then
+                # auto-discovery from coordinator.config["agents"]), pinned to
+                # the other copy only by a line-number comment; the copies
+                # could drift silently, and a preflight that saw FEWER sources
+                # than the backend raised false refusals (issue #196).
+                # Fail-closed: a discovery crash yields FEWER profiles, which
+                # can only ever produce a refusal -- never a false accept.
+                try:
+                    preflight_profiles: dict[str, str] | None = _resolve_profiles(
+                        self.config, _coordinator
+                    )
+                except Exception:
+                    preflight_profiles = None
+                # Issue #195: a profile is a STRING naming an agent.  Knowing
+                # it is MAPPED is not knowing it can be RESOLVED -- a profile
+                # naming an absent agent passes credential presence and then
+                # fails at every spawn, draining the budget instead of
+                # refusing.  Hand the preflight the names the spawn backend
+                # can actually resolve so that class refuses at startup.
+                # Fail-closed here too: unknowable-because-it-crashed becomes
+                # the empty set (refuse), never None (skip the check).
+                try:
+                    _resolvable = _spawn_resolvable_agents(_coordinator)
+                except Exception:
+                    _resolvable = frozenset()
                 check_provider_preflight(
                     graph,
                     mounted_providers=tuple(providers) if providers else (),
                     profiles=preflight_profiles,
+                    resolvable_profiles=_resolvable,
                 )
 
             # 6. Set up logs directory

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/preflight.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/preflight.py
@@ -11,6 +11,17 @@ different provider (Mode B; see the fail-loud guard in ``backend.py``).
 adapter/profile is mounted for the declared provider.  The check is purely
 static -- environment and config inspection only, never a live API call.
 
+Issue #195 closed the residual hole in that definition.  A profile is a
+*string* naming an agent; the original check only asked whether the string
+was MAPPED, never whether the thing it names can be resolved.  A profile
+naming an absent agent satisfies "mounted + credential present" and then
+fails at EVERY spawn (``AmplifierBackend._run_with_spawn`` resolves
+``coordinator.config["agents"][profile]`` and refuses an entry it cannot
+find), so the run drains its budget in exactly the #155 crash loop instead
+of refusing.  ``resolvable_profiles`` carries the set of profile names the
+spawn backend can actually resolve, so that class refuses at startup too --
+still statically, still with no live call and no spawn.
+
 Scope decisions (deliberate, documented):
 
 - **Declared providers only.**  A node with no ``llm_provider`` uses the
@@ -108,6 +119,7 @@ def check_provider_preflight(
     *,
     mounted_providers: Collection[str] = (),
     profiles: Mapping[str, str] | None = None,
+    resolvable_profiles: Collection[str] | None = None,
     env: Mapping[str, str] | None = None,
 ) -> None:
     """Refuse to start when a declared ``llm_provider`` is unserviceable.
@@ -116,12 +128,27 @@ def check_provider_preflight(
 
     - a provider MODULE mounted under that name serves it
       (``mounted_providers`` -- the orchestrator's ``providers`` dict keys);
-    - a PROFILE mapped for that name serves it *if* its credential can be
-      presumed present: for providers with a known credential env var
-      (``PROVIDER_KEY_ENV``) the var must be set -- a profile whose agent can
-      never construct its provider is exactly the issue-#155 crash loop; for
-      unknown providers the profile gets the benefit of the doubt (nothing
-      to check statically).
+    - a PROFILE mapped for that name serves it *if* BOTH
+      (a) the profile NAMES AN ADAPTER THIS RUN CAN RESOLVE -- when
+          ``resolvable_profiles`` is supplied, the profile name must be in it
+          (issue #195); and
+      (b) its credential can be presumed present: for providers with a known
+          credential env var (``PROVIDER_KEY_ENV``) the var must be set -- a
+          profile whose agent can never construct its provider is exactly the
+          issue-#155 crash loop; for unknown providers the credential gets the
+          benefit of the doubt (nothing to check statically).
+
+    ``resolvable_profiles`` is the set of profile names the backend that will
+    actually consume them can resolve to a real adapter -- for the spawn
+    backend, the keys of ``coordinator.config["agents"]``, which is precisely
+    what ``AmplifierBackend._run_with_spawn`` looks the profile up in.  Pass
+    ``None`` (the default) when that is not knowable on this path -- e.g. no
+    coordinator, no ``session.spawn`` capability (profiles are then never
+    consumed at all), or a coordinator whose config is not statically
+    inspectable.  ``None`` means "do not police adapter resolution"; it never
+    means "everything resolves".  Note (b) is NOT waived for unknown
+    providers: adapter resolution is a config lookup that is equally knowable
+    for every provider name, credentials are not.
 
     When NOTHING is mounted (no providers, no profiles) the check is skipped
     entirely: that is simulation mode, a documented degraded mode with its
@@ -129,7 +156,8 @@ def check_provider_preflight(
 
     Raises:
         ProviderPreflightError: naming every failing node, its provider, and
-        the missing credential.  Zero nodes have executed; zero budget spent.
+        what is missing (the unresolvable profile and/or the credential).
+        Zero nodes have executed; zero budget spent.
     """
     profiles = profiles or {}
     env = env if env is not None else os.environ
@@ -141,18 +169,35 @@ def check_provider_preflight(
         return
 
     mounted = set(mounted_providers)
+    resolvable = None if resolvable_profiles is None else set(resolvable_profiles)
     failures: list[str] = []  # one line per failing node
     for provider, node_ids in sorted(declared.items()):
         if provider in mounted:
             continue
         key_env = PROVIDER_KEY_ENV.get(provider)
         if provider in profiles:
-            if key_env is None or env.get(key_env):
-                continue  # profile mounted and credential present/unknowable
-            reason = (
-                f"profile '{profiles[provider]}' is mounted for it, but its "
-                f"credential {key_env} is not set"
-            )
+            profile_name = profiles[provider]
+            problems: list[str] = []
+            # (a) adapter resolution -- issue #195.  A profile is a STRING
+            # naming an agent; a name nothing can resolve fails at EVERY
+            # spawn, which is a drained budget, not a serviceable provider.
+            if resolvable is not None and profile_name not in resolvable:
+                known = ", ".join(sorted(resolvable)) or "none"
+                problems.append(
+                    f"profile '{profile_name}' is mapped for it, but no agent "
+                    f"named '{profile_name}' can be resolved for the spawn "
+                    f"backend (resolvable agents: {known}) -- every spawn for "
+                    f"this node would fail"
+                )
+            # (b) credential presence -- issue #155.
+            if key_env is not None and not env.get(key_env):
+                problems.append(
+                    f"profile '{profile_name}' is mounted for it, but its "
+                    f"credential {key_env} is not set"
+                )
+            if not problems:
+                continue  # profile resolves and credential present/unknowable
+            reason = "; ".join(problems)
         else:
             cred = f" (credential: {key_env})" if key_env else ""
             reason = f"no provider module or profile is mounted for it{cred}"

--- a/modules/loop-pipeline/tests/test_profile_resolver_parity.py
+++ b/modules/loop-pipeline/tests/test_profile_resolver_parity.py
@@ -1,0 +1,242 @@
+"""Parity: preflight and _build_backend share ONE profile resolver (issue #279).
+
+Before the extraction, ``PipelineOrchestrator.execute()``'s provider-preflight
+step 5b and ``_build_backend()`` each carried an independent copy of the same
+provider->agent-profile discovery rule (explicit ``config["profiles"]`` first,
+else auto-discovery from ``coordinator.config["agents"]``, gated on
+``session.spawn``, dict-valued entries only).  Fidelity was exact but pinned to
+nothing: the preflight copy cited "``_build_backend()`` lines 438-443 exactly"
+in a comment, and no test related the two.  A solo edit to either could drift
+silently -- and a preflight that sees FEWER sources than the backend raises
+false refusals, which is precisely how issue #196 happened.
+
+These tests make the single home ENFORCED rather than promised: a resolver
+monkeypatched ONCE must be observed by BOTH call sites, and the module must
+contain exactly one implementation of the discovery rule.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+from typing import Any
+
+import pytest
+
+import amplifier_module_loop_pipeline as mod
+from amplifier_module_loop_pipeline import (
+    PipelineOrchestrator,
+    _build_backend,
+    _resolve_profiles,
+)
+from amplifier_module_loop_pipeline.outcome import StageStatus
+from amplifier_module_loop_pipeline.preflight import ProviderPreflightError
+
+# A graph whose node declares provider "openai".  Deliberately NOT a name the
+# real resolver would ever produce for the coordinator below (real
+# auto-discovery yields {"attractor-openai": "attractor-openai"}), so ONLY a
+# call site that actually consumed the patched resolver can serve this node.
+_DOT = """\
+digraph parity {
+    graph [goal="resolver parity"]
+    start [shape=Mdiamond]
+    work [shape=box, llm_provider="openai", prompt="do the thing"]
+    done [shape=Msquare]
+    start -> work -> done
+}
+"""
+
+
+class _SpawnCoordinator:
+    """session.spawn coordinator with exactly one agent: attractor-openai."""
+
+    def __init__(self) -> None:
+        self.spawned_agents: list[str] = []
+        self.session = None
+        self.config: dict[str, Any] = {
+            "agents": {
+                "attractor-openai": {
+                    "session": {"orchestrator": {"module": "loop-agent"}},
+                },
+            }
+        }
+
+    def get_capability(self, name: str):
+        return self._spawn_fn if name == "session.spawn" else None
+
+    async def _spawn_fn(self, **kwargs):
+        self.spawned_agents.append(kwargs.get("agent_name", "?"))
+        return {"output": json.dumps({"status": "success"}), "session_id": "s-parity"}
+
+
+# ---------------------------------------------------------------------------
+# The headline: ONE patched resolver, ONE run, BOTH call sites
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_one_patched_resolver_is_consumed_by_both_call_sites(monkeypatch):
+    """A single monkeypatched ``_resolve_profiles`` must be seen by the
+    preflight AND by the backend build, in ONE ``execute()`` run.
+
+    The scenario is discriminating in both directions:
+
+    - if the PREFLIGHT still had its own copy, it would resolve
+      ``{"attractor-openai": "attractor-openai"}`` (real auto-discovery), find
+      no profile for the declared provider ``openai``, and raise
+      ``ProviderPreflightError``;
+    - if ``_build_backend`` still had its own copy, ``AmplifierBackend`` would
+      get that same mapping, ``profiles.get("openai")`` would be ``None``, and
+      the #155 no-fallback guard would fail the node without ever spawning.
+
+    Only both call sites consuming the patched resolver produces a SUCCESS with
+    a spawn of ``attractor-openai``.
+    """
+    seen: list[tuple[Any, Any]] = []
+
+    def _fake_resolver(config, coordinator):
+        seen.append((config, coordinator))
+        return {"openai": "attractor-openai"}
+
+    monkeypatch.setattr(mod, "_resolve_profiles", _fake_resolver)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-present")
+
+    coordinator = _SpawnCoordinator()
+    orchestrator = PipelineOrchestrator(config={"dot_source": _DOT})
+    result = json.loads(
+        await orchestrator.execute(
+            prompt="goal",
+            context=None,
+            providers={},
+            tools={},
+            hooks=None,
+            coordinator=coordinator,
+        )
+    )
+
+    assert result["status"] == StageStatus.SUCCESS.value, result
+    assert coordinator.spawned_agents == ["attractor-openai"], (
+        "the backend did not consume the shared resolver"
+    )
+    assert len(seen) == 2, (
+        f"expected exactly 2 resolver calls (preflight + _build_backend), got {len(seen)}"
+    )
+    # Both call sites must resolve from the SAME inputs -- that is the parity
+    # property the two copies used to promise by comment alone.
+    assert seen[0][0] is seen[1][0], "call sites passed different configs"
+    assert seen[0][1] is seen[1][1], "call sites passed different coordinators"
+
+
+@pytest.mark.asyncio
+async def test_build_backend_consumes_the_shared_resolver(monkeypatch):
+    """Direct pin on the second home: whatever the shared resolver returns is
+    exactly what ``AmplifierBackend`` is constructed with."""
+    marker = {"anthropic": "sentinel-agent"}
+    monkeypatch.setattr(mod, "_resolve_profiles", lambda config, coordinator: marker)
+
+    backend = _build_backend({}, {}, None, _SpawnCoordinator(), {"profiles": {}})
+
+    assert backend is not None
+    assert backend._profiles == marker
+
+
+# ---------------------------------------------------------------------------
+# Structural: exactly ONE implementation, and no rot-prone line citation
+# ---------------------------------------------------------------------------
+
+
+def test_module_contains_exactly_one_auto_discovery_implementation():
+    """The discovery rule's distinguishing line -- the dict-valued agent filter
+    -- must appear exactly once in the module: inside ``_resolve_profiles``.
+    A second occurrence means a copy has been reintroduced."""
+    source = inspect.getsource(mod)
+    assert source.count("isinstance(agent_cfg, dict)") == 1, (
+        "the agent auto-discovery filter appears more than once -- the single "
+        "home has been duplicated again (issue #279)"
+    )
+    assert "isinstance(agent_cfg, dict)" in inspect.getsource(_resolve_profiles)
+
+
+def test_both_call_sites_reference_the_shared_resolver_by_name():
+    """Source-level companion to the behavioral pin above: neither call site
+    may hand-roll discovery, and the rot-prone line-number citation that used
+    to stand in for this test must not come back."""
+    backend_src = inspect.getsource(_build_backend)
+    execute_src = inspect.getsource(PipelineOrchestrator.execute)
+    assert "_resolve_profiles(" in backend_src
+    assert "_resolve_profiles(" in execute_src
+    module_src = inspect.getsource(mod)
+    assert "lines 438-443" not in module_src, (
+        "a line-number citation of _build_backend() has returned; cite the "
+        "function, not its line numbers (issue #279)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# The fail-closed posture must survive the extraction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resolver_crash_refuses_it_never_falsely_accepts(monkeypatch):
+    """#279: the preflight's outer exception handling is a fail-closed posture,
+    not incidental defensiveness.  A discovery crash must yield FEWER profiles
+    -- hence a refusal -- never a silent accept of an unserviceable provider."""
+
+    def _boom(config, coordinator):
+        raise RuntimeError("malformed coordinator config")
+
+    monkeypatch.setattr(mod, "_resolve_profiles", _boom)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-present")
+
+    coordinator = _SpawnCoordinator()
+    orchestrator = PipelineOrchestrator(config={"dot_source": _DOT})
+    with pytest.raises(ProviderPreflightError) as exc_info:
+        await orchestrator.execute(
+            prompt="goal",
+            context=None,
+            providers={"anthropic": object()},
+            tools={},
+            hooks=None,
+            coordinator=coordinator,
+        )
+    assert "work" in str(exc_info.value)
+    assert not coordinator.spawned_agents, "zero spawns -- the run never started"
+
+
+# ---------------------------------------------------------------------------
+# Behavior of the shared resolver itself (the semantics both homes inherit)
+# ---------------------------------------------------------------------------
+
+
+def test_explicit_profiles_win_over_auto_discovery():
+    coordinator = _SpawnCoordinator()
+    assert _resolve_profiles({"profiles": {"anthropic": "mine"}}, coordinator) == {
+        "anthropic": "mine"
+    }
+
+
+def test_empty_explicit_profiles_fall_through_to_auto_discovery():
+    """Truthiness fall-through, preserved verbatim from BOTH former copies: an
+    explicit but EMPTY mapping auto-discovers rather than meaning "no profiles"."""
+    coordinator = _SpawnCoordinator()
+    assert _resolve_profiles({"profiles": {}}, coordinator) == {
+        "attractor-openai": "attractor-openai"
+    }
+
+
+def test_auto_discovery_is_gated_on_the_spawn_capability():
+    class _NoSpawn(_SpawnCoordinator):
+        def get_capability(self, name: str):
+            return None
+
+    assert _resolve_profiles({}, _NoSpawn()) == {}
+    assert _resolve_profiles({}, None) == {}
+
+
+def test_non_dict_agent_entries_are_filtered_out():
+    coordinator = _SpawnCoordinator()
+    coordinator.config["agents"]["not-a-dict"] = "just-a-string"
+    assert _resolve_profiles({}, coordinator) == {
+        "attractor-openai": "attractor-openai"
+    }

--- a/modules/loop-pipeline/tests/test_provider_preflight.py
+++ b/modules/loop-pipeline/tests/test_provider_preflight.py
@@ -567,3 +567,243 @@ async def test_spawn_path_matching_profile_still_routes_correctly():
     outcome = await backend.run(node, "task", PipelineContext())
     assert coordinator.spawn_called
     assert outcome.status == StageStatus.SUCCESS
+
+
+# ---------------------------------------------------------------------------
+# Adapter-resolvable profiles (issue #195) -- the residual of #155
+#
+# A profile is a STRING naming an agent.  Knowing the string is MAPPED is not
+# knowing the agent it names can be RESOLVED.  Before #195 the preflight only
+# asked the first question, so "profile mounted + credential set" accepted a
+# configuration whose every spawn was guaranteed to fail -- and the run drained
+# its whole budget in the #155 crash loop instead of refusing at startup.
+# ---------------------------------------------------------------------------
+
+_DOT_DRAIN_LOOP = """\
+digraph drain_loop {
+    graph [goal="the #155 shape: a failing node on a recovery loop"]
+    start [shape=Mdiamond]
+    critique_b [shape=box, llm_provider="openai", prompt="dual-family critique"]
+    recover [shape=box, llm_provider="anthropic", prompt="transient recovery"]
+    done [shape=Msquare]
+    start -> critique_b
+    critique_b -> done    [condition="outcome=success"]
+    critique_b -> recover [condition="outcome=fail"]
+    recover -> critique_b [loop_restart="true"]
+}
+"""
+
+
+def test_profile_naming_an_unresolvable_agent_is_unserviceable():
+    """#195: mapped profile + credential SET, but nothing can resolve the agent
+    it names -> refuse, naming the node, the profile, and what is resolvable."""
+    graph = parse_dot(_DOT_DECLARED_OPENAI)
+    with pytest.raises(ProviderPreflightError) as exc_info:
+        check_provider_preflight(
+            graph,
+            mounted_providers=("anthropic",),
+            profiles={"openai": "attractor-agent-openai"},
+            resolvable_profiles={"attractor-agent-anthropic"},
+            env={"OPENAI_API_KEY": "sk-present"},  # credential IS set
+        )
+    msg = str(exc_info.value)
+    assert "critique_b" in msg  # the failing node
+    assert "attractor-agent-openai" in msg  # the profile that cannot resolve
+    assert "attractor-agent-anthropic" in msg  # what CAN be resolved
+
+
+def test_profile_naming_a_resolvable_agent_stays_serviceable():
+    """Control: the same configuration with the agent present is accepted."""
+    graph = parse_dot(_DOT_DECLARED_OPENAI)
+    check_provider_preflight(
+        graph,
+        mounted_providers=(),
+        profiles={"openai": "attractor-agent-openai"},
+        resolvable_profiles={"attractor-agent-openai"},
+        env={"OPENAI_API_KEY": "sk-present"},
+    )  # no raise
+
+
+def test_resolvable_profiles_none_does_not_police_adapter_resolution():
+    """``None`` means "not knowable on this path", never "everything resolves":
+    the check is skipped, preserving every caller that cannot supply the set
+    (no coordinator, no session.spawn, a stub coordinator, drive_engine)."""
+    graph = parse_dot(_DOT_DECLARED_OPENAI)
+    check_provider_preflight(
+        graph,
+        mounted_providers=(),
+        profiles={"openai": "nothing-resolves-this"},
+        resolvable_profiles=None,
+        env={"OPENAI_API_KEY": "sk-present"},
+    )  # no raise -- unchanged pre-#195 behavior
+
+
+def test_adapter_resolution_is_not_waived_for_unknown_providers():
+    """The credential benefit-of-the-doubt for unknown providers does NOT
+    extend to adapter resolution: a profile name is equally checkable for
+    every provider, so an unresolvable one is refused regardless."""
+    dot = """\
+digraph unknown_provider {
+    start [shape=Mdiamond]
+    work [shape=box, llm_provider="local-llama", prompt="x"]
+    done [shape=Msquare]
+    start -> work -> done
+}
+"""
+    graph = parse_dot(dot)
+    with pytest.raises(ProviderPreflightError) as exc_info:
+        check_provider_preflight(
+            graph,
+            mounted_providers=(),
+            profiles={"local-llama": "llama-agent"},
+            resolvable_profiles=frozenset(),  # nothing resolves
+            env={},
+        )
+    assert "llama-agent" in str(exc_info.value)
+
+
+def test_refusal_names_both_the_absent_agent_and_the_missing_credential():
+    """Both defects present -> ONE refusal line naming BOTH, so a maintainer
+    fixing the credential does not then discover the missing agent."""
+    graph = parse_dot(_DOT_DECLARED_OPENAI)
+    with pytest.raises(ProviderPreflightError) as exc_info:
+        check_provider_preflight(
+            graph,
+            mounted_providers=(),
+            profiles={"openai": "attractor-agent-openai"},
+            resolvable_profiles=frozenset(),
+            env={},  # credential absent too
+        )
+    msg = str(exc_info.value)
+    assert "attractor-agent-openai" in msg
+    assert "OPENAI_API_KEY" in msg
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_execute_refuses_key_set_but_adapter_absent(monkeypatch):
+    """#195 end-to-end, on the #155 graph shape.
+
+    Before the fix this configuration passed the preflight and the run drained
+    to the engine's 200-step safety bound (critique_b executed 101 times).  It
+    must now refuse at startup with ZERO spawns.
+    """
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-present")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-present")
+
+    coordinator = _SpySpawnCoordinator()  # agents: attractor-anthropic ONLY
+    orchestrator = PipelineOrchestrator(
+        config={
+            "dot_source": _DOT_DRAIN_LOOP,
+            "profiles": {
+                "anthropic": "attractor-anthropic",
+                "openai": "attractor-openai",  # names an agent that does not exist
+            },
+        }
+    )
+    with pytest.raises(ProviderPreflightError) as exc_info:
+        await orchestrator.execute(
+            prompt="goal",
+            context=None,
+            providers={},
+            tools={},
+            hooks=None,
+            coordinator=coordinator,
+        )
+    msg = str(exc_info.value)
+    assert "critique_b" in msg
+    assert "attractor-openai" in msg
+    assert not coordinator.spawn_called, "zero spawns -- zero budget spent"
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_execute_accepts_resolvable_profiles_on_the_same_graph():
+    """Control for the test above: the SAME graph and the SAME credentials,
+    with the openai profile naming an agent that DOES exist, still runs.  The
+    fix discriminates on adapter resolution, not on the graph shape."""
+    import os
+
+    saved = {k: os.environ.get(k) for k in ("OPENAI_API_KEY", "ANTHROPIC_API_KEY")}
+    os.environ["OPENAI_API_KEY"] = "sk-present"
+    os.environ["ANTHROPIC_API_KEY"] = "sk-present"
+    try:
+        coordinator = _SpySpawnCoordinator()
+        coordinator.config["agents"]["attractor-openai"] = {
+            "session": {"orchestrator": {"module": "loop-agent"}},
+        }
+        orchestrator = PipelineOrchestrator(
+            config={
+                "dot_source": _DOT_DRAIN_LOOP,
+                "profiles": {
+                    "anthropic": "attractor-anthropic",
+                    "openai": "attractor-openai",
+                },
+            }
+        )
+        result = json.loads(
+            await orchestrator.execute(
+                prompt="goal",
+                context=None,
+                providers={},
+                tools={},
+                hooks=None,
+                coordinator=coordinator,
+            )
+        )
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+    assert result["status"] == StageStatus.SUCCESS.value, result
+    assert coordinator.spawn_called
+
+
+@pytest.mark.asyncio
+async def test_auto_discovered_profiles_are_resolvable_by_construction():
+    """#196 must stay green under #195: auto-discovered profile names ARE the
+    keys of coordinator.config["agents"], so they always resolve -- the new
+    check can never refuse an auto-discovered profile."""
+
+    class _CoordWithAgent:
+        def __init__(self) -> None:
+            self.spawn_called = False
+            self.session = None
+            self.config: dict[str, Any] = {
+                "agents": {
+                    "local-llama": {
+                        "session": {"orchestrator": {"module": "loop-agent"}}
+                    },
+                }
+            }
+
+        def get_capability(self, name: str):
+            return self._spawn_fn if name == "session.spawn" else None
+
+        async def _spawn_fn(self, **kwargs):
+            self.spawn_called = True
+            return {"output": json.dumps({"status": "success"}), "session_id": "s-ad"}
+
+    dot = """\
+digraph auto_disc {
+    graph [goal="auto-discovery"]
+    start [shape=Mdiamond]
+    work [shape=box, llm_provider="local-llama", prompt="x"]
+    done [shape=Msquare]
+    start -> work -> done
+}
+"""
+    coordinator = _CoordWithAgent()
+    orchestrator = PipelineOrchestrator(config={"dot_source": dot})  # no "profiles"
+    result = json.loads(
+        await orchestrator.execute(
+            prompt="goal",
+            context=None,
+            providers={"anthropic": object()},
+            tools={},
+            hooks=None,
+            coordinator=coordinator,
+        )
+    )
+    assert result["status"] == StageStatus.SUCCESS.value, result
+    assert coordinator.spawn_called

--- a/specs/EXTENSIONS.md
+++ b/specs/EXTENSIONS.md
@@ -2142,6 +2142,42 @@ disease, not a remedy).
   `modules/pipeline-runner/tests/test_provider_preflight_drive_engine.py` — contract + regression
   tests (including the provider-not-in-profiles class, ruling R5)
 
+*Addendum (2026-08-17): the "never a drained budget" claim above OVERSTATED what change 1
+guaranteed, and issue #195 named the residual. A profile is a STRING naming an agent, and the
+static definition only asked whether that string was MAPPED — never whether the agent it names
+could be RESOLVED. A profile naming an absent agent therefore satisfied "mounted + credential
+present", passed the preflight, and then failed at every single spawn
+(`AmplifierBackend._run_with_spawn` resolves the profile in exactly one place —
+`coordinator.config["agents"]` — and refuses an entry it cannot find). Probed at `37c8f94` on the
+#155 graph shape (a failing node on a transient-recovery loop): the run was ACCEPTED at startup
+and drained to the engine's 200-step safety bound, executing the unserviceable node 101 times.
+Change 1's serviceability definition now has a second, equally static clause: a profile must also
+NAME AN ADAPTER THIS RUN CAN RESOLVE. `check_provider_preflight` takes `resolvable_profiles` — for
+the spawn backend, the keys of `coordinator.config["agents"]`, the very mapping the spawn path
+looks the profile up in — and refuses at startup naming the node, the profile, and what IS
+resolvable. It is still a pure config lookup: no spawn, no live call, no side effect. `None` means
+"not knowable on this path" (no coordinator, no `session.spawn` — profiles are then never consumed
+at all — or a coordinator whose config is not statically inspectable) and skips the clause; it
+never means "everything resolves". The credential benefit-of-the-doubt for unknown providers is
+NOT extended to it: a profile name is equally checkable for every provider name. Auto-discovered
+profiles (§36's own §-neutral extension, issue #196) are resolvable by construction — they ARE the
+keys of that agents map — so the clause can never refuse one. Honest residual, stated plainly
+rather than re-overstated: this closes the STATICALLY DETECTABLE class only. A profile naming an
+agent that exists but whose own provider construction fails inside the spawned child is not visible
+to any startup check, and still surfaces per-visit via change 2's terminal `ValueError` — terminal
+in the RETRY ladder, which is not the same as terminal at the GRAPH level, and a graph that routes
+FAIL onto a recovery loop will still spend its iteration budget on it. Read change 1 as "a
+STATICALLY detectable provider misconfiguration costs one clear error at startup", not as a total
+guarantee against a drained budget. Also in this change (issue #279, structure not semantics): the
+two independent copies of the provider→agent-profile discovery rule — `execute()`'s preflight step
+5b and `_build_backend()` — collapse into one `_resolve_profiles(config, coordinator)`, with the
+preflight's fail-closed outer handling kept at that call site (a discovery crash yields FEWER
+profiles, hence a refusal, never a false accept) and the rot-prone "mirrors `_build_backend()` lines
+438-443 exactly" comment replaced by the function reference.
+`modules/loop-pipeline/tests/test_profile_resolver_parity.py` pins both call sites to the single
+home behaviorally (one monkeypatched resolver must be observed by both in one run), so it is
+enforced rather than promised.*
+
 ---
 
 ## 37. Bundle Composition: Always-On Guidance, Agent Registration, and Ref-Free Same-Repo Sources


### PR DESCRIPTION
Two preflight refinements in the same file territory, in one PR.

**Fixes #195, fixes #279.** Each half is earned: #195's defect was reproduced at
`37c8f94` and now refuses at startup with zero spawns; #279's duplication is
gone and the single home is pinned by a behavioral parity test.

---

## Part 1 — #195: key-set-but-adapter-absent still drains the budget

### The probe, at pristine `origin/main` (`37c8f94`)

`#195` says "a mounted profile with its credential env var SET but no provider
adapter/module present passes the startup preflight … and the original
budget-draining crash loop remains reachable". I built exactly that scenario on
the #155 graph shape — a node on a transient-recovery loop — and ran it:

- graph: `critique_b [llm_provider="openai"]`, `critique_b -> recover [outcome=fail]`,
  `recover -> critique_b [loop_restart="true"]`
- config: `profiles = {"anthropic": "attractor-anthropic", "openai": "attractor-openai"}`
- env: `OPENAI_API_KEY` **set** (dummy), `ANTHROPIC_API_KEY` **set**
- coordinator: `session.spawn` present; `config["agents"]` contains
  `attractor-anthropic` **only** — nothing can resolve `attractor-openai`

```
PREFLIGHT: ACCEPTED (no refusal) -- the walk began
FINAL STATUS      : fail
FINAL failure     : Pipeline exceeded 200 steps (safety bound): 4 nodes × 50
SPAWNS EXECUTED   : 99  (agents: ['attractor-anthropic'])
PER-NODE EXECUTION RECORDS: {'critique_b': 101, 'recover': 100, 'start': 2}
critique_b FAILURE REASON: loop-pipeline recursion guard: agent 'attractor-openai' has
  session.orchestrator.module=None. The child would inherit or re-enter loop-pipeline,
  causing infinite recursion. Fix: add an inline session.orchestrator (non-pipeline, e.g.
  loop-agent) to the 'attractor-openai' agent definition in your pipe[line profile]
```

**The drain is real and unchanged since filing.** The preflight accepted the
run; the unserviceable node executed **101 times** and the run terminated on the
engine's 200-step safety bound, not on a refusal. No re-scope needed.

The mechanism is more specific than "no adapter module": a profile is a
**string naming an agent**, and `AmplifierBackend._run_with_spawn` resolves that
string in exactly one place — `coordinator.config["agents"]` — refusing an entry
it cannot find. The old preflight only asked whether the string was **mapped**,
never whether the agent it names could be **resolved**.

(Worth stating, because it changes the fix: `resolve_latest_for: no adapter
found for provider 'openai'` — #155's original error — is **not** reachable in a
key-set world. `resolve_latest_for` builds adapters via `Client.from_env()`, so
with the key set an adapter exists. The live residual is the profile→agent
resolution above.)

### §36 overstated — verified

> **What (two changes, one doctrine — a provider misconfiguration costs one clear error at startup,
> never a drained budget or a silent substitution)**

and change 2's

> fails loud (`ValueError`, terminal in the retry ladder — never a crash loop)

Both overstate. `should_retry(ValueError)` is `False`, so it *is* terminal in
the **retry** ladder — but the retry ladder is per-node, and the probe shows the
**graph** re-entering the node 101 times via its recovery route. Terminal in the
retry ladder ≠ terminal at the graph level.

### The fix, and why this one

**A startup adapter-resolution check IS possible with no side effects**, so the
issue's fallback option (i) — fail-fast at first spawn failure — was not needed.
Argued from the code: the thing the spawn path resolves a profile against is
`coordinator.config["agents"]`, a plain mapping already fully materialized in
memory at startup. Both `_build_backend()` and `_run_with_spawn()` read exactly
that dict. Checking `profile_name in coordinator.config["agents"]` is therefore
a **pure dict membership test on data the run already holds** — no spawn, no
network, no import, no lazy resolution forced early. Adapters do *not* resolve
lazily in a way that hides this; the lazy part is the child session's own
provider construction, which is a different (and genuinely runtime-only) class.

`check_provider_preflight` gains `resolvable_profiles: Collection[str] | None`.
Serviceability via a profile now requires **both** (a) the profile names an
adapter this run can resolve, and (b) its credential is present. The refusal:

```
PROVIDER PREFLIGHT FAILED -- refusing to start the pipeline (issue #155,
EXTENSIONS.md section 36). The following nodes declare an llm_provider this run
cannot serve:
  - node 'critique_b' declares llm_provider="openai": profile 'attractor-openai' is
    mapped for it, but no agent named 'attractor-openai' can be resolved for the spawn
    backend (resolvable agents: attractor-anthropic) -- every spawn for this node would fail
…
```

Same probe at this head: **`PREFLIGHT: REFUSED at startup` / `SPAWN ATTEMPTS: 0`.**

Deliberate boundaries, all covered by tests:

- **`None` means "not knowable here", never "everything resolves."** No
  coordinator, no `session.spawn` (profiles are then never consumed at all), or
  a non-statically-inspectable config ⇒ the clause is skipped. This is what
  keeps `drive_engine()` and every stub-coordinator caller unchanged.
- **The unknown-provider benefit-of-the-doubt is NOT extended to it.** A
  credential env var is unknowable for an unknown provider; a profile *name* is
  equally checkable for every provider. An unknown provider with an unresolvable
  profile is refused.
- **#196 is safe by construction, not by luck.** Auto-discovered profile names
  *are* the keys of the agents map, so the clause can never refuse one.
- **Both problems are named in one line** when a profile is both unresolvable
  and credential-less — a maintainer fixing the credential does not then
  discover the missing agent.

Honest residual, stated in the ledger rather than re-overstated: this closes the
**statically detectable** class only. A profile naming an agent that *exists*
but whose own provider construction fails inside the spawned child is invisible
to any startup check and still surfaces per-visit via change 2's `ValueError`.

### §36 delta (dated addendum, house format)

> \*Addendum (2026-08-17): the "never a drained budget" claim above OVERSTATED what change 1
> guaranteed, and issue #195 named the residual. […] Probed at `37c8f94` on the
> #155 graph shape (a failing node on a transient-recovery loop): the run was ACCEPTED at startup
> and drained to the engine's 200-step safety bound, executing the unserviceable node 101 times.
> Change 1's serviceability definition now has a second, equally static clause: a profile must also
> NAME AN ADAPTER THIS RUN CAN RESOLVE. […] `None` means
> "not knowable on this path" […] and skips the clause; it
> never means "everything resolves". […] Honest residual, stated plainly
> rather than re-overstated: this closes the STATICALLY DETECTABLE class only. […] terminal
> in the RETRY ladder, which is not the same as terminal at the GRAPH level, and a graph that routes
> FAIL onto a recovery loop will still spend its iteration budget on it. Read change 1 as "a
> STATICALLY detectable provider misconfiguration costs one clear error at startup", not as a total
> guarantee against a drained budget. Also in this change (issue #279, structure not semantics): […]\*

No renumbering; `## 36.` heading untouched; `test_extensions_ledger_integrity.py` green.

---

## Part 2 — #279: one shared profile resolver

### The extraction

```python
def _resolve_profiles(
    config: dict[str, Any] | None,
    coordinator: Any | None,
) -> dict[str, str]:
```

plus a shared `_spawn_capability(coordinator)` helper (both former copies
hand-rolled the same `hasattr` + `try/except` capability gate).

Both call sites now consume it:

| Home | Before | After |
|---|---|---|
| `_build_backend()` (`~:416-443`) | inline source 1 + source 2 | `profiles = _resolve_profiles(orchestrator_config, coordinator)` |
| `execute()` preflight step 5b (`~:571-608`) | its own copy + `# (mirrors _build_backend() lines 438-443 exactly)` | `_resolve_profiles(self.config, _coordinator)`, comment replaced by the function reference |

Behavior-preserving, deliberately including:

- the **truthiness fall-through** — an explicit but empty `profiles` mapping
  auto-discovers, in both homes, exactly as before;
- the `session.spawn` gate on source 2 and the `isinstance(agent_cfg, dict)` filter;
- **the fail-closed outer handling stays at the preflight call site**, *not*
  inside the resolver. That is the point: `_build_backend()` never had it and
  must keep propagating a malformed-config crash, while the preflight must
  degrade to *fewer* profiles ⇒ a refusal, never a false accept. Folding the
  guard into the shared function would have silently given `_build_backend()`
  an empty-profiles fallback — a new drain risk.

### The parity test — enforced, not promised

`modules/loop-pipeline/tests/test_profile_resolver_parity.py` (9 tests). The
headline is behavioral and discriminating **in both directions**:

`test_one_patched_resolver_is_consumed_by_both_call_sites` monkeypatches
`_resolve_profiles` **once** and runs `execute()` **once**, against a graph
declaring `llm_provider="openai"` and a coordinator whose only agent is
`attractor-openai` (so the *real* resolver would return
`{"attractor-openai": "attractor-openai"}` — no profile for `openai`):

- if the **preflight** still owned a copy → `ProviderPreflightError`;
- if **`_build_backend`** still owned a copy → `profiles.get("openai") is None`
  → the #155 no-fallback `ValueError`, node FAILs, zero spawns.

Only *both* sites consuming the patched resolver yields SUCCESS with a spawn of
`attractor-openai`. It also asserts exactly 2 resolver calls and that both
received the *same* `config` and `coordinator` objects (`is` identity).

Supporting: a direct `_build_backend` pin; a structural guard that
`isinstance(agent_cfg, dict)` appears **exactly once** in the module (a
reintroduced copy fails); a guard that the string `lines 438-443` never returns;
`test_resolver_crash_refuses_it_never_falsely_accepts` (the #279 fail-closed
requirement); and four tests for the resolver's own inherited semantics.

---

## Tier classification (QUALITY_PROTOCOL §3)

**Uncharted / extension.** The canonical spec is silent here — §4.5 explicitly
delegates backend internals to the implementer — which is why §36 exists as an
EXTENSION row (`ATX-M-036`) rather than a divergence. The silence is argued, not
assumed: provider *serviceability* is implementer-level configuration
validation, and a spec-conformant `.dot` is unaffected unless it declares a
provider this run genuinely cannot serve — in which case it previously drained
its budget. The change is additive and non-interfering (`resolvable_profiles`
defaults to `None` = old behavior), and it ships with its `specs/EXTENSIONS.md`
delta in the same PR, as the tier requires. Part 2 is behavior-preserving
refactor and owes no ledger entry of its own; it is recorded in the same
addendum as "structure not semantics" because §36 lists implementation
locations.

## Gates

| Gate | Result |
|---|---|
| loop-pipeline full suite (`uv sync --extra remote && uv run pytest -q`) | **2487 passed, 25 skipped** (baseline at `37c8f94`: 2470/25 — +17 new, zero pre-existing tests changed) |
| pipeline-runner (`uv sync && uv run pytest -q`) | **76 passed, 1 skipped** |
| ★ capsule gate issue-196 (`preflight-auto-discovered-profiles.verify.sh`) | **GREEN** (rc=0) at head |
| capsule gate issue-197 (`topo006-…verify.sh`) | **GREEN** (rc=0) |
| capsule gate issue-268 (`lint-silent-unknown-shape.verify.sh`) | **GREEN** (rc=0) |
| doc/ledger guards + conformance matrix | **285 passed, 24 skipped** (`test_extensions_ledger_integrity`, `test_doc_consistency`, `test_spec_conformance_matrix`, `test_engine_semantics_doc_guard`, `test_explainer_doc_guard`, `test_drift_review_gate`) |
| leak scan (diff + new file) | clean — only `sk-present`, an obvious test dummy |
| `git diff --check` | clean |
| ruff | no new findings vs baseline (S110 4 → 1: three `except: pass` blocks removed by the extraction); changed/new files format-clean |

#197 and #268 were run anyway even though they should not be in scope, and are
not: **`validation.py` is untouched.** The four changed paths are
`preflight.py`, `__init__.py`, `tests/test_provider_preflight.py`,
`specs/EXTENSIONS.md`, plus the new parity test.

## Observations

- **The pipeline's postmortem was right about where the difficulty was.** #195
  went through twice and honestly refused; the hard part was a *discriminating*
  check. What made it tractable by hand was noticing that "adapter" is not one
  thing: `resolve_latest_for`'s adapter (env-key-constructed, and therefore
  present whenever the key is set — so *not* the residual) is a different object
  from the profile→agent binding the spawn path resolves. The issue's own phrase
  "no provider adapter/module present" reads as the first; the reachable defect
  is the second. A check aimed at the first would have found nothing.
- **The two halves fought each other slightly, and #279 won that argument.** The
  natural place to put Part 1's fail-closed guard was inside the shared
  resolver — which would have quietly handed `_build_backend()` an
  empty-profiles fallback where it previously crashed loudly. Keeping the guard
  at the call site is the less tidy-looking choice and the correct one; #279's
  "the fail-closed outer handling must survive extraction" is doing real work
  there.
- **`resolvable_profiles=None` is a fail-open default and I want that on the
  record.** It is what keeps `drive_engine()` (the *original #155 incident
  path*) unchanged in this PR. `drive_engine` has a coordinator and could supply
  the set; I deliberately left it alone to keep the blast radius to the
  orchestrator entry point rather than widening into pipeline-runner's own
  compat-gated territory in the same change. Extending it there is a clean,
  separable follow-up and would close the same class on the CLI path.
- **The 200-step safety bound is what "budget drain" actually looks like now.**
  It is `len(nodes) × 50`, so a bigger graph drains *more*, and the terminal
  outcome names the step bound rather than the provider — which is why nothing
  in the original incident surfaced the cause. The refusal message is the fix
  for that, not the bound.
- **`_MAX_GOAL_GATE_RETRIES = 50` doing double duty as the step-bound multiplier
  is a smell I did not touch.** The name says goal-gate retries; the use at
  `engine.py:611` is a global step cap. Not this PR's business, but the next
  person reading a "Pipeline exceeded 200 steps" failure will go looking for a
  goal gate that has nothing to do with it.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)
