### PR TITLE
implement: fix for #231 (spawn-report-outcome-precedence)

### DIFF
--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/backend.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/backend.py
@@ -584,9 +584,30 @@ class AmplifierBackend:
             return Outcome(status=StageStatus.FAIL, failure_reason=str(e))
 
         # Parse outcome from result.
-        # If the child produced output, _parse_outcome determines the outcome —
-        # including intentional {"status":"fail"} verdicts from goal_gate nodes.
+        # spec §35 Precedence Policy: a structured report_outcome verdict
+        # supersedes contradicting trailing prose.  Check for an explicit
+        # metadata.report_outcome envelope FIRST, before inspecting the prose
+        # output.  Only when no explicit verdict is present does the output
+        # content (empty-output path or _parse_outcome) determine the outcome.
         output = result.get("output", "") if isinstance(result, dict) else str(result)
+
+        # Hoist the spawn-result verdict check so it applies regardless of
+        # whether output is empty or non-empty (spec §35).
+        spawn_outcome = _outcome_from_spawn_result(result)
+        if spawn_outcome is not None and spawn_outcome.is_explicit:
+            # An explicit metadata.report_outcome verdict was present and
+            # mapped to a valid status.  Honor it unconditionally — the child's
+            # prose output is preserved in the transcript below but does not
+            # override the structured routing signal.
+            session_id = (
+                result.get("session_id") if isinstance(result, dict) else None
+            )
+            if session_id:
+                spawn_outcome.session_id = session_id
+            if fidelity == "full" and graph is not None and thread_key is not None:
+                self._append_to_transcript(thread_key, node.id, instruction, output)
+            return spawn_outcome
+
         if not output.strip():
             # The child's FINAL assistant message was empty — but that does NOT
             # mean the child failed.  A child that did its work via tool calls
@@ -595,7 +616,7 @@ class AmplifierBackend:
             # the SAME outcome sources the direct tool loop already uses: the
             # child's report_outcome args and the orchestrator's completion
             # status (captured in the spawn result, see _prepared.py spawn()).
-            spawn_outcome = _outcome_from_spawn_result(result)
+            # spawn_outcome is already computed above; reuse it here.
             if spawn_outcome is not None:
                 session_id = (
                     result.get("session_id") if isinstance(result, dict) else None

--- a/modules/loop-pipeline/tests/test_backend.py
+++ b/modules/loop-pipeline/tests/test_backend.py
@@ -742,6 +742,94 @@ async def test_spawn_empty_output_with_success_status_does_not_fall_back():
 
 
 @pytest.mark.asyncio
+async def test_spawn_nonempty_output_with_report_outcome_honors_metadata():
+    """Non-empty prose + metadata.report_outcome => metadata verdict wins (spec §35).
+
+    When the child's spawn result carries both non-empty prose output AND a
+    ``metadata.report_outcome`` envelope with a valid status and
+    ``preferred_label``, the parent backend must honor the structured verdict.
+    The returned Outcome must have ``is_explicit=True`` and ``preferred_label``
+    equal to the value from the metadata -- NOT None (which would be the result
+    of falling through to ``_parse_outcome``).
+
+    This is the regression test for the §35 Precedence Policy defect: the
+    previous code only consulted ``_outcome_from_spawn_result`` when
+    ``output.strip()`` was empty, silently discarding the structured verdict
+    for the normal LLM case where the child produces closing prose.
+    """
+    coordinator = MockCoordinator(
+        spawn_result={
+            "output": "The analysis is complete and the findings are documented.",
+            "session_id": "c-precedence",
+            "status": "success",
+            "metadata": {
+                "report_outcome": {
+                    "status": "success",
+                    "preferred_label": "validated",
+                    "notes": "All checks passed.",
+                }
+            },
+        }
+    )
+    backend = AmplifierBackend(
+        coordinator=coordinator,
+        profiles={"anthropic": "attractor-anthropic"},
+    )
+
+    node = _make_node(attrs={"llm_provider": "anthropic"})
+    result = await backend.run(node, "analyse", _make_context())
+
+    assert isinstance(result, Outcome)
+    assert result.is_explicit is True, (
+        "metadata.report_outcome must set is_explicit=True even when output is non-empty"
+    )
+    assert result.preferred_label == "validated", (
+        f"expected preferred_label='validated', got {result.preferred_label!r} -- "
+        "the structured verdict was discarded in favour of prose-based parsing"
+    )
+    assert result.status == StageStatus.SUCCESS
+
+
+@pytest.mark.asyncio
+async def test_spawn_nonempty_output_without_metadata_uses_parse_outcome():
+    """Non-empty prose with no metadata.report_outcome => _parse_outcome path.
+
+    When the child produces non-empty output but no ``metadata.report_outcome``
+    envelope, the backend must fall through to ``_parse_outcome`` as before.
+    This confirms the fix does not suppress the prose-based path when metadata
+    is absent.
+    """
+    coordinator = MockCoordinator(
+        spawn_result={
+            "output": '{"status": "fail", "failure_reason": "validation failed"}',
+            "session_id": "c-prose-fail",
+            "status": "success",  # spawn envelope says success -- must NOT win
+            "metadata": {},       # no report_outcome
+        }
+    )
+    backend = AmplifierBackend(
+        coordinator=coordinator,
+        profiles={"anthropic": "attractor-anthropic"},
+    )
+
+    node = _make_node(attrs={"llm_provider": "anthropic"})
+    result = await backend.run(node, "validate", _make_context())
+
+    assert isinstance(result, Outcome)
+    assert result.status == StageStatus.FAIL, (
+        "JSON fail output with no metadata should yield FAIL via _parse_outcome, "
+        f"got {result.status!r} -- the spawn envelope's success status must not win"
+    )
+    # _parse_outcome sets is_explicit=True for JSON verdicts; the key assertion
+    # is that status=FAIL (from the JSON) rather than SUCCESS (from the spawn
+    # envelope's status field, which would happen if we always used
+    # _outcome_from_spawn_result unconditionally).
+    assert result.preferred_label is None, (
+        "no preferred_label in the JSON output -- must not inherit one from spawn envelope"
+    )
+
+
+@pytest.mark.asyncio
 async def test_spawn_truly_empty_fails_loud():
     """No text, no report_outcome, no success status => FAIL (fail-loud).
 


### PR DESCRIPTION
## Implement-stage fix for #231

Refs #231. Produced by `task-runner.dot` (see `.github/capsule-pipeline/`)
converging against the capsule's own definition of done and gate:
`.github/capsule-pipeline/proposals/issue-231/spawn-report-outcome-precedence.md` /
`spawn-report-outcome-precedence.verify.sh`.

The gate script (the capsule's own DoD) passed, and this change was
additionally critiqued by an LLM reviewer against the capsule's
judgment criteria before shipping. Both reviewers ran as independent, cross-provider critics (Anthropic + OpenAI) -- enforced by this workflow's preflight check, not merely hoped for.

Gate files unmodified -- measured: `git diff --name-only origin/main HEAD -- .github/capsule-pipeline/proposals/issue-231` is empty.

This PR is opened non-draft and is NOT auto-merged -- a human reviews
the diff and the run evidence before merging.

Workflow run: https://github.com/microsoft/amplifier-bundle-attractor/actions/runs/32042376866
