### PR TITLE
fix(security): redact sensitive assignments whose value carries a quote, backslash or space

### DIFF
--- a/.github/capsule-pipeline/scrub_secrets.py
+++ b/.github/capsule-pipeline/scrub_secrets.py
@@ -274,8 +274,10 @@ SENSITIVE_NAME_TAILS = (
 #           joins ATOMICALLY -- that is how a literal backslash inside a
 #           secret reaches this rule once the line has been JSON-serialized,
 #           and consuming it whole is what keeps the pair from being split.
-#           A LONE backslash joins UNLESS it opens one of the escapes that
-#           encode a record/field SEPARATOR (`\n`, `\r`, `\t`) or an
+#           A LONE backslash joins UNLESS it is followed by ANOTHER
+#           backslash (that case belongs to the pair -- see the fence
+#           below), or it opens one of the escapes that encode a
+#           record/field SEPARATOR (`\n`, `\r`, `\t`) or an
 #           arbitrary code point (`\u`); the class is matched
 #           case-sensitively, hence the `(?-i:...)`, because JSON escapes are
 #           lower-case and `\N`/`\T` in a Windows-path-shaped value are
@@ -289,6 +291,34 @@ SENSITIVE_NAME_TAILS = (
 #           not just the lucky ones.
 #       The run may not END on a backslash (`(?<!\\)`), so it can never leave
 #       a dangling escape that would corrupt the enclosing JSON string.
+#
+# THE FENCE ON THE LONE JOINER (`[\s\\]`, not `\s`) IS NOT COSMETIC -- it is
+# what makes this rule terminate, and it was added after #292's own
+# adversarial review. Without it a backslash is AMBIGUOUS: the engine may
+# read it as half of the atomic pair `\\` OR as the lone alternative, so a
+# run of N backslashes has Fibonacci-many tilings. ONE ambiguity, TWO
+# measured defects, both on this door and its ported twin:
+#
+#   * CATASTROPHIC BACKTRACKING. The trailing `(?<!\\)` fails every tiling
+#     that ends on a backslash, so the engine enumerates all of them.
+#     Measured before the fence: `PASSWORD=` + 40 backslashes -> 15.8s;
+#     a serialized event whose secret carried 20 trailing backslashes
+#     (`json.dumps` doubles each one) -> 18.4s. After: a 40,000-backslash
+#     run returns in ~4ms. The vector is not exotic -- any tool output
+#     with a sensitive `NAME=` and a Windows path or an escaped blob is
+#     exactly the env-dump class this module exists to scrub.
+#   * OVER-REDACTION, from the SAME root. An odd tiling shifts PARITY across
+#     a following `\n`: on `MY_PASSWORD=<secret>\` + `\n` + `PATH=/usr/bin`
+#     the engine paired the SECOND and THIRD backslashes and then ate the
+#     separator's `n` as ordinary value material -- swallowing the PATH
+#     line, i.e. breaking the very invariant the paragraph above states.
+#
+# Fencing the lone alternative off a following backslash leaves EXACTLY ONE
+# tiling of any run (pairs, then at most one trailing lone backslash). That
+# is what makes the scan linear AND what keeps the `\n` parity intact. It
+# cannot under-redact: a backslash followed by a backslash is still
+# consumed -- by the pair alternative, atomically, which is the reading this
+# grammar always intended.
 #
 # RESIDUAL, named rather than implied: in PLAIN (unserialized) text, a value
 # whose lone backslash is followed by `n`/`r`/`t`/`u` still ends there -- the
@@ -312,7 +342,7 @@ _ASSIGNMENT_VALUE = (
     r"|(?P<squote>')[^'\"\r\n]{4,}?(?<!\\)(?=')"
     # (c) unquoted run, with the two fenced joiners
     r"|(?:" + _ASSIGNMENT_VALUE_CHAR + r"|[\"'](?=" + _ASSIGNMENT_VALUE_CONT + r")"
-    r"|\\\\|\\(?!\s|(?-i:[nrtu]))){4,}(?<!\\)"
+    r"|\\\\|\\(?![\s\\]|(?-i:[nrtu]))){4,}(?<!\\)"
 )
 
 # The negative lookahead keeps an already-redacted value -- bare, quoted, or

--- a/.github/capsule-pipeline/scrub_secrets.py
+++ b/.github/capsule-pipeline/scrub_secrets.py
@@ -213,8 +213,6 @@ TOKEN_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
 #   PASSWORD           PASSWORD, DB_PASSWORD, PGPASSWORD
 #   CREDENTIALS?       GOOGLE_APPLICATION_CREDENTIALS
 #
-# The negative lookahead keeps an already-redacted value from being
-# re-redacted into a less specific shape.
 SENSITIVE_NAME_TAILS = (
     "API_KEYS?",
     "SECRET_ACCESS_KEY",
@@ -224,12 +222,106 @@ SENSITIVE_NAME_TAILS = (
     "CREDENTIALS?",
 )
 
+# THE VALUE GRAMMAR (issue #289). The pre-#289 rule spelled a value as ONE
+# character class -- `[^\s"'\\]{4,}` -- which stops at the FIRST whitespace,
+# quote or backslash. A secret that merely CONTAINS one of those within its
+# first few characters therefore escaped:
+#
+#   PASSWORD=abc\<tail>      class dies at char 3 -> NOTHING is redacted
+#   PASSWORD=abc'<tail>      same -- the whole value survives
+#   PASSWORD=abcd"<tail>     lead redacted, the tail after the quote survives
+#   API_KEY="secret value"   redacted to the first space; ` value` survives
+#
+# (Measured in PR #288's adversarial review: 0 of 500 20-char-tail escapees
+# caught by this door.)
+#
+# A value is now one of three shapes, tried IN THIS ORDER. Every one of them
+# is anchored so that widening what a value MAY CONTAIN never widens how far
+# a value may REACH. Over-redaction is not cosmetic here: this same rule is
+# ported verbatim to the session-event write seam
+# (`modules/hooks-pipeline-observability/.../redaction.py`, pinned identical
+# by that module's drift tripwire), where the input is a SERIALIZED JSON LINE
+# and a match that crosses a JSON string boundary destroys the record instead
+# of the secret -- the persister re-parses the redacted line and WITHHOLDS the
+# payload if it no longer parses.
+#
+#   (a) DOUBLE-QUOTED -- `NAME="..."`, and the JSON-escaped `NAME=\"...\"`
+#       form the write seam actually sees. The content class excludes `"`
+#       outright, so the match STOPS at the first closing quote and can never
+#       leave the string it started in; it is non-greedy and refuses to end
+#       on a backslash (`(?<!\\)`), so the closing `\"`'s escape is never
+#       eaten (eating it would terminate the JSON string early). The closing
+#       quote is matched by lookahead, never consumed, and the substitution
+#       re-emits the opening quote -- so the structure stays readable:
+#       `API_KEY="[REDACTED:assignment]"`.
+#
+#   (b) SINGLE-QUOTED -- `NAME='...'`. Its content additionally excludes `"`,
+#       because an UNTERMINATED single quote inside a JSON string would
+#       otherwise let the match run past that string's own closing `"` to the
+#       next apostrophe on the line (`"note": "don't"`), silently deleting an
+#       unrelated field. The cost of that guard is stated honestly: a
+#       single-quoted value that itself contains a double quote is only
+#       partly covered (it falls through to (c)).
+#
+#   (c) UNQUOTED -- the pre-#289 class plus two fenced joiners:
+#         * a quote joins only when the NEXT character is ordinary value
+#           material (`[^\s"'\\,:;)\]}]`). In JSON a string-terminating quote
+#           is ALWAYS followed by `,` `}` `]` `:` or whitespace, so this
+#           joiner provably cannot consume a string terminator -- while in a
+#           plain log line `PASSWORD=abcd"<tail>` is one token and is
+#           redacted whole.
+#         * a backslash joins in two forms. An ESCAPED PAIR (`\\`) always
+#           joins ATOMICALLY -- that is how a literal backslash inside a
+#           secret reaches this rule once the line has been JSON-serialized,
+#           and consuming it whole is what keeps the pair from being split.
+#           A LONE backslash joins UNLESS it opens one of the escapes that
+#           encode a record/field SEPARATOR (`\n`, `\r`, `\t`) or an
+#           arbitrary code point (`\u`); the class is matched
+#           case-sensitively, hence the `(?-i:...)`, because JSON escapes are
+#           lower-case and `\N`/`\T` in a Windows-path-shaped value are
+#           ordinary value material. Stopping at the separator escapes is
+#           what keeps a serialized env dump -- an entire
+#           `MY_PASSWORD=<secret>\nPATH=/usr/bin\nHOME=/root` on ONE line --
+#           from being swallowed whole: the `\n` ends the value and PATH/HOME
+#           survive byte-identical. `\b`/`\f` are NOT separators and do not
+#           occur in this evidence, so they are treated as value interior --
+#           which is what makes `PASSWORD=abc\<tail>` redact for any tail,
+#           not just the lucky ones.
+#       The run may not END on a backslash (`(?<!\\)`), so it can never leave
+#       a dangling escape that would corrupt the enclosing JSON string.
+#
+# RESIDUAL, named rather than implied: in PLAIN (unserialized) text, a value
+# whose lone backslash is followed by `n`/`r`/`t`/`u` still ends there -- the
+# rule cannot tell `\n`-the-newline from `\n`-the-two-characters without
+# knowing whether the line is JSON, and between under-redacting a rare shape
+# and swallowing a whole env dump, this file has already learned which
+# mistake costs more (2026-08-13). The residual is always a NON-redaction,
+# never an over-redaction, and layer 4 (scan/gate) remains the backstop.
+#
+# WHAT DID NOT CHANGE, and each is load-bearing: the end-anchored name
+# (`total_tokens=` remains untouchable), the 4-character floor, and the fact
+# that no branch crosses a newline -- an unquoted value still stops dead at
+# whitespace, so a redaction can never swallow a following token or the rest
+# of a log line.
+_ASSIGNMENT_VALUE_CHAR = r"[^\s\"'\\]"
+_ASSIGNMENT_VALUE_CONT = r"[^\s\"'\\,:;)\]}]"
+_ASSIGNMENT_VALUE = (
+    # (a) double-quoted, including the JSON-escaped \"...\" form
+    r"(?P<quote>\\?\")[^\"\r\n]{4,}?(?<!\\)(?=\\?\")"
+    # (b) single-quoted
+    r"|(?P<squote>')[^'\"\r\n]{4,}?(?<!\\)(?=')"
+    # (c) unquoted run, with the two fenced joiners
+    r"|(?:" + _ASSIGNMENT_VALUE_CHAR + r"|[\"'](?=" + _ASSIGNMENT_VALUE_CONT + r")"
+    r"|\\\\|\\(?!\s|(?-i:[nrtu]))){4,}(?<!\\)"
+)
+
+# The negative lookahead keeps an already-redacted value -- bare, quoted, or
+# JSON-escaped-quoted -- from being re-redacted into a less specific shape.
 ASSIGNMENT_PATTERN = re.compile(
     r"(?P<name>[A-Za-z0-9_]*(?:" + "|".join(SENSITIVE_NAME_TAILS) + r"))"
     r"(?P<sep>\s*=\s*)"
-    r"(?P<quote>[\"']?)"
-    r"(?!\[REDACTED:)"
-    r"(?P<value>[^\s\"'\\]{4,})",
+    r"(?!\\?[\"']?\[REDACTED:)"
+    r"(?:" + _ASSIGNMENT_VALUE + r")",
     re.IGNORECASE,
 )
 
@@ -454,7 +546,12 @@ def scrub_text(text: str, literals: dict[str, str]) -> tuple[str, list[str]]:
 
     def _assignment_sub(m: re.Match[str]) -> str:
         shapes.append(f"assignment:{m.group('name')}")
-        return f"{m.group('name')}{m.group('sep')}{m.group('quote')}[REDACTED:assignment]"
+        # Exactly one of the two quote groups participates when the value was
+        # quoted (issue #289); the opening quote is re-emitted so the line
+        # keeps its shape -- `API_KEY="[REDACTED:assignment]"` -- and the
+        # closing quote was matched by lookahead, so it is still in the text.
+        quote = m.group("quote") or m.group("squote") or ""
+        return f"{m.group('name')}{m.group('sep')}{quote}[REDACTED:assignment]"
 
     text = ASSIGNMENT_PATTERN.sub(_assignment_sub, text)
     return text, shapes

--- a/.github/capsule-pipeline/test_scrub_secrets.py
+++ b/.github/capsule-pipeline/test_scrub_secrets.py
@@ -33,6 +33,7 @@ import secrets
 import subprocess
 import sys
 import tempfile
+import time
 import unittest
 from pathlib import Path
 
@@ -935,6 +936,118 @@ class AssignmentValueGrammarTests(unittest.TestCase):
                 self.assertEqual(parsed["note"], record["note"])
                 self.assertEqual(parsed["n"], record["n"])
                 self.assertNotIn(tail, after)
+
+    # ---- post-review regression: the backslash-run ReDoS and its twin ----
+    #
+    # Found by #292's OWN adversarial review, before merge. The widened
+    # branch (c) joined a backslash in two ways -- the atomic pair `\\` and
+    # the lone alternative -- and NOTHING said the lone one could not also
+    # claim a backslash that was followed by another backslash. That made a
+    # backslash AMBIGUOUS, so a run of N of them had Fibonacci-many tilings,
+    # and the trailing `(?<!\\)` rejects every tiling that ends on a
+    # backslash, so the engine enumerated the lot. ONE root cause, TWO
+    # symptoms, so ONE probe family pins both. Measured at PR #292's head,
+    # before the `[\s\\]` fence:
+    #
+    #   PASSWORD= + 40 backslashes (raw)                     15.8 s
+    #   serialized event, secret + 20 trailing backslashes   18.4 s
+    #   ...and MY_PASSWORD=<secret>\ + \n + PATH=/usr/bin
+    #      redacted the PATH LINE AWAY (parity shift across the escape)
+    #
+    # After: 4 ms for a 40,000-backslash run, and the PATH line survives.
+
+    # A wall-clock budget, not a benchmark: the fixed cost of these probes is
+    # microseconds, so ANY number near this bound means the tilings came
+    # back. 500x headroom over the measured 4 ms keeps it immune to CI
+    # jitter while still being unreachable for an exponential rule.
+    REDOS_BUDGET_S = 2.0
+
+    def assert_fast(self, text: str, label: str) -> tuple[str, list[str]]:
+        """Scrub `text`, failing if it did not finish inside the budget."""
+        started = time.perf_counter()
+        after, shapes = self.scrub(text)
+        elapsed = time.perf_counter() - started
+        self.assertLess(
+            elapsed,
+            self.REDOS_BUDGET_S,
+            f"{label}: took {elapsed:.3f}s (budget {self.REDOS_BUDGET_S}s) -- "
+            "the backslash joiner is ambiguous again and the run is being "
+            "re-tiled exponentially",
+        )
+        return after, shapes
+
+    def test_a_backslash_run_does_not_blow_up_the_matcher(self) -> None:
+        """The ReDoS itself, on the raw and the serialized shape.
+
+        The ladder is ordered SMALLEST-FIRST on purpose: a regressed rule
+        blows the budget on the first probe in ~16s and never reaches the
+        40,000-backslash one (which, ambiguous, would not finish this
+        century). A test that FAILS beats a test that HANGS.
+        """
+        tail = fake_tail()
+        probes = (
+            ("raw, 40 trailing backslashes", "PASSWORD=" + "\\" * 40),
+            (
+                "serialized event, 20 trailing backslashes",
+                json.dumps({"output": f"DB_PASSWORD={tail}" + "\\" * 20}),
+            ),
+            (
+                "serialized event, 40 trailing backslashes",
+                json.dumps({"output": f"DB_PASSWORD={tail}" + "\\" * 40}),
+            ),
+            ("raw, 40000 backslashes (linearity)", "PASSWORD=" + "\\" * 40000),
+        )
+        for label, probe in probes:
+            with self.subTest(probe=label):
+                after, _ = self.assert_fast(probe, label)
+                self.assertNotIn(tail, after)
+
+    def test_a_secret_ending_in_backslashes_still_redacts(self) -> None:
+        """Direction 1 is not allowed to regress into a non-redaction: the
+        value must still GO, raw and serialized, however many backslashes
+        trail it."""
+        tail = fake_tail()
+        for k in (1, 2, 3, 20, 40):
+            with self.subTest(backslashes=k):
+                raw = f"PASSWORD={tail}" + "\\" * k
+                after, shapes = self.assert_fast(raw, f"raw k={k}")
+                self.assertIn("[REDACTED:assignment]", after)
+                self.assertNotIn(tail, after)
+                self.assertEqual(shapes, ["assignment:PASSWORD"])
+
+                line = json.dumps({"output": f"DB_PASSWORD={tail}" + "\\" * k})
+                after, shapes = self.assert_fast(line, f"serialized k={k}")
+                self.assertIn("[REDACTED:assignment]", after)
+                self.assertNotIn(tail, after)
+                self.assertEqual(shapes, ["assignment:DB_PASSWORD"])
+                json.loads(after)  # raises if the escape run was left dangling
+
+    def test_a_secret_ending_in_a_backslash_does_not_eat_the_next_line(self) -> None:
+        r"""The OVER-REDACTION half of the same defect, pinned separately
+        because it is the one a timing budget would never catch.
+
+        `MY_PASSWORD=<secret>\` + `\n` + `PATH=/usr/bin`: serialized, the
+        secret's own backslash and the separator escape sit adjacent, and an
+        odd tiling used to pair the SECOND and THIRD backslashes -- leaving
+        the separator's `n` to be eaten as ordinary value material, taking
+        the whole PATH line with it. The PATH/HOME-survive invariant this
+        file states two screens up was, in that shape, false.
+        """
+        tail = fake_tail()
+        for k in (1, 2, 3, 5):
+            with self.subTest(backslashes=k):
+                dump = (
+                    f"MY_PASSWORD={tail}" + "\\" * k
+                    + "\nPATH=/usr/bin\nHOME=/root\ntotal_tokens=41892"
+                )
+                after, shapes = self.assert_fast(json.dumps({"result": dump}), "dump")
+                self.assertNotIn(tail, after)
+                self.assertEqual(shapes, ["assignment:MY_PASSWORD"])
+                result = json.loads(after)["result"]
+                self.assertIn("[REDACTED:assignment]", result)
+                self.assertIn("PATH=/usr/bin", result)
+                self.assertIn("HOME=/root", result)
+                self.assertIn("total_tokens=41892", result)
 
     def test_capsule_gate_token_math_still_survives_the_widened_rule(self) -> None:
         """The 2026-08-13 corruption class, re-run against the WIDER value

--- a/.github/capsule-pipeline/test_scrub_secrets.py
+++ b/.github/capsule-pipeline/test_scrub_secrets.py
@@ -29,6 +29,7 @@ import contextlib
 import io
 import json
 import os
+import secrets
 import subprocess
 import sys
 import tempfile
@@ -730,6 +731,238 @@ class ScrubTests(unittest.TestCase):
         proc2 = run_cli(["scan", str(self.root / "does-not-exist")])
         self.assertEqual(proc2.returncode, 0)
 
+
+# ---- issue #289: the VALUE grammar (quote / backslash / space escapees) ----
+#
+# The pre-#289 value class `[^\s"'\\]{4,}` stopped at the first whitespace,
+# quote or backslash, so a sensitive assignment whose value merely CONTAINED
+# one of those in its first few characters escaped BOTH scrub doors -- this
+# gate and the session-event write seam that ports these same patterns.
+# Measured in PR #288's adversarial review: 0 of 500 20-char-tail escapees
+# caught. These tests pin BOTH directions of the widening:
+#
+#   1. the escape cases are now redacted (the fix), and
+#   2. nothing innocent moved (the crux -- an over-reaching value class is
+#      how this file corrupted a shipped artifact in 2026-08-13, and at the
+#      write seam it would destroy the JSON record instead of the secret).
+#
+# Every fake secret below is MINTED AT RUNTIME. A long credential-shaped
+# literal committed to this file would be secret-shaped material in the repo,
+# which the leak scan correctly refuses.
+
+
+def fake_tail(nbytes: int = 8) -> str:
+    """A fake secret tail, minted per run.
+
+    `token_hex` deliberately: hex is provably sub-threshold for the layer-4
+    entropy heuristic (16 symbols cannot carry 4.5 bits/char) and cannot
+    contain `sk-`/`gh?_`/`github_pat_`, so a finding on these probes can only
+    be the LAYER-2 assignment rule -- never a lucky entropy or token hit.
+    """
+    return secrets.token_hex(nbytes)
+
+
+class AssignmentValueGrammarTests(unittest.TestCase):
+    """Issue #289: values that begin with, or contain, a quote/backslash/space."""
+
+    def scrub(self, text: str) -> tuple[str, list[str]]:
+        return scrub_secrets.scrub_text(text, {})
+
+    # ---- direction 1: the escapees are caught ----
+
+    def test_issue_289_escape_cases_are_now_redacted(self) -> None:
+        """The issue's named cases, plus the variants they generalize to.
+
+        Each probe is `<SENSITIVE_NAME>=<value>` where the value carries a
+        quote/backslash/space in the first few characters. Before #289 the
+        first two redacted NOTHING and the rest leaked a tail; all of them
+        must now come out with the value gone.
+        """
+        tail = fake_tail()
+        cases = {
+            # value contains a backslash at char 4 -- redacted NOTHING before
+            "backslash-inside": f"PASSWORD=abc\\{tail}",
+            # value contains a single quote at char 4 -- redacted NOTHING before
+            "apostrophe-inside": f"PASSWORD=abc'{tail}",
+            # value contains a double quote -- the tail survived before
+            "double-quote-inside": f"MY_PASSWORD=abcd\"{tail}",
+            # value BEGINS with a backslash / quote
+            "leading-backslash": f"GH_TOKEN=\\{tail}",
+            "leading-double-quote": f'GH_TOKEN="{tail}"',
+            "leading-single-quote": f"CLIENT_SECRET='{tail}'",
+            # quoted value with internal spaces -- truncated at the space before
+            "quoted-with-spaces": f'OPENAI_API_KEY="{tail} and more {tail}"',
+            "single-quoted-with-spaces": f"AWS_SECRET_ACCESS_KEY='{tail} more'",
+            # a Windows-path-shaped value (backslashes throughout)
+            "path-shaped": f"DB_PASSWORD=C:\\Secrets\\{tail}",
+        }
+        for name, line in cases.items():
+            with self.subTest(case=name):
+                after, shapes = self.scrub(line)
+                self.assertNotIn(tail, after, f"{name}: the value survived the scrub")
+                self.assertIn("[REDACTED:assignment]", after)
+                self.assertTrue(shapes, f"{name}: redacted but reported no shape")
+
+                # And the READ-ONLY gate must independently SEE it, or the
+                # upload gate stays green on a line that carries a secret.
+                sub = tempfile.TemporaryDirectory()
+                self.addCleanup(sub.cleanup)
+                Path(sub.name, "x.log").write_text(line + "\n")
+                proc = run_cli(["scan", sub.name])
+                self.assertEqual(proc.returncode, 1, f"{name}: {proc.stdout}")
+                self.assertIn("shape=assignment:", proc.stdout)
+
+    def test_a_quoted_value_keeps_its_quotes(self) -> None:
+        """Structure is preserved: the opening quote is re-emitted and the
+        closing quote is matched by LOOKAHEAD, never consumed. A reader (and
+        a JSON parser) still sees a quoted value, just not the secret."""
+        tail = fake_tail()
+        for line, expected in (
+            (f'OPENAI_API_KEY="{tail} x"', 'OPENAI_API_KEY="[REDACTED:assignment]"'),
+            (f"CLIENT_SECRET='{tail} x'", "CLIENT_SECRET='[REDACTED:assignment]'"),
+        ):
+            with self.subTest(line=line.split("=")[0]):
+                after, _ = self.scrub(line)
+                self.assertEqual(after, expected)
+
+    def test_an_already_redacted_value_is_not_re_redacted(self) -> None:
+        """The negative lookahead now has to cover three spellings of an
+        already-scrubbed value, not one."""
+        for line in (
+            "PASSWORD=[REDACTED:assignment]",
+            'API_KEY="[REDACTED:assignment]"',
+            "CLIENT_SECRET='[REDACTED:assignment]'",
+            r'{"out": "API_KEY=\"[REDACTED:assignment]\""}',
+        ):
+            with self.subTest(line=line):
+                after, shapes = self.scrub(line)
+                self.assertEqual(after, line)
+                self.assertEqual(shapes, [])
+
+    # ---- direction 2 (the crux): nothing innocent moved ----
+
+    def test_innocent_lines_survive_byte_identical(self) -> None:
+        """The widened value class must not reach one byte further than the
+        value. These are the shapes ordinary evidence is made of."""
+        innocent = (
+            "total_tokens=41892",
+            "input_tokens=5000, output_tokens=120",
+            "path=/some/dir",
+            'note="hello world"',
+            "model=claude-sonnet-4",
+            'log: user said "the password is wrong" and retried',
+            json.dumps({"model": "claude", "note": "see docs"}),
+            json.dumps({"usage": {"total_tokens": 41892}, "note": "don't worry"}),
+            "api_key_name=OPENAI_API_KEY_ALT",
+            "password_field=pw1",
+        )
+        for line in innocent:
+            with self.subTest(line=line):
+                after, shapes = self.scrub(line)
+                self.assertEqual(after, line, "innocent content was rewritten")
+                self.assertEqual(shapes, [])
+
+    def test_only_the_value_is_redacted_not_what_follows_it(self) -> None:
+        """An unquoted value still stops DEAD at whitespace, and a quoted one
+        at its closing quote -- so a trailing non-secret token on the same
+        line, and the rest of the file, survive."""
+        tail = fake_tail()
+        # NB: the survivor is spelled `next_field`, not `trailing_token` --
+        # `..._token` IS a sensitive name tail, so that spelling would be a
+        # correctly-redacted second assignment, not a survivor.
+        cases = (
+            (f"PASSWORD={tail} next_field=keepme", "next_field=keepme"),
+            (f'API_KEY="{tail}" next_field=keepme', "next_field=keepme"),
+            (f"PASSWORD=abc\\{tail} next_field=keepme", "next_field=keepme"),
+            (f"PASSWORD=abcd\"{tail} next_field=keepme", "next_field=keepme"),
+        )
+        for line, survivor in cases:
+            with self.subTest(line=line.split("=")[0]):
+                after, _ = self.scrub(line)
+                self.assertNotIn(tail, after)
+                self.assertIn(survivor, after)
+
+    def test_a_serialized_env_dump_loses_only_the_secret_line(self) -> None:
+        """The incident's own shape, and the sharpest over-redaction trap: an
+        ENTIRE env dump serialized onto ONE JSON line, its lines separated by
+        `\\n` ESCAPES rather than real newlines. A value class that treated a
+        backslash as ordinary would swallow the whole dump."""
+        tail = fake_tail()
+        line = json.dumps(
+            {"result": f"MY_PASSWORD={tail}\nPATH=/usr/bin\nHOME=/root\ntotal_tokens=41892"}
+        )
+        after, shapes = self.scrub(line)
+        self.assertNotIn(tail, after)
+        self.assertEqual(shapes, ["assignment:MY_PASSWORD"])
+        parsed = json.loads(after)
+        self.assertIn("PATH=/usr/bin", parsed["result"])
+        self.assertIn("HOME=/root", parsed["result"])
+        self.assertIn("total_tokens=41892", parsed["result"])
+
+    def test_a_redaction_never_crosses_a_json_string_boundary(self) -> None:
+        """The write-seam invariant, proven here at the canonical door: the
+        redacted line still PARSES and every field other than the one holding
+        the secret is byte-identical.
+
+        This is not decoration. The persister that shares this rule re-parses
+        its redacted line and WITHHOLDS the payload when it no longer parses,
+        so a rule that crosses a string boundary costs the whole event.
+        """
+        tail = fake_tail()
+        payloads = (
+            f"MY_PASSWORD={tail}",
+            f'MY_PASSWORD="{tail} with spaces"',
+            f"MY_PASSWORD='{tail}'",
+            f"MY_PASSWORD=abc\\{tail}",
+            f'MY_PASSWORD=abcd"{tail}',
+            f"MY_PASSWORD='{tail}",  # unterminated single quote
+            f'MY_PASSWORD="{tail}',  # unterminated double quote
+            f"MY_PASSWORD={tail}\\",  # value ends on a backslash
+            f'MY_PASSWORD={tail}"',  # value ends on a quote
+            f"MY_PASSWORD={tail}\nPATH=/usr/bin",
+        )
+        for payload in payloads:
+            with self.subTest(payload=payload.replace(tail, "<tail>")):
+                record = {
+                    "event": "tool:post",
+                    "data": {"result": payload},
+                    "note": 'keep me: "quoted", don\'t drop, ends with \\',
+                    "n": 7,
+                }
+                after, _ = self.scrub(json.dumps(record))
+                parsed = json.loads(after)  # raises if the boundary was crossed
+                self.assertEqual(list(parsed), list(record))
+                self.assertEqual(parsed["note"], record["note"])
+                self.assertEqual(parsed["n"], record["n"])
+                self.assertNotIn(tail, after)
+
+    def test_capsule_gate_token_math_still_survives_the_widened_rule(self) -> None:
+        """The 2026-08-13 corruption class, re-run against the WIDER value
+        rule: the name anchor is what protects these, and widening the value
+        must not have quietly given the name back its reach."""
+        original = "\n".join(CAPSULE_GATE_LINES_FROM_PR_205) + "\n"
+        after, shapes = self.scrub(original)
+        self.assertEqual(after, original)
+        self.assertEqual(shapes, [])
+
+    def test_known_residual_single_quoted_value_holding_a_double_quote(self) -> None:
+        """An honestly-pinned RESIDUAL, not a claim of completeness.
+
+        The single-quoted branch excludes `"` from its content so that an
+        unterminated `'` inside a JSON string cannot run past that string's
+        closing `"` and delete an unrelated field. The price is that a
+        single-quoted value which itself contains a double quote is not
+        covered. Unchanged from the pre-#289 rule (which also missed it), so
+        this is a residual, not a regression -- and it is a NON-redaction,
+        never an over-redaction.
+        """
+        tail = fake_tail()
+        line = f"CLIENT_SECRET='he said \"{tail}\"'"
+        after, shapes = self.scrub(line)
+        self.assertEqual(after, line)  # residual: not redacted
+        self.assertEqual(shapes, [])
+        # The gate's entropy layer is the backstop for material like this;
+        # what matters for THIS rule is that it does not over-reach instead.
 
 if __name__ == "__main__":
     unittest.main()

--- a/modules/hooks-pipeline-observability/amplifier_module_hooks_pipeline_observability/redaction.py
+++ b/modules/hooks-pipeline-observability/amplifier_module_hooks_pipeline_observability/redaction.py
@@ -148,12 +148,30 @@ SENSITIVE_NAME_TAILS = (
 #:       terminator).  A backslash joins in two forms: an ESCAPED PAIR
 #:       (``\\``) joins ATOMICALLY -- that is how a literal backslash inside
 #:       a secret reaches this seam once the record is serialized -- while a
-#:       LONE backslash joins UNLESS it opens one of the escapes that encode
-#:       a record/field SEPARATOR (``\n``, ``\r``, ``\t``) or an arbitrary
+#:       LONE backslash joins UNLESS it is followed by ANOTHER backslash
+#:       (that case belongs to the pair -- see the fence below), or it opens
+#:       one of the escapes that encode a record/field SEPARATOR (``\n``,
+#:       ``\r``, ``\t``) or an arbitrary
 #:       code point (``\u``).  Stopping at those is what keeps a serialized
 #:       env dump (``MY_PASSWORD=<secret>\nPATH=/usr/bin`` on ONE line) from
 #:       being swallowed whole.  The run may not END on a backslash, so it
 #:       can never leave a dangling escape that would corrupt the string.
+#:
+#: THE FENCE ON THE LONE JOINER (``[\s\\]``, not ``\s``) IS NOT COSMETIC --
+#: it is what makes this rule TERMINATE, and it matters most HERE, where the
+#: input is attacker-influenced tool output arriving on the hot write path.
+#: Without it a backslash is AMBIGUOUS (half of the atomic pair ``\\``, or
+#: the lone alternative), so a run of N backslashes has Fibonacci-many
+#: tilings and the trailing ``(?<!\\)`` forces the engine to enumerate every
+#: one.  Measured at THIS seam before the fence: a serialized event whose
+#: secret carried 20 trailing backslashes took 18.4s to redact -- one such
+#: event stalls the persister.  After: a 40,000-backslash run returns in
+#: ~4ms.  The SAME ambiguity also over-redacted: an odd tiling shifted
+#: PARITY across a following ``\n`` and swallowed the ``PATH=/usr/bin`` line
+#: the paragraph above promises will survive.  The fence leaves exactly ONE
+#: tiling of any run, which is what makes the scan linear AND keeps the
+#: ``\n`` parity intact.  It cannot under-redact: a backslash before a
+#: backslash is still consumed, by the pair alternative, atomically.
 #:
 #: RESIDUAL, named rather than implied: in PLAIN text a lone backslash
 #: followed by ``n``/``r``/``t``/``u`` still ends the value -- the rule cannot
@@ -174,7 +192,7 @@ _ASSIGNMENT_VALUE = (
     r"|(?P<squote>')[^'\"\r\n]{4,}?(?<!\\)(?=')"
     # (c) unquoted run, with the two fenced joiners
     r"|(?:" + _ASSIGNMENT_VALUE_CHAR + r"|[\"'](?=" + _ASSIGNMENT_VALUE_CONT + r")"
-    r"|\\\\|\\(?!\s|(?-i:[nrtu]))){4,}(?<!\\)"
+    r"|\\\\|\\(?![\s\\]|(?-i:[nrtu]))){4,}(?<!\\)"
 )
 
 # The negative lookahead keeps an already-redacted value -- bare, quoted, or

--- a/modules/hooks-pipeline-observability/amplifier_module_hooks_pipeline_observability/redaction.py
+++ b/modules/hooks-pipeline-observability/amplifier_module_hooks_pipeline_observability/redaction.py
@@ -107,12 +107,83 @@ SENSITIVE_NAME_TAILS = (
     "CREDENTIALS?",
 )
 
+#: THE VALUE GRAMMAR (issue #289), copied from the canonical set with the
+#: rest of layer 2.  The pre-#289 rule spelled a value as ONE character class
+#: -- ``[^\s"'\\]{4,}`` -- which stops at the FIRST whitespace, quote or
+#: backslash, so a secret containing one of those within its first few
+#: characters escaped BOTH doors: ``PASSWORD=abc\<tail>`` and
+#: ``PASSWORD=abc'<tail>`` redacted NOTHING (the class dies at char 3),
+#: ``PASSWORD=abcd"<tail>`` left the tail, and ``API_KEY="secret value"``
+#: redacted only up to the first space.
+#:
+#: A value is now one of three shapes, tried IN THIS ORDER, each anchored so
+#: that widening what a value MAY CONTAIN never widens how far a value may
+#: REACH.  That anchoring is what keeps this rule safe HERE in particular:
+#: this seam applies it to an ALREADY-SERIALIZED JSON LINE, and a match that
+#: crossed a JSON string boundary would destroy the record instead of the
+#: secret (``SessionEventPersister`` re-parses the redacted line and WITHHOLDS
+#: the payload when it no longer parses -- an over-reaching rule here costs
+#: the whole event, permanently).
+#:
+#:   (a) DOUBLE-QUOTED -- ``NAME="..."`` and the JSON-escaped ``NAME=\"...\"``
+#:       form this seam actually sees.  The content class excludes ``"``
+#:       outright, so the match STOPS at the first closing quote and can never
+#:       leave the string it started in; it is non-greedy and refuses to end
+#:       on a backslash (``(?<!\\)``), so the closing ``\"``'s escape is never
+#:       eaten.  The closing quote is matched by lookahead, never consumed,
+#:       and the opening quote is re-emitted by the substitution:
+#:       ``API_KEY="[REDACTED:assignment]"``.
+#:
+#:   (b) SINGLE-QUOTED -- ``NAME='...'``.  Its content additionally excludes
+#:       ``"``: an UNTERMINATED single quote inside a JSON string would
+#:       otherwise let the match run past that string's own closing ``"`` to
+#:       the next apostrophe on the line (``"note": "don't"``), silently
+#:       deleting an unrelated field.  Stated cost: a single-quoted value that
+#:       itself contains a double quote is only partly covered.
+#:
+#:   (c) UNQUOTED -- the pre-#289 class plus two fenced joiners: a quote joins
+#:       only when the NEXT character is ordinary value material (in JSON a
+#:       string-terminating quote is ALWAYS followed by ``,`` ``}`` ``]``
+#:       ``:`` or whitespace, so this joiner provably cannot consume a string
+#:       terminator).  A backslash joins in two forms: an ESCAPED PAIR
+#:       (``\\``) joins ATOMICALLY -- that is how a literal backslash inside
+#:       a secret reaches this seam once the record is serialized -- while a
+#:       LONE backslash joins UNLESS it opens one of the escapes that encode
+#:       a record/field SEPARATOR (``\n``, ``\r``, ``\t``) or an arbitrary
+#:       code point (``\u``).  Stopping at those is what keeps a serialized
+#:       env dump (``MY_PASSWORD=<secret>\nPATH=/usr/bin`` on ONE line) from
+#:       being swallowed whole.  The run may not END on a backslash, so it
+#:       can never leave a dangling escape that would corrupt the string.
+#:
+#: RESIDUAL, named rather than implied: in PLAIN text a lone backslash
+#: followed by ``n``/``r``/``t``/``u`` still ends the value -- the rule cannot
+#: tell ``\n``-the-newline from ``\n``-the-two-characters without knowing
+#: whether the line is JSON.  At THIS seam the input is always JSON, so the
+#: stop is the CORRECT reading here; the residual belongs to the shared
+#: canonical rule, and it is always a non-redaction, never an over-redaction.
+#:
+#: Unchanged: the end-anchored name, the 4-character floor, and the fact that
+#: no branch crosses a newline -- an unquoted value still stops dead at
+#: whitespace, so a redaction can never swallow a following token.
+_ASSIGNMENT_VALUE_CHAR = r"[^\s\"'\\]"
+_ASSIGNMENT_VALUE_CONT = r"[^\s\"'\\,:;)\]}]"
+_ASSIGNMENT_VALUE = (
+    # (a) double-quoted, including the JSON-escaped \"...\" form
+    r"(?P<quote>\\?\")[^\"\r\n]{4,}?(?<!\\)(?=\\?\")"
+    # (b) single-quoted
+    r"|(?P<squote>')[^'\"\r\n]{4,}?(?<!\\)(?=')"
+    # (c) unquoted run, with the two fenced joiners
+    r"|(?:" + _ASSIGNMENT_VALUE_CHAR + r"|[\"'](?=" + _ASSIGNMENT_VALUE_CONT + r")"
+    r"|\\\\|\\(?!\s|(?-i:[nrtu]))){4,}(?<!\\)"
+)
+
+# The negative lookahead keeps an already-redacted value -- bare, quoted, or
+# JSON-escaped-quoted -- from being re-redacted into a less specific shape.
 ASSIGNMENT_PATTERN = re.compile(
     r"(?P<name>[A-Za-z0-9_]*(?:" + "|".join(SENSITIVE_NAME_TAILS) + r"))"
     r"(?P<sep>\s*=\s*)"
-    r"(?P<quote>[\"']?)"
-    r"(?!\[REDACTED:)"
-    r"(?P<value>[^\s\"'\\]{4,})",
+    r"(?!\\?[\"']?\[REDACTED:)"
+    r"(?:" + _ASSIGNMENT_VALUE + r")",
     re.IGNORECASE,
 )
 
@@ -149,8 +220,13 @@ def redact_text(text: str) -> tuple[str, list[str]]:
 
     def _assignment_sub(m: re.Match[str]) -> str:
         findings.append(f"assignment:{m.group('name')}")
+        # Exactly one of the two quote groups participates when the value was
+        # quoted (issue #289); the opening quote is re-emitted so the line
+        # keeps its shape -- `API_KEY="[REDACTED:assignment]"` -- and the
+        # closing quote was matched by lookahead, so it is still in the text.
+        quote = m.group("quote") or m.group("squote") or ""
         return (
-            f"{m.group('name')}{m.group('sep')}{m.group('quote')}"
+            f"{m.group('name')}{m.group('sep')}{quote}"
             f"{REDACTION_MARKER_PREFIX}assignment]"
         )
 

--- a/modules/hooks-pipeline-observability/tests/test_session_events_redaction.py
+++ b/modules/hooks-pipeline-observability/tests/test_session_events_redaction.py
@@ -31,6 +31,7 @@ import importlib.util
 import json
 import secrets
 import string
+import time
 from pathlib import Path
 
 import pytest
@@ -456,6 +457,128 @@ def test_issue_289_a_serialized_env_dump_loses_only_the_secret():
     assert f"{_PLURAL_ENV_NAME}=41892" in result
 
 
+# ---------------------------------------------------------------------------
+# (f) Post-review regression: the backslash-run ReDoS, and its over-redacting
+#     twin.  ONE root cause, so the probes live together.
+# ---------------------------------------------------------------------------
+#
+# Found by PR #292's OWN adversarial review, before merge.  Branch (c) joins a
+# backslash two ways -- the atomic pair `\\` and the lone alternative -- and
+# nothing stopped the LONE one from also claiming a backslash that was
+# followed by another backslash.  A backslash was therefore AMBIGUOUS, a run
+# of N of them had Fibonacci-many tilings, and the trailing `(?<!\\)` rejects
+# every tiling that ends on a backslash, so the engine enumerated them all.
+#
+# This seam is where that costs the most: the input is attacker-influenced
+# TOOL OUTPUT, arriving on the hot write path, and the realistic carrier is
+# mundane -- a Windows path, an escaped blob, any `NAME=` followed by a
+# backslash run.  Measured HERE at PR #292's head, before the `[\s\\]` fence:
+#
+#   raw `PASSWORD=` + 40 backslashes                     15.8 s
+#   serialized event, secret + 20 trailing backslashes   18.4 s
+#
+# ...and the SAME ambiguity shifted parity across a following `\n` escape,
+# swallowing the `PATH=/usr/bin` line that section (e) promises survives.
+# After the fence: a 40,000-backslash run returns in ~4 ms, and PATH survives.
+
+#: Wall-clock budget, not a benchmark.  The honest cost of these probes is
+#: microseconds; 500x headroom over the measured 4 ms keeps this immune to CI
+#: jitter while staying unreachable for an exponentially-backtracking rule.
+_REDOS_BUDGET_S = 2.0
+
+
+def _redact_within_budget(text: str, label: str) -> tuple[str, list[str]]:
+    """Redact `text`, failing if it did not finish inside the budget."""
+    started = time.perf_counter()
+    cleaned, findings = redaction.redact_text(text)
+    elapsed = time.perf_counter() - started
+    assert elapsed < _REDOS_BUDGET_S, (
+        f"{label}: took {elapsed:.3f}s (budget {_REDOS_BUDGET_S}s) -- the "
+        "backslash joiner is ambiguous again and the run is being re-tiled "
+        "exponentially"
+    )
+    return cleaned, findings
+
+
+def test_a_backslash_run_does_not_blow_up_the_write_seam():
+    """The ReDoS itself, raw and serialized.
+
+    The ladder is SMALLEST-FIRST on purpose: a regressed rule blows the
+    budget on the first probe in ~16s and never reaches the 40,000-backslash
+    one (which, ambiguous, would not finish this century).  A test that FAILS
+    beats a test that HANGS.
+    """
+    tail = secrets.token_hex(8)
+    name = "MY" + "_PASSWORD"
+    probes = (
+        ("raw, 40 trailing backslashes", "PASSWORD=" + "\\" * 40),
+        (
+            "serialized event, 20 trailing backslashes",
+            json.dumps({"output": f"{name}={tail}" + "\\" * 20}),
+        ),
+        (
+            "serialized event, 40 trailing backslashes",
+            json.dumps({"output": f"{name}={tail}" + "\\" * 40}),
+        ),
+        ("raw, 40000 backslashes (linearity)", "PASSWORD=" + "\\" * 40000),
+    )
+    for label, probe in probes:
+        cleaned, _ = _redact_within_budget(probe, label)
+        assert tail not in cleaned, label
+
+
+def test_a_secret_ending_in_backslashes_still_redacts_at_the_write_seam():
+    """Direction 1 must not regress into a NON-redaction: the value still
+    goes, however many backslashes trail it, and the record still parses."""
+    tail = secrets.token_hex(8)
+    name = "MY" + "_PASSWORD"
+    for k in (1, 2, 3, 20, 40):
+        raw = f"{name}={tail}" + "\\" * k
+        cleaned, findings = _redact_within_budget(raw, f"raw k={k}")
+        assert tail not in cleaned, k
+        assert redaction.REDACTION_MARKER_PREFIX in cleaned, k
+        assert findings == [f"assignment:{name}"], k
+
+        line = json.dumps({"output": f"{name}={tail}" + "\\" * k})
+        cleaned, findings = _redact_within_budget(line, f"serialized k={k}")
+        assert tail not in cleaned, k
+        assert findings == [f"assignment:{name}"], k
+        json.loads(cleaned)  # raises if the escape run was left dangling
+
+
+def test_a_secret_ending_in_a_backslash_does_not_eat_the_next_line():
+    r"""The OVER-REDACTION half of the same defect -- the half a timing
+    budget would never catch.
+
+    A sensitive `<NAME>` assigned `<secret>\`, then `\n`, then
+    `PATH=/usr/bin`, serialized (the name is not spelled out here: this
+    file's own rule is that it never contains a literal
+    `<SENSITIVE_NAME>=<value>` for the leak scan to flag). The
+    secret's own backslash and the separator escape sit adjacent, and an odd
+    tiling used to pair the SECOND and THIRD backslashes, leaving the
+    separator's `n` to be eaten as ordinary value material -- taking the
+    whole PATH line with it.  At THIS seam the original bytes are never
+    written, so an over-redaction here is not recoverable.
+    """
+    tail = secrets.token_hex(8)
+    name = "MY" + "_PASSWORD"
+    for k in (1, 2, 3, 5):
+        dump = (
+            f"{name}={tail}" + "\\" * k
+            + f"\nPATH=/usr/bin\nHOME=/root\n{_PLURAL_ENV_NAME}=41892"
+        )
+        cleaned, findings = _redact_within_budget(
+            json.dumps({"result": dump}), f"env dump k={k}"
+        )
+        assert tail not in cleaned, k
+        assert findings == [f"assignment:{name}"], k
+        result = json.loads(cleaned)["result"]
+        assert redaction.REDACTION_MARKER_PREFIX in result, k
+        assert "PATH=/usr/bin" in result, k
+        assert "HOME=/root" in result, k
+        assert f"{_PLURAL_ENV_NAME}=41892" in result, k
+
+
 @pytest.mark.asyncio
 async def test_a_quoted_secret_redacts_at_the_write_seam(tmp_path):
     """End to end through the real persister (the #288 seam), on a value the
@@ -556,6 +679,17 @@ def test_the_two_doors_do_not_merely_SHARE_a_pattern_they_BEHAVE_alike():
         json.dumps({"result": f"{name}={tail}\nPATH=/usr/bin"}),
         json.dumps({"result": f'{key}="{tail} x"', "note": "keep"}),
         "prefix sk-proj-" + secrets.token_hex(24) + " suffix",
+        # ...and the post-review backslash-run corpus (section (f)): the
+        # shapes that were exponential AND over-redacting must agree at both
+        # doors too -- a fence applied to only ONE door would show up here as
+        # well as in the pattern-equality tripwire above.
+        f"{name}={tail}" + "\\",
+        f"{name}={tail}" + "\\" * 2,
+        f"{name}={tail}" + "\\" * 3,
+        f"{name}={tail}" + "\\" * 40,
+        "PASSWORD=" + "\\" * 40,
+        json.dumps({"output": f"{name}={tail}" + "\\" * 20}),
+        json.dumps({"result": f"{name}={tail}" + "\\" + "\nPATH=/usr/bin\nHOME=/root"}),
     ]
     for probe in probes:
         ported, ported_findings = redaction.redact_text(probe)

--- a/modules/hooks-pipeline-observability/tests/test_session_events_redaction.py
+++ b/modules/hooks-pipeline-observability/tests/test_session_events_redaction.py
@@ -349,6 +349,136 @@ async def test_redaction_failure_withholds_the_payload_instead_of_writing_it_raw
 
 
 # ---------------------------------------------------------------------------
+# (e) Issue #289: values that begin with, or contain, a quote/backslash/space
+# ---------------------------------------------------------------------------
+#
+# The pre-#289 value class `[^\s"'\\]{4,}` stopped at the first whitespace,
+# quote or backslash, so a secret carrying one of those in its first few
+# characters escaped BOTH doors -- this seam and the canonical upload gate.
+# The widened grammar is shared (the tripwire below pins it), so it is proven
+# HERE too: the write seam is the door where an over-reaching rule costs the
+# most, because the persister re-parses its own output and WITHHOLDS a payload
+# that no longer parses.
+
+
+def _escape_case_payloads(tail: str) -> dict[str, str]:
+    """Issue #289's named cases plus the variants they generalize to.
+
+    `tail` is minted by the caller from ``secrets`` -- nothing credential-
+    shaped is written down in this file.
+    """
+    name = "MY" + "_PASSWORD"
+    key = "SOME_API" + "_KEY"
+    return {
+        "backslash-inside": f"{name}=abc\\{tail}",
+        "apostrophe-inside": f"{name}=abc'{tail}",
+        "double-quote-inside": f'{name}=abcd"{tail}',
+        "leading-backslash": f"{name}=\\{tail}",
+        "double-quoted-with-spaces": f'{key}="{tail} and more"',
+        "single-quoted": f"{key}='{tail}'",
+        "windows-path-shaped": f"{name}=C:\\Secrets\\{tail}",
+    }
+
+
+def test_issue_289_escape_cases_redact_at_the_write_seam():
+    """Direction 1: every escapee is now redacted by the ported rule."""
+    tail = secrets.token_hex(8)
+    for case, payload in _escape_case_payloads(tail).items():
+        cleaned, findings = redaction.redact_text(payload)
+        assert tail not in cleaned, f"{case}: the value survived redaction"
+        assert redaction.REDACTION_MARKER_PREFIX in cleaned, case
+        assert findings and all(f.startswith("assignment:") for f in findings), case
+
+
+def test_issue_289_the_widened_rule_still_leaves_innocent_content_verbatim():
+    """Direction 2 (the crux): nothing innocent moves.
+
+    A value class that reached one byte further than the value would corrupt
+    the forensic record this seam exists to produce -- and at THIS door the
+    original bytes are never written, so there is nothing left to recover.
+    """
+    innocent = (
+        f"{_PLURAL_ENV_NAME}=41892",
+        "path=/some/dir",
+        'note="hello world"',
+        "model=claude-sonnet-4",
+        'the user wrote "my password is wrong" in the ticket',
+        json.dumps({"model": "claude", "note": "see docs"}),
+        json.dumps({"usage": {"total_tokens": 41892}, "note": "don't worry"}),
+    )
+    for line in innocent:
+        assert redaction.redact_text(line) == (line, []), line
+
+
+def test_issue_289_a_redaction_never_crosses_a_json_string_boundary():
+    """The invariant this seam actually depends on, exercised on the shapes
+    that would break it: the redacted line still PARSES, and every field
+    other than the one holding the secret is byte-identical."""
+    tail = secrets.token_hex(8)
+    payloads = list(_escape_case_payloads(tail).values()) + [
+        f"MY{'_PASSWORD'}='{tail}",  # unterminated single quote
+        f'MY{"_PASSWORD"}="{tail}',  # unterminated double quote
+        f"MY{'_PASSWORD'}={tail}\\",  # value ends on a backslash
+        f'MY{"_PASSWORD"}={tail}"',  # value ends on a quote
+        f"MY{'_PASSWORD'}={tail}\nPATH=/usr/bin\nHOME=/root",  # env dump
+    ]
+    for payload in payloads:
+        record = {
+            "event": "tool:post",
+            "data": {"result": payload},
+            "note": 'keep me: "quoted", don\'t drop, ends with \\',
+            "n": 7,
+        }
+        line = json.dumps(record, ensure_ascii=False)
+        cleaned, _ = redaction.redact_text(line)
+        parsed = json.loads(cleaned)  # raises if a string boundary was crossed
+        assert list(parsed) == list(record)
+        assert parsed["note"] == record["note"]
+        assert parsed["n"] == record["n"]
+        assert tail not in cleaned
+
+
+def test_issue_289_a_serialized_env_dump_loses_only_the_secret():
+    """The incident's own shape and the sharpest over-redaction trap: a whole
+    env dump on ONE serialized line, its records separated by `\\n` ESCAPES.
+    A rule that treated a backslash as ordinary would swallow the lot."""
+    tail = secrets.token_hex(8)
+    name = "MY" + "_PASSWORD"
+    line = json.dumps(
+        {"result": f"{name}={tail}\nPATH=/usr/bin\nHOME=/root\n{_PLURAL_ENV_NAME}=41892"}
+    )
+    cleaned, findings = redaction.redact_text(line)
+    assert tail not in cleaned
+    assert findings == [f"assignment:{name}"]
+    result = json.loads(cleaned)["result"]
+    assert "PATH=/usr/bin" in result
+    assert "HOME=/root" in result
+    assert f"{_PLURAL_ENV_NAME}=41892" in result
+
+
+@pytest.mark.asyncio
+async def test_a_quoted_secret_redacts_at_the_write_seam(tmp_path):
+    """End to end through the real persister (the #288 seam), on a value the
+    pre-#289 rule truncated at the first space: the file must never hold the
+    secret, the record must still parse, and the quotes must survive so the
+    line stays readable."""
+    sessions = tmp_path / "sessions"
+    persister = SessionEventPersister(lambda: str(sessions))
+    tail = secrets.token_hex(8)
+    name = "SOME_SERVICE" + "_TOKEN"
+    await persister.make_handler("tool:post")(
+        "tool:post",
+        {"session_id": "sid-289", "result": f'{name}="{tail} with spaces"\n'},
+    )
+
+    path = sessions / "sid-289" / "events.jsonl"
+    assert tail not in path.read_text()
+    record = _read_events(path)[0]
+    assert f'{name}="[REDACTED:assignment]"' in record["data"]["result"]
+    assert record["redaction"]["shapes"] == [f"assignment:{name}"]
+
+
+# ---------------------------------------------------------------------------
 # Drift tripwire: the ported shapes must stay identical to the canonical set
 # ---------------------------------------------------------------------------
 
@@ -397,3 +527,41 @@ def test_every_ported_shape_actually_redacts():
         assert value not in cleaned
         assert cleaned == f"prefix [REDACTED:{shape}] suffix"
         assert findings == [shape]
+
+
+def test_the_two_doors_do_not_merely_SHARE_a_pattern_they_BEHAVE_alike():
+    """Pattern equality is necessary but not sufficient: the two copies also
+    apply the pattern with their own substitution function, and a drift THERE
+    would be invisible to the equality assertions above.
+
+    So the same probe corpus goes through both doors and the REDACTED TEXT
+    must match byte for byte -- including the issue #289 shapes, where the
+    substitution has to re-emit an opening quote that comes from one of two
+    alternative groups.
+    """
+    canonical = _load_canonical_scrubber()
+    tail = secrets.token_hex(8)
+    name = "MY" + "_PASSWORD"
+    key = "SOME_API" + "_KEY"
+    probes = [
+        f"{name}={tail}",
+        f"{name}=abc\\{tail}",
+        f"{name}=abc'{tail}",
+        f'{name}=abcd"{tail}',
+        f'{key}="{tail} with spaces"',
+        f"{key}='{tail}'",
+        f"{name}=\\{tail}",
+        f"{_PLURAL_ENV_NAME}=41892",
+        'note="hello world"',
+        json.dumps({"result": f"{name}={tail}\nPATH=/usr/bin"}),
+        json.dumps({"result": f'{key}="{tail} x"', "note": "keep"}),
+        "prefix sk-proj-" + secrets.token_hex(24) + " suffix",
+    ]
+    for probe in probes:
+        ported, ported_findings = redaction.redact_text(probe)
+        canon, canon_shapes = canonical.scrub_text(probe, {})
+        assert ported == canon, f"the two doors redacted {probe!r} differently"
+        # The shape vocabularies are reported differently by design (the gate
+        # de-duplicates per pattern, the seam counts spans), so compare the
+        # SET of shapes, which is the part both doors promise.
+        assert set(ported_findings) == set(canon_shapes), probe


### PR DESCRIPTION
## Summary

Fixes #289.

The canonical assignment rule spelled a value as ONE character class — `[^\s"'\\]{4,}` — which stops at the FIRST whitespace, quote or backslash. A sensitive `NAME=value` whose value merely *contains* one of those within its first few characters therefore walked past **both** scrub doors: the run-evidence upload gate (`.github/capsule-pipeline/scrub_secrets.py`) and the session-event write seam (`modules/hooks-pipeline-observability/.../redaction.py`, PR #288), which ports these patterns and is pinned identical to them by a drift tripwire.

This widens the value grammar in the canonical rule and re-ports it byte-identically, so the two doors stay one source of truth.

## The escape cases: before → after

Fake values are minted at runtime and masked here as `<tail>` / `<hex>`. Run against `scrub_text` (gate), `scan_text` (gate's read-only findings) and `redact_text` (write seam):

| Input | BEFORE (gate) | `scan` BEFORE | AFTER (gate **and** seam) |
|---|---|---|---|
| `PASSWORD=abc\<tail>` | `PASSWORD=abc\<tail>` — **nothing redacted** | `[]` — **gate stayed GREEN** | `PASSWORD=[REDACTED:assignment]` |
| `PASSWORD=abc'<tail>` | `PASSWORD=abc'<tail>` — **nothing redacted** | `[]` — **gate stayed GREEN** | `PASSWORD=[REDACTED:assignment]` |
| `PASSWORD=abcd"<hex>` | `PASSWORD=[REDACTED:assignment]"<hex>` — **tail survived** | `assignment:PASSWORD` | `PASSWORD=[REDACTED:assignment]` |
| `API_KEY="<tail> with spaces"` | `API_KEY="[REDACTED:assignment] with spaces"` — **truncated at the space** | `assignment:API_KEY` | `API_KEY="[REDACTED:assignment]"` |
| `CLIENT_SECRET='<tail> more'` | `CLIENT_SECRET='[REDACTED:assignment] more'` | `assignment:CLIENT_SECRET` | `CLIENT_SECRET='[REDACTED:assignment]'` |
| `GH_TOKEN=\<tail>` | `GH_TOKEN=\<tail>` — **nothing redacted** | `[]` | `GH_TOKEN=[REDACTED:assignment]` |
| `DB_PASSWORD=C:\Secrets\<tail>` | unchanged — **nothing redacted** | `[]` | `DB_PASSWORD=[REDACTED:assignment]` |

PR #288's own measurement, re-run at both revisions (`PASSWORD=abc\<20-char tail>`, 500 runtime-minted trials):

```
BEFORE caught 0/500   AFTER caught 500/500
```

(#289's other named case, `SECRET='quoted'`, does **not** redact — but that is the NAME rule, not the value rule: `_SECRET` is end-anchored with its underscore, deliberately, so bare `SECRET=`/`TOKEN=` never matched and still doesn't. Untouched here; see Observations.)

## The widened grammar

```python
_ASSIGNMENT_VALUE_CHAR = r"[^\s\"'\\]"
_ASSIGNMENT_VALUE_CONT = r"[^\s\"'\\,:;)\]}]"
_ASSIGNMENT_VALUE = (
    # (a) double-quoted, including the JSON-escaped \"...\" form
    r"(?P<quote>\\?\")[^\"\r\n]{4,}?(?<!\\)(?=\\?\")"
    # (b) single-quoted
    r"|(?P<squote>')[^'\"\r\n]{4,}?(?<!\\)(?=')"
    # (c) unquoted run, with the two fenced joiners
    r"|(?:" + _ASSIGNMENT_VALUE_CHAR + r"|[\"'](?=" + _ASSIGNMENT_VALUE_CONT + r")"
    r"|\\\\|\\(?!\s|(?-i:[nrtu]))){4,}(?<!\\)"
)

ASSIGNMENT_PATTERN = re.compile(
    r"(?P<name>[A-Za-z0-9_]*(?:" + "|".join(SENSITIVE_NAME_TAILS) + r"))"
    r"(?P<sep>\s*=\s*)"
    r"(?!\\?[\"']?\[REDACTED:)"
    r"(?:" + _ASSIGNMENT_VALUE + r")",
    re.IGNORECASE,
)
```

## Why it does not over-redact — the anchoring argument

The widening changes what a value **may contain**, never how far a value **may reach**. Each branch has its own fence:

1. **Nothing crosses a newline.** Quoted content excludes `\r\n`; unquoted units are all non-whitespace. A redaction can never eat the rest of a file.
2. **Unquoted still stops dead at whitespace.** So a trailing non-secret token on the same line survives: `PASSWORD=<tail> next_field=keepme` → `PASSWORD=[REDACTED:assignment] next_field=keepme`.
3. **A bare quote cannot be a JSON string terminator when it joins.** The unquoted branch consumes a quote only when the *next* character is ordinary value material (`[^\s"'\\,:;)\]}]`). In JSON, a string-terminating `"` is **always** followed by `,` `}` `]` `:` or whitespace — so the joiner provably cannot swallow a terminator. In a plain log line, `PASSWORD=abcd"<tail>` really is one token, and is redacted whole.
4. **A backslash cannot swallow a serialized separator.** `\\` (JSON's literal backslash) joins **atomically**; a lone `\` joins unless it opens `\n`, `\r`, `\t` or `\u`. That is what keeps an entire env dump — `MY_PASSWORD=<secret>\nPATH=/usr/bin\nHOME=/root` on ONE serialized line — from being swallowed: only the secret goes, PATH/HOME/`total_tokens=` survive byte-identical.
5. **A run may never END on a backslash** (`(?<!\\)`), and the quoted branches are non-greedy with the same guard, so a closing `\"`'s escape is never eaten and no dangling escape is left behind — the difference between "one string value shortened" and "the record no longer parses".
6. **Quoted branches stop at the first closing quote** (content excludes the quote char), and the closing quote is matched by **lookahead**, never consumed; the opening quote is re-emitted. The single-quoted branch also excludes `"` so an unterminated `'` inside a JSON string cannot run past that string's own closing quote to the next apostrophe on the line and delete an unrelated field.
7. **The NAME anchor is untouched.** The 2026-08-13 corruption class (`input_tokens=`, `total_tokens=`, `max_tokens=`) is re-pinned against the wider value rule and still comes out byte-identical.

Why this matters most at the write seam: `SessionEventPersister` re-parses its own redacted line and **withholds the payload** when it no longer parses. An over-reaching rule there would destroy the record instead of the secret — permanently, since the raw bytes are never written.

**Measured, not asserted** (randomized, runtime-minted, both doors):

```
[JSON property, 10000 randomized serialized event lines]
  unparseable after redaction        : 0
  non-secret fields damaged          : 0
  gate/seam outputs differed         : 0
[innocent-name property, 10000 lines]
  innocent lines rewritten           : 0
[anchoring property, 10000 sensitive lines]
  neighbour token / next line eaten  : 0
```

Byte-identical through both doors (spot corpus): `total_tokens=41892`, `input_tokens=5000, output_tokens=120`, `path=/some/dir`, `note="hello world"`, `model=claude-sonnet-4`, `log: user said "the password is wrong" and retried`, `{"model": "claude", "note": "see docs"}`, `{"usage": {"total_tokens": 41892}, "note": "don't worry"}`, `api_key_name=OPENAI_API_KEY_ALT`, `password_field=pw1`.

## Lockstep

- Both doors carry the **identical pattern string and flags**; the existing drift tripwire (`TOKEN_PATTERNS` / `SENSITIVE_NAME_TAILS` / `ASSIGNMENT_PATTERN` pattern + flags) is **green at head**.
- Added a **behavioural** tripwire: a probe corpus runs through `redaction.redact_text` *and* the canonical `scrub_secrets.scrub_text`, and the redacted text must match byte for byte. Pattern equality alone could not catch this — each door applies the rule with its own substitution function, and both now have to pick the opening quote out of one of two alternative groups.
- **Mutation-proved in both directions.** Reverting the value grammar in *one* door only:
  - revert the **write seam** → `test_ported_shapes_have_not_drifted_from_the_canonical_set` FAILS, `test_the_two_doors_..._BEHAVE_alike` FAILS, plus the 3 new escape-case tests → `5 failed, 79 passed`.
  - revert the **canonical gate** → the same two tripwires FAIL (`2 failed, 82 passed`) and the canonical suite goes red across `test_issue_289_escape_cases_are_now_redacted`, `test_a_quoted_value_keeps_its_quotes`, `test_a_redaction_never_crosses_a_json_string_boundary`.
  - Restored → all green.

## Residuals, named rather than implied

1. **Plain-text `\` + `n`/`r`/`t`/`u`.** In unserialized text a lone backslash followed by one of those still ends the value — the rule cannot tell `\n`-the-newline from `\n`-the-two-characters without knowing whether the line is JSON. At the write seam (always JSON) the stop is the *correct* reading; at the gate it is a deliberate trade, because between under-redacting a rare shape and swallowing a whole env dump, this file has already learned twice which mistake costs more. Always a **non-redaction**, never an over-redaction; layer 4 (entropy) remains the gate's backstop.
2. **Single-quoted value containing a double quote** (`CLIENT_SECRET='he said "x"'`) is not covered — the `"` exclusion in branch (b) is what stops an unterminated `'` from deleting an unrelated JSON field. Unchanged from the pre-#289 rule (it missed this too), so a residual, not a regression. Pinned by `test_known_residual_single_quoted_value_holding_a_double_quote` so it stays measured rather than forgotten.
3. **Name rule untouched.** Bare `SECRET=` / `TOKEN=` still do not match (`_SECRET` / `_TOKEN` are end-anchored *with* the underscore). #289 is a value-grammar defect; widening the name set is the 2026-08-13 corruption's blast radius and belongs to its own change with its own evidence.

## Tier (`docs/QUALITY_PROTOCOL.md` §3)

**Toward-spec.** Security correctness: it closes the gap between what the layer-2 rule already promises (redact a sensitive assignment's value) and what it did (redact the value's first quote/backslash-free prefix, or nothing). No observable contract changes for pipeline authors — the redaction marker, the shape vocabulary (`assignment:<NAME>`), the CLI verbs and the exit codes are all unchanged, and the only behavioural delta is *more of a secret value* being replaced. No `specs/EXTENSIONS.md` entry: this is not spec-relevant pipeline behavior. Both doc claims changed in this PR (the value grammar in each file's comments) are pinned by the tests added here.

## Verification checklist

- [x] Unit tests pass — `hooks-pipeline-observability`: **84 passed** (78 before + 6 new); canonical door `python3 -m unittest test_scrub_secrets`: **30 tests OK** (21 before + 9 new)
- [ ] Live pipeline run — n/a (no `engine.py`/handler touched)
- [x] AGENTS.md reviewed; repo-specific gates met
- [x] Backward-compat path unchanged (marker, shapes, CLI verbs, exit codes identical; existing tests unmodified)
- [x] Observable contract: no change (see Tier)
- [x] Doc claims about code behavior ship guard tests (the grammar comments in both files are pinned by the new escape-case / anchoring / JSON-boundary tests)
- [x] PR body includes verification evidence
- [ ] CI green before merge — **do not merge**; this PR is for review

## Verification evidence

```
### canonical door: .github/capsule-pipeline/test_scrub_secrets.py ###
Ran 30 tests in 1.8s
OK

### observability module: uv run pytest tests -q ###
84 passed

### write seam + tripwire: test_session_events.py + test_session_events_redaction.py ###
25 passed
```

Write seam, end to end through the real persister (the #288 seam), on a value the old rule truncated at the first space:

```
in   : SOME_SERVICE_TOKEN="<tail> with spaces"
disk : SOME_SERVICE_TOKEN="[REDACTED:assignment]"
       redaction.shapes == ["assignment:SOME_SERVICE_TOKEN"]   (record still parses; <tail> absent from the file)
```

The sharpest over-redaction trap — a whole env dump on ONE serialized line:

```
in  : {"result": "MY_PASSWORD=<tail>\nPATH=/usr/bin\nHOME=/root\ntotal_tokens=41892"}
gate: {"result": "MY_PASSWORD=[REDACTED:assignment]\nPATH=/usr/bin\nHOME=/root\ntotal_tokens=41892"}
seam: (byte-identical to gate)   findings=['assignment:MY_PASSWORD']   still parses: True
```

Gates: `git diff --check` clean. Leak scan of the changed files: every new finding is a **documentation comment** quoting the issue's shapes (`PASSWORD=abc\<tail>`, `MY_PASSWORD=<secret>\nPATH=...`) or a **test source line** interpolating a runtime-minted `{tail}` — no literal credential material added (no 28+ char opaque run appears anywhere in the diff's added lines).

## Observations

- **The canonical door's own test file is not run by CI.** `ci.yml` runs `uv run pytest -q` per module; `.github/capsule-pipeline/test_scrub_secrets.py` sits outside any module, so its 30 tests only run locally. The observability module's tripwire (which loads `scrub_secrets.py` **by path**) is the sole CI-visible guard on the canonical file — and the behavioural tripwire added here now also exercises canonical `scrub_text` inside CI. Wiring the capsule-pipeline suite into `ci.yml` looks worth its own change.
- **`session_events.py`'s docstring is now partially stale.** It says "every pattern's character class stops at quote and backslash, so a match can never cross a JSON string boundary" — true of layer 1, no longer the mechanism for layer 2 (the fences described above are). Its next sentence is the one that actually carries the guarantee ("That is then VERIFIED rather than trusted — the redacted line is re-parsed"). Left untouched deliberately: another lane is in that module's neighbourhood and this PR's file scope was fixed in advance. One-line follow-up.
- **Pre-existing, unrelated, and unchanged by this PR:** `sep` is `\s*=\s*`, and `\s` includes newlines — so `NAME=` at end of line binds to the *next* line's first token. Both the old and new rules do this identically (verified on `AWS_SECRET_ACCESS_KEY=\t TRAIL` — byte-identical output before and after). Tightening it to `[ \t]*` is a separate behavioural change with its own blast radius.
- **Cost.** The value alternation is per-character rather than one C-level class, so a matched 8 KB assignment costs ~1 ms vs ~0.03 ms before. That is dwarfed 1000× by the *pre-existing* cost of the name prefix (`[A-Za-z0-9_]*` before the tail alternation) on a long non-matching run: 8 KB → ~939 ms after, ~940 ms before. Unchanged by this PR, but worth an issue on its own.
- **A wider name set would catch more** (bare `SECRET=`, bare `TOKEN=`, `_KEY`), and #289's own example `SECRET='quoted'` is in that set. Explicitly out of scope here: that rule's end-anchor is the fix for a shipped-artifact corruption, and changing it needs the corruption corpus re-run, not a value-grammar PR.


---

## Post-review fix: ReDoS in branch (c)

This PR's own adversarial review found a **catastrophic-backtracking (ReDoS) defect introduced by the widened branch (c)**, plus a second symptom from the same root cause. Both are fixed here, in lockstep, at both doors. Commit `5e68f2d`.

### Root cause: an ambiguous backslash

Branch (c) joins a backslash **two ways** — the atomic escaped pair `\\`, and the lone `\` alternative — and nothing stopped the *lone* one from also claiming a backslash that was followed by **another** backslash:

```
|\\\\|\\(?!\s|(?-i:[nrtu]))){4,}(?<!\\)
       ^^^^^^^^^^^^^^^^^^^^^ a lone `\` matched even before another `\`
```

So a backslash is **ambiguous**: a run of N backslashes has Fibonacci-many tilings. The trailing `(?<!\\)` then *rejects every tiling that ends on a backslash*, so the engine is forced to enumerate all of them. Exponential — on attacker-influenced tool output, at both doors.

`json.dumps` **doubles** every backslash, so the realistic carrier is mundane: any tool output with a sensitive `NAME=` followed by a backslash run — a Windows path `C:\...`, an escaped blob — i.e. exactly the env-dump class this module exists for.

**Second symptom, same root cause — over-redaction.** On `MY_PASSWORD=<secret>\` + `\n` + `PATH=/usr/bin` (serialized), an odd tiling paired the **second and third** backslashes and then ate the separator's `n` as ordinary value material — swallowing the `PATH` line. That is this PR's own "PATH/HOME survive byte-identical" invariant, false in exactly the shape the PR widened for.

### The fix — one fence, both doors, byte-identical

`.github/capsule-pipeline/scrub_secrets.py` (L345) **and** `modules/hooks-pipeline-observability/.../redaction.py` (L195), identically:

```diff
-    r"|\\\\|\\(?!\s|(?-i:[nrtu]))){4,}(?<!\\)"
+    r"|\\\\|\\(?![\s\\]|(?-i:[nrtu]))){4,}(?<!\\)"
```

A lone backslash no longer matches before **another** backslash. That case belongs to the pair alternative, atomically — the reading this grammar always intended — so any run has **exactly one tiling**. Linear, and the `\n` parity stays intact. It cannot under-redact: a backslash before a backslash is still consumed, just unambiguously. Nothing else in the branch changed.

### Before / after (measured, same machine, both doors)

| probe | gate, before | seam, before | gate, after | seam, after |
|---|---|---|---|---|
| raw `PASSWORD=` + 40 backslashes | **15 819.5 ms** | **15 848.7 ms** | 0.009 ms | 0.009 ms |
| serialized event, secret + 20 trailing backslashes | **18 354.3 ms** | **18 366.0 ms** | 0.012 ms | 0.012 ms |
| serialized event, secret + 40 trailing backslashes | *(raw-80-equivalent; unmeasurable)* | *(same)* | 0.016 ms | 0.016 ms |
| raw `PASSWORD=` + **40 000** backslashes (linearity) | *(would not finish)* | *(same)* | **2.3 ms** | **2.3 ms** |

The pre-fix growth is the Fibonacci curve directly: raw k=18/20/22 → 0.4 / 1.1 / 2.8 ms, ~2.6× per two backslashes. Serialized k=20 ≈ raw k=40 because serialization doubles the run — which is why 18.4 s and 15.8 s sit next to each other.

### Over-redaction pin

```
in   : {"output": "MY_PASSWORD=hunter2\\\nPATH=/usr/bin\nHOME=/root\n"}

before (BOTH doors):
out  : {"output": "MY_PASSWORD=[REDACTED:assignment]\nHOME=/root\n"}
       PATH=/usr/bin  ->  EATEN                       <-- invariant violated

after (BOTH doors, byte-identical):
out  : {"output": "MY_PASSWORD=[REDACTED:assignment]\\\nPATH=/usr/bin\nHOME=/root\n"}
       PATH=/usr/bin  survives : True
       HOME=/root     survives : True
       secret gone             : True
```

### #289's escape cases still redact (the point of this PR)

Both doors, values masked:

```
PASSWORD=abc\<tail>            -> PASSWORD=[REDACTED:assignment]
API_KEY="<secret with spaces>" -> API_KEY="[REDACTED:assignment]"
GH_TOKEN=\<tail>               -> GH_TOKEN=[REDACTED:assignment]
DB_PASSWORD=C:\Secrets\<tail>  -> DB_PASSWORD=[REDACTED:assignment]
```

### Regression cover

New probes at **both** doors — a sensitive assignment whose value **ends in a run of backslashes**, raw and JSON-serialized, k = 1, 2, 3, 20, 40 — asserting (a) it redacts to `[REDACTED:assignment]`, (b) a following `PATH=/usr/bin` / `HOME=/root` / `total_tokens=` line survives verbatim, and (c) it completes inside a **2 s wall-clock budget** (500× headroom over the measured ~4 ms; unreachable for an exponential rule). The same shapes join the two-door behavioural corpus, so a fence applied to only one door shows up there too.

The timing ladder is ordered **smallest-first deliberately**: a regressed rule blows the budget on the first probe in ~16 s and never reaches the 40 000-backslash one. A guard that **fails** beats a guard that **hangs**.

### Lockstep + tripwire mutation

Both `ASSIGNMENT_PATTERN` definitions are byte-identical — `sha256(pattern) = 769ff8d9f0a5f8348326c5582f37bf526d7e7f7727767efb5cb58bae0b6197b3` at both doors, flags equal. Drift tripwire green, behavioural tripwire green.

Mutation-proved — fence applied to **one door only**:

```
FAILED test_ported_shapes_have_not_drifted_from_the_canonical_set
FAILED test_the_two_doors_do_not_merely_SHARE_a_pattern_they_BEHAVE_alike
  AssertionError: the two doors redacted '{"result": "MY_PASSWORD=<tail>\\\\\\nPATH=/usr/bin\\nHOME=/root"}' differently
  - signment]\\\nPATH=/usr/bin\nHOME=/root"}     <- fixed door
  + signment]\nHOME=/root"}                      <- unfenced door ate the PATH line
2 failed, 16 deselected
```

Both tripwires catch it — the pattern-equality one on the pattern, the behavioural one on the over-redaction shape itself.

### No regression

- `.github/capsule-pipeline/test_scrub_secrets.py` — **33 passed** (was 30; +3 new).
- `modules/hooks-pipeline-observability` full suite — **87 passed** (was 84; +3 new), including the #288 write-seam e2e (`SOME_SERVICE_TOKEN="[REDACTED:assignment]"` on disk, record still parses) and both tripwires.
- Leak scan of the changed files: **no new finding class**. The observability test file stays at **zero** findings (its stated invariant); the canonical files' new findings are documentation comments and runtime-minted-`{tail}` test source lines of shapes already present there.
- `git diff --check` clean. Rebased onto current `main` (`7dc5a0a`); no overlap with #287/#283.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

