### PR TITLE
fix(behaviors): attractor-core delivers the attractorify skill

### DIFF
--- a/behaviors/attractor-core.yaml
+++ b/behaviors/attractor-core.yaml
@@ -13,6 +13,37 @@ tools:
   - module: tool-report-outcome
     source: ../modules/tool-report-outcome
 
+  # Registers this bundle's skills/ directory (today: attractorify) with the Agent
+  # Skills system.  The slash command itself comes from each skill's own
+  # `user-invocable: true` frontmatter.
+  #
+  # This lives HERE, and not only in the root bundle.md, because a behavior-only
+  # install composes THIS FILE and never the root -- so before this entry existed,
+  # such an install registered tool-skills not at all and delivered no skills.  It
+  # still registered attractor-expert (below), whose own guidance directs the user
+  # to `/attractorify` (agents/attractor-expert.md).  Shipping the pointer without
+  # the destination is the gap this closes.
+  #
+  # `tool-skills` is an EXTERNAL module, so a `git+...@main` source is correct here;
+  # the no-self-pin rule above governs SAME-repo modules only.  The skills source
+  # stays namespaced and ref-free for exactly the reason the root bundle gives: a
+  # `git+...@main#subdirectory=skills` pin would serve MAIN's SKILL.md to a branch
+  # install, while "@attractor:skills" resolves inside whatever snapshot was
+  # installed.  The @attractor: namespace is available from this file -- loading it
+  # registers @attractor: -> the repo root via foundation's nested-bundle
+  # resolution, the same mechanism the `attractor:attractor-expert` include below
+  # already relies on.
+  #
+  # Root bundle.md declares the identical entry.  When both compose, foundation
+  # merges tools: by module id and de-duplicates list-valued config, so the pair
+  # collapses to ONE tool-skills registration naming ONE skills source -- the same
+  # declared-in-both pattern this file and the root already use for attractor-expert.
+  - module: tool-skills
+    source: git+https://github.com/microsoft/amplifier-bundle-skills@main#subdirectory=modules/tool-skills
+    config:
+      skills:
+        - "@attractor:skills"
+
 hooks:
   - module: hooks-tool-truncation
     source: ../modules/hooks-tool-truncation

--- a/specs/EXTENSIONS.md
+++ b/specs/EXTENSIONS.md
@@ -2495,6 +2495,21 @@ Design record and probe evidence:
 including §8's "two resolution classes" finding — the empirical reason the self-pin sweep is
 split rather than blanket.
 
+*Addendum (2026-08-18): change 3 above made the skills registration ref-free, but left it declared
+only in root `bundle.md` — and change 2's reasoning ("registered by both `behaviors/attractor-core.yaml`
+and root `bundle.md`", so every composition gets it) was never applied to skills. The measured
+consequence is the same shape as the defect this entry exists to fix, one surface over: a
+behavior-only install composes `behaviors/attractor-core.yaml` and never the root, so it registered
+`tool-skills` **not at all** and delivered **zero skills** — while still registering
+`attractor-expert`, whose guidance directs the reader to `/attractorify`. The pointer shipped
+without the destination. `behaviors/attractor-core.yaml` now declares the identical
+`"@attractor:skills"` entry, so the behavior stands on its own. This stays inside this entry's
+"additive and non-interfering" envelope: no engine module changed, and a pipeline node's composed
+content is byte-identical (`tool-skills` mounts a session tool; no LLM-node context is added).
+Composing the root is unchanged and **measured** unchanged — foundation merges `tools:` by module id
+and de-duplicates list-valued config, so base and head both resolve to one `tool-skills`
+registration naming `"@attractor:skills"` exactly once.*
+
 ---
 
 ## 38. Unknown Node Shape Hard-Fails at Dispatch (No Default-Handler Fallback)


### PR DESCRIPTION
## Summary

Installing this bundle as a behavior — `amplifier bundle add git+…#subdirectory=behaviors/attractor-core.yaml --app` — composes `behaviors/attractor-core.yaml` and **never** the root `bundle.md`. The skills registration lived only in the root, so that install registered `tool-skills` **not at all** and delivered **zero skills**. It still registered `attractor-expert`, whose own guidance directs the reader to `/attractorify` (`agents/attractor-expert.md:530`). The pointer shipped; the destination did not.

This is the same defect class as PR #255 (*"serve the bundle's own guidance on the standard install path"*), one surface over: #255 fixed **context** and **agents** for the standard install; **skills** was left behind.

`behaviors/attractor-core.yaml` now declares the skills registration itself, in the identical form the root already uses.

## The gap, reproduced in production

This is not hypothetical. On a host with `behaviors/attractor-core.yaml` installed `--app`, in a live session:

```
> load_skill(search="attractorify")
No skills matching 'attractorify'
```

…while a *sibling* bundle installed the same way — `amplifier-bundle-design-council`'s `behaviors/design-council.yaml`, which registers `"@design-council:skills"` — **does** surface its skills (`/design-council`, `/design-council-here`) in the same session. Same install shape, same @-ref form, opposite outcome: the only difference is that design-council declares the registration in its behavior and we did not.

## Before / after — a real compose, not a code-read

Both probes load the file through foundation's `BundleRegistry` (the same loader `amplifier bundle add` uses), then run `tool-skills`' own `_resolve_skill_sources` + `discover_skills` against the result.

**BEFORE** (`origin/main` @ `1fb33d6`, behavior-only compose):

```
bundle.name          : attractor-core
source_base_paths    :
    @attractor: -> /tmp/attr-skills-fix
    @attractor-core: -> /tmp/attr-skills-fix/behaviors
tools: entries       : ['tool-report-outcome']
tool-skills entries  : 0
RESOLVED SKILL DIRS   : (n/a - tool-skills is not registered at all)
SKILLS DISCOVERED     : []
attractorify present  : NO
```

**AFTER** (this branch, behavior-only compose):

```
tool-skills entries   : 1
  source              : git+https://github.com/microsoft/amplifier-bundle-skills@main#subdirectory=modules/tool-skills
  config.skills       : ["@attractor:skills"]
[prod path] resolved-at-mount : []
[prod path] PENDING @-sources : ['@attractor:skills']   <- deferred, NOT dropped
[prod path] deferred resolve  : ['/tmp/attr-skills-fix/skills']
[eager path] resolved dirs    : ['/tmp/attr-skills-fix/skills']
SKILL DIRS (deduped)  : ['/tmp/attr-skills-fix/skills']  (count=1)
SKILLS DISCOVERED     : ['attractorify']
attractorify present  : YES
```

The probe deliberately distinguishes the two failure shapes this area is prone to. `@`-sources are **not** resolved at mount in production — `mention_resolver` is registered after modules mount, so `tool-skills` returns them as *pending* and resolves them at the first `provider:request`. A silently-dropped @-source would appear as neither resolved **nor** pending, and would have produced a registered-but-empty skills list. It shows up as `PENDING`, then resolves to a real directory, then yields a real skill. Both paths (deferred and eager) are exercised.

The BEFORE state also disproves the obvious alternative diagnosis: `@attractor:` **already resolved correctly** from this file at base (`@attractor: -> <repo root>`). Nothing was broken about the namespace; the registration simply was not there.

## Form chosen, and why

`"@attractor:skills"` — namespaced and ref-free, identical to root `bundle.md`:

```yaml
tools:
  - module: tool-skills
    source: git+https://github.com/microsoft/amplifier-bundle-skills@main#subdirectory=modules/tool-skills
    config:
      skills:
        - "@attractor:skills"
```

Three things had to be true, and each was checked rather than assumed:

1. **The @-ref form works from a behavior.** @-refs from `config.skills` were once silently dropped by the mount resolver; the fix landed upstream in `amplifier-bundle-skills` (PR #52), which is why this repo once shipped a `git+…@main#subdirectory=skills` self-reference instead. That workaround is no longer needed — proven by the AFTER probe above (pending → resolved → discovered) and corroborated by design-council doing exactly this in production today.
2. **A self-pin would be wrong.** `git+…@main#subdirectory=skills` serves **main's** `SKILL.md` to a branch install — the precise defect #255 fixed for context and agents, and the reason branch regression-testing of guidance was impossible. `"@attractor:skills"` resolves inside whatever snapshot was installed.
3. **`tool-skills` is an external module, so `git+…@main` is correct for its `source:`.** The no-self-pin rule in this file governs *same-repo* modules only. No `session.orchestrator` source is touched anywhere in this diff, so OSP-001 is unaffected (and passes).

## Dedupe

Root `bundle.md` declares the identical entry and includes this behavior, so both now compose. Foundation merges `tools:` by module id and de-duplicates list-valued config (`merge_module_lists` → `deep_merge`), so the pair collapses to one registration. Measured at base and at head:

```
### root @ BASE (root declares tool-skills; behavior does not) ###
tool-skills entries               : 1
distinct tool-skills sources      : 1 -> ['git+…amplifier-bundle-skills@main#subdirectory=modules/tool-skills']
total config.skills entries       : 9
attractor-skills references       : 1 -> ['@attractor:skills']
config.skills has duplicates      : False
ASSERT one-entry/one-ref/no-dupes : PASS

### root @ HEAD (root AND behavior both declare tool-skills) ###
tool-skills entries               : 1
distinct tool-skills sources      : 1 -> ['git+…amplifier-bundle-skills@main#subdirectory=modules/tool-skills']
total config.skills entries       : 9
attractor-skills references       : 1 -> ['@attractor:skills']
config.skills has duplicates      : False
ASSERT one-entry/one-ref/no-dupes : PASS
```

Byte-for-byte the same numbers at base and head: one entry, one source, one `@attractor:skills` reference, no duplicate skill sources. This is also the pattern this file and the root **already** use for `attractor-expert` — declared in both, collapsed by the merge — so the fix follows the house convention rather than inventing one.

## Tier (`docs/QUALITY_PROTOCOL.md` §3)

**Uncharted / extension.** The canonical spec governs the coding agent and pipeline runtime, not how a host platform's bundle packages itself; its silence here is a scope boundary, not a signal — the same argument `specs/EXTENSIONS.md` §37 already makes for this exact area.

Toll paid: §37 gains a dated addendum (this is §37's own delivery gap, one surface over — a new section would have split one claim across two homes). Additive and non-interfering: no engine module changed, `tool-skills` mounts a *session* tool and adds no LLM-node context, so a pipeline node's composed content is byte-identical and a spec-conformant graph behaves identically. No matrix row is owed — nothing here is a normative statement about graph semantics, and the coverage tripwire requires rows for DIVERGES entries only.

## Verification checklist

- [x] Unit tests pass — full `modules/loop-pipeline` suite: **2547 passed, 25 skipped**
- [x] Live pipeline run exercising changed code path — **N/A, checked with reason**: no engine or handler code is touched (YAML + ledger prose only). The equivalent proof for a composition change is a real compose, which is the before/after probe above.
- [x] AGENTS.md reviewed; repo-specific gates met
- [x] Backward-compat path unchanged — root-bundle composition proven identical at base and head (dedupe section)
- [x] Observable contract → `specs/EXTENSIONS.md` entry: §37 dated addendum ships in this PR
- [x] Doc claim about code behavior → guard test: **checked with reason** — the claims added are about bundle *composition*, which the existing guards already pin (`test_orchestrator_source_pin_guard.py` OSP-001..003 covers every composition surface including `behaviors/*.yaml`; `test_extensions_ledger_integrity.py` pins the ledger). Both run green against this diff; no new numeric/vocabulary claim about module code is introduced.
- [x] PR body includes verification evidence, not just "tests pass"
- [ ] CI is green before merge — confirm with `gh pr checks`

## Verification evidence

```
$ pytest -q modules/loop-pipeline           (uv run --extra remote)
2547 passed, 25 skipped, 3 warnings in 33.54s

$ pytest -q tests/test_extensions_ledger_integrity.py \
           tests/test_orchestrator_source_pin_guard.py \
           tests/test_spec_conformance_matrix.py
214 passed, 24 skipped in 0.39s

$ bash .github/capsule-pipeline/vendor/backlog/check-upstream-leaks.sh \
       behaviors/attractor-core.yaml specs/EXTENSIONS.md
clean (no seeded pattern matched …)

$ git diff --check
(clean)

$ python -c "yaml.safe_load(open('behaviors/attractor-core.yaml'))"   → parses
$ python -c "yaml.safe_load(bundle.md frontmatter)"                   → parses
```

## Notes for reviewers

- The diff is 6 lines of YAML; the rest is the comment explaining *why this form* and *why here*, so the next person does not "simplify" it back into a self-pin.
- The dedupe result is a property of foundation's merge, not of this file. If foundation ever changed list-merge to replace-rather-than-concat, the root and behavior entries would still name the same single source, so the outcome is stable under that change too.
- The AFTER probe's `SKILL DIRS (deduped) … (count=1)` is the behavior-only case. Under a root compose the attractor skills dir appears once among nine sources (see dedupe section) — also exactly once.

## Observations

*(`docs/QUALITY_PROTOCOL.md` §4 — noticed while doing this, not fixed here.)*

1. **The `--app` behavior install path is undocumented in-repo.** `grep -rn -- "--app"` across the tree matches only the comment this PR adds. The behavior file is a first-class, user-facing install target — `evals/guidance/harness` installs the *root*, and `docs/GETTING-STARTED.md` covers neither. Worth a documented install section naming both shapes and what each delivers, if only so the next delivery gap is visible by reading rather than by probing.
2. **Nothing guards "the behavior delivers what its own guidance names."** This gap was invisible to CI: every test passed at base while the shipped behavior pointed at a slash command it did not provide. The generalizable guard is cheap — for each composition surface, assert that every `/skill` named in the context and agents it registers is reachable from the skills sources it registers. That would have caught this, and would catch the next one on a surface nobody thought to probe.
3. **`context/attractor-awareness.md` is still root-only, deliberately** (it must not flow into pipeline LLM nodes). Consequence worth stating plainly: a behavior-only install now gets the expert **and** the skill, but not the always-on objective-first steering. Whether that is the intended split is a maintainer call, not something to change quietly under a skills fix.
