### PR TITLE
fix(backend): don't append an empty assistant turn for an explicit-verdict spawn (#287)

### DIFF
--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/backend.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/backend.py
@@ -604,7 +604,33 @@ class AmplifierBackend:
             )
             if session_id:
                 spawn_outcome.session_id = session_id
-            if fidelity == "full" and graph is not None and thread_key is not None:
+            # output.strip() guard (issue #287): a child can carry an explicit
+            # verdict AND no closing prose (it did its work via tool calls and
+            # ended on a terminal report_outcome).  Appending that exchange puts
+            # an empty turn in the transcript, which
+            # _get_parent_messages_for_thread expands into
+            # {"role": "assistant", "content": ""} for a LATER same-thread spawn
+            # — and some providers reject empty assistant content.
+            #
+            # Append NEITHER half, not just the assistant half: a transcript
+            # entry is an indivisible (instruction, output) exchange that the
+            # emission site always expands into a user+assistant PAIR, and every
+            # other empty-output path already appends nothing — the
+            # non-explicit empty-output branch below returns before reaching an
+            # append, and the tool-loop path never appends at all.  Skipping the
+            # whole exchange keeps this consistent with them (and matches the
+            # pre-#286 behavior for an empty-output child).
+            #
+            # The verdict is unaffected: spawn_outcome (status /
+            # preferred_label / is_explicit) is still returned exactly as the
+            # #231 parent-side fix made it.  Only the empty turn stops being
+            # written.
+            if (
+                fidelity == "full"
+                and graph is not None
+                and thread_key is not None
+                and output.strip()
+            ):
                 self._append_to_transcript(thread_key, node.id, instruction, output)
             return spawn_outcome
 

--- a/modules/loop-pipeline/tests/test_backend.py
+++ b/modules/loop-pipeline/tests/test_backend.py
@@ -829,6 +829,180 @@ async def test_spawn_nonempty_output_without_metadata_uses_parse_outcome():
     )
 
 
+def _make_same_thread_full_graph():
+    """Two fidelity=full nodes sharing thread_id 't', linked start->step1->step2.
+
+    Returns (node1, node2, graph, edge_to_step1, edge_to_step2).  Used by the
+    issue #287 transcript-append tests below, which need a real same-thread
+    full-fidelity setup so that _run_with_spawn resolves a thread_key and
+    reaches the transcript-append site.
+    """
+    from amplifier_module_loop_pipeline.graph import Edge, Graph
+
+    node1 = _make_node(
+        id="step1",
+        attrs={"llm_provider": "anthropic", "fidelity": "full", "thread_id": "t"},
+    )
+    node2 = _make_node(
+        id="step2",
+        attrs={"llm_provider": "anthropic", "fidelity": "full", "thread_id": "t"},
+    )
+    graph = Graph(
+        name="test",
+        nodes={
+            "start": Node(id="start", shape="Mdiamond"),
+            "step1": node1,
+            "step2": node2,
+            "exit": Node(id="exit", shape="Msquare"),
+        },
+        edges=[
+            Edge(from_node="start", to_node="step1"),
+            Edge(from_node="step1", to_node="step2"),
+            Edge(from_node="step2", to_node="exit"),
+        ],
+    )
+    return (
+        node1,
+        node2,
+        graph,
+        Edge(from_node="start", to_node="step1"),
+        Edge(from_node="step1", to_node="step2"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_spawn_explicit_verdict_empty_output_appends_no_empty_turn():
+    """Explicit verdict + EMPTY output => no empty assistant turn (issue #287).
+
+    A child can legitimately carry an explicit ``metadata.report_outcome``
+    verdict AND produce no closing prose (it did its work via tool calls and
+    ended on a terminal report_outcome).  Before the ``output.strip()`` guard,
+    the explicit-verdict path appended that empty exchange to the full-fidelity
+    transcript, and ``_get_parent_messages_for_thread`` then expanded it into
+    ``{"role": "assistant", "content": ""}`` for a LATER same-thread spawn --
+    which some providers reject.
+
+    The verdict itself must STILL round-trip (the #231/#286 parent-side fix is
+    orthogonal to the transcript append and must not regress).
+    """
+    coordinator = MockCoordinator(
+        spawn_result={
+            "output": "",  # child ended on a tool call -- no closing prose
+            "session_id": "c-empty-verdict",
+            "status": "success",
+            "metadata": {
+                "report_outcome": {
+                    "status": "success",
+                    "preferred_label": "validated",
+                    "notes": "Work done via tool calls; no closing prose.",
+                }
+            },
+        }
+    )
+    backend = AmplifierBackend(
+        coordinator=coordinator,
+        profiles={"anthropic": "attractor-anthropic"},
+    )
+    node1, node2, graph, edge1, edge2 = _make_same_thread_full_graph()
+
+    outcome = await backend.run(
+        node1, "First instruction", _make_context(), incoming_edge=edge1, graph=graph
+    )
+
+    # --- #287: no empty assistant turn reaches a later same-thread spawn ---
+    messages = backend._get_parent_messages_for_thread("t")
+    empty_assistant_turns = [
+        m
+        for m in messages
+        if m["role"] == "assistant" and not str(m["content"]).strip()
+    ]
+    assert empty_assistant_turns == [], (
+        "explicit-verdict spawn with empty output must not append an empty "
+        f"assistant turn to the same-thread transcript, got {messages!r}"
+    )
+
+    # ... and prove it at the emission seam a later same-thread spawn actually sees.
+    await backend.run(
+        node2, "Second instruction", _make_context(), incoming_edge=edge2, graph=graph
+    )
+    parent_messages = coordinator.last_spawn_kwargs.get("parent_messages") or []
+    assert not [
+        m
+        for m in parent_messages
+        if m.get("role") == "assistant" and not str(m.get("content", "")).strip()
+    ], (
+        "a later same-thread spawn must not be handed an empty assistant "
+        f"message, got parent_messages={parent_messages!r}"
+    )
+
+    # --- #231/#286 must NOT regress: the verdict still round-trips ---
+    assert isinstance(outcome, Outcome)
+    assert outcome.is_explicit is True, (
+        "metadata.report_outcome must still set is_explicit=True for an "
+        "empty-output child -- the #231 parent-side fix must not regress"
+    )
+    assert outcome.preferred_label == "validated", (
+        f"expected preferred_label='validated', got {outcome.preferred_label!r}"
+    )
+    assert outcome.status == StageStatus.SUCCESS
+    assert outcome.session_id == "c-empty-verdict"
+
+
+@pytest.mark.asyncio
+async def test_spawn_explicit_verdict_nonempty_output_still_appends_turn():
+    """Explicit verdict + NON-EMPTY output => assistant turn STILL appended.
+
+    Control for the issue #287 guard: gating the transcript append on
+    ``output.strip()`` must not over-correct and suppress the normal case where
+    the child DOES produce closing prose.  That prose must still reach a later
+    same-thread spawn as its assistant turn (the behavior #286 deliberately
+    introduced).
+    """
+    coordinator = MockCoordinator(
+        spawn_result={
+            "output": "The analysis is complete.",
+            "session_id": "c-prose-verdict",
+            "status": "success",
+            "metadata": {
+                "report_outcome": {
+                    "status": "success",
+                    "preferred_label": "validated",
+                    "notes": "All checks passed.",
+                }
+            },
+        }
+    )
+    backend = AmplifierBackend(
+        coordinator=coordinator,
+        profiles={"anthropic": "attractor-anthropic"},
+    )
+    node1, node2, graph, edge1, edge2 = _make_same_thread_full_graph()
+
+    outcome = await backend.run(
+        node1, "First instruction", _make_context(), incoming_edge=edge1, graph=graph
+    )
+
+    messages = backend._get_parent_messages_for_thread("t")
+    assert messages == [
+        {"role": "user", "content": "First instruction"},
+        {"role": "assistant", "content": "The analysis is complete."},
+    ], f"non-empty child prose must still be appended, got {messages!r}"
+
+    # The later same-thread spawn receives it as parent_messages.
+    await backend.run(
+        node2, "Second instruction", _make_context(), incoming_edge=edge2, graph=graph
+    )
+    assert coordinator.last_spawn_kwargs.get("parent_messages") == [
+        {"role": "user", "content": "First instruction"},
+        {"role": "assistant", "content": "The analysis is complete."},
+    ]
+
+    # The explicit verdict is honored here too (spec 35 / #231).
+    assert outcome.is_explicit is True
+    assert outcome.preferred_label == "validated"
+    assert outcome.status == StageStatus.SUCCESS
+
+
 @pytest.mark.asyncio
 async def test_spawn_truly_empty_fails_loud():
     """No text, no report_outcome, no success status => FAIL (fail-loud).


### PR DESCRIPTION
Fixes #287

## The defect

PR #286 (the #231 parent-side fix) made `_run_with_spawn` take the explicit-verdict path for a spawn result carrying `metadata.report_outcome` even when the child's textual `output` is empty. Side effect: that path appends `(instruction, output)` to the full-fidelity transcript **even when `output` is empty** — where the old empty-output+verdict path appended nothing.

- **Append site** — `modules/loop-pipeline/amplifier_module_loop_pipeline/backend.py:607-608` (verified at head `f739260`), inside the `if spawn_outcome is not None and spawn_outcome.is_explicit:` branch #286 introduced.
- **Emission site** — `backend.py:948` `_get_parent_messages_for_thread`, whose loop (`:961-963`) expands *every* stored triple into a **user + assistant PAIR**, unconditionally:

```python
for _, instr, out in self._thread_transcripts.get(thread_key, []):
    messages.append({"role": "user", "content": instr})
    messages.append({"role": "assistant", "content": out})
```

## Repro (BEFORE — at `origin/main` f739260, unmodified)

Drove `_run_with_spawn` via `backend.run()` with a spawn result = explicit `report_outcome` verdict + EMPTY `output`, two `fidelity=full` nodes on `thread_id="t"`, then read what a later same-thread spawn sees:

```
=== A: explicit report_outcome verdict + EMPTY output ===
  spawn result output    : ''
  Outcome.status         : StageStatus.SUCCESS
  Outcome.is_explicit    : True
  Outcome.preferred_label: 'validated'
  _thread_transcripts['t'] = [('step1', 'First instruction', '')]
  _get_parent_messages_for_thread('t') = [{"role": "user", "content": "First instruction"}, {"role": "assistant", "content": ""}]
  EMPTY assistant turns  : [{"role": "assistant", "content": ""}]
  >>> empty assistant turn present? True
  later same-thread spawn parent_messages = [{"role": "user", "content": "First instruction"}, {"role": "assistant", "content": ""}]
```

The empty turn is not merely stored — it is **handed to the next spawn** as `parent_messages`. That is the message some providers reject.

## The guard (minimal)

One condition added at the #286 append site:

```python
 if (
     fidelity == "full"
     and graph is not None
     and thread_key is not None
+    and output.strip()
 ):
     self._append_to_transcript(thread_key, node.id, instruction, output)
```

(plus a comment block explaining why). No other logic changed — the verdict recovery `_outcome_from_spawn_result(...)` → `spawn_outcome` → `return spawn_outcome` is byte-identical to what #286 shipped.

## Instruction-side decision: append NEITHER half

The instruction **is** also appended (the transcript entry is a `(node_id, instruction, output)` triple and the emission site above always expands it into a user+assistant pair). Decision: skip the whole exchange, not just the assistant half. Reasoning, measured rather than assumed:

1. **The sibling empty-output path already appends nothing.** The non-explicit empty-output branch (`backend.py:611`) returns before reaching any append. Measured at head, unchanged by this PR:
   ```
   === C: EMPTY output, NO explicit verdict (status-only) -- sibling path ===
     _thread_transcripts['t'] = None
     _get_parent_messages_for_thread('t') = []
     later same-thread spawn parent_messages = null
   ```
2. **The non-spawn path never appends at all.** `_append_to_transcript` has exactly two call sites (`backend.py:608` and `:656`), both inside `_run_with_spawn`; `_run_with_tool_loop` does not touch `_thread_transcripts`.
3. **It restores the pre-#286 behavior.** Same input against `backend.py` at `251f738^` (`d900265`): `_thread_transcripts['t'] = None`, `parent_messages = []`.
4. Skipping only the assistant half is not expressible without changing the storage model *and* the emission site, and would leave a dangling user turn with no reply — a bigger change that trades one irregular message shape for another.

## AFTER (this branch)

```
=== A: explicit report_outcome verdict + EMPTY output ===
  spawn result output    : ''
  Outcome.status         : StageStatus.SUCCESS
  Outcome.is_explicit    : True
  Outcome.preferred_label: 'validated'
  _thread_transcripts['t'] = None
  _get_parent_messages_for_thread('t') = []
  EMPTY assistant turns  : []
  >>> empty assistant turn present? False
  later same-thread spawn parent_messages = null

=== B: explicit report_outcome verdict + NON-EMPTY output (control) ===
  _thread_transcripts['t'] = [('step1', 'First instruction', 'The analysis is complete.')]
  _get_parent_messages_for_thread('t') = [{"role": "user", "content": "First instruction"}, {"role": "assistant", "content": "The analysis is complete."}]
  >>> empty assistant turn present? False
  later same-thread spawn parent_messages = [{"role": "user", "content": "First instruction"}, {"role": "assistant", "content": "The analysis is complete."}]
```

Three things proven at once: the empty turn is gone (A), **#286/#231 still works** — `is_explicit=True`, `preferred_label='validated'`, `status=SUCCESS` still round-trip on the *empty-output* child (A) — and a non-empty-output spawn **still appends** its assistant turn (B, no over-correction).

## #231 re-assertion (the DoD that must survive)

`.github/capsule-pipeline/proposals/issue-231/spawn-report-outcome-precedence.verify.sh` at this head — **exit 0**:

```
Probe1-A PASSED: preferred_label='lbl8845x20592', is_explicit=True
Probe1-B PASSED: per-call behavior confirmed
Probe1-C PASSED: JSON fail output without metadata -> FAIL (parse_outcome path)
Probe 1 PASSED: backend round-trip -- defect is not present
Probe2 PASSED: status.json has preferred_next_label='lbl8845x20592', is_explicit=True
Probe 2 PASSED: drive_engine transport round-trip -- defect is not present
test_spawn_empty_output_with_report_outcome_does_not_fall_back PASSED
Gate: all probes PASSED -- defect is not present
```

Gate files untouched: `git diff --name-only origin/main HEAD -- .github/capsule-pipeline/proposals/issue-231` is empty.

## Tests + mutation

Two tests added to `modules/loop-pipeline/tests/test_backend.py`:

- `test_spawn_explicit_verdict_empty_output_appends_no_empty_turn` — pins "explicit verdict + empty output → no empty assistant turn", asserted at **both** seams (the transcript and the later spawn's actual `parent_messages` kwargs), and re-asserts the #231 verdict round-trip in the same test so a future regression of either half is caught here.
- `test_spawn_explicit_verdict_nonempty_output_still_appends_turn` — control: non-empty prose still appended and still delivered to the later same-thread spawn.

**MUTATION** — revert just `and output.strip()`, keep the tests:

```
>       assert empty_assistant_turns == [], (
E       AssertionError: explicit-verdict spawn with empty output must not append an empty assistant turn to the same-thread transcript, got [{'role': 'user', 'content': 'First instruction'}, {'role': 'assistant', 'content': ''}]
E       assert [{'role': 'as...content': ''}] == []
E         Left contains one more item: {'role': 'assistant', 'content': ''}
FAILED tests/test_backend.py::test_spawn_explicit_verdict_empty_output_appends_no_empty_turn
1 failed, 1 passed
```

The new test fails on exactly the defect; the control still passes (it does not depend on the guard).

## Suites

| suite | base (`origin/main` f739260) | this branch |
|---|---|---|
| loop-pipeline (`uv sync --extra remote && uv run pytest -q`) | 2489 passed / 25 skipped | **2491 passed / 25 skipped** (+2 new) |
| pipeline-runner (`uv run pytest -q`) | 80 passed / 1 skipped (measured on a stashed tree) | **80 passed / 1 skipped** |

## Tier (QUALITY_PROTOCOL §3)

**Toward-spec.** Spec §5.4 requires `fidelity=full` continuity ("reuse the same session / full history preserved"); an assistant message a provider rejects breaks the very carrier that realizes it. Removing it closes a gap rather than opening one. Per the matrix that tier owes the normal evidence for its change class and **no ledger entry** — conforming is the default state, not a deviation.

**Ledger adjudication — no addendum, and here is why it stays true.** `specs/EXTENSIONS.md` §12 is the surface that describes this behavior: *"The carrier holds node-exchange granularity: one `(role=user, content=instruction)` + `(role=assistant, content=final_output)` pair per `full` node."* Its normative content is granularity (node-exchange, not inner tool-loop turns) and mechanism (`parent_messages`, not `sub_session_id`) — not a mandate to materialize an exchange that has no content. §12 already coexisted with an empty-output path that appended nothing, both before #286 and today on the non-explicit branch (measured above, scenario C), so this change creates no new divergence from it — it removes one. §35's only mention of this code is the "Implementation locations" bullet naming `backend.py` for "full-fidelity transcript continuity"; nothing normative there about empty output. `docs/CONTRACTS.md` has no transcript/`parent_messages` surface (grep: no matches).

## Observations

None arose. This is a narrow implementation defect inside behavior `docs/VISION.md` and the ledger already describe correctly; nothing here bears on the captured vision.

## Gates

- Leak scan on both changed files: no secret-shaped material, no local/absolute paths, no internal hosts.
- `git diff --check`: clean.
- Touched files: `modules/loop-pipeline/amplifier_module_loop_pipeline/backend.py` + `modules/loop-pipeline/tests/test_backend.py` only — no overlap with the concurrent `scrub_secrets.py` / `redaction.py` lane.

**Not for auto-merge** — a human reviews the diff and the evidence above before merging.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)
