### PR TITLE
fix(pipeline): a missing child dot_file= is a resolution fault, not a routing one (#200)

### DIFF
--- a/docs/DOT-AUTHORING-GUIDE.md
+++ b/docs/DOT-AUTHORING-GUIDE.md
@@ -1557,7 +1557,7 @@ changed what happened), a branching diamond, a constant emitter such as
 inequality condition, the same token twice, and an unreachable gate.
 
 **Severity:** WARNING — consistent with the rest of the family (TOPO-002
-through TOPO-009; TOPO-001 is `ERROR`).  The hazard is real but the author's
+through TOPO-010; TOPO-001 is `ERROR`).  The hazard is real but the author's
 intent is not statically provable, and it is `lint()`-only: `validate()` and
 `validate_or_raise()` stay silent, so no graph that executes today starts
 failing at run time.
@@ -1635,6 +1635,50 @@ delta: `outcome` resolves `preferred_label` first").
 
 ---
 
+### TOPO-010 — `shape=folder` child graph missing at lint time
+
+**What it detects:** A `shape=folder` (sub-pipeline) node whose `dot_file=` is
+a **static relative** path that names no file on disk when you lint.
+
+```dot
+// Flagged — child.dot is not next to this file, and nothing writes it
+child [shape=folder, dot_file="pipelines/child.dot"];
+```
+
+**Why it matters:** `dot_file=` resolution is a **precedence chain**, not a
+search path (`specs/EXTENSIONS.md` §10): a relative value resolves against the
+parent `.dot` file's **own directory** first — *not* against `--cwd`. The most
+common form of this bug is a path that is perfectly correct relative to where
+you ran the command and wrong relative to where the graph lives. Left alone it
+surfaces at run time, when the folder node is entered, as a child-DOT
+resolution error naming every candidate path that was tried.
+
+**Severity:** WARNING — and it can never be an ERROR. The linter cannot
+distinguish "the author typo'd the path" from "a node upstream writes this file
+during the run": **write-then-run composition** (a node generates a child
+`.dot` mid-run and a later folder node executes it) is a supported, shipped
+shape, and `examples/objective/objective-runner.dot` does exactly this. An
+ERROR here would refuse to lint every composition graph. Warnings do not affect
+the exit code (rc stays 0 without `--strict`), so an author with a typo sees it
+immediately and a composition graph is never blocked.
+
+**What is NOT flagged:**
+- an **absolute** `dot_file=` — a lint-time absolute path tells you nothing
+  about the machine or workspace it will resolve against at run time;
+- any value containing **`$`** (`dot_file="$target_dir/.objective/gen/child.dot"`)
+  — a `$variable` target is resolved from run-time context, so its lint-time
+  spelling is not a path. This is also the exact shape a composition graph uses
+  for a generated child;
+- a graph with no `source_dir` — an inline DOT source (`--dot-source`, a library
+  caller) has no backing file, so there is no honest base directory to resolve a
+  relative target against, and guessing one would manufacture false positives.
+
+**Fix:** Ship the child graph beside its parent, or correct the path so it is
+relative to the **parent `.dot` file's directory**. If an upstream node
+generates the file at run time, no change is needed — this warning is advisory.
+
+---
+
 ### CMD-001 — Pipe-masked exit code
 
 **What it detects:** A `parallelogram` (tool) node whose `tool_command` ends
@@ -1682,7 +1726,7 @@ If you need to see the last N lines, write to a file and read it separately
 from the routing logic.
 
 **Severity:** WARNING — consistent with the WARNING-severity TOPO rules
-(TOPO-002 through TOPO-009; note TOPO-001 is `ERROR`, not this family's
+(TOPO-002 through TOPO-010; note TOPO-001 is `ERROR`, not this family's
 default).  The hazard is real but static analysis cannot prove the command is
 a meaningful gate; conservative analysis may miss complex cases.
 
@@ -1744,7 +1788,7 @@ influence either the exit code or the emitted token?  The hazard shapes
 destroy that influence.  The honest idioms preserve it.
 
 **Severity:** WARNING — consistent with CMD-001 and the WARNING-severity TOPO
-rules (TOPO-002 through TOPO-009; TOPO-001 is `ERROR`).
+rules (TOPO-002 through TOPO-010; TOPO-001 is `ERROR`).
 
 **What this rule does NOT catch:** sentinels inside `$(...)` substitutions,
 sentinels after non-pipe-masked commands (where `&& echo TOKEN` is the honest

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/engine.py
@@ -34,6 +34,7 @@ from .feedback import collect_and_inject_feedback
 from .fidelity import RESUME_FIDELITY_CAP_KEY, resolve_fidelity
 from .graph import Graph, Node, resolve_bool_attr
 from .handlers import HandlerRegistry
+from .handlers.pipeline import ChildDotResolutionError
 from .must_write import check_must_write
 from .node_outputs import SUBSTITUTABLE_ATTRS, build_output_table
 from .outcome import Outcome, StageStatus
@@ -919,6 +920,15 @@ class PipelineEngine:
                                     hooks=self.hooks,
                                     engine=self,
                                 )
+                        except ChildDotResolutionError as _child_dot_exc:
+                            # Issue #200 -- see the sibling handler below.
+                            return await self._terminate_child_dot_resolution(
+                                node_id=current_node.id,
+                                exc=_child_dot_exc,
+                                node_start_time=node_start_time,
+                                pipeline_start_time=pipeline_start_time,
+                                execution_index=execution_index,
+                            )
                         except asyncio.TimeoutError:
                             node_duration_ms = (time.monotonic() - node_start_time) * 1000
                             _ap = current_node.attrs.get("allow_partial")
@@ -945,16 +955,33 @@ class PipelineEngine:
                                 },
                             )
                     else:
-                        outcome = await execute_with_retry(
-                            handler,
-                            current_node,
-                            self.context,
-                            self.graph,
-                            self.logs_root,
-                            retry_policy,
-                            hooks=self.hooks,
-                            engine=self,
-                        )
+                        try:
+                            outcome = await execute_with_retry(
+                                handler,
+                                current_node,
+                                self.context,
+                                self.graph,
+                                self.logs_root,
+                                retry_policy,
+                                hooks=self.hooks,
+                                engine=self,
+                            )
+                        except ChildDotResolutionError as _child_dot_exc:
+                            # Issue #200: a shape=folder node's dot_file= named
+                            # no existing child graph.  That is a child-graph
+                            # RESOLUTION fault, and it must never be allowed to
+                            # reach Step 5 below: FAIL is fail-fast there, so a
+                            # graph with no failure edge would terminate as
+                            # `no_matching_edge` / "No matching edge from node
+                            # 'X'" -- a routing framing for a missing FILE.
+                            # Terminate here instead, in the fault's own class.
+                            return await self._terminate_child_dot_resolution(
+                                node_id=current_node.id,
+                                exc=_child_dot_exc,
+                                node_start_time=node_start_time,
+                                pipeline_start_time=pipeline_start_time,
+                                execution_index=execution_index,
+                            )
                 node_duration_ms = (time.monotonic() - node_start_time) * 1000
 
                 # Spec §5.3 rule 6 is ONE hop: clear the cap the moment the
@@ -1425,6 +1452,32 @@ class PipelineEngine:
                     outcome = await handler.execute(
                         current_node, ctx, self.graph, self.logs_root, engine=self
                     )
+                except ChildDotResolutionError as exc:
+                    # Issue #200: keep the child-resolution diagnostic verbatim
+                    # here too.  run_subgraph is the shared runner for parallel
+                    # branch bodies and the manager-loop in-graph path, and its
+                    # generic wrapper below would bury the candidate-path chain
+                    # behind "Subgraph node 'X' raised: ...".
+                    fail_outcome = Outcome(
+                        status=StageStatus.FAIL,
+                        failure_reason=str(exc),
+                        notes=str(exc),
+                    )
+                    if emit_node_events:
+                        await self._emit(
+                            PIPELINE_NODE_COMPLETE,
+                            {
+                                "node_id": current_node.id,
+                                "status": fail_outcome.status.value,
+                                "duration_ms": (time.monotonic() - node_start_time)
+                                * 1000,
+                                "notes": fail_outcome.notes,
+                                "failure_reason": fail_outcome.failure_reason,
+                                "session_id": None,
+                                "attempt": 1,
+                            },
+                        )
+                    return fail_outcome
                 except Exception as exc:
                     fail_outcome = Outcome(
                         status=StageStatus.FAIL,
@@ -1971,6 +2024,61 @@ class PipelineEngine:
         return best
 
     # -- Failure routing helpers ----------------------------------------------
+
+    async def _terminate_child_dot_resolution(
+        self,
+        *,
+        node_id: str,
+        exc: ChildDotResolutionError,
+        node_start_time: float,
+        pipeline_start_time: float,
+        execution_index: int,
+    ) -> Outcome:
+        """Terminate the run on a child-graph RESOLUTION fault (issue #200).
+
+        A ``shape=folder`` node whose ``dot_file=`` names no existing child
+        graph is not a node whose work failed and not a graph whose routing is
+        incomplete -- it is a composition fault, and it gets its own terminal
+        class here rather than being laundered through edge selection into
+        ``no_matching_edge`` (EXTENSIONS.md §33), which named the wrong
+        subsystem and printed only the single chosen path.
+
+        Deliberately terminal: there is no child graph to run and no honest
+        way to route around one that does not exist.  ``validate_or_raise``
+        stays untouched -- admission remains LAZY (EXTENSIONS.md §10), so a
+        child DOT written earlier in the same run still resolves normally and
+        write-then-run composition is unaffected.
+        """
+        fail_outcome = Outcome(
+            status=StageStatus.FAIL,
+            notes=str(exc),
+            failure_reason=str(exc),
+        )
+        node_duration_ms = (time.monotonic() - node_start_time) * 1000
+        self.node_outcomes[node_id] = fail_outcome
+        self._write_node_status(node_id, fail_outcome, node_duration_ms)
+        await self._emit(
+            PIPELINE_NODE_COMPLETE,
+            {
+                "node_id": node_id,
+                "status": fail_outcome.status.value,
+                "duration_ms": node_duration_ms,
+                "notes": fail_outcome.notes,
+                "failure_reason": fail_outcome.failure_reason,
+                "session_id": None,
+                "execution_index": execution_index,
+            },
+        )
+        await self._emit(
+            PIPELINE_ERROR,
+            {
+                "node_id": node_id,
+                "error_type": "child_dot_resolution",
+                "message": str(exc),
+            },
+        )
+        await self._emit_complete(fail_outcome, pipeline_start_time)
+        return fail_outcome
 
     def _no_matching_edge_reason(self, node_id: str, outcome: Outcome) -> str:
         """Build a diagnostic 'no matching edge' message that traces back.

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/pipeline.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/handlers/pipeline.py
@@ -12,6 +12,7 @@ import logging
 import os
 import re
 import time
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -41,28 +42,203 @@ def _expand_path_variables(path: str, context: PipelineContext) -> str:
     return re.sub(r"\$(\w+)", _replace, path)
 
 
+@dataclass(frozen=True)
+class DotPathCandidate:
+    """One tier of the ``dot_file=`` precedence chain (EXTENSIONS.md §10).
+
+    ``resolve_dot_path()`` is a *precedence chain*, not a search path: the
+    first tier that yields a non-empty base wins and the rest are never
+    consulted.  Recording every tier — the winner, the tiers that were
+    skipped because an earlier one won, and the tiers that had nothing to
+    offer at all — is what makes "resolved against the wrong base directory"
+    readable in a diagnostic instead of something an author has to infer.
+    """
+
+    #: Tier name as EXTENSIONS.md §10 names it (``graph.source_dir``, …).
+    tier: str
+    #: The path this tier would produce, or None when the tier is not
+    #: applicable at all (an absolute ``dot_file=``; an empty base dir).
+    path: str | None
+    #: True for the tier ``resolve_dot_path()`` actually returned.
+    chosen: bool
+    #: Why this tier produced no path (only set when ``path`` is None).
+    unavailable_reason: str = ""
+
+    @property
+    def exists(self) -> bool:
+        """True when this tier's path names a file that exists right now."""
+        return bool(self.path) and os.path.exists(self.path)
+
+
+def resolve_dot_path_candidates(
+    dot_file: str, source_dir: str, context: PipelineContext
+) -> list[DotPathCandidate]:
+    """Enumerate every tier of the ``dot_file=`` precedence chain.
+
+    Returns the four EXTENSIONS.md §10 tiers in precedence order, with
+    exactly one marked ``chosen`` — the same path ``resolve_dot_path()``
+    returns.  This is the diagnostic sibling of ``resolve_dot_path()``: it
+    exists so a failed resolution can name *where it looked*, not only
+    *what it picked*.
+    """
+    expanded = _expand_path_variables(dot_file, context)
+    is_abs = os.path.isabs(expanded)
+    target_dir = context.get("context.target_dir") if context else None
+
+    # Build each tier's would-be path (None when the tier cannot apply).
+    # Note: for an absolute `expanded`, tiers 2-4 are genuinely inapplicable —
+    # os.path.join(base, "/abs") returns "/abs" regardless of base, so
+    # reporting them as candidates would be a lie dressed as a diagnostic.
+    _ABS = "dot_file= is absolute; the precedence chain stops at tier 1"
+    raw: list[tuple[str, str | None, str]] = []
+
+    raw.append(
+        (
+            "absolute path",
+            expanded if is_abs else None,
+            "dot_file= is relative after $variable expansion",
+        )
+    )
+    raw.append(
+        (
+            "graph.source_dir",
+            os.path.join(source_dir, expanded) if (source_dir and not is_abs) else None,
+            _ABS
+            if is_abs
+            else "graph.source_dir is empty (an inline DOT source has no backing file)",
+        )
+    )
+    raw.append(
+        (
+            "context.target_dir",
+            os.path.join(str(target_dir), expanded)
+            if (target_dir and not is_abs)
+            else None,
+            _ABS
+            if is_abs
+            else "context.target_dir is unset (no --cwd; the mounted orchestrator skips this tier)",
+        )
+    )
+    raw.append(
+        (
+            "os.getcwd()",
+            None if is_abs else os.path.join(os.getcwd(), expanded),
+            _ABS,
+        )
+    )
+
+    chosen_index = next((i for i, (_, path, _) in enumerate(raw) if path), -1)
+    return [
+        DotPathCandidate(
+            tier=tier,
+            path=path,
+            chosen=(i == chosen_index),
+            unavailable_reason="" if path else reason,
+        )
+        for i, (tier, path, reason) in enumerate(raw)
+    ]
+
+
 def resolve_dot_path(dot_file: str, source_dir: str, context: PipelineContext) -> str:
     """Resolve a dot_file path.
 
     1. Expand $variable tokens from context values.
     2. If path is absolute (starts with /), return as-is.
     3. Otherwise resolve relative to source_dir.
-    4. If source_dir is empty, resolve relative to cwd.
+    4. If source_dir is empty, resolve relative to context.target_dir, then cwd.
+
+    Resolution stays LAZY by design (EXTENSIONS.md §10): the first non-empty
+    candidate wins with NO existence check here, which is what makes
+    write-then-run composition possible (a node writes the child .dot mid-run
+    and a later shape=folder node executes it).  Existence is asserted at node
+    ENTRY instead — see ``ChildDotResolutionError``.
     """
-    expanded = _expand_path_variables(dot_file, context)
+    for candidate in resolve_dot_path_candidates(dot_file, source_dir, context):
+        if candidate.chosen and candidate.path:
+            return candidate.path
+    # Unreachable: the os.getcwd() tier always yields a path for a relative
+    # dot_file, and the absolute tier always yields one for an absolute value.
+    return _expand_path_variables(dot_file, context)
 
-    if os.path.isabs(expanded):
-        return expanded
 
-    if source_dir:
-        return os.path.join(source_dir, expanded)
+class ChildDotResolutionError(Exception):
+    """A ``shape=folder`` node's ``dot_file=`` named no existing child graph.
 
-    # Try context.target_dir before falling back to os.getcwd()
-    target_dir = context.get("context.target_dir") if context else None
-    if target_dir:
-        return os.path.join(target_dir, expanded)
+    Issue #200.  This is deliberately a *distinct* error class, raised at node
+    ENTRY, because the failure it describes is a child-graph RESOLUTION fault
+    — not the edge-routing fault the engine's ``no_matching_edge`` termination
+    used to frame it as.  A FAIL Outcome returned from here reaches edge
+    selection, where FAIL is fail-fast (no plain-edge drift), so a graph with
+    no failure edge terminated with "No matching edge from node 'X'" and the
+    real cause (a missing file, usually resolved against the wrong base
+    directory) was buried in an error_type that pointed at the wrong subsystem.
 
-    return os.path.join(os.getcwd(), expanded)
+    The message names the node, the literal ``dot_file=`` value, and every
+    tier of the EXTENSIONS.md §10 precedence chain, so a wrong-base-directory
+    resolution is readable rather than inferred.
+    """
+
+    def __init__(
+        self,
+        *,
+        node_id: str,
+        dot_file: str,
+        expanded: str,
+        resolved_path: str,
+        candidates: list[DotPathCandidate],
+    ) -> None:
+        self.node_id = node_id
+        self.dot_file = dot_file
+        self.expanded = expanded
+        self.resolved_path = resolved_path
+        self.candidates = candidates
+        super().__init__(self._format())
+
+    def _format(self) -> str:
+        expansion_note = (
+            ""
+            if self.expanded == self.dot_file
+            else f' (expanded to "{self.expanded}")'
+        )
+        lines = [
+            (
+                f"Child DOT file not found for node '{self.node_id}': "
+                f'dot_file="{self.dot_file}"{expansion_note} resolved to '
+                f"{self.resolved_path!r}, which does not exist."
+            ),
+            "This is a child-graph RESOLUTION failure, not an edge-routing failure.",
+            (
+                "Candidate paths tried (specs/EXTENSIONS.md §10 precedence chain — "
+                "the first applicable tier wins):"
+            ),
+        ]
+        for index, candidate in enumerate(self.candidates, start=1):
+            if candidate.path is None:
+                lines.append(
+                    f"  {index}. {candidate.tier}: n/a — {candidate.unavailable_reason}"
+                )
+                continue
+            marks = []
+            marks.append("CHOSEN" if candidate.chosen else "not consulted")
+            marks.append("EXISTS" if candidate.exists else "missing")
+            lines.append(
+                f"  {index}. {candidate.tier}: {candidate.path}  [{', '.join(marks)}]"
+            )
+
+        elsewhere = [c for c in self.candidates if c.exists and not c.chosen]
+        if elsewhere:
+            found = "; ".join(f"{c.tier} -> {c.path}" for c in elsewhere)
+            lines.append(
+                "NOTE: the child DOT DOES exist under a lower-precedence tier "
+                f"({found}) — dot_file= resolved against the wrong base directory."
+            )
+        lines.append(
+            "Fix: create the child DOT at the CHOSEN path, correct the dot_file= "
+            "value, or have an upstream node write it before this node runs "
+            "(write-then-run composition — resolution is intentionally lazy, so a "
+            "runtime-generated child is supported)."
+        )
+        return "\n".join(lines)
 
 
 class PipelineHandler:
@@ -111,7 +287,9 @@ class PipelineHandler:
         Steps:
         1. Get dot_file from node.attrs, FAIL if missing.
         2. Resolve path via resolve_dot_path().
-        3. Read the DOT file, FAIL if not found.
+        3. Assert the child DOT exists at node ENTRY; raise
+           ChildDotResolutionError (issue #200) naming every candidate path if
+           it does not, then read it.
         4. Parse DOT source, FAIL if invalid.
         5. Set child_graph.source_dir for nested resolution.
         6. Clone parent context.
@@ -134,18 +312,42 @@ class PipelineHandler:
                 failure_reason="Missing dot_file attribute on pipeline node",
             )
 
-        # (2) Resolve path
+        # (2) Resolve path.  Resolution itself stays LAZY (EXTENSIONS.md §10):
+        # the candidate chain is walked with no existence check, so a child DOT
+        # written earlier in THIS run (write-then-run composition) resolves
+        # exactly as it always has.
+        candidates = resolve_dot_path_candidates(dot_file, graph.source_dir, context)
         resolved_path = resolve_dot_path(dot_file, graph.source_dir, context)
 
-        # (3) Read the DOT file
+        # (3) Assert existence at node ENTRY, then read the DOT file.
+        #
+        # Issue #200: returning Outcome(FAIL, ...) here sends the failure into
+        # edge selection, where FAIL is fail-fast — so a graph with no failure
+        # edge terminated as `no_matching_edge` / "No matching edge from node
+        # 'X'", framing a missing FILE as a ROUTING fault.  Raising a distinct
+        # resolution error instead keeps the fault in its own class: the engine
+        # reports it as a child-graph resolution failure, and the message names
+        # every tier of the precedence chain so a wrong-base-directory
+        # resolution is readable rather than inferred.
+        def _resolution_error() -> ChildDotResolutionError:
+            return ChildDotResolutionError(
+                node_id=node.id,
+                dot_file=str(dot_file),
+                expanded=_expand_path_variables(str(dot_file), context),
+                resolved_path=resolved_path,
+                candidates=candidates,
+            )
+
+        if not os.path.isfile(resolved_path):
+            raise _resolution_error()
+
         try:
             with open(resolved_path) as f:
                 dot_source = f.read()
         except FileNotFoundError:
-            return Outcome(
-                status=StageStatus.FAIL,
-                failure_reason=f"Child DOT file not found: {resolved_path}",
-            )
+            # The file vanished between the check above and the open (or the
+            # path is a dangling symlink) — same fault, same diagnostic.
+            raise _resolution_error() from None
 
         # (4) Parse DOT source
         try:

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/retry.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/retry.py
@@ -229,6 +229,21 @@ async def execute_with_retry(
                 node, context, graph, logs_root, engine=engine
             )
         except Exception as e:
+            # Issue #200: a shape=folder node whose dot_file= names no existing
+            # child graph raises ChildDotResolutionError at node ENTRY.  That is
+            # a child-graph RESOLUTION fault, not node work that failed, so it
+            # must NOT be flattened into a FAIL Outcome here: a FAIL Outcome
+            # goes to edge selection, where fail-fast routing turns a missing
+            # FILE into a `no_matching_edge` termination that names the wrong
+            # subsystem.  Re-raise so the engine can report it in its own class.
+            # (Retrying it would be pointless anyway — nothing here creates the
+            # missing file.)  Lazy import: keeps retry.py's module-level import
+            # graph free of any dependency on the handlers package.
+            from .handlers.pipeline import ChildDotResolutionError
+
+            if isinstance(e, ChildDotResolutionError):
+                raise
+
             logger.warning(
                 "Node %s attempt %d/%d raised: %s",
                 node.id,

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/validation.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/validation.py
@@ -4,7 +4,7 @@ Validates parsed Graph models against the rules defined in
 spec Section 7 (Validation and Linting). Produces Diagnostic objects
 with severity ERROR (blocks execution) or WARNING (informational).
 
-Spec coverage: LINT-001–018.  TOPO-001–009 are topological basin-lint rules
+Spec coverage: LINT-001–018.  TOPO-001–010 are topological basin-lint rules
 implemented here beyond the canonical spec; they are lint-only (exposed via
 ``lint()``, not ``validate()``) and do not change run-time behaviour.
 TOPO-009 warns when an ``outcome=<status word>`` edge condition shares a
@@ -22,6 +22,7 @@ severity) and do not change run-time behaviour.
 
 from __future__ import annotations
 
+import os
 import re
 from collections import deque
 from collections.abc import Callable
@@ -128,8 +129,8 @@ def lint(graph: Graph) -> list[Diagnostic]:
     """Run topological (basin-lint) and command-content rules in addition to structural rules.
 
     This is the entry point for the ``attractor lint`` CLI command.  It runs
-    the full structural ``validate()`` suite plus the nine topological rules
-    (TOPO-001–009) that reason about cycle structure, handler semantics,
+    the full structural ``validate()`` suite plus the ten topological rules
+    (TOPO-001–010) that reason about cycle structure, handler semantics,
     evidence-routing patterns and condition-key hazards, plus the two
     command-content rules (CMD-001–002)
     that inspect ``tool_command`` strings for hazard shapes.
@@ -154,6 +155,7 @@ def lint(graph: Graph) -> list[Diagnostic]:
     _check_gate_retry_budget_dead(graph, diags)
     _check_inert_evidence_gate(graph, diags)
     _check_outcome_label_shadowing(graph, diags)
+    _check_folder_dot_file_absent(graph, diags)
     _check_pipe_masked_exit_code(graph, diags)
     _check_always_true_sentinel(graph, diags)
     return diags
@@ -793,7 +795,7 @@ def _check_response_schema(graph: Graph, diags: list[Diagnostic]) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Topological (basin-lint) rules — TOPO-001 through TOPO-009
+# Topological (basin-lint) rules — TOPO-001 through TOPO-010
 #
 # These rules reason about cycle structure and handler semantics, not just
 # graph topology.  They are exposed via ``lint()`` (not ``validate()``) so
@@ -2341,6 +2343,93 @@ def _check_outcome_label_shadowing(graph: Graph, diags: list[Diagnostic]) -> Non
                     f"off its labelled edge instead. See "
                     f"DOT-AUTHORING-GUIDE.md (TOPO-009) and "
                     f"docs/ROUTING-REFERENCE.md §3."
+                ),
+            )
+        )
+
+
+# ---------------------------------------------------------------------------
+# TOPO-010 — a shape=folder node whose STATIC relative dot_file= target is
+# absent at lint time.
+#
+# Issue #200.  The complaint there is real: a missing child DOT used to
+# surface mid-run as a `no_matching_edge` termination.  The node-entry fix
+# (handlers/pipeline.py's ChildDotResolutionError) makes that failure legible,
+# and this rule offers the author the same information one step earlier.
+#
+# Severity: WARNING, and deliberately ADVISORY — never ERROR, never in
+# validate()/validate_or_raise().  The linter genuinely cannot tell "the
+# author typo'd the path" from "a node upstream writes this file during the
+# run": write-then-run composition (a node generates a child .dot mid-run and
+# a later folder node executes it) is a supported, shipped shape —
+# examples/objective/objective-runner.dot does exactly this, and
+# EXTENSIONS.md §10's resolution is lazy precisely so it can.  An ERROR here
+# would block every composition graph; per §32's entry-point discriminator a
+# lint-only WARNING blocks nothing and fails no exit code.
+#
+# What it deliberately does NOT flag:
+#   • an ABSOLUTE dot_file= — nothing about a lint-time absolute path tells
+#     you which machine/workspace it will resolve against at run time.
+#   • any value containing `$` — a $variable target is resolved from run-time
+#     context (EXTENSIONS.md §21); its lint-time spelling is not the path.
+#     This is also the exact shape a composition graph uses for a generated
+#     child (`dot_file="$target_dir/.objective/gen/child.dot"`).
+#   • any graph with no `source_dir` — an inline DOT source (--dot-source, a
+#     library caller, the examples sweep) has no backing file, so there is no
+#     honest base directory to resolve a relative target against.  Guessing
+#     one would manufacture false positives.
+# ---------------------------------------------------------------------------
+
+
+def _check_folder_dot_file_absent(graph: Graph, diags: list[Diagnostic]) -> None:
+    """TOPO-010: a static relative ``dot_file=`` target that is absent on disk.
+
+    Advisory only.  See the section comment above for the full skip list and
+    the reason this can never be an ERROR.
+    """
+    if not graph.source_dir:
+        return
+
+    for node in graph.nodes.values():
+        if not (node.shape == "folder" or node.type == "pipeline"):
+            continue
+        dot_file = node.attrs.get("dot_file")
+        if not dot_file or not isinstance(dot_file, str):
+            continue
+        # Runtime-substituted target: its lint-time spelling is not a path.
+        if "$" in dot_file:
+            continue
+        # Absolute target: lint-time absence says nothing about run time.
+        if os.path.isabs(dot_file):
+            continue
+
+        resolved = os.path.join(graph.source_dir, dot_file)
+        if os.path.exists(resolved):
+            continue
+
+        diags.append(
+            Diagnostic(
+                rule="folder_dot_file_absent",
+                severity="WARNING",
+                message=(
+                    f"Node '{node.id}' (shape=folder) has "
+                    f'dot_file="{dot_file}", which resolves to {resolved!r} — '
+                    f"no such file at lint time.  If an upstream node writes "
+                    f"this child graph during the run (write-then-run "
+                    f"composition), this is expected and can be ignored: "
+                    f"dot_file= resolution is lazy by design (EXTENSIONS.md "
+                    f"§10).  If not, this node will fail at execution with a "
+                    f"child-DOT resolution error (TOPO-010)."
+                ),
+                node_id=node.id,
+                fix=(
+                    f"Ship the child graph at {resolved!r}, or correct the "
+                    f"dot_file= value — a relative dot_file= resolves against "
+                    f"the parent .dot file's own directory FIRST "
+                    f"(EXTENSIONS.md §10 precedence chain), not against --cwd.  "
+                    f"If an upstream node generates this file at run time, no "
+                    f"change is needed — this is a WARNING, not an error, and "
+                    f"it does not affect the exit code."
                 ),
             )
         )

--- a/modules/loop-pipeline/tests/test_child_dot_resolution.py
+++ b/modules/loop-pipeline/tests/test_child_dot_resolution.py
@@ -1,0 +1,366 @@
+"""Issue #200 -- a missing child ``dot_file=`` is a RESOLUTION fault, not a routing one.
+
+Before this change, a ``shape=folder`` node whose ``dot_file=`` named no
+existing child graph returned ``Outcome(FAIL, "Child DOT file not found: X")``.
+FAIL is fail-fast at edge selection, so a parent graph with no failure edge
+terminated with::
+
+    [PIPELINE] x Error at child (no_matching_edge): Child DOT file not found: ...
+    attractor: notes:
+    No matching edge from node 'child'
+
+-- a routing framing for a missing FILE, printing only the single chosen path
+so "resolved against the wrong base directory" had to be inferred.
+
+What this file pins:
+
+* the node-entry error class (``ChildDotResolutionError``) names the node, the
+  literal ``dot_file=`` value, and EVERY tier of the EXTENSIONS.md section 10
+  precedence chain;
+* the engine reports it as ``error_type="child_dot_resolution"`` and the
+  ``no_matching_edge`` framing is GONE (this is the RED-against-main test --
+  on main the run's notes read "No matching edge from node 'child'");
+* the load-bearing compat proof: WRITE-THEN-RUN COMPOSITION STILL WORKS.
+  Admission stays LAZY (no existence check in ``validate_or_raise``), so a
+  node that writes ``gen/child.dot`` mid-run and a later folder node that
+  executes it still succeed end to end.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from amplifier_module_loop_pipeline.context import PipelineContext
+from amplifier_module_loop_pipeline.engine import PipelineEngine
+from amplifier_module_loop_pipeline.graph import Edge, Graph, Node
+from amplifier_module_loop_pipeline.handlers import HandlerRegistry
+from amplifier_module_loop_pipeline.handlers.context import HandlerContext
+from amplifier_module_loop_pipeline.handlers.pipeline import (
+    ChildDotResolutionError,
+    PipelineHandler,
+    resolve_dot_path,
+    resolve_dot_path_candidates,
+)
+from amplifier_module_loop_pipeline.outcome import StageStatus
+from amplifier_module_loop_pipeline.validation import validate, validate_or_raise
+
+# A child graph that leaves a durable artifact, so "the child really ran" is
+# provable from the filesystem rather than from the outcome's self-report.
+_CHILD_DOT = """\
+digraph generated_child {
+    cstart [shape=Mdiamond]
+    work   [shape=parallelogram, tool_command="printf child-evidence-200 > child-proof.txt"]
+    cdone  [shape=Msquare]
+    cstart -> work -> cdone
+}
+"""
+
+
+def _make_engine(graph: Graph, logs_root: str, context: PipelineContext | None = None):
+    return PipelineEngine(
+        graph=graph,
+        context=context if context is not None else PipelineContext(),
+        handler_registry=HandlerRegistry(HandlerContext(backend=None)),
+        logs_root=logs_root,
+    )
+
+
+def _folder_parent(source_dir: str, dot_file: str) -> Graph:
+    """start -> child(folder) -> done, with NO failure edge (the issue's graph)."""
+    return Graph(
+        name="parent",
+        nodes={
+            "start": Node(id="start", shape="Mdiamond"),
+            "child": Node(id="child", shape="folder", attrs={"dot_file": dot_file}),
+            "done": Node(id="done", shape="Msquare"),
+        },
+        edges=[
+            Edge(from_node="start", to_node="child"),
+            Edge(from_node="child", to_node="done"),
+        ],
+        source_dir=source_dir,
+    )
+
+
+# ---------------------------------------------------------------------------
+# resolve_dot_path_candidates() -- the diagnostic sibling of resolve_dot_path()
+# ---------------------------------------------------------------------------
+
+
+class TestResolveDotPathCandidates:
+    """The candidate chain must describe exactly what resolve_dot_path() does."""
+
+    def test_chosen_candidate_is_what_resolve_dot_path_returns(self) -> None:
+        ctx = PipelineContext()
+        ctx.set("context.target_dir", "/workspace")
+        candidates = resolve_dot_path_candidates("child.dot", "/graphs", ctx)
+        chosen = [c for c in candidates if c.chosen]
+        assert len(chosen) == 1
+        assert chosen[0].path == resolve_dot_path("child.dot", "/graphs", ctx)
+
+    def test_all_four_tiers_are_reported_in_precedence_order(self) -> None:
+        ctx = PipelineContext()
+        ctx.set("context.target_dir", "/workspace")
+        candidates = resolve_dot_path_candidates("child.dot", "/graphs", ctx)
+        assert [c.tier for c in candidates] == [
+            "absolute path",
+            "graph.source_dir",
+            "context.target_dir",
+            "os.getcwd()",
+        ]
+        # source_dir wins; the lower tiers are reported but not chosen.
+        assert candidates[1].chosen
+        assert candidates[1].path == "/graphs/child.dot"
+        assert candidates[2].path == "/workspace/child.dot"
+        assert candidates[3].path == os.path.join(os.getcwd(), "child.dot")
+        assert not any(c.chosen for c in (candidates[0], candidates[2], candidates[3]))
+
+    def test_absolute_target_stops_the_chain_at_tier_one(self) -> None:
+        """os.path.join(base, "/abs") is "/abs" for any base -- tiers 2-4 are n/a."""
+        ctx = PipelineContext()
+        ctx.set("context.target_dir", "/workspace")
+        candidates = resolve_dot_path_candidates("/abs/child.dot", "/graphs", ctx)
+        assert candidates[0].chosen and candidates[0].path == "/abs/child.dot"
+        for lower in candidates[1:]:
+            assert lower.path is None
+            assert "absolute" in lower.unavailable_reason
+
+    def test_unavailable_tiers_say_why(self) -> None:
+        ctx = PipelineContext()  # no context.target_dir
+        candidates = resolve_dot_path_candidates("child.dot", "", ctx)
+        assert candidates[1].path is None
+        assert "graph.source_dir is empty" in candidates[1].unavailable_reason
+        assert candidates[2].path is None
+        assert "context.target_dir is unset" in candidates[2].unavailable_reason
+        assert candidates[3].chosen  # cwd is the last resort
+
+    def test_variable_expansion_happens_before_the_chain(self) -> None:
+        ctx = PipelineContext()
+        ctx.set("lane", "bugfix")
+        candidates = resolve_dot_path_candidates("$lane/child.dot", "/graphs", ctx)
+        assert candidates[1].chosen
+        assert candidates[1].path == "/graphs/bugfix/child.dot"
+
+    def test_exists_is_computed_per_candidate(self, tmp_path) -> None:
+        (tmp_path / "child.dot").write_text(_CHILD_DOT)
+        ctx = PipelineContext()
+        candidates = resolve_dot_path_candidates("child.dot", str(tmp_path), ctx)
+        assert candidates[1].exists is True
+        candidates = resolve_dot_path_candidates("nope.dot", str(tmp_path), ctx)
+        assert candidates[1].exists is False
+
+
+# ---------------------------------------------------------------------------
+# The node-entry error itself
+# ---------------------------------------------------------------------------
+
+
+class TestChildDotResolutionErrorAtNodeEntry:
+    """The handler raises a DISTINCT resolution error, with the full chain."""
+
+    @pytest.mark.asyncio
+    async def test_missing_child_raises_resolution_error_naming_every_candidate(
+        self, tmp_path
+    ) -> None:
+        graph = _folder_parent(str(tmp_path), "missing-child.dot")
+        handler = PipelineHandler()
+
+        with pytest.raises(ChildDotResolutionError) as excinfo:
+            await handler.execute(
+                graph.nodes["child"],
+                PipelineContext(),
+                graph,
+                str(tmp_path / "logs"),
+            )
+
+        exc = excinfo.value
+        assert exc.node_id == "child"
+        assert exc.dot_file == "missing-child.dot"
+
+        message = str(exc)
+        # Names the node and the LITERAL dot_file= value.
+        assert "node 'child'" in message
+        assert 'dot_file="missing-child.dot"' in message
+        # Names every candidate path that was tried.
+        for tier in (
+            "absolute path",
+            "graph.source_dir",
+            "context.target_dir",
+            "os.getcwd()",
+        ):
+            assert tier in message
+        assert str(tmp_path / "missing-child.dot") in message
+        assert "[CHOSEN, missing]" in message
+        # And says, in words, that this is not a routing problem.
+        assert "RESOLUTION failure, not an edge-routing failure" in message
+
+    @pytest.mark.asyncio
+    async def test_wrong_base_directory_is_readable_not_inferred(
+        self, tmp_path
+    ) -> None:
+        """The child exists -- under a tier the precedence chain never reached."""
+        graphs_dir = tmp_path / "graphs"
+        workspace = tmp_path / "workspace"
+        graphs_dir.mkdir()
+        workspace.mkdir()
+        (workspace / "child.dot").write_text(_CHILD_DOT)
+
+        graph = _folder_parent(str(graphs_dir), "child.dot")
+        context = PipelineContext()
+        context.set("context.target_dir", str(workspace))
+
+        with pytest.raises(ChildDotResolutionError) as excinfo:
+            await PipelineHandler().execute(
+                graph.nodes["child"], context, graph, str(tmp_path / "logs")
+            )
+
+        message = str(excinfo.value)
+        assert "wrong base directory" in message
+        assert f"context.target_dir -> {workspace / 'child.dot'}" in message
+        assert "[not consulted, EXISTS]" in message
+
+    @pytest.mark.asyncio
+    async def test_present_child_still_executes_normally(self, tmp_path) -> None:
+        """The existence assertion must not disturb the happy path."""
+        (tmp_path / "child.dot").write_text(_CHILD_DOT)
+        graph = _folder_parent(str(tmp_path), "child.dot")
+
+        outcome = await PipelineHandler().execute(
+            graph.nodes["child"],
+            PipelineContext(),
+            graph,
+            str(tmp_path / "logs"),
+        )
+        assert outcome.status == StageStatus.SUCCESS
+
+
+# ---------------------------------------------------------------------------
+# The engine's framing -- this is the RED-against-main assertion
+# ---------------------------------------------------------------------------
+
+
+class TestEngineReportsAChildResolutionFaultNotARoutingFault:
+    @pytest.mark.asyncio
+    async def test_routing_framing_is_gone(self, tmp_path) -> None:
+        """On main this run's notes read "No matching edge from node 'child'".
+
+        (Named without the literal rule token on purpose: pytest builds
+        ``tmp_path`` from the test's own name, and the paths this diagnostic
+        prints would then contain the very substring the assertions forbid.)
+        """
+        events: list[tuple[str, dict]] = []
+
+        class _Hooks:
+            async def emit(self, name, data):
+                events.append((name, data))
+
+        graph = _folder_parent(str(tmp_path), "missing-child.dot")
+        engine = PipelineEngine(
+            graph=graph,
+            context=PipelineContext(),
+            handler_registry=HandlerRegistry(HandlerContext(backend=None)),
+            logs_root=str(tmp_path / "logs"),
+            hooks=_Hooks(),
+        )
+
+        outcome = await engine.run(goal="prove the framing")
+
+        # Still a failure -- a missing child is still a failure, just a legible one.
+        assert outcome.status == StageStatus.FAIL
+        notes = f"{outcome.notes or ''}\n{outcome.failure_reason or ''}"
+        assert "No matching edge" not in notes
+        assert "no_matching_edge" not in notes
+        assert "Child DOT file not found for node 'child'" in notes
+        assert "graph.source_dir" in notes  # the candidate chain came along
+
+        error_events = [d for name, d in events if name == "pipeline:error"]
+        assert error_events, "expected a pipeline:error event"
+        assert error_events[-1]["error_type"] == "child_dot_resolution"
+        assert all(d["error_type"] != "no_matching_edge" for d in error_events)
+
+    @pytest.mark.asyncio
+    async def test_resolution_fault_is_not_retried(self, tmp_path) -> None:
+        """max_retries cannot conjure the file; the fault stays terminal and clear."""
+        graph = _folder_parent(str(tmp_path), "missing-child.dot")
+        graph.nodes["child"].attrs["max_retries"] = "2"
+
+        outcome = await _make_engine(graph, str(tmp_path / "logs")).run(goal="g")
+
+        assert outcome.status == StageStatus.FAIL
+        assert "Child DOT file not found for node 'child'" in (
+            outcome.failure_reason or ""
+        )
+
+
+# ---------------------------------------------------------------------------
+# The load-bearing compat proof: write-then-run composition still works
+# ---------------------------------------------------------------------------
+
+
+class TestWriteThenRunCompositionStillWorks:
+    """EXTENSIONS.md section 10 admission stays LAZY -- issue #200 must not change that."""
+
+    def test_admission_does_not_check_existence(self, tmp_path) -> None:
+        """validate()/validate_or_raise() stay silent about an absent dot_file=."""
+        graph = _folder_parent(str(tmp_path), "gen/child.dot")
+
+        diags = validate(graph)
+        assert not [d for d in diags if d.severity == "ERROR"]
+        # Must not raise -- a composition graph has to be admitted to run at all.
+        validate_or_raise(graph)
+
+    @pytest.mark.asyncio
+    async def test_node_writes_child_dot_and_a_later_folder_node_runs_it(
+        self, tmp_path
+    ) -> None:
+        """The 3-node shape from the F2 compat finding, run end to end."""
+        workdir = tmp_path / "work"
+        workdir.mkdir()
+        child_source = workdir / "gen" / "child.dot"
+        assert not child_source.exists()  # absent at parse AND validate time
+
+        # A tool node writes the child graph at run time.  cwd is the tool
+        # handler's working directory, so write via an absolute path.
+        write_cmd = (
+            f"mkdir -p {child_source.parent} && "
+            f"cat > {child_source} <<'CHILDEOF'\n{_CHILD_DOT}CHILDEOF\n"
+            f"printf composed"
+        )
+
+        graph = Graph(
+            name="write_then_run",
+            nodes={
+                "start": Node(id="start", shape="Mdiamond"),
+                "compose": Node(
+                    id="compose",
+                    shape="parallelogram",
+                    attrs={"tool_command": write_cmd},
+                ),
+                "child": Node(
+                    id="child", shape="folder", attrs={"dot_file": "gen/child.dot"}
+                ),
+                "done": Node(id="done", shape="Msquare"),
+            },
+            edges=[
+                Edge(from_node="start", to_node="compose"),
+                Edge(from_node="compose", to_node="child"),
+                Edge(from_node="child", to_node="done"),
+            ],
+            source_dir=str(workdir),
+        )
+        validate_or_raise(graph)  # admitted with the target still absent
+
+        context = PipelineContext()
+        context.set("context.target_dir", str(workdir))
+        outcome = await _make_engine(
+            graph, str(tmp_path / "logs"), context=context
+        ).run(goal="compose then run")
+
+        assert outcome.status == StageStatus.SUCCESS, outcome.failure_reason
+        assert child_source.exists(), "the composer never wrote the child graph"
+        # The child really ran: its own artifact is on disk.
+        proof = workdir / "child-proof.txt"
+        assert proof.exists(), "the composed child did not execute"
+        assert proof.read_text() == "child-evidence-200"

--- a/modules/loop-pipeline/tests/test_pipeline_handler.py
+++ b/modules/loop-pipeline/tests/test_pipeline_handler.py
@@ -12,6 +12,7 @@ import pytest
 from amplifier_module_loop_pipeline.context import PipelineContext
 from amplifier_module_loop_pipeline.graph import Edge, Graph, Node
 from amplifier_module_loop_pipeline.handlers.pipeline import (
+    ChildDotResolutionError,
     PipelineHandler,
     resolve_dot_path,
 )
@@ -178,8 +179,16 @@ class TestPipelineHandlerExecute:
         assert outcome.status == StageStatus.SUCCESS
 
     @pytest.mark.asyncio
-    async def test_missing_dot_file_returns_fail(self, tmp_path):
-        """Missing DOT file on disk returns FAIL with 'not found'."""
+    async def test_missing_dot_file_raises_child_dot_resolution_error(self, tmp_path):
+        """Missing DOT file on disk raises at node ENTRY (issue #200).
+
+        This used to return ``Outcome(FAIL, "Child DOT file not found: X")``.
+        A FAIL Outcome reaches edge selection, where FAIL is fail-fast, so a
+        parent with no failure edge terminated as ``no_matching_edge`` -- a
+        routing framing for a missing FILE.  The fault now has its own class;
+        the engine reports it as ``error_type="child_dot_resolution"``.
+        Full coverage lives in ``test_child_dot_resolution.py``.
+        """
         graph = _make_parent_graph(tmp_path)
         node = graph.nodes["sub"]
         # Point to a non-existent file
@@ -188,11 +197,11 @@ class TestPipelineHandlerExecute:
         logs_root = str(tmp_path / "logs")
 
         handler = PipelineHandler()
-        outcome = await handler.execute(node, context, graph, logs_root)
+        with pytest.raises(ChildDotResolutionError) as excinfo:
+            await handler.execute(node, context, graph, logs_root)
 
-        assert outcome.status == StageStatus.FAIL
-        assert outcome.failure_reason is not None
-        assert "not found" in outcome.failure_reason.lower()
+        assert "not found" in str(excinfo.value).lower()
+        assert excinfo.value.node_id == "sub"
 
     @pytest.mark.asyncio
     async def test_invalid_dot_source_returns_fail(self, tmp_path):
@@ -789,15 +798,31 @@ class TestOutputsMergeBack:
         """Outputs do not merge back to parent context when child pipeline fails.
 
         The folder node declares outputs='result' and pre-seeds
-        context.result='should_not_leak'. The child DOT references a nonexistent
-        file, so the handler returns FAIL before the merge-back code runs.
+        context.result='should_not_leak'. The child pipeline RUNS and fails
+        (its tool node exits 1), so the handler propagates FAIL and the
+        merge-back code never runs.
 
         After execution, outcome.status should be FAIL and context.get('result')
         should be None, verifying that the merge-back code only runs on
         outcome.is_success.
 
+        (The child used to be a nonexistent dot_file, which was a shortcut for
+        "the handler returns FAIL".  Issue #200 gave that case its own error
+        class -- a missing child DOT now raises ChildDotResolutionError at node
+        entry instead -- so this test exercises a real child failure, which is
+        what it was always about.)
+
         Uses default PipelineHandler() (no factory).
         """
+        failing_child = tmp_path / "child_fail.dot"
+        failing_child.write_text(
+            "digraph child_fail {\n"
+            "    start [shape=Mdiamond]\n"
+            '    fail_step [shape=parallelogram, tool_command="exit 1"]\n'
+            "    done [shape=Msquare]\n"
+            "    start -> fail_step\n"
+            "}\n"
+        )
         graph = Graph(
             name="parent",
             nodes={
@@ -807,7 +832,7 @@ class TestOutputsMergeBack:
                     shape="folder",
                     type="pipeline",
                     attrs={
-                        "dot_file": "nonexistent.dot",
+                        "dot_file": "child_fail.dot",
                         "outputs": "result",
                         "context.result": "should_not_leak",
                     },

--- a/modules/loop-pipeline/tests/test_topological_lint.py
+++ b/modules/loop-pipeline/tests/test_topological_lint.py
@@ -1,4 +1,4 @@
-"""Tests for topological (basin-lint) rules — TOPO-001 through TOPO-009.
+"""Tests for topological (basin-lint) rules — TOPO-001 through TOPO-010.
 
 These rules reason about cycle structure and handler semantics, not just
 graph topology.  They are exposed via ``lint()`` (not ``validate()``) so
@@ -2386,3 +2386,123 @@ class TestOutcomeLabelShadowingCalibration:
             f"the issue's suggested conservative form fires on only "
             f"{plus_any_status_label} graphs now (was 6 of 63) -- recheck the narrowing"
         )
+
+
+# ---------------------------------------------------------------------------
+# TOPO-010: folder_dot_file_absent
+# ---------------------------------------------------------------------------
+
+
+def _folder(node_id: str = "child", dot_file: str = "child.dot") -> Node:
+    return Node(id=node_id, shape="folder", attrs={"dot_file": dot_file})
+
+
+def _folder_graph(source_dir: str, dot_file: str = "child.dot") -> Graph:
+    return _graph(
+        nodes={
+            "start": _mdiamond(),
+            "child": _folder(dot_file=dot_file),
+            "exit": _msquare(),
+        },
+        edges=[
+            Edge(from_node="start", to_node="child"),
+            Edge(from_node="child", to_node="exit"),
+        ],
+        source_dir=source_dir,
+    )
+
+
+class TestFolderDotFileAbsent:
+    """TOPO-010 (issue #200): advisory warning for a STATIC relative dot_file=.
+
+    The rule exists to give an author with a typo'd path the same information
+    the node-entry ChildDotResolutionError gives them, one step earlier.  It
+    is advisory because the linter cannot distinguish a typo from a child
+    graph an upstream node writes during the run.
+    """
+
+    def test_absent_static_relative_target_warns(self, tmp_path):
+        diags = _diag(lint(_folder_graph(str(tmp_path))), "folder_dot_file_absent")
+        assert len(diags) == 1
+        assert diags[0].node_id == "child"
+        assert 'dot_file="child.dot"' in diags[0].message
+        assert str(tmp_path / "child.dot") in diags[0].message
+
+    def test_severity_is_warning_never_error(self, tmp_path):
+        """ERROR here would block every composition graph from starting."""
+        diags = _diag(lint(_folder_graph(str(tmp_path))), "folder_dot_file_absent")
+        assert diags and all(d.severity == "WARNING" for d in diags)
+
+    def test_rule_is_lint_only_validate_stays_silent(self, tmp_path):
+        """Admission stays LAZY: validate() must not learn about existence."""
+        g = _folder_graph(str(tmp_path))
+        assert not _diag(validate(g), "folder_dot_file_absent")
+
+    def test_present_target_does_not_warn(self, tmp_path):
+        (tmp_path / "child.dot").write_text("digraph c { a [shape=Mdiamond] }")
+        diags = _diag(lint(_folder_graph(str(tmp_path))), "folder_dot_file_absent")
+        assert not diags
+
+    def test_absolute_target_is_skipped(self, tmp_path):
+        """A lint-time absolute path says nothing about the run-time machine."""
+        g = _folder_graph(str(tmp_path), dot_file=str(tmp_path / "nope" / "child.dot"))
+        assert not _diag(lint(g), "folder_dot_file_absent")
+
+    def test_variable_target_is_skipped(self, tmp_path):
+        """`$var` targets are the exact shape a composition graph uses."""
+        g = _folder_graph(str(tmp_path), dot_file="$target_dir/.gen/child.dot")
+        assert not _diag(lint(g), "folder_dot_file_absent")
+
+    def test_empty_source_dir_is_skipped(self):
+        """An inline DOT source has no backing file -- no honest base to resolve."""
+        g = _folder_graph("", dot_file="child.dot")
+        assert not _diag(lint(g), "folder_dot_file_absent")
+
+    def test_non_folder_nodes_are_ignored(self, tmp_path):
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "work": _box(attrs={"dot_file": "child.dot"}),
+                "exit": _msquare(),
+            },
+            edges=[
+                Edge(from_node="start", to_node="work"),
+                Edge(from_node="work", to_node="exit"),
+            ],
+            source_dir=str(tmp_path),
+        )
+        assert not _diag(lint(g), "folder_dot_file_absent")
+
+    def test_type_pipeline_node_is_covered(self, tmp_path):
+        """type="pipeline" is the non-shape spelling of the same handler."""
+        g = _graph(
+            nodes={
+                "start": _mdiamond(),
+                "child": Node(
+                    id="child",
+                    shape="component",
+                    type="pipeline",
+                    attrs={"dot_file": "child.dot"},
+                ),
+                "exit": _msquare(),
+            },
+            edges=[
+                Edge(from_node="start", to_node="child"),
+                Edge(from_node="child", to_node="exit"),
+            ],
+            source_dir=str(tmp_path),
+        )
+        assert len(_diag(lint(g), "folder_dot_file_absent")) == 1
+
+    def test_write_then_run_graph_is_advisory_only(self, tmp_path):
+        """The warning may fire on a legitimate composition graph -- and must
+
+        never be more than advisory when it does.  This is the case the rule
+        genuinely cannot tell apart from a typo, which is exactly why it is a
+        WARNING and lives only in lint().
+        """
+        g = _folder_graph(str(tmp_path), dot_file="gen/child.dot")
+        diags = lint(g)
+        assert _diag(diags, "folder_dot_file_absent")
+        # No ERROR anywhere -- the CLI's exit-code contract stays 0.
+        assert not [d for d in diags if d.severity == "ERROR"]

--- a/modules/pipeline-runner/amplifier_module_pipeline_runner/cli.py
+++ b/modules/pipeline-runner/amplifier_module_pipeline_runner/cli.py
@@ -549,7 +549,7 @@ def cmd_lint(args: argparse.Namespace) -> int:
     """Static topological lint of a .dot pipeline file.
 
     Parses the DOT file and runs the full basin-lint rule set:
-    structural rules (LINT-001–018), topological rules (TOPO-001–009),
+    structural rules (LINT-001–018), topological rules (TOPO-001–010),
     and command-content rules (CMD-001–002, which inspect tool_command
     strings for pipe-masked exit codes and always-true sentinels).
 
@@ -584,6 +584,13 @@ def cmd_lint(args: argparse.Namespace) -> int:
     except Exception as e:  # noqa: BLE001 -- fail loud with the real error, no fallback
         print(f"attractor lint: failed to parse {dot_path}: {e}", file=sys.stderr)
         return 1
+
+    # Seed source_dir exactly as cmd_run does (the directory of the .dot file
+    # that produced this graph -- EXTENSIONS.md §10 tier 2).  TOPO-010 needs it
+    # to resolve a static relative dot_file= the same way the engine will at run
+    # time; without it the rule cannot tell where a relative target points and
+    # deliberately stays silent.  No other lint rule reads source_dir.
+    graph.source_dir = str(dot_path.resolve().parent)
 
     diags = lint(graph)
 

--- a/modules/pipeline-runner/tests/test_lint_folder_dot_file.py
+++ b/modules/pipeline-runner/tests/test_lint_folder_dot_file.py
@@ -1,0 +1,98 @@
+"""`attractor lint` + TOPO-010 (issue #200): advisory, never blocking.
+
+The rule warns when a ``shape=folder`` node's STATIC relative ``dot_file=``
+target is absent at lint time.  The exit-code contract is the whole point:
+the linter genuinely cannot tell "the author typo'd the path" from "a node
+upstream writes this file during the run", so it must never fail the build of
+a composition graph.  These tests pin rc=0 in both cases.
+
+They also pin the seam the rule depends on: ``cmd_lint`` seeds
+``graph.source_dir`` from the .dot file's own directory, the same way
+``cmd_run`` does (EXTENSIONS.md §10 tier 2).  Without it the rule cannot know
+where a relative target points and stays silent.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from amplifier_module_pipeline_runner import cli
+
+_PARENT_DOT = """\
+digraph parent {{
+    start [shape=Mdiamond];
+    child [shape=folder, dot_file="{target}", label="composed child"];
+    done  [shape=Msquare];
+    start -> child -> done;
+}}
+"""
+
+_CHILD_DOT = """\
+digraph child {
+    cstart [shape=Mdiamond];
+    cdone  [shape=Msquare];
+    cstart -> cdone;
+}
+"""
+
+
+def _write_parent(tmp_path: Path, target: str) -> str:
+    parent = tmp_path / "parent.dot"
+    parent.write_text(_PARENT_DOT.format(target=target), encoding="utf-8")
+    return str(parent)
+
+
+class TestFolderDotFileAbsentIsAdvisory:
+    def test_missing_static_child_warns_and_exits_zero(self, tmp_path, capsys):
+        """The issue's own graph: WARNING named, rc=0 -- lint does NOT fail."""
+        rc = cli.main(["lint", _write_parent(tmp_path, "missing-child.dot")])
+        out = capsys.readouterr().out
+
+        assert rc == 0, "an advisory warning must never fail the exit code"
+        assert "WARNING: [folder_dot_file_absent]" in out
+        assert "[child]" in out  # names the node
+        assert 'dot_file="missing-child.dot"' in out  # names the literal target
+        assert str(tmp_path / "missing-child.dot") in out  # names where it looked
+        assert "ERROR:" not in out
+
+    def test_write_then_run_graph_still_exits_zero(self, tmp_path, capsys):
+        """Target absent at lint time but written at run time: advisory, rc=0.
+
+        This is the case the rule cannot distinguish from a typo -- which is
+        exactly why it is a WARNING.  It must never block a composition graph.
+        """
+        rc = cli.main(["lint", _write_parent(tmp_path, "gen/child.dot")])
+        out = capsys.readouterr().out
+
+        assert rc == 0
+        assert "folder_dot_file_absent" in out
+        assert "ERROR:" not in out
+
+    def test_present_child_produces_no_finding(self, tmp_path, capsys):
+        (tmp_path / "child.dot").write_text(_CHILD_DOT, encoding="utf-8")
+        rc = cli.main(["lint", _write_parent(tmp_path, "child.dot")])
+        out = capsys.readouterr().out
+
+        assert rc == 0
+        assert "folder_dot_file_absent" not in out
+
+    def test_absolute_and_variable_targets_are_skipped(self, tmp_path, capsys):
+        rc_abs = cli.main(["lint", _write_parent(tmp_path, str(tmp_path / "nope.dot"))])
+        out_abs = capsys.readouterr().out
+        assert rc_abs == 0
+        assert "folder_dot_file_absent" not in out_abs
+
+        rc_var = cli.main(
+            ["lint", _write_parent(tmp_path, "$target_dir/.gen/child.dot")]
+        )
+        out_var = capsys.readouterr().out
+        assert rc_var == 0
+        assert "folder_dot_file_absent" not in out_var
+
+    def test_strict_mode_still_honours_its_own_contract(self, tmp_path, capsys):
+        """--strict fails on ANY diagnostic; the default run must not."""
+        parent = _write_parent(tmp_path, "missing-child.dot")
+
+        assert cli.main(["lint", parent]) == 0
+        capsys.readouterr()
+        assert cli.main(["lint", parent, "--strict"]) == 1

--- a/skills/attractorify/SKILL.md
+++ b/skills/attractorify/SKILL.md
@@ -378,7 +378,7 @@ the objection's disposition recorded (`caveats:` line if unresolved). Then:
    is in what you hand back.** Not "lint before handing back" -- an obligation
    you can discharge inside your own reasoning is not an obligation, which is
    why this one names where the result lands. A `.dot` that fails
-   `attractor lint` (TOPO-001 through TOPO-009, documented in
+   `attractor lint` (TOPO-001 through TOPO-010, documented in
    `docs/DOT-AUTHORING-GUIDE.md`) is not a runnable artifact: fix the findings,
    re-run, and relay the final verdict with any surviving warnings quoted. If
    the linter cannot be run here, say that in the handback, in those words, and

--- a/specs/EXTENSIONS.md
+++ b/specs/EXTENSIONS.md
@@ -289,6 +289,64 @@ on disk. The precedence chain above means an explicitly-set `graph.source_dir` a
 over `context.target_dir` for `dot_file=` resolution: pointing `--cwd` at a separate
 workspace does not require flattening a multi-file pipeline into that workspace.
 
+*Addendum (2026-08-18, issue #200): an unresolvable child `dot_file=` is now its own
+**terminal failure class at NODE ENTRY**, and the resolution diagnostic names **every** tier
+of the chain above -- not only the tier that won.*
+
+**What did not change (the load-bearing part).** Resolution stays **LAZY**. There is still no
+existence check in `resolve_dot_path()`, and still none in `validate()` /
+`validate_or_raise()`: a `dot_file=` target that does not exist at parse or admission time is
+a **supported shape**. That laziness is what makes **write-then-run composition** possible --
+a node writes a child `.dot` during the run and a later `shape=folder` node executes it --
+which `examples/objective/objective-runner.dot`'s `compose` path does today
+(`docs/designs/2026-08-15-objective-layer.md` §2 P1 / §2.6 finding F2). An admission-time
+existence gate would make that graph, and any composition layer, unable to start at all. It
+was considered and deliberately **rejected**.
+
+**What changed.** The old behaviour returned `Outcome(FAIL, "Child DOT file not found: X")`
+from `PipelineHandler.execute()` step 3. A FAIL outcome goes to edge selection, where FAIL is
+fail-fast (§16, no plain-edge drift), so a parent graph with no failure edge terminated
+through the §33 no-matching-edge hard fail:
+
+```
+[PIPELINE] ✗ Error at child (no_matching_edge): Child DOT file not found: /tmp/…/missing-child.dot
+attractor: notes:
+No matching edge from node 'child'
+```
+
+That framing named the wrong subsystem -- there was no routing problem -- and printed only
+the single chosen path, so "resolved against the wrong base directory" had to be inferred.
+
+The handler now asserts existence at **node entry** and raises `ChildDotResolutionError`
+(`handlers/pipeline.py`), a distinct class carrying the node id, the literal `dot_file=`
+value (plus its `$variable`-expanded form when they differ), and each of the four tiers above
+with its would-be path, whether that path exists, and whether it was chosen or skipped
+because an earlier tier won. When a lower-precedence tier *does* hold the file, the message
+says so outright. `execute_with_retry()` re-raises it rather than flattening it into a FAIL
+outcome (retrying cannot create the file); `PipelineEngine.run()` catches it before Step 5
+and terminates with `error_type="child_dot_resolution"`, and `run_subgraph()` preserves the
+same diagnostic verbatim for folder nodes reached through a parallel branch or the
+manager-loop in-graph path.
+
+**Deliberately terminal.** There is no child graph to run and no honest way to route around
+one that does not exist, so this fault does not participate in §3.7 per-node failure routing.
+Folder-node failure routing itself is untouched: a child that *runs* and fails still
+propagates FAIL verbatim and still takes an `outcome=fail` edge or a `retry_target`
+(`test_folder_node_failure_routing.py`). Only the "there is no child" case is terminal.
+
+**Advisory lint sibling.** `attractor lint` gained **TOPO-010** (`WARNING`, lint-only) for a
+*static relative* `dot_file=` target absent at lint time -- see §32's catalog. It is advisory
+because the linter cannot distinguish an author's typo from a child an upstream node writes
+mid-run, and it skips absolute targets, `$variable` targets, and graphs with no `source_dir`.
+It never fails the exit code and never blocks a composition graph.
+
+**Known residual (named, not silently absorbed):** the manager-loop child dotfile path
+(`handlers/manager_loop.py`, `shape=house` / `stack.manager_loop`, marked experimental in the
+shape table) still returns `Outcome(FAIL, "Child DOT file not found: …")` and is unchanged
+here. It shares `resolve_dot_path()` but not the folder node's execution branch or its
+routing semantics; converting it is a separate behaviour change with its own compat surface,
+and issue #200's repro does not cover it.
+
 ---
 
 ## 11. Sub-Pipeline and Manager-Child Execution Is a Fresh Session Boundary
@@ -1802,6 +1860,23 @@ as a status). Listed here so this entry
 stays the complete catalog of the `lint()`-only rule family; per this entry's own discriminator
 (the **entry point**, not the rule count), none of them owed a new ledger entry. All four are
 documented in `docs/DOT-AUTHORING-GUIDE.md` with fix examples.
+
+*Addendum (2026-08-18, issue #200): **TOPO-010** (`WARNING`) joins the same advisory entry point
+— a `shape=folder` node whose **static relative** `dot_file=` target is absent at lint time. It is
+the author-time sibling of §10's node-entry `ChildDotResolutionError`: the same information, one
+step earlier, for the author who simply typo'd a path. It is deliberately advisory and can never be
+an ERROR, because the linter cannot distinguish a typo from a child graph an upstream node writes
+mid-run — write-then-run composition is a supported shape (§10), and an ERROR would block every
+composition graph including `examples/objective/objective-runner.dot`. It skips absolute targets
+(a lint-time absolute path says nothing about the run-time machine), any target containing `$`
+(resolved from run-time context per §21 — and the exact shape a composition graph uses), and any
+graph with an empty `source_dir` (an inline DOT source has no backing file, so there is no honest
+base directory to resolve against; the `lint()` library entry point and
+`test_examples_lint_clean.py`'s sweep are therefore untouched). `attractor lint` seeds
+`graph.source_dir` from the `.dot` file's own directory for this rule, the same way `attractor run`
+already does. Measured over this repository's shipped corpus: **zero** of the 33 `examples/**/*.dot`
+graphs fire it. Pinned by `test_topological_lint.py::TestFolderDotFileAbsent` and
+`modules/pipeline-runner/tests/test_lint_folder_dot_file.py` (the rc=0 contract).*
 
 TOPO-009 is the first rule in the family whose whole subject is a ledgered divergence rather than
 a topology defect: §22 / ATX-5 is deliberate and load-bearing, and the rule does not argue with


### PR DESCRIPTION
Fixes #200

A `shape=folder` node whose `dot_file=` resolved to a missing/wrong path surfaced mid-run as a `no_matching_edge` error — a routing framing for a missing *file* — and printed only the single chosen path, so "resolved against the wrong base directory" had to be inferred. This makes the failure legible **without** removing the lazy resolution that write-then-run composition depends on.

Design is the maintainer's F2 comment on #200, followed as written: **keep admission lazy · fix the error at node entry · add an advisory lint WARNING**.

---

## Before → after (both quoted from real `attractor run`)

The issue's repro graph, verbatim:

```dot
digraph parent {
  start [shape=Mdiamond];
  child [shape=folder, dot_file="missing-child.dot", label="composed child"];
  done  [shape=Msquare];
  start -> child -> done;
}
```

**BEFORE** — `origin/main` @ `0cb2db0`, `attractor run parent.dot --cwd .`, rc=1:

```
[PIPELINE] ✗ Error at child (no_matching_edge): Child DOT file not found: /tmp/i200-proof/base/missing-child.dot
attractor: status=fail
attractor: notes:
No matching edge from node 'child'
```

There is no routing problem. `no_matching_edge` names the wrong subsystem, and one path is not enough to debug a four-tier precedence chain.

**AFTER** — same graph, same command, still rc=1:

```
[PIPELINE] ✗ Error at child (child_dot_resolution): Child DOT file not found for node 'child': dot_file="missing-child.dot" resolved to '/tmp/i200-proof/after/missing-child.dot', which does not exist.
This is a child-graph RESOLUTION failure, not an edge-routing failure.
Candidate paths tried (specs/EXTENSIONS.md §10 precedence chain — the first applicable tier wins):
  1. absolute path: n/a — dot_file= is relative after $variable expansion
  2. graph.source_dir: /tmp/i200-proof/after/missing-child.dot  [CHOSEN, missing]
  3. context.target_dir: /tmp/i200-proof/after/missing-child.dot  [not consulted, missing]
  4. os.getcwd(): /tmp/i200-proof/after/missing-child.dot  [not consulted, missing]
Fix: create the child DOT at the CHOSEN path, correct the dot_file= value, or have an upstream node write it before this node runs (write-then-run composition — resolution is intentionally lazy, so a runtime-generated child is supported).
attractor: status=fail
```

`no_matching_edge` is gone; the node id, the literal `dot_file=` value and every candidate are named. The run still ends `status=fail` — a missing child is still a failure, just a legible one.

And the case the issue actually cares about — **the file exists, under the wrong base directory** — is now stated rather than inferred (graph in `graphs/`, child in the `--cwd` workspace):

```
  2. graph.source_dir: /tmp/i200-proof/wrongbase/graphs/child.dot  [CHOSEN, missing]
  3. context.target_dir: /tmp/i200-proof/wrongbase/workspace/child.dot  [not consulted, EXISTS]
  4. os.getcwd(): /tmp/i200-proof/wrongbase/workspace/child.dot  [not consulted, EXISTS]
NOTE: the child DOT DOES exist under a lower-precedence tier (context.target_dir -> …/workspace/child.dot; os.getcwd() -> …/workspace/child.dot) — dot_file= resolved against the wrong base directory.
```

---

## ★ Write-then-run composition still works (the load-bearing proof)

This is the capability F2 flagged as at risk, and the reason **no** existence check was added to `validate_or_raise`.

A 3-node graph where a tool node writes `gen/child.dot` at run time and `child [shape=folder, dot_file="gen/child.dot"]` executes it. Target absent at parse **and** validate time (`ls: cannot access 'gen/child.dot': No such file or directory`):

```
attractor: status=success
```

…with both artifacts on disk afterwards:

```
-rw-rw-r-- 1 bkrabach bkrabach  18 child-proof.txt      # written by the generated CHILD
-rw-rw-r-- 1 bkrabach bkrabach 200 gen/child.dot        # written by the parent at run time
$ cat child-proof.txt
child-evidence-200
```

The exemplar is unaffected: `attractor lint examples/objective/objective-runner.dot` → **rc=0**, and exactly its two documented-deliberate warnings, unchanged:

```
WARNING: [goal_gate_has_retry] [evidence_gate] Node 'evidence_gate' has goal_gate=true but no retry_target
WARNING: [fail_routed_to_exit] [escalated] (escalated -> done) …
attractor lint: examples/objective/objective-runner.dot: 2 warning(s)
```

Its `run_child` node (`dot_file="$target_dir/.objective/gen/child.dot"`) is a `$variable` target, which TOPO-010 skips by construction — the compose path cannot be blocked by the new rule.

---

## The lint rule — TOPO-010, advisory, rc **stays** 0

`folder_dot_file_absent` / **TOPO-010**, severity **WARNING**, `lint()`-only (never `validate()` / `validate_or_raise()`).

**Flags:** a `shape=folder` node whose **static relative** `dot_file=` target is absent at lint time.
**Skips:** absolute targets (a lint-time absolute path says nothing about the run-time machine); anything containing `$` (resolved from run-time context — and the exact shape a composition graph uses); any graph with no `source_dir` (an inline DOT source has no backing file, so there is no honest base to resolve against — the `lint()` library entry point and `test_examples_lint_clean.py`'s sweep are untouched).

It can never be an ERROR: the linter cannot distinguish "the author typo'd the path" from "a node upstream writes this file", so an ERROR would refuse to lint every composition graph including the shipped exemplar.

`attractor lint` on the issue's missing-static-child graph:

```
WARNING: [folder_dot_file_absent] [child] Node 'child' (shape=folder) has dot_file="missing-child.dot", which resolves to '/tmp/i200-proof/after/missing-child.dot' — no such file at lint time. If an upstream node writes this child graph during the run (write-then-run composition), this is expected and can be ignored: dot_file= resolution is lazy by design (EXTENSIONS.md §10). If not, this node will fail at execution with a child-DOT resolution error (TOPO-010).

attractor lint: parent.dot: 2 warning(s)
LINT RC=0
```

On the **write-then-run** graph (target absent at lint time, written at run time) the warning also fires — advisory, as designed — and `LINT RC=0`. It never blocks.

Shipped-corpus sweep, all 33 `examples/**/*.dot`:

```
swept=33 files_with_errors_or_nonzero_rc=0 files_with_TOPO010=0
```

Zero new ERRORs, and zero TOPO-010 firings on shipped graphs.

---

## The design

1. **Admission stays LAZY** — no existence check in `resolve_dot_path()`, none in `validate()` / `validate_or_raise()`. A target absent at parse time remains a supported shape. Pinned by `test_admission_does_not_check_existence`.
2. **The error moved to NODE ENTRY.** `handlers/pipeline.py` gains `resolve_dot_path_candidates()`, which enumerates all four §10 tiers with each would-be path, whether it exists, and whether it was chosen or skipped because an earlier tier won; `resolve_dot_path()` delegates to it with identical semantics. The handler asserts existence at entry and raises the new `ChildDotResolutionError`.
3. **How the `no_matching_edge` framing was intercepted.** The old code returned `Outcome(FAIL, …)`; FAIL is fail-fast at edge selection, so with no failure edge the engine fell into the §33 no-matching-edge hard fail and relabelled the whole thing as routing. Two seams stop that now: `retry.py:232` re-raises `ChildDotResolutionError` instead of flattening it into a FAIL outcome (retrying cannot create the file), and `engine.py:958` catches it **before Step 5** and terminates via `_terminate_child_dot_resolution()` with `error_type="child_dot_resolution"`. `run_subgraph()` (`engine.py:1455`) keeps the same diagnostic verbatim for folder nodes under a parallel branch or the manager-loop in-graph path.
4. **Deliberately terminal, and narrowly so.** There is no child graph to run and no honest way to route around one that does not exist. Folder-node failure routing is untouched: a child that *runs* and fails still propagates FAIL verbatim and still takes an `outcome=fail` edge or a `retry_target` (`test_folder_node_failure_routing.py`, 3 tests, green).
5. **Advisory lint** — TOPO-010, above.

**Named residual, not silently absorbed:** the manager-loop child dotfile path (`handlers/manager_loop.py`, `shape=house`, marked experimental) still returns `Outcome(FAIL, "Child DOT file not found: …")`. It shares `resolve_dot_path()` but not the folder node's execution branch or its routing semantics; converting it is a separate behaviour change with its own compat surface, and #200's repro does not cover it. Recorded in the §10 addendum.

---

## Tier — QUALITY_PROTOCOL §3: **toward-spec**, with a ledger addendum paid anyway

**The diagnostic fix is toward-spec.** Canonical §3.2 step 6 says that when no edge is selected the engine returns *the last outcome unchanged if it is FAIL*. What shipped instead relabelled that outcome with a routing message — the §33 divergence. After this change the terminal outcome carries the child's real `failure_reason` rather than `"No matching edge from node 'child'"`, which is closer to the canonical shape, not further from it. No new divergence is introduced, and §33 itself is untouched for every case that genuinely is a routing dead end.

**The lint rule is additive and non-interfering.** Per §32's own discriminator — the *entry point*, not the severity or the rule count — a `lint()`-only rule owes no new ledger entry: `validate()` / `validate_or_raise()` stay silent, so no graph that runs today starts failing. Zero shipped graphs fire it.

**Ledger paid regardless**, because the node-entry behaviour change is a fact about `dot_file=` resolution worth recording: `specs/EXTENSIONS.md` §10 gets a dated addendum (2026-08-18) covering the new terminal error class, the candidate-path diagnostic, the lazy-admission constraint restated as load-bearing, the rejected admission-gate alternative, and the manager-loop residual; §32's catalog gets a dated TOPO-010 addendum. No renumbering — `test_extensions_ledger_integrity.py` green.

---

## Tests

| Test | Pins |
|---|---|
| `test_child_dot_resolution.py` (13, new) | the clear error (node id + literal `dot_file=` + all four candidates), the wrong-base-directory NOTE, `error_type="child_dot_resolution"` with the routing framing gone, no-retry, the candidate chain matching `resolve_dot_path()`, **and write-then-run end to end** |
| `test_topological_lint.py::TestFolderDotFileAbsent` (11, new) | TOPO-010: warns; severity WARNING never ERROR; absent from `validate()`; skips absolute / `$var` / empty `source_dir`; `type="pipeline"` covered; advisory on a composition graph |
| `test_lint_folder_dot_file.py` (5, new, pipeline-runner) | the **rc=0** contract at the CLI, on both the typo graph and the write-then-run graph; `--strict` still honours its own contract |
| `test_pipeline_handler.py` (2 updated) | `test_missing_dot_file_*` now pins the raise; `test_outputs_not_merged_on_child_failure` uses a child that really runs and fails (it had used a missing file as a shortcut for "returns FAIL") |

**Mutation** — revert the node-entry interception (handler returns the pre-fix routable FAIL again): **4 tests fail**, including the target assertion falling back to exactly the old framing:

```
>       assert "No matching edge" not in notes
E       AssertionError: assert 'No matching edge' not in 'No matching…ng-child.dot'
E         'No matching edge' is contained here:
E           No matching edge from node 'child'
FAILED tests/test_child_dot_resolution.py::…::test_routing_framing_is_gone
```

Restored → 13/13 green.

**Suites** (`uv sync --extra remote && uv run pytest -q`):

- loop-pipeline: **2514 passed, 25 skipped** (2489/25 at base + 25 new)
- pipeline-runner: **85 passed, 1 skipped** (80/1 at base + 5 new)

`git diff --check` clean; leak scan of all 12 changed files clean.

---

## Observations

- **The report's own premise was half right, and saying which half is the whole fix.** #200 asked for validation-time detection because "the whole graph is statically known before the run starts." True of the *graph*; false of the *filesystem the graph resolves against*. Acting on the true half (the diagnostic) while refusing the false half (admission-time gating) is what let this land without killing composition — and it is why F2's compat note was worth more than the original issue's proposed fix.
- **A precedence chain reported as a single path is a diagnostic that hides its own reasoning.** The old message printed the winner and nothing else, so the most common failure — right path, wrong base directory — was invisible at exactly the moment it mattered. Reporting the tiers that were *skipped*, and whether the file is sitting in one of them, converts a guess into a read.
- **`no_matching_edge` may be over-broad as a terminal class generally.** It is the catch-all for "the engine could not continue", so any non-routable fault that arrives as a FAIL outcome inherits a routing label. This PR carves out one such fault. Others may exist behind the same framing (a `requires=` short-circuit terminating with no failure edge is the shape I'd check next) — worth a sweep, out of scope here.
- **`attractor lint` was not seeding `graph.source_dir`, and now does.** No rule read it before, so this was invisible; it also means any future lint rule reasoning about on-disk layout now has the same base directory the engine will use. Small seam, easy to regress — `test_lint_folder_dot_file.py` pins it indirectly by depending on it.
- **Two shipped tests were using "missing dot_file" as shorthand for "child failed."** Both are now explicit about which one they mean. Convenient stand-ins for a failure mode tend to outlive the equivalence that justified them.
