### PR TITLE
feat(skill): attractor-scout demonstration layer — teach attractor on the user's own top opportunity

### DIFF
--- a/docs/designs/2026-08-19-attractor-scout-demonstration-layer.md
+++ b/docs/designs/2026-08-19-attractor-scout-demonstration-layer.md
@@ -1,0 +1,578 @@
+# Design: the attractor-scout demonstration/teaching layer
+
+**Status:** SHIPPED. Decision-complete when written (2026-08-19); built and live-proved in the
+PR that also lands this document. The design below is preserved as written except for a
+pre-publication leak sweep (`docs/QUALITY_PROTOCOL.md` section 7) and section 6, which records
+what actually changed on contact with the build.
+**Date:** 2026-08-19
+**Repo:** `amplifier-bundle-attractor`, `main` @ `4aaedcf`
+**Scope:** the "second half" of the `/attractor-scout` onboarding skill — a demonstration and
+teaching layer on top of the shipped opportunity-mining half. Design only; no implementation here.
+
+**Read against:** `skills/attractor-scout/` (SKILL.md, `scripts/attractor_scout/`, `tests/`,
+`fixtures/synthetic_corpus.py`, `evals/README.md`), `skills/attractorify/SKILL.md`
+(eval-frozen — ZERO edits planned), `examples/authoring/pipeline-author.dot` +
+`check_authored_pipeline.py` (A0–A10), `examples/patterns/convergence-factory.dot`,
+`context/attractor-awareness.md` (never-clause + self-certification output contract),
+`context/dot-reference.md` (the vocabulary), `docs/VISION.md`, `docs/QUALITY_PROTOCOL.md`
+(§2 guidance toll, §3 decision matrix, §7 leak defense).
+
+---
+
+## 0. The gap, and what ships
+
+The shipped skill delivers the mining half: deterministic spine → LLM label/cluster/verdict/author
+tiers → `rank --strict` re-verification (FATAL on mismatch) → deterministic self-contained HTML
+map. What it does not do — the maintainer's onboarding intent:
+
+1. **Teach what an attractor pipeline IS** (learn-about).
+2. **Demonstrate how attractor could have helped THEM** — for a real top opportunity, the actual
+   pipeline that would have converged their recurring scenario, with the why.
+3. Adjudicate **skillify's** role.
+
+What ships (one sentence): after the map renders, the skill authors — via one bounded
+reasoning-role delegation — a small doctrine-shaped `.dot` + companion for the user's **#1 ranked
+opportunity**, machine-gates it (`attractor lint` when available, always the vendored stdlib
+doctrine checker), assembles a **demonstration bundle** whose every number is deterministically
+re-verified, and re-renders the same self-contained HTML with a one-screen "what is an attractor
+pipeline" primer plus per-demo teaching sections; further demos are user-selected, one explicit
+yes at a time.
+
+Two invariants carry over untouched and bind everything below:
+
+- **The renderer stays LLM-free.** All generated narrative arrives as *data*; the renderer is
+  deterministic and byte-reproducible given the same inputs and a pinned timestamp.
+- **Own data only; nothing leaves the machine.** The one network-adjacent option (fetching the
+  public linter via `uvx`) is inbound, consent-gated, and never automatic (D3).
+
+---
+
+## 1. The eight decisions at a glance
+
+| # | Question | Decision |
+|---|---|---|
+| D1 | Where in the flow / how many | New SKILL.md steps **8–9 after render**: auto-demo exactly **K=1** (the top-ranked opportunity), then user-selected extras, one explicit yes each; render is re-run per demo (cheap, deterministic). Zero opportunities ⇒ primer-only. |
+| D2 | Generation mechanism | **(a) bounded fresh-context `reasoning` delegation**, fed a deterministically assembled brief (`demo brief` subcommand: evidence digest + doctrine contract + vocabulary excerpt). Budget: **2 attempts** (initial + one gate-informed retry). (b) `pipeline-author.dot` is the *offered* independent path, never the default; (c) inline authoring rejected. |
+| D3 | Machine gates | Ladder: **`attractor lint` (PATH) → consent-gated `uvx` lint (ask first, flagged as inbound fetch) → vendored stdlib doctrine checker (always runs) → honest `UNVERIFIED` label**. Verification levels `lint+doctrine` / `doctrine-only` / `none`, rendered verbatim; red verdicts after the retry ⇒ demo not published. Self-certification panel (machine-checked / not-checked / independent path) in every demo. |
+| D4 | Teaching content contract | Numbers **only** from re-verified `ranked.json` via deterministic templates; LLM narrative fills six named prose slots, validated by a **digit-whitelist** and a **node-name check** (fail loud). Primer = fixed deterministic template, once per artifact, **linking** the published explainer. Convergence math = deterministic arithmetic with labeled illustrative constants. |
+| D5 | HTML integration | Extend `render.py` with an optional `demos` input (new `--demos` flag). Primer + demo sections insert between the sampled range and the ranked table. **No demos ⇒ byte-identical output to today.** Generated `.dot`/`.md` land beside the HTML in `<outdir>/attractor-scout-demos/`; the HTML embeds the `.dot` text (self-contained) *and* states the on-disk relative path. |
+| D6 | skillify | **No runtime role** (argued); generation-time lineage acknowledged in this design doc + PR body only; possible future role named, not built. |
+| D7 | Tests/evals | CI-deterministic: assembly validation, ladder labeling, vendored-checker pin + red-proof, renderer additivity/honesty, leak guard auto-covers new files. Guidance toll discharged via the documented **fresh-session walk-through fallback** (scout precedent). LIVE proof on the maintainer's real corpus, artifacts outside the repo, leak-lens on all PR evidence. |
+| D8 | Out of scope | Auto-running generated pipelines; any edit to `skills/attractorify/SKILL.md`, `examples/authoring/*`, or the explainer; wayfinder; team-shared tier; auto-installing the CLI; demos for honest-NOs/waste; a new guidance-eval scenario (deferred, precedented). |
+
+---
+
+## 2. Decisions in full
+
+### D1 — Where demonstration happens; K; the interactive shape; cost
+
+**Decision.** Two new SKILL.md steps *after* the existing step 7 (render), leaving steps 1–7
+byte-untouched:
+
+- **Step 8 — Demonstrate (auto, K=1).** Immediately after the map is written, generate one
+  demonstration for `opportunities[0]` of `ranked.json` (the list is already score-ordered with
+  the escalating-trajectory boost; `provisional`/`unproven` flags carry into the demo header
+  verbatim — they are caveats, not disqualifiers). Then re-render the same `$OUTPUT_PATH` with
+  `--demos`. If `opportunities` is empty, skip generation and render **primer-only**
+  (`demos: []`, `primer: true`) with the honest note that a demonstration needs a subject.
+- **Step 9 — Offer more (user-selected).** Show the top 5 not-yet-demonstrated opportunity names
+  and ask exactly one question: *"Want another one demonstrated? Name or number — or no."* Each
+  yes runs the step-8 mechanics for that unit with `--append`, then re-renders. Never loop
+  without a fresh explicit yes. If the user said "map only" at any point, honor it and skip
+  step 8 entirely.
+
+**Cost story (stated in SKILL.md in one line).** Each demo costs one `reasoning`-role delegation,
+at most two when the machine gates reject the first draft; no fast-tier involvement; re-rendering
+is deterministic and free. The auto-demo is not consent-gated because demonstration *is* the
+skill's second half — the user invoked an onboarding skill whose description says it demonstrates;
+every demo beyond the first is consent-gated because that is marginal spend for marginal
+personalization.
+
+**Rationale.** The map renders first so the mining payoff is never held hostage to demo latency,
+and a demo failure leaves a complete v1 artifact (the layer is strictly additive even in failure).
+K=1 because the primer + one worked example is what teaches the concept; demo #2 onward
+personalizes further but teaches nothing new, so it should cost an explicit yes. Top-1 by rank —
+not user-picked-first — because an onboarding user cannot yet judge which unit is most
+attractor-shaped; the ranking exists precisely to make that call, and the "show me" moment dies if
+it opens with a menu.
+
+**Rejected alternatives.** *Automatic top-K for K≥2*: multiplies LLM spend with diminishing
+teaching return, and lengthens the artifact past onboarding attention. *Fully user-selected (K=0
+auto)*: breaks the maintainer's "demonstrate how attractor could have helped them" — a
+demonstration you must configure before seeing is a form, not a demonstration. *Demo before first
+render*: couples the mining payoff to generation latency and makes demo failure block the map.
+
+### D2 — Worked-pipeline generation mechanism
+
+**Decision: option (a)** — one bounded, fresh-context **`reasoning`-role delegation** per demo,
+driven by a deterministically assembled brief. Mechanics:
+
+1. `$CLI demo brief --ranked "$WORK/ranked.json" --unit <unit_id> --workdir "$WORK/demo"`
+   derives the slug (printed on stdout), creates `$WORK/demo/<slug>/`, and writes `brief.md`
+   there — assembling the instruction pack **deterministically** (no improvised prompts): the unit's
+   verified stats and gist; its fit detail (cycle/gate/recovery booleans); the most common
+   verify-class tools observed in the cluster members' terminal windows (computed from the
+   extract — this is the evidence the gate command is derived from); the A0–A10 authoring
+   contract summary; a compact vendored excerpt of the engine vocabulary (the `prompt=` /
+   `shape=` / `tool_command=` / `condition=` / `fidelity=` / `max_retries=` / `goal_gate=`
+   essentials from `context/dot-reference.md`, because a fresh-context delegate sees only what
+   the instruction carries); a **node budget of max 9 nodes** (start, exit, 1–2 workers, gate(s),
+   budget wall, loud terminal — the convergence-factory shape in miniature); and the output
+   contract: write `pipeline.dot`, `pipeline.md` (companion naming every worker — A9), and
+   `narrative.json` (six prose slots, D4) into `$WORK/demo/<slug>/`.
+2. The orchestrating session delegates with that brief (fresh context, `reasoning` role).
+3. Machine gates run (D3). On a red verdict, **one** corrective retry: re-delegate with the gate
+   reports appended verbatim (this enacts the corrective loop the demo is teaching). Still red ⇒
+   the demo is not published; say so in chat; the map keeps its primer.
+
+Demos are generated **only for `verdict ∈ {OPPORTUNITY, OPPORTUNITY(unproven)}`** units — which
+guarantees, by the fit test's own construction, that cycle and gate evidence exist for the brief
+to cite. The brief is untrusted-text-safe by the same rule as `pipeline-author.dot`: unit names
+and gists are expanded into *prompts and prose slots only*, never into a `tool_command` the
+orchestrator executes.
+
+**Rationale.** (a) is the only option that satisfies all four constraints at once: it works with
+**bundle-only installs** (no `attractor` CLI required — the doctrine checker is stdlib, D3); it
+keeps **cost bounded and known** (≤2 delegations); it preserves **nothing-leaves-the-machine**
+(delegation reasons over local text); and it keeps the **separation the never-clause needs** — a
+fresh-context author whose output the orchestrator machine-checks means the session relays machine
+verdicts about work it did not itself write into its own context.
+
+**Rejected alternatives.** **(b) drive `pipeline-author.dot` via the CLI as the default**: its own
+preflight hard-fails without `attractor`, `python3`, `sha256sum` on PATH — exactly the tools an
+onboarding user may lack; it budgets up to 4 author iterations and 14400 s wall clock — an
+unbounded-feeling cost for a teaching artifact; and it produces a *hardened reusable pipeline*,
+which is more than a demonstration needs. It is instead the **offered independent path** in every
+demo (D3's panel and D4's run-forward section carry its exact invocation with the brief
+pre-filled) — the same shape as attractorify Step 8. **(c) inline authoring by the driving
+session**: burns main-context tokens on a context already carrying the whole mined corpus;
+produces the worst self-certification posture (the certifying session is the literal author, so
+even relaying machine verdicts reads as self-vouching); and loses the clean retry seam that
+feeding gate reports to a fresh delegate provides.
+
+### D3 — Machine gates, the degradation ladder, and the self-certification contract
+
+**Decision — the ladder, exactly:**
+
+| Rung | Condition | What runs | `verification.level` |
+|---|---|---|---|
+| 1 | `command -v attractor` succeeds | `attractor lint <dot>` — findings captured **verbatim**; the only clean verdict is `OK (no findings)`; WARNINGs (e.g. the one deliberate TOPO-006 on the loud-terminal idiom) pass but are quoted; ERRORs are a red verdict | `lint+doctrine` (with rung 3) |
+| 2 | CLI absent | Ask the user **once**: *"The attractor CLI isn't installed. I can fetch and run the public linter via `uvx --from git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/pipeline-runner attractor lint <file>` — that downloads a public package (an inbound fetch; none of your mined data leaves this machine). Yes/no?"* On yes, run it via the `--lint-cmd` override. On no, skip. **Never silent, never automatic.** | `lint+doctrine` on yes |
+| 3 | always | The **vendored** stdlib doctrine checker (A0–A10) — ships inside the skill at `scripts/attractor_scout/authoring_contract.py`, a **byte-identical copy** of `examples/authoring/check_authored_pipeline.py`, pinned by a drift test (D7). Runs whether or not lint ran (second opinion / floor). `doctrine_bad` is a red verdict. | `doctrine-only` when rung 1/2 didn't run |
+| 4 | the checker itself cannot execute (environmental crash) | nothing verified | `none` |
+
+**Red verdict vs. unavailability — different fates.** A red verdict (lint ERROR or `doctrine_bad`)
+after the one retry means the demo is **not published** — the artifact never carries a broken
+demo. Unavailability of a rung is honestly *labeled*, and the demo publishes at the level that did
+run. The three level labels are exact strings the renderer must emit and tests must pin:
+
+- `lint+doctrine`: quote both verdicts verbatim.
+- `doctrine-only`: the panel's lint line reads exactly
+  `attractor lint: NOT RUN — the CLI is not installed here. Run it yourself: attractor lint <relpath>`
+  (never an implied pass — the #270 doctrine: if the linter can't run, SAY SO in the artifact).
+- `none`: a prominent `UNVERIFIED — no machine check ran on this pipeline` banner plus both
+  commands to run.
+
+**The self-certification panel** (deterministic template, injected verbatim machine output; the
+`context/attractor-awareness.md` output contract made structural) appears in **every** demo:
+
+1. **What a machine checked, and what it said** — the lint verdict verbatim (warnings included)
+   and the doctrine report's verdict line + per-check summary.
+2. **What nothing checked** — whether the prompts fit your workflow, whether the gate command is
+   the right definition-of-done for your case, whether this pipeline solves the problem you
+   actually have. Structure lints; judgment does not.
+3. **The independent path** — the exact `pipeline-author.dot` invocation with this demo's brief as
+   `--param brief=`, and the CLI install line
+   (`uv tool install "git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/pipeline-runner"`,
+   held as a single constant `CLI_INSTALL_CMD` in `demo_templates.py`).
+
+SKILL.md additionally instructs the session: when asked to vouch for a demo, answer in those three
+parts — never "yes, I'm sure" (the graded-session failure attractorify Step 6 documents).
+
+**Rationale.** Lint is the gold-standard machine verdict and must be first when reachable; the
+vendored checker is the floor that makes bundle-only installs verifiable at all; and vendoring —
+rather than referencing `examples/authoring/` by relative path — is what lets the skill's
+**standalone** test suite (its conftest forbids cross-repo imports) exercise the gate hermetically
+in CI, and keeps the skill working if it is ever installed without the full repo tree. The repo
+already sanctions exactly this pattern twice: `check_authored_pipeline.py` is itself an adapted
+copy of `check_child_contract.py` carrying its own agreement test, and `test_quality_protocol_guard.py`
+Q-307 pins two copies of the decision matrix to each other. The `uvx` rung is consent-gated
+because a skill whose headline is "nothing leaves the machine" must not initiate *any* network
+activity silently — an inbound public-package fetch is not data egress (and the artifact/SKILL.md
+say so in those words), but unrequested network I/O is still a trust-surface violation in this
+skill's frame.
+
+**Rejected alternatives.** *Require the CLI (hard dependency)*: kills bundle-only onboarding — the
+audience this layer exists for. *Auto-`uvx` without asking*: silent network activity inside a
+local-only promise. *Reference `examples/authoring/check_authored_pipeline.py` by path instead of
+vendoring*: breaks the standalone-tests principle and standalone installs; the byte-pin test makes
+the vendored copy cost one `cp` per upstream change instead of a drift risk. *Suppress unverified
+demos entirely*: the maintainer's ladder explicitly ends in an honest "unverified" label, and an
+unverified-but-labeled demo still teaches — the label itself teaches the verification doctrine.
+
+### D4 — The teaching-content contract
+
+**Decision — per demonstrated opportunity, in this order, with this deterministic/LLM split:**
+
+| Section | Source |
+|---|---|
+| 1. Header: unit name, verdict badge, THEIR verified numbers — n distinct sessions, median tool calls, median LLM cycles, median span, error rate, `provisional`/`unproven` flags verbatim | **Deterministic** (from `ranked.json`, which `rank --strict` already re-verified against the extract) |
+| 2. "What this keeps costing you by hand" — the toil restated from `leverage_detail` | **Deterministic** template |
+| 3. "In your own terms" — scenario gist | **LLM slot** `scenario_gist` |
+| 4. The three-question fit test applied to THEIR scenario — Q1/Q2/Q3 verdict lines from `fit_detail`/`recovery` (UNKNOWN renders as *unproven — a caveat, never a failure*, same invariant as the map) | Verdicts **deterministic**; one **LLM slot** per question (`q1_cycle_note`, `q2_gate_note`, `q3_recovery_note`) explaining the verdict in their scenario's terms |
+| 5. The pipeline, walked — embedded `.dot` text + per-node notes | `.dot` text **deterministic** (escaped verbatim); **LLM slot** `pipeline_walk` = array of `{node, note}` |
+| 6. Convergence math — why the loop beats the once-through run | **Deterministic** arithmetic in the template: with their median LLM-cycle count *n* (verified) as chain length and a **fixed illustrative per-step reliability of 0.9** (labeled: *"illustrative arithmetic — not a measurement of your sessions"*), render `0.9^n` once-through vs. the gated-loop retry probability with the demo's own budget wall. Computed in Python at assembly, never by the LLM |
+| 7. "Why this would have helped" — one line | **LLM slot** `payoff_note` |
+| 8. Entry points — `/attractorify` (design it conversationally), `examples/authoring/pipeline-author.dot` (converge it under executed gates), `examples/patterns/task-runner.dot` (the canonical skeleton), the objective layer (`examples/objective/objective-runner.dot`), and the repo-hosted capsule lane (`docs/ISSUE_PIPELINE.md`) | **Deterministic** template |
+| 9. "Run it going forward" — the on-disk `.dot` path, the exact `attractor run <relpath> --cwd .` invocation with its budget params, `CLI_INSTALL_CMD`, and the `pipeline-author.dot` alternative with the brief pre-filled | **Deterministic** template |
+| 10. Verification panel (D3) | **Deterministic** template + verbatim machine output |
+
+**Once per artifact — the learn-about primer:** a fixed deterministic template section, *"What an
+attractor pipeline is — in one screen"*: loop + machine-evidence gate + budget wall; the
+three-question test; the honest-no doctrine; gates-outside-workers in one sentence — followed by a
+plain link to <https://microsoft.github.io/amplifier-bundle-attractor/attractor-explained.html>.
+The repo convention is to **link the explainer, never inline it**; and a hyperlink does not breach
+the self-contained rule, which forbids *fetched resources* (CSS/JS/fonts/data), not references a
+reader may choose to follow. State that distinction in a comment in `render.py`.
+
+**The count-integrity guard (the existing doctrine, extended to narrative — SCOPED to the six
+teaching-prose slots):** every number in the six teaching-prose slots comes from a deterministic
+slot fed by re-verified `ranked.json`. The LLM slots are validated at assembly, **fail-loud**
+(exit 2, same posture as `rank --strict`):
+
+- **Digit whitelist:** every digit-run in every narrative string must be a member of the allowed
+  set = string forms of the unit's verified stats (as rendered) ∪ `{0,1,2,3,4}` (for Q1/Q2/Q3 and
+  4a/4b/4c references). An invented count anywhere in the narrative kills the assembly with the
+  offending token named. Prose like "about a dozen" is always legal.
+- **Node-name check:** every `pipeline_walk[].node` must be a node id in the parsed `.dot`
+  (parsed with the vendored checker's own `parse_dot_min` — one parser, one truth).
+- **Shape checks:** all six slots present, strings, each ≤ 600 chars; `pipeline_walk` non-empty.
+
+**Scope boundary (the claim, narrowed to what the check actually enforces).** The digit whitelist
+governs the six teaching-prose slots and *only* those. Numbers written **inside the generated
+`.dot`** — a budget, a `max_iterations`, a threshold, a figure in a node's `prompt=` or `label=` —
+are LLM-authored and rendered verbatim, and are **not** digit-whitelisted. That is deliberate, not
+an oversight: a `.dot` legitimately carries pipeline parameters, and a whitelist there would
+false-positive on real ones (a `max_iterations=6` is not a fabricated count). The `.dot` gets its
+own appropriate machine gate — `attractor lint` plus the authoring contract (D3) — which checks it
+for *structure*, not for agreement with the verified stats. The self-certification panel's part 2
+("what nothing checked") **names this surface out loud**, and a test pins that it keeps doing so,
+so the claim cannot silently re-widen.
+
+**Two named limits of the whitelist itself (documented, not closed).** The digit-run scan matches
+`\d+`, which leaves two honest gaps, each a deliberate trade rather than a defect:
+
+- **Decomposition:** a stat like `0.33` rendered as `0.33` also whitelists the bare run `33`, so a
+  narrative saying "33 minutes" would pass. Closing it would mean whitelisting only the exact
+  rendered string, which bans the legitimate `0.33`→`33%` kind of reference; the boundary here is
+  the tokenizer's, and the check fails loud on the *shape* it can define cleanly.
+- **Spelled-out numbers:** "forty-seven hours" is not a digit-run and passes. Detecting written
+  numerals is NLP guesswork, and a fail-loud guard that guessed wrong would block honest prose —
+  the worse failure for a trust surface whose whole point is not to cry wolf.
+
+Both are covered by **expected-pass regression tests**, so a future claim to have closed either one
+forces an honest update to this section rather than a silent behavior change.
+
+**Rationale.** The mining half earned trust with "every count re-verified before render"; the
+demo half inherits it by construction — the LLM never gets to *state* a number, only to narrate
+around numbers the deterministic layer placed, and the whitelist makes that machine-checked
+rather than hoped. The fixed 0.9 in the convergence math is deliberately *not* derived from their
+data: no per-step success probability is measured by the extract, and deriving one would be a
+fabricated statistic wearing their data's clothes — an illustrative constant, labeled as such, is
+the honest version.
+
+**Rejected alternatives.** *Let the LLM write the whole demo section*: unverifiable numbers in a
+skill whose trust contract is verified numbers. *Forbid digits in narrative entirely*: forces
+stilted prose and bans legitimate references like "Q2". *Derive per-step reliability from their
+error rates*: measures something (tool errors) and presents it as something else (LLM step
+success) — a fabricated measurement. *Put the primer text in SKILL.md*: guidance-surface toll for
+text users never see at invocation time; it belongs in the template module, rendered into the
+artifact.
+
+### D5 — HTML integration and on-disk layout
+
+**Decision.**
+
+- `render.py` gains an optional `demos: dict | None` parameter on `render_html`/`write_report`,
+  and the CLI `render` subcommand gains `--demos demos.json`. **When absent, output is
+  byte-identical to today** (machine-checked: no demo marker appears; determinism test holds).
+- Section placement, when demos are supplied: after the sampled simple→complex grid and before
+  "Ranked opportunities", insert (i) the primer section, then (ii) one demonstration section per
+  demo in `demos.json` order. The header sub-line appends `· N demonstrated` when N > 0. Existing
+  sections and their order are untouched (additive-in-the-middle; existing tests assert
+  substrings, not offsets).
+- The renderer consumes `demos.json` as **pure data**; every string is HTML-escaped through the
+  existing `_esc`; the `.dot` text is embedded in a `<pre>` block. Same-inputs ⇒ byte-identical
+  output with a pinned `--generated-at`. (Generation is stochastic; **verification, assembly, and
+  rendering are deterministic** — state this split in SKILL.md.)
+- **On disk:** published demo files land beside the HTML at
+  `<output_dir>/attractor-scout-demos/<slug>.dot` and `<slug>.md`, where `<slug>` is the unit
+  name sanitized to `[A-Za-z0-9._-]+` (the `pipeline_name` charset) + `-<unit_id>` for
+  uniqueness, and the directory stem is a `naming.py` constant (`DEMO_DIR_STEM = f"{SKILL_NAME}-demos"`).
+  Files are copied there **only after** the ladder finishes (publish-after-gates, the
+  `pipeline-author.dot` rule in miniature). Never inside any repo — same rule as the map.
+- **Honest reference:** the HTML both embeds the `.dot` text (survives file moves; self-contained)
+  and prints the relative path it wrote (`attractor-scout-demos/<slug>.dot`) with a relative
+  `<a href>`. Assembly fails loud if the copy failed — the HTML never claims a file that does not
+  exist.
+
+**`demos.json` schema (the assembly output; the renderer's whole input for the new sections):**
+
+```json
+{
+  "primer": true,
+  "explainer_url": "https://microsoft.github.io/amplifier-bundle-attractor/attractor-explained.html",
+  "demos": [
+    {
+      "unit_id": "c1", "name": "...", "slug": "...",
+      "dot_relpath": "attractor-scout-demos/<slug>.dot",
+      "companion_relpath": "attractor-scout-demos/<slug>.md",
+      "dot_text": "...verbatim...",
+      "stats": {"n_sessions": 0, "med_tool_calls": 0, "med_llm_cycles": 0,
+                 "med_span_s": 0, "err_rate": 0.0, "provisional": false},
+      "fit": {"cycle": true, "gate": true, "recovery": "PASS|PASS-provisional|UNKNOWN",
+               "verdict": "OPPORTUNITY|OPPORTUNITY(unproven)"},
+      "narrative": {"scenario_gist": "...", "q1_cycle_note": "...", "q2_gate_note": "...",
+                     "q3_recovery_note": "...", "pipeline_walk": [{"node": "...", "note": "..."}],
+                     "payoff_note": "..."},
+      "convergence_math": {"chain_len": 0, "p_step": 0.9, "once_through": 0.0,
+                            "gated_loop": 0.0, "budget": 2},
+      "verification": {"level": "lint+doctrine|doctrine-only|none",
+                        "lint_verdict": "...verbatim or null...",
+                        "lint_not_run_reason": "...or null...",
+                        "doctrine_verdict": "doctrine_ok",
+                        "doctrine_report": "...verbatim..."},
+      "invocation": {"run_cmd": "...", "author_cmd": "...", "install_cmd": "..."},
+      "generated_at": "ISO-8601"
+    }
+  ]
+}
+```
+
+**Rationale.** One renderer, one artifact, one trust story: the map's credibility already rests on
+"deterministic renderer over re-verified data", and the demo layer buys into it instead of
+shipping a second artifact with weaker guarantees. Byte-identity without `--demos` makes the
+change provably additive to the frozen mining half.
+
+**Rejected alternatives.** *A second, separate demo HTML file*: two artifacts to keep
+self-contained, two to leak-guard, and the teaching detaches from the data that motivates it.
+*Modal-only demos*: long-form teaching in a modal fights the medium; modals stay for unit
+deep-dives. *Inline the `.dot` only (no files on disk)*: kills "run it going forward" — the user
+needs a file path to hand to `attractor run`. *Link files only (no embed)*: the artifact stops
+being self-contained the day the folder is moved.
+
+### D6 — skillify adjudication
+
+**Runtime role: none.** skillify is an ecosystem skill for *authoring skills*; it does not ship in
+this bundle, so a runtime dependency would break exactly the bundle-only audience this layer
+serves — and nothing in the demo flow is skill-authoring-shaped (it authors a `.dot` demonstration,
+not a SKILL.md). **Generation lineage: real, and acknowledged honestly** — the maintainer's intent
+("using the skillify skill ... for creating educational material") describes how this teaching
+layer's *own packaging* is produced: skillify-style discipline shaped the mining half's SKILL.md
+and shapes this layer's step text, and that lineage is recorded here and in the PR body — not in
+SKILL.md, where it would spend guidance-surface toll on a fact no user needs at invocation time.
+**Future role, named not built:** if the demo-brief/authoring guidance ever proves reusable beyond
+this skill, extracting it *as a skill* would be a skillify job then — deliberately deferred, per
+the repo's "no primitives ahead of the evidence" resistance.
+
+### D7 — Test/eval plan
+
+**CI-deterministic (all stdlib, all under `skills/attractor-scout/tests/`, standalone per the
+existing conftest):**
+
+| Test | Asserts |
+|---|---|
+| `test_scenario6_demo_assembly.py` | Planted synthetic opportunity → `demo brief` output carries the verified stats + gate-tool evidence; assembly with the canned fixture narrative/`.dot` succeeds; **red-proofs:** an invented count in a narrative slot ⇒ exit 2 naming the token; a `pipeline_walk` node not in the `.dot` ⇒ exit 2; missing companion ⇒ exit 2; missing slot ⇒ exit 2. |
+| `test_scenario7_verification_ladder.py` | Fake `attractor` shim on PATH emitting a canned verdict ⇒ `level=lint+doctrine`, verdict relayed **verbatim**; empty PATH ⇒ `level=doctrine-only` + the exact `NOT RUN` label; checker forced to crash ⇒ `level=none` + the exact `UNVERIFIED` banner; a doctrine-red fixture (gate deleted ⇒ A4 fails) ⇒ demo refuses to publish (no files copied, no demos.json entry). Gates proven red, per repo doctrine. |
+| `test_scenario8_demo_render.py` | `--demos` ⇒ primer exactly once; explainer link exactly once; per-demo sections present; `.dot` embedded escaped; relpaths in HTML == files actually written; verification labels rendered exactly per level; **no-demos ⇒ zero demo markers and determinism (two renders byte-equal)**; UNVERIFIED never rendered as verified (the new honesty invariant, sibling of UNKNOWN-never-FAIL). |
+| `test_vendored_doctrine_checker_pin.py` | Vendored `authoring_contract.py` is **byte-identical** to `examples/authoring/check_authored_pipeline.py` when that path exists relative to the bundle root (skip when absent — standalone install); plus every attribute name in the vendored vocabulary excerpt appears in `context/dot-reference.md` when present. |
+| existing `test_no_real_data_leak.py` | Auto-covers every new shipped file (it rglobs all `.py/.md/...`) — new template text must carry no personal home paths, no emails, no identity terms; the demo fixture uses the `SYNTHETIC-` marker discipline. No changes needed; verify green. |
+| existing `test_skill_doc_claims.py` | Unchanged — by design the new SKILL.md text contains **no new percentages or pinned numerics** (the arithmetic lives in `demo_templates.py`), so the `{18, 78}` percentage set and pinned claims stay valid. |
+
+**What CI cannot test, and its substitute.** LLM generation cannot run in CI; what CI proves is
+everything around it — brief assembly, validation, gates, labels, rendering — against a **canned,
+doctrine-clean fixture** (`fixtures/demo_fixture.py`: a deterministic small `.dot` in the
+convergence-factory shape + companion + narrative + mutation helpers).
+
+**Guidance-surface toll (§2).** SKILL.md changes are a guidance surface. The standard scenarios
+structurally cannot reach an opt-in slash-command skill — the argument already accepted for this
+skill in `evals/README.md` — so the toll is discharged by the documented fallback, **stated in the
+PR in those words**: a fresh-session walk-through (PR #297-era precedent, and this skill's own
+Run-1/Run-2 precedent): a `context_depth=none` general-tier sub-agent follows only the amended
+SKILL.md over a synthetic corpus, twice — once with a fake `attractor` shim on PATH, once without —
+and must land correct artifacts with correct ladder labels both times. Fix what Run 1 surfaces;
+record both runs in `evals/README.md` (evidence itself stays outside the repo, as before). A
+dedicated guidance scenario remains deferred to the guidance-eval bundle's backlog (precedented).
+
+**LIVE proof spec (on the maintainer's real mined data; artifacts land OUTSIDE the repo, in the maintainer's local evaluation artifacts).** (1) Full run end-to-end including the auto-demo; maintainer has the real CLI
+⇒ `lint+doctrine`, quote the lint verdict verbatim. (2) Negative control: re-run with `attractor`
+masked from PATH ⇒ `doctrine-only` labels proven on real data. (3) Red control: mutate the
+generated `.dot` (delete the gate) ⇒ A4 red ⇒ publish refused. PR evidence carries **verdict lines
+and structure only** — never unit names, gists, or any session-derived text (they derive from
+private sessions); leak-lens review (§7) reads the whole diff plus the PR body under the outsider
+brief, and the PR checklist's leak line is answered non-N/A because this ships a **new
+artifact-type content class** (§2's new-public-content row: deterministic guards green **and** the
+semantic read).
+
+**Decision-matrix tier (state in the PR):** uncharted-adjacent, same argument as the scout skill
+and the leak-defense amendment — onboarding/teaching content extends no observable pipeline
+contract, so no `specs/EXTENSIONS.md` entry is owed; the silence is a scope boundary, argued in
+those words.
+
+### D8 — Scope guard (explicitly OUT)
+
+- **Auto-running the generated pipeline.** The demo hands back the file and the exact invocation;
+  launching is the human's explicit call (attractorify's "not an auto-runner", verbatim doctrine).
+- **Any edit to `skills/attractorify/SKILL.md`** (eval-frozen baseline; its doctrine is reused by
+  reference only), to `examples/authoring/*`, to `context/attractor-awareness.md`, or to the
+  published explainer.
+- **Auto-installing or auto-fetching the CLI.** The `uvx` rung is ask-first only; `uv tool
+  install` appears only as text the user may run.
+- **Demos for honest-NOs or waste findings.** Authoring a pipeline for work that failed the fit
+  test would demonstrate the anti-pattern; the map's verdict + remediation is their teaching.
+- **Wayfinder** — separate lane, untouched. **Team-shared tier** — stays scoped out; own-data-only
+  is load-bearing.
+- **No graph (Tier A/B) requirement anywhere in the demo path** — Tier C stays the floor.
+- **No new guidance-eval scenario in this PR** (deferred, precedented) and **no renderer network
+  resources** (the explainer link is an anchor, not a fetch).
+- **No rename** — `naming.py` stays the single naming source; new constants live there.
+
+---
+
+## 3. SKILL.md step text sketch (builder adapts wording, keeps every bolded rule)
+
+> **8 — Demonstrate (teach with their top opportunity).** The map shows *what* recurs; this step
+> shows *the pipeline that would have converged it*. For `opportunities[0]` in
+> `$WORK/ranked.json` (skip to the primer-only render if the list is empty, and skip entirely if
+> the user asked for the map only):
+>
+> ```bash
+> source "$WORK/env.sh"
+> SLUG=$($CLI demo brief --ranked "$WORK/ranked.json" --unit <unit_id> --workdir "$WORK/demo")
+> ```
+>
+> Delegate to a **fresh-context `reasoning` sub-agent** whose instruction is exactly the brief
+> file — it writes `pipeline.dot`, `pipeline.md`, and `narrative.json` into `$WORK/demo/$SLUG/`.
+> **Cost: one delegation; at most two if the gates reject the first draft; never more.** Then
+> gate and assemble:
+>
+> ```bash
+> $CLI demo assemble --ranked "$WORK/ranked.json" --unit <unit_id> \
+>     --workdir "$WORK/demo/$SLUG" --output-dir "$(dirname "$OUTPUT_PATH")" \
+>     --out "$WORK/demos.json" --append
+> ```
+>
+> `assemble` runs the verification ladder (`attractor lint` if on PATH; the bundled doctrine
+> checker always), validates every narrative number against the re-verified ranking (**an
+> invented count is FATAL, same as step 5**), and publishes the `.dot` + companion beside the
+> HTML **only after the gates finish**. If `attractor` is missing it will tell you; you may then
+> ask the user ONCE whether to fetch the public linter via `uvx` — **an inbound package fetch;
+> none of their mined data leaves the machine; never run it without their yes** (on yes, re-run
+> assemble with `--lint-cmd "uvx --from git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/pipeline-runner attractor"`).
+> If the gates reject the draft, re-delegate ONCE with the gate reports appended verbatim; if it
+> is still red, do not publish — say so and move on. Then re-render:
+>
+> ```bash
+> $CLI render --ranked "$WORK/ranked.json" --demos "$WORK/demos.json" --out "$OUTPUT_PATH"
+> ```
+>
+> **What you authored (via your delegate), you cannot certify.** The artifact carries the machine
+> verdicts verbatim, says which checks did NOT run, and offers the independent path
+> (`examples/authoring/pipeline-author.dot` + the CLI install line). If the user asks you to
+> vouch for the demo, answer in those three parts — never "yes, I'm sure."
+>
+> **9 — Offer more (their call).** List the top 5 not-yet-demonstrated opportunities by name and
+> ask one question: demonstrate another? Each yes repeats step 8 for that unit (`--append`) and
+> re-renders. Never generate a second demo without a fresh explicit yes.
+
+Hard-rules section gains three bullets: the self-certification rule (above, one line), *never
+auto-fetch — ask before any `uvx`, a "no" is fine and the doctrine checker is the floor*, and
+*generated `.dot`/`.md` land beside the HTML, never in a repo*. The Output section adds: "plus, when
+demonstrated, `attractor-scout-demos/<slug>.dot` + `.md` beside it." No new numeric claims anywhere
+in SKILL.md.
+
+---
+
+## 4. File-by-file build plan
+
+**New files (all under `skills/attractor-scout/` unless noted):**
+
+| File | Contents |
+|---|---|
+| `scripts/attractor_scout/demo.py` | Brief assembly (evidence digest incl. cluster gate-tool census from members; slug derivation; node budget constant `DEMO_MAX_NODES = 9`; attempt budget `DEMO_MAX_ATTEMPTS = 2`); narrative validation (digit whitelist, node-name check via the vendored parser, shape/length checks); verification-ladder driver (`lint` discovery, `--lint-cmd` override, vendored checker invocation, level resolution, verbatim capture); convergence-math computation (`p_step = 0.9` constant, labeled); publish-after-gates copy; `demos.json` read/write/append. Fail-loud via `AttractorScoutError` (exit 2 path). |
+| `scripts/attractor_scout/demo_templates.py` | All deterministic template text: primer (+ `EXPLAINER_URL`), section skeletons, verification-panel strings (the three exact level labels as constants: `LABEL_LINT_NOT_RUN`, `LABEL_UNVERIFIED`), entry-points, run-forward, `CLI_INSTALL_CMD`, the vocabulary excerpt used in briefs. No LLM anywhere. |
+| `scripts/attractor_scout/authoring_contract.py` | **Byte-identical vendored copy** of `examples/authoring/check_authored_pipeline.py` (stdlib, self-contained; importable for `parse_dot_min` and `run_checks`, runnable as a script). |
+| `fixtures/demo_fixture.py` | Deterministic doctrine-clean demo `.dot` (convergence-factory miniature, synthetic names only) + companion + narrative builders + mutation helpers (`without_gate()`, `with_invented_count()`, `with_unknown_node()`). |
+| `tests/test_scenario6_demo_assembly.py` | Per D7. |
+| `tests/test_scenario7_verification_ladder.py` | Per D7 (shim-on-PATH via tmp dir + `PATH` env). |
+| `tests/test_scenario8_demo_render.py` | Per D7. |
+| `tests/test_vendored_doctrine_checker_pin.py` | Byte-pin + vocab-excerpt pin (skip when repo files absent). |
+
+**Changed files:**
+
+| File | Change |
+|---|---|
+| `scripts/attractor_scout_cli.py` | New `demo` subcommand with `brief` and `assemble` actions (flags per §3; `assemble` accepts `--lint-cmd`, `--append`, `--output-dir`); `render` gains `--demos`. Exit-code contract unchanged (0 ok / 2 fail-loud). |
+| `scripts/attractor_scout/render.py` | `render_html(result, *, tier_note="", generated_at=None, demos=None)` + `write_report(..., demos=None)`; primer + demo section emitters (import templates from `demo_templates.py`); sub-line `· N demonstrated`; comment stating the link-vs-fetch self-contained distinction. **Guarantee: `demos=None` ⇒ byte-identical output.** |
+| `scripts/attractor_scout/naming.py` | Add `DEMO_DIR_STEM = f"{SKILL_NAME}-demos"` (single naming source preserved). |
+| `SKILL.md` | Steps 8–9, three hard-rule bullets, Output line, description sentence for the demo half. **No new percentages/numeric claims.** |
+| `evals/README.md` | New section recording the demonstration-layer walk-through fallback (both runs, summarized; evidence outside the repo) and the deferred dedicated scenario. |
+
+**No changes** to: `skills/attractorify/SKILL.md`, `examples/**`, `context/**`, `docs/**`,
+`fixtures/synthetic_corpus.py`, existing tests, `ranking.py`, extract/discover/cluster modules.
+
+---
+
+## 5. Settled — no open questions
+
+Every question raised in the ask is settled above with rationale and a rejected alternative
+(D1–D8). Points where this design deliberately exercised judgment beyond the framing: the auto-demo
+runs *after* the first render (not as a gate to it); demo #1 is not consent-gated but every
+subsequent one is; the `uvx` fetch is included but strictly ask-first; unverified demos publish
+with the honest label while gate-*failed* demos never publish; and skillify's lineage is recorded
+outside SKILL.md to keep the guidance surface lean.
+
+---
+
+## 6. Build notes — what changed on contact with the build
+
+The design above is preserved as written. These are the deviations and tooling facts the build
+produced, recorded honestly rather than folded back into the text as if they had been designed.
+
+**Deviations from the file-by-file plan (each with its one-line justification):**
+
+- **`SKILL.md` frontmatter left untouched.** §4 wanted a demo-half `description:` sentence; the
+  build kept the frontmatter exactly as PR #300 had just fixed it (`model_role: reasoning`,
+  `version: "1.0.0"`). Demonstration is announced in the body, which is what D1's consent argument
+  actually needs — the ambient one-liner does not.
+- **`demo brief` gained an optional `--extracts` flag** (not in §3's sketch). D2 requires the
+  gate-tool census to be "computed from the extract", but §3's command omitted the flag that would
+  carry it. The optional flag satisfies both; SKILL.md's step 8 passes it. Absent the flag, the
+  brief says plainly that no gate evidence was available rather than inventing one.
+
+**Tooling change — `skills/attractor-scout/ruff.toml` (new file).** The build added a ruff config to
+the skill with two settings, and both are disclosed here so the diff carries no silent surprise:
+
+- `line-length = 120`. This matches the style the whole skill was already written in. Without it,
+  ruff's default (88) reports the *pre-existing* tree as dirty: it turns **9 lint errors into 6**
+  (quieting three `I001` unsorted-import findings that only trip at the shorter width) and would
+  reformat **27 files** that were never at 88 columns. Pinning 120 is therefore not a behavior
+  change to this layer's code — it is making the linter agree with the code that already shipped,
+  so `ruff check`/`format --check` are a real signal on the new files instead of drowning in
+  reformat noise on old ones. The remaining 6 errors are all in design-frozen or out-of-scope files
+  (`evals/`, `fixtures/synthetic_corpus.py`, `__init__.py`) and are left untouched.
+- `extend-exclude = ["scripts/attractor_scout/authoring_contract.py"]`. The vendored doctrine
+  checker is a byte-identical copy pinned by a sha256 test; ruff formatting it here would fork it
+  from its upstream home and break the pin. It is linted/formatted only upstream, which is the only
+  place a change to it belongs.
+
+**Scope narrowing after adversarial review (Finding 1).** The "every number is deterministic,
+never LLM-emitted" claim was over-broad: the digit whitelist governs the six teaching-prose slots
+only, and numbers *inside* the generated `.dot` (budgets, `max_iterations`, thresholds) are
+LLM-authored and gate-checked by lint+doctrine, not whitelisted — because a `.dot` legitimately
+carries pipeline parameters and a whitelist there would false-positive on real ones. The claim was
+narrowed to match everywhere it appears (D4, SKILL.md, `demo_templates`, this doc), the
+self-certification panel's part 2 now names that surface out loud, and a test pins that it keeps
+doing so. The whitelist's two named limits (decomposition, spelled-out numerals) are documented at
+the check and in D4, with expected-pass regression tests so a future "closed it" is forced to
+update the docs honestly.

--- a/skills/attractor-scout/SKILL.md
+++ b/skills/attractor-scout/SKILL.md
@@ -195,6 +195,72 @@ verdict and remediation, waste-findings in their own channel:
 $CLI render --ranked "$WORK/ranked.json" --out "$OUTPUT_PATH"
 ```
 
+**8 — Demonstrate (teach with their top opportunity).** The map shows *what*
+recurs; this step shows *the pipeline that would have converged it*. Run it for
+`opportunities[0]` in `$WORK/ranked.json` — the ranking already made the pick, so
+do not open with a menu. Skip this step entirely if the user asked for the map
+only. If `opportunities` is empty there is no subject to demonstrate: write the
+primer-only document and re-render, then say so plainly.
+
+```bash
+source "$WORK/env.sh"
+# No opportunities? Primer only, and skip the rest of this step:
+#   $CLI demo primer-only --out "$WORK/demos.json"
+SLUG=$($CLI demo brief --ranked "$WORK/ranked.json" \
+        --extracts "$WORK/extracts.jsonl" --workdir "$WORK/demo")
+```
+
+`demo brief` writes `$WORK/demo/$SLUG/brief.md` — deterministically assembled
+from their verified stats, their fit detail, the verify-class tools actually
+seen in their own sessions' terminal windows, the A0–A10 authoring contract, and
+the engine's attribute vocabulary. Delegate to a **fresh-context `reasoning`
+sub-agent** whose instruction is exactly that file; it writes `pipeline.dot`,
+`pipeline.md` and `narrative.json` into `$WORK/demo/$SLUG/`. **Cost: one
+delegation; at most two if the gates reject the first draft; never more.**
+Then gate, validate and publish:
+
+```bash
+$CLI demo assemble --ranked "$WORK/ranked.json" \
+    --workdir "$WORK/demo/$SLUG" --output-dir "$(dirname "$OUTPUT_PATH")" \
+    --out "$WORK/demos.json" --append
+```
+
+`assemble` runs the verification ladder (`attractor lint` if it is on PATH; the
+bundled doctrine checker always), validates every number in the **six teaching-
+prose slots** against the re-verified ranking — **an invented count there is
+FATAL, same as step 5** — and copies the `.dot` + companion beside the HTML
+**only after the gates finish**. (Numbers written *inside* the generated `.dot`
+— budgets, `max_iterations`, thresholds — are gate-checked by lint+doctrine, not
+digit-whitelisted: a pipeline legitimately carries parameters, and the panel's
+"what nothing checked" names that surface out loud.)
+If `attractor` is missing it will say so in the artifact rather than imply a
+pass. You may then ask the user ONCE whether to fetch the public linter via
+`uvx` — **an inbound package fetch; none of their mined data leaves the machine;
+never run it without their yes**. On yes, re-run assemble with
+`--lint-cmd "uvx --from git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/pipeline-runner attractor"`.
+If the gates reject the draft it exits non-zero and leaves the verbatim reports
+at `$WORK/demo/$SLUG/gate-report.txt`: re-delegate **ONCE** with those reports
+appended, and if it is still red, do not publish — say so and move on. Then
+re-render the same file:
+
+```bash
+$CLI render --ranked "$WORK/ranked.json" --demos "$WORK/demos.json" --out "$OUTPUT_PATH"
+```
+
+**Generation is stochastic; verification, assembly and rendering are not.**
+And: **what you authored — via your delegate — you cannot certify.** The
+artifact carries the machine verdicts verbatim, says which checks did NOT run,
+and offers the independent path (`examples/authoring/pipeline-author.dot` plus
+the CLI install line). If the user asks you to vouch for the demo, answer in
+those three parts — never "yes, I'm sure."
+
+**9 — Offer more (their call).** List the top five not-yet-demonstrated
+opportunities by name and ask exactly one question: *"Want another one
+demonstrated? Name or number — or no."* Each yes repeats step 8 for that unit
+(`--unit <unit_id>`, with `--append`) and re-renders. **Never generate a second
+demonstration without a fresh explicit yes** — the first one is the skill's
+second half; every one after it is marginal spend for marginal personalization.
+
 ---
 
 ## Hard rules (non-negotiable — these are the trust contract)
@@ -223,6 +289,23 @@ $CLI render --ranked "$WORK/ranked.json" --out "$OUTPUT_PATH"
   all; "no bad day observed" is not "would not survive a bad day."
 - **Fail loud on an empty root** — exact string `looked in <root>, found 0`,
   non-zero exit. Never invent a count.
+- **What you authored, you cannot certify.** A demonstration your delegate
+  wrote is not something you may vouch for. Asked whether it is right, answer
+  in three parts and no fourth: what a machine checked and what it said
+  (verbatim), what nothing checked (whether the prompts fit their workflow,
+  whether the gate is the right definition-of-done, whether it solves the
+  problem they actually have), and the independent path
+  (`examples/authoring/pipeline-author.dot`, plus the CLI install line). Never
+  "yes, I'm sure."
+- **Never auto-fetch. Ask before any `uvx`.** The bundled doctrine checker is
+  the floor and it always runs, so a "no" costs nothing but a label. An inbound
+  public-package fetch is not data egress — say that plainly — but unrequested
+  network activity inside a local-only promise is still a trust violation. And
+  never run `uv tool install`: that line is text the user may choose to run.
+- **Generated `.dot`/`.md` land beside the HTML, never in a repo** — under
+  `attractor-scout-demos/` next to `$OUTPUT_PATH`, and only *after* the gates
+  finish. A demo whose gates came back red is not published at all; an
+  unverified-but-labelled demo is.
 - **The artifact is not the success test.** A pretty HTML file proves nothing;
   the ranking is only trustworthy because every count in it was re-verified
   against the raw records (step 5, `--strict`). Ship the map, but the map earns
@@ -237,6 +320,12 @@ references), written to `$OUTPUT_PATH`. That is the current working directory
 by default, or an **`AGENTS.md`-guided output path** if the repo declares one.
 Never write the user's mined data into a shared repo — their session history
 belongs in their own artifact.
+
+Plus, when demonstrated: `attractor-scout-demos/<slug>.dot` + `.md` beside it.
+The HTML embeds the pipeline text as well as naming that path, so the artifact
+stays self-contained if the folder ever moves. The one hyperlink it carries is
+the published explainer — an anchor a reader may follow, not a resource the
+page loads.
 
 ---
 

--- a/skills/attractor-scout/evals/README.md
+++ b/skills/attractor-scout/evals/README.md
@@ -65,6 +65,46 @@ skill. It is deliberately deferred: it belongs in the guidance-eval bundle's
 own backlog, and building it here would couple this skill to eval machinery it
 should not own.
 
+### Demonstration layer (steps 8–9) — the same fallback, re-discharged
+
+Steps 8–9 add new guidance to the same surface, so the same toll applies and the
+same argument discharges it: the eight ambient scenarios still cannot reach an
+opt-in slash-command skill, so the evidence is again a fresh-session
+walk-through.
+
+**Run 1 — CLEAN, no fix required.** A general-tier sub-agent with
+`context_depth=none` was handed *only* the post-change SKILL.md **body**
+(frontmatter stripped) plus a synthetic corpus root of 1,081 sessions built from
+this skill's own `fixtures/`, and told to follow the skill exactly. With no
+hints about the new steps, it reached and executed them unaided: `demo brief`
+(with `--extracts`, so the gate-tool census came from the corpus's own terminal
+windows) → **one** `reasoning` delegation → `demo assemble` → `render --demos`.
+The machine gates passed on the first draft, so no corrective retry was spent.
+It then stated step 9's offer question verbatim, listed the one
+not-yet-demonstrated opportunity, and stopped without looping.
+
+The artifact it produced verified clean: primer rendered exactly once, the
+explainer **linked** exactly once, one demonstration section, the published
+`.dot`/`.md` present on disk at the relative paths the HTML names, zero fetched
+resources, and the verification level rendered as the exact string the ladder
+resolved. Unprompted, the walk-through also answered the "can you vouch for it?"
+question in the three required parts and noted that the brief had found no
+verify-class tool for that unit — so the delegate said so plainly in the
+companion instead of inventing a check.
+
+**Ladder coverage, and where each rung was proven.** The walk-through
+environment had the CLI installed, so it exercised rung 1 (`lint+doctrine`). The
+other rungs are proven elsewhere rather than left to chance: `doctrine-only`
+with its exact `NOT RUN` label and the red-verdict refusal were both proven on
+the maintainer's real data as controls in the same evidence set, and all four
+rungs — including the `none`/`UNVERIFIED` case and a fake-CLI-on-PATH shim — are
+pinned deterministically in `tests/test_scenario7_verification_ladder.py`.
+
+As before, the walk-through evidence lives outside the repo, in the maintainer's
+local evaluation artifacts: it references a local synthetic run tree and the
+maintainer's own mined units, neither of which is shippable content. A dedicated
+guidance scenario remains deferred for the same reason as above.
+
 ---
 
 ## Stage-1 results (run against the maintainer's own corpus: 2,164 sessions / 54 clusters)

--- a/skills/attractor-scout/fixtures/demo_fixture.py
+++ b/skills/attractor-scout/fixtures/demo_fixture.py
@@ -1,0 +1,317 @@
+"""Canned demonstration artifacts — ground truth BY CONSTRUCTION.
+
+CI cannot run the authoring delegation, so what CI proves is *everything
+around it*: brief assembly, narrative validation, the verification ladder, the
+publish-after-gates rule, and rendering. All of that needs a draft to act on,
+and this module is that draft — a deterministic, doctrine-clean pipeline in
+the convergence-factory shape, its companion, and a matching narrative.
+
+**ZERO real data.** Every name here is synthetic and marked as such; the unit
+name carries the `SYNTHETIC-` marker discipline the corpus fixtures use, and
+`tests/test_no_real_data_leak.py` re-checks that claim on every run.
+
+The mutation helpers are the red-proof half. A gate that has never been shown
+failing is not a gate, so each one breaks exactly one property:
+
+* `without_gate()`      — deletes the evidence gate: A4 goes red.
+* `with_invented_count()` — plants a number the ranking never produced.
+* `with_unknown_node()` — walks a node that is not in the graph.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+#: The planted unit's marker. Obviously synthetic, and never a real name.
+DEMO_UNIT_NAME = "SYNTHETIC-UNIT-D verify and repair the generated report"
+DEMO_UNIT_ID = "d1"
+
+#: A doctrine-clean pipeline: 9 nodes, one exit, one evidence gate, a budget
+#: wall, a failure route on every worker, and one loud terminal that routes
+#: its own nonzero exit into the single exit node.
+DEMO_DOT = """\
+// SYNTHETIC demonstration pipeline (test fixture). Not mined from anyone.
+digraph SyntheticDemo {
+    graph [
+        goal="Converge the recurring repair loop: run the project check, fix what it reports, and stop only when the check is green.",
+        params="target_dir, max_iterations",
+        default_max_retries=2,
+        max_pipeline_duration="3600s"
+    ]
+
+    start [shape=Mdiamond]
+    done  [shape=Msquare]
+
+    preflight [shape=parallelogram, max_retries=0,
+        tool_command="mkdir -p .demo && B=$max_iterations; echo ${B:-3} > .demo/budget && echo 0 > .demo/iter && [ -d \\"$target_dir\\" ] && printf ready || printf blocked"]
+
+    repair [shape=box,
+        prompt="Advance the repair. Read .demo/check.log if it exists -- it holds the latest failure output -- and fix exactly what it reports in $target_dir. Objective: the project check exits clean. Constraints: change nothing the check does not force you to change. Required evidence: the check's own output, which the next node runs. Never edit the check to make it pass."]
+
+    check [shape=parallelogram, max_retries=0, goal_gate=true,
+        tool_command="n=$(cat .demo/iter 2>/dev/null || echo 0); n=$((n+1)); echo $n > .demo/iter; B=$(cat .demo/budget 2>/dev/null); B=${B:-3}; if [ \\"$n\\" -gt \\"$B\\" ]; then printf exhausted; else pytest -q > .demo/check.log 2>&1; rc=$?; [ $rc -eq 0 ] && printf green || { printf red; exit 1; }; fi"]
+
+    triage [shape=parallelogram, max_retries=0,
+        tool_command="B=$(cat .demo/budget 2>/dev/null); B=${B:-3}; n=$(cat .demo/iter 2>/dev/null || echo 0); if [ \\"$n\\" -ge \\"$B\\" ]; then printf spent; else printf retry; fi"]
+
+    salvage [shape=box,
+        prompt="The loop did not converge inside its budget. Objective: salvage the run's value. Read .demo/check.log and .demo/iter, then write .demo/report.md naming what each attempt tried, whether the failures were descending or repeating, and the single most likely root cause. Constraints: do not attempt another repair here. Required evidence: quote the check output you are reasoning from."]
+
+    salvage_check [shape=parallelogram, max_retries=0,
+        tool_command="[ -s .demo/report.md ] && printf ok || { echo 'salvage report missing' > .demo/report.md; printf stub; }"]
+
+    give_up [shape=parallelogram, max_retries=0,
+        tool_command="echo 'NOT CONVERGED: see .demo/report.md' >&2; exit 1"]
+
+    start -> preflight
+    preflight -> repair  [condition="context.tool.last_line=ready && outcome=success"]
+    preflight -> give_up [condition="context.tool.last_line=blocked && outcome=success"]
+
+    repair -> check
+    repair -> triage [condition="outcome=fail"]
+
+    check -> done    [condition="context.tool.last_line=green && outcome=success"]
+    check -> triage  [condition="outcome=fail"]
+    check -> salvage [condition="context.tool.last_line=exhausted && outcome=success", label="budget wall"]
+
+    triage -> repair  [condition="context.tool.last_line=retry && outcome=success", label="fix"]
+    triage -> salvage [condition="context.tool.last_line=spent && outcome=success", label="budget spent"]
+
+    salvage -> salvage_check
+    salvage -> give_up [condition="outcome=fail"]
+    salvage_check -> give_up
+
+    give_up -> done [condition="outcome=fail", label="loud exit -- the run's status is give_up's own nonzero exit"]
+}
+"""
+
+#: A9 requires the companion to NAME EVERY box node id: `repair`, `salvage`.
+DEMO_COMPANION = """\
+# SYNTHETIC demonstration pipeline — companion
+
+## What it converges on
+
+The project's own check command exits clean. Nothing else ends the loop: the
+exit is reachable only through `check`, and `check` only prints `green` when
+the command it ran actually succeeded.
+
+## The LLM worker nodes
+
+### `repair`
+
+Contract: advance the repair using the latest check output as its evidence.
+It is told the objective and the constraints, never the algorithm. It carries a
+failure route to `triage`, so one bad provider response does not end the run.
+
+### `salvage`
+
+Contract: when the budget is spent, write the run's postmortem instead of
+attempting another repair. It exists so that a non-converging run still produces
+something worth reading.
+
+## What the gate proves
+
+`check` runs the project's own check command and routes on its exit status. It
+is the only way to reach the exit, and it walls the iteration budget before the
+command runs, so a persistently failing loop drains the budget and routes to
+`salvage` rather than spinning.
+
+## The honest failure exit
+
+`give_up` prints why and exits nonzero. Its own failure becomes the run's
+status, which is why it routes into the single exit node rather than dead-ending.
+"""
+
+#: The six named prose slots. Deliberately digit-free except for structural
+#: references, so the fixture passes the whitelist for ANY unit's stats.
+DEMO_NARRATIVE: dict = {
+    "scenario_gist": (
+        "You keep running the project's own check, reading what it complains about, fixing that, "
+        "and running it again — until it finally comes back clean."
+    ),
+    "q1_cycle_note": (
+        "Yes: the work is attempted, checked, and re-attempted. The check output from one round is "
+        "what the next round acts on, which is exactly the shape a loop is for."
+    ),
+    "q2_gate_note": (
+        "Yes: the project's own check command is the definition of done. It is red before the work "
+        "lands and green only after, so the exit can gate on it rather than on anybody's say-so."
+    ),
+    "q3_recovery_note": (
+        "A bad day here is one attempt that makes things worse or a provider hiccup mid-repair. The "
+        "gate catches both, the loop pays for another attempt, and the budget wall stops it spinning."
+    ),
+    "pipeline_walk": [
+        {"node": "preflight", "note": "sets the budget and refuses early if the target is not there."},
+        {"node": "repair", "note": "the worker: reads the last failure and fixes exactly that."},
+        {"node": "check", "note": "the evidence gate: runs the real check and routes on its exit status."},
+        {"node": "triage", "note": "decides whether another attempt is affordable."},
+        {"node": "salvage", "note": "writes the postmortem when the budget is spent."},
+        {"node": "give_up", "note": "the loud terminal: says why, and exits nonzero."},
+    ],
+    "payoff_note": (
+        "Running this loop hands back the read-fix-recheck rhythm you have been doing by hand, and "
+        "stops only on evidence you already trust."
+    ),
+}
+
+
+def ranked_fixture(
+    *,
+    unit_id: str = DEMO_UNIT_ID,
+    name: str = DEMO_UNIT_NAME,
+    verdict: str = "OPPORTUNITY",
+    n_sessions: int = 7,
+    med_tool_calls: float = 12.0,
+    med_llm_cycles: float = 4.0,
+    med_span_s: float = 930.0,
+    err_rate: float = 0.33,
+    provisional: bool = False,
+    recovery: str = "PASS",
+    extra_opportunities: list[dict] | None = None,
+) -> dict:
+    """A minimal `ranked.json` carrying one demonstrable opportunity."""
+    unit = {
+        "unit_id": unit_id,
+        "name": name,
+        "n_sessions": n_sessions,
+        "leverage": 32.5,
+        "fit": 1,
+        "score": 22.75,
+        "author": "human",
+        "verdict": verdict,
+        "no_class": None,
+        "failed_subtest": None,
+        "remediation": None,
+        "recovery": recovery,
+        "confidence": "high",
+        "provisional": provisional,
+        "trajectory": "escalating",
+        "rung": "B",
+        "n_members": n_sessions,
+        "members": [f"synd-{i:04d}-4000-8000-{i:012d}" for i in range(n_sessions)],
+        "gist": "SYNTHETIC scenario: run the check, fix what it reports, run it again.",
+        "leverage_detail": {
+            "n_sessions": n_sessions,
+            "med_tool_calls": med_tool_calls,
+            "med_llm_cycles": med_llm_cycles,
+            "med_span_capped_s": med_span_s,
+            "errors_per_session": err_rate,
+            "leverage": 32.5,
+        },
+        "recovery_detail": {"verdict": recovery},
+        "fit_detail": {
+            "verdict": verdict,
+            "fit": 1,
+            "cycle": True,
+            "gate": True,
+            "recovery": recovery,
+            "confidence": "high",
+        },
+    }
+    opportunities = [unit, *(extra_opportunities or [])]
+    return {
+        "opportunities": opportunities,
+        "honest_no": [],
+        "waste_findings": [],
+        "below_frequency_floor": [],
+        "summary": {
+            "n_units_in": len(opportunities),
+            "n_admitted": len(opportunities),
+            "n_waste": 0,
+            "n_opportunities": len(opportunities),
+            "n_honest_no": 0,
+            "n_below_floor": 0,
+            "honest_no_rate": 0.0,
+        },
+    }
+
+
+def write_draft(
+    workdir: str | Path,
+    *,
+    dot_text: str | None = None,
+    companion: str | None = None,
+    narrative: dict | None = None,
+    omit: tuple[str, ...] = (),
+) -> Path:
+    """Materialize what the authoring delegate is contracted to write.
+
+    `omit` drops files by name, so a test can prove the missing-file paths.
+    """
+    target = Path(workdir)
+    target.mkdir(parents=True, exist_ok=True)
+    if "pipeline.dot" not in omit:
+        (target / "pipeline.dot").write_text(dot_text if dot_text is not None else DEMO_DOT, encoding="utf-8")
+    if "pipeline.md" not in omit:
+        (target / "pipeline.md").write_text(companion if companion is not None else DEMO_COMPANION, encoding="utf-8")
+    if "narrative.json" not in omit:
+        payload = narrative if narrative is not None else DEMO_NARRATIVE
+        (target / "narrative.json").write_text(json.dumps(payload, indent=1), encoding="utf-8")
+    return target
+
+
+# ------------------------------------------------------------------ mutations
+def without_gate() -> str:
+    """Delete the evidence gate, and let the exit hang off a worker instead.
+
+    A4 must go red: the exit becomes reachable by a path that never touches a
+    gate, which is the one property the whole doctrine rests on. A1-A3 still
+    pass on this graph — that is exactly why A4 exists and why this red-proof
+    is worth having.
+    """
+    out: list[str] = []
+    skipping = False
+    for line in DEMO_DOT.splitlines(keepends=True):
+        if line.lstrip().startswith("check [shape=parallelogram"):
+            skipping = True
+            continue
+        if skipping:
+            # the gate declaration runs until its closing bracket line
+            if line.rstrip().endswith("]"):
+                skipping = False
+            continue
+        if line.lstrip().startswith("check ->"):
+            continue
+        if line.strip() == "start -> preflight":
+            out.append(line.replace("start -> preflight", "start -> repair"))
+            continue
+        if line.strip() == "repair -> check":
+            out.append(line.replace("repair -> check", "repair -> done"))
+            continue
+        out.append(line)
+    return "".join(out)
+
+
+def narrative_without(node: str = "check") -> dict:
+    """The canned narrative with one node dropped from its walk.
+
+    Pairs with `without_gate()`: the mutated graph no longer carries that
+    node, and the point of the gate red-proof is to reach the LADDER, not to
+    trip the (separately proven) node-name check on the way there.
+    """
+    ok = json.loads(json.dumps(DEMO_NARRATIVE))
+    ok["pipeline_walk"] = [step for step in ok["pipeline_walk"] if step["node"] != node]
+    return ok
+
+
+def with_invented_count(field: str = "payoff_note", token: str = "97") -> dict:
+    """A narrative that states a number the ranking never produced."""
+    bad = json.loads(json.dumps(DEMO_NARRATIVE))
+    bad[field] = f"This loop would have saved you {token} separate hand-runs of the same check."
+    return bad
+
+
+def with_unknown_node(node: str = "nonexistent_node") -> dict:
+    """A `pipeline_walk` step naming a node that is not in the graph."""
+    bad = json.loads(json.dumps(DEMO_NARRATIVE))
+    bad["pipeline_walk"] = [{"node": node, "note": "this node was never in the pipeline."}]
+    return bad
+
+
+def without_slot(slot: str = "payoff_note") -> dict:
+    """A narrative missing one of the six required slots."""
+    bad = json.loads(json.dumps(DEMO_NARRATIVE))
+    bad.pop(slot, None)
+    return bad

--- a/skills/attractor-scout/ruff.toml
+++ b/skills/attractor-scout/ruff.toml
@@ -1,0 +1,13 @@
+# Lint/format settings for the attractor-scout skill.
+#
+# line-length matches the style the whole skill was written in; without it,
+# ruff's default would report every existing file as needing a reformat.
+line-length = 120
+
+# The vendored doctrine checker is a BYTE-IDENTICAL copy of
+# examples/authoring/check_authored_pipeline.py, pinned by
+# tests/test_vendored_doctrine_checker_pin.py. Formatting or auto-fixing it
+# here would break that pin and silently fork the second opinion from the
+# upstream one -- so ruff must not touch it. It is linted and formatted at
+# its upstream home, which is the only place a change to it belongs.
+extend-exclude = ["scripts/attractor_scout/authoring_contract.py"]

--- a/skills/attractor-scout/scripts/attractor_scout/authoring_contract.py
+++ b/skills/attractor-scout/scripts/attractor_scout/authoring_contract.py
@@ -1,0 +1,1128 @@
+#!/usr/bin/env python3
+"""Structural gate on an AUTHORED pipeline (the authoring contract).
+
+``pipeline-author.dot`` lets an LLM node WRITE a new reusable attractor pipeline
+from a design brief. That is only worth doing if the result is checked by
+something outside the author's context before anyone is asked to trust it. Three
+gates do that, in order:
+
+1. ``attractor lint`` -- executability and the topology bug classes the engine
+   itself knows about (dead conditional edges, stale-label collisions,
+   fail-routed-to-exit, pipe-masked gate exit codes). ERRORs block.
+2. this script -- the *doctrine* checks lint deliberately does not own, or owns
+   only as advice: is the authored graph actually an attractor, is its exit
+   really unreachable without machine evidence, does it carry a budget wall,
+   and does every worker have somewhere to fail to?
+3. an independent critique, in a fresh context, which reads what these two
+   printed and judges what neither can.
+
+**The load-bearing check is A4.** A1-A3 can all pass on a graph whose exit is
+reachable by a path that never touches a gate: a corrective loop can sit off to
+one side while ``done`` hangs directly off a worker. A4 deletes every
+evidence-bearing gate from the graph and asks whether the exit is still
+reachable from ``start``. If it is, the exit was never gated on evidence --
+which is the one property the whole doctrine rests on
+(``docs/PIPELINE_DESIGN_PRINCIPLES.md`` section 0).
+
+**A10 asks the question A4 leaves over.** A4 proves the exit is reached
+*through* a gate; it says nothing about whether the gate's answer mattered. A
+graph that routes both of a gate's tokens into the exit passes A3 (the command
+is real), A4 (the exit is gate-protected) and A8 (no *failure outcome* goes near
+the exit) while ending green whether the tests passed or failed. That shape is
+the cheapest way to comply with the letter of "do not weaken a gate" while
+defeating it: the gate is not weakened, deleted or relaxed -- it is left fully
+intact and simply unwired. A10 is pure topology, like A4, and its boundaries are
+stated on ``inert_gate_routes`` rather than left to be discovered.
+
+**What this script deliberately does NOT do** is judge whether the authored
+pipeline is any *good* for the brief it came from. Structure is checkable;
+fitness for purpose is not. That is the critique node's job, and it is why the
+authoring pipeline still pays for an LLM after these gates have already run.
+
+Token contract (Idiom A -- always exit 0 so ``tool.last_line`` is always fresh):
+
+  doctrine_ok    every check passed; the authored pipeline may go to critique
+  doctrine_bad   at least one check failed; route back to the author
+
+A nonzero exit means this script could not run at all (unwritable report). That
+routes through ``outcome=fail`` to the postmortem path -- deliberately distinct
+from ``doctrine_bad``, which is a judgement about the authored graph. A missing
+or unparseable pipeline file is a *judgement* (``doctrine_bad``), not a crash:
+the author node is the one that was supposed to write it.
+
+DOT parsing is deliberately stdlib-only and self-contained, for the same reason
+``examples/objective/check_child_contract.py`` is: this gate must run under
+whatever ``python3`` is on PATH in the target workspace, which is not the
+``attractor`` CLI's own virtualenv. It is a *second* opinion, and it runs only
+after the engine's own parser has already accepted the file via ``attractor
+lint`` -- so a disagreement fails closed (``doctrine_bad``) rather than silently
+admitting a graph neither tool understood.
+
+Usage:
+    check_authored_pipeline.py --pipeline out/my-pipeline.dot \
+                               --companion out/my-pipeline.md \
+                               --report .authoring/doctrine-report.txt
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# A small DOT reader -- only what the structural checks need
+#
+# Adapted from examples/objective/check_child_contract.py, which is pinned
+# against the engine's own parser by a shipped test. This copy carries its own
+# parser-agreement test for the same reason: a second opinion is only worth
+# anything if it reads the same graph the engine reads.
+# ---------------------------------------------------------------------------
+
+_TOKEN_RE = re.compile(
+    r"""
+    (?P<string>"(?:[^"\\]|\\.)*")        # quoted string (backslash escapes)
+  | (?P<arrow>->|--)                      # edge operators
+  | (?P<punct>[\[\]{};,=])                # structural punctuation
+  | (?P<ident>[A-Za-z_\u0080-\uffff][A-Za-z_0-9.\u0080-\uffff]*|-?\.?[0-9][0-9.]*)
+    """,
+    re.VERBOSE,
+)
+
+_KEYWORDS = {"digraph", "graph", "strict", "subgraph", "node", "edge"}
+
+
+def _strip_comments(text: str) -> str:
+    """Remove //, #, and /* */ comments without touching quoted strings."""
+    out: list[str] = []
+    i = 0
+    n = len(text)
+    while i < n:
+        ch = text[i]
+        if ch == '"':
+            out.append(ch)
+            i += 1
+            while i < n:
+                out.append(text[i])
+                if text[i] == "\\" and i + 1 < n:
+                    out.append(text[i + 1])
+                    i += 2
+                    continue
+                if text[i] == '"':
+                    i += 1
+                    break
+                i += 1
+            continue
+        if text.startswith("//", i):
+            while i < n and text[i] != "\n":
+                i += 1
+            continue
+        if text.startswith("/*", i):
+            end = text.find("*/", i + 2)
+            i = n if end == -1 else end + 2
+            continue
+        if ch == "#" and (not out or out[-1] == "\n"):
+            while i < n and text[i] != "\n":
+                i += 1
+            continue
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+
+def _unquote(token: str) -> str:
+    """Strip the quotes and process escapes exactly as the engine's parser does.
+
+    ORDER MATTERS, and it is the engine's order (``dot_parser._parse_value``):
+    ``\\\\`` collapses to ``\\`` FIRST, so a source ``\\\\n`` -- the escape
+    pattern the shipped graphs use between shell statements -- becomes a real
+    newline rather than a backslash followed by one.  Reproducing the order
+    rather than approximating it is what lets the parser-agreement test compare
+    attribute *values*, not just node ids: a reader that agreed on the shape of
+    the graph while disagreeing about what a gate's command says would gate on
+    a string the engine never runs.
+    """
+    if len(token) >= 2 and token[0] == '"' and token[-1] == '"':
+        body = token[1:-1]
+        body = body.replace("\\\\", "\\")
+        body = body.replace('\\"', '"')
+        body = body.replace("\\n", "\n")
+        body = body.replace("\\t", "\t")
+        return body
+    return token
+
+
+def _tokenize(text: str) -> list[str]:
+    return [m.group(0) for m in _TOKEN_RE.finditer(_strip_comments(text))]
+
+
+@dataclass
+class DotNode:
+    node_id: str
+    attrs: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class DotEdge:
+    src: str
+    dst: str
+    attrs: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class DotGraph:
+    nodes: dict[str, DotNode] = field(default_factory=dict)
+    edges: list[DotEdge] = field(default_factory=list)
+    graph_attrs: dict[str, str] = field(default_factory=dict)
+    node_defaults: dict[str, str] = field(default_factory=dict)
+
+    def node(self, node_id: str) -> DotNode:
+        node = self.nodes.get(node_id)
+        if node is None:
+            node = DotNode(node_id)
+            self.nodes[node_id] = node
+        return node
+
+    def attr(self, node_id: str, key: str, default: str = "") -> str:
+        node = self.nodes.get(node_id)
+        if node is not None and key in node.attrs:
+            return node.attrs[key]
+        return self.node_defaults.get(key, default)
+
+    def outgoing(self, node_id: str) -> list[DotEdge]:
+        return [e for e in self.edges if e.src == node_id]
+
+
+class DotParseError(Exception):
+    """The authored .dot could not be read as a graph."""
+
+
+def parse_dot_min(text: str) -> DotGraph:
+    """Parse the subset of DOT the shipped pipelines actually use."""
+    tokens = _tokenize(text)
+    if not tokens or tokens[0] not in ("strict", "digraph", "graph"):
+        raise DotParseError(
+            "does not start with a graph header (strict/digraph/graph) -- "
+            "this is not a DOT graph"
+        )
+    graph = DotGraph()
+    i = 0
+    total = len(tokens)
+
+    def read_attr_list(idx: int) -> tuple[dict[str, str], int]:
+        attrs: dict[str, str] = {}
+        assert tokens[idx] == "["
+        idx += 1
+        while idx < total and tokens[idx] != "]":
+            if tokens[idx] in (",", ";"):
+                idx += 1
+                continue
+            key = _unquote(tokens[idx])
+            idx += 1
+            if idx < total and tokens[idx] == "=":
+                idx += 1
+                if idx >= total:
+                    raise DotParseError("attribute list ended after '='")
+                attrs[key] = _unquote(tokens[idx])
+                idx += 1
+            else:
+                attrs[key] = "true"
+        if idx >= total:
+            raise DotParseError("unterminated attribute list")
+        return attrs, idx + 1
+
+    while i < total:
+        tok = tokens[i]
+
+        if tok in ("{", "}", ";", ","):
+            i += 1
+            continue
+
+        # `graph|node|edge [ ... ]` -- attribute defaults. Checked BEFORE the
+        # header-keyword branch, because `graph` is both a keyword and the name
+        # of the graph-attribute statement.
+        if tok in ("graph", "node", "edge") and i + 1 < total and tokens[i + 1] == "[":
+            defaults, i = read_attr_list(i + 1)
+            if tok == "node":
+                graph.node_defaults.update(defaults)
+            elif tok == "graph":
+                graph.graph_attrs.update(defaults)
+            continue
+
+        if tok in ("digraph", "graph", "strict", "subgraph"):
+            # Skip the header keyword and any graph name; the body is flat for
+            # our purposes (cluster subgraphs are flattened by the engine too).
+            i += 1
+            while i < total and tokens[i] not in ("{", ";"):
+                i += 1
+            continue
+
+        # A bare `key = value` at statement level is a graph attribute.
+        if i + 2 < total and tokens[i + 1] == "=" and tok not in _KEYWORDS:
+            graph.graph_attrs[_unquote(tok)] = _unquote(tokens[i + 2])
+            i += 3
+            continue
+
+        # Node statement or edge chain.
+        chain = [_unquote(tok)]
+        i += 1
+        while i < total and tokens[i] in ("->", "--"):
+            i += 1
+            if i >= total:
+                raise DotParseError("edge chain ended after '->'")
+            chain.append(_unquote(tokens[i]))
+            i += 1
+
+        stmt_attrs: dict[str, str] = {}
+        if i < total and tokens[i] == "[":
+            stmt_attrs, i = read_attr_list(i)
+
+        if len(chain) == 1:
+            graph.node(chain[0]).attrs.update(stmt_attrs)
+        else:
+            for src, dst in zip(chain, chain[1:], strict=False):
+                graph.node(src)
+                graph.node(dst)
+                graph.edges.append(DotEdge(src, dst, dict(stmt_attrs)))
+
+    if not graph.nodes:
+        raise DotParseError("no nodes found")
+    return graph
+
+
+# ---------------------------------------------------------------------------
+# Shape helpers -- mirror the engine's own resolution order
+# ---------------------------------------------------------------------------
+
+
+def _is_exit(graph: DotGraph, node_id: str) -> bool:
+    return (
+        graph.attr(node_id, "shape") == "Msquare"
+        or graph.attr(node_id, "type") == "exit"
+        or node_id.lower() in ("exit", "end")
+    )
+
+
+def _is_start(graph: DotGraph, node_id: str) -> bool:
+    return (
+        graph.attr(node_id, "shape") == "Mdiamond"
+        or graph.attr(node_id, "type") == "start"
+        or node_id.lower() == "start"
+    )
+
+
+def _is_tool(graph: DotGraph, node_id: str) -> bool:
+    return graph.attr(node_id, "shape") == "parallelogram" or bool(
+        graph.attr(node_id, "tool_command")
+    )
+
+
+def _is_worker(graph: DotGraph, node_id: str) -> bool:
+    """A codergen (LLM) node: shape=box, or no shape at all (box is the default)."""
+    if _is_start(graph, node_id) or _is_exit(graph, node_id):
+        return False
+    if graph.attr(node_id, "type"):
+        return False
+    return graph.attr(node_id, "shape") in ("", "box")
+
+
+def _starts(graph: DotGraph) -> list[str]:
+    return sorted(n for n in graph.nodes if _is_start(graph, n))
+
+
+def _reachable(graph: DotGraph, sources: list[str], blocked: set[str] | None = None) -> set[str]:
+    """Nodes reachable from *sources*, never entering any node in *blocked*."""
+    blocked = blocked or set()
+    seen: set[str] = set()
+    stack = [s for s in sources if s not in blocked]
+    while stack:
+        node_id = stack.pop()
+        if node_id in seen:
+            continue
+        seen.add(node_id)
+        for edge in graph.outgoing(node_id):
+            if edge.dst not in blocked:
+                stack.append(edge.dst)
+    return seen
+
+
+def _has_cycle(graph: DotGraph) -> bool:
+    adjacency: dict[str, list[str]] = {n: [] for n in graph.nodes}
+    for edge in graph.edges:
+        adjacency.setdefault(edge.src, []).append(edge.dst)
+    state: dict[str, int] = {}
+
+    def visit(node_id: str) -> bool:
+        state[node_id] = 1
+        for nxt in adjacency.get(node_id, []):
+            mark = state.get(nxt, 0)
+            if mark == 1:
+                return True
+            if mark == 0 and visit(nxt):
+                return True
+        state[node_id] = 2
+        return False
+
+    sys.setrecursionlimit(10000)
+    return any(state.get(n, 0) == 0 and visit(n) for n in graph.nodes)
+
+
+_IS_FAIL_RE = re.compile(r"outcome\s*=\s*fail\b")
+_NOT_SUCCESS_RE = re.compile(r"outcome\s*!=\s*success\b")
+_SUCCESS_CONJUNCTION_RE = re.compile(r"outcome\s*=\s*success\b")
+_LAST_LINE_RE = re.compile(r"context\.tool\.last_line\s*=")
+
+#: The token an edge routes ON, as opposed to one it routes AWAY from.
+#: ``context.tool.last_line=green && outcome=success`` yields ``green``. An
+#: inequality cannot match -- ``last_line!=green`` puts a ``!`` where this
+#: pattern requires ``=`` -- and that exclusion is deliberate: A10 reasons about
+#: which *answer* sends the run where, and "anything but green" is not an answer.
+_LAST_LINE_TOKEN_RE = re.compile(r"context\.tool\.last_line\s*=\s*([^\s&|]+)")
+
+#: Shapes that route without doing anything. Entering one of these and leaving
+#: by its single unconditional edge is indistinguishable, in every observable
+#: respect, from having taken that edge directly -- ``diamond`` is documented as
+#: a no-op node whose "outgoing edges do the deciding". A10 sees through exactly
+#: these and nothing else, so "both answers landed in the same place" can never
+#: quietly mean "the two branches ran different work and then converged".
+_TRANSPARENT_SHAPES = frozenset({"diamond", "point"})
+
+
+def _routed_token(condition: str) -> str | None:
+    """The ``tool.last_line`` value this edge condition selects on, if any."""
+    match = _LAST_LINE_TOKEN_RE.search(condition)
+    if match is None:
+        return None
+    return match.group(1).strip().strip('"').strip("'")
+
+
+def _transparent_relay(graph: DotGraph, node_id: str) -> DotEdge | None:
+    """The single edge out of a pure routing no-op, or ``None`` if not one."""
+    if _is_exit(graph, node_id) or _is_start(graph, node_id):
+        return None
+    if graph.attr(node_id, "shape") not in _TRANSPARENT_SHAPES:
+        return None
+    out = graph.outgoing(node_id)
+    if len(out) != 1 or out[0].attrs.get("condition"):
+        return None
+    return out[0]
+
+
+def _token_landing(graph: DotGraph, edge: DotEdge) -> str:
+    """Where a token edge actually puts the run, seeing through relay no-ops."""
+    node_id = edge.dst
+    seen = {edge.src}
+    while node_id not in seen:
+        seen.add(node_id)
+        relay = _transparent_relay(graph, node_id)
+        if relay is None:
+            break
+        node_id = relay.dst
+    return node_id
+
+
+def _is_failure_condition(condition: str) -> bool:
+    """Does this edge condition select the FAILURE branch of its source node?"""
+    return bool(_IS_FAIL_RE.search(condition) or _NOT_SUCCESS_RE.search(condition))
+
+
+#: The last statement of a command that ends the process nonzero, deliberately.
+#: Anchored at the end because what matters is the EXIT STATUS THE NODE LEAVES
+#: WITH -- an `exit 1` on some interior branch says nothing about the others.
+_TERMINAL_NONZERO_EXIT_RE = re.compile(r"(?:^|;|&&|\|\||\n)\s*exit\s+[1-9][0-9]*\s*;?\s*$")
+
+
+def _is_loud_terminal(graph: DotGraph, node_id: str) -> bool:
+    """Is this node a DESIGNED LOUD TERMINAL, whose own FAIL becomes the status?
+
+    A8's hazard is a failure being CONVERTED into a successful run -- classically
+    by putting one succeeding bookkeeping step (a recorder, a notifier, a
+    cleanup) between the failed gate and the exit, so the run's final status
+    comes from that step and not from the failure.  There is exactly one shape
+    where routing a failure into the exit does NOT do that, and the engine
+    settles it: at the exit node, with every goal gate satisfied,
+    ``_check_goal_gates()`` returns ``node_outcomes[completed_nodes[-1]]`` -- the
+    LAST COMPLETED node's outcome.  So if the node that routes into the exit is
+    itself the last thing that runs and it exits nonzero, the run's status IS
+    that failure: ``status=fail``, CLI exit 1.  That is the convergence-factory
+    idiom -- "a budget-exhaustion exit that deliberately ends at the single exit
+    node with a genuine FAIL outcome" (docs/DOT-AUTHORING-GUIDE.md, TOPO-006),
+    shipped in ``examples/patterns/convergence-factory.dot`` and adopted by
+    ``examples/objective/objective-runner.dot`` in #248 -- and it is the ONLY
+    way a deliberately loud terminal can exist on this engine at all, because
+    the main loop has no designed-terminus concept: a terminal that dead-ends
+    is reported as PIPELINE_ERROR ``error_type=no_matching_edge`` (issue #252).
+
+    Blocking it was therefore not strictness, it was a miscalibration: A8
+    rejected the repo's own merged flagship.  A gate that rejects
+    ``objective-runner.dot`` is a wrong gate, not a strict one -- the same rule
+    this contract's calibration suite applies to ``task-runner.dot``.
+
+    The exemption is deliberately narrow, so it cannot be worn as a costume by
+    the shape A8 exists to catch.  ALL FIVE must hold:
+
+    1. It is a TOOL node.  A worker's "failure" is a provider verdict, not a
+       process exit status; only a shell command can guarantee the exit code.
+    2. Its command's LAST statement exits NONZERO -- so it fails on EVERY path,
+       not just some branch.  A node that can exit 0 could hand the exit a
+       SUCCESS and turn the escalation green: precisely the A8 hazard.
+    3. ``max_retries=0``.  The failure is the point, not a flake to retry.
+    4. The edge into the exit is its ONLY outgoing edge.  A node with somewhere
+       else to go is a step on a path, and a step on a path is the bookkeeping
+       intermediary A8 is looking for.
+    5. That edge carries a FAILURE CONDITION (``outcome=fail`` /
+       ``outcome!=success``).  Clauses 1-4 are read off the TEXT of the graph,
+       and clause 2 is the weakest of them: the regex matches the *shape* of a
+       terminal ``exit 1``, which a command like ``rm -f scratch.tmp || exit 1``
+       wears while exiting 0 at runtime.  Wired to the exit UNCONDITIONALLY,
+       such a node is not a loud terminal at all -- it is an ungated fast path
+       to a GREEN finish, and blocking it in A4 would launder exactly the
+       evidence-free finish A4 exists to catch.  The condition is what makes
+       this exemption RUNTIME-SOUND rather than textual: an edge that only
+       fires on ``outcome=fail`` can never carry a SUCCESS into the exit,
+       whatever the command turns out to do.  Every shipped exemplar terminal
+       and ``objective-runner.dot`` already route on ``condition="outcome=fail"``.
+
+    A recorder that exits 0, a notifier with a second route, an LLM node, or a
+    node whose edge into the exit is unconditional all still block -- see the
+    mutation tests in ``test_authoring_layer_gates.py``.
+    """
+    if not _is_tool(graph, node_id):
+        return False
+    command = graph.attr(graph_node_id := node_id, "tool_command")
+    if not command or not _TERMINAL_NONZERO_EXIT_RE.search(command.strip()):
+        return False
+    if graph.attr(graph_node_id, "max_retries").strip().strip('"') != "0":
+        return False
+    outgoing = graph.outgoing(node_id)
+    return (
+        len(outgoing) == 1
+        and _is_exit(graph, outgoing[0].dst)
+        and _is_failure_condition(outgoing[0].attrs.get("condition", ""))
+    )
+
+
+def _is_truthy(value: str) -> bool:
+    return value.strip().strip('"').lower() in ("true", "1", "yes", "on")
+
+
+def _has_fail_route(graph: DotGraph, node_id: str) -> bool:
+    if graph.attr(node_id, "retry_target") or graph.graph_attrs.get("retry_target"):
+        return True
+    if graph.attr(node_id, "fallback_retry_target"):
+        return True
+    if _is_truthy(graph.attr(node_id, "continue_on_fail")):
+        return True
+    return any(
+        _is_failure_condition(edge.attrs.get("condition", "")) for edge in graph.outgoing(node_id)
+    )
+
+
+# ---------------------------------------------------------------------------
+# "Is this command checking something, or just typing?"
+#
+# A gate whose command only ever emits a constant is not a gate -- it is an
+# assertion wearing a parallelogram. `printf gate_pass` cannot fail, so nothing
+# behind it is gated on anything. This is the code-tier form of the doctrine's
+# own self-test: "is the model here for judgment, or just to type?"
+# ---------------------------------------------------------------------------
+
+#: Head words that only ever emit or arrange -- they never *check* anything.
+_CONSTANT_EMITTERS = frozenset(
+    {
+        "printf", "echo", "exit", "return", "true", "false", ":", "cd", "mkdir",
+        "touch", "sleep", "shift", "set", "umask", "export", "unset", "break",
+        "continue", "rm", "cp", "mv", "chmod",
+    }
+)
+
+#: Shell keywords and grouping tokens -- skip past them to the real head word.
+_SHELL_KEYWORDS = frozenset(
+    {
+        "if", "then", "else", "elif", "fi", "while", "until", "do", "done",
+        "case", "esac", "for", "select", "function", "time", "!", "in",
+    }
+)
+
+_ASSIGNMENT_RE = re.compile(r"^[A-Za-z_][A-Za-z_0-9]*=")
+_REDIRECT_RE = re.compile(r"^\d*[<>]")
+
+
+def _split_segments(command: str) -> list[str]:
+    """Split a shell command into command positions, respecting quotes.
+
+    Deliberately approximate -- a lint-grade reader in the same spirit as the
+    engine's own CMD-001 rule, not a shell. It errs toward *more* segments,
+    which can only make the substantive-command search more generous, never
+    less; the fail-closed direction is preserved because what gets rejected is
+    a command with no substantive head word anywhere in it.
+    """
+    segments: list[str] = []
+    current: list[str] = []
+    quote: str | None = None
+    i = 0
+    n = len(command)
+    while i < n:
+        ch = command[i]
+        if quote:
+            if ch == "\\" and i + 1 < n:
+                current.append(ch)
+                current.append(command[i + 1])
+                i += 2
+                continue
+            current.append(ch)
+            if ch == quote:
+                quote = None
+            i += 1
+            continue
+        if ch in ("'", '"'):
+            quote = ch
+            current.append(ch)
+            i += 1
+            continue
+        if command.startswith("&&", i) or command.startswith("||", i):
+            segments.append("".join(current))
+            current = []
+            i += 2
+            continue
+        if ch in (";", "|", "&", "\n", "(", ")", "{", "}", "`"):
+            segments.append("".join(current))
+            current = []
+            i += 1
+            continue
+        current.append(ch)
+        i += 1
+    segments.append("".join(current))
+    return segments
+
+
+def _head_word(segment: str) -> str:
+    """The command word a segment actually runs, or '' if it runs nothing."""
+    for word in segment.split():
+        if word in _SHELL_KEYWORDS:
+            continue
+        if _ASSIGNMENT_RE.match(word) or _REDIRECT_RE.match(word):
+            continue
+        return word.strip('"').strip("'")
+    return ""
+
+
+def substantive_commands(command: str) -> list[str]:
+    """Head words in *command* that check or compute something real.
+
+    ``[``, ``test``, ``grep``, ``pytest``, ``python3``, ``bash``, ``git``,
+    ``attractor`` -- anything that is not purely an emitter or a file
+    arrangement.
+    """
+    found: list[str] = []
+    for segment in _split_segments(command):
+        head = _head_word(segment)
+        if not head or head in _CONSTANT_EMITTERS:
+            continue
+        found.append(head)
+    return found
+
+
+#: Vocabulary A5 accepts as evidence that a node is counting something. Stated
+#: here and in README.md so the author is told the contract, not made to guess.
+_BUDGET_TOKENS = ("max_iteration", "max_round", "max_attempt", "max_retries", "budget", "iter")
+
+#: Vocabulary A5 accepts on an outgoing edge as the exhaustion route.
+_EXHAUSTION_TOKENS = ("exhaust", "budget", "stall", "over_budget", "give_up", "spent")
+
+
+# ---------------------------------------------------------------------------
+# The contract checks
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CheckResult:
+    check_id: str
+    title: str
+    passed: bool
+    detail: str
+
+
+def evidence_gates(graph: DotGraph) -> list[str]:
+    """Reachable tool nodes that run a real command AND route on the answer.
+
+    Three conditions, each load-bearing:
+
+    * **a tool node** -- ``shape=parallelogram`` or a ``tool_command``. An LLM
+      node's opinion of its own work is not evidence, however confidently it is
+      phrased (``docs/VISION.md``, "Gates outside workers").
+    * **a substantive command** -- something that can come back with an answer
+      the author did not already write. ``printf gate_pass`` is not a gate.
+    * **it routes** -- at least two outgoing edges, at least one conditional. A
+      node whose result changes nothing is not deciding anything.
+    """
+    reachable = _reachable(graph, _starts(graph))
+    gates: list[str] = []
+    for node_id in sorted(graph.nodes):
+        if node_id not in reachable or not _is_tool(graph, node_id):
+            continue
+        command = graph.attr(node_id, "tool_command")
+        if not command or not substantive_commands(command):
+            continue
+        out = graph.outgoing(node_id)
+        if len(out) < 2 or not any(e.attrs.get("condition") for e in out):
+            continue
+        gates.append(node_id)
+    return gates
+
+
+def inert_gate_routes(graph: DotGraph) -> list[str]:
+    """A10 -- evidence gates that answer into the exit no matter what they find.
+
+    ``evidence_gates`` above already refuses a gate that cannot fail
+    (``printf gate_pass``) and a gate that does not route (fewer than two
+    outgoing edges). Neither notices the shape that *satisfies both* and still
+    decides nothing::
+
+        gate -> done [condition="context.tool.last_line=green"]
+        gate -> done [condition="context.tool.last_line=red"]
+
+    The command is real, the exit is reached only through the gate, and no
+    *failure outcome* is routed anywhere near the exit -- so A3, A4 and A8 are
+    all green while the run ends successfully whether the tests passed or not.
+    A4 asks whether the exit is reached THROUGH a gate; A10 asks the question
+    left over, which is whether the gate's answer changed where the run went.
+    Both are pure topology: a set comparison over outgoing edges, no different
+    in kind from A4's reachability computation.
+
+    Deliberately narrow, in two directions, because a doctrine check that
+    over-fires teaches authors to route around it:
+
+    * **Only the exit.** Two distinct tokens landing on the same *ordinary*
+      node is inert for routing too, but it is frequently deliberate -- three
+      of this repo's own shipped graphs do it on purpose, sending several
+      distinct diagnoses to one node that writes them up
+      (``criteria_gate`` -> ``write_unspecced_finding`` on four separate
+      malformed-criteria tokens). There the token is recorded rather than
+      routed on, which is legitimate. Two tokens into the *exit* has no such
+      reading: the run ends green either way, and that is the single property
+      the whole doctrine rests on.
+    * **Only through relay no-ops.** ``_token_landing`` sees through a
+      ``diamond`` that merely forwards, because that is pure laundering of the
+      same defect. It stops at any node that *does* something -- if the two
+      answers ran different workers before converging, the gate's answer
+      demonstrably changed what happened, and whether that path should still
+      end green is a judgement A10 does not have. That is left to the critique
+      tier, honestly rather than by guessing.
+
+    Returns one message per offending gate, in the style of A7/A8: the gate,
+    the tokens, the shared target, and the edges as written.
+    """
+    exits = {n for n in graph.nodes if _is_exit(graph, n)}
+    messages: list[str] = []
+    for gate in evidence_gates(graph):
+        landed: dict[str, dict[str, str]] = {}
+        for edge in graph.outgoing(gate):
+            condition = edge.attrs.get("condition", "")
+            token = _routed_token(condition)
+            if token is None:
+                continue
+            landing = _token_landing(graph, edge)
+            if landing not in exits:
+                continue
+            landed.setdefault(landing, {})[token] = f"{gate} -> {edge.dst} [condition={condition!r}]"
+        for landing, edges in sorted(landed.items()):
+            if len(edges) < 2:
+                continue
+            tokens = sorted(edges)
+            messages.append(
+                f"{gate}: tokens {tokens} all end at the exit '{landing}' -- "
+                + "; ".join(edges[t] for t in tokens)
+            )
+    return messages
+
+
+def run_checks(graph: DotGraph, companion: Path | None) -> list[CheckResult]:
+    results: list[CheckResult] = []
+    starts = _starts(graph)
+    reachable = _reachable(graph, starts)
+    exits = sorted(n for n in graph.nodes if _is_exit(graph, n))
+    gates = evidence_gates(graph)
+
+    # --- A1: exactly one exit node -------------------------------------------
+    results.append(
+        CheckResult(
+            "A1",
+            "exactly one exit node",
+            len(exits) == 1,
+            f"exit nodes found: {exits or 'none'}"
+            + (
+                ""
+                if len(exits) == 1
+                else " -- the engine refuses to run a graph without exactly one. Express a "
+                "second honest terminal as a LOUD nonzero tool node (the escalation idiom), "
+                "never as a second Msquare"
+            ),
+        )
+    )
+
+    # --- A2: at least one corrective cycle ------------------------------------
+    has_cycle = _has_cycle(graph)
+    results.append(
+        CheckResult(
+            "A2",
+            "at least one corrective cycle",
+            has_cycle,
+            "cycle present"
+            if has_cycle
+            else "graph is acyclic -- there is nothing to converge to. "
+            "'If your pipeline graph has no cycle, it should probably have been a recipe.'",
+        )
+    )
+
+    # --- A3: an evidence-bearing gate exists ----------------------------------
+    results.append(
+        CheckResult(
+            "A3",
+            "at least one evidence-bearing gate runs a real command and routes on it",
+            bool(gates),
+            f"evidence gates: {gates or 'none'}"
+            + (
+                ""
+                if gates
+                else " -- an evidence gate is a tool node (shape=parallelogram) whose command "
+                "actually checks something (a test, a build, a linter, a grep, a file "
+                "predicate) and whose outgoing edges route on the answer. A node that only "
+                "`printf`s a constant cannot fail, so nothing behind it is gated"
+            ),
+        )
+    )
+
+    # --- A4: the exit is unreachable without passing an evidence gate ---------
+    # THE load-bearing check. Delete every evidence gate; if the exit is still
+    # reachable from start, some path to it never touched machine evidence --
+    # and that path is the one a bad day will find.
+    if len(exits) == 1 and starts:
+        exit_id = exits[0]
+        # Designed loud terminals are blocked alongside the gates. A4 asks
+        # whether the run can FINISH WITHOUT EVIDENCE; a loud terminal cannot
+        # finish at all in the sense A4 means -- it is the last node to
+        # complete, it exits nonzero, and the exit therefore returns its FAIL
+        # (status=fail, CLI exit 1). Counting that as a "bypass" would mean
+        # the only shape in which a deliberately red terminal can exist on this
+        # engine (see _is_loud_terminal) is also the shape A4 forbids, which
+        # would leave an author with no legal way to fail loudly at all.
+        # The green door is unchanged: every path that ends SUCCESSFULLY still
+        # has to pass a gate, which is the whole of what A4 was protecting.
+        loud = {n for n in graph.nodes if _is_loud_terminal(graph, n)}
+        bypass = exit_id in _reachable(graph, starts, blocked=set(gates) | loud)
+        results.append(
+            CheckResult(
+                "A4",
+                "the exit is structurally unreachable without passing an evidence gate",
+                not bypass,
+                f"with gate(s) {gates or 'none'} removed, '{exit_id}' is "
+                + ("STILL reachable from start" if bypass else "unreachable from start")
+                + (
+                    ""
+                    if not bypass
+                    else " -- there is a path from start to the exit that never passes a gate, "
+                    "so the run can finish without any machine evidence at all. Route that "
+                    "path through a deterministic gate (a file predicate is enough) before it "
+                    "reaches the exit"
+                ),
+            )
+        )
+    else:
+        results.append(
+            CheckResult(
+                "A4",
+                "the exit is structurally unreachable without passing an evidence gate",
+                False,
+                "not evaluable: "
+                + ("no start node" if not starts else f"expected exactly one exit, found {exits}"),
+            )
+        )
+
+    # --- A5: a budget wall that routes exhaustion -----------------------------
+    budget_nodes: list[str] = []
+    for node_id in sorted(graph.nodes):
+        if node_id not in reachable or not _is_tool(graph, node_id):
+            continue
+        command = graph.attr(node_id, "tool_command")
+        if not any(token in command for token in _BUDGET_TOKENS):
+            continue
+        for edge in graph.outgoing(node_id):
+            haystack = (edge.attrs.get("condition", "") + " " + edge.attrs.get("label", "")).lower()
+            if any(token in haystack for token in _EXHAUSTION_TOKENS):
+                budget_nodes.append(node_id)
+                break
+    results.append(
+        CheckResult(
+            "A5",
+            "a tool node walls an iteration budget and routes exhaustion somewhere",
+            bool(budget_nodes),
+            f"budget-walling gates: {budget_nodes or 'none'}"
+            + (
+                ""
+                if budget_nodes
+                else " -- a corrective loop with no wall spends until the engine's step cap "
+                "kills it with a bare FAIL, bypassing every salvage path. The wall is a tool "
+                f"node whose command names one of {list(_BUDGET_TOKENS)} and which has an "
+                f"outgoing edge whose condition or label names one of {list(_EXHAUSTION_TOKENS)}"
+            ),
+        )
+    )
+
+    # --- A6: every reachable LLM worker has a failure route -------------------
+    unrouted = sorted(
+        n
+        for n in graph.nodes
+        if _is_worker(graph, n) and n in reachable and not _has_fail_route(graph, n)
+    )
+    results.append(
+        CheckResult(
+            "A6",
+            "every reachable LLM worker has an outcome=fail route or a retry_target",
+            not unrouted,
+            f"workers with no failure route: {unrouted or 'none'}"
+            + (
+                ""
+                if not unrouted
+                else " -- a FAIL does not traverse plain edges. One transient provider error at "
+                "an unrouted node ends the whole run, however much work already landed"
+            ),
+        )
+    )
+
+    # --- A7: stale-label conjunctions where labels route ----------------------
+    # A tool node that exits nonzero does NOT refresh tool.last_line
+    # (docs/ROUTING-REFERENCE.md section 3). So on a node that can both fail and
+    # route on a label, a STALE label can match at the same time as the failure
+    # edge, and the engine's deterministic pick may not be the one you meant.
+    stale_violations: list[str] = []
+    for node_id in sorted(graph.nodes):
+        out = graph.outgoing(node_id)
+        label_edges = [e for e in out if _LAST_LINE_RE.search(e.attrs.get("condition", ""))]
+        fail_edges = [e for e in out if _is_failure_condition(e.attrs.get("condition", ""))]
+        if not label_edges or not fail_edges:
+            continue
+        for edge in label_edges:
+            condition = edge.attrs.get("condition", "")
+            if not _SUCCESS_CONJUNCTION_RE.search(condition):
+                stale_violations.append(f"{node_id} -> {edge.dst} [condition={condition!r}]")
+    results.append(
+        CheckResult(
+            "A7",
+            "label-routing edges conjoin && outcome=success where the source can also fail",
+            not stale_violations,
+            f"unconjoined label edges: {stale_violations or 'none'}"
+            + (
+                ""
+                if not stale_violations
+                else " -- a failing tool node does not refresh context.tool.last_line, so a "
+                "STALE label can match alongside the failure edge on a later visit. Add "
+                "'&& outcome=success' to each label edge listed above"
+            ),
+        )
+    )
+
+    # --- A8: no failure outcome routed into the exit --------------------------
+    fail_to_exit = sorted(
+        f"{e.src} -> {e.dst} [condition={e.attrs.get('condition', '')!r}]"
+        for e in graph.edges
+        if _is_exit(graph, e.dst)
+        and _is_failure_condition(e.attrs.get("condition", ""))
+        and not _is_loud_terminal(graph, e.src)
+    )
+    results.append(
+        CheckResult(
+            "A8",
+            "no failure outcome is routed into the terminal success node",
+            not fail_to_exit,
+            f"failure edges into the exit: {fail_to_exit or 'none'}"
+            + (
+                ""
+                if not fail_to_exit
+                else " -- this converts a failure into a successful run. A failure belongs on a "
+                "salvage path (postmortem, escalation) that ends LOUD, not through the success "
+                "door. The engine's own lint calls this TOPO-006 and warns; here it blocks. "
+                "The ONE exemption is a designed loud terminal: a tool node with max_retries=0 "
+                "whose command's last statement exits nonzero and whose only outgoing edge is "
+                "this one. It is then the last node to complete, so the exit returns ITS fail "
+                "and the run ends status=fail / exit 1 -- the convergence-factory idiom, and "
+                "the only way a loud terminal can exist on an engine whose main loop reports a "
+                "dead end as no_matching_edge"
+            ),
+        )
+    )
+
+    # --- A9: the companion document covers every worker -----------------------
+    workers = sorted(n for n in graph.nodes if _is_worker(graph, n) and n in reachable)
+    results.append(_check_companion(companion, workers))
+
+    # --- A10: an evidence gate's answer must be able to change the path -------
+    inert = inert_gate_routes(graph)
+    results.append(
+        CheckResult(
+            "A10",
+            "no evidence gate routes two different answers into the exit",
+            not inert,
+            f"gates whose answer cannot change the outcome: {inert or 'none'}"
+            + (
+                ""
+                if not inert
+                else " -- every one of those answers ends the run green, so the gate is "
+                "decorative: it runs, it prints a verdict, and the graph goes to the exit "
+                "either way. A4 only asks whether the exit is reached THROUGH a gate; this "
+                "asks whether the gate's answer decided anything. Route the failing token to "
+                "a repair loop, a postmortem, or a LOUD escalation -- somewhere that is not "
+                "the success door"
+            ),
+        )
+    )
+
+    return results
+
+
+def _check_companion(companion: Path | None, workers: list[str]) -> CheckResult:
+    """A9 -- the authored pipeline ships as a pair: the .dot and its .md.
+
+    Every exemplar in this repo has a paired guide, because a graph shows what
+    it does and not why it is shaped that way. The machine-checkable core of the
+    node-contract doctrine is coverage: each LLM worker in the graph has to be
+    named in the prose that explains it.
+    """
+    title = "a companion document names every LLM worker node"
+    if companion is None:
+        return CheckResult(
+            "A9", title, False, "no companion path resolved -- pass --companion or name the .md"
+        )
+    try:
+        prose = companion.read_text(encoding="utf-8", errors="replace")
+    except FileNotFoundError:
+        return CheckResult(
+            "A9",
+            title,
+            False,
+            f"{companion}: not found -- the authored pipeline ships as a pair, the .dot and "
+            "its .md companion",
+        )
+    except OSError as exc:
+        return CheckResult("A9", title, False, f"{companion}: {exc}")
+
+    if not prose.strip():
+        return CheckResult(
+            "A9",
+            title,
+            False,
+            f"{companion}: empty -- state each LLM node's contract: objective, constraints, "
+            "available capabilities, required evidence "
+            "(docs/DOT-AUTHORING-GUIDE.md, 'The node contract')",
+        )
+    missing = [w for w in workers if w not in prose]
+    return CheckResult(
+        "A9",
+        title,
+        not missing,
+        f"{companion}: {len(prose.split())} words; "
+        + (
+            "every worker documented"
+            if not missing
+            else f"undocumented workers: {missing} -- state each one's contract: objective, "
+            "constraints, available capabilities, required evidence "
+            "(docs/DOT-AUTHORING-GUIDE.md, 'The node contract')"
+        ),
+    )
+
+
+def render_report(pipeline: str, companion: str, results: list[CheckResult], verdict: str) -> str:
+    lines = [
+        "AUTHORED-PIPELINE DOCTRINE REPORT",
+        f"pipeline:  {pipeline}",
+        f"companion: {companion}",
+        f"verdict:   {verdict}",
+        "",
+    ]
+    for result in results:
+        lines.append(f"[{'PASS' if result.passed else 'FAIL'}] {result.check_id} {result.title}")
+        lines.append(f"       {result.detail}")
+    if any(not r.passed for r in results):
+        lines += [
+            "",
+            "Fix every FAIL above and rewrite the pipeline. See examples/authoring/README.md and",
+            "docs/PIPELINE_DESIGN_PRINCIPLES.md. Do not weaken a gate to get past this one.",
+        ]
+    return "\n".join(lines) + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Structural doctrine gate on an authored attractor pipeline."
+    )
+    parser.add_argument("--pipeline", required=True, help="path to the authored .dot")
+    parser.add_argument(
+        "--companion",
+        default=None,
+        help="path to the authored .md companion (default: the .dot path with a .md suffix)",
+    )
+    parser.add_argument(
+        "--report",
+        default=".authoring/doctrine-report.txt",
+        help="where to write the human-readable report",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    report_path = Path(args.report)
+    try:
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:  # pragma: no cover - environment failure
+        print(f"check_authored_pipeline: cannot create report dir: {exc}", file=sys.stderr)
+        return 2
+
+    pipeline_path = Path(args.pipeline)
+    companion_path = Path(args.companion) if args.companion else pipeline_path.with_suffix(".md")
+
+    results: list[CheckResult] = []
+    graph: DotGraph | None = None
+    try:
+        graph = parse_dot_min(pipeline_path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        results.append(
+            CheckResult(
+                "A0",
+                "the authored pipeline exists",
+                False,
+                f"{pipeline_path}: not found -- the author node was asked to write exactly this path",
+            )
+        )
+    except OSError as exc:
+        results.append(
+            CheckResult("A0", "the authored pipeline is readable", False, f"{pipeline_path}: {exc}")
+        )
+    except DotParseError as exc:
+        results.append(
+            CheckResult("A0", "the authored pipeline parses", False, f"{pipeline_path}: {exc}")
+        )
+
+    if graph is not None:
+        results.extend(run_checks(graph, companion_path))
+
+    verdict = "doctrine_ok" if results and all(r.passed for r in results) else "doctrine_bad"
+
+    try:
+        report_path.write_text(
+            render_report(str(pipeline_path), str(companion_path), results, verdict),
+            encoding="utf-8",
+        )
+    except OSError as exc:  # pragma: no cover - environment failure
+        print(f"check_authored_pipeline: cannot write report: {exc}", file=sys.stderr)
+        return 2
+
+    print(verdict, end="")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - thin CLI wrapper
+    raise SystemExit(main())

--- a/skills/attractor-scout/scripts/attractor_scout/demo.py
+++ b/skills/attractor-scout/scripts/attractor_scout/demo.py
@@ -1,0 +1,773 @@
+"""The demonstration layer: brief assembly, gates, validation, publication.
+
+The mining half answers *what recurs*. This half answers *what the pipeline
+that would have converged it looks like* — for the user's own top-ranked
+opportunity, with their own verified numbers.
+
+Three properties are load-bearing, and each is machine-checked here rather
+than promised:
+
+**1. The LLM never states a number in the SIX TEACHING-PROSE SLOTS.**
+`validate_narrative` scans every digit run in every prose slot against a
+whitelist built from the re-verified stats this unit actually carries. An
+invented count kills the assembly (exit 2, the same posture as `rank --strict`)
+with the offending token named. Prose like "about a dozen" is always legal;
+"12 sessions" is only legal if 12 is one of their verified numbers.
+
+The scope of this guard is exactly those six slots, and the claim is scoped to
+match. Numbers written INSIDE the generated `.dot` — budgets, `max_iterations`,
+thresholds, a figure in a node's prompt or label — are NOT digit-whitelisted:
+a `.dot` legitimately carries pipeline parameters, and a whitelist there would
+false-positive on real ones. The `.dot` gets its own appropriate machine gate,
+`attractor lint` + the authoring contract (see property 2); its numbers are
+checked for structure, not cross-checked against the verified stats. The
+self-certification panel's "what nothing checked" names that surface out loud
+(`demo_templates.PANEL_PART2_BODY`), and see `validate_narrative` for the two
+named limits of the whitelist itself.
+
+**2. Nothing is published before the gates finish.** `run_ladder` walks the
+degradation ladder — `attractor lint` when reachable, the vendored stdlib
+doctrine checker always — and `assemble` copies the `.dot` and companion
+beside the HTML only after a green verdict. A red verdict raises
+`DemoGateRed`: the artifact never carries a broken demo. Unavailability of a
+rung is a different fate from a red verdict — it is *labelled*, honestly, and
+the demo still publishes at the level that actually ran.
+
+**3. Execution order inside the ladder is not the rung order.** The doctrine
+checker is the FLOOR, so it runs first in code: if it cannot execute at all,
+nothing was verified and the honest label is `none` — asking the linter after
+that could only produce a level label that lied about what ran. The rendered
+panel still presents lint first, because that is the order of authority.
+
+The one network-adjacent rung (`uvx`) is never reached from here on its own:
+it arrives only as an explicit `--lint-cmd` override, which the skill supplies
+only after the user says yes out loud.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shlex
+import shutil
+import subprocess
+from collections import Counter
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from . import demo_templates as T
+from .errors import AttractorScoutError
+from .naming import DEMO_DIR_STEM
+
+# --------------------------------------------------------------------------
+# Budgets and constants (D2 / D4).
+# --------------------------------------------------------------------------
+
+#: The convergence-factory shape in miniature: start, exit, 1-2 workers,
+#: gate(s), budget wall, loud terminal.
+DEMO_MAX_NODES = 9
+
+#: One delegation, plus at most one gate-informed retry. Never more.
+DEMO_MAX_ATTEMPTS = 2
+
+#: Illustrative per-step reliability for the convergence arithmetic. This is
+#: DELIBERATELY not derived from the user's data: nothing in the extract
+#: measures per-step LLM success, and deriving one would be a fabricated
+#: statistic wearing their data's clothes. Labeled as illustrative wherever
+#: it is rendered.
+P_STEP = 0.9
+
+#: Attempt budget assumed for the gated-loop arithmetic when the generated
+#: pipeline does not declare one of its own.
+BUDGET_FALLBACK = 2
+BUDGET_MAX = 12
+
+#: The six named prose slots. All six required; no others honoured.
+NARRATIVE_TEXT_SLOTS = (
+    "scenario_gist",
+    "q1_cycle_note",
+    "q2_gate_note",
+    "q3_recovery_note",
+    "payoff_note",
+)
+NARRATIVE_WALK_SLOT = "pipeline_walk"
+NARRATIVE_SLOTS = (*NARRATIVE_TEXT_SLOTS, NARRATIVE_WALK_SLOT)
+
+MAX_SLOT_CHARS = 600
+
+#: Small integers the narrative may always use: Q1/Q2/Q3 and the 4a/4b/4c
+#: sub-test references. They name structure, not counts.
+STRUCTURAL_DIGITS = frozenset({"0", "1", "2", "3", "4"})
+
+#: Verdicts a demonstration may be generated for. An honest-NO is never
+#: demonstrated: authoring a pipeline for work that failed the fit test would
+#: demonstrate the anti-pattern.
+DEMOABLE_VERDICTS = frozenset({"OPPORTUNITY", "OPPORTUNITY(unproven)"})
+
+_DIGIT_RUN_RE = re.compile(r"\d+")
+_SLUG_BAD_RE = re.compile(r"[^A-Za-z0-9._-]+")
+_LINT_ERROR_RE = re.compile(r"\bERROR\b")
+
+#: Verify-class tools, borrowed from the gate detector so the brief's evidence
+#: and the fit verdict cannot disagree about what "a check" means.
+_REQUIRED_FILES = ("pipeline.dot", "pipeline.md", "narrative.json")
+
+
+class DemoGateRed(AttractorScoutError):
+    """A machine gate returned a red verdict — the demo must not publish.
+
+    Distinct from every other fail-loud condition: the inputs were fine and
+    the tooling worked. The authored pipeline is what failed, and the honest
+    response is to re-delegate once with the gate report attached, then stop.
+    """
+
+
+class DemoNarrativeInvalid(AttractorScoutError):
+    """A narrative slot broke the count-integrity contract or its shape."""
+
+
+# --------------------------------------------------------------------------
+# Unit lookup and stat rendering.
+# --------------------------------------------------------------------------
+
+
+def load_ranked(path: str | Path) -> dict:
+    try:
+        return json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise AttractorScoutError(f"could not read the ranking at {path}: {exc}") from exc
+
+
+def find_unit(ranked: dict, unit_id: str | None) -> dict:
+    """The unit to demonstrate. `None` means `opportunities[0]` (D1: K=1)."""
+    opportunities = ranked.get("opportunities") or []
+    if not opportunities:
+        raise AttractorScoutError(
+            "there are no opportunities in this ranking, so there is no subject to demonstrate. "
+            "Render the primer-only artifact instead."
+        )
+    if unit_id is None:
+        return opportunities[0]
+    for unit in opportunities:
+        if str(unit.get("unit_id")) == str(unit_id):
+            return unit
+    known = ", ".join(str(u.get("unit_id")) for u in opportunities[:10])
+    raise AttractorScoutError(f"unit {unit_id!r} is not in this ranking's opportunities. Known unit ids: {known}")
+
+
+def assert_demoable(unit: dict) -> None:
+    verdict = str(unit.get("verdict", ""))
+    if verdict not in DEMOABLE_VERDICTS:
+        raise AttractorScoutError(
+            f"unit {unit.get('unit_id')!r} carries verdict {verdict!r}. Demonstrations are only "
+            f"generated for {sorted(DEMOABLE_VERDICTS)} — a pipeline authored for work that failed "
+            f"the fit test would demonstrate the anti-pattern. Its remediation is its teaching."
+        )
+
+
+def slugify(name: str, unit_id: str) -> str:
+    """`<sanitized name>-<unit_id>` in the `pipeline_name` charset."""
+    base = _SLUG_BAD_RE.sub("-", str(name or "unit")).strip("-._") or "unit"
+    tail = _SLUG_BAD_RE.sub("-", str(unit_id or "u")).strip("-._") or "u"
+    return f"{base[:60]}-{tail}".strip("-._").lower()
+
+
+def _num(value, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _render_number(value: float) -> str:
+    """How a stat appears in the artifact — the exact string the whitelist uses."""
+    rounded = round(value, 2)
+    if abs(rounded - round(rounded)) < 1e-9:
+        return str(round(rounded))
+    return f"{rounded:g}"
+
+
+def unit_stats(unit: dict) -> dict:
+    """The verified stats block. Every number in a demo traces back to here."""
+    lev = unit.get("leverage_detail") or {}
+    return {
+        "n_sessions": round(_num(unit.get("n_sessions"))),
+        "med_tool_calls": round(_num(lev.get("med_tool_calls")), 2),
+        "med_llm_cycles": round(_num(lev.get("med_llm_cycles")), 2),
+        "med_span_s": round(_num(lev.get("med_span_capped_s")), 2),
+        "err_rate": round(_num(lev.get("errors_per_session")), 2),
+        "provisional": bool(unit.get("provisional")),
+    }
+
+
+def unit_fit(unit: dict) -> dict:
+    fit_detail = unit.get("fit_detail") or {}
+    return {
+        "cycle": bool(fit_detail.get("cycle")),
+        "gate": bool(fit_detail.get("gate")),
+        "recovery": str(unit.get("recovery") or fit_detail.get("recovery") or "UNKNOWN"),
+        "verdict": str(unit.get("verdict", "")),
+    }
+
+
+def rendered_stat_strings(stats: dict) -> list[str]:
+    return [
+        _render_number(stats["n_sessions"]),
+        _render_number(stats["med_tool_calls"]),
+        _render_number(stats["med_llm_cycles"]),
+        _render_number(stats["med_span_s"]),
+        _render_number(stats["err_rate"]),
+    ]
+
+
+def allowed_digit_runs(stats: dict) -> set[str]:
+    """The digit whitelist: their verified numbers, plus the structural 0-4."""
+    allowed = set(STRUCTURAL_DIGITS)
+    for rendered in rendered_stat_strings(stats):
+        allowed.add(rendered)
+        allowed.update(_DIGIT_RUN_RE.findall(rendered))
+    return allowed
+
+
+# --------------------------------------------------------------------------
+# Gate-tool evidence: what THEY already reach for to decide work is done.
+# --------------------------------------------------------------------------
+
+
+def gate_tool_census(unit: dict, extracts: list[dict] | None, *, top: int = 5) -> list[str]:
+    """Verify-class tools seen in this unit's members' TERMINAL windows.
+
+    This is the evidence the demo's gate command is derived from — the check
+    the user already runs, not one invented for them. Returns [] honestly when
+    no extract is available or nothing verify-shaped was observed; the brief
+    says so in those words rather than fabricating a gate.
+    """
+    if not extracts:
+        return []
+    from .fit_gate import DEFAULT_GATE_CONFIG
+
+    members = {str(m) for m in (unit.get("members") or [])}
+    if not members:
+        return []
+    counts: Counter[str] = Counter()
+    window = DEFAULT_GATE_CONFIG.tail_window
+    for rec in extracts:
+        if str(rec.get("session_id")) not in members:
+            continue
+        tail = rec.get("tool_tail") or (rec.get("tool_seq") or [])[-window:]
+        for tool in tail:
+            if str(tool) in DEFAULT_GATE_CONFIG.verify_tools:
+                counts[str(tool)] += 1
+    return [name for name, _ in counts.most_common(top)]
+
+
+def read_extracts_if_present(path: str | Path | None) -> list[dict] | None:
+    if not path:
+        return None
+    p = Path(path)
+    if not p.is_file():
+        return None
+    out: list[dict] = []
+    for line in p.read_text(encoding="utf-8", errors="replace").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            out.append(json.loads(line))
+        except ValueError:
+            continue
+    return out
+
+
+# --------------------------------------------------------------------------
+# Brief assembly (D2).
+# --------------------------------------------------------------------------
+
+
+def _stats_lines(stats: dict) -> list[str]:
+    return [
+        f"distinct sessions:        {_render_number(stats['n_sessions'])}",
+        f"median tool calls:        {_render_number(stats['med_tool_calls'])}",
+        f"median LLM cycles:        {_render_number(stats['med_llm_cycles'])}",
+        f"median wall span (s):     {_render_number(stats['med_span_s'])}",
+        f"errors per session:       {_render_number(stats['err_rate'])}",
+        f"frequency:                {'provisional (seen in only 2-3 sessions)' if stats['provisional'] else 'confirmed'}",
+    ]
+
+
+def _fit_lines(fit: dict) -> list[str]:
+    return [
+        f"4a cycle:     {'yes' if fit['cycle'] else 'no'}",
+        f"4b gate:      {'yes' if fit['gate'] else 'no'}",
+        f"4c recovery:  {T.RECOVERY_RENDER.get(fit['recovery'], fit['recovery'])}",
+    ]
+
+
+def build_brief(
+    *,
+    ranked_path: str | Path,
+    unit_id: str | None,
+    workdir: str | Path,
+    extracts_path: str | Path | None = None,
+) -> tuple[str, Path]:
+    """Write `<workdir>/<slug>/brief.md`. Returns `(slug, brief_path)`.
+
+    Deterministic: the same ranking and unit always produce the same brief.
+    """
+    ranked = load_ranked(ranked_path)
+    unit = find_unit(ranked, unit_id)
+    assert_demoable(unit)
+
+    slug = slugify(str(unit.get("name")), str(unit.get("unit_id")))
+    stats = unit_stats(unit)
+    fit = unit_fit(unit)
+    extracts = read_extracts_if_present(extracts_path)
+
+    target = Path(workdir) / slug
+    target.mkdir(parents=True, exist_ok=True)
+    brief_path = target / "brief.md"
+    brief_path.write_text(
+        T.brief_markdown(
+            unit_name=str(unit.get("name")),
+            unit_id=str(unit.get("unit_id")),
+            slug=slug,
+            verdict=fit["verdict"],
+            stats_lines=_stats_lines(stats),
+            fit_lines=_fit_lines(fit),
+            gate_evidence=gate_tool_census(unit, extracts),
+            gist=unit.get("gist"),
+            max_nodes=DEMO_MAX_NODES,
+        ),
+        encoding="utf-8",
+    )
+    return slug, brief_path
+
+
+# --------------------------------------------------------------------------
+# Narrative validation (D4) — fail loud, name the offending token.
+# --------------------------------------------------------------------------
+
+
+def validate_narrative(narrative, stats: dict, dot_text: str) -> dict:
+    """Shape, digit-whitelist and node-name checks. Raises on any violation.
+
+    Scope, stated precisely so the claim can't quietly widen: this guards the
+    SIX teaching-prose slots. Numbers inside the generated ``.dot`` are not its
+    business — that file gets ``attractor lint`` + the authoring contract, and
+    a whitelist over pipeline parameters (``max_iterations``, thresholds) would
+    false-positive on legitimate ones.
+
+    Two NAMED LIMITS of the whitelist itself, documented rather than closed —
+    both covered by expected-pass regression tests in
+    ``tests/test_scenario6_demo_assembly.py`` so a future "I fixed it" is forced
+    to update this docstring honestly:
+
+    * **Decomposition.** The scan matches ``\\d+``, and a rendered stat like
+      ``0.33`` whitelists the bare run ``33`` as a side effect, so "33 minutes"
+      passes. Closing it would mean whitelisting only the exact rendered string
+      and would ban the legitimate ``0.33`` -> ``33%`` kind of reference; the
+      boundary is the tokenizer's, and the guard fails loud on the shape it can
+      define cleanly (``93`` from ``930`` IS still rejected — decomposition only
+      leaks the whole sub-runs a stat literally contains).
+    * **Spelled-out numbers.** "forty-seven hours" is not a digit-run and
+      passes. Detecting written numerals is NLP guesswork, and a fail-loud guard
+      that guessed wrong would block honest prose — the worse failure for a
+      trust surface whose whole value is not crying wolf.
+    """
+    if not isinstance(narrative, dict):
+        raise DemoNarrativeInvalid(f"narrative.json must be a JSON object, got {type(narrative).__name__}")
+
+    missing = [slot for slot in NARRATIVE_SLOTS if slot not in narrative]
+    if missing:
+        raise DemoNarrativeInvalid(
+            f"narrative.json is missing required slot(s): {', '.join(missing)}. "
+            f"All of {', '.join(NARRATIVE_SLOTS)} must be present."
+        )
+
+    allowed = allowed_digit_runs(stats)
+
+    def _check_text(where: str, value) -> str:
+        if not isinstance(value, str) or not value.strip():
+            raise DemoNarrativeInvalid(f"narrative slot {where!r} must be a non-empty string")
+        if len(value) > MAX_SLOT_CHARS:
+            raise DemoNarrativeInvalid(
+                f"narrative slot {where!r} is {len(value)} characters; the limit is {MAX_SLOT_CHARS}"
+            )
+        for token in _DIGIT_RUN_RE.findall(value):
+            if token not in allowed:
+                raise DemoNarrativeInvalid(
+                    f"narrative slot {where!r} states the number {token!r}, which is not one of this "
+                    f"unit's re-verified stats. Every number in the artifact comes from the "
+                    f"deterministic layer; narrative may not invent one. "
+                    f"(allowed: {', '.join(sorted(allowed))})"
+                )
+        return value
+
+    cleaned: dict = {}
+    for slot in NARRATIVE_TEXT_SLOTS:
+        cleaned[slot] = _check_text(slot, narrative[slot])
+
+    walk = narrative[NARRATIVE_WALK_SLOT]
+    if not isinstance(walk, list) or not walk:
+        raise DemoNarrativeInvalid("narrative slot 'pipeline_walk' must be a non-empty array")
+
+    node_ids = dot_node_ids(dot_text)
+    cleaned_walk: list[dict] = []
+    for i, step in enumerate(walk):
+        if not isinstance(step, dict) or "node" not in step or "note" not in step:
+            raise DemoNarrativeInvalid(f"pipeline_walk[{i}] must be an object with 'node' and 'note'")
+        node = str(step["node"])
+        if node not in node_ids:
+            raise DemoNarrativeInvalid(
+                f"pipeline_walk[{i}] names node {node!r}, which does not exist in the pipeline. "
+                f"Nodes actually in the graph: {', '.join(sorted(node_ids)) or '(none)'}"
+            )
+        cleaned_walk.append({"node": node, "note": _check_text(f"pipeline_walk[{i}].note", step["note"])})
+    cleaned[NARRATIVE_WALK_SLOT] = cleaned_walk
+    return cleaned
+
+
+def dot_node_ids(dot_text: str) -> set[str]:
+    """Node ids, parsed with the VENDORED checker's parser — one parser, one truth."""
+    from .authoring_contract import DotParseError, parse_dot_min
+
+    try:
+        graph = parse_dot_min(dot_text)
+    except DotParseError as exc:
+        raise DemoNarrativeInvalid(f"the generated pipeline does not parse: {exc}") from exc
+    return set(graph.nodes)
+
+
+# --------------------------------------------------------------------------
+# Convergence arithmetic (D4) — computed here, never by the LLM.
+# --------------------------------------------------------------------------
+
+
+def budget_from_dot(dot_text: str) -> int:
+    """The demo pipeline's own attempt budget, read off the graph when stated."""
+    from .authoring_contract import DotParseError, parse_dot_min
+
+    try:
+        graph = parse_dot_min(dot_text)
+    except DotParseError:
+        return BUDGET_FALLBACK
+    found: list[int] = []
+    for node in graph.nodes.values():
+        raw = node.attrs.get("max_retries")
+        if raw is None:
+            continue
+        try:
+            val = int(str(raw).strip())
+        except ValueError:
+            continue
+        if val > 0:
+            found.append(val)
+    if not found:
+        return BUDGET_FALLBACK
+    return max(1, min(BUDGET_MAX, max(found)))
+
+
+def convergence_math(*, med_llm_cycles: float, budget: int) -> dict:
+    """`p^n` once-through vs the gated loop's chance within its budget.
+
+    Illustrative arithmetic with a fixed, labeled per-step reliability. Both
+    numbers are computed in Python at assembly time; neither is ever asked of
+    a language model.
+    """
+    chain_len = max(1, round(_num(med_llm_cycles, 1.0)))
+    once_through = P_STEP**chain_len
+    gated_loop = 1.0 - (1.0 - once_through) ** max(1, budget)
+    return {
+        "chain_len": chain_len,
+        "p_step": P_STEP,
+        "once_through": round(once_through, 4),
+        "gated_loop": round(gated_loop, 4),
+        "budget": max(1, budget),
+        "label": T.MATH_LABEL,
+    }
+
+
+# --------------------------------------------------------------------------
+# The verification ladder (D3).
+# --------------------------------------------------------------------------
+
+
+@dataclass
+class LadderResult:
+    level: str
+    lint_verdict: str | None = None
+    lint_not_run_reason: str | None = None
+    doctrine_verdict: str | None = None
+    doctrine_report: str | None = None
+    red: bool = False
+    red_reasons: list[str] = field(default_factory=list)
+
+    def as_dict(self) -> dict:
+        return {
+            "level": self.level,
+            "lint_verdict": self.lint_verdict,
+            "lint_not_run_reason": self.lint_not_run_reason,
+            "doctrine_verdict": self.doctrine_verdict,
+            "doctrine_report": self.doctrine_report,
+        }
+
+
+def run_doctrine_checker(dot_path: Path, companion_path: Path | None) -> tuple[str, str]:
+    """The FLOOR (rung 3). Returns `(verdict, verbatim report)`.
+
+    Runs in-process against the vendored, byte-pinned copy: no `python3` on
+    PATH required, which is exactly the bundle-only case this rung exists for.
+    Raises on an environmental crash so the caller can label `none`.
+    """
+    from .authoring_contract import CheckResult, DotParseError, parse_dot_min, render_report, run_checks
+
+    pipeline_label = dot_path.name
+    companion_label = companion_path.name if companion_path else "(none)"
+    try:
+        graph = parse_dot_min(dot_path.read_text(encoding="utf-8"))
+    except (OSError, DotParseError) as exc:
+        results = [CheckResult("A0", "the authored pipeline parses", False, f"{pipeline_label}: {exc}")]
+        return "doctrine_bad", render_report(pipeline_label, companion_label, results, "doctrine_bad")
+
+    results = run_checks(graph, companion_path)
+    verdict = "doctrine_ok" if all(r.passed for r in results) else "doctrine_bad"
+    return verdict, render_report(pipeline_label, companion_label, results, verdict)
+
+
+def _run_lint(lint_argv: list[str], dot_path: Path) -> tuple[str, bool]:
+    """Run a linter and capture its findings VERBATIM. Returns `(text, red)`."""
+    try:
+        # argv comes from a configured command, never from mined text.
+        proc = subprocess.run(
+            [*lint_argv, "lint", str(dot_path.name)],
+            cwd=str(dot_path.parent),
+            capture_output=True,
+            text=True,
+            timeout=300,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return f"attractor lint: could not run ({exc})", False
+    body = (proc.stdout or "") + (proc.stderr or "")
+    body = body.strip() or f"(no output; exit {proc.returncode})"
+    red = proc.returncode != 0 or bool(_LINT_ERROR_RE.search(body))
+    return body, red
+
+
+def run_ladder(
+    *,
+    dot_path: Path,
+    companion_path: Path | None,
+    relpath: str,
+    lint_cmd: str | None = None,
+) -> LadderResult:
+    """Walk the degradation ladder and resolve the honest verification level.
+
+    Execution order puts the doctrine checker first because it is the floor:
+    if it cannot execute, nothing was verified and `none` is the only truthful
+    label — running the linter afterwards could only produce a level string
+    that overstated what happened. The rendered panel still shows lint first.
+    """
+    try:
+        doctrine_verdict, doctrine_report = run_doctrine_checker(dot_path, companion_path)
+    except Exception as exc:  # noqa: BLE001 - ANY environmental crash of the checker is rung 4, by design
+        return LadderResult(
+            level=T.LEVEL_NONE,
+            lint_verdict=None,
+            lint_not_run_reason=(
+                "the bundled doctrine checker could not execute in this environment "
+                f"({type(exc).__name__}: {exc}), so nothing machine-checked this pipeline"
+            ),
+            doctrine_verdict=None,
+            doctrine_report=None,
+        )
+
+    doctrine_red = doctrine_verdict != "doctrine_ok"
+
+    if lint_cmd:
+        lint_argv = shlex.split(lint_cmd)
+    elif shutil.which("attractor"):
+        lint_argv = ["attractor"]
+    else:
+        lint_argv = []
+
+    if not lint_argv:
+        return LadderResult(
+            level=T.LEVEL_DOCTRINE_ONLY,
+            lint_verdict=None,
+            lint_not_run_reason=T.lint_not_run_label(relpath),
+            doctrine_verdict=doctrine_verdict,
+            doctrine_report=doctrine_report,
+            red=doctrine_red,
+            red_reasons=([f"doctrine: {doctrine_verdict}"] if doctrine_red else []),
+        )
+
+    lint_text, lint_red = _run_lint(lint_argv, dot_path)
+    reasons: list[str] = []
+    if lint_red:
+        reasons.append("attractor lint reported ERROR-level findings")
+    if doctrine_red:
+        reasons.append(f"doctrine: {doctrine_verdict}")
+    return LadderResult(
+        level=T.LEVEL_LINT_DOCTRINE,
+        lint_verdict=lint_text,
+        lint_not_run_reason=None,
+        doctrine_verdict=doctrine_verdict,
+        doctrine_report=doctrine_report,
+        red=bool(reasons),
+        red_reasons=reasons,
+    )
+
+
+# --------------------------------------------------------------------------
+# Assembly + publication (D5).
+# --------------------------------------------------------------------------
+
+
+def _read_workdir(workdir: Path) -> tuple[str, Path, Path, dict]:
+    dot_path = workdir / "pipeline.dot"
+    companion_path = workdir / "pipeline.md"
+    narrative_path = workdir / "narrative.json"
+    missing = [name for name in _REQUIRED_FILES if not (workdir / name).is_file()]
+    if missing:
+        raise AttractorScoutError(
+            f"the demo workdir {workdir} is missing {', '.join(missing)}. The authoring delegate "
+            f"must write all three files: {', '.join(_REQUIRED_FILES)}."
+        )
+    try:
+        narrative = json.loads(narrative_path.read_text(encoding="utf-8"))
+    except ValueError as exc:
+        raise DemoNarrativeInvalid(f"{narrative_path} is not valid JSON: {exc}") from exc
+    return dot_path.read_text(encoding="utf-8"), dot_path, companion_path, narrative
+
+
+def _publish(dot_path: Path, companion_path: Path, output_dir: Path, slug: str) -> tuple[str, str]:
+    """Copy beside the HTML — AFTER the gates. Fails loud if the copy failed."""
+    dest_dir = output_dir / DEMO_DIR_STEM
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    dest_dot = dest_dir / f"{slug}.dot"
+    dest_md = dest_dir / f"{slug}.md"
+    try:
+        shutil.copyfile(dot_path, dest_dot)
+        shutil.copyfile(companion_path, dest_md)
+    except OSError as exc:
+        raise AttractorScoutError(
+            f"could not publish the demo files into {dest_dir}: {exc}. The artifact must never "
+            f"claim a file that does not exist."
+        ) from exc
+    if not dest_dot.is_file() or not dest_md.is_file():
+        raise AttractorScoutError(f"publication into {dest_dir} did not produce both files")
+    return f"{DEMO_DIR_STEM}/{slug}.dot", f"{DEMO_DIR_STEM}/{slug}.md"
+
+
+def assemble_demo(
+    *,
+    ranked_path: str | Path,
+    unit_id: str | None,
+    workdir: str | Path,
+    output_dir: str | Path,
+    lint_cmd: str | None = None,
+    generated_at: str,
+) -> dict:
+    """Gate, validate, publish, and return one `demos.json` demo entry."""
+    ranked = load_ranked(ranked_path)
+    unit = find_unit(ranked, unit_id)
+    assert_demoable(unit)
+
+    workdir = Path(workdir)
+    slug = slugify(str(unit.get("name")), str(unit.get("unit_id")))
+    dot_text, dot_path, companion_path, narrative = _read_workdir(workdir)
+
+    stats = unit_stats(unit)
+    fit = unit_fit(unit)
+    cleaned_narrative = validate_narrative(narrative, stats, dot_text)
+
+    dot_relpath = f"{DEMO_DIR_STEM}/{slug}.dot"
+    ladder = run_ladder(
+        dot_path=dot_path,
+        companion_path=companion_path,
+        relpath=dot_relpath,
+        lint_cmd=lint_cmd,
+    )
+    if ladder.red:
+        report_path = workdir / "gate-report.txt"
+        report_path.write_text(
+            "\n\n".join(
+                part
+                for part in (
+                    "=== attractor lint ===\n" + (ladder.lint_verdict or "(not run)"),
+                    "=== authoring contract ===\n" + (ladder.doctrine_report or "(not run)"),
+                )
+            ),
+            encoding="utf-8",
+        )
+        raise DemoGateRed(
+            f"the machine gates rejected this draft ({'; '.join(ladder.red_reasons)}). It was NOT "
+            f"published — the artifact never carries a broken demo. The verbatim gate reports are "
+            f"at {report_path}; re-delegate ONCE with them appended, and if it is still red, say so "
+            f"and move on."
+        )
+
+    published_dot, published_md = _publish(dot_path, companion_path, Path(output_dir), slug)
+    budget = budget_from_dot(dot_text)
+
+    return {
+        "unit_id": str(unit.get("unit_id")),
+        "name": str(unit.get("name")),
+        "slug": slug,
+        "dot_relpath": published_dot,
+        "companion_relpath": published_md,
+        "dot_text": dot_text,
+        "stats": stats,
+        "fit": fit,
+        "leverage_detail": {
+            "leverage": round(_num(unit.get("leverage")), 3),
+            "score": round(_num(unit.get("score")), 3),
+        },
+        "narrative": cleaned_narrative,
+        "convergence_math": convergence_math(med_llm_cycles=stats["med_llm_cycles"], budget=budget),
+        "verification": ladder.as_dict(),
+        "invocation": {
+            "run_cmd": T.run_cmd(published_dot),
+            "author_cmd": T.author_cmd(unit_name=str(unit.get("name")), verdict=fit["verdict"], slug=slug),
+            "install_cmd": T.CLI_INSTALL_CMD,
+        },
+        "generated_at": generated_at,
+    }
+
+
+def empty_demos_doc() -> dict:
+    """The primer-only document: a demonstration needs a subject."""
+    return {"primer": True, "explainer_url": T.EXPLAINER_URL, "demos": []}
+
+
+def write_demos(demo: dict | None, out_path: str | Path, *, append: bool = False) -> dict:
+    """Write (or append into) `demos.json`. Same unit twice replaces, never duplicates."""
+    out = Path(out_path)
+    doc = empty_demos_doc()
+    if append and out.is_file():
+        try:
+            existing = json.loads(out.read_text(encoding="utf-8"))
+        except ValueError as exc:
+            raise AttractorScoutError(f"{out} exists but is not valid JSON: {exc}") from exc
+        if isinstance(existing, dict) and isinstance(existing.get("demos"), list):
+            doc["demos"] = list(existing["demos"])
+    if demo is not None:
+        doc["demos"] = [d for d in doc["demos"] if d.get("unit_id") != demo["unit_id"]]
+        doc["demos"].append(demo)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(doc, indent=1, ensure_ascii=False) + "\n", encoding="utf-8")
+    return doc
+
+
+def not_yet_demonstrated(ranked: dict, demos_doc: dict, *, top: int = 5) -> list[dict]:
+    """Step 9's menu: the next candidates, in rank order, already-done removed."""
+    done = {str(d.get("unit_id")) for d in (demos_doc.get("demos") or [])}
+    out = []
+    for unit in ranked.get("opportunities") or []:
+        if str(unit.get("unit_id")) in done:
+            continue
+        out.append({"unit_id": str(unit.get("unit_id")), "name": str(unit.get("name"))})
+        if len(out) >= top:
+            break
+    return out

--- a/skills/attractor-scout/scripts/attractor_scout/demo_templates.py
+++ b/skills/attractor-scout/scripts/attractor_scout/demo_templates.py
@@ -1,0 +1,509 @@
+"""Every deterministic string the demonstration layer emits. NO LLM in here.
+
+The mining half earned its trust with one rule: *every number in the artifact
+was re-verified against the raw records before it was rendered*. The teaching
+half inherits that rule by construction rather than by hope --- which is what
+this module is for. All narrative scaffolding, all section headings, all
+verification labels, the whole learn-about primer, and every command a reader
+is invited to run live HERE, as constants and pure functions over already
+verified stats. The LLM never gets to *state* a number; it only narrates
+around numbers the deterministic layer placed (see `demo.validate_narrative`,
+which machine-checks exactly that).
+
+Three constants are load-bearing enough to be pinned by tests:
+
+* `LABEL_UNVERIFIED` --- the honest banner when nothing machine-checked the
+  pipeline. An unverified demo still teaches; the label is part of what it
+  teaches.
+* `lint_not_run_label()` --- the exact wording used when the CLI is absent.
+  Never an implied pass: if the linter could not run, the artifact SAYS so.
+* `CLI_INSTALL_CMD` --- the one place the install line is written down.
+
+Nothing here fetches anything. `EXPLAINER_URL` is a hyperlink a reader may
+choose to follow, not a resource the artifact loads (see the note in
+`render.py` about why that does not breach the self-contained rule).
+"""
+
+from __future__ import annotations
+
+import shlex
+
+# --------------------------------------------------------------------------
+# Public endpoints and commands --- written down exactly once.
+# --------------------------------------------------------------------------
+
+#: The published explainer. LINKED, never inlined (repo convention).
+EXPLAINER_URL = "https://microsoft.github.io/amplifier-bundle-attractor/attractor-explained.html"
+
+#: The single source of the install line, quoted in every demo's panel.
+CLI_INSTALL_CMD = (
+    'uv tool install "git+https://github.com/microsoft/amplifier-bundle-attractor'
+    '@main#subdirectory=modules/pipeline-runner"'
+)
+
+#: The ASK-FIRST inbound fetch. Never run without an explicit yes (rung 2).
+UVX_LINT_CMD = (
+    "uvx --from git+https://github.com/microsoft/amplifier-bundle-attractor"
+    "@main#subdirectory=modules/pipeline-runner attractor"
+)
+
+#: The offered independent path --- never invoked automatically by this skill.
+AUTHOR_PIPELINE_PATH = "examples/authoring/pipeline-author.dot"
+
+# --------------------------------------------------------------------------
+# Verification-ladder labels --- exact strings, pinned by tests.
+# --------------------------------------------------------------------------
+
+LEVEL_LINT_DOCTRINE = "lint+doctrine"
+LEVEL_DOCTRINE_ONLY = "doctrine-only"
+LEVEL_NONE = "none"
+
+#: Rung 3 ran, rungs 1-2 did not. The #270 doctrine: if the linter could not
+#: run, SAY SO in the artifact --- silence reads as a pass, and is not one.
+LABEL_LINT_NOT_RUN = (
+    "attractor lint: NOT RUN — the CLI is not installed here. Run it yourself: attractor lint {relpath}"
+)
+
+#: Rung 4: nothing verified anything. Loud, and honest about it.
+LABEL_UNVERIFIED = "UNVERIFIED — no machine check ran on this pipeline"
+
+
+def lint_not_run_label(relpath: str) -> str:
+    """The exact `NOT RUN` line, with this demo's published path filled in."""
+    return LABEL_LINT_NOT_RUN.format(relpath=relpath)
+
+
+# --------------------------------------------------------------------------
+# The learn-about primer --- one screen, once per artifact, deterministic.
+# --------------------------------------------------------------------------
+
+PRIMER_TITLE = "What an attractor pipeline is — in one screen"
+
+PRIMER_LEAD = (
+    "The map above says what recurs in your own work. This says what an attractor pipeline is, "
+    "so the demonstration below reads as something you could actually build."
+)
+
+#: (heading, body) pairs. Rendered in order; the renderer escapes both.
+PRIMER_PARTS: tuple[tuple[str, str], ...] = (
+    (
+        "A loop, not a checklist",
+        (
+            "An attractor is work that gets ATTEMPTED, CHECKED, and RE-ATTEMPTED until it lands. "
+            "Straight-through work — do this, then this, then this — is a recipe. A recipe does not "
+            "need a pipeline; it needs a script, or just doing."
+        ),
+    ),
+    (
+        "The exit gates on machine evidence, from OUTSIDE the worker",
+        (
+            "The loop stops when a real command says so: a test suite, a linter, a build, a readback "
+            "— something that can be RED today and GREEN only when the work is done. It never stops "
+            "because the model reports that it finished. A claim about your own output is not "
+            "evidence; that is the one rule the whole doctrine rests on."
+        ),
+    ),
+    (
+        "A budget wall, so it cannot spin",
+        (
+            "Every loop carries a cap on attempts, and exhausting the cap routes somewhere honest — a "
+            "salvage path, a postmortem, a loud failure — never quietly out the success door."
+        ),
+    ),
+    (
+        "Gates live outside the workers",
+        (
+            "The node that does the work and the node that judges it are different nodes. The judge "
+            "runs a command; it does not read the worker's own summary of how well things went."
+        ),
+    ),
+    (
+        "The three-question test",
+        (
+            "Q1 — is there a cycle? Q2 — is the exit gated on machine-checkable evidence? Q3 — would "
+            "it survive one node having a bad day? Three yeses and the work is attractor-shaped. "
+            "Anything less has a name and a home elsewhere."
+        ),
+    ),
+    (
+        "The honest NO is a real answer",
+        (
+            "Most recurring work is NOT attractor-shaped, and saying so is the valuable output — that "
+            "is why the map above reports honest-NOs with the sub-test each one failed and what would "
+            "change the answer. A pipeline built for recipe-shaped work teaches the anti-pattern to "
+            "everyone who copies it."
+        ),
+    ),
+)
+
+PRIMER_LINK_LEAD = "The full explainer, with worked examples:"
+
+
+# --------------------------------------------------------------------------
+# Per-demo section headings and fixed prose.
+# --------------------------------------------------------------------------
+
+SEC_COST = "What this keeps costing you by hand"
+SEC_GIST = "In your own terms"
+SEC_FIT = "The three-question test, applied to this"
+SEC_WALK = "The pipeline, walked"
+SEC_MATH = "Why the loop beats the once-through run"
+SEC_PAYOFF = "Why this would have helped"
+SEC_ENTRY = "Where to take it next"
+SEC_RUN = "Run it going forward"
+SEC_PANEL = "Can I vouch for this? — the three-part answer"
+
+DEMO_LEAD = (
+    "This is a demonstration authored for THIS unit of your work, then machine-gated before it was "
+    "published. Generation was a language model; verification, assembly and rendering were not."
+)
+
+#: Section 10, part 2 --- the same three parts every time, because the honest
+#: answer to "can you vouch for it" does not vary with the demo.
+PANEL_PART1_TITLE = "What a machine checked, and what it said"
+PANEL_PART2_TITLE = "What nothing checked"
+PANEL_PART2_BODY = (
+    "Whether these prompts fit the way you actually work. Whether the gate command is the right "
+    "definition-of-done for your case. Whether this pipeline solves the problem you actually have. "
+    "And any number written inside the pipeline itself — a budget, a threshold, a figure in a "
+    "node's prompt or label — which the engine's linter and the authoring contract gate for "
+    "structure, but which is NOT cross-checked against your verified stats the way the teaching "
+    "text above it is. Structure lints; judgment does not."
+)
+PANEL_PART3_TITLE = "The independent path"
+PANEL_PART3_BODY = (
+    "Do not take this session's word for it. The authoring pipeline below converges a draft under "
+    "the engine's own linter, a structural authoring contract, and a critique that inherits none of "
+    "the author's context:"
+)
+
+MATH_LABEL = "illustrative arithmetic — not a measurement of your sessions"
+MATH_LEAD = (
+    "A once-through run has to get every step right the first time. A gated loop only has to get "
+    "there within its budget, because the gate catches the miss and the loop pays for another "
+    "attempt. With a per-step success rate held fixed for illustration:"
+)
+
+FIT_Q1 = "Q1 — is there a cycle?"
+FIT_Q2 = "Q2 — is the exit gated on machine-checkable evidence?"
+FIT_Q3 = "Q3 — would it survive one node having a bad day?"
+
+#: UNKNOWN is a caveat, never a failure --- the same invariant the map holds.
+RECOVERY_RENDER = {
+    "PASS": "PASS — a real error was observed and the work still finished",
+    "PASS-provisional": "PASS-provisional — recovery was observed, but on thin evidence",
+    "UNKNOWN": "unproven — no bad day was ever observed, which is a caveat, never a failure",
+}
+
+#: Section 8. (label, target, why) --- deterministic, identical in every demo.
+ENTRY_POINTS: tuple[tuple[str, str, str], ...] = (
+    (
+        "Design it conversationally",
+        "/attractorify",
+        "applies the three-question test to one piece of work and designs the shape with you.",
+    ),
+    (
+        "Converge it under executed gates",
+        AUTHOR_PIPELINE_PATH,
+        "authors a hardened, reusable pipeline and hardens it against real gate runs.",
+    ),
+    (
+        "The canonical skeleton",
+        "examples/patterns/task-runner.dot",
+        "the smallest complete attempt/check/re-attempt shape worth copying.",
+    ),
+    (
+        "When the work has a definition of done per item",
+        "examples/objective/objective-runner.dot",
+        "the objective layer, for fan-out over a list of things each with its own gate.",
+    ),
+    (
+        "The repo-hosted lane",
+        "docs/ISSUE_PIPELINE.md",
+        "how the same discipline runs against issues, in a repo, unattended.",
+    ),
+)
+
+
+# --------------------------------------------------------------------------
+# Brief assembly --- the instruction pack handed to the fresh-context author.
+# --------------------------------------------------------------------------
+
+#: The attribute vocabulary a fresh-context delegate cannot see for itself.
+#: Every name here must exist in `context/dot-reference.md`; a pin test checks
+#: exactly that, so this excerpt can never drift into inventing a spelling.
+VOCAB_ATTRIBUTES: tuple[str, ...] = (
+    "shape",
+    "prompt",
+    "tool_command",
+    "goal_gate",
+    "condition",
+    "max_retries",
+    "retry_target",
+    "fidelity",
+)
+
+VOCAB_EXCERPT = """\
+ENGINE VOCABULARY (this is the whole vocabulary you may use — an attribute that
+is not on this list is not read by anything, and a graph that *looks* configured
+runs unconfigured):
+
+  shape=Mdiamond      the start node. Not `circle`.
+  shape=Msquare       the single exit node. Not `doublecircle`.
+  shape=box           an LLM worker. The default tier. There is no `agent=`.
+  shape=parallelogram an evidence gate: a node that RUNS A REAL COMMAND and
+                      routes the graph on what the command said.
+  shape=diamond       a pure routing node (no work, no judgment).
+
+  prompt="..."        what an LLM worker is asked. The engine reads `prompt=`,
+                      NEVER `instruction=`; an invented attribute is silently
+                      dropped and the node runs with no prompt at all.
+  tool_command="..."  the shell command a gate or tool node runs.
+  goal_gate="..."     an assertion the engine itself evaluates.
+  condition="..."     edge selection: `outcome=success`, `outcome=fail`, or
+                      `context.tool.last_line=<token>` from a real command.
+  max_retries=N       per-node retry budget.
+  retry_target=<node> where a failed node routes instead of ending the run.
+  fidelity=<mode>     context handling: full, truncate, compact, summary:low,
+                      summary:medium, summary:high. Those six, no others.
+
+Edge rules that bite: a label-routing edge whose source can also fail must
+conjoin `&& outcome=success`; no failure outcome may route into the exit node.
+"""
+
+CONTRACT_SUMMARY = """\
+THE STRUCTURAL CONTRACT (A0–A10). Your draft is machine-checked against this
+before anyone sees it, so write to it deliberately:
+
+  A0  the pipeline file exists and parses
+  A1  EXACTLY ONE exit node (shape=Msquare). A second honest terminal is a LOUD
+      nonzero tool node, never a second Msquare
+  A2  at least one corrective cycle
+  A3  at least one evidence-bearing gate that runs a REAL command and routes on
+      it. A node that only prints a constant is not a gate
+  A4  the exit is structurally UNREACHABLE without passing an evidence gate.
+      This is the load-bearing check
+  A5  a budget wall: a node that counts attempts and routes exhaustion somewhere
+      that is not the success door
+  A6  every reachable LLM worker carries an `outcome=fail` route or a
+      `retry_target`
+  A7  label-routing edges conjoin `&& outcome=success` where the source can fail
+  A8  NO failure outcome is routed into the exit node
+  A9  the companion .md NAMES EVERY LLM worker node id and states its contract
+  A10 no evidence gate routes both of its answers into the exit — a gate whose
+      answer cannot change the path gates nothing
+"""
+
+NARRATIVE_CONTRACT = """\
+NARRATIVE RULES (machine-enforced at assembly — a violation kills the demo):
+
+  * DO NOT STATE ANY NUMBER that is not one of the verified stats quoted above.
+    Every count in the published artifact is placed by a deterministic template
+    from re-verified data; your prose narrates AROUND those numbers. Digits are
+    scanned: any digit-run that is not a verified stat (or one of 0–4, for
+    referring to Q1/Q2/Q3 and the 4a/4b/4c sub-tests) fails the assembly and
+    the demo is discarded. Prose like "about a dozen" is always fine.
+  * Every `pipeline_walk[].node` must be a node id that actually exists in your
+    pipeline.dot. Invented node names fail the assembly.
+  * Every slot is a plain string of at most 600 characters. All six must be
+    present. `pipeline_walk` must be non-empty.
+  * Write to the user, about THEIR work, in second person. No preamble, no
+    apology, no meta-commentary about being a language model.
+"""
+
+
+def brief_markdown(
+    *,
+    unit_name: str,
+    unit_id: str,
+    slug: str,
+    verdict: str,
+    stats_lines: list[str],
+    fit_lines: list[str],
+    gate_evidence: list[str],
+    gist: str | None,
+    max_nodes: int,
+) -> str:
+    """Assemble the demo brief. Deterministic — no improvised prompting.
+
+    `unit_name` / `gist` are untrusted text from the user's own corpus: they
+    are expanded into PROSE and PROMPTS here and nowhere else. Nothing in this
+    document becomes a command the orchestrating session executes.
+    """
+    stats_block = "\n".join(f"  {line}" for line in stats_lines)
+    fit_block = "\n".join(f"  {line}" for line in fit_lines)
+    if gate_evidence:
+        gate_block = "\n".join(f"  - {tool}" for tool in gate_evidence)
+        gate_note = (
+            "These are the verify-class tools that actually appear in the terminal window of\n"
+            "this unit's own sessions. Derive the gate command from THIS evidence — it is what\n"
+            "the user already reaches for to decide the work is done:\n" + gate_block
+        )
+    else:
+        gate_note = (
+            "No verify-class tool was observed in the terminal window of this unit's sessions.\n"
+            "Say so plainly in the companion, and choose the most conservative real check the\n"
+            "scenario admits — never invent evidence that was not there."
+        )
+    gist_block = gist.strip() if gist else "(no gist recorded for this unit)"
+
+    return f"""\
+# Demonstration brief — author one small attractor pipeline
+
+You are writing a TEACHING DEMONSTRATION for one unit of recurring work that was
+mined from the user's own session history. Someone who has never built an
+attractor pipeline will read your output next to their own numbers. Small,
+correct and legible beats clever.
+
+## The unit
+
+  name:     {unit_name}
+  unit id:  {unit_id}
+  verdict:  {verdict}
+
+Scenario, as recorded:
+
+{gist_block}
+
+## Their VERIFIED stats (already re-verified against the raw records)
+
+{stats_block}
+
+## Why it passed the fit test
+
+{fit_block}
+
+## Gate evidence observed in their own sessions
+
+{gate_note}
+
+## What to write
+
+Write exactly THREE files into this directory:
+
+### 1. `pipeline.dot`
+
+A small attractor pipeline that would have converged THIS scenario. Hard budget:
+**at most {max_nodes} nodes** — start, exit, one or two workers, the gate(s), a
+budget wall, and a loud terminal. This is the convergence-factory shape in
+miniature, not a production system. Keep the control plane lean: gates, budgets,
+walls, feedback. Do NOT decompose the domain into graph nodes — plan/implement/
+test as separate nodes is the anti-pattern.
+
+{VOCAB_EXCERPT}
+{CONTRACT_SUMMARY}
+### 2. `pipeline.md`
+
+The companion. It MUST name every LLM (box) node id in your graph and state each
+one's contract in prose (that is A9, and it is checked). Also say what the
+pipeline converges on, what the gate proves, and what the honest failure exit
+looks like.
+
+### 3. `narrative.json`
+
+Exactly this shape, six slots, no others:
+
+```json
+{{
+  "scenario_gist": "one short paragraph, in the user's own terms, describing the recurring work",
+  "q1_cycle_note": "why this work has a real cycle, in their scenario's terms",
+  "q2_gate_note": "what the machine-checkable definition-of-done is here, in their terms",
+  "q3_recovery_note": "what a bad day looks like for this work and how the pipeline absorbs it",
+  "pipeline_walk": [{{"node": "<a node id from your pipeline.dot>", "note": "what this node is for"}}],
+  "payoff_note": "one line: why running this loop would have helped them"
+}}
+```
+
+{NARRATIVE_CONTRACT}
+## Slug
+
+The published files will be named `{slug}.dot` and `{slug}.md`.
+"""
+
+
+def author_brief_line(unit_name: str, verdict: str) -> str:
+    """A one-paragraph brief for the OFFERED independent authoring path.
+
+    Deterministic, and short enough to survive a copy-paste into a shell.
+    """
+    return (
+        f"Author a reusable attractor pipeline for this recurring unit of work: {unit_name}. "
+        f"It was mined from real session history and classified {verdict}. The loop must gate its "
+        f"exit on a real command that is red before the work is done and green only after, carry a "
+        f"budget wall, and route exhaustion somewhere honest."
+    )
+
+
+def run_cmd(dot_relpath: str) -> str:
+    """The exact invocation that runs the published demo pipeline."""
+    return f"attractor run {shlex.quote(dot_relpath)} --cwd ."
+
+
+def author_cmd(*, unit_name: str, verdict: str, slug: str) -> str:
+    """The `pipeline-author.dot` invocation, with this demo's brief pre-filled."""
+    brief = shlex.quote(author_brief_line(unit_name, verdict))
+    return (
+        f"attractor run {AUTHOR_PIPELINE_PATH} --cwd . \\\n"
+        f"    --param brief={brief} \\\n"
+        f"    --param authoring_dir=examples/authoring \\\n"
+        f"    --param target_dir=. \\\n"
+        f"    --param pipeline_name={shlex.quote(slug)}"
+    )
+
+
+def uvx_consent_question(relpath: str) -> str:
+    """The ask-first question for rung 2. Named as an inbound fetch, out loud."""
+    return (
+        "The attractor CLI isn't installed. I can fetch and run the public linter via "
+        f"`{UVX_LINT_CMD} lint {relpath}` — that downloads a public package (an inbound fetch; "
+        "none of your mined data leaves this machine). Yes/no?"
+    )
+
+
+__all__ = [
+    "AUTHOR_PIPELINE_PATH",
+    "CLI_INSTALL_CMD",
+    "CONTRACT_SUMMARY",
+    "DEMO_LEAD",
+    "ENTRY_POINTS",
+    "EXPLAINER_URL",
+    "FIT_Q1",
+    "FIT_Q2",
+    "FIT_Q3",
+    "LABEL_LINT_NOT_RUN",
+    "LABEL_UNVERIFIED",
+    "LEVEL_DOCTRINE_ONLY",
+    "LEVEL_LINT_DOCTRINE",
+    "LEVEL_NONE",
+    "MATH_LABEL",
+    "MATH_LEAD",
+    "NARRATIVE_CONTRACT",
+    "PANEL_PART1_TITLE",
+    "PANEL_PART2_BODY",
+    "PANEL_PART2_TITLE",
+    "PANEL_PART3_BODY",
+    "PANEL_PART3_TITLE",
+    "PRIMER_LEAD",
+    "PRIMER_LINK_LEAD",
+    "PRIMER_PARTS",
+    "PRIMER_TITLE",
+    "RECOVERY_RENDER",
+    "SEC_COST",
+    "SEC_ENTRY",
+    "SEC_FIT",
+    "SEC_GIST",
+    "SEC_MATH",
+    "SEC_PANEL",
+    "SEC_PAYOFF",
+    "SEC_RUN",
+    "SEC_WALK",
+    "UVX_LINT_CMD",
+    "VOCAB_ATTRIBUTES",
+    "VOCAB_EXCERPT",
+    "author_brief_line",
+    "author_cmd",
+    "brief_markdown",
+    "lint_not_run_label",
+    "run_cmd",
+    "uvx_consent_question",
+]

--- a/skills/attractor-scout/scripts/attractor_scout/naming.py
+++ b/skills/attractor-scout/scripts/attractor_scout/naming.py
@@ -14,4 +14,9 @@ SKILL_TITLE = "Attractor Scout"
 # Artifact filename stem used by render.py (cwd-relative by default).
 ARTIFACT_STEM = SKILL_NAME
 
-__all__ = ["ARTIFACT_STEM", "SKILL_NAME", "SKILL_TITLE"]
+# Directory (beside the HTML artifact) where demonstrated pipelines are
+# published: `<output_dir>/<DEMO_DIR_STEM>/<slug>.dot` + `.md`. Derived from
+# SKILL_NAME so the single-naming-source rule survives the demo layer.
+DEMO_DIR_STEM = f"{SKILL_NAME}-demos"
+
+__all__ = ["ARTIFACT_STEM", "DEMO_DIR_STEM", "SKILL_NAME", "SKILL_TITLE"]

--- a/skills/attractor-scout/scripts/attractor_scout/render.py
+++ b/skills/attractor-scout/scripts/attractor_scout/render.py
@@ -15,6 +15,21 @@ Layout:
 
 Renderer honesty invariant (machine-checked): a 4c-UNKNOWN unit is NEVER
 rendered as FAIL. `unproven` is displayed as a caveat on an opportunity.
+
+Its sibling, added with the demonstration layer: an UNVERIFIED demo is NEVER
+rendered as verified. The verification level is printed as the exact label the
+ladder resolved, and "the linter did not run here" is stated in those words
+rather than left as a silence a reader would read as a pass.
+
+**Additivity is a hard guarantee.** With `demos=None` this module emits the
+byte-identical artifact it emitted before the demonstration layer existed:
+every new byte — CSS included — is inside a conditional. A test pins it.
+
+**The explainer is LINKED, never inlined, and that does not breach the
+self-contained rule.** Self-contained forbids *fetched resources* — CSS, JS,
+fonts, data the document loads in order to display itself. A hyperlink loads
+nothing; it is a reference a reader may choose to follow, and the artifact
+renders completely with the network unplugged.
 """
 
 from __future__ import annotations
@@ -24,6 +39,7 @@ import json
 from datetime import datetime, timezone
 from pathlib import Path
 
+from . import demo_templates as T
 from .naming import ARTIFACT_STEM, SKILL_TITLE
 
 _VERDICT_CLASS = {
@@ -113,6 +129,34 @@ document.addEventListener('keydown', function(e){ if(e.key==='Escape'){closeModa
 """
 
 
+#: Appended to _CSS **only** when demos are supplied, so that the no-demos
+#: artifact stays byte-identical to the pre-demonstration-layer output.
+_DEMO_CSS = """
+.demo{background:var(--panel);border:1px solid var(--line);border-radius:10px;
+padding:18px 20px;margin:14px 0}
+.demo h3{margin:22px 0 6px;font-size:15px}
+.demo h3:first-of-type{margin-top:10px}
+.primer{background:#141824;border:1px solid var(--line);border-radius:10px;padding:18px 20px}
+.primer dt{font-weight:600;margin-top:12px}
+.primer dd{margin:2px 0 0;color:var(--dim)}
+.statline{display:flex;flex-wrap:wrap;gap:14px;font-size:12px;color:var(--dim);margin:8px 0 0}
+.statline b{color:var(--fg);font-weight:600}
+pre.dotsrc{background:#0b0d12;border:1px solid var(--line);border-radius:8px;padding:12px 14px;
+overflow:auto;font-size:12px;line-height:1.45;max-height:520px;white-space:pre}
+pre.cmd{background:#0b0d12;border:1px solid var(--line);border-radius:8px;padding:10px 12px;
+overflow:auto;font-size:12px;white-space:pre-wrap}
+.panel{border-left:3px solid var(--acc);background:#1c2130;padding:10px 12px;
+border-radius:0 6px 6px 0;margin-top:8px}
+.panel h4{margin:0 0 4px;font-size:13px}
+.panel + .panel{margin-top:10px}
+.unverified{border-left-color:var(--no);background:#2a1a1d}
+.lvl{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:12px}
+.walk{margin:6px 0 0;padding-left:18px;font-size:13px}
+.walk li{margin-bottom:4px}
+.math{font-size:13px}
+"""
+
+
 def _esc(value) -> str:
     return html.escape("" if value is None else str(value), quote=True)
 
@@ -187,8 +231,179 @@ def _units_index(*groups: list[dict]) -> dict:
     return index
 
 
-def render_html(result: dict, *, tier_note: str = "", generated_at: str | None = None) -> str:
-    """Render the ranked result to a single self-contained HTML string."""
+def _primer_section() -> str:
+    """The learn-about primer — fixed template, rendered at most ONCE."""
+    parts = "".join(f"<dt>{_esc(head)}</dt><dd>{_esc(body)}</dd>" for head, body in T.PRIMER_PARTS)
+    return (
+        f'<h2 id="primer-section">{_esc(T.PRIMER_TITLE)}</h2>'
+        f'<div class="primer"><p class="note">{_esc(T.PRIMER_LEAD)}</p>'
+        f"<dl>{parts}</dl>"
+        f'<p class="note">{_esc(T.PRIMER_LINK_LEAD)} '
+        f'<a href="{_esc(T.EXPLAINER_URL)}">{_esc(T.EXPLAINER_URL)}</a></p></div>'
+    )
+
+
+def _demo_stats(demo: dict) -> str:
+    stats = demo.get("stats") or {}
+    cells = [
+        ("distinct sessions", stats.get("n_sessions")),
+        ("median tool calls", stats.get("med_tool_calls")),
+        ("median LLM cycles", stats.get("med_llm_cycles")),
+        ("median span (s)", stats.get("med_span_s")),
+        ("errors per session", stats.get("err_rate")),
+    ]
+    body = "".join(f"<span>{_esc(label)} <b>{_esc(value)}</b></span>" for label, value in cells)
+    if stats.get("provisional"):
+        body += "<span><b>provisional</b> (n in {2,3})</span>"
+    return f'<div class="statline">{body}</div>'
+
+
+def _demo_fit(demo: dict) -> str:
+    fit = demo.get("fit") or {}
+    narrative = demo.get("narrative") or {}
+    rows = [
+        (T.FIT_Q1, "yes" if fit.get("cycle") else "no", narrative.get("q1_cycle_note")),
+        (T.FIT_Q2, "yes" if fit.get("gate") else "no", narrative.get("q2_gate_note")),
+        (
+            T.FIT_Q3,
+            T.RECOVERY_RENDER.get(str(fit.get("recovery")), str(fit.get("recovery"))),
+            narrative.get("q3_recovery_note"),
+        ),
+    ]
+    return "".join(
+        f"<p><b>{_esc(question)}</b> {_esc(verdict)}<br><span class='note'>{_esc(note)}</span></p>"
+        for question, verdict, note in rows
+    )
+
+
+def _demo_math(demo: dict) -> str:
+    math = demo.get("convergence_math") or {}
+    chain = math.get("chain_len")
+    once = math.get("once_through")
+    gated = math.get("gated_loop")
+    budget = math.get("budget")
+    p_step = math.get("p_step")
+    return (
+        f'<p class="note">{_esc(T.MATH_LEAD)}</p>'
+        f'<ul class="math">'
+        f"<li>chain length taken from your verified median LLM cycles: <b>{_esc(chain)}</b></li>"
+        f"<li>illustrative per-step success rate: <b>{_esc(p_step)}</b></li>"
+        f"<li>once-through, everything right the first time: <b>{_esc(once)}</b></li>"
+        f"<li>gated loop, within its budget of <b>{_esc(budget)}</b> attempt(s): <b>{_esc(gated)}</b></li>"
+        f"</ul>"
+        f'<p class="note">{_esc(T.MATH_LABEL)}</p>'
+    )
+
+
+def _demo_panel(demo: dict) -> str:
+    """Section 10 — the three-part self-certification answer, every time."""
+    ver = demo.get("verification") or {}
+    level = str(ver.get("level", T.LEVEL_NONE))
+    lint_verdict = ver.get("lint_verdict")
+    not_run = ver.get("lint_not_run_reason")
+
+    machine: list[str] = [f'<p class="lvl">verification level: <b>{_esc(level)}</b></p>']
+    if level == T.LEVEL_NONE:
+        machine.append(f"<p><b>{_esc(T.LABEL_UNVERIFIED)}</b></p>")
+        if not_run:
+            machine.append(f'<p class="note">{_esc(not_run)}</p>')
+        machine.append(
+            f"<p class='note'>Run both yourself: <code>attractor lint {_esc(demo.get('dot_relpath'))}</code>"
+            f" and the bundled authoring-contract checker.</p>"
+        )
+    else:
+        if lint_verdict:
+            machine.append(f"<p><b>attractor lint</b>, verbatim:</p><pre class='cmd'>{_esc(lint_verdict)}</pre>")
+        elif not_run:
+            machine.append(f"<pre class='cmd'>{_esc(not_run)}</pre>")
+        if ver.get("doctrine_report"):
+            machine.append(
+                f"<p><b>authoring contract</b> ({_esc(ver.get('doctrine_verdict'))}), verbatim:</p>"
+                f"<pre class='cmd'>{_esc(ver.get('doctrine_report'))}</pre>"
+            )
+
+    invocation = demo.get("invocation") or {}
+    unverified_class = " unverified" if level == T.LEVEL_NONE else ""
+    return (
+        f"<h3>{_esc(T.SEC_PANEL)}</h3>"
+        f'<div class="panel{unverified_class}"><h4>1. {_esc(T.PANEL_PART1_TITLE)}</h4>{"".join(machine)}</div>'
+        f'<div class="panel"><h4>2. {_esc(T.PANEL_PART2_TITLE)}</h4>'
+        f'<p class="note">{_esc(T.PANEL_PART2_BODY)}</p></div>'
+        f'<div class="panel"><h4>3. {_esc(T.PANEL_PART3_TITLE)}</h4>'
+        f'<p class="note">{_esc(T.PANEL_PART3_BODY)}</p>'
+        f"<pre class='cmd'>{_esc(invocation.get('author_cmd'))}</pre>"
+        f"<p class='note'>The CLI itself, if you do not have it:</p>"
+        f"<pre class='cmd'>{_esc(invocation.get('install_cmd'))}</pre></div>"
+    )
+
+
+def _demo_section(demo: dict) -> str:
+    narrative = demo.get("narrative") or {}
+    fit = demo.get("fit") or {}
+    verdict = str(fit.get("verdict", ""))
+    walk = "".join(
+        f"<li><code>{_esc(step.get('node'))}</code> — {_esc(step.get('note'))}</li>"
+        for step in (narrative.get("pipeline_walk") or [])
+    )
+    entries = "".join(
+        f"<li><b>{_esc(label)}</b> — <code>{_esc(target)}</code>: {_esc(why)}</li>"
+        for label, target, why in T.ENTRY_POINTS
+    )
+    invocation = demo.get("invocation") or {}
+    stats = demo.get("stats") or {}
+    return (
+        f'<h2 class="demo-heading">Demonstration — {_esc(demo.get("name"))}</h2>'
+        f'<div class="demo">'
+        f'<span class="badge {_vclass(verdict)}">{_esc(verdict)}</span>'
+        f"{'<span class="badge">provisional n</span>' if stats.get('provisional') else ''}"
+        f'<p class="note">{_esc(T.DEMO_LEAD)}</p>'
+        f"{_demo_stats(demo)}"
+        f"<h3>{_esc(T.SEC_COST)}</h3>"
+        f"<p class='note'>Across {_esc(stats.get('n_sessions'))} distinct sessions this unit ran a median of "
+        f"{_esc(stats.get('med_tool_calls'))} tool calls and {_esc(stats.get('med_llm_cycles'))} LLM cycles, "
+        f"taking a median of {_esc(stats.get('med_span_s'))} seconds of wall time, with "
+        f"{_esc(stats.get('err_rate'))} tool errors per session — every one of those numbers re-verified "
+        f"against your own records before it was printed here.</p>"
+        f"<h3>{_esc(T.SEC_GIST)}</h3><p>{_esc(narrative.get('scenario_gist'))}</p>"
+        f"<h3>{_esc(T.SEC_FIT)}</h3>{_demo_fit(demo)}"
+        f"<h3>{_esc(T.SEC_WALK)}</h3><ul class='walk'>{walk}</ul>"
+        f"<pre class='dotsrc'>{_esc(demo.get('dot_text'))}</pre>"
+        f"<p class='note'>Written to <a href=\"{_esc(demo.get('dot_relpath'))}\">"
+        f"<code>{_esc(demo.get('dot_relpath'))}</code></a>, with its companion at "
+        f'<a href="{_esc(demo.get("companion_relpath"))}"><code>{_esc(demo.get("companion_relpath"))}</code></a>, '
+        f"beside this file.</p>"
+        f"<h3>{_esc(T.SEC_MATH)}</h3>{_demo_math(demo)}"
+        f"<h3>{_esc(T.SEC_PAYOFF)}</h3><p>{_esc(narrative.get('payoff_note'))}</p>"
+        f"<h3>{_esc(T.SEC_ENTRY)}</h3><ul class='walk'>{entries}</ul>"
+        f"<h3>{_esc(T.SEC_RUN)}</h3>"
+        f"<pre class='cmd'>{_esc(invocation.get('run_cmd'))}</pre>"
+        f"{_demo_panel(demo)}"
+        f"</div>"
+    )
+
+
+def _demos_block(demos: dict | None) -> str:
+    """Primer + one section per demo. Empty string when nothing was supplied."""
+    if not demos:
+        return ""
+    body = _primer_section() if demos.get("primer", True) else ""
+    for demo in demos.get("demos") or []:
+        body += _demo_section(demo)
+    return f"\n{body}\n" if body else ""
+
+
+def render_html(
+    result: dict,
+    *,
+    tier_note: str = "",
+    generated_at: str | None = None,
+    demos: dict | None = None,
+) -> str:
+    """Render the ranked result to a single self-contained HTML string.
+
+    `demos=None` reproduces the pre-demonstration-layer artifact byte for
+    byte: every demonstration byte, CSS included, is inside a conditional.
+    """
     from .ranking import sample_simple_to_complex
 
     opportunities = result.get("opportunities", [])
@@ -199,6 +414,13 @@ def render_html(result: dict, *, tier_note: str = "", generated_at: str | None =
 
     sample_cards = "".join(_card(u) for u in sample) or "<p class='note'>Nothing cleared the frequency floor.</p>"
     stamp = generated_at or datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+    # Every demonstration byte is conditional, CSS included: with demos=None
+    # the artifact below is byte-identical to the pre-demo-layer output.
+    demo_block = _demos_block(demos)
+    demo_css = _DEMO_CSS if demo_block else ""
+    n_demonstrated = len((demos or {}).get("demos") or [])
+    demo_count_note = f" &middot; {_esc(n_demonstrated)} demonstrated" if n_demonstrated else ""
     data_json = json.dumps({"units": _units_index(opportunities, honest_nos)}, sort_keys=True)
     script = _JS.replace("__DATA__", data_json)
 
@@ -214,18 +436,18 @@ def render_html(result: dict, *, tier_note: str = "", generated_at: str | None =
 <html lang="en"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>{_esc(SKILL_TITLE)} report</title>
-<style>{_CSS}</style></head><body><div class="wrap">
+<style>{_CSS}{demo_css}</style></head><body><div class="wrap">
 <h1>{_esc(SKILL_TITLE)}</h1>
 <p class="sub">Generated {_esc(stamp)} &middot; own data only, computed locally &middot;
 {_esc(summary.get("n_opportunities", 0))} opportunities &middot;
 {_esc(summary.get("n_honest_no", 0))} honest-NOs &middot;
-{_esc(summary.get("n_waste", 0))} waste findings{(" &middot; " + _esc(tier_note)) if tier_note else ""}</p>
+{_esc(summary.get("n_waste", 0))} waste findings{demo_count_note}{(" &middot; " + _esc(tier_note)) if tier_note else ""}</p>
 
 <h2>A range of what you already do (simple &rarr; complex)</h2>
 <p class="note">Sampled across the grain axis, not the top of the ranking &mdash; this shows
 breadth. The ranked list below orders everything.</p>
 <div class="grid">{sample_cards}</div>
-
+{demo_block}
 <h2>Ranked opportunities</h2>
 <table><thead><tr><th>Unit</th><th>Sessions</th><th>Leverage</th><th>Score</th><th>Verdict</th></tr></thead>
 <tbody>{_rows(opportunities, show_remediation=False) or '<tr><td colspan="5">none</td></tr>'}</tbody></table>
@@ -256,9 +478,13 @@ def write_report(
     *,
     tier_note: str = "",
     generated_at: str | None = None,
+    demos: dict | None = None,
 ) -> Path:
     """Write the artifact. Default target is the CURRENT WORKING DIRECTORY."""
     path = Path(out_path) if out_path else Path.cwd() / f"{ARTIFACT_STEM}-report.html"
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(render_html(result, tier_note=tier_note, generated_at=generated_at), encoding="utf-8")
+    path.write_text(
+        render_html(result, tier_note=tier_note, generated_at=generated_at, demos=demos),
+        encoding="utf-8",
+    )
     return path

--- a/skills/attractor-scout/scripts/attractor_scout_cli.py
+++ b/skills/attractor-scout/scripts/attractor_scout_cli.py
@@ -11,11 +11,14 @@ the skill's importable path can never disagree about what a signal means.
     detect      run the deterministic detectors over an extract
     rank        admission gate + score -> ranked JSON
     render      ranked JSON -> self-contained HTML (deterministic, no LLM)
+    demo        brief | assemble -- the demonstration/teaching layer
     run         the whole pipeline end to end
     census      event-name / tool-name census (Gap-1 allow-list finalization)
 
 Exit codes: 0 ok · 2 fail-loud (empty corpus, schema mismatch, graph demanded
-but unavailable). A fail-loud condition NEVER exits 0 with a fabricated count.
+but unavailable, an invented count in a demo narrative, a red machine gate).
+A fail-loud condition NEVER exits 0 with a fabricated count, and a demo whose
+gates came back red is NEVER published.
 """
 
 from __future__ import annotations
@@ -24,6 +27,7 @@ import argparse
 import json
 import sys
 from collections import Counter
+from datetime import datetime, timezone
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -190,9 +194,60 @@ def cmd_rank(args) -> int:
 
 def cmd_render(args) -> int:
     result = json.loads(Path(args.ranked).read_text(encoding="utf-8"))
-    path = render.write_report(result, args.out, generated_at=args.generated_at)
+    demos = None
+    if args.demos:
+        demos_path = Path(args.demos)
+        if not demos_path.is_file():
+            raise AttractorScoutError(f"--demos was given but {demos_path} does not exist")
+        demos = json.loads(demos_path.read_text(encoding="utf-8"))
+    path = render.write_report(result, args.out, generated_at=args.generated_at, demos=demos)
     print(f"wrote {path}", file=sys.stderr)
     return 0
+
+
+def cmd_demo(args) -> int:
+    """The demonstration layer: assemble a brief, or gate + publish a draft."""
+    from attractor_scout import demo as demo_mod
+
+    if args.action == "brief":
+        slug, brief_path = demo_mod.build_brief(
+            ranked_path=args.ranked,
+            unit_id=args.unit,
+            workdir=args.workdir,
+            extracts_path=args.extracts,
+        )
+        print(f"brief -> {brief_path}", file=sys.stderr)
+        # The slug is the ONLY thing on stdout: the skill captures it directly.
+        print(slug)
+        return 0
+
+    if args.action == "assemble":
+        stamp = args.generated_at or datetime.now(timezone.utc).isoformat(timespec="seconds")
+        entry = demo_mod.assemble_demo(
+            ranked_path=args.ranked,
+            unit_id=args.unit,
+            workdir=args.workdir,
+            output_dir=args.output_dir,
+            lint_cmd=args.lint_cmd,
+            generated_at=stamp,
+        )
+        doc = demo_mod.write_demos(entry, args.out, append=args.append)
+        print(
+            f"published {entry['dot_relpath']} + {entry['companion_relpath']} "
+            f"(verification: {entry['verification']['level']}); "
+            f"{len(doc['demos'])} demo(s) in {args.out}",
+            file=sys.stderr,
+        )
+        print(entry["verification"]["level"])
+        return 0
+
+    if args.action == "primer-only":
+        demo_mod.write_demos(None, args.out, append=False)
+        print(f"primer-only demos document -> {args.out}", file=sys.stderr)
+        print("primer-only")
+        return 0
+
+    raise ValueError(f"unknown demo action: {args.action!r}")
 
 
 def cmd_run(args) -> int:
@@ -284,7 +339,40 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--ranked", default="ranked.json")
     p.add_argument("--out", default=None, help="default: ./<skill>-report.html")
     p.add_argument("--generated-at", default=None, help="pin the timestamp for byte-reproducible output")
+    p.add_argument(
+        "--demos",
+        default=None,
+        help="demos.json from `demo assemble`; omitted => byte-identical to the pre-demo artifact",
+    )
     p.set_defaults(func=cmd_render)
+
+    p = sub.add_parser(
+        "demo",
+        help="the demonstration/teaching layer: assemble a brief, or gate+publish a draft",
+    )
+    p.add_argument("action", choices=["brief", "assemble", "primer-only"])
+    p.add_argument("--ranked", default="ranked.json")
+    p.add_argument(
+        "--unit",
+        default=None,
+        help="unit_id to demonstrate; default is opportunities[0], the top-ranked one",
+    )
+    p.add_argument("--workdir", default=None, help="brief: the demo parent dir; assemble: the slug dir")
+    p.add_argument(
+        "--extracts",
+        default=None,
+        help="brief: extracts.jsonl, so the gate-tool census is drawn from THEIR terminal windows",
+    )
+    p.add_argument("--output-dir", default=None, help="assemble: the directory the HTML map lives in")
+    p.add_argument("--out", default=None, help="assemble: the demos.json to write")
+    p.add_argument(
+        "--lint-cmd",
+        default=None,
+        help="assemble: override the linter argv (rung 2 -- only ever after an explicit user yes)",
+    )
+    p.add_argument("--append", action="store_true", help="assemble: add to an existing demos.json")
+    p.add_argument("--generated-at", default=None, help="pin the demo timestamp for reproducible output")
+    p.set_defaults(func=cmd_demo)
 
     p = sub.add_parser("run")
     add_selector(p)

--- a/skills/attractor-scout/tests/test_scenario6_demo_assembly.py
+++ b/skills/attractor-scout/tests/test_scenario6_demo_assembly.py
@@ -1,0 +1,312 @@
+"""Scenario 6 — the demonstration brief and the count-integrity guard.
+
+The mining half's trust contract is "every count re-verified before render".
+The demonstration half inherits it BY CONSTRUCTION: the LLM never states a
+number, it only narrates around numbers the deterministic layer placed. This
+file is the enforcement of that claim.
+
+Layer 1 — the brief is DETERMINISTIC and carries the evidence.
+Layer 2 — RED PROOFS. A guard that has never been shown failing is not a
+guard, so every validation path is exercised against a fixture mutated to
+break exactly one property: an invented count, a walked node that is not in
+the graph, a missing slot, a missing file.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from attractor_scout import demo
+from attractor_scout.errors import AttractorScoutError
+
+from fixtures import demo_fixture as F
+
+SKILL_DIR = Path(__file__).resolve().parent.parent
+CLI = [sys.executable, str(SKILL_DIR / "scripts" / "attractor_scout_cli.py")]
+
+
+def _write_ranked(tmp_path: Path, **kwargs) -> Path:
+    path = tmp_path / "ranked.json"
+    path.write_text(json.dumps(F.ranked_fixture(**kwargs)), encoding="utf-8")
+    return path
+
+
+def _write_extracts(tmp_path: Path, ranked: dict) -> Path:
+    """An extract whose members' terminal windows carry verify-class tools."""
+    unit = ranked["opportunities"][0]
+    path = tmp_path / "extracts.jsonl"
+    lines = []
+    for sid in unit["members"]:
+        lines.append(
+            json.dumps(
+                {
+                    "session_id": sid,
+                    "tool_tail": ["read_file", "edit_file", "python_check"],
+                    "tool_seq": ["read_file", "edit_file", "python_check"],
+                }
+            )
+        )
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------- layer 1
+def test_brief_carries_the_verified_stats_and_is_deterministic(tmp_path: Path):
+    ranked_path = _write_ranked(tmp_path)
+    slug, brief_path = demo.build_brief(ranked_path=ranked_path, unit_id=None, workdir=tmp_path / "demo")
+    text = brief_path.read_text(encoding="utf-8")
+
+    assert slug.endswith(f"-{F.DEMO_UNIT_ID}"), "the slug must carry the unit id for uniqueness"
+    for rendered in ("7", "12", "4", "930", "0.33"):
+        assert rendered in text, f"the brief must quote the verified stat {rendered}"
+    assert F.DEMO_UNIT_NAME in text
+    assert "at most 9 nodes" in text, "the node budget must be stated to the author"
+    assert "A10" in text and "A4" in text, "the A0-A10 contract summary must be carried"
+    assert "prompt=" in text and "tool_command=" in text, "the vocabulary excerpt must be carried"
+
+    # Determinism: same ranking, same brief, byte for byte.
+    _, again = demo.build_brief(ranked_path=ranked_path, unit_id=None, workdir=tmp_path / "demo2")
+    assert again.read_text(encoding="utf-8") == text
+
+
+def test_brief_carries_the_gate_tool_evidence_from_their_own_sessions(tmp_path: Path):
+    ranked = F.ranked_fixture()
+    ranked_path = tmp_path / "ranked.json"
+    ranked_path.write_text(json.dumps(ranked), encoding="utf-8")
+    extracts = _write_extracts(tmp_path, ranked)
+
+    _, brief_path = demo.build_brief(
+        ranked_path=ranked_path,
+        unit_id=None,
+        workdir=tmp_path / "demo",
+        extracts_path=extracts,
+    )
+    text = brief_path.read_text(encoding="utf-8")
+    assert "python_check" in text, "the census must name the verify-class tool actually observed"
+    assert "read_file" not in text.split("## What to write")[0], "non-verify tools are not gate evidence"
+
+
+def test_brief_is_honest_when_no_gate_evidence_was_observed(tmp_path: Path):
+    ranked_path = _write_ranked(tmp_path)
+    _, brief_path = demo.build_brief(ranked_path=ranked_path, unit_id=None, workdir=tmp_path / "demo")
+    text = brief_path.read_text(encoding="utf-8")
+    assert "No verify-class tool was observed" in text
+    assert "never invent evidence that was not there" in text
+
+
+def test_assembly_succeeds_on_the_canned_fixture(tmp_path: Path):
+    ranked_path = _write_ranked(tmp_path)
+    slug, _ = demo.build_brief(ranked_path=ranked_path, unit_id=None, workdir=tmp_path / "demo")
+    F.write_draft(tmp_path / "demo" / slug)
+
+    entry = demo.assemble_demo(
+        ranked_path=ranked_path,
+        unit_id=None,
+        workdir=tmp_path / "demo" / slug,
+        output_dir=tmp_path / "out",
+        generated_at="2020-01-01T00:00:00+00:00",
+    )
+    assert entry["slug"] == slug
+    assert entry["stats"]["n_sessions"] == 7
+    assert entry["convergence_math"]["p_step"] == demo.P_STEP
+    assert entry["convergence_math"]["chain_len"] == 4
+    assert entry["convergence_math"]["gated_loop"] > entry["convergence_math"]["once_through"]
+    assert (tmp_path / "out" / entry["dot_relpath"]).is_file()
+    assert (tmp_path / "out" / entry["companion_relpath"]).is_file()
+
+
+def test_only_opportunity_verdicts_may_be_demonstrated(tmp_path: Path):
+    ranked_path = _write_ranked(tmp_path, verdict="HONEST-NO")
+    with pytest.raises(AttractorScoutError) as exc:
+        demo.build_brief(ranked_path=ranked_path, unit_id=None, workdir=tmp_path / "demo")
+    assert "anti-pattern" in str(exc.value)
+
+
+def test_unproven_is_a_caveat_not_a_disqualifier(tmp_path: Path):
+    ranked_path = _write_ranked(tmp_path, verdict="OPPORTUNITY(unproven)", recovery="UNKNOWN")
+    slug, brief_path = demo.build_brief(ranked_path=ranked_path, unit_id=None, workdir=tmp_path / "demo")
+    assert "unproven" in brief_path.read_text(encoding="utf-8")
+    F.write_draft(tmp_path / "demo" / slug)
+    entry = demo.assemble_demo(
+        ranked_path=ranked_path,
+        unit_id=None,
+        workdir=tmp_path / "demo" / slug,
+        output_dir=tmp_path / "out",
+        generated_at="2020-01-01T00:00:00+00:00",
+    )
+    assert entry["fit"]["recovery"] == "UNKNOWN"
+    assert entry["fit"]["verdict"] == "OPPORTUNITY(unproven)"
+
+
+# ---------------------------------------------------------------- layer 2
+def _assemble_cli(tmp_path: Path, ranked_path: Path, slug: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [
+            *CLI,
+            "demo",
+            "assemble",
+            "--ranked",
+            str(ranked_path),
+            "--workdir",
+            str(tmp_path / "demo" / slug),
+            "--output-dir",
+            str(tmp_path / "out"),
+            "--out",
+            str(tmp_path / "demos.json"),
+            "--generated-at",
+            "2020-01-01T00:00:00+00:00",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_red_proof_an_invented_count_is_fatal_and_names_the_token(tmp_path: Path):
+    ranked_path = _write_ranked(tmp_path)
+    slug, _ = demo.build_brief(ranked_path=ranked_path, unit_id=None, workdir=tmp_path / "demo")
+    F.write_draft(tmp_path / "demo" / slug, narrative=F.with_invented_count(token="97"))
+
+    proc = _assemble_cli(tmp_path, ranked_path, slug)
+    assert proc.returncode == 2, "an invented count must be FATAL, same posture as rank --strict"
+    assert "'97'" in proc.stderr, "the offending token must be named"
+    assert not (tmp_path / "out").exists(), "nothing may be published when validation failed"
+
+
+def test_red_proof_a_walked_node_not_in_the_dot_is_fatal(tmp_path: Path):
+    ranked_path = _write_ranked(tmp_path)
+    slug, _ = demo.build_brief(ranked_path=ranked_path, unit_id=None, workdir=tmp_path / "demo")
+    F.write_draft(tmp_path / "demo" / slug, narrative=F.with_unknown_node("ghost_node"))
+
+    proc = _assemble_cli(tmp_path, ranked_path, slug)
+    assert proc.returncode == 2
+    assert "ghost_node" in proc.stderr
+    assert not (tmp_path / "demos.json").exists()
+
+
+def test_red_proof_a_missing_slot_is_fatal(tmp_path: Path):
+    ranked_path = _write_ranked(tmp_path)
+    slug, _ = demo.build_brief(ranked_path=ranked_path, unit_id=None, workdir=tmp_path / "demo")
+    F.write_draft(tmp_path / "demo" / slug, narrative=F.without_slot("payoff_note"))
+
+    proc = _assemble_cli(tmp_path, ranked_path, slug)
+    assert proc.returncode == 2
+    assert "payoff_note" in proc.stderr
+
+
+def test_red_proof_a_missing_companion_is_fatal(tmp_path: Path):
+    ranked_path = _write_ranked(tmp_path)
+    slug, _ = demo.build_brief(ranked_path=ranked_path, unit_id=None, workdir=tmp_path / "demo")
+    F.write_draft(tmp_path / "demo" / slug, omit=("pipeline.md",))
+
+    proc = _assemble_cli(tmp_path, ranked_path, slug)
+    assert proc.returncode == 2
+    assert "pipeline.md" in proc.stderr
+
+
+def test_red_proof_an_over_long_slot_is_fatal(tmp_path: Path):
+    ranked_path = _write_ranked(tmp_path)
+    slug, _ = demo.build_brief(ranked_path=ranked_path, unit_id=None, workdir=tmp_path / "demo")
+    long_narrative = json.loads(json.dumps(F.DEMO_NARRATIVE))
+    long_narrative["scenario_gist"] = "x" * (demo.MAX_SLOT_CHARS + 1)
+    F.write_draft(tmp_path / "demo" / slug, narrative=long_narrative)
+
+    proc = _assemble_cli(tmp_path, ranked_path, slug)
+    assert proc.returncode == 2
+    assert "scenario_gist" in proc.stderr
+
+
+def test_prose_numbers_that_ARE_their_stats_are_legal(tmp_path: Path):
+    ranked_path = _write_ranked(tmp_path)
+    ranked = json.loads(ranked_path.read_text(encoding="utf-8"))
+    stats = demo.unit_stats(ranked["opportunities"][0])
+    ok = json.loads(json.dumps(F.DEMO_NARRATIVE))
+    ok["payoff_note"] = "Across 7 sessions this shape repeated; about a dozen tool calls each time."
+    cleaned = demo.validate_narrative(ok, stats, F.DEMO_DOT)
+    assert "about a dozen" in cleaned["payoff_note"]
+
+
+# -------------------------------------------------------- named-limit pins
+# Finding 2: the digit whitelist has two documented, deliberately-unclosed
+# bypasses. These tests pin the CURRENT (passing) behavior on purpose, so a
+# future claim to have closed either one turns them RED and forces an honest
+# update to demo.validate_narrative's docstring and the design's D4 section,
+# rather than a silent behavior change. See that docstring for the rationale.
+def test_named_limit_decomposition_bypass_is_expected_to_pass(tmp_path: Path):
+    """`0.33` rendered as `0.33` also whitelists the bare run `33` — documented.
+
+    Closing it would ban the legitimate `0.33`->`33%` reference; the boundary
+    is the tokenizer's. If this ever starts RAISING, the bypass was closed and
+    the docs must be updated to match.
+    """
+    stats = {
+        "n_sessions": 7,
+        "med_tool_calls": 12.0,
+        "med_llm_cycles": 4.0,
+        "med_span_s": 930.0,
+        "err_rate": 0.33,
+        "provisional": False,
+    }
+    assert "33" in demo.allowed_digit_runs(stats), "the sub-run 33 leaks from the rendered 0.33"
+    narrative = json.loads(json.dumps(F.DEMO_NARRATIVE))
+    narrative["payoff_note"] = "It shaved 33 minutes off the loop."  # 33 is not a stat, but decomposes in
+    cleaned = demo.validate_narrative(narrative, stats, F.DEMO_DOT)
+    assert "33 minutes" in cleaned["payoff_note"]
+
+
+def test_named_limit_spelled_out_numbers_are_expected_to_pass(tmp_path: Path):
+    """ "forty-seven hours" is not a digit-run and passes — documented.
+
+    Detecting written numerals is NLP guesswork; a fail-loud guard that guessed
+    wrong would block honest prose. If this ever starts RAISING, spelled-out
+    detection was added and the docs must be updated to match.
+    """
+    ranked_path = _write_ranked(tmp_path)
+    stats = demo.unit_stats(json.loads(ranked_path.read_text(encoding="utf-8"))["opportunities"][0])
+    narrative = json.loads(json.dumps(F.DEMO_NARRATIVE))
+    narrative["payoff_note"] = "It reclaimed forty-seven hours of hand-running the same check."
+    cleaned = demo.validate_narrative(narrative, stats, F.DEMO_DOT)
+    assert "forty-seven hours" in cleaned["payoff_note"]
+
+
+def test_the_still_closed_cases_stay_closed(tmp_path: Path):
+    """The bypasses are narrow: `93` from `930` and node-smuggling STAY rejected."""
+    ranked_path = _write_ranked(tmp_path)
+    stats = demo.unit_stats(json.loads(ranked_path.read_text(encoding="utf-8"))["opportunities"][0])
+    # 930 is a stat (med_span_s); 93 is NOT one of its whitelisted sub-runs.
+    assert "93" not in demo.allowed_digit_runs(stats)
+    bad = json.loads(json.dumps(F.DEMO_NARRATIVE))
+    bad["payoff_note"] = "It ran 93 times."
+    with pytest.raises(demo.DemoNarrativeInvalid) as exc:
+        demo.validate_narrative(bad, stats, F.DEMO_DOT)
+    assert "'93'" in str(exc.value)
+
+
+def test_empty_opportunity_list_refuses_to_invent_a_subject(tmp_path: Path):
+    ranked_path = tmp_path / "ranked.json"
+    ranked_path.write_text(json.dumps({"opportunities": [], "summary": {}}), encoding="utf-8")
+    with pytest.raises(AttractorScoutError) as exc:
+        demo.build_brief(ranked_path=ranked_path, unit_id=None, workdir=tmp_path / "demo")
+    assert "primer-only" in str(exc.value)
+
+
+def test_demos_json_append_replaces_rather_than_duplicates(tmp_path: Path):
+    out = tmp_path / "demos.json"
+    entry = {"unit_id": "d1", "name": "first"}
+    demo.write_demos(entry, out, append=False)
+    demo.write_demos({"unit_id": "d2", "name": "second"}, out, append=True)
+    doc = demo.write_demos({"unit_id": "d1", "name": "first again"}, out, append=True)
+    assert [d["unit_id"] for d in doc["demos"]] == ["d2", "d1"]
+    assert doc["primer"] is True
+    assert doc["explainer_url"].endswith("attractor-explained.html")
+
+
+def test_step9_menu_hides_already_demonstrated_units(tmp_path: Path):
+    extra = [dict(F.ranked_fixture(unit_id="d2", name="SYNTHETIC-UNIT-E")["opportunities"][0])]
+    ranked = F.ranked_fixture(extra_opportunities=extra)
+    remaining = demo.not_yet_demonstrated(ranked, {"demos": [{"unit_id": "d1"}]})
+    assert [u["unit_id"] for u in remaining] == ["d2"]

--- a/skills/attractor-scout/tests/test_scenario7_verification_ladder.py
+++ b/skills/attractor-scout/tests/test_scenario7_verification_ladder.py
@@ -1,0 +1,258 @@
+"""Scenario 7 — the degradation ladder, and the two fates it distinguishes.
+
+A rung being UNAVAILABLE and a rung coming back RED are different things, and
+conflating them is how an artifact ends up implying a pass nobody earned:
+
+* unavailable  -> labelled honestly, the demo still publishes at the level
+                  that actually ran;
+* red          -> the demo is NOT published, at all, ever.
+
+Every rung is exercised for real: a fake `attractor` shim on PATH for rung 1,
+an emptied PATH for rung 3-only, a deliberately broken checker for rung 4, and
+a fixture with its evidence gate deleted for the red path. Gates proven red,
+per repo doctrine — a gate that has only ever been seen passing is not a gate.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import sys
+from pathlib import Path
+
+import pytest
+from attractor_scout import demo
+from attractor_scout import demo_templates as T
+
+from fixtures import demo_fixture as F
+
+SKILL_DIR = Path(__file__).resolve().parent.parent
+
+
+def _shim(tmp_path: Path, payload: str, *, exit_code: int = 0) -> Path:
+    """A fake `attractor` on PATH that emits a canned lint verdict."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir(parents=True, exist_ok=True)
+    shim = bindir / "attractor"
+    shim.write_text(
+        "#!/bin/sh\n"
+        + "".join(f'printf "%s\\n" {json.dumps(line)}\n' for line in payload.splitlines())
+        + f"exit {exit_code}\n",
+        encoding="utf-8",
+    )
+    shim.chmod(shim.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    return bindir
+
+
+def _draft(tmp_path: Path, **kwargs) -> Path:
+    return F.write_draft(tmp_path / "wk", **kwargs)
+
+
+RELPATH = "attractor-scout-demos/synthetic-demo.dot"
+
+
+# ------------------------------------------------------------------ rung 1
+def test_rung1_cli_on_path_gives_lint_plus_doctrine_and_relays_verbatim(tmp_path, monkeypatch):
+    verdict_text = "attractor lint: pipeline.dot: OK (no findings)"
+    bindir = _shim(tmp_path, verdict_text)
+    monkeypatch.setenv("PATH", str(bindir))
+    wk = _draft(tmp_path)
+
+    result = demo.run_ladder(
+        dot_path=wk / "pipeline.dot",
+        companion_path=wk / "pipeline.md",
+        relpath=RELPATH,
+    )
+    assert result.level == T.LEVEL_LINT_DOCTRINE
+    assert result.lint_verdict == verdict_text, "the lint verdict is relayed VERBATIM, never paraphrased"
+    assert result.lint_not_run_reason is None
+    assert result.doctrine_verdict == "doctrine_ok"
+    assert not result.red
+
+
+def test_rung1_warnings_pass_but_are_quoted(tmp_path, monkeypatch):
+    warning = "WARNING: [TOPO-006] [give_up] (give_up -> done) routes a failure outcome into the exit node."
+    monkeypatch.setenv("PATH", str(_shim(tmp_path, warning)))
+    wk = _draft(tmp_path)
+
+    result = demo.run_ladder(dot_path=wk / "pipeline.dot", companion_path=wk / "pipeline.md", relpath=RELPATH)
+    assert result.level == T.LEVEL_LINT_DOCTRINE
+    assert not result.red, "a WARNING is not a red verdict"
+    assert "TOPO-006" in (result.lint_verdict or ""), "the warning must still be quoted"
+
+
+def test_rung1_lint_errors_are_a_red_verdict(tmp_path, monkeypatch):
+    monkeypatch.setenv("PATH", str(_shim(tmp_path, "ERROR: [shape_resolvable] [check] unknown shape", exit_code=1)))
+    wk = _draft(tmp_path)
+
+    result = demo.run_ladder(dot_path=wk / "pipeline.dot", companion_path=wk / "pipeline.md", relpath=RELPATH)
+    assert result.red
+    assert any("ERROR" in reason for reason in result.red_reasons)
+
+
+def test_rung2_lint_cmd_override_is_used_when_supplied(tmp_path, monkeypatch):
+    """Rung 2 arrives ONLY as an explicit override — never automatically."""
+    monkeypatch.setenv("PATH", "")
+    bindir = _shim(tmp_path, "attractor lint: pipeline.dot: OK (no findings)")
+    wk = _draft(tmp_path)
+
+    result = demo.run_ladder(
+        dot_path=wk / "pipeline.dot",
+        companion_path=wk / "pipeline.md",
+        relpath=RELPATH,
+        lint_cmd=str(bindir / "attractor"),
+    )
+    assert result.level == T.LEVEL_LINT_DOCTRINE
+    assert "OK (no findings)" in (result.lint_verdict or "")
+
+
+def test_the_uvx_rung_is_asked_out_loud_and_named_as_an_inbound_fetch():
+    question = T.uvx_consent_question(RELPATH)
+    assert "Yes/no?" in question
+    assert "inbound fetch" in question
+    assert "none of your mined data leaves this machine" in question
+    assert "uvx --from" in question
+
+
+# ------------------------------------------------------------------ rung 3
+def test_rung3_no_cli_gives_doctrine_only_and_the_exact_not_run_label(tmp_path, monkeypatch):
+    monkeypatch.setenv("PATH", "")
+    wk = _draft(tmp_path)
+
+    result = demo.run_ladder(dot_path=wk / "pipeline.dot", companion_path=wk / "pipeline.md", relpath=RELPATH)
+    assert result.level == T.LEVEL_DOCTRINE_ONLY
+    assert result.lint_verdict is None
+    assert result.lint_not_run_reason == (
+        f"attractor lint: NOT RUN — the CLI is not installed here. Run it yourself: attractor lint {RELPATH}"
+    )
+    assert result.doctrine_verdict == "doctrine_ok"
+    assert "[PASS] A4" in (result.doctrine_report or ""), "the per-check summary must be carried verbatim"
+
+
+def test_rung3_runs_even_when_the_cli_is_present(tmp_path, monkeypatch):
+    """The floor is a second opinion, not a fallback: it always runs."""
+    monkeypatch.setenv("PATH", str(_shim(tmp_path, "attractor lint: pipeline.dot: OK (no findings)")))
+    wk = _draft(tmp_path)
+    result = demo.run_ladder(dot_path=wk / "pipeline.dot", companion_path=wk / "pipeline.md", relpath=RELPATH)
+    assert result.doctrine_report is not None
+
+
+# ------------------------------------------------------------------ rung 4
+def test_rung4_a_checker_that_cannot_execute_yields_none_and_the_unverified_banner(tmp_path, monkeypatch):
+    wk = _draft(tmp_path)
+
+    def _boom(*_args, **_kwargs):
+        raise RuntimeError("simulated environmental failure of the doctrine checker")
+
+    monkeypatch.setattr(demo, "run_doctrine_checker", _boom)
+    result = demo.run_ladder(dot_path=wk / "pipeline.dot", companion_path=wk / "pipeline.md", relpath=RELPATH)
+
+    assert result.level == T.LEVEL_NONE
+    assert result.doctrine_verdict is None
+    assert result.doctrine_report is None
+    assert "nothing machine-checked this pipeline" in (result.lint_not_run_reason or "")
+    assert T.LABEL_UNVERIFIED == "UNVERIFIED — no machine check ran on this pipeline"
+
+
+# ------------------------------------------------------------- the red fate
+def test_a_doctrine_red_demo_is_never_published(tmp_path, monkeypatch):
+    """Delete the evidence gate: A4 goes red, and NOTHING lands on disk."""
+    monkeypatch.setenv("PATH", "")
+    ranked_path = tmp_path / "ranked.json"
+    ranked_path.write_text(json.dumps(F.ranked_fixture()), encoding="utf-8")
+    slug, _ = demo.build_brief(ranked_path=ranked_path, unit_id=None, workdir=tmp_path / "demo")
+    F.write_draft(tmp_path / "demo" / slug, dot_text=F.without_gate(), narrative=F.narrative_without("check"))
+
+    verdict, report = demo.run_doctrine_checker(
+        tmp_path / "demo" / slug / "pipeline.dot",
+        tmp_path / "demo" / slug / "pipeline.md",
+    )
+    assert verdict == "doctrine_bad", "deleting the gate must be caught"
+    assert "[FAIL] A4" in report, "A4 is the load-bearing check"
+
+    with pytest.raises(demo.DemoGateRed) as exc:
+        demo.assemble_demo(
+            ranked_path=ranked_path,
+            unit_id=None,
+            workdir=tmp_path / "demo" / slug,
+            output_dir=tmp_path / "out",
+            generated_at="2020-01-01T00:00:00+00:00",
+        )
+    assert "NOT" in str(exc.value) and "published" in str(exc.value)
+    assert not (tmp_path / "out").exists(), "no files may be copied when the gates came back red"
+    assert not (tmp_path / "demos.json").exists(), "no demos.json entry may be written"
+    assert (tmp_path / "demo" / slug / "gate-report.txt").is_file(), (
+        "the verbatim gate reports must be left on disk for the ONE corrective retry"
+    )
+
+
+def test_the_red_fate_exits_two_through_the_cli(tmp_path, monkeypatch):
+    import subprocess
+
+    env = dict(os.environ, PATH="")
+    ranked_path = tmp_path / "ranked.json"
+    ranked_path.write_text(json.dumps(F.ranked_fixture()), encoding="utf-8")
+    slug, _ = demo.build_brief(ranked_path=ranked_path, unit_id=None, workdir=tmp_path / "demo")
+    F.write_draft(tmp_path / "demo" / slug, dot_text=F.without_gate(), narrative=F.narrative_without("check"))
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SKILL_DIR / "scripts" / "attractor_scout_cli.py"),
+            "demo",
+            "assemble",
+            "--ranked",
+            str(ranked_path),
+            "--workdir",
+            str(tmp_path / "demo" / slug),
+            "--output-dir",
+            str(tmp_path / "out"),
+            "--out",
+            str(tmp_path / "demos.json"),
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    assert proc.returncode == 2
+    assert "DemoGateRed" in proc.stderr
+
+
+def test_publish_happens_only_after_the_gates(tmp_path, monkeypatch):
+    """The publish-after-gates rule, stated as an ordering invariant."""
+    monkeypatch.setenv("PATH", "")
+    ranked_path = tmp_path / "ranked.json"
+    ranked_path.write_text(json.dumps(F.ranked_fixture()), encoding="utf-8")
+    slug, _ = demo.build_brief(ranked_path=ranked_path, unit_id=None, workdir=tmp_path / "demo")
+    F.write_draft(tmp_path / "demo" / slug)
+
+    seen: list[str] = []
+    real_ladder = demo.run_ladder
+    real_publish = demo._publish
+
+    def spy_ladder(**kwargs):
+        seen.append("ladder")
+        return real_ladder(**kwargs)
+
+    def spy_publish(*args, **kwargs):
+        seen.append("publish")
+        return real_publish(*args, **kwargs)
+
+    monkeypatch.setattr(demo, "run_ladder", spy_ladder)
+    monkeypatch.setattr(demo, "_publish", spy_publish)
+    demo.assemble_demo(
+        ranked_path=ranked_path,
+        unit_id=None,
+        workdir=tmp_path / "demo" / slug,
+        output_dir=tmp_path / "out",
+        generated_at="2020-01-01T00:00:00+00:00",
+    )
+    assert seen == ["ladder", "publish"]
+
+
+def test_the_three_level_labels_are_the_exact_strings_the_design_pins():
+    assert T.LEVEL_LINT_DOCTRINE == "lint+doctrine"
+    assert T.LEVEL_DOCTRINE_ONLY == "doctrine-only"
+    assert T.LEVEL_NONE == "none"

--- a/skills/attractor-scout/tests/test_scenario8_demo_render.py
+++ b/skills/attractor-scout/tests/test_scenario8_demo_render.py
@@ -1,0 +1,281 @@
+"""Scenario 8 — the renderer stays deterministic, additive, and honest.
+
+Three properties, each machine-checked here:
+
+**Additive.** With no demos, the artifact is BYTE-IDENTICAL to what the
+mining-only renderer produced. Every demonstration byte — CSS included — is
+inside a conditional, so the frozen half cannot be disturbed by the new half.
+
+**Deterministic.** Same inputs plus a pinned timestamp produce the same bytes.
+Generation is stochastic; verification, assembly and rendering are not.
+
+**Honest.** The new invariant, sibling of "UNKNOWN never renders as FAIL":
+an UNVERIFIED demo is NEVER rendered as verified. If the linter did not run,
+the artifact says so in those words rather than leaving a silence a reader
+would read as a pass.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from html import escape
+from pathlib import Path
+
+from attractor_scout import demo, render
+from attractor_scout import demo_templates as T
+
+from fixtures import demo_fixture as F
+
+PINNED = "2020-01-01T00:00:00+00:00"
+
+#: Substrings that exist ONLY because a demo was rendered.
+DEMO_MARKERS = (
+    "primer-section",
+    "demo-heading",
+    "attractor-explained.html",
+    T.SEC_PANEL,
+    T.MATH_LABEL,
+    "demonstrated",
+)
+
+
+def _build(tmp_path: Path, **ranked_kwargs) -> tuple[dict, dict, Path]:
+    """Ranked + a fully assembled single-demo demos.json, published on disk."""
+    ranked = F.ranked_fixture(**ranked_kwargs)
+    ranked_path = tmp_path / "ranked.json"
+    ranked_path.write_text(json.dumps(ranked), encoding="utf-8")
+    slug, _ = demo.build_brief(ranked_path=ranked_path, unit_id=None, workdir=tmp_path / "demo")
+    F.write_draft(tmp_path / "demo" / slug)
+    out_dir = tmp_path / "out"
+    entry = demo.assemble_demo(
+        ranked_path=ranked_path,
+        unit_id=None,
+        workdir=tmp_path / "demo" / slug,
+        output_dir=out_dir,
+        generated_at=PINNED,
+    )
+    demos = demo.write_demos(entry, tmp_path / "demos.json", append=False)
+    return ranked, demos, out_dir
+
+
+# ------------------------------------------------------------- additivity
+def test_no_demos_means_zero_demo_markers(tmp_path: Path):
+    ranked = F.ranked_fixture()
+    html = render.render_html(ranked, generated_at=PINNED)
+    for marker in DEMO_MARKERS:
+        assert marker not in html, f"a demo marker leaked into the no-demos artifact: {marker!r}"
+    assert "demo-css" not in html
+
+
+def test_no_demos_is_byte_identical_to_the_pre_demo_layer_output(tmp_path: Path):
+    """Additivity as a hard test: demos=None must change nothing at all."""
+    ranked = F.ranked_fixture()
+    baseline = render.render_html(ranked, generated_at=PINNED)
+    with_none = render.render_html(ranked, generated_at=PINNED, demos=None)
+    with_empty_doc = render.render_html(ranked, generated_at=PINNED, demos={})
+    assert baseline == with_none == with_empty_doc
+
+
+def test_rendering_is_deterministic(tmp_path: Path):
+    ranked, demos, _ = _build(tmp_path)
+    first = render.render_html(ranked, generated_at=PINNED, demos=demos)
+    second = render.render_html(ranked, generated_at=PINNED, demos=demos)
+    assert first == second, "same inputs + pinned timestamp must give byte-identical output"
+
+
+def test_existing_sections_survive_the_insertion(tmp_path: Path):
+    ranked, demos, _ = _build(tmp_path)
+    html = render.render_html(ranked, generated_at=PINNED, demos=demos)
+    for heading in (
+        "A range of what you already do",
+        "Ranked opportunities",
+        "Honest NOs",
+        "Waste findings",
+    ):
+        assert heading in html
+    assert html.index("A range of what you already do") < html.index("primer-section")
+    assert html.index("primer-section") < html.index("Ranked opportunities")
+
+
+# ------------------------------------------------------------------ primer
+def test_primer_renders_exactly_once_and_links_the_explainer_exactly_once(tmp_path: Path):
+    ranked, demos, _ = _build(tmp_path)
+    html = render.render_html(ranked, generated_at=PINNED, demos=demos)
+    assert html.count('id="primer-section"') == 1
+    assert html.count(f'href="{T.EXPLAINER_URL}"') == 1, "the explainer is LINKED once, never inlined"
+    assert T.PRIMER_TITLE in html
+    for heading, _body in T.PRIMER_PARTS:
+        assert heading in html
+
+
+def test_primer_only_artifact_when_there_is_nothing_to_demonstrate(tmp_path: Path):
+    ranked = F.ranked_fixture()
+    ranked["opportunities"] = []
+    doc = demo.empty_demos_doc()
+    html = render.render_html(ranked, generated_at=PINNED, demos=doc)
+    assert html.count('id="primer-section"') == 1
+    assert "demo-heading" not in html
+    assert "demonstrated" not in html, "the sub-line must not claim demos that do not exist"
+
+
+def test_the_header_subline_counts_demonstrations(tmp_path: Path):
+    ranked, demos, _ = _build(tmp_path)
+    html = render.render_html(ranked, generated_at=PINNED, demos=demos)
+    assert "1 demonstrated" in html
+
+
+# -------------------------------------------------------------- the demo
+def test_demo_section_carries_the_dot_escaped_and_the_walk(tmp_path: Path):
+    ranked, demos, _ = _build(tmp_path)
+    html = render.render_html(ranked, generated_at=PINNED, demos=demos)
+    assert html.count('class="demo-heading"') == 1
+    assert "digraph SyntheticDemo" in html, "the .dot text is embedded, so the artifact survives a file move"
+    assert "<digraph" not in html
+    assert "&quot;" in html, "the embedded .dot must be HTML-escaped through _esc"
+    for step in F.DEMO_NARRATIVE["pipeline_walk"]:
+        assert f"<code>{step['node']}</code>" in html
+
+
+def test_relpaths_in_the_html_match_files_actually_written(tmp_path: Path):
+    ranked, demos, out_dir = _build(tmp_path)
+    html = render.render_html(ranked, generated_at=PINNED, demos=demos)
+    hrefs = set(re.findall(r'href="([^"]+)"', html))
+    local = {h for h in hrefs if not h.startswith("http")}
+    assert local, "the artifact must print the on-disk paths it wrote"
+    for rel in local:
+        assert (out_dir / rel).is_file(), f"the HTML claims {rel}, which does not exist on disk"
+
+
+def test_the_artifact_fetches_nothing(tmp_path: Path):
+    """Self-contained: an anchor is a reference, not a fetched resource."""
+    ranked, demos, _ = _build(tmp_path)
+    html = render.render_html(ranked, generated_at=PINNED, demos=demos)
+    assert "<link " not in html
+    assert "src=" not in html
+    assert "@import" not in html
+    external = [u for u in re.findall(r'href="(https?://[^"]+)"', html)]
+    assert external == [T.EXPLAINER_URL], "the only external reference is the explainer anchor"
+
+
+def test_convergence_math_is_rendered_with_its_illustrative_label(tmp_path: Path):
+    ranked, demos, _ = _build(tmp_path)
+    html = render.render_html(ranked, generated_at=PINNED, demos=demos)
+    assert T.MATH_LABEL in html
+    assert "0.9" in html
+    math = demos["demos"][0]["convergence_math"]
+    assert str(math["once_through"]) in html
+    assert str(math["gated_loop"]) in html
+
+
+def test_the_self_certification_panel_has_all_three_parts(tmp_path: Path):
+    ranked, demos, _ = _build(tmp_path)
+    html = render.render_html(ranked, generated_at=PINNED, demos=demos)
+    assert T.PANEL_PART1_TITLE in html
+    assert T.PANEL_PART2_TITLE in html
+    assert T.PANEL_PART3_TITLE in html
+    assert "Structure lints; judgment does not." in html
+    # The commands are escaped through _esc like every other string.
+    assert escape(T.CLI_INSTALL_CMD, quote=True) in html
+    assert T.AUTHOR_PIPELINE_PATH in html
+
+
+def test_panel_part2_names_the_dot_prose_surface_the_whitelist_does_not_cover(tmp_path: Path):
+    """Finding 1 honesty pin, so the 'every number' claim cannot re-widen.
+
+    The digit whitelist governs the six teaching-prose slots only; numbers
+    written inside the generated .dot (budgets, max_iterations, thresholds) are
+    gate-checked by lint+doctrine, not whitelisted. The panel that exists to
+    say 'what nothing checked' must NAME that surface out loud — in the
+    constant AND in the rendered artifact.
+    """
+    body = T.PANEL_PART2_BODY.lower()
+    assert "number" in body, "part 2 must own the un-whitelisted number surface, not just prompts"
+    assert "inside the pipeline" in body or ".dot" in body or "pipeline itself" in body, (
+        "part 2 must name the .dot as the surface, not leave it implicit"
+    )
+    assert "not" in body and ("verified stats" in body or "cross-check" in body), (
+        "part 2 must say those numbers are NOT cross-checked against the verified stats"
+    )
+    # And it must actually reach the reader.
+    ranked, demos, _ = _build(tmp_path)
+    html = render.render_html(ranked, generated_at=PINNED, demos=demos)
+    assert escape(T.PANEL_PART2_BODY, quote=True) in html
+
+
+# ------------------------------------------------------------- the labels
+def _relabel(demos: dict, verification: dict) -> dict:
+    doc = json.loads(json.dumps(demos))
+    doc["demos"][0]["verification"] = verification
+    return doc
+
+
+def test_doctrine_only_renders_the_exact_not_run_label(tmp_path: Path):
+    ranked, demos, _ = _build(tmp_path)
+    relpath = demos["demos"][0]["dot_relpath"]
+    doc = _relabel(
+        demos,
+        {
+            "level": T.LEVEL_DOCTRINE_ONLY,
+            "lint_verdict": None,
+            "lint_not_run_reason": T.lint_not_run_label(relpath),
+            "doctrine_verdict": "doctrine_ok",
+            "doctrine_report": "AUTHORED-PIPELINE DOCTRINE REPORT\nverdict:   doctrine_ok\n",
+        },
+    )
+    html = render.render_html(ranked, generated_at=PINNED, demos=doc)
+    assert f"attractor lint: NOT RUN — the CLI is not installed here. Run it yourself: attractor lint {relpath}" in html
+    assert T.LABEL_UNVERIFIED not in html, "doctrine-only is verified, just not by lint"
+    assert "doctrine-only" in html
+
+
+def test_level_none_renders_the_unverified_banner_and_never_reads_as_verified(tmp_path: Path):
+    ranked, demos, _ = _build(tmp_path)
+    doc = _relabel(
+        demos,
+        {
+            "level": T.LEVEL_NONE,
+            "lint_verdict": None,
+            "lint_not_run_reason": "the bundled doctrine checker could not execute in this environment",
+            "doctrine_verdict": None,
+            "doctrine_report": None,
+        },
+    )
+    html = render.render_html(ranked, generated_at=PINNED, demos=doc)
+    assert T.LABEL_UNVERIFIED in html
+    assert "doctrine_ok" not in html, "an unverified demo must never display a passing verdict"
+    assert "unverified" in html, "the banner carries its own visual treatment"
+    assert "attractor lint" in html, "both commands to run yourself are offered"
+
+
+def test_lint_plus_doctrine_quotes_both_verdicts_verbatim(tmp_path: Path):
+    ranked, demos, _ = _build(tmp_path)
+    verbatim = "attractor lint: pipeline.dot: OK (no findings)"
+    doc = _relabel(
+        demos,
+        {
+            "level": T.LEVEL_LINT_DOCTRINE,
+            "lint_verdict": verbatim,
+            "lint_not_run_reason": None,
+            "doctrine_verdict": "doctrine_ok",
+            "doctrine_report": "[PASS] A4 the exit is structurally unreachable without passing an evidence gate",
+        },
+    )
+    html = render.render_html(ranked, generated_at=PINNED, demos=doc)
+    assert verbatim in html
+    assert "[PASS] A4" in html
+    assert "lint+doctrine" in html
+
+
+def test_unknown_recovery_renders_as_a_caveat_never_as_fail(tmp_path: Path):
+    ranked, demos, _ = _build(tmp_path, verdict="OPPORTUNITY(unproven)", recovery="UNKNOWN")
+    html = render.render_html(ranked, generated_at=PINNED, demos=demos)
+    assert "unproven — no bad day was ever observed, which is a caveat, never a failure" in html
+    assert "FAIL" not in html.split('class="demo"')[1].split("</div>")[0]
+
+
+def test_write_report_threads_demos_through(tmp_path: Path):
+    ranked, demos, out_dir = _build(tmp_path)
+    path = render.write_report(ranked, out_dir / "report.html", generated_at=PINNED, demos=demos)
+    assert path.is_file()
+    assert "primer-section" in path.read_text(encoding="utf-8")

--- a/skills/attractor-scout/tests/test_vendored_doctrine_checker_pin.py
+++ b/skills/attractor-scout/tests/test_vendored_doctrine_checker_pin.py
@@ -1,0 +1,98 @@
+"""The drift tripwire on the vendored doctrine checker.
+
+`scripts/attractor_scout/authoring_contract.py` is a BYTE-IDENTICAL copy of
+`examples/authoring/check_authored_pipeline.py`. Vendoring — rather than
+importing the repo file by relative path — is what lets this skill's suite
+exercise the gate hermetically (its conftest forbids cross-repo imports) and
+what keeps the skill working when it is installed without the full repo tree.
+
+The cost of that choice is drift, and this file is the price paid for it: a
+sha256 equality check that turns "someone improved the upstream checker and
+the vendored second opinion silently kept its old mind" from a quiet wrong
+answer into a red test. Upstream change now costs exactly one `cp`.
+
+The repo already sanctions this pattern twice: the upstream checker is itself
+an adapted copy of `examples/objective/check_child_contract.py` carrying its
+own agreement test, and `test_quality_protocol_guard.py` Q-307 pins two copies
+of the decision matrix to each other.
+
+Both checks SKIP when the repo file is absent — that is the standalone-install
+case, not a failure.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+from attractor_scout import demo_templates as T
+
+SKILL_DIR = Path(__file__).resolve().parent.parent
+BUNDLE_ROOT = SKILL_DIR.parent.parent
+
+VENDORED = SKILL_DIR / "scripts" / "attractor_scout" / "authoring_contract.py"
+UPSTREAM = BUNDLE_ROOT / "examples" / "authoring" / "check_authored_pipeline.py"
+DOT_REFERENCE = BUNDLE_ROOT / "context" / "dot-reference.md"
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def test_the_vendored_copy_exists_and_is_importable():
+    assert VENDORED.is_file(), "the doctrine checker must ship INSIDE the skill (bundle-only installs)"
+    from attractor_scout.authoring_contract import parse_dot_min, run_checks
+
+    assert callable(parse_dot_min)
+    assert callable(run_checks)
+
+
+def test_vendored_checker_is_byte_identical_to_upstream():
+    if not UPSTREAM.is_file():
+        pytest.skip("standalone install: the repo's examples/authoring tree is not present")
+    vendored_sha = _sha256(VENDORED)
+    upstream_sha = _sha256(UPSTREAM)
+    assert vendored_sha == upstream_sha, (
+        "the vendored doctrine checker has DRIFTED from "
+        f"{UPSTREAM.relative_to(BUNDLE_ROOT)}.\n"
+        f"  vendored: {vendored_sha}\n"
+        f"  upstream: {upstream_sha}\n"
+        "A stale second opinion returns a confidently wrong answer. Re-copy it:\n"
+        f"  cp {UPSTREAM.relative_to(BUNDLE_ROOT)} "
+        f"{VENDORED.relative_to(BUNDLE_ROOT)}"
+    )
+
+
+def test_every_vocabulary_attribute_in_the_brief_is_real():
+    """The brief teaches a fresh-context delegate the engine's vocabulary.
+
+    An invented attribute is not an error at runtime — it is SILENTLY DROPPED,
+    and the graph runs unconfigured. So the excerpt may never drift into a
+    spelling the engine does not read.
+    """
+    if not DOT_REFERENCE.is_file():
+        pytest.skip("standalone install: the repo's context/dot-reference.md is not present")
+    reference = DOT_REFERENCE.read_text(encoding="utf-8")
+    missing = [attr for attr in T.VOCAB_ATTRIBUTES if f"{attr}=" not in reference]
+    assert not missing, (
+        f"the brief's vocabulary excerpt names attribute(s) absent from "
+        f"{DOT_REFERENCE.relative_to(BUNDLE_ROOT)}: {missing}. An attribute that is not on that "
+        f"page is not read by anything."
+    )
+
+
+def test_every_vocabulary_attribute_appears_in_the_excerpt_itself():
+    for attr in T.VOCAB_ATTRIBUTES:
+        assert f"{attr}=" in T.VOCAB_EXCERPT, f"{attr} is listed but not actually taught"
+
+
+def test_the_vendored_checker_and_the_demo_layer_share_one_parser():
+    """One parser, one truth: the node-name check must not invent a second."""
+    import inspect
+
+    from attractor_scout import demo
+
+    source = inspect.getsource(demo.dot_node_ids)
+    assert "authoring_contract" in source
+    assert "parse_dot_min" in source


### PR DESCRIPTION
## Summary
The **demonstration/teaching layer** for `skills/attractor-scout/` — the second half of the maintainer's onboarding ask (transcript-replay-verified): the skill now not only *finds* a user's attractor-shaped opportunities, it **teaches attractor and demonstrates it on their own top opportunity**. After rendering the map, the skill auto-generates ONE worked demonstration for the top-ranked opportunity (user-opt-in for extras): a real attractor `.dot` authored by a bounded fresh-context `reasoning`-role delegation from a **deterministic brief** (`demo brief` subcommand), pushed through a machine-gate ladder — `attractor lint` on PATH → **consent-gated** `uvx` lint (inbound fetch named out loud, never silent) → vendored stdlib doctrine checker (byte-identical copy of `examples/authoring/check_authored_pipeline.py`, sha-pin-tested) → honest `UNVERIFIED` label. **Gate-FAILED demos never publish.** Every published demo carries the three-part self-certification panel (machine-checked facts / what nothing checked / the independent path) per `context/attractor-awareness.md`'s binding contract. A LEARN-ABOUT primer renders once per artifact, **linking** the published explainer page. `render.py` gains `--demos`; with no demos the artifact is **byte-identical** to pre-change (pinned in CI and re-proven cross-version in review). Design doc ships in-repo (`docs/designs/2026-08-19-attractor-scout-demonstration-layer.md`).

**Decision-matrix tier: Uncharted (extension), purely additive** — zero engine/module/spec changes (`git diff --stat origin/main...HEAD` is entirely `docs/designs/` + `skills/attractor-scout/`); the nlspec governs pipeline semantics, not onboarding tooling; this routes users INTO spec-faithful pipelines.

## Verification checklist
- [x] Unit tests — skill suite **306 passed / 47 skipped** (was 221/39): brief assembly, ladder-label states, vendored-checker byte-pin + red-proofs, renderer additivity, prose-slot fail-loud validation, self-certification panel integrity, leak guard (176) over all new content
- [x] Live pipeline run — real-corpus live proof: `rank --strict` exit 0; real top opportunity; real `reasoning` delegation; **ladder rung 1 fired**; attempt 1 caught by the doctrine gate (`[FAIL] A5` budget wall → `DemoGateRed`, nothing published) → corrective retry → `lint+doctrine`, published. Controls: CLI masked → `doctrine-only` w/ exact `NOT RUN` label; gate deleted → `[FAIL] A4` refused, output empty. Every number re-verified by independent recompute; artifacts live outside the repo (maintainer's local evaluation artifacts)
- [x] Independent adversarial review — **MERGE-AFTER-FIX**, all findings closed: 5/5 gate mutations RED (publish-on-red bypass, false labeling, fabricated numbers incl. node-name smuggling, panel deletion, vendored-pin drift); cross-version additivity re-proven byte-identical by the reviewer
- [x] Guidance-surface toll — **the guidance eval cannot reach this surface** (opt-in, user-invoked skill); discharged via the documented fallback: a fresh-session walk-through following the SKILL.md body only — **run 1 clean**, reached the new demo steps unaided, volunteered the self-certification answer unprompted
- [x] Pre-publication leak review (§7) — deterministic guards green AND an outsider-brief read by the independent reviewer over the full diff (this PR introduces a new public content class: published demo `.dot`/`.md` beside the artifact): zero identity values, zero internal paths; design doc swept before shipping (17-line diff vs the working copy, all genericization)
- [x] EXTENSIONS entry — N/A with reason: zero observable pipeline-contract change; the ledger records engine/contract extensions, not skill content
- [x] Backward compat — additivity pinned: no demos ⇒ byte-identical artifact

## Required disclosures
1. **Numbers-claim scope:** the digit-whitelist governs the **six teaching-prose slots only**; text inside the generated `.dot` (prompts/labels) is gate-checked by lint+doctrine but NOT digit-whitelisted (a whitelist there would false-positive on legitimate pipeline params). The self-certification panel's "what nothing checked" part names this surface explicitly, pinned by test.
2. **Named whitelist limits** (regression-pinned as expected-pass): decomposed decimals (`33` from `0.33`) and spelled-out numbers pass; node-name smuggling and substring matches stay closed.
3. **`ruff.toml`** sets `line-length=120` (quiets 3 pre-existing I001 errors and 27 would-be-reformat files) + excludes the byte-pinned vendored checker from formatting; disclosed in the design doc's build notes.
4. **skillify lineage (design D6):** skillify has **no runtime role** (wrong shape; would break bundle-only installs); its skill-authoring discipline informed the generation design — acknowledged here per the design's own mandate. Future role named in the design doc, not built.
5. Builder environment note: fresh-context generations in the build ran via `amplifier run --mode single` (equivalent isolation; the shipped SKILL.md prescribes `delegate`).
