### PR TITLE
fix(skills): attractor-scout demo UX — --unit in step 8, A5 vocabulary in briefs, numeric batch sizes

### DIFF
--- a/skills/attractor-scout/SKILL.md
+++ b/skills/attractor-scout/SKILL.md
@@ -122,8 +122,11 @@ not fabricate a count from a shallower glob.
 **2 — Semantic label + cluster (`fast` role).** The deterministic spine dedups
 by tool-signature, but the large majority of real opportunities are found ONLY
 by reading the work's *meaning* across differently-worded sessions. Delegate
-this to `fast`-role sub-agents over **local text only**, in **small batches (a
-few dozen sessions each)** run in **waves of a handful, in series**. The `fast`
+this to `fast`-role sub-agents over **local text only**, in **batches of ~40
+sessions**, run in **waves of 5 batches in series**. Those two numbers are the
+calibrated shape: ~40 keeps a batch inside one workspace's coherence so a
+cluster is not split across unrelated work, and 5-at-a-time in series stays
+under provider rate limits on a corpus of any size. The `fast`
 role does this reliably at scale — every batch measured in this build placed
 every session with **zero invented ids**. Each batch returns cluster
 assignments as JSON; collect them into an intermediate `$WORK/fast-clusters.json`
@@ -206,7 +209,10 @@ primer-only document and re-render, then say so plainly.
 source "$WORK/env.sh"
 # No opportunities? Primer only, and skip the rest of this step:
 #   $CLI demo primer-only --out "$WORK/demos.json"
-SLUG=$($CLI demo brief --ranked "$WORK/ranked.json" \
+# Pin the unit ONCE, and pass it to every demo command in this step:
+UNIT=$(python -c 'import json,sys; print(json.load(open(sys.argv[1]))["opportunities"][0]["unit_id"])' \
+        "$WORK/ranked.json")
+SLUG=$($CLI demo brief --ranked "$WORK/ranked.json" --unit "$UNIT" \
         --extracts "$WORK/extracts.jsonl" --workdir "$WORK/demo")
 ```
 
@@ -220,10 +226,16 @@ delegation; at most two if the gates reject the first draft; never more.**
 Then gate, validate and publish:
 
 ```bash
-$CLI demo assemble --ranked "$WORK/ranked.json" \
+$CLI demo assemble --ranked "$WORK/ranked.json" --unit "$UNIT" \
     --workdir "$WORK/demo/$SLUG" --output-dir "$(dirname "$OUTPUT_PATH")" \
     --out "$WORK/demos.json" --append
 ```
+
+**`brief` and `assemble` must both point at the SAME unit.** `--unit` defaults
+to `opportunities[0]` on *each* command independently, so an `assemble` that
+omits it silently validates the draft against the top-ranked unit's numbers —
+which is why `$UNIT` is pinned once above and passed to both. Mismatch it and
+the count check fails on numbers the delegate never wrote.
 
 `assemble` runs the verification ladder (`attractor lint` if it is on PATH; the
 bundled doctrine checker always), validates every number in the **six teaching-
@@ -256,10 +268,12 @@ those three parts — never "yes, I'm sure."
 
 **9 — Offer more (their call).** List the top five not-yet-demonstrated
 opportunities by name and ask exactly one question: *"Want another one
-demonstrated? Name or number — or no."* Each yes repeats step 8 for that unit
-(`--unit <unit_id>`, with `--append`) and re-renders. **Never generate a second
-demonstration without a fresh explicit yes** — the first one is the skill's
-second half; every one after it is marginal spend for marginal personalization.
+demonstrated? Name or number — or no."* Each yes repeats step 8 for that unit —
+re-point `$UNIT` at the chosen `unit_id` so **both** `demo brief` and `demo
+assemble` carry the same `--unit`, keep `--append`, and re-render. **Never
+generate a second demonstration without a fresh explicit yes** — the first one
+is the skill's second half; every one after it is marginal spend for marginal
+personalization.
 
 ---
 

--- a/skills/attractor-scout/scripts/attractor_scout/demo_templates.py
+++ b/skills/attractor-scout/scripts/attractor_scout/demo_templates.py
@@ -28,6 +28,8 @@ from __future__ import annotations
 
 import shlex
 
+from . import authoring_contract as _contract
+
 # --------------------------------------------------------------------------
 # Public endpoints and commands --- written down exactly once.
 # --------------------------------------------------------------------------
@@ -294,6 +296,70 @@ before anyone sees it, so write to it deliberately:
       answer cannot change the path gates nothing
 """
 
+# --------------------------------------------------------------------------
+# A5 in detail --- the check first drafts actually fail.
+# --------------------------------------------------------------------------
+#
+# Measured on real runs: the brief above described the budget wall in PROSE
+# ("a budget wall, so it cannot spin"), and both live demonstrations came back
+# `[FAIL] A5` on the first draft --- costing a second delegation every time.
+# A5 is not a judgement about whether the pipeline is well budgeted; it is a
+# LITERAL SUBSTRING MATCH over the graph text. A delegate that cannot see the
+# checker cannot guess the tokens, so the brief now quotes them.
+#
+# The tuples are read off the vendored checker itself rather than retyped: it
+# is byte-pinned to upstream (`test_vendored_doctrine_checker_pin.py`), so a
+# private-name read here is the only way to keep ONE source of truth. If
+# upstream ever changes the vocabulary, the brief follows on the next `cp` and
+# the pin test proves it did.
+
+#: Substrings A5 accepts in a reachable tool node's `tool_command`.
+A5_BUDGET_TOKENS: tuple[str, ...] = tuple(_contract._BUDGET_TOKENS)
+
+#: Substrings A5 accepts on that node's outgoing edge (`condition` / `label`).
+A5_EXHAUSTION_TOKENS: tuple[str, ...] = tuple(_contract._EXHAUSTION_TOKENS)
+
+
+def _token_line(tokens: tuple[str, ...]) -> str:
+    """The tokens as the author must spell them --- backticked, comma-joined."""
+    return ", ".join(f"`{token}`" for token in tokens)
+
+
+#: The worked shape handed to the author. Written ONCE, here: a test wraps this
+#: exact fragment in the smallest legal graph and runs the real checker over
+#: it, so an example that would not itself pass A5 cannot ship in the brief.
+A5_WORKED_EXAMPLE = """\
+  wall [shape=parallelogram,
+        tool_command="max_attempts=3; test $(cat .n) -lt $max_attempts && echo under_budget || echo budget_exhausted"]
+  wall -> worker  [condition="context.tool.last_line=under_budget"]
+  wall -> give_up [condition="context.tool.last_line=budget_exhausted"]"""
+
+
+A5_BUDGET_WALL_CONTRACT = f"""\
+A5 IN DETAIL — this is the check first drafts fail, so it is spelled out. A5 is
+a LITERAL SUBSTRING MATCH over your graph's text, not a reading of your prose:
+a companion that eloquently describes a budget wall scores nothing. The checker
+requires, verbatim:
+
+  1. A TOOL node (`shape=parallelogram`, or any node carrying a `tool_command`)
+     that is REACHABLE from start, and whose `tool_command` contains one of
+     these substrings, spelled exactly like this — the match is case-sensitive:
+       {_token_line(A5_BUDGET_TOKENS)}
+  2. That SAME node has an OUTGOING EDGE whose `condition` or `label` contains
+     one of these substrings (this match is case-insensitive):
+       {_token_line(A5_EXHAUSTION_TOKENS)}
+  3. That exhaustion edge routes somewhere honest — a LOUD nonzero terminal —
+     never into the exit as a success (A1, A8).
+
+A worked shape that satisfies all three:
+
+{A5_WORKED_EXAMPLE}
+
+`max_attempts` carries the budget token; `budget_exhausted` carries the
+exhaustion token on the edge. Counting attempts in a worker's prompt, or naming
+a budget only in the companion, leaves A5 red.
+"""
+
 NARRATIVE_CONTRACT = """\
 NARRATIVE RULES (machine-enforced at assembly — a violation kills the demo):
 
@@ -392,6 +458,7 @@ test as separate nodes is the anti-pattern.
 
 {VOCAB_EXCERPT}
 {CONTRACT_SUMMARY}
+{A5_BUDGET_WALL_CONTRACT}
 ### 2. `pipeline.md`
 
 The companion. It MUST name every LLM (box) node id in your graph and state each
@@ -461,6 +528,9 @@ def uvx_consent_question(relpath: str) -> str:
 
 
 __all__ = [
+    "A5_BUDGET_TOKENS",
+    "A5_BUDGET_WALL_CONTRACT",
+    "A5_EXHAUSTION_TOKENS",
     "AUTHOR_PIPELINE_PATH",
     "CLI_INSTALL_CMD",
     "CONTRACT_SUMMARY",

--- a/skills/attractor-scout/tests/test_scenario6_demo_assembly.py
+++ b/skills/attractor-scout/tests/test_scenario6_demo_assembly.py
@@ -90,6 +90,64 @@ def test_brief_carries_the_gate_tool_evidence_from_their_own_sessions(tmp_path: 
     assert "read_file" not in text.split("## What to write")[0], "non-verify tools are not gate evidence"
 
 
+def test_brief_quotes_the_a5_budget_wall_vocabulary(tmp_path: Path):
+    """A5 is a literal token match, so the brief must NAME the tokens.
+
+    Measured on real runs: with the budget wall described only in prose, both
+    live demonstrations came back `[FAIL] A5` on the first draft and cost a
+    second delegation. A fresh-context delegate cannot read the checker, so
+    every token the checker matches on is quoted into the brief verbatim.
+    """
+    from attractor_scout import authoring_contract as contract
+
+    ranked_path = _write_ranked(tmp_path)
+    _, brief_path = demo.build_brief(ranked_path=ranked_path, unit_id=None, workdir=tmp_path / "demo")
+    text = brief_path.read_text(encoding="utf-8")
+
+    assert "A5 IN DETAIL" in text, "the A5 shape must be spelled out, not left to the contract summary"
+    for token in contract._BUDGET_TOKENS:
+        assert token in text, f"the brief must name the A5 budget token {token!r} the checker matches on"
+    for token in contract._EXHAUSTION_TOKENS:
+        assert token in text, f"the brief must name the A5 exhaustion token {token!r} the checker matches on"
+    assert "tool_command" in text and "condition" in text, "A5 needs BOTH halves: the command and the edge"
+
+
+def test_the_briefs_worked_a5_example_actually_passes_a5(tmp_path: Path):
+    """The example the brief hands the author must survive the real checker.
+
+    A worked example that does not itself pass is worse than none: it teaches
+    a shape the gate rejects. So the shipped fragment — the same string the
+    brief embeds — is wrapped in the smallest legal graph and fed to the
+    vendored checker.
+    """
+    from attractor_scout import authoring_contract as contract
+    from attractor_scout import demo_templates as T
+
+    ranked_path = _write_ranked(tmp_path)
+    _, brief_path = demo.build_brief(ranked_path=ranked_path, unit_id=None, workdir=tmp_path / "demo")
+    assert T.A5_WORKED_EXAMPLE in brief_path.read_text(encoding="utf-8"), "the brief must carry the example"
+
+    dot = (
+        "digraph demo {\n"
+        "  start [shape=Mdiamond];\n"
+        "  done [shape=Msquare];\n"
+        '  worker [shape=box, prompt="do the work"];\n'
+        '  gate [shape=parallelogram, tool_command="pytest -q"];\n'
+        '  give_up [shape=parallelogram, tool_command="echo out of budget; exit 1", max_retries="0"];\n'
+        f"{T.A5_WORKED_EXAMPLE}\n"
+        "  start -> wall;\n"
+        '  worker -> gate [condition="outcome=success"];\n'
+        '  worker -> give_up [condition="outcome=fail"];\n'
+        '  gate -> done [condition="context.tool.last_line=green && outcome=success"];\n'
+        '  gate -> wall [condition="context.tool.last_line=red && outcome=success"];\n'
+        '  give_up -> done [condition="outcome=fail"];\n'
+        "}\n"
+    )
+    results = {r.check_id: r for r in contract.run_checks(contract.parse_dot_min(dot), None)}
+    assert results["A5"].passed, f"the brief's own worked example fails A5: {results['A5'].detail}"
+    assert results["A8"].passed, f"the example routes exhaustion badly: {results['A8'].detail}"
+
+
 def test_brief_is_honest_when_no_gate_evidence_was_observed(tmp_path: Path):
     ranked_path = _write_ranked(tmp_path)
     _, brief_path = demo.build_brief(ranked_path=ranked_path, unit_id=None, workdir=tmp_path / "demo")


### PR DESCRIPTION
## Summary
Three real-user-test findings from a full live run of `/attractor-scout` on a real corpus (a fresh session following SKILL.md verbatim — the run succeeded; these are UX/cost defects it surfaced):
1. **Step 8's `demo assemble` snippet omitted `--unit`** — assemble silently validates against `opportunities[0]`; the live runner's demo-2 assemble failed against the wrong unit's digit whitelist until it discovered the flag. Step 8 now pins `$UNIT` once and passes it to BOTH `brief` and `assemble`, with the same-unit rule stated; step 9 re-points `$UNIT`. Flags verified against `_cli.py` reality.
2. **Demo briefs omitted the doctrine checker's A5 budget-wall vocabulary** — both live demos went gate-red on first draft for the same predictable reason. New `A5_BUDGET_WALL_CONTRACT` block in the brief quotes the checker's actual required token sets (read off `authoring_contract.py`, not retyped) + a worked example. Expected effect: ~halves demo LLM cost (1 authoring attempt instead of 2). The checker itself and its byte-pin are untouched (pin test green).
3. **Batch/wave sizes made numeric** — batches of ~40 sessions, waves of 5 in series, with the rate-safety/coherence rationale (the live runner had to improvise these numbers).

## Verification checklist
- [x] Unit tests — suite **308 passed / 47 skipped** (was 306/47); new: `test_brief_quotes_the_a5_budget_wall_vocabulary`, `test_the_briefs_worked_a5_example_actually_passes_a5` (the brief's own example is executed through the real A5 check)
- [x] Live pipeline run — N/A: skill docs + brief-template text only; no engine/handler/.dot changes (`git diff --stat` confined to `skills/attractor-scout/`)
- [x] Vendored-checker byte-pin — untouched, pin test green
- [x] EXTENSIONS entry — N/A: no observable pipeline contract touched
- [x] Pre-publication leak review — deterministic guards green; diff adds only checker-derived vocabulary + numeric guidance; zero identity values
- [x] CI green before merge — will confirm
