### PR TITLE
fix(skills): model_role → routing-matrix token + metadata hygiene (attractorify, attractor-scout)

### DIFF
--- a/skills/attractor-scout/SKILL.md
+++ b/skills/attractor-scout/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: attractor-scout
+version: "1.0.0"
 description: >
   Mine YOUR OWN local context-intelligence session history to find the
   attractor-shaped opportunities hiding in your real recurring work — the
@@ -10,23 +11,12 @@ description: >
   automate?", "find my attractor opportunities", "scout my sessions", "what do
   I keep doing by hand?", "mine my own work for pipelines".
 user-invocable: true
-model_role: >
-  You are the attractor-scout orchestrator. You run a fixed pipeline: a
-  deterministic mining spine (bundled scripts, no LLM) hands you compact
-  records; you pay the LLM only for the two things no matcher can do —
-  semantic clustering of cross-worded work (a `fast`-role pass) and fit
-  verdicts plus author adjudication (a `reasoning`- and `general`-role pass) —
-  and then you hand every count the LLM emitted BACK to the deterministic
-  layer to be re-verified against the raw records before it can influence a
-  ranking. You never rank the machine's own ceremony as the user's work. You
-  never render a verdict you did not earn from evidence. You decline, out loud,
-  when the shape does not fit.
+model_role: reasoning
 allowed-tools:
   - bash
   - read_file
   - write_file
   - delegate
-shortcut: attractor-scout
 ---
 
 # /attractor-scout — mine your own work for the loops worth building

--- a/skills/attractorify/SKILL.md
+++ b/skills/attractorify/SKILL.md
@@ -1,24 +1,18 @@
 ---
 name: attractorify
+version: "1.0.0"
 description: >
   Analyze the current session and decide whether an attractor pipeline is
   warranted — then design one conversationally if it is. Triggers: "/attractorify",
   "should this be an attractor?", "design a pipeline for", "attractorify this",
   "do I need an attractor pipeline?", "turn this into a pipeline".
 user-invocable: true
-model_role: >
-  You are an attractor pipeline design assistant. You diagnose whether a pipeline
-  is warranted, design one conversationally when it is, and ask targeted clarifying
-  questions when the session under-determines the design. You consult the
-  attractor:attractor-expert agent by delegation at design start and final review
-  (reading agents/attractor-expert.md directly only when delegation is
-  unavailable); you do not restate the doctrine from memory.
+model_role: reasoning
 allowed-tools:
   - read_file
   - write_file
   - bash
   - delegate
-shortcut: attractorify
 ---
 
 # /attractorify — Attractor Pipeline Design Skill


### PR DESCRIPTION
## Summary
Metadata hygiene for the bundle's two skills — `attractorify` and `attractor-scout`. Both declared `model_role:` as a **descriptive prose paragraph** instead of a routing-matrix role token. The loader only reads `model_role` in the fork path (`_execute_fork()`), so it is inert for these inline skills today — but the prose is wrong-shaped against the convention (every canonical `amplifier-bundle-skills` skill uses a single token; inline skills like `council-here`/`skillify` carry one too) and is a landmine if either skill is ever converted to `context: fork` (prose → no matrix match → silent fallback to the parent model). The skill **body** never sees this text (`extract_skill_body()` returns only post-frontmatter markdown), so the change is behavior-neutral for inline execution.

Per file (both): `model_role:` prose → `reasoning`; delete `shortcut:` (equalled `name`, registers nothing — `/attractorify` and `/attractor-scout` work via `user-invocable: true`); add `version: "1.0.0"`. Everything else byte-identical — `name`, `description`, `user-invocable`, `allowed-tools` (callable-name form matches the repo's own convention), and `context` (absent = inline = correct; both must stay inline — they are conversational and need cwd/AGENTS.md/repo state).

## Verification checklist
- [x] Unit tests — attractor-scout suite **221 passed / 39 skipped** (incl. `test_no_real_data_leak.py`, `test_skill_doc_claims.py`); no reaction to `reasoning`/`1.0.0`
- [x] Live pipeline run — N/A: skill-frontmatter only, no engine/handler/.dot touched
- [x] Backward-compat — behavior-neutral by construction (inline path never reads `model_role`; body unchanged; `attractorify`'s eval baseline body is untouched — the prose was never surfaced to any model)
- [x] EXTENSIONS entry — N/A: no observable pipeline contract touched
- [x] Doc-claim guards — N/A (no doc claims changed)
- [x] Pre-publication leak review — outsider read + identity scan of the diff: only role tokens/version added, prose removed; zero identity values
- [x] CI green before merge — will confirm before merging

## Notes for reviewers
- `model_role: reasoning` is **advisory-until-forked** for an inline skill (matches the `council-here`/`skillify` inline-with-token convention) — chosen because both skills are analysis/orchestration-heavy and `reasoning` exists in the active matrix.
- The removed prose was captured verbatim in the commit context. `attractorify`'s prose is already restated in its body (no relocation needed). `attractor-scout`'s prose named a load-bearing re-verification contract; if any of it is missing from the body, that is a separate **eval-gated** follow-up, not this metadata PR.
