### PR TITLE
fix(loop-agent): transport the child's report_outcome verdict to the parent

### DIFF
--- a/modules/loop-agent/amplifier_module_loop_agent/__init__.py
+++ b/modules/loop-agent/amplifier_module_loop_agent/__init__.py
@@ -11,9 +11,12 @@ from __future__ import annotations
 # Amplifier module metadata
 __amplifier_module_type__ = "orchestrator"
 
+import asyncio
 import logging
 from pathlib import Path
 from typing import Any
+
+from amplifier_core.events import ORCHESTRATOR_COMPLETE
 
 from .agent_session import KNOWN_PROVIDERS, AgentSession, canonical_provider
 from .config import SessionConfig
@@ -190,7 +193,7 @@ class AgentOrchestrator:
         # raises a clear FileNotFoundError naming the value and path tried — (4).
         return _resolve_system_prompt_file(spf).read_text(encoding="utf-8")
 
-    async def execute(
+    async def _execute_session(
         self,
         prompt: str,
         context: Any,
@@ -346,4 +349,158 @@ class AgentOrchestrator:
             self._coordinator.register_capability(
                 "self_delegation_depth", config.current_depth
             )
+
+        # EXTENSIONS.md 35: the mounted report tool's `last_outcome` is a single
+        # semantic completion register that OUTLIVES an invocation (the tool
+        # instance is mounted once per session, and a session is reused across
+        # execute() calls).  Reset it here, before the loop runs, so invocation
+        # N+1 can never inherit invocation N's verdict and report a stale
+        # envelope as if the child had just asserted it.
+        report_tool = self._report_outcome_tool(self._session)
+        if report_tool is not None:
+            report_tool.last_outcome = None
+
         return await self._session.process_input(prompt)
+
+    async def execute(
+        self,
+        prompt: str,
+        context: Any,
+        providers: dict[str, Any],
+        tools: dict[str, Any],
+        hooks: Any,
+        coordinator: Any = None,
+    ) -> str:
+        """Run one agent invocation and publish its completion envelope.
+
+        Wraps `_execute_session` (the actual agent loop) with the
+        EXTENSIONS.md 35 completion envelope.  EXACTLY ONE
+        `orchestrator:complete` event is emitted per invocation -- including
+        when initialization fails or the loop raises -- because the spawn
+        boundary (foundation's `PreparedBundle.spawn`) reads that event to
+        build the child's result dict, and a missing emission is
+        indistinguishable there from "the child had nothing to say".
+
+        The envelope has two deliberately separate layers:
+
+          * top-level `status` is LIFECYCLE ONLY (success / incomplete /
+            cancelled) -- how the invocation ended, never what the node
+            decided;
+          * `metadata.report_outcome` is the SEMANTIC verdict -- the child's
+            own `report_outcome` arguments, and the only thing that lets a
+            parent record `is_explicit=True`.
+
+        The return contract is unchanged: this still returns the loop's final
+        string, so every existing caller is unaffected.
+        """
+        provider_calls_before = self._provider_call_count(self._session)
+        cooperative_cancels_before = self._cooperative_cancel_count(self._session)
+
+        try:
+            response = await self._execute_session(
+                prompt, context, providers, tools, hooks, coordinator
+            )
+        except asyncio.CancelledError:
+            # Emit BEFORE re-raising: an interrupted invocation still owes the
+            # spawn boundary an envelope, and it must not promote a partial
+            # report as if the invocation had completed.
+            await self._emit_completion(
+                hooks, "cancelled", provider_calls_before, include_report=False
+            )
+            raise
+        except Exception:
+            await self._emit_completion(
+                hooks, "incomplete", provider_calls_before, include_report=False
+            )
+            raise
+
+        termination_reason = self._termination_reason(self._session)
+        if (
+            self._cooperative_cancel_count(self._session) > cooperative_cancels_before
+            or termination_reason == "cancelled"
+        ):
+            status = "cancelled"
+        elif termination_reason == "natural":
+            status = "success"
+        else:
+            # max_turns / tool_round_limit / context_limit / awaiting_input:
+            # the loop stopped because it ran into a wall, not because the work
+            # finished.
+            status = "incomplete"
+
+        await self._emit_completion(
+            hooks,
+            status,
+            provider_calls_before,
+            # EXTENSIONS.md 35: interrupted invocations do NOT promote a
+            # partial report.
+            include_report=status == "success",
+        )
+        return response
+
+    # ------------------------------------------------------------------
+    # Completion envelope helpers (EXTENSIONS.md 35)
+    # ------------------------------------------------------------------
+    #
+    # Each reads through getattr with a default rather than touching the
+    # attribute directly: `_session` is None until the first successful
+    # initialization (so an init failure still emits a well-formed envelope),
+    # and loop-agent is routinely driven in tests by hand-rolled session
+    # doubles that predate these counters.
+
+    @staticmethod
+    def _provider_call_count(session: AgentSession | None) -> int:
+        """Cumulative attempted provider calls for this session."""
+        return getattr(session, "_provider_call_count", 0)
+
+    @staticmethod
+    def _cooperative_cancel_count(session: AgentSession | None) -> int:
+        """Cumulative count of cooperatively-cancelled invocations."""
+        return getattr(session, "_cooperative_cancel_count", 0)
+
+    @staticmethod
+    def _termination_reason(session: AgentSession | None) -> str:
+        """Terminal condition of the session's most recent invocation."""
+        return getattr(session, "termination_reason", "natural")
+
+    @staticmethod
+    def _report_outcome_tool(session: AgentSession | None) -> Any | None:
+        """Return the mounted report_outcome tool, when this session has one."""
+        tools = getattr(session, "_tools", None)
+        return tools.get("report_outcome") if tools is not None else None
+
+    async def _emit_completion(
+        self,
+        hooks: Any,
+        status: str,
+        provider_calls_before: int,
+        *,
+        include_report: bool,
+    ) -> None:
+        """Emit the single `orchestrator:complete` envelope for an invocation.
+
+        `metadata` is `{}` unless this invocation both COMPLETED and left a
+        successful report behind -- a status-only completion carries no
+        verdict, which is exactly what keeps a downstream goal gate
+        fail-closed (EXTENSIONS.md 25).
+        """
+        report_tool = self._report_outcome_tool(self._session)
+        report_outcome = getattr(report_tool, "last_outcome", None)
+        metadata = (
+            {"report_outcome": report_outcome}
+            if include_report and isinstance(report_outcome, dict)
+            else {}
+        )
+
+        await hooks.emit(
+            ORCHESTRATOR_COMPLETE,
+            {
+                "orchestrator": "loop-agent",
+                "status": status,
+                "turn_count": max(
+                    0,
+                    self._provider_call_count(self._session) - provider_calls_before,
+                ),
+                "metadata": metadata,
+            },
+        )

--- a/modules/loop-agent/amplifier_module_loop_agent/agent_session.py
+++ b/modules/loop-agent/amplifier_module_loop_agent/agent_session.py
@@ -153,6 +153,17 @@ class AgentSession:
         self._use_streaming = self._detect_streaming_support()
         self._follow_up_depth = 0  # Tracks recursion depth for SESSION_END timing
         self._tracked_processes: set[Any] = set()  # M-7: running tool subprocesses
+        # EXTENSIONS.md 35 -- completion-envelope inputs.  These two are
+        # CUMULATIVE session-lifetime counters, not per-invocation ones: the
+        # orchestrator snapshots them before an invocation and diffs after, so
+        # a session reused across several execute() calls still reports a
+        # per-invocation turn_count and a per-invocation cancellation signal.
+        self._provider_call_count = 0
+        self._cooperative_cancel_count = 0
+        # Terminal condition of the MOST RECENT invocation.  Reset at the top of
+        # every process_input() so a prior invocation's ending can never
+        # classify this one's lifecycle status.
+        self._termination_reason = "natural"
 
     # ------------------------------------------------------------------
     # Streaming detection
@@ -316,6 +327,16 @@ class AgentSession:
     # Public API
     # ------------------------------------------------------------------
 
+    @property
+    def termination_reason(self) -> str:
+        """Terminal condition of the most recent invocation.
+
+        One of ``natural``, ``cancelled``, ``max_turns``, ``context_limit``,
+        ``awaiting_input`` or ``tool_round_limit``.  Read by the orchestrator to
+        classify the EXTENSIONS.md 35 completion envelope's lifecycle status.
+        """
+        return self._termination_reason
+
     async def process_input(self, prompt: str) -> str:
         """Process a user input through the agentic loop.
 
@@ -323,6 +344,9 @@ class AgentSession:
         execution, and returns the final text response.  The loop exits
         on natural completion (no tool calls), round limit, or turn limit.
         """
+        # EXTENSIONS.md 35: per-invocation reset -- a prior invocation's
+        # terminal condition must never classify this one.
+        self._termination_reason = "natural"
         # Emit session_start once (spec: SESSION_START on session creation)
         if not self._session_started:
             self._session_started = True
@@ -353,6 +377,8 @@ class AgentSession:
         while _max_rounds <= 0 or round_count < _max_rounds:
             # Checkpoint 1: Graceful cancellation at top of loop
             if self._is_cancelled():
+                self._termination_reason = "cancelled"
+                self._cooperative_cancel_count += 1
                 self._state_machine.complete()
                 await self._emit_session_end()
                 return await self._process_follow_ups(last_text)
@@ -362,6 +388,7 @@ class AgentSession:
                 self._config.max_turns > 0
                 and self._history.turn_count >= self._config.max_turns
             ):
+                self._termination_reason = "max_turns"
                 await self._hooks.emit(
                     AGENT_TURN_LIMIT,
                     {"total_turns": self._history.turn_count},
@@ -383,8 +410,12 @@ class AgentSession:
 
             # Call LLM — streaming or non-streaming based on provider capability
             try:
+                # EXTENSIONS.md 35 turn_count: count ATTEMPTED provider calls,
+                # so a call that raises still shows up in the envelope.
+                self._provider_call_count += 1
                 call_result = await self._call_provider(request)
             except ContextLengthError as e:
+                self._termination_reason = "context_limit"
                 # Spec Appendix B / STOP-005: ContextLengthError is handled
                 # separately from other non-retryable errors.  Emit a context
                 # warning (reusing AGENT_CONTEXT_WARNING) and return to IDLE
@@ -418,6 +449,8 @@ class AgentSession:
 
             # Checkpoint 2: Immediate cancellation after provider call
             if self._is_immediate_cancel():
+                self._termination_reason = "cancelled"
+                self._cooperative_cancel_count += 1
                 self._state_machine.complete()
                 await self._emit_session_end()
                 return await self._process_follow_ups(last_text)
@@ -491,6 +524,7 @@ class AgentSession:
             if not tool_calls:
                 # Detect if the model is asking the user a question
                 if self._looks_like_question(text):
+                    self._termination_reason = "awaiting_input"
                     self._state_machine.await_input()  # PROCESSING -> AWAITING_INPUT
                     await self._hooks.emit(
                         AGENT_AWAITING_INPUT,
@@ -510,6 +544,26 @@ class AgentSession:
             self._history.append(ToolResultsTurn(results=results))
             round_count += 1
 
+            # EXTENSIONS.md 35 (Ordering barrier): after the COMPLETE declared
+            # batch has run, a successful report_outcome terminates this
+            # execute() invocation -- no further provider call, and no
+            # automatic follow-up processing.  The verdict IS the node's
+            # answer; burning another provider call to have the model narrate
+            # it is what produced the cheerful-prose-after-a-FAIL class of
+            # incident in the first place.
+            #
+            # Already-queued follow-ups deliberately REMAIN queued (they are
+            # neither cleared nor consumed here) so a later explicit
+            # process_input() can still drain them.  That is also why this
+            # returns last_text directly rather than via _process_follow_ups.
+            if any(
+                tool_call.name == "report_outcome" and result.success
+                for tool_call, result in zip(raw_tool_calls, results, strict=True)
+            ):
+                self._state_machine.complete()  # PROCESSING -> IDLE
+                await self._emit_session_end()
+                return last_text
+
             # Record tool calls for loop detection
             if self._config.enable_loop_detection:
                 for tc in raw_tool_calls:
@@ -522,6 +576,7 @@ class AgentSession:
             await self._check_loop_detection()
 
         # Round limit reached
+        self._termination_reason = "tool_round_limit"
         await self._hooks.emit(AGENT_TURN_LIMIT, {"round_count": round_count})
         self._state_machine.complete()  # PROCESSING -> IDLE
         # SESSION_END emitted after follow-ups are fully drained
@@ -671,10 +726,24 @@ class AgentSession:
         """Execute tool calls, parallel or sequential based on config.
 
         Uses asyncio.gather() when supports_parallel_tool_calls is True
-        AND there are multiple tool calls. Otherwise executes sequentially
-        to preserve ordering guarantees (spec Section 3.2).
+        AND there are multiple ORDINARY tool calls (spec Section 3.2).
+
+        EXTENSIONS.md 35 (Ordering barrier): a batch containing AT LEAST ONE
+        ``report_outcome`` call is the exception -- every call in that batch
+        runs sequentially, in provider-declared order.  ``report_outcome``
+        writes a single semantic completion register (the tool's
+        ``last_outcome``); under asyncio.gather() the winner of two reports in
+        one batch would be decided by scheduling order rather than by the order
+        the model declared them, so "the last declared report wins" would not
+        be a statement anyone could rely on.  Batches without report_outcome
+        keep the configured parallel behavior unchanged.
         """
-        use_parallel = self._config.supports_parallel_tool_calls and len(tool_calls) > 1
+        has_report_outcome = any(tc.name == "report_outcome" for tc in tool_calls)
+        use_parallel = (
+            self._config.supports_parallel_tool_calls
+            and len(tool_calls) > 1
+            and not has_report_outcome
+        )
 
         if use_parallel:
             try:

--- a/modules/loop-agent/tests/test_events.py
+++ b/modules/loop-agent/tests/test_events.py
@@ -8,6 +8,7 @@ through the hooks parameter at the correct times with correct data.
 import pytest
 from unittest.mock import AsyncMock, MagicMock
 
+from amplifier_core.events import ORCHESTRATOR_COMPLETE
 from amplifier_core.message_models import ChatResponse, ToolCall, Usage
 from amplifier_core.models import ToolResult
 
@@ -289,8 +290,11 @@ async def test_event_ordering_simple():
     ate_idx = names.index(AGENT_ASSISTANT_TEXT_END)
     assert resp_idx < ate_idx
 
-    # session_end should come last
-    assert names[-1] == AGENT_SESSION_END
+    # EXTENSIONS.md 35: the OUTER orchestrator completion envelope is emitted
+    # after the inner agent-session lifecycle events, so it -- not session_end
+    # -- is last.  The spawn boundary reads that final event.
+    assert names[-2] == AGENT_SESSION_END
+    assert names[-1] == ORCHESTRATOR_COMPLETE
 
 
 @pytest.mark.asyncio
@@ -305,9 +309,11 @@ async def test_event_ordering_with_tools():
     await orch.execute("go", ctx, provs, tools, hooks)
     names = [e[0] for e in hooks._emitted]
 
-    # session_start first, session_end last
+    # session_start first; the outer orchestrator completion envelope follows
+    # session_end (EXTENSIONS.md 35).
     assert names[0] == AGENT_SESSION_START
-    assert names[-1] == AGENT_SESSION_END
+    assert names[-2] == AGENT_SESSION_END
+    assert names[-1] == ORCHESTRATOR_COMPLETE
 
     # First provider round: request -> response -> assistant_text_end
     first_req = names.index(PROVIDER_REQUEST)

--- a/modules/loop-agent/tests/test_orchestrator_completion.py
+++ b/modules/loop-agent/tests/test_orchestrator_completion.py
@@ -1,0 +1,413 @@
+"""Contract tests for the `orchestrator:complete` completion envelope.
+
+EXTENSIONS.md §35 ("Spawned-Agent Outcome Transport and `report_outcome`
+Ordering Barrier").
+
+WHY THIS FILE EXISTS (issue #285): a spawned child's semantic verdict reaches
+its parent through exactly one channel — the `orchestrator:complete` event's
+`metadata.report_outcome`.  Foundation's `PreparedBundle.spawn` registers a
+temporary hook on that event and copies `metadata` verbatim into the spawn
+result dict; loop-pipeline's `_outcome_from_spawn_result` then reads
+`metadata["report_outcome"]` and is the ONLY place an `is_explicit=True`
+outcome can come from on the spawn path.
+
+Before #285, loop-agent never emitted this event at all, so every spawned
+child arrived at its parent as a verdict-less status-only completion and the
+parent recorded `notes="Child session completed with empty final message",
+is_explicit=false` — no matter what the child had actually reported.
+
+The two layers of the envelope are deliberately separate and are asserted
+separately below:
+
+  * top-level `status` — LIFECYCLE ONLY (how the invocation ended)
+  * `metadata.report_outcome` — the SEMANTIC verdict (what the node decided)
+"""
+
+import asyncio
+from typing import ClassVar
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from amplifier_core.events import ORCHESTRATOR_COMPLETE
+from amplifier_core.message_models import ChatResponse, ToolCall, Usage
+from amplifier_core.models import ToolResult
+from amplifier_module_loop_agent import AgentOrchestrator
+
+# ---------------------------------------------------------------------------
+# Harness
+# ---------------------------------------------------------------------------
+
+
+def _text_response(text: str) -> ChatResponse:
+    return ChatResponse(
+        content=[{"type": "text", "text": text}],
+        tool_calls=None,
+        usage=Usage(input_tokens=10, output_tokens=5, total_tokens=15),
+    )
+
+
+def _tool_response(*calls, text: str = "") -> ChatResponse:
+    """A response carrying tool calls, optionally alongside assistant text."""
+    return ChatResponse(
+        content=[{"type": "text", "text": text}] if text else [],
+        tool_calls=[
+            ToolCall(id=cid, name=name, arguments=args) for cid, name, args in calls
+        ],
+        usage=Usage(input_tokens=10, output_tokens=5, total_tokens=15),
+    )
+
+
+class _ReportOutcomeDouble:
+    """Faithful stand-in for `tool-report-outcome`'s `ReportOutcomeTool`.
+
+    loop-agent does not depend on the tool package, so the two behaviors the
+    envelope actually relies on are reproduced here verbatim:
+
+      * a SUCCESSFUL call overwrites `last_outcome` (last-write-wins);
+      * a call that fails validation returns an unsuccessful ToolResult and
+        leaves `last_outcome` untouched.
+
+    The real tool is exercised end-to-end against this same contract in
+    ``modules/pipeline-runner/tests/test_spawn_report_outcome_transport.py``.
+    """
+
+    name = "report_outcome"
+    description = "Report the outcome of your work."
+    input_schema: ClassVar[dict] = {
+        "type": "object",
+        "properties": {"status": {"type": "string"}},
+        "required": ["status"],
+    }
+
+    def __init__(self) -> None:
+        self.last_outcome: dict | None = None
+
+    async def execute(self, input: dict) -> ToolResult:
+        status = input.get("status")
+        if status not in {"success", "fail", "partial_success", "retry"}:
+            return ToolResult(
+                success=False,
+                output=f"Invalid status: {status!r}",
+                error={"message": "invalid status"},
+            )
+        self.last_outcome = {k: v for k, v in input.items() if v is not None}
+        return ToolResult(success=True, output={"message": f"Outcome: {status}"})
+
+
+def _make_hooks():
+    hooks = MagicMock()
+    hooks._emitted: list[tuple[str, dict]] = []
+
+    async def _emit(event: str, data: dict):
+        hooks._emitted.append((event, data))
+        return MagicMock(action="continue")
+
+    hooks.emit = AsyncMock(side_effect=_emit)
+    return hooks
+
+
+def _make_orchestrator(responses, tools=None, config=None):
+    provider = AsyncMock()
+    provider.complete = AsyncMock(side_effect=responses)
+    providers = {"test": provider}
+    cfg = {"system_prompt": "You are a test coding agent.", **(config or {})}
+    orch = AgentOrchestrator(coordinator=MagicMock(), config=cfg)
+    return orch, MagicMock(), providers, dict(tools or {}), _make_hooks()
+
+
+def _completions(hooks) -> list[dict]:
+    return [d for name, d in hooks._emitted if name == ORCHESTRATOR_COMPLETE]
+
+
+# ---------------------------------------------------------------------------
+# The transport itself
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_report_outcome_verdict_rides_the_completion_envelope():
+    """A child's report_outcome lands in `metadata.report_outcome`.
+
+    This is the #285 defect in one assertion: at origin/main no
+    `orchestrator:complete` was emitted at all, so this list was empty and the
+    verdict never crossed the spawn boundary.
+    """
+    report = _ReportOutcomeDouble()
+    orch, ctx, provs, tools, hooks = _make_orchestrator(
+        responses=[
+            _tool_response(
+                ("tc1", "report_outcome", {"status": "fail", "preferred_label": "escalate"})
+            )
+        ],
+        tools={"report_outcome": report},
+    )
+
+    await orch.execute("go", ctx, provs, tools, hooks)
+
+    completions = _completions(hooks)
+    assert len(completions) == 1, "exactly one completion envelope per invocation"
+    envelope = completions[0]
+    assert envelope["orchestrator"] == "loop-agent"
+    assert envelope["status"] == "success"
+    assert envelope["metadata"]["report_outcome"] == {
+        "status": "fail",
+        "preferred_label": "escalate",
+    }
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_status_is_not_the_semantic_verdict():
+    """A FAIL verdict does NOT make the lifecycle status 'fail'.
+
+    The two layers stay separate: the invocation completed cleanly (lifecycle
+    `success`) while the node's verdict is `fail`.  Collapsing them would make
+    every reporting child look like a broken session.
+    """
+    report = _ReportOutcomeDouble()
+    orch, ctx, provs, tools, hooks = _make_orchestrator(
+        responses=[_tool_response(("tc1", "report_outcome", {"status": "fail"}))],
+        tools={"report_outcome": report},
+    )
+
+    await orch.execute("go", ctx, provs, tools, hooks)
+
+    envelope = _completions(hooks)[0]
+    assert envelope["status"] == "success"
+    assert envelope["metadata"]["report_outcome"]["status"] == "fail"
+
+
+@pytest.mark.asyncio
+async def test_execute_still_returns_the_final_string():
+    """§35 Compatibility: the `execute(...) -> str` contract is unchanged."""
+    orch, ctx, provs, tools, hooks = _make_orchestrator(
+        responses=[_text_response("the answer")]
+    )
+    assert await orch.execute("go", ctx, provs, tools, hooks) == "the answer"
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed: no verdict must never look like a verdict
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_report_outcome_leaves_metadata_empty():
+    """A child that never reports carries NO verdict — `metadata == {}`.
+
+    This is what keeps a downstream goal gate fail-closed (EXTENSIONS.md §25):
+    the parent sees a status-only completion and records `is_explicit=False`.
+    """
+    orch, ctx, provs, tools, hooks = _make_orchestrator(
+        responses=[_text_response("I did the thing, all good!")]
+    )
+
+    await orch.execute("go", ctx, provs, tools, hooks)
+
+    envelope = _completions(hooks)[0]
+    assert envelope["status"] == "success"
+    assert envelope["metadata"] == {}
+
+
+@pytest.mark.asyncio
+async def test_a_rejected_report_is_not_promoted():
+    """A report that fails validation leaves no verdict behind."""
+    report = _ReportOutcomeDouble()
+    orch, ctx, provs, tools, hooks = _make_orchestrator(
+        responses=[
+            _tool_response(("tc1", "report_outcome", {"status": "nonsense"})),
+            _text_response("oh well"),
+        ],
+        tools={"report_outcome": report},
+    )
+
+    await orch.execute("go", ctx, provs, tools, hooks)
+
+    assert report.last_outcome is None
+    assert _completions(hooks)[0]["metadata"] == {}
+
+
+# ---------------------------------------------------------------------------
+# Per-invocation isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_verdict_does_not_leak_into_the_next_invocation():
+    """`last_outcome` is reset before each invocation.
+
+    The tool instance is mounted once per session and the session is reused
+    across `execute()` calls, so without the reset invocation #2 would report
+    invocation #1's verdict as if the child had just asserted it.
+    """
+    report = _ReportOutcomeDouble()
+    orch, ctx, provs, tools, hooks = _make_orchestrator(
+        responses=[
+            _tool_response(("tc1", "report_outcome", {"status": "fail"})),
+            _text_response("nothing to report this time"),
+        ],
+        tools={"report_outcome": report},
+    )
+
+    await orch.execute("first", ctx, provs, tools, hooks)
+    await orch.execute("second", ctx, provs, tools, hooks)
+
+    first, second = _completions(hooks)
+    assert first["metadata"]["report_outcome"]["status"] == "fail"
+    assert second["metadata"] == {}, "invocation 2 inherited invocation 1's verdict"
+
+
+@pytest.mark.asyncio
+async def test_turn_count_is_per_invocation():
+    """`turn_count` counts THIS invocation's provider calls, not the session's."""
+    orch, ctx, provs, tools, hooks = _make_orchestrator(
+        responses=[
+            _tool_response(("tc1", "noop", {})),
+            _text_response("done"),
+            _text_response("second invocation"),
+        ],
+        tools={"noop": _make_noop_tool()},
+    )
+
+    await orch.execute("first", ctx, provs, tools, hooks)
+    await orch.execute("second", ctx, provs, tools, hooks)
+
+    first, second = _completions(hooks)
+    assert first["turn_count"] == 2
+    assert second["turn_count"] == 1
+
+
+def _make_noop_tool():
+    tool = MagicMock()
+    tool.name = "noop"
+    tool.description = "no-op"
+    tool.input_schema = {"type": "object", "properties": {}}
+    tool.execute = AsyncMock(return_value=ToolResult(success=True, output="ok"))
+    return tool
+
+
+# ---------------------------------------------------------------------------
+# Last-declared-report-wins
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_last_successful_report_in_a_batch_wins():
+    """Two valid reports in one batch: the LAST declared one is transported."""
+    report = _ReportOutcomeDouble()
+    orch, ctx, provs, tools, hooks = _make_orchestrator(
+        responses=[
+            _tool_response(
+                ("tc1", "report_outcome", {"status": "success", "preferred_label": "first"}),
+                ("tc2", "report_outcome", {"status": "fail", "preferred_label": "second"}),
+            )
+        ],
+        tools={"report_outcome": report},
+    )
+
+    await orch.execute("go", ctx, provs, tools, hooks)
+
+    verdict = _completions(hooks)[0]["metadata"]["report_outcome"]
+    assert verdict["status"] == "fail"
+    assert verdict["preferred_label"] == "second"
+
+
+@pytest.mark.asyncio
+async def test_a_later_invalid_report_does_not_erase_a_valid_one():
+    """§35: 'A later report that fails ... does not erase the prior valid report.'"""
+    report = _ReportOutcomeDouble()
+    orch, ctx, provs, tools, hooks = _make_orchestrator(
+        responses=[
+            _tool_response(
+                ("tc1", "report_outcome", {"status": "fail", "preferred_label": "escalate"}),
+                ("tc2", "report_outcome", {"status": "not-a-status"}),
+            )
+        ],
+        tools={"report_outcome": report},
+    )
+
+    await orch.execute("go", ctx, provs, tools, hooks)
+
+    verdict = _completions(hooks)[0]["metadata"]["report_outcome"]
+    assert verdict == {"status": "fail", "preferred_label": "escalate"}
+
+
+# ---------------------------------------------------------------------------
+# Terminal report path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_successful_report_terminates_the_invocation():
+    """A successful report ends the invocation — no further provider call.
+
+    The provider below would raise if a second call were made, so this asserts
+    the barrier rather than merely observing a convenient response list.
+    """
+    report = _ReportOutcomeDouble()
+    orch, ctx, provs, tools, hooks = _make_orchestrator(
+        responses=[
+            _tool_response(
+                ("tc1", "report_outcome", {"status": "success"}),
+                text="closing prose emitted alongside the verdict",
+            ),
+            AssertionError("a second provider call was made after report_outcome"),
+        ],
+        tools={"report_outcome": report},
+    )
+
+    result = await orch.execute("go", ctx, provs, tools, hooks)
+
+    assert result == "closing prose emitted alongside the verdict"
+    assert provs["test"].complete.await_count == 1
+    assert _completions(hooks)[0]["turn_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Interrupted invocations
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_raising_invocation_still_emits_exactly_one_envelope():
+    """An exception must not swallow the envelope — the spawn boundary needs it."""
+    boom = RuntimeError("provider exploded")
+    orch, ctx, provs, tools, hooks = _make_orchestrator(responses=[boom])
+
+    with pytest.raises(RuntimeError, match="provider exploded"):
+        await orch.execute("go", ctx, provs, tools, hooks)
+
+    completions = _completions(hooks)
+    assert len(completions) == 1
+    assert completions[0]["status"] == "incomplete"
+    assert completions[0]["metadata"] == {}
+
+
+@pytest.mark.asyncio
+async def test_a_cancelled_invocation_reports_cancelled_and_no_verdict():
+    """Cancellation is a lifecycle state, and never promotes a partial report."""
+    orch, ctx, provs, tools, hooks = _make_orchestrator(
+        responses=[asyncio.CancelledError()]
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await orch.execute("go", ctx, provs, tools, hooks)
+
+    completions = _completions(hooks)
+    assert len(completions) == 1
+    assert completions[0]["status"] == "cancelled"
+    assert completions[0]["metadata"] == {}
+
+
+@pytest.mark.asyncio
+async def test_a_turn_limited_invocation_is_incomplete():
+    """max_turns is a wall, not a completion — lifecycle status says so."""
+    orch, ctx, provs, tools, hooks = _make_orchestrator(
+        responses=[_text_response("never reached")],
+        config={"max_turns": 1},
+    )
+
+    await orch.execute("go", ctx, provs, tools, hooks)
+
+    envelope = _completions(hooks)[0]
+    assert envelope["status"] == "incomplete"
+    assert envelope["metadata"] == {}

--- a/modules/loop-agent/tests/test_parallel_gating.py
+++ b/modules/loop-agent/tests/test_parallel_gating.py
@@ -332,3 +332,104 @@ async def test_single_tool_always_sequential():
 
     assert tool_a.execute.call_count == 1
     assert order == ["tool_a"]
+
+
+# ---------------------------------------------------------------------------
+# report_outcome ordering barrier (EXTENSIONS.md §35)
+# ---------------------------------------------------------------------------
+#
+# `report_outcome` writes a SINGLE semantic completion register (the tool's
+# `last_outcome`), which the orchestrator then transports to the parent as
+# `metadata.report_outcome`.  Under asyncio.gather() the winner of two reports
+# in one batch would be decided by scheduling order rather than by the order
+# the model declared them — so "the last declared report wins" would not be a
+# statement anyone could rely on.  A batch carrying at least one
+# `report_outcome` therefore runs sequentially; every other batch keeps the
+# configured parallel behavior.
+
+
+def _make_report_outcome_tool(order_tracker: list):
+    """Stand-in for tool-report-outcome that records declared-order writes."""
+    tool = MagicMock()
+    tool.name = "report_outcome"
+    tool.description = "Report the outcome of your work."
+    tool.input_schema = {
+        "type": "object",
+        "properties": {"status": {"type": "string"}},
+        "required": ["status"],
+    }
+    tool.last_outcome = None
+
+    async def _execute(args):
+        # Yield control so a gather()-based execution would interleave here.
+        await asyncio.sleep(0)
+        order_tracker.append(args.get("preferred_label"))
+        tool.last_outcome = dict(args)
+        return ToolResult(success=True, output="reported")
+
+    tool.execute = AsyncMock(side_effect=_execute)
+    return tool
+
+
+@pytest.mark.asyncio
+async def test_batch_with_report_outcome_runs_sequentially():
+    """A batch containing report_outcome executes in provider-declared order."""
+    order: list[str] = []
+    report = _make_report_outcome_tool(order)
+    slow = _make_slow_tool("slow_tool", delay=0.05)
+
+    provider = AsyncMock()
+    provider.complete = AsyncMock(
+        side_effect=[
+            _multi_tool_response(
+                ("tc1", "slow_tool", {}),
+                ("tc2", "report_outcome", {"status": "fail", "preferred_label": "a"}),
+                ("tc3", "report_outcome", {"status": "success", "preferred_label": "b"}),
+            ),
+        ]
+    )
+
+    session = AgentSession(
+        config=SessionConfig(
+            system_prompt="You are a test coding agent.",
+            supports_parallel_tool_calls=True,
+        ),
+        provider=provider,
+        tools={"slow_tool": slow, "report_outcome": report},
+        hooks=_make_hooks(),
+    )
+    await session.process_input("go")
+
+    # Declared order preserved, so the LAST declared report is the one left in
+    # the register — deterministically, not by scheduling luck.
+    assert order == ["a", "b"]
+    assert report.last_outcome["preferred_label"] == "b"
+
+
+@pytest.mark.asyncio
+async def test_batch_without_report_outcome_still_runs_in_parallel():
+    """The barrier is scoped to report_outcome — ordinary batches are unchanged."""
+    tracker = _ConcurrencyTracker()
+    tool_a = _make_tracked_tool("tool_a", tracker, delay=0.05)
+    tool_b = _make_tracked_tool("tool_b", tracker, delay=0.05)
+
+    provider = AsyncMock()
+    provider.complete = AsyncMock(
+        side_effect=[
+            _multi_tool_response(("tc1", "tool_a", {}), ("tc2", "tool_b", {})),
+            _text_response("done."),
+        ]
+    )
+
+    session = AgentSession(
+        config=SessionConfig(
+            system_prompt="You are a test coding agent.",
+            supports_parallel_tool_calls=True,
+        ),
+        provider=provider,
+        tools={"tool_a": tool_a, "tool_b": tool_b},
+        hooks=_make_hooks(),
+    )
+    await session.process_input("go")
+
+    assert tracker.max_in_flight == 2

--- a/modules/pipeline-runner/pyproject.toml
+++ b/modules/pipeline-runner/pyproject.toml
@@ -60,6 +60,18 @@ override-dependencies = [
 [tool.uv.sources]
 amplifier-module-loop-pipeline = { path = "../loop-pipeline" }
 amplifier-module-remote-source = { path = "../remote-source" }
+# Test-only, same-repo path sources.  tests/test_spawn_report_outcome_transport.py
+# drives the REAL producer (loop-agent) and the REAL verdict tool
+# (tool-report-outcome) against the REAL consumer (loop-pipeline) so the
+# child->parent report_outcome transport is asserted end-to-end rather than
+# re-implemented on both sides of the seam (issue #285).  Path sources, not git
+# refs: a branch must test ITS OWN modules, never main's.
+# `editable` so the test always runs the working tree's modules.  A
+# non-editable path source is COPIED at sync time, so a local edit to
+# loop-agent would be silently invisible here until the next `uv sync` --
+# exactly the kind of stale-copy result this test exists to rule out.
+amplifier-module-loop-agent = { path = "../loop-agent", editable = true }
+amplifier-module-tool-report-outcome = { path = "../tool-report-outcome", editable = true }
 
 [tool.hatch.build.targets.wheel]
 packages = [
@@ -73,6 +85,9 @@ allow-direct-references = true
 dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=1.0.0",
+    # See the [tool.uv.sources] note above -- both are TEST-ONLY.
+    "amplifier-module-loop-agent",
+    "amplifier-module-tool-report-outcome",
 ]
 
 [tool.pytest.ini_options]

--- a/modules/pipeline-runner/tests/test_spawn_report_outcome_transport.py
+++ b/modules/pipeline-runner/tests/test_spawn_report_outcome_transport.py
@@ -1,0 +1,338 @@
+"""The child->parent `report_outcome` verdict transport, end to end (issue #285).
+
+This is the ONE test file in the repo where all three parties to the transport
+are the REAL implementations at the same time:
+
+  * PRODUCER  -- `amplifier_module_loop_agent.AgentOrchestrator`, which emits the
+    `orchestrator:complete` envelope (EXTENSIONS.md §35);
+  * VERDICT TOOL -- `amplifier_module_tool_report_outcome.ReportOutcomeTool`, the
+    thing the child actually calls;
+  * CONSUMER  -- `amplifier_module_loop_pipeline.backend.AmplifierBackend`, whose
+    `_outcome_from_spawn_result` is the only place a spawn-path
+    `is_explicit=True` outcome can come from.
+
+Only two things are doubles, and both are deliberate:
+
+  * the LLM provider (scripted responses -- no network in CI);
+  * the SPAWN PLUMBING, which reproduces foundation's
+    `PreparedBundle.spawn` result assembly verbatim (see `_spawn_result_from`
+    below).  Standing up a real `AmplifierSession` child would test
+    foundation, not this repo's seam.
+
+Why it lives in `pipeline-runner`: this module already sits above both halves
+(it owns `make_spawn_fn`), and issue #285 asked specifically for "a
+pipeline-runner-level regression asserting is_explicit == true and a non-null
+preferred_label after a child agent *actually calls* report_outcome -- i.e.
+proving the envelope **travelled**, not merely that the parent would honor one
+if it had."
+
+RED against origin/main: at `701edc7` loop-agent emitted no
+`orchestrator:complete` at all, so `metadata` was always `{}` and the parent
+recorded `notes="Child session completed with empty final message",
+is_explicit=False`.
+"""
+
+from typing import Any, ClassVar
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from amplifier_core.events import ORCHESTRATOR_COMPLETE
+from amplifier_core.message_models import ChatResponse, ToolCall, Usage
+from amplifier_module_loop_agent import AgentOrchestrator
+from amplifier_module_loop_pipeline.backend import AmplifierBackend
+from amplifier_module_loop_pipeline.context import PipelineContext
+from amplifier_module_loop_pipeline.graph import Node
+from amplifier_module_loop_pipeline.outcome import StageStatus
+from amplifier_module_tool_report_outcome import ReportOutcomeTool
+
+# ---------------------------------------------------------------------------
+# Child-side harness: a real loop-agent invocation with a scripted provider
+# ---------------------------------------------------------------------------
+
+
+def _text_response(text: str) -> ChatResponse:
+    return ChatResponse(
+        content=[{"type": "text", "text": text}],
+        tool_calls=None,
+        usage=Usage(input_tokens=10, output_tokens=5, total_tokens=15),
+    )
+
+
+def _tool_response(*calls, text: str = "") -> ChatResponse:
+    return ChatResponse(
+        content=[{"type": "text", "text": text}] if text else [],
+        tool_calls=[
+            ToolCall(id=cid, name=name, arguments=args) for cid, name, args in calls
+        ],
+        usage=Usage(input_tokens=10, output_tokens=5, total_tokens=15),
+    )
+
+
+class _CapturingHooks:
+    """Stands in for the child session's hook registry.
+
+    Mirrors what foundation's `PreparedBundle.spawn` does: it registers a
+    temporary `orchestrator:complete` subscriber and keeps the last payload.
+    """
+
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict]] = []
+        self.completion: dict[str, Any] = {}
+
+    async def emit(self, event: str, data: dict) -> Any:
+        self.events.append((event, data))
+        if event == ORCHESTRATOR_COMPLETE:
+            self.completion.update(data)
+        return MagicMock(action="continue")
+
+
+async def _run_child(responses) -> dict[str, Any]:
+    """Run one REAL loop-agent invocation and return a foundation-shaped result.
+
+    The returned dict's four keys and their defaults are copied from
+    `amplifier_foundation/bundle/_prepared.py::PreparedBundle.spawn` -- the
+    `status`/`turn_count`/`metadata` fallbacks are foundation's own, and the
+    `"success"` default for `status` is precisely why a child that emitted NO
+    completion envelope still looked like a clean completion to the parent.
+    """
+    provider = AsyncMock()
+    provider.complete = AsyncMock(side_effect=responses)
+    hooks = _CapturingHooks()
+    report_tool = ReportOutcomeTool(config={}, coordinator=None)
+
+    orch = AgentOrchestrator(
+        coordinator=MagicMock(),
+        config={"system_prompt": "You are a test coding agent."},
+    )
+    output = await orch.execute(
+        "do the work",
+        MagicMock(),
+        {"test": provider},
+        {"report_outcome": report_tool},
+        hooks,
+    )
+
+    return {
+        "output": output,
+        "session_id": "child-session-1",
+        "status": hooks.completion.get("status", "success"),
+        "turn_count": hooks.completion.get("turn_count", 1),
+        "metadata": hooks.completion.get("metadata", {}),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Parent-side harness: the real AmplifierBackend over a canned spawn result
+# ---------------------------------------------------------------------------
+
+
+class _Session:
+    config: ClassVar[dict[str, Any]] = {}
+
+
+class _Coordinator:
+    """Minimal coordinator exposing the `session.spawn` capability."""
+
+    def __init__(self, spawn_result: dict[str, Any]) -> None:
+        self._spawn_result = spawn_result
+        self.session = _Session()
+        self.config: dict[str, Any] = {
+            "agents": {
+                "attractor-anthropic": {
+                    "session": {"orchestrator": {"module": "loop-agent"}}
+                }
+            }
+        }
+
+    def get_capability(self, name: str):
+        return self._spawn_fn if name == "session.spawn" else None
+
+    async def _spawn_fn(self, **kwargs: Any) -> dict[str, Any]:
+        return self._spawn_result
+
+
+async def _parent_outcome(spawn_result: dict[str, Any], **node_attrs: Any):
+    backend = AmplifierBackend(
+        coordinator=_Coordinator(spawn_result),
+        profiles={"anthropic": "attractor-anthropic"},
+    )
+    node = Node(
+        id="intake",
+        prompt="Do the work",
+        attrs={"llm_provider": "anthropic", **node_attrs},
+    )
+    return await backend.run(node, "Do the work", PipelineContext())
+
+
+# ---------------------------------------------------------------------------
+# 1. The transport (the #285 defect)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_child_verdict_survives_the_spawn_boundary():
+    """A child's report_outcome reaches the parent as an EXPLICIT outcome.
+
+    This is the exact incident from #231/#285: the child calls report_outcome
+    with a real verdict and emits no closing prose.  Before the transport
+    shipped, the parent recorded
+    `notes="Child session completed with empty final message"`,
+    `is_explicit=False`, `preferred_label=None`.
+    """
+    result = await _run_child(
+        [
+            _tool_response(
+                (
+                    "tc1",
+                    "report_outcome",
+                    {
+                        "status": "fail",
+                        "preferred_label": "escalate",
+                        "failure_reason": "probe verdict",
+                        "notes": "transport probe verdict",
+                    },
+                )
+            )
+        ]
+    )
+
+    # The envelope travelled.
+    assert result["metadata"]["report_outcome"]["preferred_label"] == "escalate"
+
+    outcome = await _parent_outcome(result)
+
+    assert outcome.is_explicit is True
+    assert outcome.status is StageStatus.FAIL
+    assert outcome.preferred_label == "escalate"
+    assert outcome.failure_reason == "probe verdict"
+    assert outcome.notes == "transport probe verdict"
+    assert outcome.notes != "Child session completed with empty final message"
+
+
+@pytest.mark.asyncio
+async def test_context_updates_ride_along():
+    """The envelope carries the whole verdict, not just status + label."""
+    result = await _run_child(
+        [
+            _tool_response(
+                (
+                    "tc1",
+                    "report_outcome",
+                    {
+                        "status": "success",
+                        "context_updates": {"artifact": "report.md"},
+                        "suggested_next_ids": ["publish"],
+                    },
+                )
+            )
+        ]
+    )
+
+    outcome = await _parent_outcome(result)
+
+    assert outcome.is_explicit is True
+    assert outcome.context_updates == {"artifact": "report.md"}
+    assert outcome.suggested_next_ids == ["publish"]
+
+
+# ---------------------------------------------------------------------------
+# 2. Fail-closed (EXTENSIONS.md §25 / §35 Compatibility)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_child_without_a_verdict_stays_non_explicit():
+    """A status-only completion must NOT be promoted to an explicit verdict.
+
+    The whole point of `is_explicit` is that a goal gate can only be satisfied
+    by an asserted verdict (EXTENSIONS.md §25).  Adding the transport must not
+    hand every clean child an explicit-looking outcome for free.
+    """
+    result = await _run_child([_text_response("")])
+
+    assert result["status"] == "success"
+    assert result["metadata"] == {}
+
+    outcome = await _parent_outcome(result)
+
+    assert outcome.is_explicit is False
+    assert outcome.status is StageStatus.SUCCESS
+    assert outcome.notes == "Child session completed with empty final message"
+
+
+@pytest.mark.asyncio
+async def test_goal_gate_still_fails_closed_without_a_verdict():
+    """A goal_gate node whose child never reported does not pass the gate.
+
+    Plain prose + `goal_gate=true` degrades to RETRY with `is_explicit=False`
+    (the §25 parser rung), so the gate cannot be satisfied by a child that
+    merely finished.
+    """
+    result = await _run_child([_text_response("All done, everything looks great!")])
+
+    assert result["metadata"] == {}
+
+    outcome = await _parent_outcome(result, goal_gate="true")
+
+    assert outcome.is_explicit is False
+    assert outcome.status is StageStatus.RETRY
+
+
+# ---------------------------------------------------------------------------
+# 3. Precedence (EXTENSIONS.md §35 Precedence Policy)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fail_verdict_beats_cheerful_prose():
+    """Evidence over self-report: `status=fail` + "mission accomplished" => FAIL.
+
+    Without the transport the parent has nothing but the prose to go on, and
+    `_parse_outcome` reads cheerful prose as SUCCESS.
+    """
+    result = await _run_child(
+        [
+            _tool_response(
+                (
+                    "tc1",
+                    "report_outcome",
+                    {
+                        "status": "fail",
+                        "failure_reason": "the work did not converge",
+                    },
+                ),
+                text="All done, mission accomplished!",
+            )
+        ]
+    )
+
+    # The prose really is there -- this is not an empty-output shortcut.
+    assert result["output"] == "All done, mission accomplished!"
+
+    outcome = await _parent_outcome(result)
+
+    assert outcome.status is StageStatus.FAIL
+    assert outcome.is_explicit is True
+    assert outcome.failure_reason == "the work did not converge"
+
+
+@pytest.mark.asyncio
+async def test_last_declared_verdict_is_the_one_transported():
+    """Two verdicts in one batch: the LAST declared one reaches the parent.
+
+    The §35 ordering barrier makes this deterministic -- the batch runs in
+    provider-declared order rather than under `asyncio.gather`.
+    """
+    result = await _run_child(
+        [
+            _tool_response(
+                ("tc1", "report_outcome", {"status": "success", "preferred_label": "ship"}),
+                ("tc2", "report_outcome", {"status": "fail", "preferred_label": "escalate"}),
+            )
+        ]
+    )
+
+    outcome = await _parent_outcome(result)
+
+    assert outcome.status is StageStatus.FAIL
+    assert outcome.preferred_label == "escalate"

--- a/specs/EXTENSIONS.md
+++ b/specs/EXTENSIONS.md
@@ -2188,20 +2188,57 @@ This is additive at the spawn boundary:
   `metadata.report_outcome`; status-only spawn results remain non-explicit.
 - Parallel execution is unchanged for batches without `report_outcome`.
 
+*Addendum (2026-08-18, issue #285): **everything above this line described a transport that was
+not on `main`.** The entry's prose landed; its child-side implementation did not — the commit that
+would have carried it (`9251a6a`, "fix: preserve spawned agent outcomes") was written on a review
+branch and was never an ancestor of `main`. Measured at `701edc7`: `git log origin/main -S
+report_outcome -- modules/loop-agent` returned ZERO commits, and
+`modules/loop-agent/tests/test_orchestrator_completion.py` — named below as a contract test — did
+not exist. The only "Implementation location" that was real was `backend.py`, the CONSUMER,
+faithfully reading a `metadata.report_outcome` that nothing produced. The observable cost was the
+`#231` incident shape: a child that demonstrably called `report_outcome` (its own `events.jsonl`
+carrying `Outcome reported: fail (preferred_label=escalate)`) was nonetheless recorded on the
+parent node as `notes="Child session completed with empty final message"`, `is_explicit=false`,
+`preferred_next_label=null` — because `AgentOrchestrator.execute()` emitted no
+`orchestrator:complete` event at all, so foundation's `PreparedBundle.spawn` capture hook had
+nothing to copy and the spawn result's `metadata` was always `{}`. The envelope, the ordering
+barrier, the terminal report path and the per-invocation reset are now implemented and the
+locations below are true. Re-derived against current `main` rather than cherry-picked: `9251a6a`
+predates ~98 commits of consumer drift.*
+
+*Addendum (2026-08-18, issue #285) — one consequence the original text did not spell out: because
+the envelope now reports a REAL lifecycle status, an INTERRUPTED child no longer reaches its parent
+disguised as a clean one. Foundation's spawn-result assembly defaults `status` to `"success"` when
+no completion event arrives (`_prepared.py`), so before this shipped EVERY child — including one
+that burned its `max_turns` without a single provider call — arrived at `_outcome_from_spawn_result`
+carrying `status="success"`. An empty-output child in that state was recorded SUCCESS (with
+`is_explicit=false`, so a goal gate still failed closed, but a plain node passed). Such a child now
+reports `status="incomplete"`, which is not in `_SPAWN_SUCCESS_STATUSES`, so an empty-output
+limit-terminated child is recorded FAIL (`"No output from child session"`) rather than a silent
+success. This is fail-loud by intent and consistent with §25's fail-closed direction; it is called
+out here because it changes an outcome, not merely an observability field. Children that produce
+output are unaffected — that path never consults the lifecycle status unless an explicit verdict is
+present.*
+
 ### Implementation locations
 
 - `modules/loop-agent/amplifier_module_loop_agent/__init__.py` —
   per-invocation reset, exactly-one completion emission, lifecycle classification, provider-call
   `turn_count`, and `metadata.report_outcome` transport
 - `modules/loop-agent/amplifier_module_loop_agent/agent_session.py` —
-  provider-call counting, invocation termination reason, and the `report_outcome` batch ordering
-  barrier
+  provider-call counting, invocation termination reason, the `report_outcome` batch ordering
+  barrier, and the terminal report path
 - `modules/loop-pipeline/amplifier_module_loop_pipeline/backend.py` —
   spawn-result precedence, semantic `Outcome` reconstruction, response/session preservation, and
   full-fidelity transcript continuity
 - `modules/loop-agent/tests/test_orchestrator_completion.py`,
   `modules/loop-agent/tests/test_parallel_gating.py`, and
   `modules/loop-pipeline/tests/test_backend_fidelity.py` — contract tests
+- `modules/pipeline-runner/tests/test_spawn_report_outcome_transport.py` — the CROSS-BOUNDARY
+  regression. The contract tests above each cover one side of the seam; this one runs the real
+  producer (`loop-agent`), the real verdict tool (`tool-report-outcome`) and the real consumer
+  (`loop-pipeline`) in a single test, so it proves the envelope TRAVELLED rather than that each
+  side would have honored one. It is the test that goes red if the transport is removed.
 
 ---
 


### PR DESCRIPTION
Fixes #285
Fixes #231

`#231` had two independent defects wearing one symptom. The **parent-side precedence** half
landed in #286. This PR ships the other half — the **child-side transport** — so `#231` is now
fully resolved.

---

## The defect: the verdict never left the child

A spawned child's semantic verdict reaches its parent through exactly one channel. Foundation's
`PreparedBundle.spawn` registers a temporary hook on `orchestrator:complete` and copies its
`metadata` verbatim into the spawn-result dict:

```python
# amplifier_foundation/bundle/_prepared.py
return {
    "output": response,
    "session_id": child_session.session_id,
    # Enriched fields from orchestrator:complete event
    "status": completion_data.get("status", "success"),
    "turn_count": completion_data.get("turn_count", 1),
    "metadata": completion_data.get("metadata", {}),
}
```

loop-pipeline's `_outcome_from_spawn_result` then reads `metadata["report_outcome"]` — and that is
the **only** place a spawn-path `is_explicit=True` outcome can come from.

`loop-agent` never emitted that event. `AgentOrchestrator.execute()` was a straight
`return await self._session.process_input(prompt)`. So `completion_data` stayed empty, `metadata`
was always `{}`, branch (1) never fired, and every spawned child arrived as a verdict-less
status-only completion.

### Live repro at `origin/main` (`701edc7`)

A three-node pipeline whose `intake` box node instructs the child to call `report_outcome` with
`status=fail, preferred_label=escalate` and emit no closing prose.

The child **did** report — from its own `events.jsonl`:

```
{"event": "tool:post", "data": {"result": "{\"message\": \"Outcome reported: fail (preferred_label=escalate) - transport probe verdict\", \"status\": \"fail\", \"preferred_label\": \"escalate\", ...
```

The parent recorded — `<logs>/intake/status.json`:

```json
{
  "node_id": "intake",
  "outcome": "success",
  "preferred_next_label": null,
  "notes": "Child session completed with empty final message",
  "session_id": "514060c6-3553-4188-a018-4bb8621c2c3b",
  "is_explicit": false
}
```

That is the `#231` incident shape, byte for byte: a FAIL verdict with a routing label, recorded as
an unlabelled, non-explicit SUCCESS.

---

## ★ Live proof after the fix — the verdict survives the spawn boundary

The **same pipeline**, same probe, at this branch's HEAD (`a2286a0`) — `<logs>/intake/status.json`:

```json
{
  "node_id": "intake",
  "outcome": "fail",
  "preferred_next_label": "escalate",
  "notes": "transport probe verdict",
  "failure_reason": "probe verdict",
  "session_id": "e98a180c-c13c-4d0a-af73-668a07b17bee",
  "is_explicit": true
}
```

`fail` / `escalate` / `is_explicit: true`. And the label is load-bearing, not decorative — the
engine routed through the `escalate` edge (`trace.jsonl`):

```json
{"node_id": "intake",    "status": "fail",    "preferred_label": "escalate", "is_explicit": true}
{"node_id": "escalated", "status": "success", "preferred_label": null,       "is_explicit": false}
```

These are real `attractor run` invocations against a live Anthropic provider, not in-process
harnesses.

---

## The transport mechanism

**Seam:** `modules/loop-agent/amplifier_module_loop_agent/__init__.py:349` — the last line of the
old `execute()`. That method is now `_execute_session()`, and a new `execute()` wraps it and emits
the envelope.

How the child's `report_outcome` reaches `metadata.report_outcome`:

1. The child calls `report_outcome`. `ReportOutcomeTool.execute` validates the args and stores them
   on `self.last_outcome` (`tool-report-outcome/__init__.py:167`). This already happened before this
   PR — the register was written and then nobody read it.
2. `_execute_session` resets that register **before** the loop runs
   (`__init__.py`, `_report_outcome_tool(...).last_outcome = None`). The tool is mounted once per
   session and the session is reused across `execute()` calls, so without the reset invocation N+1
   would report invocation N's verdict as if the child had just asserted it.
3. `AgentSession.process_input` runs the batch. A batch containing `report_outcome` runs
   **sequentially** in provider-declared order (the §35 ordering barrier), so "the last declared
   report wins" is deterministic rather than a scheduling accident. After the complete batch, a
   successful report **terminates the invocation** — no further provider call, no automatic
   follow-up processing, and already-queued follow-ups stay queued.
4. `execute()` classifies the lifecycle (`success` / `incomplete` / `cancelled`) from the session's
   `termination_reason` and cooperative-cancel counter, computes `turn_count` as this invocation's
   attempted provider calls, and emits **exactly one** `orchestrator:complete` — including on
   initialization failure and on a raised or cancelled loop, because a missing emission is
   indistinguishable at the spawn boundary from "the child had nothing to say."
5. Foundation's capture hook copies `metadata` into the spawn result; `_outcome_from_spawn_result`
   takes branch (1); `_run_with_spawn`'s #286 hoist honors it regardless of prose.

The two layers stay deliberately separate: top-level `status` is **lifecycle only**;
`metadata.report_outcome` is the **verdict**. A child that reports `fail` still has lifecycle
`success` — it completed cleanly, it just judged the work failed.

`execute(...) -> str` is unchanged. Consumers that ignore `metadata` see the documented envelope.

---

## Fail-closed is preserved (§25)

`metadata` is `{}` unless the invocation **both** completed **and** left a successful report behind.
No fabricated `is_explicit=True` for a child that did not report.

Live, same harness — a `goal_gate=true` node whose child is told **not** to call `report_outcome`.
Identical at base and at HEAD, which is the point:

```json
{
  "node_id": "gate",
  "outcome": "fail",
  "preferred_next_label": null,
  "failure_reason": "Max retries exceeded",
  "is_explicit": false
}
```

The gate still fails closed. `test_child_without_a_verdict_stays_non_explicit` pins the exact
status-only branch (`metadata == {}` → `is_explicit=False` →
`notes="Child session completed with empty final message"`), and
`test_goal_gate_still_fails_closed_without_a_verdict` pins the gate.

---

## Precedence: evidence over self-report (§35)

Live — a child that writes cheerful closing prose **and** reports `status=fail` in the same message:

```
output: "All done, mission accomplished!"
```

```json
{
  "node_id": "judge",
  "outcome": "fail",
  "notes": "structured verdict beats cheerful prose",
  "failure_reason": "probe: the work did not converge",
  "is_explicit": true
}
```

At base the same run recorded `outcome: "success"`, `is_explicit: false`,
`notes: "Child session completed with empty final message"` — the FAIL was lost outright.

---

## §35 made true, and amended

`specs/EXTENSIONS.md` §35 documented this transport as shipped when **none of its child-side code
was on `main`** — the commit that would have carried it (`9251a6a`) was written on a review branch
and is not an ancestor of `main`. Measured at `701edc7`:
`git log origin/main -S report_outcome -- modules/loop-agent` returns zero commits, and
`test_orchestrator_completion.py` — named by §35 as a contract test — did not exist. Built fresh
against current `main`, not cherry-picked: `9251a6a` predates ~98 commits of consumer drift.

Two dated addenda were added (no renumbering; `test_extensions_ledger_integrity.py` green):

1. **The ledger-truth gap**, recorded plainly, with the git evidence and the observable cost.
2. **One behavioral consequence §35's text did not spell out.** Foundation defaults `status` to
   `"success"` when no completion event arrives — so before this PR, *every* child arrived looking
   like a clean completion, including one that burned its `max_turns` without a single provider
   call. Such a child now reports `status="incomplete"`, which is not in
   `_SPAWN_SUCCESS_STATUSES`, so an **empty-output, limit-terminated** child is recorded FAIL
   (`"No output from child session"`) instead of a silent SUCCESS. Fail-loud by intent and
   consistent with §25's direction, but it changes an outcome rather than an observability field,
   so it is called out rather than left to be discovered. Children that produce output are
   unaffected.

"Implementation locations" now names the files this PR actually adds/changes, including the
cross-boundary regression. §35 claims nothing unshipped.

---

## Tests + mutation

**New:**
- `modules/loop-agent/tests/test_orchestrator_completion.py` (13) — the §35 envelope contract:
  transport, lifecycle/verdict separation, `metadata == {}` with no report, rejected reports not
  promoted, per-invocation reset, per-invocation `turn_count`, last-declared-wins, a later invalid
  report not erasing a valid one, the terminal report path, and exactly-one emission on raise /
  cancel / turn-limit.
- `modules/pipeline-runner/tests/test_spawn_report_outcome_transport.py` (6) — **the cross-boundary
  regression.** The only test in the repo running the real producer (`loop-agent`), the real verdict
  tool (`tool-report-outcome`) and the real consumer (`loop-pipeline`) in one test, so it proves the
  envelope **travelled** rather than that each side would have honored one. Only the LLM provider
  and foundation's result assembly are doubled. Requested by #285 itself.
- `modules/loop-agent/tests/test_parallel_gating.py` (+2) — the ordering barrier: a batch with
  `report_outcome` runs in declared order; batches without it still run in parallel.

**Changed:** `test_events.py` — the outer completion envelope now follows the inner
`agent:session_end`, so two ordering assertions moved from `names[-1]` to `names[-2]`/`names[-1]`.

**Mutation (both RED):**

| Mutation | Result |
|---|---|
| Revert the transport wiring entirely — `execute()` == `_execute_session()`, no emission (byte-for-byte `main`) | **4 failed, 2 passed** in the cross-boundary file. `test_child_verdict_survives_the_spawn_boundary` → `KeyError: 'report_outcome'`; the parent falls back to the empty-final-message branch. The 2 that pass are the fail-closed tests — correct, that behavior is identical at `main`. |
| Keep the envelope, drop only `metadata.report_outcome` | **4 failed** (cross-boundary) + **5 failed** (loop-agent contract). |

Restored: green.

**Suites** (all at HEAD):

| Suite | Result |
|---|---|
| loop-pipeline (`uv sync --extra remote && uv run pytest -q`) | **2514 passed, 25 skipped** (baseline 2514/25) |
| loop-agent | **533 passed** (baseline 518 + 15 new) |
| pipeline-runner | **91 passed, 1 skipped** (baseline 85/1 + 6 new) |
| tool-report-outcome | **21 passed** |

**#231 parent-side capsule gate** (`spawn-report-outcome-precedence.verify.sh`) at head — still
GREEN, #286 not regressed:

```
Probe 1 PASSED: backend round-trip -- defect is not present
Probe 2 PASSED: drive_engine transport round-trip -- defect is not present
Gate: all probes PASSED -- defect is not present
```

`git diff --check` clean. Leak scan of every changed file: clean.

---

## Tier

**Uncharted / extension** (QUALITY_PROTOCOL §3). The nlspec is silent on `report_outcome` — §4.5
delegates the `CodergenBackend`'s internals to the implementer, so a metadata channel inside an
already-implemented spawn boundary is not drift from anything the spec says. §35 is an
already-ledgered, sanctioned extension; this PR does not open new uncharted ground, it makes an
existing entry true. Additive: `execute(...) -> str` is unchanged, consumers that ignore `metadata`
see the documented envelope, and parallel execution is untouched for batches without
`report_outcome`. The decision-matrix gate for building this was passed before work began.

---

## Observations

- **The consumer shipped first and waited.** `_outcome_from_spawn_result` has read
  `metadata["report_outcome"]` faithfully for a long time; #286 even hoisted the check above the
  prose path. It was a correct reader of a channel with no writer. That is a failure mode worth
  naming: a half-seam is invisible to every test on either side of it, and each side reviews as
  correct. The only test that catches it is one that spans the seam — which is why
  `test_spawn_report_outcome_transport.py` intentionally imports across three modules rather than
  living tidily in one.

- **The ledger was the load-bearing bug.** §35 read as shipped, so a reader debugging the `#231`
  symptom would have gone looking for the fault in `backend.py` — which is exactly what happened,
  and what #284 was originally scoped to fix. The spec entry actively misdirected the
  investigation. Documentation drift here was not cosmetic; it cost a whole capsule's worth of
  aim.

- **The default was doing real damage.** Foundation's `completion_data.get("status", "success")`
  is a reasonable-looking default that quietly asserts "if a child said nothing about how it ended,
  assume it ended well." Combined with a producer that never spoke, it meant *every* child looked
  clean — including ones that burned their turn budget without a single provider call. Fixing the
  transport also removed that fabricated optimism, which is why the addendum calls it out: a
  default that makes silence look like success is a fail-open in disguise.

- **The terminal report path is a small efficiency win with a correctness rationale.** Before it,
  a child that reported a verdict got one more provider call to narrate it — and that narration is
  precisely the "all done, mission accomplished" prose the §35 Precedence Policy exists to
  overrule. Stopping at the verdict removes the contradiction at its source rather than adjudicating
  it downstream.

- **`bundles/` is scanned by OSP-001.** A temporary local-source bundle used to point the live
  probes at branch-local modules failed
  `test_orchestrator_source_pin_guard::test_osp001_every_orchestrator_source_is_a_git_pin` while it
  sat in `bundles/`. Correct behavior by the guard, worth knowing: live-run scaffolding belongs
  outside the repo tree, not in `bundles/` with a dotfile name.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)
