### PR TITLE
fix(implement-lane): a stalled task-runner.dot run exited without committing, and this lane discarded the work

### DIFF
--- a/.github/capsule-pipeline/README.md
+++ b/.github/capsule-pipeline/README.md
@@ -1094,3 +1094,46 @@ against the DENY list) is exercised directly by `leak_gate` in
   method on vendored and source: 35 node declarations / 62 edges on BOTH
   sides (35/62 at the prior pin -- exactly the zero-topology delta the
   source commit claims).
+
+- **2026-08-17** -- `task-runner.dot` re-synced
+  `b3bcedb5da8d60ce4490ad9ad9e2d547235891f5` ->
+  `fae27d0e1969fd48f9b890b9c9660b10f2489471` (WORK DURABILITY, issue #220).
+  One new deterministic node, `salvage`, and three rewired edges. The defect
+  it closes: `package` was the ONLY node in the graph that composed a commit,
+  reachable by exactly one edge (`verdict=ship`), so every non-shipping exit
+  (stall, budget exhaustion, blocked diagnosis) ran `escalate -> abandon` --
+  `echo ... >&2; exit 1` -- with the run's entire product still uncommitted in
+  the runner's working tree. Incident run 31789137305 destroyed a complete,
+  gate-GREEN implementation that way, and THIS repository's
+  `capsule-implement.yml` was the actor that named the eight files and
+  refused. `salvage` commits the tree AS IT STANDS to the CURRENT branch on
+  the three non-shipping doors into the human gate (`diagnose_gate` blocked,
+  `postmortem`, `pm_gate`), then routes to `escalate` on one unconditional
+  edge. `ship_check`'s dirty leg is deliberately NOT routed through it (that
+  door owes a human the forensic picture the gate just refused).
+  - **Step 2 (`uplift_dir` references):** unchanged in BOTH directions --
+    `grep -n uplift_dir` on the re-synced source and on the prior pin returns
+    the identical two hits (`setup`'s `check-upstream-leaks.sh` preflight is
+    `capsule.dot`'s, not this graph's; `task-runner.dot` itself references no
+    `$uplift_dir` path at all, before or after). No checker added, removed,
+    renamed, or newly called; nothing to vendor and nothing to delete.
+  - **Steps 2a/2b:** no new or newly-vendored Python checker, and no new
+    graph-level call site of any checker -- the new node shells out to `git`
+    and nothing else. Both steps are vacuous for this sync, recorded rather
+    than skipped silently.
+  - **Byte parity:** `tail -n +97 .github/capsule-pipeline/task-runner.dot`
+    is byte-identical to the source's `runner/task-runner.dot` at the pinned
+    commit; that body's sha256
+    (`7c93fe011563c9c13521c178ede6e530ed91bfde13a536b6b745f053d9c49f47`) is
+    now pinned in this file's provenance box, so parity is checkable here
+    without access to the source repository. The prior pin's body sha256 was
+    `62b50b53b87e8fdd0b457145be646f5cc54ab414081b1f321c721b7c45f0d53e`.
+  - **Topology, same comment-stripped count method on both sides:** 23 -> 24
+    node declarations, 36 -> 37 edges. `attractor lint` on the re-synced
+    `.dot`: 0 ERRORs, 1 warning -- the pre-existing `CMD-001` on `ship_check`,
+    byte-identical to the warning at the prior pin.
+  - **Source-side rig:** 30/30 green, including a new control
+    (`runner/tests/test_task_runner_salvage.sh`, 34 assertions) whose engine
+    battery runs the REAL engine over the REAL terminal path in both
+    directions -- a reconstructed PRE-FIX wiring that must lose the work, and
+    the shipped wiring on the identical fixture that must keep it.

--- a/.github/capsule-pipeline/task-runner.dot
+++ b/.github/capsule-pipeline/task-runner.dot
@@ -1,13 +1,19 @@
 // ============================================================================
 // VENDORED COPY -- see .github/capsule-pipeline/README.md for provenance,
 // scope, and re-sync instructions. Source: a private working repository
-// (not publicly reachable), pinned at its commit b3bcedb5da8d60ce4490ad9ad9e2d547235891f5
-// (runner/task-runner.dot, 2026-08-09 -- subtraction sweep: source header
-// slimmed 518 -> 419 lines (155 -> 56-line header; doctrine -> primer
-// cites) plus three stale in-body pointer fixes; node/edge declarations
-// UNCHANGED, 24). This copy is byte-identical to the source file below this
-// header -- do not hand-edit the body; re-sync from source and re-apply
-// this header instead.
+// (not publicly reachable), pinned at its commit fae27d0e1969fd48f9b890b9c9660b10f2489471
+// (runner/task-runner.dot, 2026-08-17 -- WORK DURABILITY re-sync, issue #220:
+// one new deterministic `salvage` node commits the run's working tree to the
+// CURRENT branch on the three NON-shipping doors into the human gate
+// (diagnose_gate-blocked, postmortem, pm_gate), so a stalled or
+// budget-exhausted run's product outlives its runner instead of dying as an
+// uncommitted tree; `package`, `ship_check` and the whole verdict=ship path
+// are untouched. Node declarations 23 -> 24, edge declarations 36 -> 37).
+// This copy is byte-identical to the source file below this header -- the
+// body's sha256 is 7c93fe011563c9c13521c178ede6e530ed91bfde13a536b6b745f053d9c49f47
+// (`tail -n +97 task-runner.dot | sha256sum`), so parity is checkable without
+// access to the source repository. Do not hand-edit the body; re-sync from
+// source and re-apply this header instead.
 //
 // WHY THIS FILE IS VENDORED HERE: this is the "implement" stage of the
 // issue->attractor->PR system (see DESIGN-issue-to-attractor-pipeline.md
@@ -127,13 +133,20 @@
 // FILE CONTRACTS (specific to this graph; mechanism details live at the
 // nodes/edges that implement them):
 //   - PARAM NAMESPACE: shell vars in tool_commands (VF, n, rc, sig, B, N,
-//     prev, ok, a, b, la, lb, sc, f, hs, last) are safe ONLY because no param
-//     shares their name. Never add a param named like a shell var (§6.12).
+//     prev, ok, a, b, la, lb, sc, f, hs, last, GD, err) are safe ONLY because
+//     no param shares their name. Never add a param named like a shell var
+//     (§6.12).
 //   - BUDGET: .ai/iter counts TOTAL verify attempts and is LEDGER-DERIVED —
 //     verify recomputes it from .ai/convergence.jsonl (append-only; workers
 //     don't touch it) and writes .ai/iter only as a downstream mirror. The
 //     budget wall lives IN verify, so green-path and transient re-entries
 //     spend iterations too (see the TRANSIENT-RECOVERY edge block).
+//   - WORK DURABILITY: `package` is the ONLY node that composes a shipping
+//     commit, and it is reachable only on verdict=ship. Every OTHER route to
+//     the human gate therefore passes through `salvage` first, which commits
+//     the working tree AS IT STANDS to the CURRENT branch so a non-converging
+//     run outlives its runner. See the node for the .ai/ exclusion rule and
+//     the one door deliberately left un-salvaged.
 //   - CONVERGENCE RECORD: exactly TWO gates append to .ai/convergence.jsonl —
 //     verify ({"gate": "verify", ...} + budget-exhausted records) and verdict
 //     ({"gate": "critique", "ship", "a", "b"}; an unwritten verdict is
@@ -387,8 +400,50 @@ digraph BacklogTaskRunner {
     forge_fail [shape=parallelogram, class="glue", max_retries=0,
         tool_command="echo 'FORGE-GUARD FAIL: .ai/critique.md failed the stamp check at the verdict read - either the file was rewritten after its post-critique stamp (single-actor consensus forge, or an accidental clobber), or the stamp itself (.ai/critique.hash) was absent/truncated at verdict time (stamp_a writes-or-fails, so that is never benign). Inspect .ai/critique.md against .ai/critique.hash and the run events before trusting this round.' >&2; exit 1"]
 
+    // ---------- salvage: the work outlives the runner ----------
+    // WHY THIS NODE EXISTS (issue #220; incident run 31789137305). `package`
+    // is the only node in this graph that composes a commit, and exactly one
+    // edge reaches it (verdict=ship). So every non-shipping exit — stall,
+    // budget exhaustion, blocked diagnosis, a package that could not close
+    // cleanly — used to end with the run's ENTIRE product living only in the
+    // runner's dirty working tree, which dies with the runner. That is not
+    // hypothetical: run 31789137305 built a complete, gate-GREEN feature (6/6
+    // acceptance criteria, 724 + 1836 tests passing, critic A shipping),
+    // stalled on critic B's documentation findings three rounds running, and
+    // eight files of finished work were named in the invoking workflow's own
+    // refusal message and then destroyed.
+    //
+    // PLACED BEFORE THE HEXAGON, NOT ON THE ABANDON LEG. In that same run the
+    // `escalate` hexagon itself RAISED (no interviewer configured) and the run
+    // died AT the decision point — a salvage hanging off `escalate -> abandon`
+    // would never have executed. Making the tree durable BEFORE the gate is
+    // asked also means the [C] Continue leg simply commits a WIP checkpoint and
+    // carries on; `package` composes its own commit on top, and `ship_check` is
+    // unaffected (it asserts a clean tree and a commit at HEAD — both still
+    // true).
+    //
+    // .ai/ IS NEVER IN THE SALVAGE COMMIT, by two independent mechanisms: the
+    // node writes the repo's own `.git/info/exclude` convention (the same one
+    // `package` is told to honor) BEFORE staging, and then unstages `.ai`
+    // outright if the index carries it anyway — which is what covers the
+    // TRACKED-.ai leak channel `ship_check` guards. The salvage commit
+    // therefore contains exactly the paths an invoking workflow's porcelain
+    // guard would have refused to push, and nothing else.
+    //
+    // EXIT-0 GUARANTEED, LOUD ANYWAY (pm_gate's idiom, and for pm_gate's
+    // reason): on a FAIL outcome the engine does not traverse unconditional
+    // edges (spec §3.7 fail-fast), so a non-zero exit here would strand the run
+    // BEFORE the human gate — failure handling must not become a second
+    // failure. Nothing is swallowed to buy that: every branch writes a labeled
+    // record to .ai/salvage.md AND echoes it to stderr, carrying git's own
+    // refusal text verbatim (SALVAGED / NOTHING-TO-SALVAGE / SALVAGE-FAILED /
+    // SALVAGE-IMPOSSIBLE), and `escalate` names that file so the human deciding
+    // [A] vs [C] reads what actually happened rather than assuming it worked.
+    salvage [shape=parallelogram, class="glue", max_retries=0,
+        tool_command="n=$(cat .ai/iter 2>/dev/null || echo '?'); mkdir -p .ai; f=.ai/salvage.md; if ! git rev-parse --verify -q HEAD >/dev/null 2>&1; then echo 'SALVAGE-IMPOSSIBLE: the target tree is not a git repository with a commit at HEAD, so nothing can be committed here. The work survives only as the run evidence under .ai/.' > $f; cat $f >&2; printf salvage_impossible; exit 0; fi; GD=$(git rev-parse --git-common-dir 2>/dev/null || printf .git); mkdir -p \"$GD/info\"; grep -qxF '.ai/' \"$GD/info/exclude\" 2>/dev/null || printf '.ai/\\n' >> \"$GD/info/exclude\"; err=$(git add -A 2>&1); if [ $? -ne 0 ]; then { echo 'SALVAGE-FAILED: git add -A refused, so the working tree was NOT committed and this run produced no durable artifact beyond .ai/. git said:'; echo \"$err\"; } > $f; cat $f >&2; printf salvage_failed; exit 0; fi; [ -n \"$(git ls-files -- .ai)\" ] && git reset -q -- .ai; if git diff --cached --quiet; then echo 'NOTHING-TO-SALVAGE: at the escalation gate the tree carried no uncommitted change outside .ai/ (the work was already committed, or none was produced).' > $f; cat $f >&2; printf nothing; exit 0; fi; err=$(git commit -q -m \"salvage: non-converged run WIP at iteration ${n}\" -m \"task-runner.dot reached its escalation gate without a ship verdict. This commit preserves the working tree exactly as the run left it, so the work outlives the runner. NOT a proven fix: there is no critique consensus and there may be no green gate. The verdict trail is in .ai/ (convergence.jsonl, postmortem/report.md, verify.log), which is excluded from version control and published as run evidence.\" 2>&1); if [ $? -ne 0 ]; then { echo 'SALVAGE-FAILED: git commit refused, so the working tree was NOT committed. git said:'; echo \"$err\"; } > $f; cat $f >&2; printf salvage_failed; exit 0; fi; { echo \"SALVAGED: $(git rev-parse --short HEAD) on $(git rev-parse --abbrev-ref HEAD) - the non-converged run working tree is now a commit on the CURRENT branch.\"; echo; git show --stat --format='%H%n%s' HEAD | head -60; } > $f; cat $f >&2; printf salvaged"]
+
     escalate [shape=hexagon,
-        prompt="The runner could not converge within budget, or could not package cleanly. Review .ai/postmortem/ and .ai/convergence.jsonl before choosing."]
+        prompt="The runner could not converge within budget, or could not package cleanly. Review .ai/postmortem/ and .ai/convergence.jsonl before choosing. The working tree has already been committed to the current branch where that was possible — .ai/salvage.md records exactly what was salvaged, or why nothing was; read it before assuming the work is safe."]
 
     // Budget bumps are capped so the engine step cap can never become the
     // real terminator (which would bypass the postmortem path with a bare FAIL).
@@ -396,7 +451,7 @@ digraph BacklogTaskRunner {
         tool_command="B=$(cat .ai/budget 2>/dev/null); B=${B:-6}; N=$((B+3)); [ $N -gt 15 ] && N=15; echo $N > .ai/budget; rm -f .ai/last-fail-sig; printf continue"]
 
     abandon [shape=parallelogram, class="glue", max_retries=0,
-        tool_command="echo 'ABANDONED: see .ai/postmortem/report.md and .ai/convergence.jsonl' >&2; exit 1"]
+        tool_command="echo 'ABANDONED: see .ai/postmortem/report.md, .ai/convergence.jsonl, and .ai/salvage.md — the run work-in-progress was committed to the current branch unless that file says otherwise' >&2; exit 1"]
 
     // ================= edges =================
     start -> setup
@@ -427,7 +482,7 @@ digraph BacklogTaskRunner {
 
     diagnose -> diagnose_gate
     diagnose_gate -> attempt  [condition="context.tool.last_line=continue", label="change course"]
-    diagnose_gate -> escalate [condition="context.tool.last_line=blocked"]
+    diagnose_gate -> salvage  [condition="context.tool.last_line=blocked"]
 
     // Expensive gate: two independent family-diverse reviewers in
     // sequence, then a deterministic consensus verdict.
@@ -500,9 +555,22 @@ digraph BacklogTaskRunner {
     // labeled artifact. Same unconditional+outcome=fail edge idiom as the
     // critique nodes (box node — no tool.last_line, so the stale-label
     // defensive conjunction does not apply here).
-    postmortem -> escalate
+    postmortem -> salvage
     postmortem -> pm_gate  [condition="outcome=fail", label="no report after engine retries — synthesize"]
-    pm_gate -> escalate
+    pm_gate -> salvage
+    // WORK DURABILITY (issue #220): the three non-shipping doors to the human
+    // gate route through `salvage` first, so the run's product is a commit on
+    // the current branch before anyone is asked [A]/[C] — and before the
+    // hexagon gets a chance to raise. `salvage` is exit-0 guaranteed, so this
+    // one unconditional edge carries every outcome it can produce (a labeled
+    // .ai/salvage.md carries WHICH one); no last_line= condition is read here,
+    // so the stale-label conjunction rule (primer §6.11) has nothing to bind.
+    // ship_check's dirty leg is DELIBERATELY NOT routed here: that door means
+    // `package` already committed and left the tree unclean (stray porcelain,
+    // or the TRACKED-.ai leak channel), and the work is therefore already
+    // durable — what a human needs at that door is the forensic picture the
+    // gate just refused, not another commit on top of it.
+    salvage -> escalate
     escalate -> abandon     [label="[A] Abandon — keep the postmortem"]
     escalate -> bump_budget [label="[C] Continue — raise the budget"]
     bump_budget -> attempt

--- a/.github/workflows/capsule-implement.yml
+++ b/.github/workflows/capsule-implement.yml
@@ -622,6 +622,36 @@ jobs:
 
       - name: Push fix branch and open PR
         id: pr
+        # LOAD-BEARING, AND FRAGILE ON PURPOSE -- READ BEFORE "FIXING" THE
+        # EXIT CAPTURE (issue #220 salvage, both layers).
+        #
+        # This `if:` is the ONLY door the salvage paths have. A non-converged
+        # run reaches this step exclusively through GitHub's absent-output
+        # coercion: the run step above executes under `set -uo pipefail` with
+        # `bash -e` semantics, so when the engine exits non-zero the step
+        # ABORTS BEFORE its `echo "attractor_exit=$?" >> "$GITHUB_OUTPUT"`
+        # line runs at all. The output is therefore never written, and GitHub
+        # coerces a missing output to '0' in an `== '0'` comparison -- which
+        # is precisely why the non-converged path gets in here to salvage and
+        # push. (The `classify` step above exists because that same coercion
+        # makes ABSENT and CONVERGED indistinguishable to an `if:`; it
+        # recovers the truth from checkpoint.json and everything below
+        # branches on `steps.classify.outputs.converged`, not on this value.)
+        #
+        # CONSEQUENCE: if anyone ever makes the run step record
+        # attractor_exit=1 RELIABLY -- an `|| true`, a `set +e`, an explicit
+        # capture into a variable, a composite action -- this condition goes
+        # FALSE on exactly the runs salvage exists for, this step is skipped,
+        # and BOTH salvage layers' commits (task-runner.dot's own `salvage`
+        # node and this step's own Layer-2 commit) strand on a runner that is
+        # about to be destroyed. That is the #220 bug again, reintroduced by a
+        # change that looks like an unambiguous improvement.
+        #
+        # If you fix the exit capture, you MUST widen this condition in the
+        # same commit -- e.g. gate on `steps.locate.outputs.skip != 'true'`
+        # alone and let the `classify` step's `converged` output (already the
+        # sole classifier below) decide converged-vs-salvage. Do not change one
+        # without the other.
         if: always() && steps.locate.outputs.skip != 'true' && steps.run.outputs.attractor_exit == '0'
         # See capsule-specify.yml's "Open capsule PR" step for the
         # confirmed platform limitation this token falls back around:
@@ -713,6 +743,66 @@ jobs:
             # postmortem -- there is simply no branch worth pushing.
             echo "::warning::Non-converged run produced nothing to salvage: HEAD matches origin/main and the tree is clean outside .ai/. No work-in-progress PR is opened, because there is no work to put in one."
             exit 0
+          fi
+
+          # SECRET SCAN GATE ON THE PUSH -- the guarantee this egress never had.
+          #
+          # Everything above this line can put WORKER-WRITTEN bytes onto a
+          # commit that the next line makes PUBLIC, and on the salvage paths
+          # those bytes passed no critic, no gate and no human: task-runner.dot's
+          # own `salvage` node commits the dirty tree on its non-shipping doors
+          # (Layer 1), and the block above commits whatever the engine died
+          # before capturing (Layer 2). The converged path is not exempt either
+          # -- ship_check proves the tree is CLEAN and GATE-GREEN, which is a
+          # different claim from "contains no credential"; that push has always
+          # been unscanned too, and closing it here costs nothing.
+          #
+          # This is not hypothetical for this repo. The scrub step above exists
+          # because a worker agent dumped its environment mid-run and a literal
+          # OPENAI_API_KEY landed in worker-written files on disk (2026-08
+          # incident); GitHub's live-log masking does not touch bytes on disk.
+          # The run-evidence artifact got BOTH a scrub and a scan out of that
+          # incident. A pushed branch is at least as public as an artifact and
+          # cannot be un-pushed the same way -- yet it had NEITHER. Per this
+          # workflow's own doctrine (see the scrub step's comment above): scrub
+          # is best-effort cleaning, the scan is the GUARANTEE. Here is the
+          # guarantee.
+          #
+          # Fail-closed: any finding means no push, a red job, and a refusal
+          # that names the offending files. `scan` prints file:line:shape and
+          # NEVER the matched value (scrub_secrets.py's scan_text returns shapes
+          # and variable names only), so the refusal is safe in a public log.
+          #
+          # ARGUMENT PLUMBING, deliberately:
+          #   -z                NUL-separated, UNQUOTED paths. A bare
+          #                     --name-only would let a filename containing a
+          #                     space split into two bogus roots, and would
+          #                     C-quote non-ASCII names into paths that do not
+          #                     exist. Paired with `xargs -0`.
+          #   --diff-filter=d   drop DELETED paths -- they are not in the
+          #                     worktree, so there are no bytes there to scan.
+          #   xargs -r          an empty diff runs the scanner ZERO times rather
+          #                     than invoking it with no roots (argparse requires
+          #                     at least one and would exit non-zero, turning
+          #                     "nothing changed" into a false refusal).
+          # `origin/main HEAD` is two-dot on purpose (the same idiom as the
+          # GATE_CHANGED measurement below). If main moved during the run this
+          # over-scans by the few files main gained -- over-scanning is the
+          # fail-closed direction, and this checkout was taken from origin/main
+          # at job start, so in practice the two-dot and three-dot sets agree.
+          PUSH_SCAN_LOG="$(mktemp)"
+          if git diff --name-only --diff-filter=d -z origin/main HEAD \
+              | xargs -0 -r python3 .github/capsule-pipeline/scrub_secrets.py scan \
+              > "$PUSH_SCAN_LOG" 2>&1; then
+            cat "$PUSH_SCAN_LOG"
+            echo "push secret gate: clean -- every file this push adds or changes relative to origin/main was scanned, and nothing secret-shaped was found."
+          else
+            cat "$PUSH_SCAN_LOG" >&2
+            SCAN_FILES="$(sed -n 's/^scan FINDING //p' "$PUSH_SCAN_LOG" \
+              | sed -e 's/:[0-9][0-9]*: shape=.*$//' -e 's/: unreadable .*$//' \
+              | sort -u | tr '\n' ' ' || true)"
+            echo "::error::The push secret gate BLOCKED this branch -- secret-shaped material was found in the bytes this job was about to push to the public branch '$BRANCH'. NOTHING WAS PUSHED and no PR was opened. Offending file(s): ${SCAN_FILES:-see the scan findings above}. The findings above give file:line:shape; the values themselves are never printed. This gate covers both salvage layers (task-runner.dot's own \`salvage\` commit and this workflow's Layer-2 commit) and the converged path -- salvaged work is UNREVIEWED by construction, so it is scanned before it can leave the runner. Rotate any credential these findings implicate, then clean the tree before re-running." >&2
+            exit 1
           fi
 
           git push origin "HEAD:refs/heads/$BRANCH"

--- a/.github/workflows/capsule-implement.yml
+++ b/.github/workflows/capsule-implement.yml
@@ -638,19 +638,81 @@ jobs:
           ISSUE="${{ steps.locate.outputs.issue_number }}"
           CAPSULE_ID="${{ steps.locate.outputs.capsule_id }}"
 
-          # Defensive: task-runner.dot's own ship_check gate already
-          # asserts a clean tree (no tracked .ai/ leakage, no stray
-          # porcelain) before reaching `done` -- a second, independent
-          # check here costs nothing and this push must start from a
-          # genuinely proven tree.
-          if [ -n "$(git status --porcelain | grep -v -E '^\?\? \.ai')" ]; then
-            echo "::error::Workspace has unexpected changes outside .ai/ after a 'done' run -- refusing to push an unproven tree." >&2
+          # WORK DURABILITY, LAYER 2 (issue #220). The converged and the
+          # non-converged paths reach this step for opposite reasons, and a
+          # single porcelain rule served one of them and destroyed the other.
+          #
+          # CONVERGED: unchanged, and deliberately so. task-runner.dot's own
+          # ship_check gate already asserts a clean tree (no tracked .ai/
+          # leakage, no stray porcelain) before reaching `done`; this second,
+          # independent check costs nothing and this push must start from a
+          # genuinely proven tree. That guard is load-bearing -- in run
+          # 31789137305 it was the CORRECT actor and the reason nothing
+          # unproven shipped. It is not weakened, relaxed, or bypassed below.
+          #
+          # NON-CONVERGED: this branch already opens a work-in-progress PR that
+          # claims no gate and no critique, precisely so a non-converging run's
+          # work "is not lost". Refusing it for being dirty is what actually
+          # lost it: in run 31789137305 this guard printed eight files of
+          # finished, gate-GREEN work by name and then the runner was torn down
+          # with all of it still uncommitted. So on THIS path an uncommitted
+          # tree is committed rather than refused.
+          #
+          # Layer 1 is the engine's own `salvage` node, which now commits the
+          # tree on every non-shipping route into its human gate, so on the
+          # ordinary non-convergence path this block finds nothing left to do.
+          # Layer 2 exists because the engine can die BEFORE that node runs at
+          # all -- a crash in the maker/critic lane, the step timeout, an OOM
+          # kill -- and the two layers are independent on purpose.
+          CONVERGED="${{ steps.classify.outputs.converged }}"
+          SALVAGE_NOTE="task-runner.dot's own \`salvage\` node had already committed the run's tree (or there was nothing outside \`.ai/\` to commit); this workflow added no commit of its own."
+          DIRTY="$(git status --porcelain | grep -v -E '^\?\? \.ai' || true)"
+          if [ -n "$DIRTY" ]; then
+            if [ "$CONVERGED" = "true" ]; then
+              echo "::error::Workspace has unexpected changes outside .ai/ after a 'done' run -- refusing to push an unproven tree." >&2
+              git status --porcelain >&2 || true
+              exit 1
+            fi
+            echo "::warning::Non-converged run left an uncommitted tree that task-runner.dot's own salvage node did not capture -- committing it here so the work is not discarded (issue #220). This is work-in-progress, not a proven fix."
             git status --porcelain >&2 || true
-            exit 1
+            # .ai/ is run EVIDENCE, not product: it ships as an uploaded
+            # artifact, never as a commit. Belt and braces, same as the engine
+            # node -- write the repo's own exclude convention BEFORE staging,
+            # then unstage .ai outright in case a worker had already git-added
+            # it (the tracked-.ai leak channel ship_check guards).
+            EXCLUDE="$(git rev-parse --git-common-dir)/info/exclude"
+            mkdir -p "$(dirname "$EXCLUDE")"
+            grep -qxF '.ai/' "$EXCLUDE" 2>/dev/null || printf '.ai/\n' >> "$EXCLUDE"
+            git add -A
+            if [ -n "$(git ls-files -- .ai)" ]; then git reset -q -- .ai; fi
+            if git diff --cached --quiet; then
+              SALVAGE_NOTE="The tree was dirty only under \`.ai/\` (run evidence), so nothing was committed by this workflow."
+            else
+              git commit -q \
+                -m "salvage(workflow): non-converged implement run WIP for #${ISSUE}" \
+                -m "task-runner.dot did not converge and left this tree uncommitted -- committed by capsule-implement.yml so the work survives the runner (issue #220). NOT a proven fix: none of the converged path's gate or critique claims apply. Run evidence is in the workflow run's uploaded artifacts."
+              SALVAGE_NOTE="The engine did not reach its own \`salvage\` node, so THIS WORKFLOW committed the uncommitted tree as \`$(git rev-parse --short HEAD)\` -- see the \`salvage(workflow):\` commit on this branch."
+              echo "workflow-level salvage commit: $(git rev-parse --short HEAD)"
+            fi
+            # Re-assert the invariant the converged guard asserts: whichever
+            # branch ran, nothing outside .ai/ may remain uncommitted at push.
+            if [ -n "$(git status --porcelain | grep -v -E '^\?\? \.ai' || true)" ]; then
+              echo "::error::Workspace is STILL dirty outside .ai/ after the work-in-progress salvage commit -- refusing to push a tree this step cannot account for." >&2
+              git status --porcelain >&2 || true
+              exit 1
+            fi
           fi
           if [ "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)" ]; then
-            echo "::error::task-runner.dot reported success but HEAD matches origin/main -- no fix was actually committed. Refusing to open an empty PR." >&2
-            exit 1
+            if [ "$CONVERGED" = "true" ]; then
+              echo "::error::task-runner.dot reported success but HEAD matches origin/main -- no fix was actually committed. Refusing to open an empty PR." >&2
+              exit 1
+            fi
+            # Honest non-event, not a failure of this step: the run genuinely
+            # produced nothing. The job is still failed for non-convergence by
+            # the final step, and the issue comment still carries the
+            # postmortem -- there is simply no branch worth pushing.
+            echo "::warning::Non-converged run produced nothing to salvage: HEAD matches origin/main and the tree is clean outside .ai/. No work-in-progress PR is opened, because there is no work to put in one."
+            exit 0
           fi
 
           git push origin "HEAD:refs/heads/$BRANCH"
@@ -734,6 +796,8 @@ jobs:
               echo "Measured classification: engine exit code \`${EXIT_RAW:-<absent>}\` (absent means the"
               echo "engine exited non-zero and the run step aborted before recording it), the"
               echo "pipeline's own recorded outcome \`${RECORDED_OUTCOME}\` (checkpoint.json)."
+              echo
+              echo "Where this branch's commits came from (issue #220): ${SALVAGE_NOTE}"
               echo
               echo "$GATE_NOTE"
               echo


### PR DESCRIPTION
Fixes #220.

`task-runner.dot`'s `package` node was the **only** node in the graph that composed a commit, and exactly one edge reached it:

```
verdict  -> package  [condition="context.tool.last_line=ship && outcome=success"]
```

Every other terminal route — quality-loop stall, budget exhaustion, blocked diagnosis — ran `escalate -> abandon`, whose whole body is `echo ... >&2; exit 1`. The run's entire product stayed unstaged in the runner's working tree, this workflow's porcelain guard correctly refused to push an unproven tree, and the runner was torn down with the work still in it. Run 31789137305 destroyed a complete, gate-GREEN implementation that way — and **this lane's own guard printed the eight files by name on the way to discarding them**.

---

## 1. The loss, reproduced BEFORE touching anything

At `37c8f94` (this PR's base), with the issue's own minimal graph and `--on-human-gate auto-approve` (so the hexagon is *answered*, not crashed — this is the clean, declared abandonment):

```
$ git status --porcelain      # before
 M f.txt
?? g.dot
?? g.txt

$ uv run --project modules/pipeline-runner attractor run /tmp/repro220/tree/g.dot \
    --cwd /tmp/repro220/tree --logs-root /tmp/repro220/logs --on-human-gate auto-approve
[PIPELINE] ✗ Error at abandon (no_matching_edge): Command exited with code 1: ABANDONED: see .ai/postmortem/report.md and .ai/convergence.jsonl
attractor: status=fail
{"status": "fail", "notes": "No matching edge from node 'abandon'", "logs_dir": "/tmp/repro220/logs"}
EXIT=1

$ git status --porcelain      # after -- unchanged, nothing committed
 M f.txt
?? g.dot
?? g.txt
$ git log --oneline
eef839b base
```

The same loss is reproduced a second time **through the real engine on the real terminal path**, as a permanent RED control inside the source-side rig (`E1`, below): the pre-fix wiring is reconstructed and must lose the work.

## 2. The work SURVIVES, after

Same fixture, same abandon path, shipped wiring (rig `E2`, real engine, real extracted `salvage`/`abandon` commands, real git repo):

```
ok:   E1 BEFORE (pre-fix wiring): escalate -> [A] Abandon exits FAIL with the run's work STILL
      UNCOMMITTED (HEAD unmoved at 52bd6f9; porcelain still
      ['M f.txt', '?? .ai/', '?? _cost.py']) -- the #220 loss, reproduced
ok:   E2 AFTER (shipped wiring): the SAME abandon path leaves the work as commit 521def9
      'salvage: non-converged run WIP at iteration 4' carrying ['_cost.py', 'f.txt']
      -- and .ai/salvage.md records it
ok:   E2 AFTER: the run still ends FAIL at abandon -- salvaging work never launders a
      non-converged run into a success
ok:   E2 AFTER: the tree is clean outside .ai/ -- an invoking workflow's porcelain guard now
      has nothing to refuse on this path
```

The salvage commit lands on **the current branch** (no branch is invented; the workflow's `git push origin HEAD:refs/heads/$BRANCH` target is unchanged), its subject is `salvage: non-converged run WIP at iteration N`, and its body says `NOT a proven fix` in as many words so a reviewer cannot mistake it for a shipped commit.

---

## 3. Fix mechanics — both sides

Both were cheap, and each covers the other's blind spot, so this is deliberate defense in depth.

### (a) `.dot` side — a new `salvage` node

Re-vendored `.github/capsule-pipeline/task-runner.dot` (source `b3bcedb` → `fae27d0`). One new deterministic node and three rewired edges:

```
diagnose_gate -> salvage  [condition="context.tool.last_line=blocked"]
postmortem -> salvage
pm_gate -> salvage
salvage -> escalate
```

- **Placed BEFORE the hexagon, not on the abandon leg.** In the incident the `escalate` hexagon *itself* raised (`HumanGateHandler requires an Interviewer but none was provided`) and the run died **at** the decision point. A salvage hanging off `escalate -> abandon` would never have executed. Making the tree durable before the gate is asked also means the `[C] Continue` leg simply commits a WIP checkpoint and carries on; `package` composes its own commit on top and `ship_check` still sees a clean tree with a commit at HEAD.
- **`.ai/` is never in the salvage commit**, by two independent mechanisms: the node writes the repo's own `.git/info/exclude` convention (the same one `package`'s prompt is told to honor) *before* staging, and unstages `.ai` outright if the index carries it anyway — which is what covers the **tracked-`.ai` leak channel** `ship_check` guards. The leak evidence itself is left intact (`git ls-files .ai/` still shows it); it is not buried.
- **Exit-0 guaranteed, loud anyway** — `pm_gate`'s idiom, for `pm_gate`'s reason. On a FAIL outcome the engine does **not** traverse unconditional edges (spec §3.7 fail-fast; `edge_selection.py`), so a non-zero exit here would strand the run *before* the human gate: failure handling must not become a second failure. Nothing is swallowed to buy that — every branch writes a labeled `.ai/salvage.md` **and** echoes it to stderr carrying git's own refusal text verbatim (`SALVAGED` / `NOTHING-TO-SALVAGE` / `SALVAGE-FAILED` / `SALVAGE-IMPOSSIBLE`), and both exit doors (`escalate`'s prompt, `abandon`'s message) name that file so nobody assumes the work is safe.
- **House rules:** `salvage` reads no `context.tool.last_line` and carries a single unconditional out-edge, so no stale-label conjunction is owed; the rig nevertheless sweeps **every** edge in the file for the foot-gun (`&& outcome=success` on any `last_line=` edge sharing a source with an `outcome=fail` edge) rather than spot-checking the new one. New shell vars (`GD`, `err`) are added to the header's PARAM-NAMESPACE list per §6.12.

### (b) Workflow side — `capsule-implement.yml`

The `Push fix branch and open PR` step's porcelain rule now branches on the classifier's `converged` verdict, and on the non-converged branch commits the tree instead of refusing it (belt-and-braces behind the engine's own node — the engine can die *before* that node runs: a crash in the maker/critic lane, the step timeout, an OOM kill). The work-in-progress PR body now states **which layer** produced the branch's commits.

## 4. The porcelain-guard story — what still refuses what

The guard is load-bearing; in run 31789137305 it was the **correct** actor and the reason nothing unproven shipped. It is not weakened.

| Path | Tree state | Behavior |
|---|---|---|
| **CONVERGED** (`done`) | dirty outside `.ai/` | **Refuses, byte-for-byte unchanged** — same `::error::Workspace has unexpected changes outside .ai/ after a 'done' run` message, `exit 1`, nothing pushed |
| **CONVERGED** | `HEAD == origin/main` | **Refuses, unchanged** — `reported success but HEAD matches origin/main`, `exit 1` |
| **NON-converged** | dirty outside `.ai/` | Commits it (`salvage(workflow): ...`), **then re-asserts the identical clean-tree invariant** before pushing; still refuses if anything survives the commit |
| **NON-converged** | dirty only under `.ai/` | Commits nothing (`.ai/` is evidence, not product); honest note in the PR body |
| **NON-converged** | `HEAD == origin/main`, clean | `::warning::` and **no PR** — an honest non-event; the job is still failed by `Fail the job on genuine non-convergence`, and the issue comment still carries the postmortem |
| **`ship_check -> escalate [dirty]`** | — | **Deliberately un-salvaged in both layers**: `package` already committed there, so the work is already durable, and what a human needs at that door is the forensic picture the gate just refused, not another commit on top of it |

## 5. Evidence

**Source-side rig** — 30/30 files green (was 29/29), including a new control `runner/tests/test_task_runner_salvage.sh`, **34 assertions**: graph shape (all three doors rewired, no bypass edge left, `ship_check`'s leg untouched, `escalate -> salvage` deliberately absent, whole-file stale-label sweep over all 29 conditioned edges), behavioral halves driving the **real extracted `tool_command`** against real git repos (tracked-`.ai` leak channel, clean tree → no empty commit, no repo at all, a git refusal that stays loud and verbatim while still exiting 0, non-default branch preserved), and the E1/E2 engine battery above. `test_verdict_classification.sh` grew from 87 to 89 assertions: its `postmortem -> escalate` assertion now asserts **both** legs of the new hop, so a future re-sync that reverts the rewiring fails in the rig rather than in a live run.

**`attractor lint`** on the vendored `.dot`: **0 ERRORs**, 1 warning — the pre-existing `CMD-001` on `ship_check`, byte-identical to the warning at the prior pin. Graph declarations **23 → 24 nodes, 36 → 37 edges** (same comment-stripped count method on both sides of the vendoring).

**Workflow, dry-run locally** (no live GHA run is claimed — see Observations):
- `actionlint` 1.7.7 on `capsule-implement.yml`: **clean, rc=0**
- `bash -n` on **all 12** extracted `run:` steps: clean
- the `pr` step extracted, GHA expressions substituted, and **executed against a real fixture repo with a real bare `origin`** across six scenarios: converged+dirty → refuses (`STEP_RC=1`, no commit); non-converged+dirty → commits `8a14d87` carrying `README.md _cost.py`, porcelain empty, branch pushed, PR body carries the workflow-layer note; converged+empty → refuses (`STEP_RC=1`); non-converged+empty → warns, `STEP_RC=0`, no PR URL emitted; non-converged+`.ai`-only dirt → no commit; non-converged with the engine's own salvage commit already present → pushes it and reports layer 1 in the body.

**Bundle gates:** `loop-pipeline` **2470 passed, 25 skipped**; `pipeline-runner` **76 passed, 1 skipped**; `git diff --check` clean; `check-upstream-leaks.sh --self-test` PASS (RED ×4, GREEN ×2), and a before/after scan of the three changed files returns **9 hit groups at base and 10 at HEAD** (both rc=1) — **one new group**, ~~the identical hit set~~. That original claim was falsified in adversarial review and is corrected here: the delta is measured, quoted and adjudicated in *Post-review fixes → 2* below. No new pattern class and no new task ID is introduced, and `capsule-implement.yml` is clean on both sides.

## 6. Vendoring parity

```
$ tail -n +97 .github/capsule-pipeline/task-runner.dot | sha256sum
7c93fe011563c9c13521c178ede6e530ed91bfde13a536b6b745f053d9c49f47

$ sha256sum <source>/runner/task-runner.dot          # at pinned commit fae27d0
7c93fe011563c9c13521c178ede6e530ed91bfde13a536b6b745f053d9c49f47
```

The body sha256 is now **pinned in the file's own provenance box**, so parity is checkable in this repo without access to the source repository (the prior pin's body sha256, `62b50b53b87e8fdd0b457145be646f5cc54ab414081b1f321c721b7c45f0d53e`, is recorded in the re-sync log for the same reason). Re-sync checklist steps 2 / 2a / 2b are recorded as **vacuous and why**, not skipped: `grep -n uplift_dir` returns the identical hits on both sides, no checker was added/removed/renamed, no new Python checker exists, and the new node shells out to `git` and nothing else.

## 7. Tier classification — QUALITY_PROTOCOL §3

**Toward-spec.** Stated as a claim a reviewer can disagree with, not defaulted to:

- The change is built **entirely from constructs the spec already specifies** — a `shape=parallelogram` tool node with a `tool_command`, conditional edges on `context.tool.last_line`, and one unconditional edge. It adds no engine capability, no new attribute, and no new routing semantics.
- It **relies on** an already-specified engine behavior rather than introducing one: §3.7's rule that a FAIL outcome does not traverse unconditional edges is precisely *why* the node is exit-0 guaranteed. Being pushed toward that rule instead of around it is the sense in which this closes a gap rather than opening one.
- Nothing is owed by the other two rows and nothing is quietly skipped: no `specs/EXTENSIONS.md` entry (no extension), no `SPEC_CONFORMANCE.md` ledger row or conformance-matrix row (no divergence, and the vendored copy carries no matrix row — the only `task-runner.dot` the matrix names is the exemplar at `examples/patterns/`, which this PR does not touch).
- The workflow half is CI process, outside the engine's conformance surface entirely; it makes this lane do what its own comment already claimed ("salvages the committed work-in-progress so it is not lost").

## Observations

- **A full live GHA proof is NOT claimed here, and deliberately so.** Exercising the real non-convergence path end-to-end means burning a real 30–90 minute dual-provider implement run and *engineering it to stall*, which costs real money for a path this PR already proves at the two layers that matter (the real engine over the real terminal path; the real workflow bash over a real git fixture). The residual risk this leaves is GHA-environment-specific — token/permission behavior on `gh pr create` for a salvage branch — and that path is unchanged by this PR; only what is committed before it changes.
- **`examples/patterns/task-runner.dot` (the teaching copy) is deliberately NOT changed, and it still teaches the shape this PR fixes.** Naming that plainly rather than leaving it implicit: the *doctrine* — "an attractor whose product lives in a working tree must make it durable before any non-shipping exit" — is genuinely transferable and worth teaching. But that exemplar is a different, older lineage (single critic, no forge guard, `abandon -> done [outcome=fail]`, `retry_target="abandon"`, unconditional `postmortem -> pm_gate`), so the port is not a copy and needs its own proof; and its companion `task-runner.md` narrates exactly five numbered hardening lessons, each tied to a live-run failure **in this repository**. A sixth lesson citing another repo's implement-lane incident would be a documentation claim I cannot substantiate for that graph. Worth a follow-up issue that gives it its own evidence, rather than a passenger on a defect fix.
- **`[C] Continue` now produces an extra WIP commit** on runs that later converge, because salvage runs before the gate rather than on the abandon leg. That is the accepted cost of covering the incident's actual failure (a *raising* hexagon). It is honest history, `ship_check` is unaffected, and the converged PR's diff against `origin/main` is unchanged.
- **The `salvage` commit deliberately carries no `Co-Authored-By` trailer**, unlike `package`'s (which is an LLM-composed commit told to add one). This node is deterministic glue in a graph that also runs outside this repo; it states what it did and declines to assert an attribution it cannot verify.
- **The workflow-level salvage commits whatever the porcelain guard would have refused** — including, in principle, junk a maker left behind that the repo's `.gitignore` does not cover. That is the intended semantics (the commit contains *exactly* the set of paths the guard was refusing to push, and the PR is labeled work-in-progress with no gate or critique claim), but it is a real difference from `package`'s curated commit and a reviewer should know it.
- **The engine's `salvage` node writes `.ai/` into `.git/info/exclude`** on paths where `package` never ran. This is the repo's own documented convention and idempotent (`grep -qxF` guarded), but it is a write to the checkout's git dir that did not previously happen on the stall path.

---

## Post-review fixes

Adversarial review returned **MERGE-AFTER-FIX**: one required fix, one falsified claim, one maintainer note. All three are addressed in `4f946d8` (workflow only — the `.dot` needed no change). The branch is rebased onto current `origin/main` (`ccbd89f`, which carries #280); no file overlap.

### 1. REQUIRED — a secret scan gate at the push

**The finding.** This PR created a new public egress with no scan on it. Both salvage layers put **worker-written bytes** onto a branch that `git push origin HEAD:refs/heads/$BRANCH` makes public, and on those paths the bytes passed no critic, no gate and no human. This repo has already been burned by exactly that shape: the scrub step exists because a worker agent dumped its environment mid-run and a literal `OPENAI_API_KEY` landed in worker-written files on disk, where GitHub's live-log masking does not reach. The run-evidence artifact got **both** a scrub and a scan out of that incident — and this workflow's own comment (`capsule-implement.yml:608-610`) says why:

> the residual scan step before the upload step (defense in depth — **scrub is best-effort cleaning; the scan is the guarantee**).

The push had *neither*. Fixed:

```diff
           echo "::warning::Non-converged run produced nothing to salvage: HEAD matches origin/main..."
           exit 0
         fi

+        # SECRET SCAN GATE ON THE PUSH -- the guarantee this egress never had.
+        #   [~45 lines of rationale: both salvage layers, the converged path,
+        #    the 2026-08 incident, the scrub-vs-scan doctrine, and the
+        #    argument plumbing below]
+        PUSH_SCAN_LOG="$(mktemp)"
+        if git diff --name-only --diff-filter=d -z origin/main HEAD \
+            | xargs -0 -r python3 .github/capsule-pipeline/scrub_secrets.py scan \
+            > "$PUSH_SCAN_LOG" 2>&1; then
+          cat "$PUSH_SCAN_LOG"
+          echo "push secret gate: clean -- every file this push adds or changes relative to origin/main was scanned, and nothing secret-shaped was found."
+        else
+          cat "$PUSH_SCAN_LOG" >&2
+          SCAN_FILES="$(sed -n 's/^scan FINDING //p' "$PUSH_SCAN_LOG" \
+            | sed -e 's/:[0-9][0-9]*: shape=.*$//' -e 's/: unreadable .*$//' \
+            | sort -u | tr '\n' ' ' || true)"
+          echo "::error::The push secret gate BLOCKED this branch -- secret-shaped material was found in the bytes this job was about to push to the public branch '$BRANCH'. NOTHING WAS PUSHED and no PR was opened. Offending file(s): ${SCAN_FILES:-see the scan findings above}. ..." >&2
+          exit 1
+        fi
+
         git push origin "HEAD:refs/heads/$BRANCH"
```

**One gate, three egresses.** It sits at the single choke point every path funnels through, so it covers the engine-side `salvage` commit (Layer 1), this workflow's Layer-2 commit, **and the converged path** — which was a *pre-existing* unscanned egress. `ship_check` proves the converged tree is clean and gate-GREEN; that is a different claim from "contains no credential." Closing it here was free, and it is noted rather than smuggled.

**Fail-closed by construction.** Findings → no push, red job, and a refusal that names the files. `scan` prints `file:line:shape` and never the matched value (`scrub_secrets.py`'s `scan_text` returns shapes and variable names only), so the refusal is safe to read in a public log. The `if ... ; then` wrapper is load-bearing: under `set -euo pipefail` a bare pipeline would abort the step *silently* on a finding, and the whole point is the loud named refusal.

### Proof — extracted-step dry runs against a real fixture repo + a real bare origin

**No live GHA run is claimed or required.** The house pattern: the `pr` step's `run:` block is parsed out of the YAML, its `${{ }}` expressions substituted with fixture values, and the resulting bash executed against a throwaway repo whose `origin` is a real bare repo — so "was it pushed?" is answered by `for-each-ref` on the bare origin, not by trusting the step's own output.

- `actionlint` 1.7.7 on `capsule-implement.yml`: **clean, rc=0** (and it clears a pre-existing `SC2143` that `origin/main` still carries).
- `bash -n` on **all 12** extracted `run:` steps: **0 failures**.

**(a) Non-converged salvage carrying a planted `sk-`style key → scan FIRES, push REFUSED**

```
--- porcelain before:
     M README.md
    ?? .ai/
    ?? worker_client.py          <- contains sk-proj-A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8S9t0
--- STEP OUTPUT ---
::warning::Non-converged run left an uncommitted tree that task-runner.dot's own salvage node did not capture -- committing it here so the work is not discarded (issue #220). ...
workflow-level salvage commit: 2dea46a
scan FINDING worker_client.py:2: shape=openai-key
scan FINDING worker_client.py:2: shape=high-entropy-token
scrub_secrets: RESIDUAL SECRET-SHAPED MATERIAL FOUND (scanned 2 file(s)). The upload must be blocked.
::error::The push secret gate BLOCKED this branch -- secret-shaped material was found in the bytes this job was about to
push to the public branch 'capsule/implement-220'. NOTHING WAS PUSHED and no PR was opened. Offending file(s):
worker_client.py . ...
--- STEP_RC=1
--- REFS ON THE BARE ORIGIN (what was actually pushed):
    refs/heads/main                            <- the salvage branch is ABSENT
--- gh calls: (none -- no PR opened)
```

The salvage commit still exists **locally** (`2dea46a`) — the work is not destroyed, it simply cannot leave the runner. That is the correct outcome: #220 is about not *losing* work, not about publishing it unchecked.

**(b) Clean salvage commit → scan passes, push proceeds**

```
workflow-level salvage commit: ad56c11
scrub_secrets: clean -- scanned 2 file(s), no secret-shaped material.
push secret gate: clean -- every file this push adds or changes relative to origin/main was scanned, and nothing secret-shaped was found.
To /tmp/pushgate-rig/origin.git
 * [new branch]      HEAD -> capsule/implement-220
--- STEP_RC=0
--- REFS ON THE BARE ORIGIN: refs/heads/capsule/implement-220, refs/heads/main
--- gh calls: GH-STUB called: pr create ... --title implement: work-in-progress for #220 (cap-fixture) -- did not converge ...
```

**(c) Converged path, clean tree → unchanged behavior**

```
--- porcelain before:                          <- clean
scrub_secrets: clean -- scanned 1 file(s), no secret-shaped material.
push secret gate: clean -- every file this push adds or changes relative to origin/main was scanned, and nothing secret-shaped was found.
 * [new branch]      HEAD -> capsule/implement-220
--- STEP_RC=0
--- gh calls: GH-STUB called: pr create ... --title implement: fix for #220 (cap-fixture) ...
```

Converged title, converged body, same push — the gate adds one clean line and changes nothing else on this path.

### Proof — the scan invocation's argument plumbing

Each flag earns its place; all four cases were run directly against the same pipeline:

| Case | Handling | Measured |
|---|---|---|
| **No changed files** | `xargs -r` runs the scanner **zero** times (invoking it with no roots would exit non-zero on argparse and turn "nothing changed" into a false refusal) | diff is `0000000` empty; `gate rc=0` |
| **Deleted file in the diff** | `--diff-filter=d` drops it — a deleted path has no bytes on disk to scan | raw diff `README.md `; filtered diff empty; `gate rc=0` |
| **All-deletions diff** | same, and correctly does **not** false-refuse | filtered diff `''`; `gate rc=0` |
| **Filename with a space / a newline** | **`-z` + `xargs -0`** — `scrub_secrets.py scan` takes file roots positionally (`p_scan.add_argument("roots", nargs="+")`), so NUL-delimited argv is exactly the right interface | both files scanned; planted key found at `my worker notes.txt:1` |

The space/newline case is the one where a bare `--name-only` would have failed *silently and wrongly* — worth quoting side by side:

```
  paths in the diff, NUL-delimited (| marks each NUL):
    my worker notes.txt|weird
    name.txt|
  -- what a BARE --name-only would have produced (git C-quotes it):
    my worker notes.txt          <- word-splits into 3 nonexistent roots
    "weird\nname.txt"            <- C-quoted into a path that does not exist
  scan FINDING my worker notes.txt:1: shape=openai-key
  >> gate rc=123                 <- xargs' "child exited 1-125"; caught by the `if`
```

Both bogus forms would have hit `scrub_secrets.py`'s *"root does not exist, skipping"* branch — a **silent pass** on an unscanned file. No limitation to document: the script's interface is positional paths, and `-z`/`-0` conveys them losslessly.

### 2. FALSIFIED CLAIM — corrected

The Evidence section claimed the before/after leak scan returned "the **identical** hit set." **That was false**, and this PR's own rule (*"a hit is a question, not a verdict"* — adjudicate, don't assert identity) is exactly what it violated. Re-measured, base `ccbd89f` vs this branch, `check-upstream-leaks.sh` over the three changed files:

```
  base     -> 9 hit group(s)     BLOCKED: 9 deny-list hit group(s)   rc=1
  head     -> 10 hit group(s)    BLOCKED: 10 deny-list hit group(s)  rc=1
```

Both `rc=1`; **9 → 10 groups**. The delta is exactly one new group, all of it in the pipeline README:

```
LEAK-HIT [README.md] pattern 'pm[_-]?gate\b' (UNANCHORED — no examples/patterns/task-runner citation in artifact):
1111:  `postmortem`, `pm_gate`), then routes to `escalate` on one unconditional
```

**Adjudication: benign, ship it.** Stated as a judgment a reviewer may overturn, not as a fact:

- The line is this PR's own prose naming the three non-shipping doors `salvage` was wired onto. `pm_gate` is a **node name in the vendored graph this PR edits** — the README is describing the file sitting next to it.
- The token is **already public in this repo on `origin/main`**, in four tracked files including the sibling `task-runner.dot` (`pm_gate [shape=parallelogram, ...]` at line 377 of the base copy) and the scanner's own GREEN fixture. It carries **no new pattern class and no new task ID**; `capsule-implement.yml` is clean on both sides (`rc=0`), and the post-review commit adds nothing (`myhead` still measures **10**).
- The scanner's `pm[_-]?gate` seed is **explicitly dual-status** in its own SEED NOTES (upstream's exemplar ships a `pm_gate` node; unanchored uses block pending a human call). This is that human call, recorded here rather than asserted away.
- `check-upstream-leaks.sh --self-test`: **PASS (RED ×4, GREEN ×2)**.

The original claim is corrected in place in §5 above rather than quietly deleted.

### 3. MAINTAINER NOTE — the Layer-2 reachability dependency is now pinned

Layer 2 is reachable **only** through GitHub's absent-output coercion, and nothing said so at the site that depends on it. A comment now pins it at the push step's `if:` (`capsule-implement.yml:625`):

```yaml
      - name: Push fix branch and open PR
        id: pr
        # LOAD-BEARING, AND FRAGILE ON PURPOSE -- READ BEFORE "FIXING" THE
        # EXIT CAPTURE (issue #220 salvage, both layers).
        #
        # This `if:` is the ONLY door the salvage paths have. A non-converged
        # run reaches this step exclusively through GitHub's absent-output
        # coercion: the run step above executes under `set -uo pipefail` with
        # `bash -e` semantics, so when the engine exits non-zero the step
        # ABORTS BEFORE its `echo "attractor_exit=$?" >> "$GITHUB_OUTPUT"`
        # line runs at all. The output is therefore never written, and GitHub
        # coerces a missing output to '0' in an `== '0'` comparison -- which
        # is precisely why the non-converged path gets in here to salvage and
        # push. (The `classify` step above exists because that same coercion
        # makes ABSENT and CONVERGED indistinguishable to an `if:`; it
        # recovers the truth from checkpoint.json and everything below
        # branches on `steps.classify.outputs.converged`, not on this value.)
        #
        # CONSEQUENCE: if anyone ever makes the run step record
        # attractor_exit=1 RELIABLY -- an `|| true`, a `set +e`, an explicit
        # capture into a variable, a composite action -- this condition goes
        # FALSE on exactly the runs salvage exists for, this step is skipped,
        # and BOTH salvage layers' commits (task-runner.dot's own `salvage`
        # node and this step's own Layer-2 commit) strand on a runner that is
        # about to be destroyed. That is the #220 bug again, reintroduced by a
        # change that looks like an unambiguous improvement.
        #
        # If you fix the exit capture, you MUST widen this condition in the
        # same commit -- e.g. gate on `steps.locate.outputs.skip != 'true'`
        # alone and let the `classify` step's `converged` output (already the
        # sole classifier below) decide converged-vs-salvage. Do not change one
        # without the other.
        if: always() && steps.locate.outputs.skip != 'true' && steps.run.outputs.attractor_exit == '0'
```

It names the trap **and** the correct fix, so a future exit-capture cleanup either widens the condition in the same commit or trips over the reason it must.

### 4. Suites

**Untouched, and stated rather than re-run for show.** The post-review commit changes exactly one file, `.github/workflows/capsule-implement.yml`, which no suite exercises (`grep -rl capsule-implement modules/` is empty) — GitHub Actions is not on the engine's conformance surface. The `loop-pipeline` **2470 passed / 25 skipped** and `pipeline-runner` **76 passed / 1 skipped** results in §5 stand unchanged. `git diff --check`: clean. Leak scan of this commit's own file: **rc=0, clean**.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

