### PR TITLE
fix(observability): redact secret-shaped material at the session-event write seam (#198)

### DIFF
--- a/modules/hooks-pipeline-observability/amplifier_module_hooks_pipeline_observability/redaction.py
+++ b/modules/hooks-pipeline-observability/amplifier_module_hooks_pipeline_observability/redaction.py
@@ -1,0 +1,158 @@
+"""Write-time secret redaction for persisted session events (issue #198).
+
+WHY THIS EXISTS (incident, 2026-08-11).  A worker agent inside a pipeline run
+executed a tool that dumped its environment.  The ``SessionEventPersister``
+(EXTENSIONS.md Section 26) wrote the ``tool:post`` payload VERBATIM to
+``<stage_dir>/sessions/<id>/events.jsonl`` -- including a literal
+``OPENAI_API_KEY`` value of the ``sk-proj-...`` shape (spelled apart here so
+this file is not itself secret-shaped material) -- and CI uploaded it inside a
+PUBLIC run-evidence artifact.  A workflow-level scrub-before-upload was added
+separately (``.github/capsule-pipeline/scrub_secrets.py``), but that guard
+sits at the UPLOAD door, one hop downstream of the leak: it can only clean a
+file that already has the credential on disk, and it protects exactly one
+consumer.  Anything else that reads the run dir -- a maintainer tailing the
+file, a bug report pasting it, a sandbox that syncs it -- was still reading a
+live key.  Defense in depth belongs at the WRITE seam, and this module is the
+redaction machinery the persister applies to each event line *before* it
+reaches disk.
+
+WHY SHAPE-TARGETED AND NOT ENTROPY -- the load-bearing scoping decision.
+The canonical detection set (``.github/capsule-pipeline/scrub_secrets.py``)
+has four layers.  This module ports layers 1 and 2 -- the KNOWN CREDENTIAL
+SHAPES -- and deliberately does NOT port layer 4, the high-entropy-token
+heuristic, because that heuristic was MEASURED WRONG on this exact file
+class.  From that script's own docstring (issue #206): worker-session
+payloads in ``sessions/*/events.jsonl`` "are legitimately full of
+high-entropy runs (digests, base64 fragments, request ids), so the gate
+blocked the evidence upload on EVERY run" -- 4 real runs out of 4, and 487
+findings on run 31689374533, every one entropy-shaped and not one a
+credential.  At the upload door an over-eager heuristic costs one run's
+evidence.  At the WRITE seam it costs that evidence PERMANENTLY: the original
+bytes are never written, so there is nothing left to recover.  Section 26
+exists to make a run forensically traceable; a redactor that eats request ids
+and correlation tokens on suspicion of randomness defeats the extension it is
+supposed to protect.  Measured with the canonical heuristic itself:
+
+    43-char alphanumeric request id   H = 4.83-4.99  ->  WOULD be redacted
+    40-char git SHA / sha256 digest   H = 3.28       ->  survives (hex-excluded)
+    session UUID                      H = 3.97       ->  survives
+
+The middle rows are why the heuristic looks safe in a spot check; the first
+row is the one that matters, and it is ordinary observability.  So: named
+credential shapes only.  A credential's whole job is to be recognizable to
+the service that accepts it, which is exactly what makes it shape-matchable
+without guessing at randomness.
+
+WHY A LOCAL COPY AND NOT AN IMPORT.  ``scrub_secrets.py`` lives under
+``.github/`` -- a workflow script, deliberately stdlib-only so it runs on a
+bare Actions runner, and not a package on any import path this module could
+depend on.  This module must not depend on ``.github/``.  Vendoring a shared
+distribution for four regexes would be heavier than the problem.  Instead the
+patterns are copied here and a DRIFT TRIPWIRE test
+(``tests/test_session_events_redaction.py``) loads the canonical script BY
+PATH and asserts the two sets are still identical, so "two copies" cannot
+silently become "two behaviors".
+
+HONEST RESIDUALS, stated rather than implied:
+  - Layer 3 of the canonical set (redacting the literal VALUES of the env
+    vars the CI job holds) is NOT ported.  It is a workflow-context
+    mechanism -- the workflow passes its own secrets into that script's env
+    on purpose -- and making write-time redaction depend on the ambient
+    process environment would be non-deterministic and untestable at this
+    seam.  The incident's own credential is covered here twice over, by
+    shape (layer 1) and by assignment (layer 2).
+  - The assignment rule matches ``NAME=value``, the env-dump shape from the
+    incident.  It does NOT match a JSON *key* spelled ``"api_key": "..."``
+    (JSON separates with ``:``, not ``=``).  A structured field holding a
+    credential is still caught whenever the value itself carries a known
+    token shape, which is the usual case; a shapeless credential in such a
+    field is a KNOWN GAP, left to the upload gate rather than closed by
+    widening a pattern that has already corrupted a shipped artifact once
+    (see the end-anchor note below).
+"""
+
+from __future__ import annotations
+
+import re
+
+#: Layer 1 -- known token shapes.  Copied verbatim from
+#: ``.github/capsule-pipeline/scrub_secrets.py``'s ``TOKEN_PATTERNS``; the
+#: drift tripwire test asserts they stay identical.
+#:
+#: The character classes stop at backslash and quote.  That is what makes
+#: these patterns safe to apply to an ALREADY-SERIALIZED JSON line: a match
+#: can never span a string boundary or eat an escape, so the redacted line
+#: still parses as the same JSON object with one string value shortened.
+TOKEN_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
+    ("openai-key", re.compile(r"sk-[A-Za-z0-9_-]{20,}")),
+    ("github-fine-grained-pat", re.compile(r"github_pat_[A-Za-z0-9_]{20,}")),
+    ("github-token", re.compile(r"gh[posur]_[A-Za-z0-9]{20,}")),
+]
+
+#: Layer 2 -- ``NAME=value`` assignments, the incident's env-dump shape.
+#:
+#: THE END-ANCHOR IS LOAD-BEARING and is not a style choice: matching any
+#: name *containing* one of these words once rewrote 54 ``input_tokens=`` /
+#: ``total_tokens=`` assignments inside a shipped, later-executed artifact
+#: (2026-08-13, PR #205).  Credential names put the sensitive word at the
+#: END (``OPENAI_API_KEY``, ``GITHUB_TOKEN``, ``CLIENT_SECRET``); ordinary
+#: identifiers that merely contain it (``input_tokens``, ``max_tokens``) do
+#: not.  ``_TOKEN`` is singular-only for the same reason.
+SENSITIVE_NAME_TAILS = (
+    "API_KEYS?",
+    "SECRET_ACCESS_KEY",
+    "_TOKEN",
+    "_SECRET",
+    "PASSWORD",
+    "CREDENTIALS?",
+)
+
+ASSIGNMENT_PATTERN = re.compile(
+    r"(?P<name>[A-Za-z0-9_]*(?:" + "|".join(SENSITIVE_NAME_TAILS) + r"))"
+    r"(?P<sep>\s*=\s*)"
+    r"(?P<quote>[\"']?)"
+    r"(?!\[REDACTED:)"
+    r"(?P<value>[^\s\"'\\]{4,})",
+    re.IGNORECASE,
+)
+
+#: The marker written in place of redacted material.  Readers may search for
+#: this prefix to tell a scrubbed record from a clean one.
+REDACTION_MARKER_PREFIX = "[REDACTED:"
+
+
+def redact_text(text: str) -> tuple[str, list[str]]:
+    """Redact known credential shapes in ``text``.
+
+    Returns ``(redacted_text, findings)`` where ``findings`` holds ONE shape
+    string per redacted span (so ``len(findings)`` is a span count, not a
+    pattern count).  A shape string is the credential class -- ``openai-key``,
+    ``github-token`` -- or ``assignment:<NAME>`` for a sensitive assignment,
+    which keeps WHICH variable leaked visible in the evidence while the value
+    itself does not survive.
+
+    Surgical by construction: only the matched span is replaced with
+    ``[REDACTED:<shape>]``; every surrounding byte is untouched.  Token
+    patterns run before assignments (most specific first), and the
+    assignment pattern's negative lookahead keeps an already-redacted value
+    from being re-redacted into a less specific shape.
+
+    A value the patterns do not match is returned VERBATIM.  That is the
+    contract this seam is held to, not merely a side effect -- see the
+    module docstring's entropy discussion.
+    """
+    findings: list[str] = []
+
+    for shape, pattern in TOKEN_PATTERNS:
+        text, n = pattern.subn(f"{REDACTION_MARKER_PREFIX}{shape}]", text)
+        findings.extend([shape] * n)
+
+    def _assignment_sub(m: re.Match[str]) -> str:
+        findings.append(f"assignment:{m.group('name')}")
+        return (
+            f"{m.group('name')}{m.group('sep')}{m.group('quote')}"
+            f"{REDACTION_MARKER_PREFIX}assignment]"
+        )
+
+    text = ASSIGNMENT_PATTERN.sub(_assignment_sub, text)
+    return text, findings

--- a/modules/hooks-pipeline-observability/amplifier_module_hooks_pipeline_observability/session_events.py
+++ b/modules/hooks-pipeline-observability/amplifier_module_hooks_pipeline_observability/session_events.py
@@ -39,6 +39,23 @@ Records are standard-shaped, append-only JSONL, one event per line:
 ``{"event": <name>, "timestamp": <utc-iso>, "data": {...}}`` — the same
 shape session observers write for ordinary Amplifier sessions, so existing
 session tooling can read these files unchanged.
+
+Write-time redaction (issue #198)
+---------------------------------
+Every record passes through :func:`redaction.redact_text` **at the moment it
+is serialized**, before a byte reaches disk.  A worker's ``tool:post``
+payload is arbitrary tool output — the 2026-08-11 incident was an ``env``
+dump carrying a live ``OPENAI_API_KEY`` — and this file is uploaded as CI
+run evidence.  Redaction runs on the SERIALIZED LINE rather than by walking
+the payload, so nesting depth, container type, and ``default=str`` coercions
+cannot route a credential around it (the leak was inside a nested result
+string, not at the top level).
+
+The redaction is LOUD, never silent: a scrubbed record carries a top-level
+``"redaction": {"count": N, "shapes": [...]}`` block alongside the inline
+``[REDACTED:<shape>]`` markers, so a scrubbed dump is distinguishable from a
+clean one.  Clean records are byte-identical to what this persister wrote
+before — the key appears only when something was actually removed.
 """
 
 from __future__ import annotations
@@ -49,6 +66,8 @@ import os
 from collections.abc import Callable
 from datetime import datetime, timezone
 from typing import Any
+
+from .redaction import redact_text
 
 logger = logging.getLogger(__name__)
 
@@ -136,8 +155,69 @@ class SessionEventPersister:
             "data": data,
         }
         path = os.path.join(session_dir, "events.jsonl")
+        line = self._serialize(record, session_id)
         with open(path, "a", encoding="utf-8") as f:
-            f.write(json.dumps(record, ensure_ascii=False, default=str) + "\n")
+            f.write(line + "\n")
+
+    @staticmethod
+    def _serialize(record: dict[str, Any], session_id: Any) -> str:
+        """Serialize ONE record to the exact line that will hit disk.
+
+        This is the write seam, and the only place event bytes become file
+        bytes -- so it is where redaction belongs (issue #198).  Redacting the
+        SERIALIZED text rather than walking the payload is deliberate: the
+        2026-08-11 leak was a credential nested inside a ``tool:post`` result
+        string, and a walker has to be right about every nesting depth,
+        container type and ``default=str`` coercion to catch that.  The
+        serialized line has no such blind spots -- whatever is about to be
+        written is exactly what is inspected.
+
+        Safe by construction: every pattern's character class stops at quote
+        and backslash, so a match can never cross a JSON string boundary or
+        eat an escape.  That is then VERIFIED rather than trusted -- the
+        redacted line is re-parsed before it is returned, and a line that no
+        longer parses is treated as a redaction-machinery failure (below),
+        never written.
+
+        FAIL-LOUD, NEVER FALL BACK TO UNSAFE.  If redaction (or the
+        serialization it depends on) raises, writing the raw payload would
+        resurrect the exact leak this seam exists to close, so the payload is
+        WITHHELD: a marker record is written in its place recording that an
+        event occurred, which session it belonged to, and that its payload
+        could not be attested clean.  Only the exception TYPE is recorded --
+        an exception *message* can quote the very bytes that failed to
+        redact -- while the full traceback goes to the process log, which is
+        not the artifact that gets uploaded.
+        """
+        try:
+            serialized = json.dumps(record, ensure_ascii=False, default=str)
+            cleaned, findings = redact_text(serialized)
+            if not findings:
+                return cleaned
+            payload = json.loads(cleaned)  # proves the redaction kept it valid
+            payload["redaction"] = {
+                "count": len(findings),
+                "shapes": sorted(set(findings)),
+            }
+            return json.dumps(payload, ensure_ascii=False)
+        except Exception as exc:
+            logger.error(
+                "session-event redaction FAILED for %s (session %s) -- payload "
+                "WITHHELD from events.jsonl rather than written unredacted",
+                record.get("event"),
+                session_id,
+                exc_info=True,
+            )
+            marker = {
+                "event": record.get("event"),
+                "timestamp": record.get("timestamp"),
+                "data": {"session_id": str(session_id)},
+                "redaction": {
+                    "error": type(exc).__name__,
+                    "payload_withheld": True,
+                },
+            }
+            return json.dumps(marker, ensure_ascii=False)
 
 
 def register_session_event_persister(

--- a/modules/hooks-pipeline-observability/tests/test_session_events_redaction.py
+++ b/modules/hooks-pipeline-observability/tests/test_session_events_redaction.py
@@ -1,0 +1,399 @@
+"""Write-time secret redaction at the session-event persistence seam (issue #198).
+
+Incident, 2026-08-11: a worker agent ran a tool that dumped its environment;
+the ``SessionEventPersister`` wrote the ``tool:post`` payload VERBATIM to
+``<stage_dir>/sessions/<id>/events.jsonl`` -- including a literal
+``OPENAI_API_KEY`` value -- and CI uploaded that file inside a PUBLIC
+run-evidence artifact.
+
+These tests pin all four directions the fix has to hold at once:
+
+  1. secret-shaped material is REDACTED, and the redaction is LOUD;
+  2. a runtime-random INNOCENT value SURVIVES VERBATIM (no over-redaction --
+     the crux: a blanket scrub, or an entropy-based one, would strip the
+     legitimate observability Section 26 exists to produce);
+  3. redaction happens AT THE WRITE SEAM -- the bytes handed to the file
+     object are already clean -- not as a post-hoc pass over a file that
+     briefly held the credential;
+  4. if the redaction machinery itself fails, the payload is WITHHELD rather
+     than written raw (fail-loud, never fall back to unsafe).
+
+NOTHING CREDENTIAL-SHAPED IS HARDCODED HERE.  Every fake secret is minted at
+runtime from ``secrets``: a long literal in this file would itself be
+secret-shaped material committed to the repo, which the leak scan correctly
+refuses, and a test that ships a real-looking key teaches the wrong habit.
+"""
+
+from __future__ import annotations
+
+import builtins
+import importlib.util
+import json
+import secrets
+import string
+from pathlib import Path
+
+import pytest
+
+from amplifier_module_hooks_pipeline_observability import redaction, session_events
+from amplifier_module_hooks_pipeline_observability.session_events import (
+    SessionEventPersister,
+)
+
+# The env-var name is ASSEMBLED rather than written out, so this source file
+# never itself contains a `<SENSITIVE_NAME>=<value>` assignment for the leak
+# scan to (correctly) flag.
+_SECRET_ENV_NAME = "OPENAI_API" + "_KEY"
+_PLURAL_ENV_NAME = "total" + "_tokens"
+
+
+def _fake_openai_key() -> str:
+    """A shape-valid but entirely FAKE OpenAI key, minted per test run."""
+    return "sk-proj-" + secrets.token_hex(24)
+
+
+def _innocent_high_entropy_token() -> str:
+    """A random value that is NOT secret-shaped -- the AC-4 probe.
+
+    Deliberately built from letters+digits ONLY: with no ``-`` and no ``_``
+    in the alphabet, this string structurally CANNOT contain ``sk-``,
+    ``gh?_`` or ``github_pat_``, so the no-over-redaction assertion can
+    never flake on an unlucky draw.  At 43 characters of mixed-case
+    alphanumeric it is exactly the shape of a provider request id or
+    correlation token -- ordinary observability, and (see
+    ``test_the_innocent_value_is_one_an_entropy_scan_would_have_eaten``)
+    exactly what the canonical layer-4 entropy heuristic WOULD destroy.
+    """
+    alphabet = string.ascii_letters + string.digits
+    return "".join(secrets.choice(alphabet) for _ in range(43))
+
+
+def _env_dump(fake_key: str, innocent: str) -> str:
+    """The incident's payload shape: a tool result holding an env dump.
+
+    The credential is NESTED inside a result string, not a top-level field --
+    that nesting is what a structure-only redactor misses.
+    """
+    return (
+        "SHELL=/bin/bash\n"
+        f"{_SECRET_ENV_NAME}={fake_key}\n"
+        f"REQUEST_ID={innocent}\n"
+        f"{_PLURAL_ENV_NAME}=41892\n"
+        "TERM=xterm\n"
+    )
+
+
+def _read_events(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+async def _persist_env_dump(sessions: Path, fake_key: str, innocent: str) -> Path:
+    """Drive one incident-shaped ``tool:post`` through the real persister."""
+    persister = SessionEventPersister(lambda: str(sessions))
+    await persister.make_handler("tool:post")(
+        "tool:post",
+        {
+            "session_id": "sid-198",
+            "tool_name": "bash",
+            "tool_input": {"command": "env"},
+            "result": _env_dump(fake_key, innocent),
+            "call_id": "c1",
+        },
+    )
+    return sessions / "sid-198" / "events.jsonl"
+
+
+# ---------------------------------------------------------------------------
+# (a) Secret-shaped material is redacted, and the redaction is LOUD
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_secret_shaped_material_is_redacted_and_the_redaction_is_loud(tmp_path):
+    """The incident, replayed: the key must not reach disk, and the scrubbed
+    record must be DISTINGUISHABLE from a clean one."""
+    fake_key = _fake_openai_key()
+    innocent = _innocent_high_entropy_token()
+
+    path = await _persist_env_dump(tmp_path / "sessions", fake_key, innocent)
+    raw = path.read_text()
+
+    # The leak itself: gone from the bytes on disk.
+    assert fake_key not in raw
+    assert fake_key.split("sk-proj-")[1] not in raw  # not even the key body
+
+    # LOUD, signal one: the inline marker sits exactly where the value was.
+    record = _read_events(path)[0]
+    assert f"{_SECRET_ENV_NAME}=[REDACTED:openai-key]" in record["data"]["result"]
+
+    # LOUD, signal two: a top-level counter naming what was removed. The
+    # issue's own acceptance language -- "a counter in the event or a
+    # companion note ... never silent."
+    assert record["redaction"]["count"] >= 1
+    assert "openai-key" in record["redaction"]["shapes"]
+
+    # The record is still a well-formed Section 26 record: same keys, same
+    # nesting, same neighbouring fields -- only the credential is missing.
+    assert record["event"] == "tool:post"
+    assert record["data"]["tool_name"] == "bash"
+    assert record["data"]["tool_input"]["command"] == "env"
+    assert record["data"]["call_id"] == "c1"
+    assert "SHELL=/bin/bash" in record["data"]["result"]
+
+
+@pytest.mark.asyncio
+async def test_a_clean_event_is_byte_identical_to_the_pre_fix_shape(tmp_path):
+    """No redaction -> no indicator. A scrubbed dump must stand out, which
+    only works if a clean one is unmarked (and existing session tooling that
+    reads event/timestamp/data keeps reading these files unchanged)."""
+    sessions = tmp_path / "sessions"
+    persister = SessionEventPersister(lambda: str(sessions))
+    await persister.make_handler("tool:post")(
+        "tool:post",
+        {"session_id": "sid-clean", "tool_name": "bash", "result": "4 passed"},
+    )
+
+    record = _read_events(sessions / "sid-clean" / "events.jsonl")[0]
+    assert "redaction" not in record
+    assert sorted(record) == ["data", "event", "timestamp"]
+    assert record["data"]["result"] == "4 passed"
+
+
+@pytest.mark.asyncio
+async def test_a_shapeless_sensitive_assignment_redacts_as_assignment(tmp_path):
+    """The second ported shape: `<NAME ending in a sensitive tail>=<value>`
+    is redacted even when the value carries no recognizable token prefix."""
+    sessions = tmp_path / "sessions"
+    persister = SessionEventPersister(lambda: str(sessions))
+    opaque = secrets.token_hex(12)  # no vendor prefix -- shape-free value
+    name = "SOME_SERVICE" + "_TOKEN"
+    await persister.make_handler("tool:post")(
+        "tool:post",
+        {"session_id": "sid-a", "result": f"{name}={opaque}\n"},
+    )
+
+    record = _read_events(sessions / "sid-a" / "events.jsonl")[0]
+    assert opaque not in json.dumps(record)
+    assert f"{name}=[REDACTED:assignment]" in record["data"]["result"]
+    assert record["redaction"]["shapes"] == [f"assignment:{name}"]
+
+
+# ---------------------------------------------------------------------------
+# (b) NO OVER-REDACTION -- the crux
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_an_innocent_runtime_random_value_survives_verbatim(tmp_path):
+    """AC-4: a random but NOT-secret-shaped value must survive the write
+    UNTOUCHED, in the same event that had a real credential stripped.
+
+    This is the pin against the two tempting wrong fixes: replacing the whole
+    payload, and redacting on entropy.  Either would pass the leak test above
+    and silently destroy the forensic record Section 26 exists to create.
+    """
+    fake_key = _fake_openai_key()
+    innocent = _innocent_high_entropy_token()
+
+    path = await _persist_env_dump(tmp_path / "sessions", fake_key, innocent)
+    record = _read_events(path)[0]
+
+    # Survives verbatim -- byte for byte, in place, in the same string that
+    # had the credential removed two lines above it.
+    assert innocent in path.read_text()
+    assert f"REQUEST_ID={innocent}" in record["data"]["result"]
+
+    # ...and so does the documented false-positive class the canonical
+    # assignment rule was end-anchored to protect (`total_tokens=`, not a
+    # credential name -- PR #205 corrupted a shipped artifact over this).
+    assert f"{_PLURAL_ENV_NAME}=41892" in record["data"]["result"]
+
+    # Exactly ONE span was removed: the credential, and nothing else.
+    assert record["redaction"]["count"] == 1
+
+
+def test_the_innocent_value_is_one_an_entropy_scan_would_have_eaten():
+    """The 'shape-targeted, not entropy' decision, MEASURED rather than asserted.
+
+    Loads the canonical layer-4 heuristic and shows the AC-4 probe from the
+    test above is a value that heuristic WOULD have redacted.  That is the
+    whole argument for not porting layer 4 to the write seam: at the upload
+    door a false positive costs one run's evidence (measured at 4 runs out of
+    4, issue #206); at the WRITE seam it costs the evidence permanently,
+    because the original bytes are never written down at all.
+    """
+    canonical = _load_canonical_scrubber()
+    innocent = _innocent_high_entropy_token()
+
+    # The heuristic would have flagged it...
+    assert canonical._entropy_suspicious(innocent)
+    # ...and the shipped, shape-targeted redactor leaves it alone.
+    cleaned, findings = redaction.redact_text(innocent)
+    assert cleaned == innocent
+    assert findings == []
+
+    # Same story for the legitimate observability the heuristic DOES exclude,
+    # kept here so the contrast is on the record rather than assumed.
+    for benign in (secrets.token_hex(20), "b3f1c2d4-5e6a-7b8c-9d0e-1f2a3b4c5d6e"):
+        assert redaction.redact_text(benign) == (benign, [])
+
+
+# ---------------------------------------------------------------------------
+# (c) The redaction is AT THE WRITE SEAM, not a post-hoc scrub
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_redaction_is_at_the_write_seam_not_a_post_hoc_pass(
+    tmp_path, monkeypatch
+):
+    """The bytes handed to the file object are ALREADY redacted.
+
+    A post-hoc scrubber (the workflow-level guard that already exists) writes
+    the credential and cleans it afterwards, so the file transiently holds a
+    live key and anything reading it in that window -- or reading it on a
+    path where the scrubber never runs -- sees the secret.  This test proves
+    the value never becomes file bytes at all: events.jsonl is opened exactly
+    ONCE, in append mode, and the single string passed to write() is already
+    clean.  A re-write pass would show up here as a second open.
+    """
+    real_open = builtins.open
+    opens: list[tuple[str, str]] = []
+    writes: list[str] = []
+
+    class _SpyFile:
+        def __init__(self, fh):
+            self._fh = fh
+
+        def write(self, data):
+            writes.append(data)
+            return self._fh.write(data)
+
+        def __enter__(self):
+            self._fh.__enter__()
+            return self
+
+        def __exit__(self, *exc):
+            return self._fh.__exit__(*exc)
+
+        def __getattr__(self, name):
+            return getattr(self._fh, name)
+
+    def _spy_open(file, mode="r", *args, **kwargs):
+        fh = real_open(file, mode, *args, **kwargs)
+        if str(file).endswith("events.jsonl"):
+            opens.append((str(file), mode))
+            return _SpyFile(fh)
+        return fh
+
+    fake_key = _fake_openai_key()
+    innocent = _innocent_high_entropy_token()
+
+    monkeypatch.setattr(builtins, "open", _spy_open)
+    path = await _persist_env_dump(tmp_path / "sessions", fake_key, innocent)
+    monkeypatch.undo()
+
+    assert [mode for _, mode in opens] == ["a"], (
+        "events.jsonl must be opened exactly once, append-only -- a second "
+        "open (or a 'w'/'r+' mode) would mean the credential hit disk first "
+        "and was cleaned afterwards, which is the leak this fix closes."
+    )
+    assert len(writes) == 1
+    assert fake_key not in writes[0], "the credential never becomes file bytes"
+    assert "[REDACTED:openai-key]" in writes[0]
+    assert innocent in writes[0]
+
+    # And the byte stream is exactly what landed on disk.
+    assert path.read_text() == writes[0]
+
+
+# ---------------------------------------------------------------------------
+# (d) Fail-loud: a broken redactor withholds the payload, never writes it raw
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_redaction_failure_withholds_the_payload_instead_of_writing_it_raw(
+    tmp_path, monkeypatch, caplog
+):
+    """If the redaction machinery throws, falling back to the raw write would
+    resurrect the exact leak. The house rule is fail-loud, not
+    fall-back-to-unsafe: the payload is withheld and a marker records why."""
+    fake_key = _fake_openai_key()
+    innocent = _innocent_high_entropy_token()
+
+    def _boom(_text: str):
+        # The message quotes the credential ON PURPOSE: an exception message
+        # is untrusted content, and the marker must not echo it to disk.
+        raise RuntimeError(f"redactor exploded while handling {fake_key}")
+
+    monkeypatch.setattr(session_events, "redact_text", _boom)
+    path = await _persist_env_dump(tmp_path / "sessions", fake_key, innocent)
+
+    raw = path.read_text()
+    assert fake_key not in raw
+    assert "redactor exploded" not in raw  # only the exception TYPE is recorded
+    assert innocent not in raw  # the whole payload is withheld, not just the key
+
+    record = _read_events(path)[0]
+    assert record["redaction"] == {"error": "RuntimeError", "payload_withheld": True}
+    # Still correlatable: which event, which session, when.
+    assert record["event"] == "tool:post"
+    assert record["data"] == {"session_id": "sid-198"}
+    assert record["timestamp"]
+
+    # Loud in the process log too, at ERROR -- not swallowed at debug.
+    assert any(
+        r.levelname == "ERROR" and "WITHHELD" in r.getMessage() for r in caplog.records
+    )
+
+
+# ---------------------------------------------------------------------------
+# Drift tripwire: the ported shapes must stay identical to the canonical set
+# ---------------------------------------------------------------------------
+
+
+def _load_canonical_scrubber():
+    """Load ``.github/capsule-pipeline/scrub_secrets.py`` BY PATH.
+
+    The engine module deliberately does NOT import this at runtime -- it is a
+    workflow script under ``.github/``, stdlib-only so it runs on a bare
+    Actions runner, and not a package on any import path.  A TEST may reach
+    it, and that is what keeps "two copies" from becoming "two behaviors".
+    """
+    root = Path(__file__).resolve().parents[3]
+    script = root / ".github" / "capsule-pipeline" / "scrub_secrets.py"
+    if not script.exists():  # module installed standalone, outside the repo
+        pytest.skip(f"canonical scrubber not present at {script}")
+    spec = importlib.util.spec_from_file_location("_canonical_scrub", script)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_ported_shapes_have_not_drifted_from_the_canonical_set():
+    """The redaction shapes here are a COPY of the repo's canonical set, and
+    a copy that is allowed to drift is worse than no copy at all."""
+    canonical = _load_canonical_scrubber()
+
+    assert [(s, p.pattern) for s, p in redaction.TOKEN_PATTERNS] == [
+        (s, p.pattern) for s, p in canonical.TOKEN_PATTERNS
+    ]
+    assert redaction.SENSITIVE_NAME_TAILS == canonical.SENSITIVE_NAME_TAILS
+    assert redaction.ASSIGNMENT_PATTERN.pattern == canonical.ASSIGNMENT_PATTERN.pattern
+    assert redaction.ASSIGNMENT_PATTERN.flags == canonical.ASSIGNMENT_PATTERN.flags
+
+
+def test_every_ported_shape_actually_redacts():
+    """Each named shape is exercised, so a pattern cannot rot into a no-op."""
+    cases = {
+        "openai-key": "sk-proj-" + secrets.token_hex(24),
+        "github-fine-grained-pat": "github_pat_" + secrets.token_hex(22),
+        "github-token": "ghp_" + secrets.token_hex(20),
+    }
+    for shape, value in cases.items():
+        cleaned, findings = redaction.redact_text(f"prefix {value} suffix")
+        assert value not in cleaned
+        assert cleaned == f"prefix [REDACTED:{shape}] suffix"
+        assert findings == [shape]

--- a/modules/loop-pipeline/tests/test_worker_session_observability.py
+++ b/modules/loop-pipeline/tests/test_worker_session_observability.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import sys
+import types
 from pathlib import Path
 
 import pytest
@@ -72,14 +73,33 @@ def _make_engine(backend, logs_root: str) -> PipelineEngine:
 
 
 def _load_shipped_persister_module():
-    """Load the REAL shipped session_events.py by file path."""
-    path = (
+    """Load the REAL shipped session_events.py by file path.
+
+    Loaded UNDER a synthetic parent package rather than as a bare top-level
+    module: ``session_events`` imports its sibling ``redaction`` (the
+    write-time secret redaction added for issue #198) with a relative
+    import, which cannot resolve without a package context.  The synthetic
+    parent is a bare namespace whose ``__path__`` points at the real shipped
+    directory -- so the sibling that gets imported is the real shipped
+    ``redaction.py``, not a stub -- while the module's own ``__init__.py``
+    (which pulls in the rest of the hooks module) is deliberately NOT
+    executed, preserving this test's point: loop-pipeline does not install
+    hooks-pipeline-observability, and the runtime coupling stays lazy in
+    both directions.
+    """
+    pkg_dir = (
         Path(__file__).resolve().parents[2]
         / "hooks-pipeline-observability"
         / "amplifier_module_hooks_pipeline_observability"
-        / "session_events.py"
     )
-    spec = importlib.util.spec_from_file_location("_shipped_session_events", path)
+    path = pkg_dir / "session_events.py"
+    pkg_name = "_shipped_observability_pkg"
+    pkg = sys.modules.get(pkg_name)
+    if pkg is None:
+        pkg = types.ModuleType(pkg_name)
+        pkg.__path__ = [str(pkg_dir)]  # type: ignore[attr-defined]
+        sys.modules[pkg_name] = pkg
+    spec = importlib.util.spec_from_file_location(f"{pkg_name}.session_events", path)
     assert spec is not None and spec.loader is not None, f"missing shipped file: {path}"
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module

--- a/specs/EXTENSIONS.md
+++ b/specs/EXTENSIONS.md
@@ -1041,6 +1041,68 @@ Fully backward-compatible and fail-safe:
 - `response.md` is written only when `response_text` is present; infrastructure-failure
   Outcomes (no child output) skip it.
 
+*Addendum (2026-08-17): the persister now REDACTS SECRET-SHAPED MATERIAL AT WRITE TIME (issue
+#198), and the "Compatibility" bullet above about silent no-ops does NOT extend to this — a
+redaction failure is loud. Incident 2026-08-11: a worker agent ran a tool that dumped its
+environment, and the "captured, not reconstructed" property this entry is built on — the
+persister writes the worker's REAL `tool:post` payload — meant a literal `OPENAI_API_KEY` value
+of the `sk-proj-...` shape (spelled apart here so this ledger is not itself secret-shaped
+material) was written verbatim into `<stage_dir>/sessions/<id>/events.jsonl`, which CI then
+uploaded inside a PUBLIC run-evidence artifact. (Artifacts deleted, key rotated; a workflow-level scrub-before-upload was added
+separately.) That guard sits at the UPLOAD door, one hop downstream of the leak: it can only
+clean a file that already holds the credential, and it protects exactly one consumer — anything
+else reading the run dir (a maintainer tailing the file, a bug report pasting it, a sandbox that
+syncs it) still read a live key. Defense in depth belongs at the WRITE seam, which is
+`SessionEventPersister._serialize` — the single place event bytes become file bytes.
+
+**Mechanics.** Each record is serialized, passed through the module's own
+`redaction.redact_text`, re-parsed as a validity self-check, and only then appended; each matched
+span becomes `[REDACTED:<shape>]`. Redaction runs on the SERIALIZED LINE rather than by walking
+the payload because the leak was nested inside a `tool:post` result STRING — a walker has to be
+right about every nesting depth, container type and `default=str` coercion, while the serialized
+line has no blind spots: whatever is about to be written is exactly what is inspected.
+
+**Shape-targeted, deliberately NOT entropy.** The shapes are a copy of layers 1 and 2 of this
+repository's canonical detection set (`.github/capsule-pipeline/scrub_secrets.py`): the known
+token prefixes (`sk-`, `github_pat_`, `gh[posur]_`) and end-anchored sensitive `NAME=value`
+assignments. Layer 4, the high-entropy heuristic, is NOT ported, and that is the load-bearing
+scoping decision rather than an omission — it was MEASURED WRONG on this exact file class
+(issue #206: worker-session `events.jsonl` is legitimately full of digests, base64 fragments and
+request ids; it blocked the evidence upload on 4 of 4 real runs, and produced 487 entropy-only
+findings on run 31689374533). At the upload door a false positive costs one run's evidence; at
+the WRITE seam it costs that evidence PERMANENTLY, because the original bytes are never written
+at all — which would defeat the forensic-navigation contract above. `redaction.py` is a local
+copy and not an import: the canonical script lives under `.github/`, is deliberately stdlib-only
+so it runs on a bare Actions runner, and is not a package this module may depend on. A drift
+tripwire test loads it BY PATH and asserts the two pattern sets are still identical, so two
+copies cannot quietly become two behaviors.
+
+**Loud, never silent.** A scrubbed record carries a top-level
+`"redaction": {"count": N, "shapes": [...]}` block beside the inline markers. A CLEAN record is
+byte-identical to what this entry originally specified — the key appears only when something was
+actually removed — so the record shape documented above still holds for every event that had
+nothing to redact, and existing session tooling reading `event`/`timestamp`/`data` is unaffected.
+**Fail-loud on redaction failure:** if the machinery raises, the payload is WITHHELD and a
+`{"error": <exception type>, "payload_withheld": true}` marker is written in its place. Falling
+back to the raw write would resurrect the exact leak; only the exception TYPE is recorded,
+because an exception MESSAGE can quote the very bytes that failed to redact.
+
+**Honest residuals.** The canonical set's layer 3 (redacting the literal VALUES of the env vars
+the CI job holds) is not ported — it is a workflow-context mechanism, and making write-time
+redaction depend on ambient process environment would be non-deterministic and untestable at
+this seam; the incident's own credential is covered here twice over, by shape and by assignment.
+And the assignment rule matches `NAME=value`, not a JSON key spelled `"api_key": "..."`, so a
+SHAPELESS credential in a structured field remains the upload gate's job rather than being
+closed by widening a pattern that has already corrupted a shipped artifact once (PR #205). Files:
+`modules/hooks-pipeline-observability/amplifier_module_hooks_pipeline_observability/redaction.py`
+(new), `.../session_events.py` (`_serialize`). Pinned by
+`modules/hooks-pipeline-observability/tests/test_session_events_redaction.py`, which holds all
+four directions at once — secret-shaped material redacted AND loud; an innocent runtime-random
+value surviving VERBATIM in the same event (the no-over-redaction pin, measured against the
+entropy heuristic that WOULD have eaten it); the redaction proved to be AT the write seam
+(`events.jsonl` opened exactly once, append-only, the bytes handed to `write()` already clean,
+so no post-hoc rewrite could be what cleaned it); and the fail-loud path.*
+
 ---
 
 ## 27. `must_write=` Node Attribute — Fail-Closed Artifact Contract


### PR DESCRIPTION
## Summary

Fixes #198.

Incident 2026-08-11: a worker agent ran a tool that dumped its environment. `SessionEventPersister` — the worker-session observability shipped in T1-4/#117, EXTENSIONS §26 — wrote the `tool:post` payload **verbatim** to `<stage_dir>/sessions/<id>/events.jsonl`, including a literal `OPENAI_API_KEY` value, and CI uploaded that file inside a **public** run-evidence artifact. (Artifacts deleted, key rotated; a workflow-level scrub-before-upload was added separately.)

That workflow guard sits at the **upload door**, one hop downstream of the leak: it can only clean a file that *already holds* the credential, and it protects exactly one consumer. Anything else reading the run dir — a maintainer tailing the file, a bug report pasting it, a sandbox that syncs it — still read a live key. This PR puts the defense at the **write seam**.

**Write seam:** `modules/hooks-pipeline-observability/amplifier_module_hooks_pipeline_observability/session_events.py` — at base, `_persist()` L133–140: the `json.dumps(record, ...)` whose result is appended to `events.jsonl`. That serialization now lives in a new `_serialize()`, which redacts **before the bytes reach the file object**. (`modules/loop-pipeline/.../worker_observability.py` is only the ContextVar that routes worker events here; it holds no payload and is unchanged.)

## Verification checklist

- [x] Unit tests pass (`pytest modules/loop-pipeline/`) — 2489 passed, 25 skipped (baseline unchanged)
- [x] Live pipeline run exercising changed code path — not an `engine.py`/handler change; the persister is driven end-to-end through the real engine + real amplifier-core `HookRegistry` by `test_worker_session_observability.py`, and the paired before/after event line is quoted below
- [x] AGENTS.md reviewed; repo-specific gates met
- [x] Backward-compat path unchanged — a **clean** record is byte-identical to before; the `redaction` key appears only when something was actually removed
- [x] Observable-contract change ships a `specs/EXTENSIONS.md` entry — dated addendum on §26 (quoted below)
- [x] Doc claim pinned to code — the addendum's "shapes are a copy of the canonical set" claim is pinned by a **drift tripwire test** that loads `.github/capsule-pipeline/scrub_secrets.py` by path and asserts the pattern sets are identical
- [x] PR body includes verification evidence, not just "tests pass"
- [ ] **CI is green before merge** — do **not** merge; this PR is for review

## Verification evidence

### 1. The leak, reproduced at base (origin/main @ `251f738`)

Same event driven through the persister at base and at the fix. The "key" is **fake and minted at runtime** (`secrets.token_hex`) — never a real credential — and masked again here.

```
===== BASE  origin/main @ 251f738 =====
{"event": "tool:post", "timestamp": "...", "data": {"session_id": "sid-198", "tool_name": "bash",
 "tool_input": {"command": "env"},
 "result": "SHELL=/bin/bash\nOPENAI_API_KEY=sk-proj-<FAKE-48-HEX-MASKED-FOR-THIS-REPORT>\nREQUEST_ID=eqklBST24Ul55MJNeoPHQirDoN3vIlRM3xqMJ4liAw4\ntotal_tokens=41892\nTERM=xterm\n",
 "call_id": "c1"}}
-- literal fake key present VERBATIM on disk : True
-- '[REDACTED:' marker present               : False
-- innocent 43-char token survives VERBATIM  : True
-- loud indicator                            : <absent>
```

### 2. The redacted write, after the fix

```
===== AFTER fix/198 @ 208f231 =====
{"event": "tool:post", "timestamp": "...", "data": {"session_id": "sid-198", "tool_name": "bash",
 "tool_input": {"command": "env"},
 "result": "SHELL=/bin/bash\nOPENAI_API_KEY=[REDACTED:openai-key]\nREQUEST_ID=eqklBST24Ul55MJNeoPHQirDoN3vIlRM3xqMJ4liAw4\ntotal_tokens=41892\nTERM=xterm\n",
 "call_id": "c1"},
 "redaction": {"count": 1, "shapes": ["openai-key"]}}
-- literal fake key present VERBATIM on disk : False
-- '[REDACTED:' marker present               : True
-- innocent 43-char token survives VERBATIM  : True
-- total_tokens=41892 survives (end-anchor)  : True
-- loud indicator                            : {'count': 1, 'shapes': ['openai-key']}
```

Note what did **not** change: `SHELL=`, `TERM=`, `tool_input`, `call_id`, the record's key set and nesting. Only the credential span is gone.

### 3. Fix mechanics

Redaction runs on the **serialized line**, not by walking the payload. The leak was nested inside a `tool:post` result *string*; a walker has to be right about every nesting depth, container type and `default=str` coercion, while the serialized line has no blind spots — whatever is about to be written is exactly what is inspected. Every ported pattern's character class stops at quote and backslash, so a match can never cross a JSON string boundary or eat an escape; that is then **verified rather than trusted** — the redacted line is re-parsed before it is returned, and a line that no longer parses is treated as a redaction-machinery failure (below), never written.

### 4. Shape-targeted, deliberately NOT entropy

New `redaction.py` ports **layers 1 and 2** of the repo's canonical set (`.github/capsule-pipeline/scrub_secrets.py`): the known token prefixes (`sk-[A-Za-z0-9_-]{20,}`, `github_pat_...`, `gh[posur]_...`) and end-anchored sensitive `NAME=value` assignments (`API_KEYS?`, `SECRET_ACCESS_KEY`, `_TOKEN`, `_SECRET`, `PASSWORD`, `CREDENTIALS?`). Matches become `[REDACTED:openai-key]` / `[REDACTED:assignment]` etc.

**Layer 4 — the high-entropy heuristic — is deliberately not ported**, and that is the load-bearing decision rather than an omission. It was *measured wrong on this exact file class*: per that script's own docstring (issue #206), worker-session `events.jsonl` "are legitimately full of high-entropy runs (digests, base64 fragments, request ids)", it blocked the evidence upload on **4 of 4 real runs**, and produced **487 entropy-only findings** on run 31689374533 without a single credential among them. The asymmetry is what settles it: at the upload door a false positive costs one run's artifact; at the **write seam** it costs that evidence *permanently*, because the original bytes are never written at all — which would defeat the forensic-navigation contract §26 exists to provide.

Measured with the canonical heuristic itself, and encoded as a test:

| value | Shannon H | entropy heuristic | this PR |
|---|---|---|---|
| 43-char alphanumeric request id | 4.83–4.99 | **would redact** | survives verbatim |
| 40-char git SHA / sha256 digest | 3.28 | survives (hex-excluded) | survives verbatim |
| session UUID | 3.97 | survives | survives verbatim |

The first row is ordinary observability, and it is exactly the AC-4 probe below.

**Local copy, not an import — and not a dependency on `.github/`.** The canonical script is a workflow script under `.github/`, deliberately stdlib-only so it runs on a bare Actions runner, and is not a package this module may depend on; vendoring a shared distribution for four regexes would be heavier than the problem. So the patterns are copied — and a **drift tripwire test** loads the canonical script *by path* and asserts `TOKEN_PATTERNS`, `SENSITIVE_NAME_TAILS` and `ASSIGNMENT_PATTERN` (pattern **and** flags) are still identical. Two copies cannot quietly become two behaviors.

### 5. The loud indicator

Two independent signals, so a scrubbed dump is distinguishable from a clean one:

1. the inline `[REDACTED:<shape>]` marker, sitting exactly where the value was (`OPENAI_API_KEY=[REDACTED:openai-key]` — the *name* survives, so evidence still shows **which** variable leaked);
2. a top-level `"redaction": {"count": 1, "shapes": ["openai-key"]}` block.

A **clean** record carries neither and is byte-identical to the pre-fix shape (`sorted(record) == ["data","event","timestamp"]`, pinned by a test) — which is what makes the marked ones stand out, and keeps existing session tooling reading these files unchanged.

**Fail-loud on redaction-machinery errors.** If redaction (or the serialization it depends on) raises, the payload is **withheld** and a marker is written in its place:

```json
{"event": "tool:post", "timestamp": "...", "data": {"session_id": "sid-198"},
 "redaction": {"error": "RuntimeError", "payload_withheld": true}}
```

Falling back to the raw write would resurrect the exact leak, so that is not an option; writing *nothing* would silently drop the event. Only the exception **type** is recorded — an exception *message* can quote the very bytes that failed to redact, and the fail-loud test proves it does not reach disk by raising an error whose message contains the fake key. The full traceback goes to `logger.error` (process log, not the artifact).

### 6. No over-redaction — the crux

Pinned as a test, in the **same event** that had a credential stripped:

- `REQUEST_ID=<43-char runtime-random alphanumeric>` survives **verbatim** — the value the entropy heuristic would have eaten (table above);
- `total_tokens=41892` survives — the documented false-positive class the canonical end-anchor exists to protect (PR #205 corrupted a shipped artifact over exactly this);
- `record["redaction"]["count"] == 1` — **exactly one** span was removed: the credential, and nothing else.

The probe alphabet is letters+digits only (no `-`, no `_`), so it structurally *cannot* contain `sk-`, `gh?_` or `github_pat_` — the assertion cannot flake on an unlucky draw.

### 7. Tests + mutation

`modules/hooks-pipeline-observability/tests/test_session_events_redaction.py` (9 tests) pins all directions:

| direction | test |
|---|---|
| (a) secret-shaped → redacted + loud | `test_secret_shaped_material_is_redacted_and_the_redaction_is_loud` |
| (b) innocent value → survives verbatim | `test_an_innocent_runtime_random_value_survives_verbatim` |
| (b′) shape-targeted ≠ entropy, **measured** | `test_the_innocent_value_is_one_an_entropy_scan_would_have_eaten` |
| (c) redaction is at the **write seam** | `test_redaction_is_at_the_write_seam_not_a_post_hoc_pass` |
| fail-loud | `test_redaction_failure_withholds_the_payload_instead_of_writing_it_raw` |
| clean record unmarked | `test_a_clean_event_is_byte_identical_to_the_pre_fix_shape` |
| assignment shape | `test_a_shapeless_sensitive_assignment_redacts_as_assignment` |
| drift tripwire | `test_ported_shapes_have_not_drifted_from_the_canonical_set` |
| every shape still bites | `test_every_ported_shape_actually_redacts` |

(c) is a *persister-level* test, not a post-hoc scrub check: it spies on `open` and asserts `events.jsonl` is opened **exactly once, append-only**, and that the single string handed to `write()` already contains `[REDACTED:` and not the key. A re-write pass — which is what a post-hoc scrubber does — would show up as a second open.

**Mutation** (revert the redaction call at the seam, keep the tests):

```
-            cleaned, findings = redact_text(serialized)
+            cleaned, findings = serialized, []  # MUTATION: redaction call reverted

FAILED test_secret_shaped_material_is_redacted_and_the_redaction_is_loud
FAILED test_a_shapeless_sensitive_assignment_redacts_as_assignment
FAILED test_an_innocent_runtime_random_value_survives_verbatim
FAILED test_redaction_is_at_the_write_seam_not_a_post_hoc_pass
FAILED test_redaction_failure_withholds_the_payload_instead_of_writing_it_raw
5 failed, 73 passed
```

### 8. Suites + leak scan

| suite | result |
|---|---|
| `modules/hooks-pipeline-observability` | **78 passed** (69 before + 9 new) |
| `test_worker_session_observability.py` + `test_parallel_branch_observability.py` | **18 passed** |
| `modules/loop-pipeline` full (`uv sync --extra remote && uv run pytest -q`) | **2489 passed, 25 skipped** — baseline unchanged |
| `modules/pipeline-runner` | **76 passed, 1 skipped** — baseline unchanged |
| `test_extensions_ledger_integrity.py` | **8 passed** |
| `scrub_secrets.py scan <changed files>` | `clean -- scanned 5 file(s), no secret-shaped material` |
| `git diff --check` | clean |

One test-only change outside the module: `test_worker_session_observability.py` loads the shipped `session_events.py` **by file path** (loop-pipeline deliberately does not install the hooks module). That bare load cannot resolve the new relative import of its `redaction` sibling, so the loader now runs it under a synthetic parent package whose `__path__` is the real shipped directory — it imports the **real** shipped `redaction.py`, and still never executes the hooks module's `__init__.py`, preserving the test's point that the coupling stays lazy in both directions.

### 9. The §26 addendum

`specs/EXTENSIONS.md` §26 gains a dated addendum (house format; no renumbering). Opening and the load-bearing claims:

> *Addendum (2026-08-17): the persister now REDACTS SECRET-SHAPED MATERIAL AT WRITE TIME (issue #198), and the "Compatibility" bullet above about silent no-ops does NOT extend to this — a redaction failure is loud. […] That guard sits at the UPLOAD door, one hop downstream of the leak: it can only clean a file that already holds the credential, and it protects exactly one consumer […]. Defense in depth belongs at the WRITE seam, which is `SessionEventPersister._serialize` — the single place event bytes become file bytes.*
>
> ***Shape-targeted, deliberately NOT entropy.*** *[…] Layer 4, the high-entropy heuristic, is NOT ported, and that is the load-bearing scoping decision rather than an omission — it was MEASURED WRONG on this exact file class (issue #206 […]). At the upload door a false positive costs one run's evidence; at the WRITE seam it costs that evidence PERMANENTLY, because the original bytes are never written at all — which would defeat the forensic-navigation contract above.*
>
> ***Loud, never silent.*** *A scrubbed record carries a top-level `"redaction": {"count": N, "shapes": [...]}` block beside the inline markers. A CLEAN record is byte-identical to what this entry originally specified […]. **Fail-loud on redaction failure:** if the machinery raises, the payload is WITHHELD and a `{"error": <exception type>, "payload_withheld": true}` marker is written in its place.*

### 10. Tier classification — QUALITY_PROTOCOL §3

**Uncharted / extension** (the resisted tier), addendum'd onto the existing §26 rather than claiming a new number.

- *Why not toward-spec:* there is no canonical-spec gap being closed. The spec does not specify worker-session event persistence at all — §26 exists precisely because of that silence — so it cannot have a redaction requirement to converge on. Claiming toward-spec here would be taking the cheapest tier by default, which §3 explicitly warns against.
- *Why not drift:* nothing moves away from anything the spec specifies. No graph semantics, routing, verdict, retry, budget, or node/edge/attribute vocabulary is touched. No `SPEC_CONFORMANCE.md` row is owed.
- *Why the spec's silence is not itself a signal:* the artifact being protected is a **run-evidence file this repo's CI uploads publicly** — a property of this repository's delivery pipeline, not of the spec's execution model. The spec has no view on it because it has no view on the file's existence.
- *Additive and non-interfering:* a spec-conformant graph behaves identically. A clean event's persisted line is byte-identical to before; only a record that actually contained credential-shaped material differs, and only in the credential span plus one added key. Full loop-pipeline suite unchanged at 2489/25.
- *Ledgering:* per §26's own subject boundary — the write-time behavior of the persister this entry already owns — this is an **addendum to §26**, not a new entry. Same discriminator the §31 addendum used ("the entry point, not the rule count"). `test_extensions_ledger_integrity.py` passes: dated, no renumbering, sequence contiguous.

## Observations

- **The workflow guard and this fix are not redundant, and neither subsumes the other.** The upload gate still does two things this cannot: it redacts the *literal values of the CI job's own secrets* (canonical layer 3, which needs the job's env), and it hard-blocks on anything shape-detected anywhere under the evidence roots — including files this persister never wrote. This fix covers the one thing the gate structurally cannot: the credential never becomes file bytes in the first place.
- **Honest residual, stated rather than implied.** The assignment rule matches `NAME=value` — the incident's env-dump shape — and *not* a JSON key spelled `"api_key": "..."` (JSON separates with `:`). A structured field holding a credential is still caught whenever its value carries a known token shape, which is the usual case; a *shapeless* credential in such a field remains the upload gate's job. I chose not to widen the pattern for it: the same widening instinct (a CONTAINS match instead of an end-anchor) corrupted a shipped, later-executed artifact in PR #205, and widening it here would also break the single-source-of-truth property the drift tripwire buys.
- **The fail-loud behavior is a genuine judgment call, so it is worth a reviewer's disagreement.** Three options existed: write raw (rejected — resurrects the leak), write nothing (rejected — silently drops an event, and §26's whole point is that the stream is complete), or write a payload-withheld marker (chosen — loses the payload, keeps the fact and the correlation keys). If a reviewer prefers a fourth option — e.g. withhold only the offending *field* — that needs a walker, which is exactly the blind-spot-prone approach the serialized-line design avoids.
- **Redaction cost is bounded and does not scale with payload randomness.** Three prefix regexes plus one assignment regex per event line — versus the entropy heuristic, which tokenizes every 28+ char run and computes a Shannon estimate for each. That is a second, quieter reason the entropy layer does not belong on a per-event hot path.
- **Deliberately not done:** no back-scrub of `events.jsonl` files already on disk from past runs. This is a write-seam fix; existing artifacts are the incident response's business (already handled: artifacts deleted, key rotated), and silently rewriting historical evidence is its own hazard.
