### PR TITLE
fix(preflight): thread resolvable_profiles through drive_engine (#283)

### DIFF
--- a/modules/loop-pipeline/tests/test_provider_preflight.py
+++ b/modules/loop-pipeline/tests/test_provider_preflight.py
@@ -627,7 +627,13 @@ def test_profile_naming_a_resolvable_agent_stays_serviceable():
 def test_resolvable_profiles_none_does_not_police_adapter_resolution():
     """``None`` means "not knowable on this path", never "everything resolves":
     the check is skipped, preserving every caller that cannot supply the set
-    (no coordinator, no session.spawn, a stub coordinator, drive_engine)."""
+    (no coordinator, no session.spawn, a stub coordinator).
+
+    ``drive_engine`` used to be on that list and no longer is: issue #283 wired
+    it to the same ``_spawn_resolvable_agents`` resolver, so it supplies the set
+    whenever a coordinator with ``session.spawn`` is in scope -- which is the
+    production case -- and passes ``None`` only on the genuinely-unknowable
+    no-spawn path."""
     graph = parse_dot(_DOT_DECLARED_OPENAI)
     check_provider_preflight(
         graph,

--- a/modules/pipeline-runner/amplifier_module_pipeline_runner/compat.py
+++ b/modules/pipeline-runner/amplifier_module_pipeline_runner/compat.py
@@ -93,10 +93,24 @@ import importlib
 # older engine snapshot (the incident: remote_dot absent <= bc6cbec, #96).
 _REQUIRED_ENGINE_SYMBOLS: list[tuple[str, str]] = [
     ("amplifier_module_loop_pipeline.remote_dot", "load_remote_or_local_graph"),
+    # issue #283: drive_engine() imports the engine's shared spawn-resolver to
+    # feed `resolvable_profiles` into the startup provider preflight.  This
+    # entry is also the only gate we CAN have on that keyword argument itself:
+    # `check_provider_preflight` existed before it gained `resolvable_profiles`,
+    # so a symbol probe on the function would pass against a stale engine and
+    # the call would then die on a bare `TypeError` mid-run (the skew this
+    # module's `_load_graph` docstring warns about).  `_spawn_resolvable_agents`
+    # and that keyword landed in the SAME engine commit (ccbd89f, PR #280), so
+    # probing the symbol is a faithful proxy for the signature.
+    ("amplifier_module_loop_pipeline", "_spawn_resolvable_agents"),
 ]
 
 # Human-readable minimum description for the actionable error message.
-_ENGINE_MIN_DESCRIPTION = "engine with remote_dot support (commit bc6cbec or later, PR #96)"
+_ENGINE_MIN_DESCRIPTION = (
+    "engine with remote_dot support (commit bc6cbec or later, PR #96) and the "
+    "shared spawn-resolver / resolvable_profiles preflight argument "
+    "(commit ccbd89f or later, PR #280)"
+)
 
 
 class IncompatibleEngineError(RuntimeError):

--- a/modules/pipeline-runner/amplifier_module_pipeline_runner/runner.py
+++ b/modules/pipeline-runner/amplifier_module_pipeline_runner/runner.py
@@ -294,9 +294,51 @@ async def drive_engine(
         # Always on: the incident path was exactly this invoker.  A hermetic
         # harness that mocks spawn satisfies the static check by setting the
         # provider's env var (presence is checked, never validity).
+        #
+        # Issue #283 -- the residual of #195/#280 on THIS path.  A profile is
+        # a STRING naming an agent; knowing the string is MAPPED is not
+        # knowing the agent it names can be RESOLVED.  "profile mounted +
+        # credential set" therefore used to accept a configuration whose
+        # EVERY spawn was guaranteed to fail, and the run drained its whole
+        # budget in exactly the #155 crash loop instead of refusing at
+        # startup.  #280 closed that at `PipelineOrchestrator.execute()`;
+        # drive_engine still passed no `resolvable_profiles` and so stayed
+        # fail-open -- and drive_engine IS the original #155 incident invoker
+        # (`attractor run` -> run_pipeline -> here).
+        #
+        # The set comes from the engine's OWN shared resolver,
+        # `_spawn_resolvable_agents` -- the single home #280 established for
+        # this rule, and exactly what `execute()` step 5b calls.  Re-deriving
+        # `coordinator.config["agents"]` here would be a second copy of a rule
+        # that MUST stay identical to what the spawn actually resolves
+        # against; a preflight seeing a different set than the backend is
+        # precisely the #196 false-refusal disease.
+        #
+        # Fail-closed when knowable, benefit of the doubt when not -- the same
+        # posture as execute():
+        #   * `None` (no `session.spawn` capability, or a coordinator whose
+        #     config/agents is not a statically inspectable Mapping -- e.g. a
+        #     bare stub coordinator) means "not knowable here, do not police
+        #     it", never "everything resolves".  Those paths keep their
+        #     current behavior exactly.
+        #   * a discovery CRASH becomes the empty set (refuse), never None:
+        #     unknowable-because-it-broke must not silently re-open the hole.
+        from amplifier_module_loop_pipeline import _spawn_resolvable_agents
         from amplifier_module_loop_pipeline.preflight import check_provider_preflight
 
-        check_provider_preflight(graph, profiles=dict(profiles or DEFAULT_PROFILES))
+        # ONE profiles dict, shared with the AmplifierBackend constructed
+        # below, so the map the preflight judges is literally the object the
+        # backend routes with -- not an equal-looking rebuild of it.
+        resolved_profiles = dict(profiles or DEFAULT_PROFILES)
+        try:
+            resolvable_profiles = _spawn_resolvable_agents(coordinator)
+        except Exception:
+            resolvable_profiles = frozenset()
+        check_provider_preflight(
+            graph,
+            profiles=resolved_profiles,
+            resolvable_profiles=resolvable_profiles,
+        )
 
         # Default engine/handler observability to the coordinator's own hook stack
         # when the caller didn't supply hooks. A mounted observability hook (e.g.
@@ -312,8 +354,14 @@ async def drive_engine(
         effective_hooks = hooks if hooks is not None else getattr(coordinator, "hooks", None)
 
         backend = AmplifierBackend(
+            # The SAME coordinator the preflight above read
+            # `config["agents"]` from, and the SAME profiles dict it judged:
+            # `AmplifierBackend._run_with_spawn` looks each profile up in
+            # `coordinator.config["agents"]`, which is precisely the mapping
+            # `_spawn_resolvable_agents(coordinator)` returned the keys of.
+            # Nothing between that call and this one mutates either.
             coordinator=coordinator,
-            profiles=dict(profiles or DEFAULT_PROFILES),
+            profiles=resolved_profiles,
         )
         registry = HandlerRegistry(
             HandlerContext(

--- a/modules/pipeline-runner/tests/test_provider_preflight_drive_engine.py
+++ b/modules/pipeline-runner/tests/test_provider_preflight_drive_engine.py
@@ -10,6 +10,16 @@ budget against a defect that had nothing to do with the work.
 These tests pin the fix: drive_engine now refuses AT STARTUP -- before any
 node executes, before any LLM call -- naming the node, the provider, and the
 missing credential.
+
+Issue #283 adds the second half of that refusal on this path.  #195/#280
+closed the "key set but the profile names an ABSENT agent" hole at
+``PipelineOrchestrator.execute()``; drive_engine still passed no
+``resolvable_profiles``, so the original #155 incident invoker stayed
+fail-open for exactly that class: profile mapped + credential set + named
+agent absent -> accepted at startup -> every visit fails at spawn -> the
+budget drains to the engine's 200-step safety bound.  The tests below pin
+BOTH directions: the refusal, and -- the crux, the #196 disease inverse --
+that a run which WOULD work is still not refused.
 """
 
 from __future__ import annotations
@@ -114,3 +124,193 @@ def test_drive_engine_runs_when_declared_provider_is_serviceable(
 
     assert outcome.status.value == "success", outcome
     assert coordinator.spawn_called
+
+
+# ---------------------------------------------------------------------------
+# Adapter-resolvable profiles on the drive_engine path (issue #283)
+#
+# The residual of #195/#280.  A profile is a STRING naming an agent; knowing
+# the string is MAPPED is not knowing the agent it names can be RESOLVED.
+# ``AmplifierBackend._run_with_spawn`` resolves it in exactly one place --
+# ``coordinator.config["agents"]`` -- so a profile naming an absent agent
+# fails at EVERY spawn.  drive_engine must hand the preflight that same key
+# set (the engine's shared ``_spawn_resolvable_agents``) and refuse at
+# startup instead of draining the budget.
+# ---------------------------------------------------------------------------
+
+_DOT_DRAIN_LOOP = """\
+digraph drain_loop {
+    graph [goal="the #155 shape: a failing node on a recovery loop"]
+    start [shape=Mdiamond]
+    critique_b [shape=box, llm_provider="openai", prompt="dual-family critique"]
+    recover [shape=box, llm_provider="anthropic", prompt="transient recovery"]
+    done [shape=Msquare]
+    start -> critique_b
+    critique_b -> done    [condition="outcome=success"]
+    critique_b -> recover [condition="outcome=fail"]
+    recover -> critique_b [loop_restart="true"]
+}
+"""
+
+_PROFILES_NAMING_AN_ABSENT_AGENT = {
+    "anthropic": "attractor-anthropic",
+    "openai": "attractor-openai",  # names an agent the coordinator does not have
+}
+
+_LOOP_AGENT: dict[str, Any] = {"session": {"orchestrator": {"module": "loop-agent"}}}
+
+
+class _AgentsCoordinator:
+    """Coordinator whose ``config['agents']`` is set by the test.
+
+    This is the mapping ``AmplifierBackend._run_with_spawn`` indexes the
+    profile into, so it is also exactly what the preflight must judge.
+    """
+
+    def __init__(self, *agent_names: str) -> None:
+        self.spawn_calls: list[str] = []
+        self.session = None
+        self.hooks = None
+        self.config: dict[str, Any] = {
+            "agents": {name: dict(_LOOP_AGENT) for name in agent_names}
+        }
+
+    def get_capability(self, name: str):
+        return self._spawn_fn if name == "session.spawn" else None
+
+    async def _spawn_fn(self, **kwargs):
+        self.spawn_calls.append(str(kwargs.get("agent_name")))
+        return {
+            "output": json.dumps({"status": "success", "notes": "stub"}),
+            "session_id": "child-1",
+        }
+
+
+class _NoSpawnCoordinator:
+    """A bare coordinator: no ``session.spawn`` capability at all."""
+
+    hooks = None
+    session = None
+    config: dict[str, Any] = {"agents": {}}
+
+    def get_capability(self, name: str):
+        return None
+
+
+def test_drive_engine_refuses_when_profile_names_an_absent_agent(
+    tmp_path, monkeypatch
+) -> None:
+    """#283: credential SET, profile MAPPED, named agent ABSENT -> refuse.
+
+    Against the pre-fix runner this configuration was ACCEPTED and the run
+    drained to the engine's 200-step safety bound (critique_b executed 101
+    times, 99 real spawns issued for the recovery node).  It must now refuse
+    at startup with ZERO spawns, naming the profile, the missing agent, and
+    what IS resolvable -- the same message shape as the execute() path.
+    """
+    from amplifier_module_loop_pipeline.preflight import ProviderPreflightError
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-present")  # credential IS set
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-present")
+
+    coordinator = _AgentsCoordinator("attractor-anthropic")  # NOT attractor-openai
+
+    with pytest.raises(ProviderPreflightError) as exc_info:
+        asyncio.run(
+            drive_engine(
+                _DOT_DRAIN_LOOP,
+                coordinator,
+                cwd=tmp_path,
+                logs_root=tmp_path / "logs",
+                profiles=_PROFILES_NAMING_AN_ABSENT_AGENT,
+                transform=True,
+            )
+        )
+
+    msg = str(exc_info.value)
+    assert "critique_b" in msg  # the failing node
+    assert "attractor-openai" in msg  # the profile that cannot resolve
+    assert "attractor-anthropic" in msg  # what CAN be resolved
+    assert not coordinator.spawn_calls, "zero spawns -- zero budget spent"
+
+
+def test_drive_engine_runs_when_the_named_agent_is_present(tmp_path, monkeypatch) -> None:
+    """The no-false-refusal crux (#196's disease, inverted).
+
+    SAME graph, SAME credentials, SAME profiles map as the test above -- the
+    single difference is that the agent the profile names EXISTS.  The run
+    must still start and succeed.  The fix discriminates on adapter
+    resolution, never on the graph shape or the profile string.
+    """
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-present")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-present")
+
+    coordinator = _AgentsCoordinator("attractor-anthropic", "attractor-openai")
+
+    outcome = asyncio.run(
+        drive_engine(
+            _DOT_DRAIN_LOOP,
+            coordinator,
+            cwd=tmp_path,
+            logs_root=tmp_path / "logs",
+            profiles=_PROFILES_NAMING_AN_ABSENT_AGENT,  # identical map
+            transform=True,
+        )
+    )
+
+    assert outcome.status.value == "success", outcome
+    assert "attractor-openai" in coordinator.spawn_calls
+
+
+def test_drive_engine_preflight_sees_exactly_the_keys_the_spawn_resolves_against() -> None:
+    """Same dict, same moment.
+
+    ``_spawn_resolvable_agents`` returns the keys of ``coordinator.config
+    ["agents"]``; ``AmplifierBackend._run_with_spawn`` looks the profile up in
+    that same mapping on the same coordinator object drive_engine hands the
+    backend.  Pinning the identity here is what keeps the preflight from ever
+    judging a DIFFERENT set than the spawn will -- the #196 failure mode.
+    """
+    from amplifier_module_loop_pipeline import _spawn_resolvable_agents
+
+    coordinator = _AgentsCoordinator("attractor-anthropic", "attractor-openai")
+    backend_indexes_into = (getattr(coordinator, "config", None) or {}).get("agents", {})
+
+    assert backend_indexes_into is coordinator.config["agents"]
+    assert set(_spawn_resolvable_agents(coordinator)) == set(backend_indexes_into)
+
+
+def test_drive_engine_does_not_police_resolution_without_a_spawn_capability(
+    tmp_path, monkeypatch
+) -> None:
+    """The bare path keeps its current behavior: ``None``, not a refusal.
+
+    With no ``session.spawn`` capability the profiles map is never consumed by
+    a spawn at all, so adapter resolution is genuinely not knowable here.
+    ``None`` means "do not police it" -- it never means "everything
+    resolves" -- and this path must not acquire a new refusal.
+    """
+    from amplifier_module_loop_pipeline import _spawn_resolvable_agents
+    from amplifier_module_loop_pipeline.preflight import ProviderPreflightError
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-present")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-present")
+
+    bare = _NoSpawnCoordinator()
+    assert _spawn_resolvable_agents(bare) is None
+
+    try:
+        asyncio.run(
+            drive_engine(
+                _DOT_DRAIN_LOOP,
+                bare,
+                cwd=tmp_path,
+                logs_root=tmp_path / "logs",
+                profiles=_PROFILES_NAMING_AN_ABSENT_AGENT,
+                transform=True,
+            )
+        )
+    except ProviderPreflightError as exc:  # pragma: no cover - the defect
+        pytest.fail(f"bare no-spawn path must not be refused at startup: {exc}")
+    except Exception:
+        pass  # any NON-preflight failure means the preflight let it through

--- a/specs/EXTENSIONS.md
+++ b/specs/EXTENSIONS.md
@@ -2240,6 +2240,35 @@ profiles, hence a refusal, never a false accept) and the rot-prone "mirrors `_bu
 home behaviorally (one monkeypatched resolver must be observed by both in one run), so it is
 enforced rather than promised.*
 
+*Addendum (2026-08-17, issue #283): the addendum above wired the new clause into
+`PipelineOrchestrator.execute()` only. `drive_engine()` -- the standalone/CLI path, and the
+ORIGINAL #155 incident invoker (`attractor run` -> `run_pipeline` -> `drive_engine`) -- kept
+calling `check_provider_preflight` with no `resolvable_profiles`, so on that path the clause was
+never armed and the key-set-but-adapter-absent class stayed fail-open. The "Implementation
+locations" list above named `runner.py` under §36 without that qualification, which read as more
+coverage than the path actually had. Probed at `efe9da2` through `drive_engine` on the same #155
+graph shape (openai node on a transient-recovery loop, `OPENAI_API_KEY` set, profile
+`attractor-openai` mapped, coordinator agents = `attractor-anthropic` only): ACCEPTED at startup,
+then drained to the 200-step safety bound -- `Pipeline exceeded 200 steps (safety bound): 4 nodes
+x 50` -- with the unserviceable node executed 101 times and 99 real spawns issued for the recovery
+node, each failure reading `loop-pipeline recursion guard: agent 'attractor-openai' has
+session.orchestrator.module=None`. `drive_engine` now passes the set too, computed by the SAME
+shared resolver `execute()` step 5b uses (`_spawn_resolvable_agents(coordinator)`) rather than a
+second copy of the rule -- the coordinator is already in scope at that call site, so the answer was
+always knowable there; it simply was not asked for. Same fail-closed-when-knowable posture: `None`
+still means "not knowable on this path" and still skips the clause (a coordinator with no
+`session.spawn` capability never consumes a profile at all, so that path's behavior is unchanged),
+and a discovery crash yields the EMPTY set (refuse), never `None`. The set is the key set of
+`coordinator.config["agents"]` on the very coordinator object handed to `AmplifierBackend` a few
+lines later -- the same mapping `_run_with_spawn` indexes the profile into -- so the preflight can
+never judge a different set than the spawn resolves against (the #196 false-refusal failure mode).
+The runner's compat gate gained `_spawn_resolvable_agents` as a required engine symbol: it is also
+the only available proxy for the `resolvable_profiles` KEYWORD, which a symbol probe on
+`check_provider_preflight` cannot see (both landed in the same engine commit, `ccbd89f`).
+`modules/pipeline-runner/tests/test_provider_preflight_drive_engine.py` pins both directions on
+this path -- the refusal, and the no-false-refusal control (same graph, same credentials, same
+profiles map, agent PRESENT -> still runs to success).*
+
 ---
 
 ## 37. Bundle Composition: Always-On Guidance, Agent Registration, and Ref-Free Same-Repo Sources


### PR DESCRIPTION
Fixes #283

`drive_engine()` — the standalone/CLI path, and the **original #155 incident
invoker** (`attractor run` → `run_pipeline` → `drive_engine`) — still called
`check_provider_preflight` with no `resolvable_profiles` after PR #280 closed
that hole at `PipelineOrchestrator.execute()`. It therefore stayed fail-open
for exactly the #195 class: profile mapped + credential set + named agent
absent → accepted at startup → per-visit spawn failures drain the budget.

## The drain, before (at `efe9da2`, through `drive_engine`)

The #155/#195 shape: an `openai` node on a transient-recovery loop,
`OPENAI_API_KEY` **set**, profile `attractor-openai` **mapped**, coordinator
agents = `attractor-anthropic` **only**.

```
coordinator.config['agents'] keys: ['attractor-anthropic']
profiles: {'anthropic': 'attractor-anthropic', 'openai': 'attractor-openai'}
OPENAI_API_KEY set: True
----------------------------------------------------------------------
RESULT: PREFLIGHT ACCEPTED -- the run started
outcome.status : fail
failure_reason : Pipeline exceeded 200 steps (safety bound): 4 nodes × 50
spawns actually issued (budget spent): 99
spawns by agent: {'attractor-anthropic': 99}
critique_b stage dirs (executions of the unserviceable node): 101
  first status.json: {
  "node_id": "critique_b",
  "iteration": 99,
  "outcome": "fail",
  "status": "fail",
  ...
  "failure_reason": "loop-pipeline recursion guard: agent 'attracto…
```

101 executions of a node that could never be served, 99 real spawns of the
recovery node, and the run dies on the safety bound — the #155 incident,
verbatim.

## The refusal, after (same script, same scenario)

```
RESULT: REFUSED AT STARTUP (ProviderPreflightError)
spawns: 0
----------------------------------------------------------------------
PROVIDER PREFLIGHT FAILED -- refusing to start the pipeline (issue #155,
EXTENSIONS.md section 36). The following nodes declare an llm_provider this
run cannot serve:
  - node 'critique_b' declares llm_provider="openai": profile
    'attractor-openai' is mapped for it, but no agent named 'attractor-openai'
    can be resolved for the spawn backend (resolvable agents:
    attractor-anthropic) -- every spawn for this node would fail
…
```

Same message shape as #280's `execute()` path: the node, the profile that
cannot resolve, and what **is** resolvable. Zero spawns, zero budget.

## Shared-resolver reuse — no second copy of the rule

`modules/pipeline-runner/.../runner.py:326` (was `:299`):

```python
from amplifier_module_loop_pipeline import _spawn_resolvable_agents
from amplifier_module_loop_pipeline.preflight import check_provider_preflight

resolved_profiles = dict(profiles or DEFAULT_PROFILES)
try:
    resolvable_profiles = _spawn_resolvable_agents(coordinator)
except Exception:
    resolvable_profiles = frozenset()
check_provider_preflight(
    graph,
    profiles=resolved_profiles,
    resolvable_profiles=resolvable_profiles,
)
```

`_spawn_resolvable_agents` is the engine's own resolver — the single home #280
established, and literally what `execute()` step 5b calls. Re-deriving
`coordinator.config["agents"]` in the runner would be a second copy of a rule
that must stay identical to what the spawn resolves against; a preflight that
saw a *different* set than the backend is precisely the #196 false-refusal
disease. The fail-closed outer handling (`except → frozenset()`, refuse) mirrors
`execute()`'s exactly: unknowable-because-it-broke must not re-open the hole.

The runner's compat gate gains `_spawn_resolvable_agents` as a required engine
symbol. That entry is also the **only available gate on the `resolvable_profiles`
keyword itself** — `check_provider_preflight` predates the parameter, so a symbol
probe on the function passes against a stale engine and the call then dies on a
bare `TypeError` mid-run (the skew `_load_graph`'s docstring warns about). The
symbol and the keyword landed in the same engine commit (`ccbd89f`), so probing
one is a faithful proxy for the other.

## No false refusal — the crux (#196's disease, inverted)

**Same dict, same moment.** `_spawn_resolvable_agents` returns
`frozenset(coordinator.config["agents"])`. `AmplifierBackend._run_with_spawn`
resolves the profile in exactly one place — `backend.py:434-435`:

```python
coordinator_config = getattr(self._coordinator, "config", None) or {}
agent_configs: dict[str, Any] = coordinator_config.get("agents", {})
```

…on the *same coordinator object* `drive_engine` hands the backend 30 lines
after the preflight, with nothing in between mutating it. The profiles map is
now built **once** and shared with that `AmplifierBackend`, so the map the
preflight judges is the object the backend routes with — not an equal-looking
rebuild. Measured:

```
C. same-dict-same-moment identity
   preflight resolvable set          : {'attractor-anthropic'}
   backend's agent_configs keys      : {'attractor-anthropic'}
   backend mapping is coord.config['agents'] (identity): True
   sets equal: True
```

**The adversarial passing case** — same graph, same credentials, the *same
profiles map that was refused above*, single difference: the agent exists.

```
A. adversarial no-false-refusal: 'attractor-openai' agent PRESENT
   agents: ['attractor-anthropic', 'attractor-openai']
   profiles: {'anthropic': 'attractor-anthropic', 'openai': 'attractor-openai'}
   RESULT: RAN. status = success
   spawns: 1 ['attractor-openai']
```

The fix discriminates on adapter resolution — never on the graph shape or the
profile string.

**#196 capsule gate, GREEN at head** (`drive_engine` shares
`check_provider_preflight` and now the resolver too):

```
$ bash .github/capsule-pipeline/proposals/issue-196/preflight-auto-discovered-profiles.verify.sh
… 2479 passed, 24 skipped, 3 warnings in 31.14s
All checks passed: defect is NOT present.
EXIT=0
```

## The bare (no-coordinator) path — verified, unchanged

`drive_engine`'s `coordinator` is a required positional, so there is no literal
`None`-coordinator path; the reachable bare shape is a coordinator with **no
`session.spawn` capability** (test stubs, `object()`). All of those return
`None` — genuinely not knowable, since no spawn will ever consume a profile —
and keep their current behavior exactly:

```
B. bare path: coordinator WITHOUT session.spawn
   _spawn_resolvable_agents(bare) = None
   _spawn_resolvable_agents(object()) = None
   _spawn_resolvable_agents(None) = None
   RESULT: not refused (unchanged behavior).
```

`None` means "do not police it", never "everything resolves".

## §36 delta

`specs/EXTENSIONS.md` §36 did not state the residual; its *Implementation
locations* list named `runner.py — drive_engine wiring` **without** the
qualification that only change 1's credential clause was armed there — reading
as more coverage than the path had. Adjudicated: warranted, and recorded as a
dated addendum (house format, no renumbering; `test_extensions_ledger_integrity.py`
green, 8 passed). Opening of the new addendum:

> *Addendum (2026-08-17, issue #283): the addendum above wired the new clause
> into `PipelineOrchestrator.execute()` only. `drive_engine()` — the
> standalone/CLI path, and the ORIGINAL #155 incident invoker … — kept calling
> `check_provider_preflight` with no `resolvable_profiles`, so on that path the
> clause was never armed and the key-set-but-adapter-absent class stayed
> fail-open. … Probed at `efe9da2` … ACCEPTED at startup, then drained to the
> 200-step safety bound … with the unserviceable node executed 101 times and 99
> real spawns issued … `drive_engine` now passes the set too, computed by the
> SAME shared resolver `execute()` step 5b uses …*

Also corrected: `test_provider_preflight.py`'s
`test_resolvable_profiles_none_does_not_police_adapter_resolution` docstring
listed `drive_engine` among callers that "cannot supply the set" — a claim this
PR falsifies.

## Tests, mutation, gates

| Gate | Result |
|---|---|
| New refusal test, **RED against main's `runner.py`** | `DID NOT RAISE ProviderPreflightError` + `Pipeline safety bound exceeded: 201 steps (max=200)` — 1 failed, 5 passed |
| **MUTATION**: revert only `resolvable_profiles=` from the call | same test fails identically — 1 failed, 5 passed |
| pipeline-runner (`uv sync`; `uv run pytest -q`) | **80 passed, 1 skipped** (baseline 76/1 + 4 new) |
| loop-pipeline (`uv sync --extra remote`; `uv run pytest -q`) | **2489 passed, 25 skipped** (baseline unchanged) |
| `test_extensions_ledger_integrity.py` | 8 passed |
| #196 capsule gate | exit 0, "defect is NOT present" |
| leak scan (changed files) | `clean (no seeded pattern matched)` |
| `git diff --check` | clean |

Four tests added to `test_provider_preflight_drive_engine.py`: the refusal, the
no-false-refusal control, the same-dict identity pin, and the bare no-spawn path.

## Tier classification (QUALITY_PROTOCOL §3)

**Uncharted / extension** — same tier as #280, and for the same reason: the
canonical spec is silent on backend internals (§4.5 delegates them to the
implementer), which is why §36 exists as an EXTENSION row (`ATX-M-036`) rather
than a divergence. The silence is argued, not assumed: provider *serviceability*
is implementer-level configuration validation. Additive and non-interfering — a
spec-conformant `.dot` behaves identically unless it declares a provider this
run genuinely cannot serve, in which case it previously drained its budget. The
ledger delta ships in this PR, as the tier requires. No new §: this extends
§36's existing coverage to its second entry point, so it lands as a dated
addendum.

## Observations

- **The residual #280 named is now closed, but §36's honest residual still
  stands and is unchanged by this PR**: a profile naming an agent that *exists*
  but whose own provider construction fails inside the spawned child is not
  visible to any startup check, on either entry point. That still surfaces
  per-visit and a graph routing FAIL onto a recovery loop will still spend its
  budget on it.
- **`DEFAULT_PROFILES` is now load-bearing on this path.** `drive_engine`
  defaults to mapping all three providers; if a caller's coordinator defines
  only some of the three agents, a graph declaring one of the missing ones now
  refuses at startup instead of draining. That is the intended fix, and the
  shipped bundle is safe (`bundles/attractor-pipeline.yaml` defines
  `attractor-agent-{anthropic,openai,gemini}`, matching `DEFAULT_PROFILES`
  exactly) — but a *third-party* coordinator with a partial agent set will see
  a new, loud refusal where it previously saw a slow drain. Called out
  deliberately: that is a behavior change, and the refusal names precisely what
  to add.
- **The compat-gate entry is doing double duty**, and that is worth knowing:
  it gates an imported symbol *and* stands in for a keyword argument no symbol
  probe can see. If the engine ever gains another preflight keyword without a
  co-landing new symbol, that trick does not repeat — the runner would need a
  real signature probe (`inspect.signature`) at that point. Not built now:
  speculative, and this instance is covered.
- **Scoped out (deliberately):** `drive_engine` still passes no
  `mounted_providers` to the preflight. It is correct today — the path only ever
  constructs `AmplifierBackend` from `profiles` and mounts no provider modules —
  so an empty collection is the true answer, not an omission. Noting it because
  the two call sites now differ in exactly one argument, and a future reader
  will wonder whether that is the same bug again. It is not.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)
