### PR TITLE
feat(lint): flag an LLM node configured in attributes the engine never reads (VOCAB-001)

### DIFF
--- a/agents/attractor-expert.md
+++ b/agents/attractor-expert.md
@@ -364,6 +364,16 @@ that in the handback, in those words, and tell the caller the exact command to
 run: `attractor lint <path>`. An unrun lint reported as unrun is honest; an unrun
 lint left unmentioned is the failure.
 
+**3. Relay the findings, not the exit code.** `attractor lint` exits 0 on
+warnings by design, and the inert twelve-node graph above exits **0** -- so
+"passed", "exit 0" and "no errors" are all true of a file whose every prompt was
+dropped. The only clean verdict is the linter's own line
+`attractor lint: <file>: OK (no findings)`; anything else is findings, and each
+one goes in the handback. `VOCAB-001` is the rule that now names this exact
+defect (`LLM node 'x' will run with no prompt: it carries `instruction=` but the
+engine reads `prompt=``) -- a WARNING, at rc=0, which is precisely why summarising
+the exit code instead of the findings would bury it.
+
 ## Your Knowledge Base
 
 You have deep knowledge loaded from these references. **Start with the engine

--- a/context/attractor-awareness.md
+++ b/context/attractor-awareness.md
@@ -59,7 +59,9 @@ the independent path: `@attractor:examples/authoring/`, or a fresh reviewer.
   Vocabulary: `@attractor:context/dot-reference.md`.
 - **The file is not delivered until `attractor lint <file>` has run and its
   verdict is in your reply.** Lint not relayed is lint not run: you hand over
-  an unverified file.
+  an unverified file. Relay the **findings**, not the exit code -- lint exits 0
+  on warnings, and `VOCAB-001` ("will run with no prompt") is a warning. The
+  only clean verdict is `OK (no findings)`.
 
 ## Depth, on demand
 

--- a/context/dot-reference.md
+++ b/context/dot-reference.md
@@ -23,8 +23,12 @@ one of them is inert:
 | an invented `verdict` variable in a condition | `condition="outcome=success"`, or `condition="context.tool.last_line=<token>"` from a real command |
 | `fidelity="stateless"`, `fidelity="fresh"` -- a real attribute, an invented value | one of the six modes below: `full`, `truncate`, `compact`, `summary:low`, `summary:medium`, `summary:high` |
 
-An unrecognized `shape=` falls back to the **codergen (LLM)** handler -- so a node you meant as a
-gate quietly becomes another model call, and the graph looks gated while nothing is being checked.
+An unrecognized `shape=` is **refused at dispatch** -- `HandlerRegistry.get()` raises, naming the
+shape, the node, and the valid set (specs/EXTENSIONS.md §38; the canonical spec's fall-through to
+the LLM handler is a deliberate divergence, because a typo must not silently re-class a gate as a
+model call). `attractor lint` reports it as a `shape_resolvable` **ERROR** before you ever run.
+So a typo'd shape is the one invented spelling on this page that is *already* loud. The rest are
+not -- which is what the next section is about.
 
 ## The output contract: a `.dot` is not delivered until you have linted it
 
@@ -38,10 +42,28 @@ obligation, which is why this one names **where the result lands**: in the reply
 
 So: author, run the linter, relay what it said -- warnings included, in the same message as the
 file. The linter is what turns a silently-inert attribute into a message a human can read: a node
-carrying an invented `instruction=` surfaces as `[prompt_on_llm_nodes] LLM node 'x' has no prompt
-and no explicit label`. Handing someone a `.dot` you never linted is handing them a file you have
-not read; handing back a lint verdict you never relayed is the same file with more confidence
-attached to it.
+carrying an invented `instruction=` and no `prompt=` surfaces as
+
+```
+WARNING: [VOCAB-001] [fetch_pr] LLM node 'fetch_pr' will run with no prompt: it carries
+`instruction=` but the engine reads `prompt=`.
+```
+
+Handing someone a `.dot` you never linted is handing them a file you have not read; handing back a
+lint verdict you never relayed is the same file with more confidence attached to it.
+
+**And the verdict is the findings, not the exit code.** `attractor lint` exits 0 on warnings by
+design -- the inert twelve-node graph above exits **0**. So "it passed", "exit 0", "no errors" and
+"lint clean" are all things you can say truthfully about a file whose every prompt is dropped.
+There is exactly one clean verdict, and it is the linter's own words:
+
+```
+attractor lint: <file>: OK (no findings)
+```
+
+Anything else is findings, and findings get relayed -- each one, in the reply, next to the file.
+Reporting rc instead of the findings is the same failure as not linting, one step later: it is the
+obligation discharged in a way the reader cannot check.
 
 ### The other half: you cannot certify the file yourself
 

--- a/docs/DOT-AUTHORING-GUIDE.md
+++ b/docs/DOT-AUTHORING-GUIDE.md
@@ -1799,6 +1799,81 @@ where the pipe appears in a non-final `;`-separated segment (e.g.
 
 ---
 
+### VOCAB-001 — LLM node configured in attributes the engine never reads
+
+**What it detects:** A codergen (LLM) node that carries **no `prompt=` at all**
+but does carry an invented spelling from `context/dot-reference.md`'s
+invented-attribute table — `instruction=`, a node-level `goal=`,
+`attractor_goal=`, `agent=`, `handler=`, or `attractor_handler=`.
+
+**Why it matters:** The parser promotes exactly `{label, shape, type, prompt}`
+to node fields (`dot_parser._NODE_FIELD_MAP`). Every other attribute survives
+as an inert `node.attrs` entry that no handler ever reads. So a `.dot`
+authored with `instruction=` parses cleanly, validates cleanly, and runs its
+LLM nodes **with no prompt at all** — no error, no warning, and no visible
+difference between "configured" and "unconfigured".
+
+This is measured, not hypothetical. Two graded sessions (issue #261) authored
+twelve-node pipelines carrying `instruction=` on all twelve nodes and
+`prompt=` on none; one of them linted **rc=0** with a single unrelated
+warning. `prompt_on_llm_nodes` could not see them: it fires only when a node
+has no prompt **and** no explicit label, and every node in both files was
+labelled.
+
+```dot
+// WRONG — parses, lints rc=0, runs with no prompt
+fetch_pr [
+    shape=box,
+    label="Fetch PR Branch",
+    instruction="Fetch the PR branch using git."
+];
+
+// CORRECT — prompt= is the attribute the engine reads
+fetch_pr [
+    shape=box,
+    label="Fetch PR Branch",
+    prompt="Fetch the PR branch using git."
+];
+```
+
+**Severity:** WARNING — consistent with CMD-001/002 and TOPO-002 through
+TOPO-010. It must never be an ERROR: the rule infers *intent* from an
+attribute the engine is entitled to ignore, and a graph may legitimately carry
+passthrough attributes the rule does not know about.
+
+**What this rule does NOT flag** (the false-positive discipline):
+
+- A node that has a real `prompt=` **and** also carries `instruction=`,
+  `agent=`, or any other attribute — the prompt is real, so the node is
+  configured. Carrying an extra attribute is not by itself a defect.
+- Any non-codergen node: a `parallelogram` tool node (configured by
+  `tool_command=`), a `hexagon` human gate, a `diamond` router, a
+  `component`/`tripleoctagon` parallel node, a `folder` sub-pipeline
+  (`goal=` on a `folder` node is a child parameter, not a dropped prompt).
+- Start (`Mdiamond`) and exit (`Msquare`) nodes.
+- A node whose `shape=` is *unrecognized* — dispatch refuses that node
+  outright (specs/EXTENSIONS.md §38) and `shape_resolvable` already reports
+  it as an **ERROR**; flagging it here too would double-diagnose.
+- A bare LLM node with no prompt and no invented spelling — that is
+  `prompt_on_llm_nodes`' existing territory.
+
+Measured over this repository's shipped corpus: **zero** of the 33
+`examples/**/*.dot` graphs fire it. Pinned by
+`modules/loop-pipeline/tests/test_inert_vocabulary_lint.py`.
+
+**Related — an invented `fidelity=` value:** `fidelity` is a real attribute,
+but `fidelity="stateless"` / `"fresh"` are not among its six values, and
+`backend.py` falls back to `compact`. That case is reported by the existing
+`fidelity_valid` rule (WARNING), which runs in both `validate()` and
+`attractor lint`.
+
+**Reading the verdict:** VOCAB-001 is a WARNING, so `attractor lint` exits
+**0** on a graph whose every prompt was dropped. Relay the *findings*, not the
+exit code — the only clean verdict is
+`attractor lint: <file>: OK (no findings)`.
+
+---
+
 ### Record-validating gates: parse, don't grep
 
 A companion design rule to the CMD family, for gates whose evidence is a

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/validation.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/validation.py
@@ -18,6 +18,11 @@ CMD-001–002 are command-content lint rules that inspect ``tool_command``
 strings for two specific hazard shapes: pipe-masked exit codes (CMD-001) and
 always-true trailing sentinels (CMD-002).  Both are lint-only (WARNING
 severity) and do not change run-time behaviour.
+
+VOCAB-001 is an inert-vocabulary lint rule: an LLM node that carries no
+``prompt=`` at all but does carry an invented spelling the parser keeps and no
+handler ever reads (``instruction=``, ``agent=``, ...).  It is lint-only
+(WARNING severity) and does not change run-time behaviour.
 """
 
 from __future__ import annotations
@@ -133,7 +138,9 @@ def lint(graph: Graph) -> list[Diagnostic]:
     (TOPO-001–010) that reason about cycle structure, handler semantics,
     evidence-routing patterns and condition-key hazards, plus the two
     command-content rules (CMD-001–002)
-    that inspect ``tool_command`` strings for hazard shapes.
+    that inspect ``tool_command`` strings for hazard shapes, plus the
+    inert-vocabulary rule (VOCAB-001) that catches an LLM node configured
+    entirely in attribute spellings the engine does not read.
 
     All lint-only rules do not change run-time validation behaviour.  Existing
     graphs that execute today will not start failing at ``run`` time because of
@@ -158,6 +165,7 @@ def lint(graph: Graph) -> list[Diagnostic]:
     _check_folder_dot_file_absent(graph, diags)
     _check_pipe_masked_exit_code(graph, diags)
     _check_always_true_sentinel(graph, diags)
+    _check_inert_prompt_vocabulary(graph, diags)
     return diags
 
 
@@ -2998,3 +3006,146 @@ def _find_all_bare_pipes(cmd: str) -> list[int]:
                     positions.append(i)
         i += 1
     return positions
+
+
+# ---------------------------------------------------------------------------
+# Inert-vocabulary rule — VOCAB-001
+#
+# The failure this catches is silent by construction.  `_NODE_FIELD_MAP` in
+# `dot_parser.py` promotes exactly {label, shape, type, prompt} to Node
+# fields; every other attribute survives as an inert `node.attrs` entry that
+# no handler ever reads.  So a `.dot` authored with `instruction=` instead of
+# `prompt=` parses cleanly, validates cleanly, and runs its LLM nodes with no
+# prompt at all — there is no error, no warning, and no diff between
+# "configured" and "unconfigured" that a reader can see.
+#
+# Measured (issue #261): two graded sessions authored twelve-node pipelines
+# carrying `instruction=` on all twelve nodes and `prompt=` on none.  One of
+# them linted rc=0 with a single unrelated warning.
+#
+# `prompt_on_llm_nodes` (in `validate()`) is the near-miss sibling: it fires
+# only when a codergen node has NO prompt *and* NO explicit label.  Both
+# evidence files label every node, so it stayed silent on all twenty-four.
+# This rule asks the sharper question — is the prompt *missing*, and is there
+# an inert attribute here that the author plainly wrote as the prompt?
+# ---------------------------------------------------------------------------
+
+# Invented spellings the reference card (`context/dot-reference.md`) names as
+# inert, mapped to the attribute the engine actually reads.  Deliberately
+# limited to the card's own table: the card is declared the single attribute
+# vocabulary, so the lint rule and the card cannot drift into two lists.
+#
+# `goal` is node-scoped here.  Graph-level `goal=` is real (it is in
+# `dot_parser._GRAPH_FIELD_ATTRS` and backs `$goal` substitution); a
+# *node*-level `goal=` is not read by anything.  This rule only ever inspects
+# `node.attrs`, so the real graph attribute is never touched.
+_INERT_PROMPT_SPELLINGS: dict[str, str] = {
+    "instruction": "prompt",
+    "goal": "prompt",
+    "attractor_goal": "prompt",
+}
+
+# Invented spellings for "who executes this node".  A node carrying one of
+# these was written as though naming an executor were the same as configuring
+# one; the engine picks the executor from `shape=` alone.  They are reported
+# by the same rule because the *consequence* is identical and worse: the node
+# has no prompt AND the delegation the author wrote is inert.
+_INERT_HANDLER_SPELLINGS: dict[str, str] = {
+    "agent": "shape=box",
+    "handler": "shape=box",
+    "attractor_handler": "shape=box",
+}
+
+
+def _is_codergen_node(node: Node) -> bool:
+    """True when this node will actually dispatch to the LLM (codergen) handler.
+
+    Deliberately stricter than ``prompt_on_llm_nodes``'s
+    ``SHAPE_TO_HANDLER.get(node.shape, "codergen")``: an *unrecognized* shape
+    is NOT treated as an LLM node here.  Since PR #19 the engine refuses at
+    dispatch rather than falling back to codergen (``HandlerRegistry.get()``
+    raises; specs/EXTENSIONS.md §38), and ``shape_resolvable`` already emits
+    an ERROR for exactly that node.  Treating an unknown shape as codergen
+    would double-diagnose a node the author is already being told to fix.
+
+    A missing ``shape=`` is codergen: ``Node.shape`` defaults to ``"box"``.
+    """
+    if node.is_start_node() or node.is_exit_node():
+        return False
+    if node.type:
+        return node.type == "codergen"
+    return SHAPE_TO_HANDLER.get(node.shape) == "codergen"
+
+
+def _check_inert_prompt_vocabulary(graph: Graph, diags: list[Diagnostic]) -> None:
+    """VOCAB-001: an LLM node with no ``prompt=`` that carries an inert spelling.
+
+    Fires when ALL of the following hold:
+
+    * the node dispatches to the codergen (LLM) handler — see
+      ``_is_codergen_node``;
+    * ``node.prompt`` is empty — the node will run with no prompt at all;
+    * ``node.attrs`` carries at least one spelling from the reference card's
+      invented-attribute table (``instruction=``, ``agent=``, …).
+
+    Deliberately silent on:
+
+    * a node that has ``prompt=`` and *also* carries some other attribute —
+      the prompt is real, so the node is configured.  Carrying an extra
+      attribute is not by itself a defect, and warning about it would make
+      the rule noise on every graph using a custom passthrough attribute.
+    * a tool / human-gate / conditional / fan-in node with no prompt — those
+      never take one, and their real configuration lives in ``tool_command=``,
+      ``goal_gate=``, ``condition=``.
+    * a node with a typo'd shape — ``shape_resolvable`` owns that node.
+    * a node with no prompt and no inert spelling — that is
+      ``prompt_on_llm_nodes``'s existing territory, not this rule's.
+
+    Severity: WARNING.  It must never be an ERROR: the diagnosis rests on
+    reading the author's *intent* from an attribute the engine is entitled to
+    ignore, and a graph can legitimately carry passthrough attributes this
+    rule does not know about.  Advisory keeps ``attractor lint`` at rc=0 and
+    keeps ``validate_or_raise()`` (the admission gate) untouched.
+    """
+    for node in graph.nodes.values():
+        if not _is_codergen_node(node):
+            continue
+        if node.prompt:
+            continue  # configured — an extra attribute alongside a real prompt is not a defect
+
+        found_prompt = [a for a in _INERT_PROMPT_SPELLINGS if a in node.attrs]
+        found_handler = [a for a in _INERT_HANDLER_SPELLINGS if a in node.attrs]
+        if not found_prompt and not found_handler:
+            continue  # no prompt, but nothing here claims to be one
+
+        carried = ", ".join(f"`{a}=`" for a in found_prompt + found_handler)
+        if found_prompt:
+            reads = "`prompt=`"
+            fix = (
+                f"Rename {', '.join(f'`{a}=`' for a in found_prompt)} to `prompt=` on "
+                f"node '{node.id}'."
+            )
+        else:
+            reads = "`prompt=`, and picks the handler from `shape=` alone"
+            fix = (
+                f"Add a `prompt=` attribute to node '{node.id}'; "
+                f"{', '.join(f'`{a}=`' for a in found_handler)} does not select a handler "
+                f"(use `shape=box` for an LLM node)."
+            )
+
+        diags.append(
+            Diagnostic(
+                rule="VOCAB-001",
+                severity="WARNING",
+                message=(
+                    f"LLM node '{node.id}' will run with no prompt: it carries "
+                    f"{carried} but the engine reads {reads}.  The parser keeps "
+                    f"unknown attributes on the node and no handler ever looks at "
+                    f"them, so this node is inert while reading as configured.  "
+                    f"See context/dot-reference.md for the full attribute "
+                    f"vocabulary and DOT-AUTHORING-GUIDE.md (VOCAB-001)."
+                ),
+                node_id=node.id,
+                fix=fix,
+            )
+        )

--- a/modules/loop-pipeline/tests/test_inert_vocabulary_lint.py
+++ b/modules/loop-pipeline/tests/test_inert_vocabulary_lint.py
@@ -1,0 +1,388 @@
+"""Tests for the inert-vocabulary lint rule — VOCAB-001.
+
+VOCAB-001: an LLM (codergen) node that carries NO ``prompt=`` but does carry an
+invented attribute spelling the parser keeps and no handler ever reads
+(``instruction=``, ``agent=``, ``goal=`` at node level, …).  The node runs with
+no prompt at all while reading as fully configured — the failure issue #261
+measured in two graded sessions.
+
+Test pattern mirrors test_command_content_lint.py / test_topological_lint.py:
+construct Graph/Node/Edge objects directly (no DOT parsing) for speed and
+isolation, except where the point of the test is the parse path itself.
+
+False-positive discipline is the primary focus.  The rule reads *intent* from
+an attribute the engine is entitled to ignore, so every silent case below
+documents WHY the node is legitimately not a defect.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from amplifier_module_loop_pipeline.dot_parser import parse_dot
+from amplifier_module_loop_pipeline.graph import Edge, Graph, Node
+from amplifier_module_loop_pipeline.validation import (
+    Diagnostic,
+    lint,
+    validate,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers — mirrors test_command_content_lint.py
+# ---------------------------------------------------------------------------
+
+
+def _mdiamond(node_id: str = "start") -> Node:
+    return Node(id=node_id, shape="Mdiamond", label="Start")
+
+
+def _msquare(node_id: str = "done") -> Node:
+    return Node(id=node_id, shape="Msquare", label="Done")
+
+
+def _graph(nodes: dict[str, Node], edges: list[Edge] | None = None) -> Graph:
+    return Graph(name="test", nodes=nodes, edges=edges or [])
+
+
+def _wrap(work: Node) -> Graph:
+    """A minimal valid graph: start -> work -> done."""
+    return _graph(
+        nodes={"start": _mdiamond(), work.id: work, "done": _msquare()},
+        edges=[Edge("start", work.id), Edge(work.id, "done")],
+    )
+
+
+def _vocab(diags: list[Diagnostic]) -> list[Diagnostic]:
+    return [d for d in diags if d.rule == "VOCAB-001"]
+
+
+def _rule(diags: list[Diagnostic], rule: str) -> list[Diagnostic]:
+    return [d for d in diags if d.rule == rule]
+
+
+# ---------------------------------------------------------------------------
+# (a) Positive cases — the rule MUST fire
+# ---------------------------------------------------------------------------
+
+
+class TestVocab001Fires:
+    def test_instruction_without_prompt_warns(self) -> None:
+        """The exact issue #261 shape: shape=box + instruction=, no prompt."""
+        node = Node(
+            id="fetch_pr",
+            shape="box",
+            label="Fetch PR Branch",
+            attrs={"instruction": "Fetch the PR branch using git."},
+        )
+        found = _vocab(lint(_wrap(node)))
+        assert len(found) == 1
+        d = found[0]
+        assert d.severity == "WARNING"
+        assert d.node_id == "fetch_pr"
+        assert "will run with no prompt" in d.message
+        assert "`instruction=`" in d.message
+        assert "`prompt=`" in d.message
+        assert "prompt=" in d.fix
+
+    def test_message_names_node_invented_attr_and_real_attr(self) -> None:
+        """The message must carry all three facts an author needs to act."""
+        node = Node(id="review", shape="box", attrs={"instruction": "review it"})
+        (d,) = _vocab(lint(_wrap(node)))
+        assert "'review'" in d.message  # the node
+        assert "`instruction=`" in d.message  # the invented attribute
+        assert "`prompt=`" in d.message  # the one the engine reads
+
+    def test_agent_without_prompt_warns(self) -> None:
+        """`agent=` is inert too — the engine picks the handler from shape=."""
+        node = Node(id="fetch", shape="box", attrs={"agent": "foundation:git-ops"})
+        (d,) = _vocab(lint(_wrap(node)))
+        assert "`agent=`" in d.message
+        assert "shape=box" in d.fix
+
+    def test_agent_and_instruction_reported_together_once(self) -> None:
+        """A node carrying both gets ONE diagnostic naming both."""
+        node = Node(
+            id="fetch_branch",
+            shape="box",
+            label="Fetch PR Branch",
+            attrs={"agent": "foundation:git-ops", "instruction": "check it out"},
+        )
+        found = _vocab(lint(_wrap(node)))
+        assert len(found) == 1, "one diagnostic per node, not one per attribute"
+        assert "`instruction=`" in found[0].message
+        assert "`agent=`" in found[0].message
+
+    def test_node_level_goal_without_prompt_warns(self) -> None:
+        """A *node*-level goal= is inert; graph-level goal= is real (untouched)."""
+        node = Node(id="work", shape="box", attrs={"goal": "make it converge"})
+        assert len(_vocab(lint(_wrap(node)))) == 1
+
+    def test_attractor_goal_without_prompt_warns(self) -> None:
+        node = Node(id="work", shape="box", attrs={"attractor_goal": "converge"})
+        assert len(_vocab(lint(_wrap(node)))) == 1
+
+    def test_missing_shape_defaults_to_llm_and_warns(self) -> None:
+        """Node.shape defaults to 'box' — the second evidence file's shape."""
+        node = Node(id="run_tests", label="Run Tests", attrs={"instruction": "go"})
+        assert node.shape == "box"
+        assert len(_vocab(lint(_wrap(node)))) == 1
+
+    def test_explicit_type_codergen_warns(self) -> None:
+        """type=codergen dispatches to the LLM handler regardless of shape."""
+        node = Node(
+            id="work",
+            shape="ellipse",
+            type="codergen",
+            attrs={"instruction": "do the thing"},
+        )
+        assert len(_vocab(lint(_wrap(node)))) == 1
+
+    def test_explicit_label_does_not_suppress(self) -> None:
+        """The near-miss that let #261 through: prompt_on_llm_nodes needs BOTH
+        no-prompt AND no-explicit-label.  Every evidence node had a label."""
+        node = Node(
+            id="fetch_pr",
+            shape="box",
+            label="Fetch PR Branch",
+            attrs={"instruction": "fetch it"},
+        )
+        diags = lint(_wrap(node))
+        assert _rule(diags, "prompt_on_llm_nodes") == [], (
+            "the labelled node is exactly what the old rule cannot see"
+        )
+        assert len(_vocab(diags)) == 1
+
+
+# ---------------------------------------------------------------------------
+# (b) Invalid fidelity — already shipped as `fidelity_valid`; pinned here so
+#     the second half of issue #261's ask cannot silently regress.
+# ---------------------------------------------------------------------------
+
+
+class TestFidelityValidCoversIssue261:
+    @pytest.mark.parametrize("bad", ["stateless", "fresh"])
+    def test_invented_fidelity_value_warns(self, bad: str) -> None:
+        node = Node(id="work", shape="box", prompt="do it", attrs={"fidelity": bad})
+        found = _rule(lint(_wrap(node)), "fidelity_valid")
+        assert len(found) == 1
+        assert found[0].severity == "WARNING"
+        assert bad in found[0].message
+        assert "compact" in found[0].message  # the valid set is named
+
+    @pytest.mark.parametrize(
+        "good",
+        [
+            "full",
+            "truncate",
+            "compact",
+            "summary:low",
+            "summary:medium",
+            "summary:high",
+        ],
+    )
+    def test_valid_fidelity_is_silent(self, good: str) -> None:
+        node = Node(id="work", shape="box", prompt="do it", attrs={"fidelity": good})
+        assert _rule(lint(_wrap(node)), "fidelity_valid") == []
+
+
+# ---------------------------------------------------------------------------
+# (c) False-positive pins — the rule MUST stay silent
+# ---------------------------------------------------------------------------
+
+
+class TestVocab001FalsePositives:
+    def test_prompt_plus_other_attr_is_silent(self) -> None:
+        """A node can legitimately carry prompt= AND another attribute."""
+        node = Node(
+            id="work",
+            shape="box",
+            prompt="Do the real work",
+            attrs={"instruction": "leftover from an edit", "fidelity": "full"},
+        )
+        assert _vocab(lint(_wrap(node))) == []
+
+    def test_prompt_plus_agent_is_silent(self) -> None:
+        node = Node(
+            id="work",
+            shape="box",
+            prompt="Do the real work",
+            attrs={"agent": "foundation:git-ops"},
+        )
+        assert _vocab(lint(_wrap(node))) == []
+
+    def test_tool_node_without_prompt_is_silent(self) -> None:
+        """A tool node never takes a prompt — its config is tool_command=."""
+        node = Node(
+            id="gate",
+            shape="parallelogram",
+            attrs={"tool_command": "pytest -q", "instruction": "run the suite"},
+        )
+        assert _vocab(lint(_wrap(node))) == []
+
+    def test_human_gate_without_prompt_is_silent(self) -> None:
+        node = Node(id="approve", shape="hexagon", label="Human Approval")
+        assert _vocab(lint(_wrap(node))) == []
+
+    def test_human_gate_with_instruction_is_silent(self) -> None:
+        """Even carrying an inert spelling — a hexagon is not an LLM node."""
+        node = Node(
+            id="approve",
+            shape="hexagon",
+            label="Human Approval",
+            attrs={"instruction": "approve the release"},
+        )
+        assert _vocab(lint(_wrap(node))) == []
+
+    def test_conditional_node_is_silent(self) -> None:
+        node = Node(id="router", shape="diamond", label="Route")
+        assert _vocab(lint(_wrap(node))) == []
+
+    def test_folder_node_with_goal_is_silent(self) -> None:
+        """A sub-pipeline node passing goal= to its child is not an LLM node."""
+        node = Node(
+            id="child",
+            shape="folder",
+            attrs={"dot_file": "child.dot", "goal": "converge the child"},
+        )
+        assert _vocab(lint(_wrap(node))) == []
+
+    def test_start_and_exit_nodes_are_silent(self) -> None:
+        start = Node(id="start", shape="Mdiamond", attrs={"instruction": "begin"})
+        done = Node(id="done", shape="Msquare", attrs={"instruction": "end"})
+        graph = _graph(
+            nodes={"start": start, "done": done}, edges=[Edge("start", "done")]
+        )
+        assert _vocab(lint(graph)) == []
+
+    def test_llm_node_with_no_prompt_and_no_inert_attr_is_silent(self) -> None:
+        """Bare no-prompt LLM node is prompt_on_llm_nodes' territory, not ours."""
+        node = Node(id="work", shape="box", label="Do Work")
+        assert _vocab(lint(_wrap(node))) == []
+
+    def test_typoed_shape_is_left_to_shape_resolvable(self) -> None:
+        """No double-diagnosis: dispatch hard-fails on an unknown shape
+        (specs/EXTENSIONS.md §38) and shape_resolvable already ERRORs."""
+        node = Node(id="work", shape="parallelgram", attrs={"instruction": "run it"})
+        diags = lint(_wrap(node))
+        assert _vocab(diags) == []
+        assert len(_rule(diags, "shape_resolvable")) == 1
+
+    def test_graph_level_goal_is_untouched(self) -> None:
+        """Graph-level goal= is a real attribute backing $goal substitution."""
+        graph = _wrap(Node(id="work", shape="box", prompt="do it"))
+        graph.graph_attrs["goal"] = "converge the repo"
+        graph.goal = "converge the repo"
+        assert _vocab(lint(graph)) == []
+
+
+# ---------------------------------------------------------------------------
+# (d) Entry-point + exit-code contract
+# ---------------------------------------------------------------------------
+
+
+class TestVocab001Contract:
+    def test_never_emits_error_severity(self) -> None:
+        """Advisory only — VOCAB-001 must never block a run (rc stays 0)."""
+        node = Node(id="work", shape="box", attrs={"instruction": "go", "agent": "x"})
+        diags = lint(_wrap(node))
+        assert _vocab(diags), "sanity: the rule fired"
+        assert [d for d in diags if d.severity == "ERROR"] == [], (
+            "a VOCAB-001-only graph must produce zero ERRORs so lint exits 0"
+        )
+        assert all(d.severity == "WARNING" for d in _vocab(diags))
+
+    def test_lint_only_not_in_validate(self) -> None:
+        """validate()/validate_or_raise() — the admission gate — is untouched."""
+        graph = _wrap(Node(id="work", shape="box", attrs={"instruction": "go"}))
+        assert _vocab(validate(graph)) == []
+        assert _vocab(lint(graph)) != []
+
+
+# ---------------------------------------------------------------------------
+# (e) Regression: the measured evidence shape from issue #261, via the parser
+# ---------------------------------------------------------------------------
+
+
+_EVIDENCE_DOT = """
+digraph pr_automation {
+    start [shape=Mdiamond, label="Start"];
+    exit  [shape=Msquare,  label="Exit"];
+
+    fetch_pr [
+        shape=box,
+        label="Fetch PR Branch",
+        instruction="Fetch the PR branch using git.",
+        fidelity="stateless"
+    ];
+
+    run_linter [
+        shape=box,
+        label="Run Linter",
+        instruction="Run the linter on the fetched PR branch.",
+        fidelity="stateless"
+    ];
+
+    start -> fetch_pr;
+    fetch_pr -> run_linter;
+    run_linter -> exit;
+}
+"""
+
+
+class TestIssue261EvidenceShape:
+    def test_evidence_dot_is_caught_end_to_end(self) -> None:
+        """Parse -> lint: both LLM nodes flagged, both fidelities flagged, no ERROR."""
+        graph = parse_dot(_EVIDENCE_DOT)
+        diags = lint(graph)
+
+        vocab_nodes = {d.node_id for d in _vocab(diags)}
+        assert vocab_nodes == {"fetch_pr", "run_linter"}
+
+        fidelity_nodes = {d.node_id for d in _rule(diags, "fidelity_valid")}
+        assert fidelity_nodes == {"fetch_pr", "run_linter"}
+
+        assert [d for d in diags if d.severity == "ERROR"] == [], (
+            "the whole finding is advisory — rc must stay 0"
+        )
+
+    def test_renaming_instruction_to_prompt_clears_the_warning(self) -> None:
+        """The fix the message prescribes actually resolves the finding."""
+        fixed = _EVIDENCE_DOT.replace("instruction=", "prompt=").replace(
+            'fidelity="stateless"', 'fidelity="compact"'
+        )
+        diags = lint(parse_dot(fixed))
+        assert _vocab(diags) == []
+        assert _rule(diags, "fidelity_valid") == []
+
+
+# ---------------------------------------------------------------------------
+# (f) Calibration: zero fires across the shipped examples corpus
+#     (mirrors TestOutcomeLabelShadowingCalibration in test_topological_lint.py)
+# ---------------------------------------------------------------------------
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_EXAMPLES_DIR = _REPO_ROOT / "examples"
+_EXAMPLE_DOTS = sorted(_EXAMPLES_DIR.rglob("*.dot")) if _EXAMPLES_DIR.is_dir() else []
+
+
+@pytest.mark.skipif(
+    not _EXAMPLE_DOTS,
+    reason="examples/ directory not present (installed-package run)",
+)
+def test_vocab_001_fires_on_zero_shipped_examples() -> None:
+    """Calibration pin: every shipped example uses prompt= correctly.
+
+    If this goes red, the example is wrong — fix the example, do not
+    loosen the rule.
+    """
+    offenders: list[str] = []
+    for dot_path in _EXAMPLE_DOTS:
+        graph = parse_dot(dot_path.read_text(encoding="utf-8"))
+        for d in _vocab(lint(graph)):
+            offenders.append(f"{dot_path.relative_to(_REPO_ROOT)}: {d.message}")
+    assert not offenders, "VOCAB-001 fired on shipped examples:\n" + "\n".join(
+        offenders
+    )

--- a/skills/attractorify/SKILL.md
+++ b/skills/attractorify/SKILL.md
@@ -378,12 +378,19 @@ the objection's disposition recorded (`caveats:` line if unresolved). Then:
    is in what you hand back.** Not "lint before handing back" -- an obligation
    you can discharge inside your own reasoning is not an obligation, which is
    why this one names where the result lands. A `.dot` that fails
-   `attractor lint` (TOPO-001 through TOPO-010, documented in
-   `docs/DOT-AUTHORING-GUIDE.md`) is not a runnable artifact: fix the findings,
-   re-run, and relay the final verdict with any surviving warnings quoted. If
-   the linter cannot be run here, say that in the handback, in those words, and
-   give the user the exact command -- an unrun lint reported as unrun is honest;
-   an unrun lint left unmentioned is how an inert graph ships.
+   `attractor lint` (TOPO-001 through TOPO-010, CMD-001/002 and VOCAB-001, all
+   documented in `docs/DOT-AUTHORING-GUIDE.md`) is not a runnable artifact: fix
+   the findings, re-run, and relay the final verdict with any surviving warnings
+   quoted. If the linter cannot be run here, say that in the handback, in those
+   words, and give the user the exact command -- an unrun lint reported as unrun
+   is honest; an unrun lint left unmentioned is how an inert graph ships.
+
+   **Relay the findings, not the exit code.** Lint exits 0 on warnings, so
+   "passed" / "exit 0" / "no errors" are all true of a graph whose every prompt
+   was silently dropped -- the measured shape of issue #261, which `VOCAB-001`
+   now reports as a WARNING at rc=0. The only clean verdict is the linter's own
+   `attractor lint: <file>: OK (no findings)`. See
+   `@attractor:context/dot-reference.md` for the full contract.
 
    **The other half of the same contract: you do not certify what you wrote.**
    Lint is a machine verdict, so relay it as a fact. Your own reading of your

--- a/specs/EXTENSIONS.md
+++ b/specs/EXTENSIONS.md
@@ -1887,6 +1887,33 @@ form (the collision scoped to one node's out-edges, and to the unconditional lab
 §3.3 Step 2 can actually select) fires on zero. That zero is pinned by
 `test_topological_lint.py::TestOutcomeLabelShadowingCalibration`.*
 
+*Addendum (2026-08-18, issue #261): **VOCAB-001** (`WARNING`) joins the same advisory entry point,
+and opens a second family on it — an *inert-vocabulary* rule, about attribute spelling rather than
+topology or command content. It fires on a codergen node that carries **no `prompt=` at all** but
+does carry a spelling from `context/dot-reference.md`'s invented-attribute table (`instruction=`,
+a node-level `goal=`, `attractor_goal=`, `agent=`, `handler=`, `attractor_handler=`). `dot_parser`'s
+`_NODE_FIELD_MAP` promotes exactly `{label, shape, type, prompt}`; everything else survives as an
+inert `node.attrs` entry no handler reads — so such a graph parses, validates, and runs its LLM
+nodes with no prompt, with no error and no visible difference from a configured one. Measured
+(issue #261): two graded sessions authored twelve-node pipelines with `instruction=` on all twelve
+nodes and `prompt=` on none; one of them linted **rc=0** with a single unrelated warning. The
+near-miss sibling `prompt_on_llm_nodes` (in `validate()`) could not see them: it requires no prompt
+**and** no explicit label, and every evidence node was labelled. VOCAB-001 is deliberately advisory
+and can never be an ERROR — it infers *intent* from an attribute the engine is entitled to ignore,
+and a graph may legitimately carry passthrough attributes the rule does not know about. It skips a
+node that has a real `prompt=` (carrying an extra attribute alongside a real prompt is not a
+defect), every non-codergen handler (a tool/human-gate/conditional/fan-in/sub-pipeline node never
+takes a prompt), start and exit nodes, and — unlike `prompt_on_llm_nodes`'s
+`SHAPE_TO_HANDLER.get(shape, "codergen")` — any node whose shape is *unrecognized*, because §38
+above makes that a dispatch refusal and `shape_resolvable` already ERRORs on it; treating it as an
+LLM node would double-diagnose. Measured over this repository's shipped corpus: **zero** of the 33
+`examples/**/*.dot` graphs fire it. Pinned by
+`test_inert_vocabulary_lint.py` (including
+`test_vocab_001_fires_on_zero_shipped_examples`, the calibration pin, and the false-positive class
+in `TestVocab001FalsePositives`). The invalid-`fidelity=` half of issue #261 needed no new rule:
+`fidelity_valid` (WARNING, in `validate()`) already reports it, and
+`TestFidelityValidCoversIssue261` pins that so it cannot silently regress.*
+
 **Why a separate entry point, not folded into `validate()`:** the five TOPO rules are
 judgment calls about pipeline *design quality* (is this graph shaped like a converging
 attractor?), not about whether the graph is *executable*. `validate_or_raise()` — the
@@ -1903,12 +1930,14 @@ never consulted by the engine at run time.
 
 **Implementation locations:**
 - `modules/loop-pipeline/amplifier_module_loop_pipeline/validation.py` — `lint()` entry point;
-  `_check_dead_conditional_edge()` (TOPO-001) and the four sibling TOPO-002–005 checks
+  `_check_dead_conditional_edge()` (TOPO-001) and the four sibling TOPO-002–005 checks;
+  `_check_inert_prompt_vocabulary()` (VOCAB-001)
 - `modules/pipeline-runner/amplifier_module_pipeline_runner/cli.py` — `attractor lint` subcommand
 - `docs/DOT-AUTHORING-GUIDE.md` — "Static Lint Rules (`attractor lint`)" section documents all
   five rules with fix examples
 - Tests: `modules/loop-pipeline/tests/test_topological_lint.py`,
-  `modules/loop-pipeline/tests/test_examples_lint_clean.py`
+  `modules/loop-pipeline/tests/test_examples_lint_clean.py`,
+  `modules/loop-pipeline/tests/test_inert_vocabulary_lint.py`
 
 ---
 


### PR DESCRIPTION
Fixes #261

## The failure this catches

`dot_parser._NODE_FIELD_MAP` promotes exactly `{label, shape, type, prompt}` to node fields. Every other attribute survives as an inert `node.attrs` entry that no handler ever reads. So a `.dot` authored with `instruction=` instead of `prompt=` **parses cleanly, validates cleanly, and runs its LLM nodes with no prompt at all** — no error, no warning, no visible difference between "configured" and "unconfigured".

The vocabulary half was already served (`context/dot-reference.md` names these exact spellings). The **enforcement** half was not. This ships it.

## The evidence files, before → after

Both real artifacts from #261, linted with the real `attractor lint` CLI.

### `20260816T040008Z/…/pr_automation.dot` — 12 `instruction=`, 0 `prompt=`

**Before:** zero diagnostics about the twelve dropped prompts. `prompt_on_llm_nodes` fired only on parser artifacts from `#`-comment lines, never on a real node.

**After** (11 new WARNINGs — the 12th node is `shape=parallelogram`, a *tool* node, correctly skipped):

```
WARNING: [VOCAB-001] [fetch_pr] LLM node 'fetch_pr' will run with no prompt: it carries
  `instruction=` but the engine reads `prompt=`.
WARNING: [VOCAB-001] [run_linter] …
WARNING: [VOCAB-001] [run_tests] …
WARNING: [VOCAB-001] [review_diff] …
WARNING: [VOCAB-001] [summarize_review] …
WARNING: [VOCAB-001] [post_comment] …
WARNING: [VOCAB-001] [recheck_tests] …
WARNING: [VOCAB-001] [approve_pr] …
WARNING: [VOCAB-001] [merge_pr] …
WARNING: [VOCAB-001] [tag_release] …
WARNING: [VOCAB-001] [finalize] …

attractor lint: …/pr_automation.dot: 37 error(s), 61 warning(s)
```

Warnings 50 → 61. The 37 ERRORs and the 12 `fidelity_valid` warnings are pre-existing.

### `20260816T043510Z/…/pr-to-merged.dot` — 12 `instruction=`, 12 `agent=`, 0 `prompt=`

This is the clean demonstration. **Before:** `rc=0`, one unrelated `acyclic_graph` warning. A twelve-node pipeline with zero prompts passed the linter.

**After** — 12 new WARNINGs, still `rc=0`:

```
WARNING: [VOCAB-001] [fetch_branch] LLM node 'fetch_branch' will run with no prompt:
  it carries `instruction=`, `agent=` but the engine reads `prompt=`.
  fix: Rename `instruction=` to `prompt=` on node 'fetch_branch'.
… (12 total: fetch_branch, run_linter, run_tests, review_diff, summarize_review,
   post_comment, wait_author, recheck_tests, approve_pr, merge_pr, tag_release,
   update_changelog)

attractor lint: …/pr-to-merged.dot: 13 warning(s)
```

## Half 1 — the rule

**`VOCAB-001`**, severity **WARNING**, on the `lint()`-only entry point. `validate()` / `validate_or_raise()` — the admission gate — are untouched, pinned by `test_lint_only_not_in_validate`.

**Fires** when all three hold: the node dispatches to the codergen (LLM) handler; `node.prompt` is empty; and `node.attrs` carries a spelling from the reference card's invented-attribute table (`instruction=`, node-level `goal=`, `attractor_goal=`, `agent=`, `handler=`, `attractor_handler=`). One diagnostic per node, naming the node, every invented attribute found, and the real one.

**The false-positive story** — this is the whole design risk, since the rule infers *intent* from an attribute the engine is entitled to ignore. It stays silent on:

| Case | Why |
|---|---|
| `prompt=` **and** `instruction=` on the same node | The prompt is real. Carrying an extra attribute is not a defect. |
| tool / human-gate / conditional / parallel / fan-in node | Never takes a prompt; configured by `tool_command=`, `goal_gate=`, `condition=`. |
| `folder` sub-pipeline with `goal=` | That is a child parameter, not a dropped prompt. |
| start (`Mdiamond`) / exit (`Msquare`) | Not LLM nodes. |
| LLM node, no prompt, **no** invented spelling | `prompt_on_llm_nodes`' existing territory. |
| unrecognized `shape=` | Dispatch already refuses it (§38) and `shape_resolvable` already **ERRORs** — flagging here too would double-diagnose. |
| graph-level `goal=` | Real attribute backing `$goal`; the rule only ever reads `node.attrs`. |

**Why `prompt_on_llm_nodes` did not already catch this** — it requires no prompt **and** no explicit label. Every node in both evidence files was labelled. Pinned by `test_explicit_label_does_not_suppress`.

### The two other cases from the issue — deliberately *not* new rules

- **Invalid `fidelity=`** is **already shipped**: `fidelity_valid` (WARNING) reports `fidelity="stateless"` / `"fresh"` today, and did so on the evidence file before this PR (12 warnings). Adding a second rule would double-diagnose. Instead I pinned it — `TestFidelityValidCoversIssue261` covers both invented values and all six valid ones — so the half of #261 that is already served cannot silently regress.
- **Invented `shape=`** is **already covered**, and the issue's description of it is stale. `shape=circle` / `doublecircle` / a typo are `shape_resolvable` **ERRORs**, and dispatch refuses them outright (§38) rather than falling back to codergen. `shape=parallelogram` is now a *recognized* shape (`tool`), which is why `pr_automation.dot`'s `wait_author` is correctly skipped by VOCAB-001. No third check.

## Half 2 — the guidance output-contract

#270 already made "run the linter, put the verdict in your reply" the contract. I did not duplicate it. What I found instead were **two false claims and one live loophole**:

1. **`context/dot-reference.md` promised an enforcement that did not exist.** The card told authors that an invented `instruction=` "surfaces as `[prompt_on_llm_nodes] LLM node 'x' has no prompt and no explicit label`" — which is exactly what did *not* happen, because every evidence node had a label. The card now quotes the message the linter really emits, and after this PR that promise is true.
2. **The card taught the wrong failure mode for an unrecognized `shape=`** ("falls back to the codergen handler"). Stale since PR #19; dispatch refuses, per the ledgered §38 divergence. Corrected, with the pointer to §38 and `shape_resolvable`.
3. **The loophole this rule itself opens: `rc=0` is not "clean".** Lint exits 0 on warnings by design — the inert twelve-node graph exits **0**. So "it passed", "exit 0", "no errors" are all things a session can say truthfully about a file whose every prompt was dropped. The contract now says: **relay the findings, not the exit code**; there is exactly one clean verdict, and it is the linter's own `attractor lint: <file>: OK (no findings)`.

Point 3 is the load-bearing addition, and it is added once (on the always-served card) and referenced from `agents/attractor-expert.md`, `skills/attractorify/SKILL.md`, and `context/attractor-awareness.md` rather than restated.

## Proof

| Check | Result |
|---|---|
| Evidence file 1 | 11 VOCAB-001 WARNINGs (12th node is a tool node) |
| Evidence file 2 | 12 VOCAB-001 WARNINGs, **rc=0** |
| ★ `examples/**/*.dot` sweep (33 files) | **0** VOCAB-001 fires, **0** ERRORs, rc=0 everywhere |
| Wider sweep — **all 63** tracked `.dot` files | **0** VOCAB-001 fires |
| New tests | 33 passed |
| **Mutation** (unregister the rule from `lint()`) | evidence file 2: 12 → **0** warnings; 12 of 33 tests fail. Rule is load-bearing. |
| `loop-pipeline` suite | **2547 passed, 25 skipped** (baseline 2514 + 33 new) |
| `pipeline-runner` suite | 91 passed, 1 skipped |
| `test_examples_lint_clean.py` | green |
| `test_extensions_ledger_integrity.py` | green |
| `test_doc_consistency.py`, `test_validation.py` (shape-table guard), `test_authoring_layer_gates.py` | green |
| `git diff --check`, leak scan on changed files | clean |

Note the mutation's 21 survivors are the false-positive pins and the `fidelity_valid` tests — they assert *silence*, so they correctly stay green. The mutation kills only the load-bearing assertions.

## Ledger / docs

- `specs/EXTENSIONS.md` §32 — addendum registering VOCAB-001 on the same advisory entry point, in the house format used for TOPO-006…010, plus the implementation-locations update. Per §32's own discriminator (the **entry point**, not the rule count) no new numbered entry is owed.
- `docs/DOT-AUTHORING-GUIDE.md` — full `### VOCAB-001` section after CMD-002: what it detects, why it matters, wrong/correct DOT, severity rationale, the complete does-NOT-flag list, the `fidelity_valid` cross-reference, and the read-the-findings-not-rc note.

## Tier (QUALITY_PROTOCOL §3)

**Toward-spec, additive, non-interfering.** Canonical spec §7.4 explicitly provides the extension point this lands on (`extra_rules` on `validate()`; `lint()` composes exactly that mechanism), so the rule closes a gap *using* the surface the spec offers rather than moving away from it. A spec-conformant graph behaves identically: `validate()` and `validate_or_raise()` are untouched, the rule is reachable only through `lint()`, run-time behaviour is unchanged, and the finding is advisory at rc=0 — it can never block a pipeline that runs today.

The extension-point toll was already paid by §32, which states that what owes a ledger entry is the *entry point*, not the rule count; I extended §32's catalog rather than opening a new numbered entry, exactly as TOPO-006…010 and CMD-001/002 did.

One place this touches ledgered territory without creating any: the rule deliberately does **not** treat an unrecognized shape as codergen. That is *consuming* the already-ledgered §38 divergence (dispatch refuses unknown shapes) rather than introducing a new one — and the doc corrections in Half 2 move two guidance claims back into agreement with §38 and with the linter's real output, which is toward-truth in the same direction.

## Observations

- **The card asserted an enforcement that did not exist.** `context/dot-reference.md` told authors this defect would surface as `prompt_on_llm_nodes` — a message the linter could not emit for the cited case, because every evidence node was labelled. A guidance surface promising a check that isn't there is worse than silence: it converts "I should verify this" into "the tooling has this covered." Worth a sweep for other guidance claims of the form "the linter will catch X" that no rule actually implements.
- **My own fix opens the next loophole, and it is the same shape as the original.** #261's finding was "an instruction satisfiable by citing it is not a gate." The successor is "a verdict satisfiable by reporting `rc` is not a verdict" — VOCAB-001 is a WARNING, so the evidence file still exits 0 after this PR. I closed it in prose (relay the findings, not the exit code), which is the same *class* of control that already failed twice. The mechanical version — the issue's own suggestion 2, a `machine_checks` assertion that lint was *invoked* on the authored file and that its findings were relayed — remains unbuilt and is where I would put the next increment.
- **`pr_automation.dot` exposes an unrelated parser behaviour.** Its `#`-prefixed comment lines are parsed as node statements, manufacturing ~37 phantom nodes (`Fetch`, `PR`, `branch`, `and`, `of`…) that produce all 37 `reachability` ERRORs and 37 spurious `prompt_on_llm_nodes` warnings. `#` is only a line-comment at the start of a line in DOT, and these lines are indented. That is a real diagnostic-noise bug, out of scope here, and worth its own issue.
- **A tool node with no `tool_command=` is still silent.** `pr_automation.dot`'s `wait_author` was meant as a human gate, carries `shape=parallelogram`, and so becomes a *tool* node with no command — correctly skipped by VOCAB-001 (it is not an LLM node) and flagged by nothing else. The adjacent rule "a `parallelogram` node with no `tool_command=` runs an empty gate" looks like the natural VOCAB-002.
- **The rule's vocabulary is deliberately closed, and that is a maintenance edge.** It flags only the spellings the reference card names. A session inventing a *new* spelling (`task=`, `directive=`) gets no warning. Widening it to "any unknown attribute on a prompt-less LLM node" would catch more but fire on legitimate passthrough attributes; I chose the calibrated form (0 fires across all 63 tracked graphs) over the broad one. Keeping card and rule in sync is now a two-place edit — a derived guard, like `test_doc_shape_tables_match_shape_to_handler` does for shapes, would close that.
