### PR TITLE
feat(skill): attractor-scout deck mode — gated, deck-grade personalized artifact (opt-in step 10)

### DIFF
--- a/docs/designs/2026-08-19-attractor-scout-deck-mode.md
+++ b/docs/designs/2026-08-19-attractor-scout-deck-mode.md
@@ -1,0 +1,255 @@
+# Design: attractor-scout deck mode
+
+**Status:** SHIPPED. Built and live-proved in the PR that also lands this document.
+**Date:** 2026-08-19
+**Repo:** `amplifier-bundle-attractor`, `main` @ `c8e71dd`
+**Scope:** an OPT-IN step 10 on `/attractor-scout` that turns the same verified mining data into
+one authored, deck-grade, educational HTML artifact — with deterministic quality/honesty gates.
+**Decision-matrix tier:** **additive extension.** Deck mode adds a new optional artifact and two
+new CLI subcommands; it changes no observable contract of the mining spine, the demonstration
+layer, or the deterministic renderer. Steps 1–9 are byte-untouched in behavior. No
+`specs/EXTENSIONS.md` entry is owed, for the same reason the demonstration layer owed none:
+onboarding/teaching output extends no pipeline contract.
+
+**Read against:** `skills/attractor-scout/SKILL.md` (steps 8–9 — the demo-brief pattern this
+copies), `scripts/attractor_scout/demo.py` + `demo_templates.py` (the pattern's reference
+implementation), `docs/designs/2026-08-19-attractor-scout-demonstration-layer.md` (the design
+register this matches), `docs/QUALITY_PROTOCOL.md` (§2 guidance toll, §7 leak defense).
+
+---
+
+## 0. The gap, and what ships
+
+The skill's standard artifact is a **deterministic modal report**: `render.py` places every number
+from `ranked.json`, which `rank --strict` already re-verified against the raw records. Its trust
+story is structural — *no language model is ever in a position to state a number*.
+
+That guarantee is also its ceiling. A deterministic renderer produces a report, not a deck. It
+cannot open a section on a claim, cannot draw the reader's own pipeline in the house diagram
+grammar, cannot vary its argument to fit what this particular run actually found.
+
+What ships (one sentence): **after step 9, on one explicit yes, the skill assembles a
+deterministic deck brief, hands it to ONE fresh-context `reasoning` delegation, runs five
+deterministic gates over the result, and publishes `attractor-scout-deck.html` beside the report —
+or refuses, with the gate report.**
+
+The trade is stated plainly, because it is the whole design: **what the renderer guaranteed by
+construction, deck mode guarantees by inspection.**
+
+---
+
+## 1. Recipe provenance
+
+The method is not new. It was **recovered from a session-transcript replay** of a manual build:
+reading back what actually happened when a deck-grade artifact was produced by hand from a real
+run, and extracting the repeatable procedure from it. (Described generically on purpose — no
+session identifiers, no run identifiers, no corpus content appears in this repo, per §7.)
+
+The recovered recipe, in its own terms:
+
+> **Learn the house TECHNIQUES from an exemplar; build FRESH content from REAL inlined data;
+> verify with scripted gates.**
+
+Three properties of that recipe are load-bearing and all three survive into the shipped version:
+
+1. **Fresh-context delegation + inline brief.** The author sees the brief and nothing else. It
+   cannot lean on the orchestrator's context, so everything it needs — the style contract, the
+   constraints, the data, the gate rules — must be *in the brief*. This is the same seam
+   `demo brief` established, and the same reason it exists: an author whose output the
+   orchestrator machine-checks lets the session relay verdicts about work it did not itself write.
+2. **Techniques, not text.** The exemplar teaches *how* (section arc, diagram grammar,
+   progressive disclosure), never *what*. `deck_templates.STYLE_CONTRACT` is the exemplar's method
+   written down as prose; no sentence of the exemplar's own content ships.
+3. **Scripted gates, not care.** In the manual build, 101 displayed numbers were re-verified **by
+   hand**, and diagram fidelity was compared **by hand**. That is exactly the discipline that does
+   not survive repetition. `deck verify` is that hand-verification turned into code.
+
+**Evidence that the gate reproduces the manual discipline.** Run against the manual prototype, the
+shipped `deck verify` passes gates (a), (b), (c) and (e) — including *diagram node/edge-multiset
+fidelity exact on both demonstrations* — and flags exactly **five** numeric tokens under gate (d).
+All five are the values the manual build justified by hand arithmetic (a session total and its two
+addends, a covered-session subtotal, and an hours total). They are not wrong; they are
+*underivable by machine from the run data alone*. That is precisely the case the `derived-values`
+mechanism exists for, and it is why the mechanism exists rather than a looser whitelist.
+
+---
+
+## 2. The gate design
+
+`deck verify <deck.html> --ranked <ranked.json> [--demos <demos.json>]` → exit 0 iff all five pass;
+exit 3 on a red gate (distinct from the skill's existing exit 2 fail-loud, so a red gate is
+never mistaken for a broken input). Failures name the file and the reason.
+
+| Gate | Checks | Why it is a gate and not a lint |
+|---|---|---|
+| **a — it parses** | Balanced nesting across 33 container element types; `<!doctype html>`; an `<html>` element. Deliberately excludes the implicit-close family (`p`, `li`, `td`) and SVG leaf shapes, which are legally written unclosed and would produce noise, not signal. | An unclosed `<dialog>` silently swallows the rest of the page. |
+| **b — self-contained** | No `<img>` / `<link>` / `<script src>` / `@import` / `<iframe>` / `srcset`; `url(` only ever as `url(#…)`; **exactly two** `https` hrefs; zero `file://`. | The artifact's promise is "own data, one machine, no network". A page that fetches breaks that promise silently, and breaks entirely offline. |
+| **c — modals** | Every trigger resolves to a dialog; every dialog is reachable from ≥1 trigger; no duplicate dialog ids. | An orphan modal is content the reader can never reach; a dangling trigger is a button that lies. |
+| **d — every number resolves** ★ | Every numeric token in **visible text** must resolve against a whitelist built from the run data, or be declared in the deck's own `derived-values` block. | This is the deterministic renderer's guarantee, re-established by inspection. It is the reason deck mode is allowed to exist at all. |
+| **e — diagram fidelity** ★ | For each demonstration: node **set** and edge **MULTISET**, read off `data-node`/`data-edge`, must equal the real `.dot`'s. | A diagram that drops the awkward corrective back-edge teaches the wrong shape — and is the single most plausible way an authored diagram goes wrong. |
+
+### Gate (d) — the whitelist, and the derived-values mechanism
+
+**Whitelist sources**, in order of authority: every numeric in `ranked.json`; every numeric in
+`demos.json` (verified stats, convergence arithmetic); every digit run inside a **named** set of
+string fields that legitimately carry numerics (the generated `.dot` text, the verbatim machine
+gate reports, identifiers, timestamps, invocation commands); each demonstration's node and edge
+**counts**, computed from its `.dot` by the vendored parser; collection sizes; and the structural
+digits 0–4 (Q1/Q2/Q3, the 4a/4b/4c sub-tests — the same allowance `demo.validate_narrative` makes).
+
+**The derived-values mechanism, in one sentence:** a deck declares any number it computed itself —
+a total, a percentage, a unit conversion — in a `<script type="application/json"
+id="derived-values">` block as `{value, from, inputs}`, where `from` is the arithmetic provenance
+in words and `inputs` is a **mandatory, non-empty** array of the supplied numbers it was computed
+from; the gate whitelists declared values only when every input is itself a supplied number **and**
+the `from` text references each input it lists — so a bare `{"value":"8731","from":"qqq"}` with no
+inputs, or a junk `from` that names nothing, is rejected.
+
+**Why `inputs` is mandatory (the self-dealing fix).** An earlier cut made `inputs` optional; a
+fabricated value with a one-word `from` and no inputs then passed, because the only check was that
+`from` was non-empty. That is self-dealing — the author declaring their own fiction legitimate.
+Requiring a non-empty `inputs`, each a supplied number, and a `from` that references them, means a
+derivation cannot be conjured from nothing: every declared number is anchored to numbers the run
+actually produced.
+
+**Why declarative and not recomputed (a named limit).** The gate checks that a derivation exists,
+is attributed, and cites only supplied inputs referenced by its provenance; it does **not** evaluate
+`from` as an expression. Evaluating natural language would be guesswork, and a formal expression
+language would force every legitimate derivation through a parser the author cannot see. The one gap
+this leaves open, on purpose: a declaration with **real inputs but a wrong total**
+(`{"value":"9999","from":"120 + 180","inputs":["120","180"]}`) passes, because the gate trusts the
+stated arithmetic. Closing it would mean recomputing, which the design rejects for the reasons
+above; it is named limit #4 in §3.
+
+### Gate (e) — how a diagram is matched to a pipeline
+
+Primary: the `<svg>` carries `data-diagram="<slug>"`. Fallback: a unique node-set match. The
+fallback exists so a deck authored before the attribute convention — the recovered exemplar —
+still verifies; the mandate asks for the explicit attribute because inference is not a contract.
+
+---
+
+## 3. Named limits (documented, not closed)
+
+Each has an expected-pass regression test in `tests/test_scenario9_deck_gates.py`, so a future
+"I fixed it" is forced to update the docs honestly. The first two are inherited verbatim from
+`demo.validate_narrative`'s whitelist and are named the same way.
+
+1. **Spelled-out numbers.** "twenty-five noes" is not a numeric token and passes unchecked.
+   Detecting written numerals is NLP guesswork, and a fail-loud guard that guessed wrong would
+   block honest prose — the worse failure for a trust surface whose whole value is not crying
+   wolf. The brief tells the author this in as many words, *and tells them not to use it as a
+   loophole*.
+2. **Decomposition.** A whitelisted `397.5` also whitelists the bare runs `397` and `5`, because a
+   rendered stat's own sub-runs are how legitimate prose refers to it. `398` is still rejected, so
+   the leak is bounded to runs a supplied number literally contains.
+
+   **§3.2 — how large this leak actually is (measured, not hand-waved).** "Decomposition" undersells
+   it, so here are the figures from the live-proof run's own whitelist (946 supplied values): of the
+   ten single digits **0–9, 100% are always free** (0–4 are structural; 5–9 are supplied or
+   decomposed sub-runs); of the ninety two-digit values **10–99, ~94% resolve**; of the
+   three-digit values **100–999, only ~14% resolve**. The shape is the point: a fabricated *two*-digit
+   figure will almost always ride an existing decomposition and pass, so the gate's real teeth are on
+   larger numbers, where the supplied set is sparse. This is why the brief pushes authors to spell
+   out or declare, and why gate (d) is a strong check on the big aggregates a deck is tempted to
+   invent, not on small incidental counts.
+3. **Computed / concatenated script strings.** Gate (d) now scans prose-bearing string *literals*
+   in executable inline `<script>` bodies (closing the `document.title = "8731 units examined"`
+   bypass), but a number *assembled at runtime* (`"" + n + " units"`), or written as a bare numeric
+   literal in code rather than inside a string, is not a literal and is not seen. And only literals
+   carrying a 3+ letter word are checked, so a CSS/geometry string (`"-45% 0px -50% 0px"`, which the
+   recovered exemplar's IntersectionObserver actually uses) is not treated as a displayed claim —
+   the alternative, scanning every literal, would false-positive on exactly that pattern.
+4. **Provenance is declarative.** Gate (d) does not recompute `from`: a declaration with **real,
+   supplied inputs but a wrong total** passes (`{"value":"9999","from":"120 + 180",
+   "inputs":["120","180"]}`). What the hardening *did* close is the self-dealing case — `inputs` is
+   now mandatory and non-empty, every input must be a supplied number, and `from` must reference
+   each input — so a value can no longer be conjured with a junk `from` and no inputs. Recomputing
+   the arithmetic is the residual, rejected for the reasons in §2.
+5. **Scope: text and prose-script only.** Numbers in non-text attribute values (`aria-label`,
+   `viewBox`, path geometry, `id` references) are **not** scanned: SVG coordinates are numbers by
+   the thousand, so whitelisting them would gut the gate and flagging them would make it useless.
+   The deck's *visible claims* are what a reader trusts, and those are what is checked.
+6. **Not a strict bijection.** Gate (c) permits **several triggers for one dialog** — the exemplar
+   does exactly this, with two entry points into one deep-dive. What is forbidden is an orphan in
+   either direction. Stated because "bijection" was the word in the ask and this is deliberately
+   weaker than it.
+
+---
+
+## 4. What resisted templating
+
+Two things could not be reduced to a deterministic template, and both are handled by *mandating an
+honest label* rather than by generating a value.
+
+**Absent workspace/project fields.** The ranking records which sessions a unit covers, not which
+project or repository they belong to. A deck's natural shape wants to say "this happens mostly in
+X". There is no honest way to synthesize that, and a plausible-looking guess is the worst possible
+output for a trust artifact. So `deck brief` **computes the absences** (workspace attribution,
+first/last-seen dates, gists, per-step reliability) and hands the author an explicit
+"WHAT THIS RUN DOES NOT HAVE" list, under Mandate 4: *say so in the deck, visibly; never fill the
+hole.* The absence is content.
+
+**Testimony vs. artifact.** The most interesting stories a deck can tell are about things for
+which no file exists: what a rejected first draft looked like, what a gate report said before it
+was superseded. Those are real and worth telling — and they are **testimony**, not recovered
+artifacts. No gate can tell the difference, because there is nothing on disk to compare against.
+Mandate 4 therefore requires the deck to *label* them ("reported, not recovered from a file"),
+distinctly from anything quoted verbatim. This is the one honesty property in deck mode enforced
+by instruction rather than by code, and it is named here so that limit is on the record.
+
+---
+
+## 5. Cost, consent, and refusal
+
+- **Opt-in, one explicit yes**, asked once, after step 9, with the LLM cost named in the question.
+  Unlike demo #1 — which is the skill's advertised second half — a deck is a bonus. The report and
+  the demonstrations are already complete artifacts.
+- **Budget: 2 attempts.** One delegation, plus at most one re-delegation with the verify-red report
+  fed back **verbatim** — the same corrective loop the demonstrations teach, applied to the deck
+  that teaches it.
+- **Refusal is a normal outcome.** Still red after the retry ⇒ do not publish, name the failing
+  gates, move on. A gate-failed deck is discarded, never shipped with a caveat. (This differs from
+  the demo layer's *unavailability* case, where an unverified-but-labelled artifact still
+  publishes: there, a rung could not run; here, a check ran and said no.)
+- **The vision rung is a ladder, not a requirement.** After — and only after — `deck verify`
+  passes: if a vision-analysis tool is available in the session, render/inspect for layout defects
+  and take at most one fix round (re-verifying afterwards, because a visual fix must not break a
+  gate). If no such tool is available, the deck carries `<!-- vision QA: NOT RUN -->`. Same
+  philosophy as the demo lint ladder: **a rung that could not run is labelled, never silently
+  treated as a pass.**
+
+---
+
+## 6. Files
+
+**New:**
+
+| File | Contents |
+|---|---|
+| `scripts/attractor_scout/deck.py` | Brief assembly; the five gates; whitelist construction; the `derived-values` reader; publish-after-gates. |
+| `scripts/attractor_scout/deck_templates.py` | The style/technique contract, the hard constraints, the four mandates, the brief template. No LLM anywhere. |
+| `fixtures/deck_fixture.py` | A clean synthetic deck that clears every gate, plus one mutation per gate class. |
+| `tests/test_scenario9_deck_gates.py` | Green baseline + red proof per gate class + the named-limit regression tests. |
+| `tests/test_scenario10_deck_brief.py` | Brief carries the mandates, the real `.dot` text, the gate verdicts, the absences; CLI exit-code contract (0 / 3). |
+| `docs/designs/2026-08-19-attractor-scout-deck-mode.md` | This document. |
+
+**Changed:** `scripts/attractor_scout_cli.py` (new `deck brief|verify` subcommand; exit code 3
+documented), `scripts/attractor_scout/naming.py` (`DECK_FILENAME`, single naming source preserved),
+`SKILL.md` (step 10, three hard-rule bullets, Output line — no new numeric claims).
+
+**Unchanged:** every module of the mining spine, `demo.py`, `demo_templates.py`, `render.py`, the
+byte-pinned `authoring_contract.py`, and every pre-existing test.
+
+---
+
+## 7. Out of scope
+
+- **Rendering the deck deterministically.** That artifact already exists; it is the report.
+- **Auto-running the vision rung, or making it a requirement.** A missing tool is labelled.
+- **Recomputing derived arithmetic** (see §3.4).
+- **Decks for honest-NOs or waste findings as standalone artifacts.** They are *sections* of the
+  one deck; a deck per finding is spend without teaching.
+- **Any edit to the deterministic renderer's output.** `render.py` is untouched; a deck is a
+  sibling file, never a modification of the map.
+- **Shipping the exemplar.** No sentence of it is committed. Only the method is.

--- a/skills/attractor-scout/SKILL.md
+++ b/skills/attractor-scout/SKILL.md
@@ -275,6 +275,91 @@ generate a second demonstration without a fresh explicit yes** — the first one
 is the skill's second half; every one after it is marginal spend for marginal
 personalization.
 
+**10 — Deck mode (OPT-IN; ask once, and only after step 9).** Steps 7–9 produce
+a deterministic report: a renderer places every number, so no model can invent
+one. Deck mode produces something different — ONE authored, deck-grade,
+personalized page over the same verified data — and pays for that freedom with
+machine gates instead of with a deterministic renderer. Offer it in one
+question, naming the cost out loud:
+
+> *"I can also build a deck-grade version of this — one self-contained page
+> that teaches the ideas and walks your own results, authored rather than
+> templated. It costs one more reasoning-model delegation (two if the gates
+> reject the first draft), and it only publishes if it passes them. Want it?"*
+
+**Never build a deck without an explicit yes.** On yes:
+
+```bash
+source "$WORK/env.sh"
+RUNDIR="$(dirname "$OUTPUT_PATH")"
+BRIEF=$($CLI deck brief --ranked "$WORK/ranked.json" --demos "$WORK/demos.json" \
+        --workdir "$WORK/deck")
+```
+
+`deck brief` writes `$WORK/deck/deck-brief.md` — deterministically assembled
+from the same verified data the report rests on: the ranking, the honest-NOs,
+the waste channel, every generated `.dot` verbatim with its gate verdicts, the
+house style/technique contract, the hard self-containment constraints, and the
+four MANDATES that make the gates passable. Delegate to a **fresh-context
+`reasoning` sub-agent** whose instruction is exactly that file; it writes ONE
+file, `deck.html`, into `$WORK/deck/`. **Cost: one delegation; at most two if
+the gates reject the first draft; never more.**
+
+**Drive that delegation across resumed turns, not one giant request.** A deck is
+tens of thousands of tokens of markup, and a single request that tries to emit
+the whole file in one response reliably exceeds the provider's ~600 s request
+timeout and loses the work. Have the fresh-context author build the file up in
+several turns — the document head/stylesheet/`<defs>` first, then one section
+per turn, then the dialogs and the closing script — resuming the same session
+each turn so it is still ONE fresh context. The brief tells the author this too;
+it is stated here because the orchestrating session is what sequences the turns.
+
+Then gate it:
+
+```bash
+$CLI deck verify --deck "$WORK/deck/deck.html" \
+    --ranked "$WORK/ranked.json" --demos "$WORK/demos.json" \
+    --report "$WORK/deck/deck-gate-report.txt"
+```
+
+`deck verify` is deterministic and it is the only thing that decides whether the
+deck publishes. Five gates: **(a)** the HTML parses; **(b)** the page is
+self-contained — no `<img>`/`<link>`/`<script src>`/`@import`/`<iframe>`/
+`srcset`, `url(` only as `url(#…)`, exactly two https links, zero `file://`;
+**(c)** every modal has a trigger and every trigger has a modal; **(d)** every
+number displayed in visible text re-verifies against the run data or against a
+derivation the deck itself declares, with provenance, in its
+`<script type="application/json" id="derived-values">` block — **an undeclared
+number is FATAL, same as step 5**; **(e)** every pipeline diagram matches its
+real `.dot` node-for-node and edge-for-edge (an edge MULTISET comparison, so a
+back-edge quietly not drawn is caught). Exit 0 means all five passed; **exit 3
+means a gate came back red and the deck must NOT be published**.
+
+If it exits 3, re-delegate **ONCE** with `$WORK/deck/deck-gate-report.txt`
+appended verbatim, then re-verify. Still red? **Do not publish.** Say which
+gates failed and move on — the report and the demonstrations are already
+complete artifacts. On green, publish it beside the report:
+
+```bash
+cp "$WORK/deck/deck.html" "$RUNDIR/attractor-scout-deck.html"
+```
+
+**Optional vision rung — only AFTER `deck verify` passes.** If a
+vision-analysis tool is available in this session, render the published deck to
+images, stitch them, and inspect for layout defects (overlap, clipping,
+unreadable contrast, a diagram running off its viewBox). At most **one** fix
+round: hand the defects back to the same fresh-context author, re-run
+`deck verify` (a visual fix must not break a gate), and republish. If no such
+tool is available, do **not** imply it was checked — leave the honest label in
+the deck's footer comment:
+
+```
+<!-- vision QA: NOT RUN -->
+```
+
+Same ladder philosophy as the demo lint rung: a rung that could not run is
+*labelled*, never silently treated as a pass.
+
 ---
 
 ## Hard rules (non-negotiable — these are the trust contract)
@@ -319,7 +404,20 @@ personalization.
 - **Generated `.dot`/`.md` land beside the HTML, never in a repo** — under
   `attractor-scout-demos/` next to `$OUTPUT_PATH`, and only *after* the gates
   finish. A demo whose gates came back red is not published at all; an
-  unverified-but-labelled demo is.
+  unverified-but-labelled demo is. **The deck lands there too**, as
+  `attractor-scout-deck.html` — never in a repo, and never before
+  `deck verify` exits 0.
+- **Deck mode is opt-in, and a gate-failed deck never publishes.** Ask once,
+  name the cost, and build nothing without a yes. The deck is *authored*, so
+  it does not inherit the renderer's structural guarantee — it earns trust from
+  `deck verify` instead, and a red gate after the one retry means the deck is
+  discarded, not shipped with a caveat. The report and the demonstrations are
+  already complete artifacts; a deck is a bonus, never a hostage.
+- **Every number a deck displays is re-verified or declared.** The deck may do
+  arithmetic the run data does not contain — a total, a percentage, a unit
+  conversion — but it must declare each one, with its provenance, in its own
+  `derived-values` block. An undeclared number is FATAL. And where the run has
+  no value for something, the deck says so out loud; it never fills the hole.
 - **The artifact is not the success test.** A pretty HTML file proves nothing;
   the ranking is only trustworthy because every count in it was re-verified
   against the raw records (step 5, `--strict`). Ship the map, but the map earns
@@ -340,6 +438,12 @@ The HTML embeds the pipeline text as well as naming that path, so the artifact
 stays self-contained if the folder ever moves. The one hyperlink it carries is
 the published explainer — an anchor a reader may follow, not a resource the
 page loads.
+
+Plus, when deck mode was accepted AND every gate passed:
+`attractor-scout-deck.html` beside them — one authored, self-contained,
+deck-grade page over the same verified data, carrying exactly two outbound
+anchors (the explainer and the bundle repository) and loading nothing. A deck
+that failed `deck verify` is never written there at all.
 
 ---
 

--- a/skills/attractor-scout/fixtures/deck_fixture.py
+++ b/skills/attractor-scout/fixtures/deck_fixture.py
@@ -1,0 +1,573 @@
+"""Canned DECK-MODE artifacts — ground truth BY CONSTRUCTION.
+
+CI cannot author a deck (that is one fresh-context `reasoning` delegation), so
+what CI proves is *everything around it*: brief assembly and, above all, the
+five deterministic gates. All of that needs a candidate deck to act on, and
+this module is that candidate — a minimal, clean, self-contained page that
+clears every gate, plus one mutation per gate class that breaks exactly one
+property.
+
+A gate that has never been shown failing is not a gate. So:
+
+* `broken_nesting()`        — an unclosed container: gate (a) goes red.
+* `with_external_resource()`— an `<img>`: gate (b) goes red.
+* `with_orphan_dialog()`    — a modal no trigger opens: gate (c) goes red.
+* `with_fabricated_number()`— a figure the run never produced: gate (d) red.
+* `without_derived_block()` — a real derivation, undeclared: gate (d) red.
+* `with_unprovenanced_derivation()` — declared with no `from`: gate (d) red.
+* `with_edge_dropped()`     — one back-edge undrawn: gate (e) red.
+
+**ZERO real data.** Every name here is synthetic and marked as such; the unit
+name carries the `SYNTHETIC-` marker discipline the corpus fixtures use, and
+`tests/test_no_real_data_leak.py` re-checks that claim on every run.
+"""
+
+from __future__ import annotations
+
+DECK_UNIT_NAME = "SYNTHETIC-UNIT-K repair the generated report until the check is green"
+DECK_UNIT_ID = "k1"
+DECK_SLUG = "synthetic-unit-k-k1"
+
+#: 6 nodes, 7 edges — the convergence-factory shape in miniature. The edge
+#: multiset is what gate (e) compares, so this is deliberately a shape with
+#: two edges INTO the budget wall: dropping either one must be caught.
+DECK_DOT = """\
+// SYNTHETIC deck-mode demonstration pipeline (test fixture). Not mined from anyone.
+digraph SyntheticDeckDemo {
+    start [shape=Mdiamond]
+    exit  [shape=Msquare]
+
+    worker [shape=box,
+        prompt="Advance the repair. Read the last check output, fix exactly what it reports, and change nothing it does not force you to change."]
+
+    verify_gate [shape=parallelogram, max_retries=0,
+        tool_command="pytest -q"]
+
+    budget_wall [shape=parallelogram, max_retries=0,
+        tool_command="n=$(cat .k/iter 2>/dev/null || echo 0); n=$((n+1)); echo $n > .k/iter; max_attempts=3; if [ $n -ge $max_attempts ]; then echo budget_exhausted; else echo under_budget; fi"]
+
+    loud_fail [shape=parallelogram, max_retries=0,
+        tool_command="echo 'NOT CONVERGED: the check never went green' >&2; exit 1"]
+
+    start -> worker
+    worker -> verify_gate [condition="outcome=success"]
+    worker -> budget_wall [condition="outcome=fail"]
+    verify_gate -> exit [label="pass", condition="outcome=success"]
+    verify_gate -> budget_wall [label="fail", condition="outcome=fail"]
+    budget_wall -> worker [label="under_budget", condition="context.tool.last_line=under_budget && outcome=success"]
+    budget_wall -> loud_fail [label="budget_exhausted", condition="context.tool.last_line=budget_exhausted && outcome=success"]
+}
+"""
+
+#: Every node id in DECK_DOT, in draw order.
+DECK_NODES = ("start", "worker", "verify_gate", "exit", "budget_wall", "loud_fail")
+
+#: Every edge in DECK_DOT, as the deck's `data-edge` attributes spell them.
+DECK_EDGES = (
+    "start->worker",
+    "worker->verify_gate",
+    "worker->budget_wall",
+    "verify_gate->exit",
+    "verify_gate->budget_wall",
+    "budget_wall->worker",
+    "budget_wall->loud_fail",
+)
+
+
+def deck_ranked_fixture() -> dict:
+    """A minimal `ranked.json`: one opportunity, one honest-NO, one waste find."""
+    return {
+        "opportunities": [
+            {
+                "unit_id": DECK_UNIT_ID,
+                "name": DECK_UNIT_NAME,
+                "n_sessions": 7,
+                "leverage": 32.5,
+                "fit": 1,
+                "score": 22.75,
+                "author": "human",
+                "verdict": "OPPORTUNITY",
+                "recovery": "PASS",
+                "confidence": "high",
+                "provisional": False,
+                "trajectory": "escalating",
+                "gist": "SYNTHETIC scenario: run the check, fix what it reports, run it again.",
+                "leverage_detail": {
+                    "n_sessions": 7,
+                    "med_tool_calls": 12.0,
+                    "med_llm_cycles": 4.0,
+                    "med_span_capped_s": 930.0,
+                    "errors_per_session": 0.33,
+                },
+                "fit_detail": {"cycle": True, "gate": True},
+            }
+        ],
+        "honest_no": [
+            {
+                "unit_id": "k2",
+                "name": "SYNTHETIC-UNIT-L draft the weekly summary",
+                "n_sessions": 5,
+                "leverage": 9.0,
+                "verdict": "HONEST-NO",
+                "no_class": "recipe",
+                "failed_subtest": "4a",
+                "remediation": "This runs straight through. A script, or just doing it, beats a pipeline here.",
+                "gist": "SYNTHETIC scenario: assemble the same summary from the same places each week.",
+            }
+        ],
+        "waste_findings": [
+            {
+                "unit_id": "k3",
+                "name": "SYNTHETIC-UNIT-M trivial liveness probes",
+                "author": "harness",
+                "n_sessions": 11,
+                "leverage": 1.25,
+                "reclaimable_hours": 1.5,
+                "note": "harness ceremony - a waste finding to eliminate, not an opportunity to act on",
+            }
+        ],
+        "below_frequency_floor": [],
+        "summary": {
+            "n_units_in": 3,
+            "n_admitted": 2,
+            "n_waste": 1,
+            "n_opportunities": 1,
+            "n_honest_no": 1,
+            "n_below_floor": 0,
+            "honest_no_rate": 0.5,
+        },
+    }
+
+
+def deck_demos_fixture() -> dict:
+    """A minimal `demos.json` carrying the fixture pipeline verbatim."""
+    return {
+        "primer": True,
+        "explainer_url": "https://microsoft.github.io/amplifier-bundle-attractor/attractor-explained.html",
+        "demos": [
+            {
+                "unit_id": DECK_UNIT_ID,
+                "name": DECK_UNIT_NAME,
+                "slug": DECK_SLUG,
+                "dot_relpath": f"attractor-scout-demos/{DECK_SLUG}.dot",
+                "companion_relpath": f"attractor-scout-demos/{DECK_SLUG}.md",
+                "dot_text": DECK_DOT,
+                "stats": {
+                    "n_sessions": 7,
+                    "med_tool_calls": 12.0,
+                    "med_llm_cycles": 4.0,
+                    "med_span_s": 930.0,
+                    "err_rate": 0.33,
+                    "provisional": False,
+                },
+                "fit": {"cycle": True, "gate": True, "recovery": "PASS", "verdict": "OPPORTUNITY"},
+                "narrative": {
+                    "scenario_gist": "You run the check, fix what it reports, and run it again.",
+                    "q1_cycle_note": "Yes: attempted, checked, re-attempted.",
+                    "q2_gate_note": "Yes: the check is red before and green after.",
+                    "q3_recovery_note": "A bad attempt is caught by the gate and paid for by the budget.",
+                    "pipeline_walk": [
+                        {"node": "worker", "note": "the worker: reads the last failure and fixes exactly that."},
+                        {"node": "verify_gate", "note": "the evidence gate: runs the real check."},
+                    ],
+                    "payoff_note": "The loop stops on evidence you already trust.",
+                },
+                "convergence_math": {
+                    "chain_len": 4,
+                    "p_step": 0.9,
+                    "once_through": 0.6561,
+                    "gated_loop": 0.8817,
+                    "budget": 2,
+                    "label": "illustrative arithmetic - not a measurement of your sessions",
+                },
+                "verification": {
+                    "level": "doctrine-only",
+                    "lint_verdict": None,
+                    "lint_not_run_reason": "attractor lint: NOT RUN - the CLI is not installed here.",
+                    "doctrine_verdict": "doctrine_ok",
+                    "doctrine_report": "AUTHORED-PIPELINE DOCTRINE REPORT\nverdict:   doctrine_ok\n",
+                },
+                "invocation": {
+                    "run_cmd": f"attractor run attractor-scout-demos/{DECK_SLUG}.dot --cwd .",
+                    "author_cmd": "attractor run examples/authoring/pipeline-author.dot --cwd .",
+                    "install_cmd": "uv tool install attractor",
+                },
+                "generated_at": "2026-08-19T00:00:00+00:00",
+            }
+        ],
+    }
+
+
+# --------------------------------------------------------------------------
+# The clean deck.
+# --------------------------------------------------------------------------
+
+_NODE_ROWS = "\n".join(
+    f'      <g {"data-node"}="{node}"><rect class="n" x="{20 + 130 * i}" y="40" width="110" height="46" rx="6"/>'
+    f'<text class="nl" x="{75 + 130 * i}" y="68" text-anchor="middle">{node}</text></g>'
+    for i, node in enumerate(DECK_NODES)
+)
+
+_EDGE_ROWS = "\n".join(
+    f'      <line class="e" data-edge="{edge.replace("->", "-&gt;")}" '
+    f'x1="{20 + 20 * i}" y1="110" x2="{60 + 20 * i}" y2="110" marker-end="url(#ar)"/>'
+    for i, edge in enumerate(DECK_EDGES)
+)
+
+CLEAN_DECK = f"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Your work, mapped &mdash; a synthetic deck</title>
+<meta name="description" content="A synthetic deck-mode fixture: one opportunity, one honest NO, one waste finding.">
+<style>
+  :root {{ --ink:#eef2f7; --bg:#0b0e13; --accent:#ffa62b; --pass:#45d483; }}
+  body {{ background:var(--bg); color:var(--ink);
+    font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif; }}
+  .n {{ fill:#151b23; stroke:#3a4855; }}
+  .e {{ stroke:#3a4855; }}
+  .hot:focus-visible {{ outline:2px solid var(--accent); }}
+  @media (prefers-reduced-motion: reduce) {{ * {{ animation:none !important; transition:none !important; }} }}
+</style>
+</head>
+<body>
+<svg aria-hidden="true" focusable="false" style="position:absolute;width:0;height:0;overflow:hidden">
+  <defs>
+    <marker id="ar" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6"
+      orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="#3a4855"/></marker>
+  </defs>
+</svg>
+
+<main>
+<section id="map">
+  <h1>Your work, mapped.</h1>
+  <p>Something on this machine read your own session history and grouped it into recurring units of
+  work. Nothing left the machine.</p>
+  <p>One unit came back loop-shaped. It shows up in seven distinct sessions, and each one costs a
+  median of twelve tool calls before it lands.</p>
+  <p>Across the opportunity and the waste ledger together, eighteen sessions are accounted for.</p>
+</section>
+
+<section id="shape">
+  <h2>An attractor is a basin, not a checklist.</h2>
+  <p>Work that is attempted, checked against evidence produced outside the worker, and re-attempted
+  until it lands &mdash; under a budget that routes exhaustion somewhere honest.</p>
+  <p>The three-question test: is there a cycle? is the exit gated on machine-checkable evidence?
+  would it survive one node having a bad day?</p>
+  <p>Illustrative arithmetic, not a measurement of your sessions: a four-step chain that has to get
+  every step right once has worse odds than the same chain inside a gated loop with a budget.</p>
+</section>
+
+<section id="opportunities">
+  <h2>One piece of your work is already loop-shaped.</h2>
+  <p class="hot" role="button" tabindex="0" data-modal="m-unit">The repair loop &mdash; seven
+  sessions, twelve median tool calls. Open detail.</p>
+  <p>This run recorded no project attribution for that unit, so this page does not name one.</p>
+</section>
+
+<section id="demos">
+  <h2>One of them was built, not just recommended.</h2>
+  <svg class="dg" viewBox="0 0 900 200" role="img" aria-labelledby="d1T d1D" data-diagram="{DECK_SLUG}">
+      <title id="d1T">The generated repair pipeline: six nodes and seven edges</title>
+      <desc id="d1D">Start leads to the worker. The worker leads to the verify gate on success and
+      to the budget wall on failure. The gate passes to the exit or fails into the budget wall. The
+      budget wall either routes back to the worker or out to a loud failure that is not an exit
+      node.</desc>
+{_NODE_ROWS}
+{_EDGE_ROWS}
+  </svg>
+  <p>Six nodes, seven edges, one door. The authoring contract came back clean; the engine's own
+  linter did not run here, and this page does not pretend it did.</p>
+</section>
+
+<section id="honest">
+  <h2>One recurring habit that is still not worth automating.</h2>
+  <p>The weekly summary runs straight through. That is a recipe, not an attractor, and the honest
+  answer is to keep doing it by hand or write a script.</p>
+  <p>Separately, the waste ledger holds harness ceremony worth about an hour and a half.</p>
+</section>
+
+<section id="forward">
+  <h2>Four doors, smallest commitment first.</h2>
+  <p>Read the explainer. Try the conversational designer on one piece of work. Copy the canonical
+  skeleton. Run the authoring pipeline under executed gates.</p>
+</section>
+</main>
+
+<footer>
+  <p>The full explainer:
+  <a href="https://microsoft.github.io/amplifier-bundle-attractor/attractor-explained.html">attractor, explained</a></p>
+  <p>The bundle:
+  <a href="https://github.com/microsoft/amplifier-bundle-attractor">the bundle repository</a></p>
+</footer>
+
+<dialog id="m-unit" aria-labelledby="h-unit">
+  <div class="mbox" tabindex="-1">
+    <h3 id="h-unit">The repair loop</h3>
+    <p>Seven distinct sessions. A median of twelve tool calls and four LLM cycles per session, over
+    a median span of nine hundred and thirty seconds, with about a third of an error per session.</p>
+    <button class="m-close" type="button" aria-label="Close">Close</button>
+  </div>
+</dialog>
+
+<script type="application/json" id="derived-values">
+[
+  {{"value": "18",
+   "from": "7 sessions inside the one opportunity + 11 in the waste ledger",
+   "inputs": ["7", "11"]}}
+]
+</script>
+
+<script>
+(function(){{
+  "use strict";
+  var triggers = document.querySelectorAll("[data-modal]");
+  Array.prototype.forEach.call(triggers, function(el){{
+    el.addEventListener("click", function(){{
+      var d = document.getElementById(el.getAttribute("data-modal"));
+      if (d && typeof d.showModal === "function") {{ d.showModal(); }}
+    }});
+  }});
+}})();
+</script>
+</body>
+</html>
+"""
+
+
+# --------------------------------------------------------------------------
+# The mutations — one broken property each.
+# --------------------------------------------------------------------------
+
+
+def clean_deck() -> str:
+    return CLEAN_DECK
+
+
+def broken_nesting() -> str:
+    """Gate (a): a container element that is never closed."""
+    return CLEAN_DECK.replace('</section>\n\n<section id="shape">', '\n\n<section id="shape">', 1)
+
+
+def with_external_resource() -> str:
+    """Gate (b): a resource the page would have to fetch."""
+    return CLEAN_DECK.replace(
+        "<h1>Your work, mapped.</h1>",
+        '<h1>Your work, mapped.</h1>\n  <img src="chart.png" alt="a chart">',
+        1,
+    )
+
+
+def with_orphan_dialog() -> str:
+    """Gate (c): a modal no trigger can open."""
+    return CLEAN_DECK.replace(
+        '<script type="application/json" id="derived-values">',
+        '<dialog id="m-orphan"><div class="mbox"><h3>Unreachable</h3></div></dialog>\n\n'
+        '<script type="application/json" id="derived-values">',
+        1,
+    )
+
+
+def with_fabricated_number() -> str:
+    """Gate (d): a figure this run never produced, stated as fact."""
+    return CLEAN_DECK.replace(
+        "One unit came back loop-shaped.",
+        "One unit came back loop-shaped, out of 4812 units examined.",
+        1,
+    )
+
+
+def without_derived_block() -> str:
+    """Gate (d): the deck does real arithmetic and never declares it."""
+    start = CLEAN_DECK.index('<script type="application/json" id="derived-values">')
+    end = CLEAN_DECK.index("</script>", start) + len("</script>")
+    stripped = CLEAN_DECK[:start] + CLEAN_DECK[end:]
+    # State the derived total in digits, so the scan has something to catch.
+    return stripped.replace("eighteen sessions are accounted for", "18 sessions are accounted for", 1)
+
+
+def with_unprovenanced_derivation() -> str:
+    """Gate (d): declared, but with no arithmetic provenance."""
+    return CLEAN_DECK.replace(
+        '"from": "7 sessions inside the one opportunity + 11 in the waste ledger",',
+        '"from": "",',
+        1,
+    )
+
+
+def with_edge_dropped() -> str:
+    """Gate (e): the corrective back-edge is simply not drawn."""
+    dropped = DECK_EDGES[-2].replace("->", "-&gt;")
+    lines = [line for line in CLEAN_DECK.splitlines(keepends=True) if f'data-edge="{dropped}"' not in line]
+    return "".join(lines)
+
+
+def with_node_added() -> str:
+    """Gate (e): a node drawn for visual balance that the pipeline never had."""
+    return CLEAN_DECK.replace(
+        '<g data-node="start">',
+        '<g data-node="tidy_up"><rect class="n" x="20" y="150" width="80" height="30" rx="6"/></g>\n'
+        '      <g data-node="start">',
+        1,
+    )
+
+
+# ---- FIX 1: derived-values self-dealing (inputs now mandatory) -------------
+
+
+def with_inputless_derivation() -> str:
+    """Gate (d): the reviewer's exact probe --- a fabricated value with a junk
+    one-word `from` and NO `inputs`. Used to PASS; must now be RED."""
+    body = CLEAN_DECK.replace(
+        "One unit came back loop-shaped.",
+        "One unit came back loop-shaped, out of 8731 examined.",
+        1,
+    )
+    return body.replace(
+        '[\n  {"value": "18",\n   "from": "7 sessions inside the one opportunity + 11 in the waste ledger",\n   "inputs": ["7", "11"]}\n]',
+        '[\n  {"value": "8731", "from": "qqq"}\n]',
+        1,
+    )
+
+
+def with_empty_inputs_derivation() -> str:
+    """Gate (d): inputs present but empty --- still a bare assertion, RED."""
+    return CLEAN_DECK.replace('"inputs": ["7", "11"]', '"inputs": []', 1)
+
+
+def with_from_not_referencing_inputs() -> str:
+    """Gate (d): real inputs, but a `from` that references neither --- RED."""
+    return CLEAN_DECK.replace(
+        '"from": "7 sessions inside the one opportunity + 11 in the waste ledger",',
+        '"from": "a total of some sessions",',
+        1,
+    )
+
+
+def with_wrong_total_but_real_inputs() -> str:
+    """Gate (d) NAMED LIMIT (expected PASS): real inputs, `from` references them,
+    but the arithmetic is wrong (7 + 11 != 900). The gate does not recompute, so
+    this passes --- the declarative-provenance residual, kept on purpose."""
+    body = CLEAN_DECK.replace(
+        "eighteen sessions are accounted for",
+        "900 sessions are accounted for",
+        1,
+    )
+    return body.replace(
+        '{"value": "18",\n   "from": "7 sessions inside the one opportunity + 11 in the waste ledger",\n   "inputs": ["7", "11"]}',
+        '{"value": "900",\n   "from": "7 sessions plus 11 in the waste ledger",\n   "inputs": ["7", "11"]}',
+        1,
+    )
+
+
+# ---- FIX 2: gate (b) blocklist holes --------------------------------------
+
+
+def _inject_after_h1(snippet: str) -> str:
+    return CLEAN_DECK.replace("<h1>Your work, mapped.</h1>", "<h1>Your work, mapped.</h1>\n  " + snippet, 1)
+
+
+def with_object_data() -> str:
+    """Gate (b): <object data="https://..."> loads an external resource."""
+    return _inject_after_h1('<object data="https://example.invalid/x.pdf" type="application/pdf"></object>')
+
+
+def with_xlink_href() -> str:
+    """Gate (b): SVG xlink:href to an external image (the `\\shref` count is blind to it)."""
+    return _inject_after_h1('<svg><image xlink:href="https://example.invalid/x.png" width="10" height="10"/></svg>')
+
+
+def with_media_source() -> str:
+    """Gate (b): <video><source src="https://..."> --- both the element and the src."""
+    return _inject_after_h1('<video controls><source src="https://example.invalid/x.mp4" type="video/mp4"></video>')
+
+
+def with_embed() -> str:
+    """Gate (b): <embed src="https://...">."""
+    return _inject_after_h1('<embed src="https://example.invalid/x.swf" type="application/x-shockwave-flash">')
+
+
+def with_track() -> str:
+    """Gate (b): <track src="https://...">."""
+    return _inject_after_h1('<track src="https://example.invalid/subs.vtt" kind="subtitles">')
+
+
+def with_use_href() -> str:
+    """Gate (b): SVG <use href="https://..."> pointing at an external document."""
+    return _inject_after_h1('<svg><use href="https://example.invalid/icons.svg#gear"/></svg>')
+
+
+def with_local_use_href() -> str:
+    """Gate (b) expected PASS: <use href="#local"> is a legal same-document reference."""
+    return _inject_after_h1('<svg><use href="#ar"/></svg>')
+
+
+# ---- FIX 3: gate (d) blind to script-injected text ------------------------
+
+
+def with_script_injected_number() -> str:
+    """Gate (d): a fabricated number injected by JS into a displayed string.
+    Never appears as a DOM text node; must be caught in the script literal."""
+    return CLEAN_DECK.replace(
+        '  "use strict";',
+        '  "use strict";\n  document.title = "8731 units examined";',
+        1,
+    )
+
+
+def with_script_geometry_string() -> str:
+    """Gate (d) NAMED LIMIT (expected PASS): a CSS/geometry string literal with
+    digits but no prose word (like the exemplar's IntersectionObserver rootMargin)
+    is not treated as a displayed claim."""
+    return CLEAN_DECK.replace(
+        '  "use strict";',
+        '  "use strict";\n  var rootMargin = "-45% 0px -50% 0px";',
+        1,
+    )
+
+
+def with_script_concatenated_number() -> str:
+    """Gate (d) NAMED LIMIT (expected PASS): a number built by concatenation from
+    a bare numeric literal (not inside a string) is not a literal and is not seen."""
+    return CLEAN_DECK.replace(
+        '  "use strict";',
+        '  "use strict";\n  var label = "" + 8731 + " units examined";',
+        1,
+    )
+
+
+__all__ = [
+    "CLEAN_DECK",
+    "DECK_DOT",
+    "DECK_EDGES",
+    "DECK_NODES",
+    "DECK_SLUG",
+    "DECK_UNIT_ID",
+    "DECK_UNIT_NAME",
+    "broken_nesting",
+    "clean_deck",
+    "deck_demos_fixture",
+    "deck_ranked_fixture",
+    "with_edge_dropped",
+    "with_embed",
+    "with_empty_inputs_derivation",
+    "with_external_resource",
+    "with_fabricated_number",
+    "with_from_not_referencing_inputs",
+    "with_inputless_derivation",
+    "with_local_use_href",
+    "with_media_source",
+    "with_node_added",
+    "with_object_data",
+    "with_orphan_dialog",
+    "with_script_concatenated_number",
+    "with_script_geometry_string",
+    "with_script_injected_number",
+    "with_track",
+    "with_unprovenanced_derivation",
+    "with_use_href",
+    "with_wrong_total_but_real_inputs",
+    "with_xlink_href",
+    "without_derived_block",
+]

--- a/skills/attractor-scout/scripts/attractor_scout/deck.py
+++ b/skills/attractor-scout/scripts/attractor_scout/deck.py
@@ -1,0 +1,1109 @@
+"""DECK MODE: brief assembly, and the deterministic gates a deck must clear.
+
+The map (step 7) and the demonstrations (steps 8-9) are produced by a
+deterministic renderer over re-verified data, so their trust story is
+structural: no language model ever places a number. Deck mode gives that up on
+purpose --- a deck-grade page is *authored*, by a fresh-context delegate, in one
+file, with its own layout and its own prose --- and buys the trust back with
+gates instead.
+
+That is the whole design: **what the renderer guaranteed by construction, the
+gates here guarantee by inspection.** Five of them, all deterministic, all
+stdlib, run over the candidate deck plus the run's own data:
+
+  a. **It parses.** Container elements nest and close.
+  b. **It is self-contained.** No `<img>`/`<link>`/`<script src>`/`@import`/
+     `<iframe>`/`srcset`; `url(` only ever as `url(#...)`; exactly two https
+     hrefs; zero `file://`. A page that fetches is a page that can break, leak
+     a referrer, or render differently tomorrow.
+  c. **Every modal has a trigger, every trigger has a modal.** An orphan
+     dialog is dead weight the reader can never reach; a trigger pointing at
+     nothing is a button that lies.
+  d. **Every displayed number resolves.** ★ The load-bearing gate. Each numeric
+     token in the deck's visible text must resolve against a whitelist built
+     from the run data, the generated pipelines' own numerics, and the machine
+     gate reports --- or be declared, with arithmetic provenance, in the deck's
+     own `derived-values` JSON block. An unresolvable token fails the deck and
+     names itself.
+  e. **Every pipeline diagram is the real pipeline.** Node set and edge
+     MULTISET, read off `data-node`/`data-edge` attributes, must equal the
+     `.dot`'s. A diagram that quietly drops the awkward back-edge is a diagram
+     that teaches the wrong shape.
+
+`verify_deck` returns a report; the CLI exits 0 only when every gate passed.
+**A gate-failed deck is never published** --- the same posture as
+`demo assemble`'s red verdict, for the same reason.
+
+Gate (d) scans DOM text nodes, the `<meta name="description">` content, AND
+prose-bearing string literals in every executable inline `<script>` body (so a
+number injected by JS, e.g. `document.title = "8731 units examined"`, cannot
+slip past a scan of the static DOM). Three named limits, documented rather than
+closed, each with an expected-pass regression test in
+``tests/test_scenario9_deck_gates.py`` so a future "I fixed it" is forced to
+update this docstring honestly:
+
+* **Spelled-out numbers.** "twenty-five noes" is not a numeric token and
+  passes. Detecting written numerals is NLP guesswork, and a fail-loud guard
+  that guessed wrong would block honest prose --- the worse failure for a trust
+  surface whose whole value is not crying wolf. (The brief tells the author
+  this in as many words, and tells them not to use it as a loophole.)
+* **Decomposition.** A whitelisted ``397.5`` also whitelists the bare runs
+  ``397`` and ``5``, because a rendered stat's own sub-runs are how legitimate
+  prose refers to it ("397 hours and change"). Closing it would ban the
+  honest reference; ``398`` is still rejected, so the leak is bounded to runs a
+  supplied number literally contains. On real data this is not a rare edge:
+  0--9 are all free (structural), roughly 94% of 10--99 and only ~14% of
+  100--999 resolve from a typical run's supplied set, so a fabricated
+  two-digit figure is far likelier to ride a decomposition than a three-digit
+  one --- the design doc (§3.2) states the measured figures.
+* **Computed / concatenated script strings.** The script scan reads string
+  LITERALS only. A number assembled at runtime (`"" + n + " units"`), or
+  written as a bare numeric literal in code rather than inside a string, is not
+  a literal and is not seen. And only PROSE-bearing literals (a 3+ letter word)
+  are checked, so a CSS/geometry string (``"-45% 0px -50% 0px"``) is not
+  treated as a displayed claim --- which is exactly the false positive that
+  scanning every literal would produce, and the reason the recovered exemplar's
+  own IntersectionObserver `rootMargin` does not trip the gate.
+
+A scope boundary, stated so it cannot quietly widen: numbers inside non-text
+attribute values (`aria-label`, `id`, `viewBox`, path geometry) are NOT
+scanned --- SVG coordinates are numbers by the thousand and whitelisting them
+would gut the gate, while flagging them would make it useless. The deck's
+*visible* claims are what the reader trusts, and those are what is checked.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+from collections import Counter
+from dataclasses import dataclass, field
+from html.parser import HTMLParser
+from pathlib import Path
+
+from . import deck_templates as DT
+from .errors import AttractorScoutError
+from .naming import DECK_FILENAME
+
+# --------------------------------------------------------------------------
+# Constants.
+# --------------------------------------------------------------------------
+
+#: One authoring delegation, plus at most one gate-informed retry. Never more.
+DECK_MAX_ATTEMPTS = 2
+
+#: Small integers the deck may always state: Q1/Q2/Q3, the 4a/4b/4c sub-tests,
+#: and ordinary structural counts of the test itself. They name structure, not
+#: measurements --- the same allowance `demo.validate_narrative` makes.
+STRUCTURAL_DIGITS = frozenset({"0", "1", "2", "3", "4"})
+
+#: String-valued fields whose digit runs are legitimately quotable: machine
+#: output the deck relays verbatim, identifiers the run itself assigned, and
+#: the pipeline text. Numbers inside these are supplied data, not invention.
+NUMERIC_STRING_FIELDS = frozenset(
+    {
+        "author_cmd",
+        "companion_relpath",
+        "doctrine_report",
+        "dot_relpath",
+        "dot_text",
+        "generated_at",
+        "install_cmd",
+        "level",
+        "lint_not_run_reason",
+        "lint_verdict",
+        "run_cmd",
+        "slug",
+        "unit_id",
+    }
+)
+
+#: Container elements whose nesting gate (a) enforces. Deliberately excludes
+#: the implicit-close family (`p`, `li`, `td`, ...) and SVG leaf shapes, which
+#: are legally written unclosed or self-closed and would produce noise, not
+#: signal.
+BALANCED_TAGS = frozenset(
+    {
+        "html",
+        "head",
+        "body",
+        "style",
+        "script",
+        "main",
+        "section",
+        "article",
+        "aside",
+        "nav",
+        "header",
+        "footer",
+        "dialog",
+        "div",
+        "svg",
+        "g",
+        "defs",
+        "marker",
+        "table",
+        "ul",
+        "ol",
+        "figure",
+        "button",
+        "pre",
+        "blockquote",
+        "details",
+        "form",
+        "h1",
+        "h2",
+        "h3",
+        "h4",
+        "h5",
+        "h6",
+    }
+)
+
+VOID_TAGS = frozenset(
+    {"area", "base", "br", "col", "embed", "hr", "img", "input", "link", "meta", "param", "source", "track", "wbr"}
+)
+
+#: A numeric token: an optionally thousands-grouped integer with an optional
+#: decimal tail. Grouping must be exact 3-digit runs, so "sections 1,2 and 3"
+#: reads as three tokens rather than one bogus 12.
+_NUMBER_TOKEN_RE = re.compile(r"\d{1,3}(?:,\d{3})+(?:\.\d+)?|\d+(?:\.\d+)?")
+_DIGIT_RUN_RE = re.compile(r"\d+")
+
+_HTTPS_HREF_RE = re.compile(r"""\shref\s*=\s*["'](https://[^"']*)["']""", re.IGNORECASE)
+_URL_FUNC_RE = re.compile(r"url\(\s*([^)]*)\)", re.IGNORECASE)
+
+#: Any start tag carrying a `src=` attribute. A self-contained one-file deck
+#: loads nothing, so ANY `src=` is a violation --- this catches script/img/
+#: iframe/source/embed/track/video/audio/frame in one sweep.
+_SRC_ATTR_RE = re.compile(r"<[a-zA-Z][^>]*\bsrc\s*=", re.IGNORECASE)
+
+#: `xlink:href` (the legacy SVG resource attribute) --- the plain `\shref`
+#: count below cannot see it, because the colon breaks the whitespace boundary.
+_XLINK_HREF_RE = re.compile(r"""xlink:href\s*=\s*["']([^"']*)["']""", re.IGNORECASE)
+
+#: External `href` on the SVG resource elements `<use>` / `<image>` (a local
+#: `#fragment` is legal; anything else pulls in an external document).
+_USE_HREF_RE = re.compile(r"""<(?:use|image)\b[^>]*?\shref\s*=\s*["']([^"']*)["']""", re.IGNORECASE)
+
+#: A JS string literal --- double, single, or backtick quoted.
+_JS_STRING_RE = re.compile(r'"(?:[^"\\]|\\.)*"|\'(?:[^\'\\]|\\.)*\'|`(?:[^`\\]|\\.)*`', re.DOTALL)
+
+#: A run of 3+ ASCII letters --- the mark of PROSE inside a string literal.
+#: Only prose-bearing script strings are number-checked, so a bare CSS/geometry
+#: string (``"-45% 0px -50% 0px"``, ``"0 0 900 340"``) is not treated as a
+#: displayed claim; a displayed claim (``"8731 units examined"``) always is.
+_PROSE_WORD_RE = re.compile(r"[A-Za-z]{3,}")
+
+
+class DeckGateRed(AttractorScoutError):
+    """A deterministic deck gate returned a red verdict --- do not publish.
+
+    Distinct from every other fail-loud condition here: the inputs were fine
+    and the tooling worked. The authored deck is what failed, and the honest
+    response is to re-delegate once with the gate report attached, then stop.
+    """
+
+
+# --------------------------------------------------------------------------
+# Deck document parsing.
+# --------------------------------------------------------------------------
+
+
+@dataclass
+class DeckSvg:
+    """One inline SVG, with the fidelity attributes it declared."""
+
+    diagram: str | None = None
+    nodes: list[str] = field(default_factory=list)
+    edges: list[str] = field(default_factory=list)
+
+
+class _DeckParser(HTMLParser):
+    """Structural read of a candidate deck. Never raises on content."""
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.stack: list[tuple[str, int]] = []
+        self.nesting_errors: list[str] = []
+        self.text_parts: list[str] = []
+        self.dialog_ids: list[str] = []
+        self.trigger_targets: list[str] = []
+        self.svgs: list[DeckSvg] = []
+        self.json_blocks: dict[str, list[str]] = {}
+        self.script_bodies: list[str] = []
+        self.meta_description: str | None = None
+        self._svg_stack: list[DeckSvg] = []
+        self._suppress_text = 0
+        self._json_block_id: str | None = None
+        self._capturing_js = False
+        self._js_buf: list[str] = []
+
+    # -- helpers ---------------------------------------------------------
+    def _start(self, tag: str, attrs: list[tuple[str, str | None]], *, self_closing: bool) -> None:
+        adict = {k.lower(): (v if v is not None else "") for k, v in attrs}
+        if tag == "svg":
+            svg = DeckSvg(diagram=adict.get(DT.DIAGRAM_ATTR) or None)
+            self.svgs.append(svg)
+            self._svg_stack.append(svg)
+        if self._svg_stack:
+            current = self._svg_stack[-1]
+            if DT.NODE_ATTR in adict:
+                current.nodes.append(adict[DT.NODE_ATTR])
+            if DT.EDGE_ATTR in adict:
+                current.edges.append(adict[DT.EDGE_ATTR])
+        if tag == "dialog" and adict.get("id"):
+            self.dialog_ids.append(adict["id"])
+        if adict.get("data-modal"):
+            self.trigger_targets.append(adict["data-modal"])
+        if tag == "meta" and adict.get("name", "").lower() == "description":
+            self.meta_description = adict.get("content", "")
+        if tag in ("style", "script"):
+            self._suppress_text += 1
+            if tag == "script":
+                if adict.get("id"):
+                    self._json_block_id = adict["id"]
+                # Capture EXECUTABLE (non-JSON, non-external) script bodies so
+                # their string literals can be number-checked (gate d). The
+                # derived-values block is `type="application/json"`, so it is
+                # NOT captured here --- its numbers are read as declarations.
+                stype = adict.get("type", "").strip().lower()
+                if not adict.get("src") and "json" not in stype:
+                    self._capturing_js = True
+        if self_closing or tag in VOID_TAGS:
+            if tag == "svg" and self._svg_stack:
+                self._svg_stack.pop()
+            if tag in ("style", "script"):
+                self._suppress_text = max(0, self._suppress_text - 1)
+                self._json_block_id = None
+                self._capturing_js = False
+            return
+        if tag in BALANCED_TAGS:
+            self.stack.append((tag, self.getpos()[0]))
+
+    # -- HTMLParser hooks ------------------------------------------------
+    def handle_starttag(self, tag, attrs):
+        self._start(tag.lower(), attrs, self_closing=False)
+
+    def handle_startendtag(self, tag, attrs):
+        self._start(tag.lower(), attrs, self_closing=True)
+
+    def handle_endtag(self, tag):
+        tag = tag.lower()
+        if tag == "svg" and self._svg_stack:
+            self._svg_stack.pop()
+        if tag in ("style", "script"):
+            self._suppress_text = max(0, self._suppress_text - 1)
+            self._json_block_id = None
+            if tag == "script" and self._capturing_js:
+                self.script_bodies.append("".join(self._js_buf))
+                self._js_buf = []
+                self._capturing_js = False
+        if tag not in BALANCED_TAGS:
+            return
+        if not self.stack:
+            self.nesting_errors.append(f"line {self.getpos()[0]}: </{tag}> with nothing open")
+            return
+        if self.stack[-1][0] == tag:
+            self.stack.pop()
+            return
+        for depth in range(len(self.stack) - 1, -1, -1):
+            if self.stack[depth][0] == tag:
+                unclosed = [t for t, _ in self.stack[depth + 1 :]]
+                self.nesting_errors.append(
+                    f"line {self.getpos()[0]}: </{tag}> closed while {', '.join(f'<{u}>' for u in unclosed)} still open"
+                )
+                del self.stack[depth:]
+                return
+        self.nesting_errors.append(f"line {self.getpos()[0]}: </{tag}> has no matching opening tag")
+
+    def handle_data(self, data):
+        if self._json_block_id:
+            self.json_blocks.setdefault(self._json_block_id, []).append(data)
+        if self._capturing_js:
+            self._js_buf.append(data)
+        if self._suppress_text:
+            return
+        self.text_parts.append(data)
+
+    def close(self):
+        super().close()
+        for tag, line in self.stack:
+            self.nesting_errors.append(f"line {line}: <{tag}> was never closed")
+        self.stack = []
+
+
+@dataclass
+class DeckDocument:
+    raw: str
+    parser: _DeckParser
+
+    @property
+    def visible_text(self) -> str:
+        parts = list(self.parser.text_parts)
+        if self.parser.meta_description:
+            parts.append(self.parser.meta_description)
+        return "\n".join(parts)
+
+
+def parse_deck(raw: str) -> DeckDocument:
+    parser = _DeckParser()
+    parser.feed(raw)
+    parser.close()
+    return DeckDocument(raw=raw, parser=parser)
+
+
+# --------------------------------------------------------------------------
+# The number whitelist.
+# --------------------------------------------------------------------------
+
+
+def _number_forms(value: float) -> set[str]:
+    """Every string form a supplied number may legitimately be rendered as."""
+    forms: set[str] = set()
+    try:
+        as_float = float(value)
+    except (TypeError, ValueError):
+        return forms
+    if math.isnan(as_float) or math.isinf(as_float):
+        return forms
+    if as_float < 0:
+        as_float = -as_float
+    forms.add(f"{as_float:g}")
+    if as_float == int(as_float):
+        forms.add(str(int(as_float)))
+    for places in (1, 2):
+        forms.add(f"{round(as_float, places):g}")
+    forms.add(str(as_float))
+    return forms
+
+
+def _walk_numbers(obj, out: set[str]) -> None:
+    """Collect every numeric --- and every quotable numeric string --- in a doc."""
+    if isinstance(obj, bool):
+        return
+    if isinstance(obj, (int, float)):
+        out |= _number_forms(obj)
+        return
+    if isinstance(obj, dict):
+        for key, val in obj.items():
+            if isinstance(val, str) and str(key) in NUMERIC_STRING_FIELDS:
+                out |= set(_DIGIT_RUN_RE.findall(val))
+            else:
+                _walk_numbers(val, out)
+        return
+    if isinstance(obj, (list, tuple)):
+        for item in obj:
+            _walk_numbers(item, out)
+
+
+def dot_graph_counts(dot_text: str) -> tuple[set[str], Counter]:
+    """`(node ids, edge multiset)` from a `.dot`, via the vendored parser."""
+    from .authoring_contract import DotParseError, parse_dot_min
+
+    try:
+        graph = parse_dot_min(dot_text)
+    except DotParseError as exc:
+        raise AttractorScoutError(f"a demonstration pipeline does not parse: {exc}") from exc
+    edges: Counter = Counter((e.src, e.dst) for e in graph.edges)
+    return set(graph.nodes), edges
+
+
+def build_number_whitelist(ranked: dict, demos: dict | None) -> set[str]:
+    """Every number the deck may state without declaring it.
+
+    Sources, in order of authority: the re-verified ranking; the demonstration
+    bundle (verified stats, convergence arithmetic, verbatim machine reports);
+    the generated `.dot` files' own numerics and their node/edge counts; and
+    the structural digits 0-4.
+    """
+    allowed: set[str] = set(STRUCTURAL_DIGITS)
+    _walk_numbers(ranked, allowed)
+    if demos:
+        _walk_numbers(demos, allowed)
+        for demo in demos.get("demos") or []:
+            dot_text = str(demo.get("dot_text") or "")
+            if not dot_text.strip():
+                continue
+            nodes, edges = dot_graph_counts(dot_text)
+            allowed |= _number_forms(len(nodes))
+            allowed |= _number_forms(sum(edges.values()))
+    # Collection sizes the deck will inevitably state.
+    for key in ("opportunities", "honest_no", "waste_findings", "below_frequency_floor"):
+        allowed |= _number_forms(len(ranked.get(key) or []))
+    if demos:
+        allowed |= _number_forms(len(demos.get("demos") or []))
+    # Decomposition (named limit): a supplied number's own sub-runs ride along.
+    for form in list(allowed):
+        allowed |= set(_DIGIT_RUN_RE.findall(form))
+    return {a for a in allowed if a}
+
+
+def _token_candidates(token: str) -> set[str]:
+    raw = token.replace(",", "")
+    out = {raw}
+    try:
+        val = float(raw)
+    except ValueError:
+        return out
+    out |= _number_forms(val)
+    return out
+
+
+def read_derived_declarations(doc: DeckDocument) -> tuple[list[dict], list[str]]:
+    """`(entries, problems)` from the deck's own `derived-values` JSON block."""
+    chunks = doc.parser.json_blocks.get(DT.DERIVED_BLOCK_ID)
+    if not chunks:
+        return [], []
+    text = "".join(chunks).strip()
+    if not text:
+        return [], [f'the <script id="{DT.DERIVED_BLOCK_ID}"> block is empty']
+    try:
+        payload = json.loads(text)
+    except ValueError as exc:
+        return [], [f'the <script id="{DT.DERIVED_BLOCK_ID}"> block is not valid JSON: {exc}']
+    if isinstance(payload, dict):
+        payload = payload.get("derived") or payload.get("values") or []
+    if not isinstance(payload, list):
+        return [], [
+            (
+                f'the <script id="{DT.DERIVED_BLOCK_ID}"> block must hold a JSON array of '
+                f"{{value, from}} objects (or an object with a 'derived' array)"
+            )
+        ]
+    entries: list[dict] = []
+    problems: list[str] = []
+    for i, item in enumerate(payload):
+        if not isinstance(item, dict):
+            problems.append(f"derived-values[{i}] is not an object")
+            continue
+        value = item.get("value")
+        if value is None or str(value).strip() == "":
+            problems.append(f"derived-values[{i}] has no 'value'")
+            continue
+        value_s = str(value).strip()
+        provenance = str(item.get("from") or "").strip()
+        if not provenance:
+            problems.append(
+                f"derived-values[{i}] declares {value_s!r} with no 'from' provenance. An "
+                f"undocumented derivation is indistinguishable from an invented number."
+            )
+            continue
+        # `inputs` is MANDATORY and non-empty: a derivation with no declared
+        # inputs is a bare assertion the gate cannot check against the run
+        # data. This is what closes the self-dealing hole --- a fabricated
+        # value with a junk one-word `from` and no inputs used to pass.
+        inputs_raw = item.get("inputs")
+        if not isinstance(inputs_raw, list) or not inputs_raw:
+            problems.append(
+                f"derived-values[{i}] declares {value_s!r} with no 'inputs'. Every derived value "
+                f"MUST list the supplied numbers it was computed from (a non-empty array), so the "
+                f"derivation can be checked against the run data. An input-less declaration is a bare "
+                f"assertion, indistinguishable from an invented number."
+            )
+            continue
+        inputs = [str(x).strip() for x in inputs_raw if str(x).strip()]
+        if not inputs:
+            problems.append(f"derived-values[{i}] declares {value_s!r} with an empty 'inputs' list")
+            continue
+        # `from` must be NON-TRIVIAL: it must actually reference every input it
+        # claims to combine, so "qqq" cannot stand in for a real derivation.
+        # Comma-insensitive substring match against the provenance text.
+        from_norm = provenance.replace(",", "")
+        unreferenced = [inp for inp in inputs if inp.replace(",", "") not in from_norm]
+        if unreferenced:
+            problems.append(
+                f"derived-values[{i}] declares {value_s!r} but its 'from' text does not reference "
+                f"input(s) {unreferenced}. The provenance must name the numbers it combines, so a "
+                f"trivial or junk 'from' cannot launder a fabricated value."
+            )
+            continue
+        entries.append({"value": value_s, "from": provenance, "inputs": inputs})
+    return entries, problems
+
+
+# --------------------------------------------------------------------------
+# The gates.
+# --------------------------------------------------------------------------
+
+
+@dataclass
+class GateResult:
+    letter: str
+    name: str
+    passed: bool
+    detail: str
+    findings: list[str] = field(default_factory=list)
+
+    def as_dict(self) -> dict:
+        return {
+            "letter": self.letter,
+            "name": self.name,
+            "passed": self.passed,
+            "detail": self.detail,
+            "findings": self.findings,
+        }
+
+
+@dataclass
+class DeckReport:
+    deck_path: str
+    gates: list[GateResult]
+
+    @property
+    def ok(self) -> bool:
+        return all(g.passed for g in self.gates)
+
+    def as_dict(self) -> dict:
+        return {"deck": self.deck_path, "ok": self.ok, "gates": [g.as_dict() for g in self.gates]}
+
+    def render(self) -> str:
+        lines = [f"DECK VERIFY REPORT\ndeck: {self.deck_path}\nverdict: {'PASS' if self.ok else 'FAIL'}", ""]
+        for gate in self.gates:
+            lines.append(f"[{'PASS' if gate.passed else 'FAIL'}] {gate.letter} {gate.name}")
+            lines.append(f"       {gate.detail}")
+            for finding in gate.findings[:40]:
+                lines.append(f"       - {finding}")
+            if len(gate.findings) > 40:
+                lines.append(f"       ... and {len(gate.findings) - 40} more")
+        return "\n".join(lines)
+
+
+def gate_parses(doc: DeckDocument) -> GateResult:
+    findings = list(doc.parser.nesting_errors)
+    if "<!doctype" not in doc.raw[:200].lower():
+        findings.append("the document does not open with <!doctype html>")
+    if "<html" not in doc.raw.lower():
+        findings.append("there is no <html> element")
+    return GateResult(
+        letter="a",
+        name="the HTML parses",
+        passed=not findings,
+        detail=(
+            f"{len(BALANCED_TAGS)} container element types checked for balanced nesting; "
+            f"{len(findings)} structural problem(s)"
+        ),
+        findings=findings,
+    )
+
+
+def gate_self_contained(doc: DeckDocument) -> GateResult:
+    raw = doc.raw
+    findings: list[str] = []
+    lowered = raw.lower()
+    external = 0  # count of external-resource elements/attributes found
+
+    # (1) Elements that exist ONLY to load or embed another resource. Presence
+    #     alone is a violation, regardless of attributes.
+    for pattern, why in (
+        (r"<img\b", "<img> (every graphic must be inline SVG)"),
+        (r"<link\b", "<link>"),
+        (r"<iframe\b", "<iframe>"),
+        (r"<object\b", "<object> (its data= attribute loads an external resource)"),
+        (r"<embed\b", "<embed>"),
+        (r"<source\b", "<source> (a media/picture src)"),
+        (r"<track\b", "<track> (a subtitle src)"),
+    ):
+        n = len(re.findall(pattern, raw, re.IGNORECASE))
+        if n:
+            external += n
+            findings.append(f"{n} occurrence(s) of a banned {why} element")
+
+    # (2) A `src` attribute on ANY element. A self-contained one-file deck
+    #     loads nothing, so a src attribute anywhere (script/video/audio/frame/
+    #     and the banned elements above) is a violation.
+    src_attrs = _SRC_ATTR_RE.findall(raw)
+    if src_attrs:
+        external += len(src_attrs)
+        findings.append(f"{len(src_attrs)} element(s) carrying a src attribute (no resource may be loaded)")
+
+    # (3) `xlink:href` / `<use>`/`<image> href` pointing anywhere but a local
+    #     #fragment. The anchor-href count below uses `\shref`, which CANNOT
+    #     see `xlink:href` (the colon breaks the whitespace boundary) --- so
+    #     these external references are checked explicitly here.
+    ext_refs = [
+        v.strip()
+        for v in (_XLINK_HREF_RE.findall(raw) + _USE_HREF_RE.findall(raw))
+        if v.strip() and not v.strip().startswith("#")
+    ]
+    if ext_refs:
+        external += len(ext_refs)
+        findings.append(f"{len(ext_refs)} external xlink:href / <use> href reference(s): {ext_refs[:5]}")
+
+    # (4) CSS @import and responsive srcset.
+    for needle, why in (("@import", "a CSS @import"), ("srcset", "a srcset attribute")):
+        n = lowered.count(needle)
+        if n:
+            external += n
+            findings.append(f"{n} occurrence(s) of {why}")
+
+    bad_urls = [m.group(1).strip() for m in _URL_FUNC_RE.finditer(raw) if not m.group(1).strip().startswith("#")]
+    if bad_urls:
+        findings.append(f"{len(bad_urls)} url(...) reference(s) that are not url(#local-id): {bad_urls[:5]}")
+    file_urls = lowered.count("file://")
+    if file_urls:
+        findings.append(f"{file_urls} file:// URL(s)")
+    https_hrefs = _HTTPS_HREF_RE.findall(raw)
+    if len(https_hrefs) != DT.ALLOWED_HTTPS_HREFS:
+        findings.append(
+            f"{len(https_hrefs)} https href(s); exactly {DT.ALLOWED_HTTPS_HREFS} are permitted "
+            f"(the published explainer and the bundle repository): {https_hrefs[:6]}"
+        )
+    return GateResult(
+        letter="b",
+        name="the page is self-contained (zero external requests)",
+        passed=not findings,
+        detail=(
+            f"{len(https_hrefs)} https href(s), {len(bad_urls)} non-local url(), {file_urls} file:// URL(s), "
+            f"{external} external-resource element(s)/attribute(s)"
+        ),
+        findings=findings,
+    )
+
+
+def gate_dialogs(doc: DeckDocument) -> GateResult:
+    dialogs = doc.parser.dialog_ids
+    triggers = doc.parser.trigger_targets
+    dialog_set = set(dialogs)
+    trigger_set = set(triggers)
+    findings: list[str] = []
+    dupes = [d for d, n in Counter(dialogs).items() if n > 1]
+    if dupes:
+        findings.append(f"duplicate dialog id(s): {sorted(dupes)}")
+    dangling = sorted(trigger_set - dialog_set)
+    if dangling:
+        findings.append(f"{len(dangling)} trigger(s) point at no dialog: {dangling[:10]}")
+    orphans = sorted(dialog_set - trigger_set)
+    if orphans:
+        findings.append(f"{len(orphans)} dialog(s) no trigger can open: {orphans[:10]}")
+    return GateResult(
+        letter="c",
+        name="every modal has a trigger and every trigger has a modal",
+        passed=not findings,
+        detail=f"{len(dialogs)} dialog(s), {len(triggers)} trigger(s), {len(dialog_set & trigger_set)} paired",
+        findings=findings,
+    )
+
+
+def gate_numbers(doc: DeckDocument, whitelist: set[str]) -> GateResult:
+    declared, problems = read_derived_declarations(doc)
+    findings = list(problems)
+    allowed = set(whitelist)
+    for entry in declared:
+        allowed |= _token_candidates(entry["value"])
+        allowed.add(entry["value"])
+    for entry in declared:
+        for supplied in entry["inputs"] or []:
+            if not (_token_candidates(str(supplied)) & whitelist):
+                findings.append(
+                    f"derived-values entry {entry['value']!r} claims input {str(supplied)!r}, which is not "
+                    f"one of this run's supplied numbers"
+                )
+
+    text = doc.visible_text
+    unknown: list[str] = []
+    seen: set[str] = set()
+    for match in _NUMBER_TOKEN_RE.finditer(text):
+        token = match.group(0)
+        if _token_candidates(token) & allowed:
+            continue
+        if token in seen:
+            continue
+        seen.add(token)
+        start = max(0, match.start() - 45)
+        context = " ".join(text[start : match.end() + 45].split())
+        unknown.append(f"{token!r} is not a supplied number and is not declared derived --- ...{context}...")
+
+    # Script-injected text: a claim written by JS (`document.title = "8731
+    # units examined"`) never appears as a DOM text node, so the scan above
+    # cannot see it. Scan PROSE-bearing string literals in every executable
+    # inline <script> body against the same whitelist. Only literals carrying a
+    # 3+ letter word are checked, so a bare CSS/geometry string is not treated
+    # as a displayed claim (see _PROSE_WORD_RE). Named residual below.
+    script_unknown: list[str] = []
+    for body in doc.parser.script_bodies:
+        for lit in _JS_STRING_RE.findall(body):
+            inner = lit[1:-1]
+            if not _PROSE_WORD_RE.search(inner):
+                continue
+            for match in _NUMBER_TOKEN_RE.finditer(inner):
+                token = match.group(0)
+                if _token_candidates(token) & allowed or token in seen:
+                    continue
+                seen.add(token)
+                snippet = " ".join(inner.split())[:90]
+                script_unknown.append(
+                    f"{token!r} appears in an inline <script> string literal and is not a supplied "
+                    f'number or declared derivation --- "{snippet}"'
+                )
+    findings.extend(unknown)
+    findings.extend(script_unknown)
+    scanned = len(_NUMBER_TOKEN_RE.findall(text))
+    return GateResult(
+        letter="d",
+        name="every displayed number resolves against the run data or a declared derivation",
+        passed=not findings,
+        detail=(
+            f"{scanned} numeric token(s) in visible text + {len(doc.parser.script_bodies)} inline script "
+            f"body(ies) re-verified against {len(whitelist)} supplied value(s) + {len(declared)} declared "
+            f"derivation(s); {len(unknown) + len(script_unknown)} unresolved"
+        ),
+        findings=findings,
+    )
+
+
+def _match_svg(svg_list: list[DeckSvg], slug: str, nodes: set[str]) -> DeckSvg | None:
+    for svg in svg_list:
+        if svg.diagram and svg.diagram == slug:
+            return svg
+    candidates = [svg for svg in svg_list if svg.nodes and set(svg.nodes) == nodes]
+    if len(candidates) == 1:
+        return candidates[0]
+    return None
+
+
+def gate_diagram_fidelity(doc: DeckDocument, demos: dict | None) -> GateResult:
+    svgs_with_data = [s for s in doc.parser.svgs if s.nodes or s.edges]
+    demo_list = list((demos or {}).get("demos") or [])
+    findings: list[str] = []
+    if not demo_list:
+        if svgs_with_data:
+            findings.append(
+                f"the deck carries {len(svgs_with_data)} pipeline diagram(s) but no demonstration bundle was "
+                f"supplied to check them against"
+            )
+        return GateResult(
+            letter="e",
+            name="every pipeline diagram matches its real .dot node-for-node and edge-for-edge",
+            passed=not findings,
+            detail="0 demonstration(s) in this run; 0 diagram(s) checked",
+            findings=findings,
+        )
+
+    checked = 0
+    for demo in demo_list:
+        slug = str(demo.get("slug") or demo.get("unit_id") or "?")
+        dot_text = str(demo.get("dot_text") or "")
+        if not dot_text.strip():
+            findings.append(f"demonstration {slug!r} carries no .dot text to check a diagram against")
+            continue
+        real_nodes, real_edges = dot_graph_counts(dot_text)
+        svg = _match_svg(svgs_with_data, slug, real_nodes)
+        if svg is None:
+            findings.append(
+                f"no diagram in the deck could be matched to demonstration {slug!r}. Give its <svg> a "
+                f'{DT.DIAGRAM_ATTR}="{slug}" attribute, or make its {DT.NODE_ATTR} set equal the pipeline\'s '
+                f"{len(real_nodes)} node(s): {sorted(real_nodes)}"
+            )
+            continue
+        checked += 1
+        drawn_nodes = set(svg.nodes)
+        node_dupes = [n for n, c in Counter(svg.nodes).items() if c > 1]
+        if node_dupes:
+            findings.append(f"{slug}: node(s) drawn more than once: {sorted(node_dupes)}")
+        if drawn_nodes != real_nodes:
+            missing = sorted(real_nodes - drawn_nodes)
+            extra = sorted(drawn_nodes - real_nodes)
+            findings.append(
+                f"{slug}: node set differs from the pipeline --- missing {missing or '(none)'}, "
+                f"not in the pipeline {extra or '(none)'}"
+            )
+        drawn_edges: Counter = Counter()
+        for raw_edge in svg.edges:
+            if "->" not in raw_edge:
+                findings.append(f"{slug}: {DT.EDGE_ATTR}={raw_edge!r} is not in `src->dst` form")
+                continue
+            src, dst = raw_edge.split("->", 1)
+            drawn_edges[(src.strip(), dst.strip())] += 1
+        if drawn_edges != real_edges:
+            missing = sorted((real_edges - drawn_edges).elements())
+            extra = sorted((drawn_edges - real_edges).elements())
+            findings.append(
+                f"{slug}: edge multiset differs from the pipeline --- "
+                f"undrawn {[f'{s}->{d}' for s, d in missing] or '(none)'}, "
+                f"not in the pipeline {[f'{s}->{d}' for s, d in extra] or '(none)'} "
+                f"({sum(drawn_edges.values())} drawn vs {sum(real_edges.values())} declared)"
+            )
+    return GateResult(
+        letter="e",
+        name="every pipeline diagram matches its real .dot node-for-node and edge-for-edge",
+        passed=not findings,
+        detail=f"{checked} of {len(demo_list)} demonstration diagram(s) matched and compared",
+        findings=findings,
+    )
+
+
+def verify_deck(
+    *,
+    deck_path: str | Path,
+    ranked_path: str | Path,
+    demos_path: str | Path | None = None,
+) -> DeckReport:
+    """Run every gate over a candidate deck. Deterministic; never publishes."""
+    deck_file = Path(deck_path)
+    try:
+        raw = deck_file.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise AttractorScoutError(f"could not read the candidate deck at {deck_file}: {exc}") from exc
+    ranked = _load_json(ranked_path, "ranking")
+    demos = _load_json(demos_path, "demonstration bundle") if demos_path else None
+
+    doc = parse_deck(raw)
+    whitelist = build_number_whitelist(ranked, demos)
+    gates = [
+        gate_parses(doc),
+        gate_self_contained(doc),
+        gate_dialogs(doc),
+        gate_numbers(doc, whitelist),
+        gate_diagram_fidelity(doc, demos),
+    ]
+    return DeckReport(deck_path=str(deck_file), gates=gates)
+
+
+# --------------------------------------------------------------------------
+# Brief assembly.
+# --------------------------------------------------------------------------
+
+
+def _load_json(path: str | Path | None, what: str) -> dict:
+    if path is None:
+        raise AttractorScoutError(f"no {what} was supplied")
+    try:
+        return json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise AttractorScoutError(f"could not read the {what} at {path}: {exc}") from exc
+
+
+def _fmt(value) -> str:
+    if isinstance(value, bool):
+        return "yes" if value else "no"
+    if isinstance(value, (int, float)):
+        forms = _number_forms(value)
+        as_float = float(value)
+        if as_float == int(as_float):
+            return str(int(as_float))
+        return f"{round(as_float, 2):g}" if forms else str(value)
+    return str(value)
+
+
+def _summary_lines(ranked: dict, demos: dict | None) -> list[str]:
+    summary = ranked.get("summary") or {}
+    lines = [f"{key}: {_fmt(val)}" for key, val in summary.items()]
+    lines.append(f"opportunities listed: {len(ranked.get('opportunities') or [])}")
+    lines.append(f"honest-NOes listed: {len(ranked.get('honest_no') or [])}")
+    lines.append(f"waste findings listed: {len(ranked.get('waste_findings') or [])}")
+    lines.append(f"demonstrations generated: {len((demos or {}).get('demos') or [])}")
+    return lines
+
+
+def _opportunity_block(index: int, unit: dict) -> str:
+    lev = unit.get("leverage_detail") or {}
+    fit = unit.get("fit_detail") or {}
+    flags = []
+    if unit.get("provisional"):
+        flags.append("provisional (seen in only 2-3 sessions)")
+    if str(unit.get("verdict", "")).endswith("(unproven)"):
+        flags.append("unproven recovery --- a caveat, never a failure")
+    return "\n".join(
+        [
+            f"### {index}. {unit.get('name')}  [{unit.get('unit_id')}]",
+            f"  verdict:            {unit.get('verdict')}",
+            f"  distinct sessions:  {_fmt(unit.get('n_sessions'))}",
+            f"  leverage:           {_fmt(unit.get('leverage'))}",
+            f"  score:              {_fmt(unit.get('score'))}",
+            f"  median tool calls:  {_fmt(lev.get('med_tool_calls'))}",
+            f"  median LLM cycles:  {_fmt(lev.get('med_llm_cycles'))}",
+            f"  median span (s):    {_fmt(lev.get('med_span_capped_s'))}",
+            f"  errors per session: {_fmt(lev.get('errors_per_session'))}",
+            f"  trajectory:         {unit.get('trajectory')}",
+            f"  confidence:         {unit.get('confidence')}",
+            f"  fit  4a cycle:      {_fmt(fit.get('cycle'))}",
+            f"  fit  4b gate:       {_fmt(fit.get('gate'))}",
+            f"  fit  4c recovery:   {unit.get('recovery')}",
+            f"  flags:              {'; '.join(flags) if flags else '(none)'}",
+            f"  gist:               {unit.get('gist') or '(no gist recorded for this unit)'}",
+            "",
+        ]
+    )
+
+
+def _honest_no_block(unit: dict) -> str:
+    return "\n".join(
+        [
+            f"### {unit.get('name')}  [{unit.get('unit_id')}]",
+            f"  distinct sessions:  {_fmt(unit.get('n_sessions'))}",
+            f"  leverage:           {_fmt(unit.get('leverage'))}",
+            f"  class:              {unit.get('no_class')}",
+            f"  failed sub-test:    {unit.get('failed_subtest')}",
+            f"  remediation:        {unit.get('remediation')}",
+            f"  gist:               {unit.get('gist') or '(no gist recorded for this unit)'}",
+            "",
+        ]
+    )
+
+
+def _waste_block(unit: dict) -> str:
+    return "\n".join(
+        [
+            f"### {unit.get('name')}  [{unit.get('unit_id')}]",
+            f"  sessions:           {_fmt(unit.get('n_sessions'))}",
+            f"  reclaimable hours:  {_fmt(unit.get('reclaimable_hours'))}",
+            f"  note:               {unit.get('note')}",
+            "",
+        ]
+    )
+
+
+def _demo_block(demo: dict) -> str:
+    verification = demo.get("verification") or {}
+    narrative = demo.get("narrative") or {}
+    maths = demo.get("convergence_math") or {}
+    dot_text = str(demo.get("dot_text") or "")
+    nodes, edges = (set(), Counter())
+    if dot_text.strip():
+        nodes, edges = dot_graph_counts(dot_text)
+    walk = "\n".join(f"    - {step.get('node')}: {step.get('note')}" for step in (narrative.get("pipeline_walk") or []))
+    return "\n".join(
+        [
+            f"### {demo.get('name')}  [{demo.get('unit_id')}]  slug: {demo.get('slug')}",
+            f"  published as:        {demo.get('dot_relpath')} + {demo.get('companion_relpath')}",
+            f"  graph shape:         {len(nodes)} node(s), {sum(edges.values())} edge(s)",
+            f"  node ids:            {', '.join(sorted(nodes)) or '(none)'}",
+            "  edges (multiset):    " + (", ".join(f"{s}->{d}" for s, d in sorted(edges.elements())) or "(none)"),
+            f"  verification level:  {verification.get('level')}",
+            f"  attractor lint:      {verification.get('lint_verdict') or verification.get('lint_not_run_reason')}",
+            f"  doctrine verdict:    {verification.get('doctrine_verdict')}",
+            (
+                f"  convergence math:    chain {_fmt(maths.get('chain_len'))} steps at "
+                f"p={_fmt(maths.get('p_step'))} -> once-through {_fmt(maths.get('once_through'))} vs "
+                f"gated loop {_fmt(maths.get('gated_loop'))} within a budget of {_fmt(maths.get('budget'))} "
+                f"({maths.get('label')})"
+            ),
+            "",
+            "  narrative slots (already gate-checked; reuse the CONTENT, rewrite the prose):",
+            f"    scenario_gist:    {narrative.get('scenario_gist')}",
+            f"    q1_cycle_note:    {narrative.get('q1_cycle_note')}",
+            f"    q2_gate_note:     {narrative.get('q2_gate_note')}",
+            f"    q3_recovery_note: {narrative.get('q3_recovery_note')}",
+            f"    payoff_note:      {narrative.get('payoff_note')}",
+            "    pipeline_walk:",
+            walk or "      (none)",
+            "",
+            "  THE REAL PIPELINE (verbatim --- your diagram must match this graph exactly):",
+            "",
+            "```dot",
+            dot_text.rstrip(),
+            "```",
+            "",
+            "  THE MACHINE GATE REPORT (verbatim --- quote it, never paraphrase a verdict):",
+            "",
+            "```",
+            str(verification.get("doctrine_report") or "(not run)").rstrip(),
+            "```",
+            "",
+        ]
+    )
+
+
+def _absent_fields(ranked: dict, demos: dict | None) -> list[str]:
+    """What the run's shape wants and this run does not have. Honest, computed."""
+    absent: list[str] = []
+    units = list(ranked.get("opportunities") or []) + list(ranked.get("honest_no") or [])
+    if units and not any(u.get("workspace") or u.get("workspaces") for u in units):
+        absent.append(
+            "workspace / project attribution per unit --- the ranking records which sessions a unit "
+            "covers, but not which project or repository they belong to. Do not guess a project name."
+        )
+    if units and not any(u.get("first_seen") or u.get("last_seen") for u in units):
+        absent.append(
+            "first-seen / last-seen dates per unit --- this run records how often work recurred, not "
+            "when it started or whether it is still happening."
+        )
+    if not any((u.get("gist") or "").strip() for u in units):
+        absent.append("scenario gists --- no unit in this run carries a recorded gist.")
+    if not (demos or {}).get("demos"):
+        absent.append("generated demonstration pipelines --- none were produced in this run.")
+    absent.append(
+        "per-step LLM success rate --- nothing in the run measures it. The convergence arithmetic uses a "
+        "FIXED illustrative rate, and must be labelled as illustrative wherever it appears."
+    )
+    absent.append(
+        "any artifact for what happened BEFORE a file was written --- a first draft that was rejected, a "
+        "gate report that was superseded. If the deck tells that story it is TESTIMONY, and must say so."
+    )
+    return absent
+
+
+def build_deck_brief(
+    *,
+    ranked_path: str | Path,
+    demos_path: str | Path | None,
+    workdir: str | Path,
+    run_label: str | None = None,
+) -> Path:
+    """Write `<workdir>/deck-brief.md`. Deterministic; returns its path."""
+    ranked = _load_json(ranked_path, "ranking")
+    demos = _load_json(demos_path, "demonstration bundle") if demos_path else None
+
+    target = Path(workdir)
+    target.mkdir(parents=True, exist_ok=True)
+    brief_path = target / "deck-brief.md"
+
+    opportunities = list(ranked.get("opportunities") or [])
+    honest_nos = list(ranked.get("honest_no") or [])
+    waste = list(ranked.get("waste_findings") or [])
+    demo_list = list((demos or {}).get("demos") or [])
+
+    whitelist = sorted(build_number_whitelist(ranked, demos), key=lambda s: (len(s), s))
+
+    brief_path.write_text(
+        DT.deck_brief_markdown(
+            run_label=run_label or "one attractor-scout run over your own session history",
+            summary_lines=_summary_lines(ranked, demos),
+            opportunity_blocks=[_opportunity_block(i + 1, u) for i, u in enumerate(opportunities)],
+            honest_no_blocks=[_honest_no_block(u) for u in honest_nos],
+            waste_blocks=[_waste_block(u) for u in waste],
+            demo_blocks=[_demo_block(d) for d in demo_list],
+            absent_fields=_absent_fields(ranked, demos),
+            allowed_numbers=whitelist,
+            deck_filename=DECK_FILENAME,
+        ),
+        encoding="utf-8",
+    )
+    return brief_path
+
+
+def publish_deck(candidate: str | Path, output_dir: str | Path) -> Path:
+    """Copy a VERIFIED deck beside the report. Never called before the gates."""
+    import shutil
+
+    dest = Path(output_dir) / DECK_FILENAME
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        shutil.copyfile(Path(candidate), dest)
+    except OSError as exc:
+        raise AttractorScoutError(f"could not publish the deck into {dest.parent}: {exc}") from exc
+    if not dest.is_file():
+        raise AttractorScoutError(f"publication into {dest.parent} did not produce {DECK_FILENAME}")
+    return dest
+
+
+__all__ = [
+    "DECK_MAX_ATTEMPTS",
+    "DeckGateRed",
+    "DeckReport",
+    "GateResult",
+    "build_deck_brief",
+    "build_number_whitelist",
+    "dot_graph_counts",
+    "gate_diagram_fidelity",
+    "gate_dialogs",
+    "gate_numbers",
+    "gate_parses",
+    "gate_self_contained",
+    "parse_deck",
+    "publish_deck",
+    "read_derived_declarations",
+    "verify_deck",
+]

--- a/skills/attractor-scout/scripts/attractor_scout/deck_templates.py
+++ b/skills/attractor-scout/scripts/attractor_scout/deck_templates.py
@@ -1,0 +1,427 @@
+"""Every deterministic string DECK MODE emits. NO LLM in here.
+
+Deck mode is the optional third artifact: after the deterministic map (step 7)
+and the machine-gated demonstrations (steps 8-9), the skill can produce ONE
+deck-grade, personalized, educational HTML page from the same verified data.
+
+The demonstration layer proved a shape: *deterministic brief -> fresh-context
+`reasoning` delegation -> machine gates -> publish-or-refuse*. Deck mode reuses
+it verbatim, at a larger scale, and this module is the brief half. It carries
+three things a fresh-context author cannot see for itself:
+
+**(a) The house style/technique contract.** What the deck's section arc IS, and
+what the diagram grammar IS --- learned from an exemplar and written down here
+as TEXT so the delegate builds FRESH content in that idiom rather than copying
+an exemplar's sentences.
+
+**(b) The hard constraints.** One file, inline everything, zero external
+requests, works from `file://`. These are the same self-containment rules the
+deterministic renderer honours; a hand-authored page has to be TOLD them.
+
+**(c) The mandates that make the gates passable.** This is the load-bearing
+part. `deck verify` is deterministic and unforgiving: an undeclared number
+fails the whole deck. A delegate that does not know the whitelist rule will
+fail it by accident, so the brief states the rule, lists the numbers that are
+already legal, and specifies the exact escape hatch (the `derived-values` JSON
+block) for arithmetic the deck computes for itself.
+
+Nothing here fetches anything. The two links the deck footer carries are
+anchors a reader may follow, not resources the page loads --- the same
+distinction `render.py` documents.
+"""
+
+from __future__ import annotations
+
+from . import demo_templates as T
+
+# --------------------------------------------------------------------------
+# The one machine-readable seam between the authored deck and the gate.
+# --------------------------------------------------------------------------
+
+#: The id of the JSON block a deck carries to declare arithmetic it did itself.
+#: `deck verify` reads exactly this id; the brief tells the author exactly this
+#: id; one constant, so they can never disagree.
+DERIVED_BLOCK_ID = "derived-values"
+
+#: The attribute pair that makes diagram fidelity machine-checkable. Every
+#: node group and every edge element in a demonstration diagram carries one.
+NODE_ATTR = "data-node"
+EDGE_ATTR = "data-edge"
+
+#: The attribute that names WHICH demonstration a diagram is of. Optional:
+#: when absent the gate falls back to matching on the node set, which is how
+#: the recovered exemplar verifies. When present the mapping is explicit.
+DIAGRAM_ATTR = "data-diagram"
+
+#: The two links the footer carries, and the only two the gate permits.
+FOOTER_LINKS: tuple[tuple[str, str], ...] = (
+    ("the published explainer", T.EXPLAINER_URL),
+    ("the bundle repository", "https://github.com/microsoft/amplifier-bundle-attractor"),
+)
+
+#: Exactly how many `href="https://..."` attributes a verified deck may carry.
+ALLOWED_HTTPS_HREFS = len(FOOTER_LINKS)
+
+
+# --------------------------------------------------------------------------
+# (a) The house style / technique contract --- the section arc, as TEXT.
+# --------------------------------------------------------------------------
+
+STYLE_CONTRACT = """\
+THE HOUSE DECK IDIOM (learn the TECHNIQUES; write FRESH content)
+
+This is a DECK, not a report. A report enumerates; a deck argues. Every section
+opens on a claim a reader can disagree with, then pays it off with the run's own
+verified evidence. Write for one specific reader --- the person whose work this
+run mined --- in second person, in their vocabulary, with no internal jargon and
+no meta-commentary about being a language model.
+
+THE SECTION ARC (six sections, in this order; each is one <section> element):
+
+  1. HERO --- "your work, mapped". One headline claim. The scope of the run
+     stated plainly: what was read, that it was read locally, that nothing left
+     the machine. A short stat strip of the run's shape. This section sets the
+     honesty tone for everything after it: name what the run did NOT see.
+
+  2. TEACH THE BASIN --- what an attractor actually is, before any
+     recommendation is made. An attractor is a BASIN, not a checklist: work
+     that is attempted, checked against evidence produced OUTSIDE the worker,
+     and re-attempted until it lands, under a budget that routes exhaustion
+     somewhere honest. Carry the THREE-QUESTION TEST here (cycle? evidence
+     gate? survives one node having a bad day?), and the CONVERGENCE MATH ---
+     once-through odds versus a gated loop's odds within its budget --- LABELLED
+     as illustrative arithmetic, never as a measurement of the reader's
+     sessions.
+
+  3. RANKED OPPORTUNITIES --- the units that cleared all three questions,
+     strongest first, as cards. Each card is a claim plus the reader's own
+     verified numbers. Depth lives in a MODAL per card, never inline: the card
+     is skimmable, the modal is the deep-dive. Give EVERY ranked opportunity in
+     the data its own card and its own modal --- depth scales with the number of
+     findings, not to a fixed quota; do not stop at a "top few" and drop the
+     rest. Say what makes each unit loop-shaped in ITS terms, not in the test's
+     terms.
+
+  4. DEMONSTRATIONS --- the pipelines that were actually generated and machine-
+     gated for this run, drawn as INLINE SVG in the house diagram grammar (see
+     below). Each diagram is the real graph, node for node and edge for edge.
+     Quote the machine verdicts verbatim. Say which checks did NOT run. Never
+     vouch for the pipeline yourself.
+
+  5. HONEST NOES AND WASTE --- the units that recur and cost real effort and are
+     still NOT worth automating, each with the sub-test it failed and what would
+     change the answer; plus the waste channel (ceremony that cost time but is
+     not an opportunity to act on). Give EVERY honest-NO in the data its own
+     modal too, the same as the opportunities --- the credibility of this
+     section is that it withholds nothing; depth scales with the findings, to no
+     fixed quota. This section is the deck's credibility: a deck that only sells
+     is an advertisement.
+
+  6. GOING FORWARD --- the entry points, ordered by how much the reader has to
+     commit. Smallest first. End on the smallest possible next step.
+
+  FOOTER --- exactly two outbound links and no others: the published explainer,
+  and the bundle repository.
+
+TECHNIQUES THAT MAKE IT READ AS A DECK:
+
+  * A claim-shaped heading per section, not a label. "Nine pieces of your work
+    are already loop-shaped" beats "Opportunities".
+  * Progressive disclosure. Surface = skimmable; depth = modals. A reader who
+    reads only the headings still gets the whole argument.
+  * One idea per screen. Long prose blocks are the failure mode.
+  * Typographic hierarchy carries the structure --- a kicker, a headline, a
+    deck line, then body. System fonts only.
+  * Diagrams do work no paragraph can: use one wherever a relationship, a flow,
+    or a distribution is the point.
+  * Honesty is a design element. Absent data gets a visible, styled note ---
+    never a blank, never an invented value.
+
+THE DIAGRAM GRAMMAR (every inline SVG uses exactly this vocabulary):
+
+  * NEUTRAL fill = an LLM worker node. ACCENT fill = an evidence gate or a
+    control node that runs a real command. GREEN = the passing edge and the
+    single exit door.
+  * SOLID line = normal flow. DASHED line = a corrective back-edge (the loop
+    closing) or a failure route.
+  * Arrowheads come from ONE shared <defs> block declared once at the top of
+    the document and referenced with url(#...) --- never re-declared per
+    diagram, never fetched.
+  * Every diagram is accessible: role="img" plus a <title> and a <desc> that
+    a screen reader can follow end to end, referenced by aria-labelledby.
+  * A diagram of a REAL generated pipeline additionally carries the fidelity
+    attributes (see the mandates below) --- that is what makes it checkable.
+"""
+
+
+# --------------------------------------------------------------------------
+# (b) The hard constraints --- verbatim, non-negotiable.
+# --------------------------------------------------------------------------
+
+HARD_CONSTRAINTS = """\
+HARD CONSTRAINTS (verbatim --- a violation fails the deck):
+
+  * ONE FILE. A single .html document. No companion assets of any kind.
+  * INLINE CSS AND JS ONLY. One <style> block, one <script> block. No
+    <link>, no <script src>, no @import, no <iframe>, no srcset.
+  * ZERO EXTERNAL REQUESTS. Nothing the page loads may come from the network.
+    `url(` is legal ONLY as `url(#local-id)` --- never `url(http...)`, never
+    `url(data:...)`, never a font or image URL. NO resource-loading element or
+    attribute of ANY kind: no <object>, <embed>, <source>, <track>, <video>,
+    <audio>; no `src=` attribute anywhere; and no `xlink:href` or `<use>`/
+    `<image>` href that points at anything but a local `#fragment`. The gate
+    checks for every one of these by name.
+  * NO <img>. Every graphic is INLINE SVG, drawn in markup.
+  * SYSTEM FONTS ONLY. Declare font stacks from fonts that already exist on
+    the reader's machine. No webfont of any kind.
+  * WORKS FROM file://. Opened by double-clicking the file, with no server and
+    no network, the page must be complete and fully functional.
+  * EXACTLY TWO OUTBOUND LINKS, both https, both in the footer: the published
+    explainer and the bundle repository. Zero `file://` URLs anywhere.
+  * ACCESSIBLE. Every diagram carries role="img" with a <title> and a <desc>
+    referenced by aria-labelledby. Every modal is reachable and dismissable by
+    keyboard. Honour `prefers-reduced-motion` --- animation is opt-out by the
+    reader's own setting, in the stylesheet.
+  * NO INTERNAL JARGON. No repo-internal codenames, no issue numbers, no
+    build-process vocabulary, no "the harness", no tool names the reader never
+    typed. Write about their work, in their words.
+  * NO IDENTITY. No hostnames, usernames, home directories, absolute local
+    paths, or e-mail addresses --- not in text, not in comments.
+"""
+
+
+# --------------------------------------------------------------------------
+# (c) The MANDATES --- the four rules that make the machine gates passable.
+# --------------------------------------------------------------------------
+
+MANDATES = f"""\
+THE FOUR MANDATES (machine-enforced by `deck verify`; a violation means the
+deck is NOT published --- these are not style advice, they are the gate):
+
+  ** MANDATE 1 --- EVERY DISPLAYED NUMBER RESOLVES. **
+  Every number that appears in the deck's visible text must EITHER be one of the
+  numbers supplied in the DATA section below (the run's re-verified stats, the
+  generated pipelines' own numerics, the machine gate reports), OR be declared
+  as derived arithmetic in the block described in Mandate 2. There is no third
+  option. An undeclared number fails the whole deck, and the failure names the
+  token. This applies to text a SCRIPT writes as well: a number placed by JS
+  (e.g. `element.textContent = "8731 units examined"`) is scanned in the
+  script's string literals exactly as if it were in the DOM, so injecting a
+  figure through JavaScript does not evade the gate. Prose like "about a dozen"
+  or "twenty-five" (spelled out) is always legal --- the scan reads digits, not
+  words. When in doubt, spell it out or declare it.
+
+  ** MANDATE 2 --- DECLARE EVERY DERIVED VALUE. **
+  A deck legitimately does arithmetic the run data does not contain: a total, a
+  percentage, a sum of two supplied numbers, a unit conversion. Every such
+  number must be declared, ONCE, in a JSON block the deck carries. (The numbers
+  below are ILLUSTRATIVE placeholders, not your run's data --- use your own.)
+
+      <script type="application/json" id="{DERIVED_BLOCK_ID}">
+      [
+        {{"value": "300",
+         "from": "120 sessions inside named units + 180 in the waste ledger",
+         "inputs": ["120", "180"]}},
+        {{"value": "40",
+         "from": "8 opportunities out of 20 named units, as a percentage",
+         "inputs": ["8", "20"]}}
+      ]
+      </script>
+
+  `value` is the number exactly as the deck displays it, minus any thousands
+  separator or unit. `from` is the arithmetic provenance in plain words --- what
+  was combined, and how. `inputs` is MANDATORY and must be a NON-EMPTY array;
+  every entry must itself be a number the DATA section supplied, AND the `from`
+  text must reference each input it lists. These are not optional niceties ---
+  they are what makes a derivation checkable instead of a bare assertion. Any of
+  these fails the whole deck: an empty or missing `from`; a missing, empty, or
+  non-array `inputs`; an input that is not a supplied number; or a `from` that
+  does not mention an input it claims to combine. (What the gate does NOT do is
+  re-evaluate the arithmetic: it trusts that `120 + 180 = 300` because you said
+  so and named real inputs. Declaring real inputs with a wrong total is the one
+  gap left open, on purpose --- see the design doc's named limits.)
+
+  ** MANDATE 3 --- DIAGRAM FIDELITY IS CHECKED, NODE BY NODE AND EDGE BY EDGE. **
+  Every diagram of a REAL generated pipeline must carry, on its SVG elements:
+
+    * `{NODE_ATTR}="<node id>"` on the group that draws each node, exactly once
+      per node, spelled exactly as the `.dot` spells it.
+    * `{EDGE_ATTR}="<src>-&gt;<dst>"` on the element that draws each edge, once
+      per edge in the `.dot` --- INCLUDING duplicates. Two edges between the
+      same pair of nodes means two elements carrying that attribute. The gate
+      compares a MULTISET, so an edge drawn once but declared twice in the
+      `.dot` (or the reverse) is a failure.
+    * `{DIAGRAM_ATTR}="<slug>"` on the `<svg>` element itself, naming which
+      demonstration it draws. (Optional but strongly preferred: without it the
+      gate has to infer the mapping from the node set.)
+
+  Draw the pipeline that was actually generated. Do not simplify it, do not
+  add a node for visual balance, do not drop an edge that clutters the layout.
+  The diagram IS the graph.
+
+  ** MANDATE 4 --- ABSENT DATA GETS AN HONEST NOTE; TESTIMONY IS LABELLED. **
+  Where the run data has no value for something the deck's shape wants, SAY SO
+  in the deck, visibly --- "this run did not record that" --- and never fill the
+  hole with a plausible number, a placeholder, or a rounded guess. And where the
+  deck tells a story about something for which no artifact exists in the run
+  data --- what a gate report would have said, what a failed draft looked like,
+  what happened before the artifact was written --- label it as TESTIMONY
+  ("reported, not recovered from a file"), distinctly from anything quoted from
+  a real artifact. A reader must always be able to tell which is which.
+"""
+
+
+# --------------------------------------------------------------------------
+# The brief itself.
+# --------------------------------------------------------------------------
+
+_OUTPUT_CONTRACT = """\
+## What to write
+
+Write exactly ONE file: `deck.html`, into this same directory.
+
+It is the whole deliverable. There is no companion, no asset folder, no second
+file. Write it in full --- do not emit a fragment, a patch, or a description of
+what you would write.
+
+ONE FILE, BUILT IN PASSES. A deck of this size is tens of thousands of tokens
+of markup, and trying to emit all of it in a single model response reliably hits
+a provider request timeout. So build the file up across SEVERAL tool calls:
+write the document head, the stylesheet, the shared `<defs>` and the first
+section; then append each remaining section, then the dialogs, then the closing
+script. Finish every pass with valid, closeable markup so a partial file is
+never mistaken for a finished one, and make the LAST pass the one that writes
+the closing `</body></html>`. The result is still exactly one file.
+
+When you are done, the orchestrating session runs `deck verify` over it. That
+gate is deterministic and it is the only thing that decides whether the deck is
+published. It checks, in order: that the HTML parses; that the page is fully
+self-contained; that every modal has a trigger and every trigger has a modal;
+that every displayed number resolves (Mandate 1/2); and that every pipeline
+diagram matches its real `.dot` node-for-node and edge-for-edge (Mandate 3).
+"""
+
+
+def _fmt_allowed_numbers(allowed: list[str], *, cap: int = 400) -> str:
+    """The whitelist, as the author must see it: sorted, capped, honest."""
+    if not allowed:
+        return "  (none --- this run supplied no numerics, which is itself worth saying out loud)"
+    shown = allowed[:cap]
+    body = "\n".join("  " + ", ".join(shown[i : i + 12]) for i in range(0, len(shown), 12))
+    if len(allowed) > cap:
+        body += f"\n  ... and {len(allowed) - cap} more (every numeric in the DATA below is legal)"
+    return body
+
+
+def deck_brief_markdown(
+    *,
+    run_label: str,
+    summary_lines: list[str],
+    opportunity_blocks: list[str],
+    honest_no_blocks: list[str],
+    waste_blocks: list[str],
+    demo_blocks: list[str],
+    absent_fields: list[str],
+    allowed_numbers: list[str],
+    deck_filename: str,
+) -> str:
+    """Assemble the deck brief. Deterministic --- no improvised prompting.
+
+    Every block passed in is already rendered from re-verified data by
+    `deck.py`; this function only arranges them. Mined text (unit names, gists)
+    is expanded into PROSE here and nowhere else --- nothing in this document
+    becomes a command the orchestrating session executes.
+    """
+    absent_block = (
+        "\n".join(f"  - {line}" for line in absent_fields)
+        if absent_fields
+        else "  (nothing the deck's shape wants is missing from this run)"
+    )
+    return f"""\
+# Deck brief --- build one deck-grade page from this run's verified data
+
+You are building a DECK: one self-contained HTML page that teaches a person what
+an attractor pipeline is, shows them where their own recurring work is already
+loop-shaped, and is honest about everything it does not know. The reader is the
+person whose sessions this run mined. They have never built an attractor
+pipeline. They are smart and busy and will not read a wall of text.
+
+You are NOT copying an exemplar. You are learning the house TECHNIQUES stated
+below and building FRESH content from the REAL data inlined below.
+
+Run: {run_label}
+
+---
+
+{STYLE_CONTRACT}
+---
+
+{HARD_CONSTRAINTS}
+---
+
+{MANDATES}
+---
+
+## NUMBERS THAT ARE ALREADY LEGAL
+
+Every number below came from this run's re-verified data or from the generated
+pipelines themselves. You may state any of them freely. Anything else must be
+declared per Mandate 2.
+
+{_fmt_allowed_numbers(allowed_numbers)}
+
+Two things the number scan deliberately does NOT catch, so do not rely on them
+as loopholes: spelled-out numerals ("twenty-five") pass unchecked, and a
+decimal's sub-runs pass with it. Using either to smuggle in a figure the data
+does not support breaks the deck's whole promise, which is that every number on
+the page traces back to something that was actually measured.
+
+## WHAT THIS RUN DOES NOT HAVE
+
+Per Mandate 4, these get a visible honest note in the deck --- never a value:
+
+{absent_block}
+
+---
+
+# THE DATA
+
+## Run summary (re-verified)
+
+{chr(10).join("  " + line for line in summary_lines)}
+
+## Opportunities --- units that cleared all three questions
+
+{chr(10).join(opportunity_blocks) if opportunity_blocks else "  (none in this run)"}
+
+## Honest NOes --- recurring, costly, and still not worth automating
+
+{chr(10).join(honest_no_blocks) if honest_no_blocks else "  (none in this run)"}
+
+## Waste findings --- time spent, but not an opportunity to act on
+
+{chr(10).join(waste_blocks) if waste_blocks else "  (none in this run)"}
+
+## Demonstrations --- the pipelines that were generated and machine-gated
+
+{chr(10).join(demo_blocks) if demo_blocks else "  (none in this run --- say so, and skip the demonstrations section)"}
+
+---
+
+{_OUTPUT_CONTRACT}
+The published file will be named `{deck_filename}`.
+"""
+
+
+__all__ = [
+    "ALLOWED_HTTPS_HREFS",
+    "DERIVED_BLOCK_ID",
+    "DIAGRAM_ATTR",
+    "EDGE_ATTR",
+    "FOOTER_LINKS",
+    "HARD_CONSTRAINTS",
+    "MANDATES",
+    "NODE_ATTR",
+    "STYLE_CONTRACT",
+    "deck_brief_markdown",
+]

--- a/skills/attractor-scout/scripts/attractor_scout/naming.py
+++ b/skills/attractor-scout/scripts/attractor_scout/naming.py
@@ -19,4 +19,8 @@ ARTIFACT_STEM = SKILL_NAME
 # SKILL_NAME so the single-naming-source rule survives the demo layer.
 DEMO_DIR_STEM = f"{SKILL_NAME}-demos"
 
-__all__ = ["ARTIFACT_STEM", "DEMO_DIR_STEM", "SKILL_NAME", "SKILL_TITLE"]
+# The opt-in deck-mode artifact, published beside the HTML map. Derived from
+# SKILL_NAME so the single-naming-source rule survives deck mode too.
+DECK_FILENAME = f"{SKILL_NAME}-deck.html"
+
+__all__ = ["ARTIFACT_STEM", "DECK_FILENAME", "DEMO_DIR_STEM", "SKILL_NAME", "SKILL_TITLE"]

--- a/skills/attractor-scout/scripts/attractor_scout_cli.py
+++ b/skills/attractor-scout/scripts/attractor_scout_cli.py
@@ -12,13 +12,15 @@ the skill's importable path can never disagree about what a signal means.
     rank        admission gate + score -> ranked JSON
     render      ranked JSON -> self-contained HTML (deterministic, no LLM)
     demo        brief | assemble -- the demonstration/teaching layer
+    deck        brief | verify -- OPT-IN deck mode (an authored deck-grade page)
     run         the whole pipeline end to end
     census      event-name / tool-name census (Gap-1 allow-list finalization)
 
 Exit codes: 0 ok · 2 fail-loud (empty corpus, schema mismatch, graph demanded
-but unavailable, an invented count in a demo narrative, a red machine gate).
-A fail-loud condition NEVER exits 0 with a fabricated count, and a demo whose
-gates came back red is NEVER published.
+but unavailable, an invented count in a demo narrative, a red machine gate)
+· 3 a deck-mode gate came back red (`deck verify`; its report goes to stdout).
+A fail-loud condition NEVER exits 0 with a fabricated count, and neither a demo
+nor a deck whose gates came back red is EVER published.
 """
 
 from __future__ import annotations
@@ -250,6 +252,49 @@ def cmd_demo(args) -> int:
     raise ValueError(f"unknown demo action: {args.action!r}")
 
 
+def cmd_deck(args) -> int:
+    """Deck mode (OPT-IN): assemble the deck brief, or gate a candidate deck."""
+    from attractor_scout import deck as deck_mod
+
+    if args.action == "brief":
+        brief_path = deck_mod.build_deck_brief(
+            ranked_path=args.ranked,
+            demos_path=args.demos,
+            workdir=args.workdir,
+            run_label=args.run_label,
+        )
+        print(f"deck brief -> {brief_path}", file=sys.stderr)
+        # The path is the ONLY thing on stdout: the skill captures it directly.
+        print(brief_path)
+        return 0
+
+    if args.action == "verify":
+        report = deck_mod.verify_deck(
+            deck_path=args.deck,
+            ranked_path=args.ranked,
+            demos_path=args.demos,
+        )
+        text = report.render()
+        print(text)
+        if args.report:
+            Path(args.report).parent.mkdir(parents=True, exist_ok=True)
+            Path(args.report).write_text(text + "\n", encoding="utf-8")
+        if args.json_out:
+            _emit(report.as_dict(), args.json_out)
+        if not report.ok:
+            failed = ", ".join(g.letter for g in report.gates if not g.passed)
+            print(
+                f"DECK GATE RED [{failed}]: {args.deck} was NOT published. Re-delegate ONCE with this "
+                f"report appended verbatim; if it is still red, say so and do not publish.",
+                file=sys.stderr,
+            )
+            return 3
+        print(f"deck verified: {args.deck}", file=sys.stderr)
+        return 0
+
+    raise ValueError(f"unknown deck action: {args.action!r}")
+
+
 def cmd_run(args) -> int:
     result = pipeline.run(
         root=args.root,
@@ -373,6 +418,20 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--append", action="store_true", help="assemble: add to an existing demos.json")
     p.add_argument("--generated-at", default=None, help="pin the demo timestamp for reproducible output")
     p.set_defaults(func=cmd_demo)
+
+    p = sub.add_parser(
+        "deck",
+        help="OPT-IN deck mode: assemble the deck brief, or run the deterministic gates over a candidate deck",
+    )
+    p.add_argument("action", choices=["brief", "verify"])
+    p.add_argument("--ranked", default="ranked.json", help="the re-verified ranking (both actions)")
+    p.add_argument("--demos", default=None, help="demos.json from `demo assemble`; carries the real .dot text")
+    p.add_argument("--workdir", default=None, help="brief: where deck-brief.md is written")
+    p.add_argument("--run-label", default=None, help="brief: a short human label for this run")
+    p.add_argument("--deck", default=None, help="verify: the candidate deck HTML to gate")
+    p.add_argument("--report", default=None, help="verify: also write the verbatim gate report here")
+    p.add_argument("--json-out", default=None, help="verify: also write the machine-readable report here")
+    p.set_defaults(func=cmd_deck)
 
     p = sub.add_parser("run")
     add_selector(p)

--- a/skills/attractor-scout/tests/test_scenario10_deck_brief.py
+++ b/skills/attractor-scout/tests/test_scenario10_deck_brief.py
@@ -1,0 +1,260 @@
+"""Scenario 10 — the deck brief, and the CLI contract around deck mode.
+
+The brief is the ONLY thing a fresh-context deck author sees. If it does not
+carry the mandates, the author cannot pass the gates; if it does not carry the
+real `.dot` text, the author cannot draw the real pipeline. Both are asserted
+here rather than promised.
+
+The CLI half pins the exit-code contract: 0 when every gate passed, 3 when one
+did not. **A gate-red deck is never published** — the same posture the demo
+layer takes on a red verification ladder.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from attractor_scout import deck as deck_mod
+from attractor_scout import deck_templates as DT
+from attractor_scout.naming import DECK_FILENAME, SKILL_NAME
+
+from fixtures import deck_fixture as F
+
+SKILL_DIR = Path(__file__).resolve().parent.parent
+CLI = SKILL_DIR / "scripts" / "attractor_scout_cli.py"
+
+
+@pytest.fixture
+def run_dir(tmp_path: Path) -> Path:
+    (tmp_path / "ranked.json").write_text(json.dumps(F.deck_ranked_fixture()), encoding="utf-8")
+    (tmp_path / "demos.json").write_text(json.dumps(F.deck_demos_fixture()), encoding="utf-8")
+    return tmp_path
+
+
+def _run_cli(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(CLI), *args],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+
+
+# ------------------------------------------------------------------- brief
+def test_brief_is_written_and_deterministic(run_dir: Path):
+    first = deck_mod.build_deck_brief(
+        ranked_path=run_dir / "ranked.json", demos_path=run_dir / "demos.json", workdir=run_dir / "deck"
+    )
+    assert first.name == "deck-brief.md"
+    text_a = first.read_text(encoding="utf-8")
+    second = deck_mod.build_deck_brief(
+        ranked_path=run_dir / "ranked.json", demos_path=run_dir / "demos.json", workdir=run_dir / "deck2"
+    )
+    assert second.read_text(encoding="utf-8") == text_a, "the same run must always produce the same brief"
+
+
+def test_brief_carries_all_four_mandates(run_dir: Path):
+    """★ Without these, the gates are unpassable by an author who cannot see them."""
+    brief = deck_mod.build_deck_brief(
+        ranked_path=run_dir / "ranked.json", demos_path=run_dir / "demos.json", workdir=run_dir / "deck"
+    ).read_text(encoding="utf-8")
+    for mandate in (
+        "MANDATE 1 --- EVERY DISPLAYED NUMBER RESOLVES",
+        "MANDATE 2 --- DECLARE EVERY DERIVED VALUE",
+        "MANDATE 3 --- DIAGRAM FIDELITY IS CHECKED",
+        "MANDATE 4 --- ABSENT DATA GETS AN HONEST NOTE",
+    ):
+        assert mandate in brief, f"the brief must state {mandate!r}"
+    assert DT.DERIVED_BLOCK_ID in brief
+    assert DT.NODE_ATTR in brief and DT.EDGE_ATTR in brief
+    assert "TESTIMONY" in brief
+
+
+def test_brief_carries_the_real_dot_text_verbatim(run_dir: Path):
+    """★ The diagram must be OF the pipeline, so the pipeline must be IN the brief."""
+    brief = deck_mod.build_deck_brief(
+        ranked_path=run_dir / "ranked.json", demos_path=run_dir / "demos.json", workdir=run_dir / "deck"
+    ).read_text(encoding="utf-8")
+    assert F.DECK_DOT.rstrip() in brief
+    for node in F.DECK_NODES:
+        assert node in brief
+    for edge in F.DECK_EDGES:
+        assert edge in brief, f"the brief must spell edge {edge!r} the way the gate expects it"
+
+
+def test_brief_carries_the_style_contract_and_hard_constraints(run_dir: Path):
+    brief = deck_mod.build_deck_brief(
+        ranked_path=run_dir / "ranked.json", demos_path=run_dir / "demos.json", workdir=run_dir / "deck"
+    ).read_text(encoding="utf-8")
+    for marker in (
+        "THE SECTION ARC",
+        "HERO",
+        "TEACH THE BASIN",
+        "RANKED OPPORTUNITIES",
+        "DEMONSTRATIONS",
+        "HONEST NOES AND WASTE",
+        "GOING FORWARD",
+        "THE DIAGRAM GRAMMAR",
+        "HARD CONSTRAINTS",
+        "ZERO EXTERNAL REQUESTS",
+        "WORKS FROM file://",
+        "SYSTEM FONTS ONLY",
+        "prefers-reduced-motion",
+    ):
+        assert marker in brief, f"the brief must carry {marker!r}"
+
+
+def test_brief_carries_the_gate_verdicts_verbatim(run_dir: Path):
+    brief = deck_mod.build_deck_brief(
+        ranked_path=run_dir / "ranked.json", demos_path=run_dir / "demos.json", workdir=run_dir / "deck"
+    ).read_text(encoding="utf-8")
+    assert "doctrine_ok" in brief
+    assert "doctrine-only" in brief
+    assert "NOT RUN" in brief
+
+
+def test_brief_names_what_the_run_does_not_have(run_dir: Path):
+    """Mandate 4 needs a subject: the absences are computed, not guessed."""
+    brief = deck_mod.build_deck_brief(
+        ranked_path=run_dir / "ranked.json", demos_path=run_dir / "demos.json", workdir=run_dir / "deck"
+    ).read_text(encoding="utf-8")
+    assert "WHAT THIS RUN DOES NOT HAVE" in brief
+    assert "workspace / project attribution" in brief
+    assert "per-step LLM success rate" in brief
+
+
+def test_brief_lists_the_numbers_that_are_already_legal(run_dir: Path):
+    brief = deck_mod.build_deck_brief(
+        ranked_path=run_dir / "ranked.json", demos_path=run_dir / "demos.json", workdir=run_dir / "deck"
+    ).read_text(encoding="utf-8")
+    assert "NUMBERS THAT ARE ALREADY LEGAL" in brief
+    whitelist = deck_mod.build_number_whitelist(
+        json.loads((run_dir / "ranked.json").read_text()),
+        json.loads((run_dir / "demos.json").read_text()),
+    )
+    assert "930" in whitelist and "12" in whitelist and "7" in whitelist
+
+
+def test_brief_works_with_no_demonstrations(run_dir: Path):
+    brief = deck_mod.build_deck_brief(
+        ranked_path=run_dir / "ranked.json", demos_path=None, workdir=run_dir / "deck"
+    ).read_text(encoding="utf-8")
+    assert "none were produced in this run" in brief
+    assert "skip the demonstrations section" in brief
+
+
+def test_brief_names_the_published_filename(run_dir: Path):
+    brief = deck_mod.build_deck_brief(
+        ranked_path=run_dir / "ranked.json", demos_path=run_dir / "demos.json", workdir=run_dir / "deck"
+    ).read_text(encoding="utf-8")
+    assert DECK_FILENAME in brief
+    assert DECK_FILENAME == f"{SKILL_NAME}-deck.html"
+
+
+# --------------------------------------------------------------------- CLI
+def test_cli_brief_prints_only_the_path(run_dir: Path):
+    proc = _run_cli(
+        "deck",
+        "brief",
+        "--ranked",
+        str(run_dir / "ranked.json"),
+        "--demos",
+        str(run_dir / "demos.json"),
+        "--workdir",
+        str(run_dir / "deck"),
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout.strip() == str(run_dir / "deck" / "deck-brief.md")
+
+
+def test_cli_verify_exits_zero_on_a_clean_deck(run_dir: Path):
+    (run_dir / "deck.html").write_text(F.clean_deck(), encoding="utf-8")
+    proc = _run_cli(
+        "deck",
+        "verify",
+        "--deck",
+        str(run_dir / "deck.html"),
+        "--ranked",
+        str(run_dir / "ranked.json"),
+        "--demos",
+        str(run_dir / "demos.json"),
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "verdict: PASS" in proc.stdout
+
+
+def test_cli_verify_exits_three_on_a_red_gate(run_dir: Path):
+    """★ The publish-or-refuse seam: a red gate is a distinct, loud exit code."""
+    (run_dir / "deck.html").write_text(F.with_fabricated_number(), encoding="utf-8")
+    proc = _run_cli(
+        "deck",
+        "verify",
+        "--deck",
+        str(run_dir / "deck.html"),
+        "--ranked",
+        str(run_dir / "ranked.json"),
+        "--demos",
+        str(run_dir / "demos.json"),
+        "--report",
+        str(run_dir / "deck-gate-report.txt"),
+    )
+    assert proc.returncode == 3, proc.stdout + proc.stderr
+    assert "verdict: FAIL" in proc.stdout
+    assert "DECK GATE RED [d]" in proc.stderr
+    assert "was NOT published" in proc.stderr
+    report = (run_dir / "deck-gate-report.txt").read_text(encoding="utf-8")
+    assert "[FAIL] d" in report
+
+
+def test_cli_verify_writes_a_machine_readable_report(run_dir: Path):
+    (run_dir / "deck.html").write_text(F.clean_deck(), encoding="utf-8")
+    proc = _run_cli(
+        "deck",
+        "verify",
+        "--deck",
+        str(run_dir / "deck.html"),
+        "--ranked",
+        str(run_dir / "ranked.json"),
+        "--demos",
+        str(run_dir / "demos.json"),
+        "--json-out",
+        str(run_dir / "gates.json"),
+    )
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads((run_dir / "gates.json").read_text(encoding="utf-8"))
+    assert payload["ok"] is True
+    assert len(payload["gates"]) == 5
+
+
+def test_cli_fails_loud_on_a_missing_deck(run_dir: Path):
+    proc = _run_cli(
+        "deck",
+        "verify",
+        "--deck",
+        str(run_dir / "nope.html"),
+        "--ranked",
+        str(run_dir / "ranked.json"),
+    )
+    assert proc.returncode == 2
+    assert "FAIL-LOUD" in proc.stderr
+
+
+# ------------------------------------------------------------------ publish
+def test_publish_lands_beside_the_report(run_dir: Path, tmp_path: Path):
+    candidate = run_dir / "deck.html"
+    candidate.write_text(F.clean_deck(), encoding="utf-8")
+    out_dir = tmp_path / "artifacts"
+    out_dir.mkdir()
+    published = deck_mod.publish_deck(candidate, out_dir)
+    assert published == out_dir / DECK_FILENAME
+    assert published.read_text(encoding="utf-8") == F.clean_deck()
+
+
+def test_deck_mode_is_bounded_to_two_attempts():
+    """One authoring delegation, plus at most one gate-informed retry. Never more."""
+    assert deck_mod.DECK_MAX_ATTEMPTS == 2

--- a/skills/attractor-scout/tests/test_scenario9_deck_gates.py
+++ b/skills/attractor-scout/tests/test_scenario9_deck_gates.py
@@ -1,0 +1,464 @@
+"""Scenario 9 — the deck-mode gates, proven GREEN and proven RED.
+
+Deck mode gives up the deterministic renderer's structural guarantee (a
+language model authors the whole page) and buys the trust back with gates. A
+gate that has never been shown failing is not a gate, so every gate class here
+is exercised twice: once over the clean synthetic deck, and once over a
+mutation that breaks exactly one property.
+
+No LLM anywhere. The candidate deck is a fixture; the run data is a fixture;
+everything in between is stdlib and deterministic.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from attractor_scout import deck as deck_mod
+from attractor_scout import deck_templates as DT
+
+from fixtures import deck_fixture as F
+
+
+@pytest.fixture
+def run_dir(tmp_path: Path) -> Path:
+    """A completed run's data on disk: ranked.json + demos.json."""
+    (tmp_path / "ranked.json").write_text(json.dumps(F.deck_ranked_fixture()), encoding="utf-8")
+    (tmp_path / "demos.json").write_text(json.dumps(F.deck_demos_fixture()), encoding="utf-8")
+    return tmp_path
+
+
+def _verify(run_dir: Path, html: str, *, name: str = "deck.html") -> deck_mod.DeckReport:
+    candidate = run_dir / name
+    candidate.write_text(html, encoding="utf-8")
+    return deck_mod.verify_deck(
+        deck_path=candidate,
+        ranked_path=run_dir / "ranked.json",
+        demos_path=run_dir / "demos.json",
+    )
+
+
+def _gate(report: deck_mod.DeckReport, letter: str) -> deck_mod.GateResult:
+    for gate in report.gates:
+        if gate.letter == letter:
+            return gate
+    raise AssertionError(f"no gate {letter!r} in the report")
+
+
+# --------------------------------------------------------------------- GREEN
+def test_clean_deck_passes_every_gate(run_dir: Path):
+    """★ The green baseline: a minimal clean deck clears all five gates."""
+    report = _verify(run_dir, F.clean_deck())
+    failing = [f"{g.letter}: {g.findings}" for g in report.gates if not g.passed]
+    assert report.ok, f"the clean fixture deck must pass every gate; failures: {failing}"
+    assert [g.letter for g in report.gates] == ["a", "b", "c", "d", "e"]
+
+
+def test_clean_deck_report_reports_real_numbers(run_dir: Path):
+    report = _verify(run_dir, F.clean_deck())
+    assert "2 https href(s)" in _gate(report, "b").detail
+    assert "1 dialog(s), 1 trigger(s), 1 paired" in _gate(report, "c").detail
+    assert "declared derivation" in _gate(report, "d").detail
+    assert "1 of 1 demonstration diagram(s) matched" in _gate(report, "e").detail
+
+
+def test_verdict_line_says_pass(run_dir: Path):
+    report = _verify(run_dir, F.clean_deck())
+    assert "verdict: PASS" in report.render()
+
+
+# ----------------------------------------------------------- (a) it parses
+def test_red_unclosed_container_fails_gate_a(run_dir: Path):
+    report = _verify(run_dir, F.broken_nesting())
+    assert not report.ok
+    gate = _gate(report, "a")
+    assert not gate.passed
+    assert any("section" in f for f in gate.findings), gate.findings
+
+
+def test_red_missing_doctype_fails_gate_a(run_dir: Path):
+    report = _verify(run_dir, F.clean_deck().replace("<!doctype html>\n", "", 1))
+    assert not _gate(report, "a").passed
+
+
+# ------------------------------------------------- (b) it is self-contained
+def test_red_external_image_fails_gate_b(run_dir: Path):
+    report = _verify(run_dir, F.with_external_resource())
+    assert not report.ok
+    gate = _gate(report, "b")
+    assert not gate.passed
+    assert any("<img>" in f for f in gate.findings), gate.findings
+
+
+@pytest.mark.parametrize(
+    ("mutation", "needle"),
+    [
+        ('<link rel="stylesheet" href="deck.css">', "<link>"),
+        ('<script src="deck.js"></script>', "src attribute"),
+        ("<style>@import url(other.css);</style>", "@import"),
+        ('<iframe src="x.html"></iframe>', "<iframe>"),
+        ('<source srcset="a.png 1x">', "srcset"),
+    ],
+)
+def test_red_each_external_resource_class_fails_gate_b(run_dir: Path, mutation: str, needle: str):
+    html = F.clean_deck().replace("</head>", f"{mutation}\n</head>", 1)
+    gate = _gate(_verify(run_dir, html), "b")
+    assert not gate.passed
+    assert any(needle in f for f in gate.findings), (needle, gate.findings)
+
+
+def test_red_non_local_url_reference_fails_gate_b(run_dir: Path):
+    html = F.clean_deck().replace("--bg:#0b0e13;", "--bg:url(https://example.invalid/bg.png);", 1)
+    gate = _gate(_verify(run_dir, html), "b")
+    assert not gate.passed
+    assert any("url(" in f for f in gate.findings)
+
+
+def test_red_third_https_link_fails_gate_b(run_dir: Path):
+    html = F.clean_deck().replace(
+        "</footer>",
+        '<p><a href="https://example.invalid/more">more</a></p></footer>',
+        1,
+    )
+    gate = _gate(_verify(run_dir, html), "b")
+    assert not gate.passed
+    assert f"exactly {DT.ALLOWED_HTTPS_HREFS} are permitted" in " ".join(gate.findings)
+
+
+def test_red_file_url_fails_gate_b(run_dir: Path):
+    html = F.clean_deck().replace("The bundle:", 'The bundle: <a href="file:///tmp/x">local</a>', 1)
+    gate = _gate(_verify(run_dir, html), "b")
+    assert not gate.passed
+    assert any("file://" in f for f in gate.findings)
+
+
+# ------------------------------------------- (c) dialogs and their triggers
+def test_red_orphan_dialog_fails_gate_c(run_dir: Path):
+    report = _verify(run_dir, F.with_orphan_dialog())
+    assert not report.ok
+    gate = _gate(report, "c")
+    assert not gate.passed
+    assert any("m-orphan" in f for f in gate.findings), gate.findings
+
+
+def test_red_trigger_pointing_at_nothing_fails_gate_c(run_dir: Path):
+    html = F.clean_deck().replace('data-modal="m-unit"', 'data-modal="m-missing"', 1)
+    gate = _gate(_verify(run_dir, html), "c")
+    assert not gate.passed
+    assert any("m-missing" in f for f in gate.findings)
+
+
+def test_two_triggers_for_one_dialog_is_legal(run_dir: Path):
+    """Not a strict bijection: a dialog may be opened from more than one place.
+
+    The recovered exemplar does exactly this (two entry points into one
+    deep-dive). What is forbidden is an ORPHAN in either direction.
+    """
+    html = F.clean_deck().replace(
+        '</section>\n\n<section id="demos">',
+        '<p class="hot" role="button" tabindex="0" data-modal="m-unit">Same detail, second door.</p>'
+        '</section>\n\n<section id="demos">',
+        1,
+    )
+    gate = _gate(_verify(run_dir, html), "c")
+    assert gate.passed, gate.findings
+    assert "2 trigger(s)" in gate.detail
+
+
+# -------------------------------------------------- (d) every number resolves
+def test_red_fabricated_number_fails_gate_d(run_dir: Path):
+    """★ The load-bearing red-proof: a figure the run never produced."""
+    report = _verify(run_dir, F.with_fabricated_number())
+    assert not report.ok
+    gate = _gate(report, "d")
+    assert not gate.passed
+    assert any("4812" in f or "4,812" in f for f in gate.findings), gate.findings
+
+
+def test_red_undeclared_derivation_fails_gate_d(run_dir: Path):
+    """Real arithmetic, correct answer, never declared — still red."""
+    report = _verify(run_dir, F.without_derived_block())
+    gate = _gate(report, "d")
+    assert not gate.passed
+    assert any("'18'" in f for f in gate.findings), gate.findings
+
+
+def test_red_derivation_without_provenance_fails_gate_d(run_dir: Path):
+    """Declared, but with no arithmetic provenance — indistinguishable from invention."""
+    report = _verify(run_dir, F.with_unprovenanced_derivation())
+    gate = _gate(report, "d")
+    assert not gate.passed
+    assert any("provenance" in f for f in gate.findings), gate.findings
+
+
+def test_red_derivation_citing_an_unsupplied_input_fails_gate_d(run_dir: Path):
+    html = F.clean_deck().replace('"inputs": ["7", "11"]', '"inputs": ["7", "9999"]', 1)
+    gate = _gate(_verify(run_dir, html), "d")
+    assert not gate.passed
+    assert any("9999" in f for f in gate.findings), gate.findings
+
+
+def test_malformed_derived_block_fails_gate_d(run_dir: Path):
+    html = F.clean_deck().replace('[\n  {"value": "18",', "[ not json {", 1)
+    gate = _gate(_verify(run_dir, html), "d")
+    assert not gate.passed
+
+
+def test_supplied_stats_are_stateable_without_declaration(run_dir: Path):
+    """A verified stat may be printed in digits with no ceremony at all."""
+    html = F.clean_deck().replace(
+        "<h1>Your work, mapped.</h1>",
+        "<h1>Your work, mapped.</h1><p>7 sessions, 12 median tool calls, 930 seconds.</p>",
+        1,
+    )
+    gate = _gate(_verify(run_dir, html), "d")
+    assert gate.passed, gate.findings
+
+
+def test_pipeline_parameters_are_stateable(run_dir: Path):
+    """Numbers written inside the generated .dot are supplied data, not invention."""
+    html = F.clean_deck().replace(
+        "<h1>Your work, mapped.</h1>",
+        "<h1>Your work, mapped.</h1><p>The wall stops after 3 attempts.</p>",
+        1,
+    )
+    assert _gate(_verify(run_dir, html), "d").passed
+
+
+def test_named_limit_spelled_out_numbers_are_not_caught(run_dir: Path):
+    """NAMED LIMIT — documented in `deck.py`, not closed.
+
+    A written numeral is not a numeric token and passes unchecked. Detecting
+    written numerals is NLP guesswork; a fail-loud guard that guessed wrong
+    would block honest prose. If this test ever starts failing because someone
+    closed the hole, the docstring in `deck.py` must be updated to match.
+    """
+    html = F.clean_deck().replace(
+        "<h1>Your work, mapped.</h1>",
+        "<h1>Your work, mapped.</h1><p>Four thousand eight hundred and twelve units were examined.</p>",
+        1,
+    )
+    assert _gate(_verify(run_dir, html), "d").passed
+
+
+def test_named_limit_decomposition_rides_along(run_dir: Path):
+    """NAMED LIMIT — a supplied decimal's own sub-runs pass with it.
+
+    `0.33` whitelists the bare run `33`, so "33 percent" passes. A neighbouring
+    value the data does not contain is still rejected, so the leak is bounded
+    to runs a supplied number literally contains.
+    """
+    clean = F.clean_deck()
+    ok = clean.replace("<h1>Your work, mapped.</h1>", "<h1>Your work, mapped.</h1><p>About 33 percent.</p>", 1)
+    assert _gate(_verify(run_dir, ok), "d").passed
+    bad = clean.replace("<h1>Your work, mapped.</h1>", "<h1>Your work, mapped.</h1><p>About 37 percent.</p>", 1)
+    assert not _gate(_verify(run_dir, bad), "d").passed
+
+
+def test_scope_boundary_attribute_numbers_are_not_scanned(run_dir: Path):
+    """SCOPE BOUNDARY — SVG geometry and id references are not visible claims.
+
+    Stated so it cannot quietly widen: gate (d) reads text nodes plus the meta
+    description. Coordinates are numbers by the thousand and whitelisting them
+    would gut the gate.
+    """
+    html = F.clean_deck().replace('viewBox="0 0 900 200"', 'viewBox="0 0 1234 5678"', 1)
+    assert _gate(_verify(run_dir, html), "d").passed
+
+
+def test_meta_description_is_scanned(run_dir: Path):
+    """The page's own summary sentence is a visible claim, and is checked."""
+    html = F.clean_deck().replace(
+        'content="A synthetic deck-mode fixture:',
+        'content="A synthetic deck-mode fixture over 4812 sessions:',
+        1,
+    )
+    assert not _gate(_verify(run_dir, html), "d").passed
+
+
+# ---------------------------------------------------- (e) diagram fidelity
+def test_red_edge_multiset_off_by_one_fails_gate_e(run_dir: Path):
+    """★ The corrective back-edge quietly not drawn — the exact failure that matters."""
+    report = _verify(run_dir, F.with_edge_dropped())
+    assert not report.ok
+    gate = _gate(report, "e")
+    assert not gate.passed
+    joined = " ".join(gate.findings)
+    assert "edge multiset differs" in joined
+    assert "budget_wall->worker" in joined, gate.findings
+
+
+def test_red_duplicate_edge_drawn_once_fails_gate_e(run_dir: Path):
+    """A multiset, not a set: an edge declared twice must be drawn twice."""
+    doubled_dot = F.DECK_DOT.replace(
+        "    start -> worker\n",
+        "    start -> worker\n    start -> worker\n",
+        1,
+    )
+    demos = F.deck_demos_fixture()
+    demos["demos"][0]["dot_text"] = doubled_dot
+    (run_dir / "demos.json").write_text(json.dumps(demos), encoding="utf-8")
+    gate = _gate(_verify(run_dir, F.clean_deck()), "e")
+    assert not gate.passed
+    assert "start->worker" in " ".join(gate.findings)
+
+
+def test_red_invented_node_fails_gate_e(run_dir: Path):
+    gate = _gate(_verify(run_dir, F.with_node_added()), "e")
+    assert not gate.passed
+    assert "tidy_up" in " ".join(gate.findings)
+
+
+def test_red_no_matching_diagram_fails_gate_e(run_dir: Path):
+    html = F.clean_deck().replace(f'data-diagram="{F.DECK_SLUG}"', "", 1).replace('data-node="start"', "", 1)
+    gate = _gate(_verify(run_dir, html), "e")
+    assert not gate.passed
+    assert "could be matched" in " ".join(gate.findings)
+
+
+def test_node_set_fallback_matches_when_data_diagram_is_absent(run_dir: Path):
+    """The recovered exemplar carries no `data-diagram`; the gate still works."""
+    html = F.clean_deck().replace(f' data-diagram="{F.DECK_SLUG}"', "", 1)
+    gate = _gate(_verify(run_dir, html), "e")
+    assert gate.passed, gate.findings
+
+
+def test_diagram_with_no_demonstration_to_check_against_is_red(tmp_path: Path):
+    (tmp_path / "ranked.json").write_text(json.dumps(F.deck_ranked_fixture()), encoding="utf-8")
+    candidate = tmp_path / "deck.html"
+    candidate.write_text(F.clean_deck(), encoding="utf-8")
+    report = deck_mod.verify_deck(deck_path=candidate, ranked_path=tmp_path / "ranked.json", demos_path=None)
+    gate = _gate(report, "e")
+    assert not gate.passed
+    assert "no demonstration bundle was supplied" in " ".join(gate.findings)
+
+
+# ------------------------------------------------------------ report shape
+def test_failures_name_the_file_and_the_reason(run_dir: Path):
+    report = _verify(run_dir, F.with_fabricated_number(), name="candidate-deck.html")
+    text = report.render()
+    assert "candidate-deck.html" in text
+    assert "verdict: FAIL" in text
+    assert "[FAIL] d" in text
+    assert "[PASS] a" in text
+
+
+def test_report_round_trips_as_json(run_dir: Path):
+    report = _verify(run_dir, F.clean_deck())
+    payload = json.loads(json.dumps(report.as_dict()))
+    assert payload["ok"] is True
+    assert [g["letter"] for g in payload["gates"]] == ["a", "b", "c", "d", "e"]
+
+
+# ===================================================================
+# HARDENING (adversarial review MERGE-AFTER-FIX) --- RED + PASS proofs
+# ===================================================================
+
+
+# ---- FIX 1: derived-values self-dealing (inputs now mandatory) ------------
+def test_red_inputless_derivation_fails_gate_d(run_dir: Path):
+    """The reviewer's exact probe: {"value":"8731","from":"qqq"} with no inputs.
+
+    This used to PASS (inputs were optional, only a non-empty `from` was
+    required). It must now be RED --- a value cannot be conjured from nothing.
+    """
+    report = _verify(run_dir, F.with_inputless_derivation())
+    assert not report.ok
+    gate = _gate(report, "d")
+    assert not gate.passed
+    assert any("no 'inputs'" in f for f in gate.findings), gate.findings
+
+
+def test_red_empty_inputs_derivation_fails_gate_d(run_dir: Path):
+    gate = _gate(_verify(run_dir, F.with_empty_inputs_derivation()), "d")
+    assert not gate.passed
+    assert any("inputs" in f for f in gate.findings), gate.findings
+
+
+def test_red_from_not_referencing_inputs_fails_gate_d(run_dir: Path):
+    """A `from` that lists inputs but references none of them is junk provenance."""
+    gate = _gate(_verify(run_dir, F.with_from_not_referencing_inputs()), "d")
+    assert not gate.passed
+    assert any("does not reference" in f for f in gate.findings), gate.findings
+
+
+def test_named_limit_wrong_total_with_real_inputs_passes_gate_d(run_dir: Path):
+    """NAMED LIMIT (expected PASS) --- P5/P6 kept: the gate does not recompute.
+
+    A declaration with real, supplied inputs and a `from` that references them
+    passes even when the stated total is wrong (7 + 11 != 900). Recomputing is
+    the residual; declaring real inputs is what the hardening forces. If this
+    ever fails because someone added arithmetic evaluation, deck.py's named
+    limit and design doc must be updated to match.
+    """
+    gate = _gate(_verify(run_dir, F.with_wrong_total_but_real_inputs()), "d")
+    assert gate.passed, gate.findings
+
+
+# ---- FIX 2: gate (b) blocklist holes --------------------------------------
+@pytest.mark.parametrize(
+    ("mutation", "needle"),
+    [
+        (F.with_object_data, "<object>"),
+        (F.with_xlink_href, "xlink:href"),
+        (F.with_media_source, "<source>"),
+        (F.with_embed, "<embed>"),
+        (F.with_track, "<track>"),
+        (F.with_use_href, "xlink:href / <use> href"),
+    ],
+)
+def test_red_each_gate_b_hole_now_fails(run_dir: Path, mutation, needle):
+    """Every external-resource construct the review found publishing clean is RED."""
+    report = _verify(run_dir, mutation())
+    assert not report.ok, f"{mutation.__name__} should fail gate b"
+    gate = _gate(report, "b")
+    assert not gate.passed
+    assert any(needle in f for f in gate.findings), (needle, gate.findings)
+
+
+def test_gate_b_detail_line_is_truthful_when_violated(run_dir: Path):
+    """The detail line must report the real external-resource count, not a hardcoded 0."""
+    gate = _gate(_verify(run_dir, F.with_object_data()), "b")
+    assert "0 external-resource" not in gate.detail
+    assert "external-resource element(s)/attribute(s)" in gate.detail
+
+
+def test_local_use_href_is_legal(run_dir: Path):
+    """A same-document <use href="#local"> reference is not external --- PASS."""
+    gate = _gate(_verify(run_dir, F.with_local_use_href()), "b")
+    assert gate.passed, gate.findings
+
+
+# ---- FIX 3: gate (d) blind to script-injected text ------------------------
+def test_red_script_injected_number_fails_gate_d(run_dir: Path):
+    """document.title = "8731 units examined" --- injected via JS, must be caught."""
+    report = _verify(run_dir, F.with_script_injected_number())
+    assert not report.ok
+    gate = _gate(report, "d")
+    assert not gate.passed
+    assert any("8731" in f and "script" in f for f in gate.findings), gate.findings
+
+
+def test_named_limit_script_geometry_string_passes_gate_d(run_dir: Path):
+    """NAMED LIMIT (expected PASS) --- a CSS/geometry string literal with digits but
+    no prose word (the exemplar's own IntersectionObserver rootMargin) is not a
+    displayed claim and is not scanned. Scanning every literal would false-positive
+    here; if this ever fails, the named limit in deck.py must be updated."""
+    gate = _gate(_verify(run_dir, F.with_script_geometry_string()), "d")
+    assert gate.passed, gate.findings
+
+
+def test_named_limit_script_concatenated_number_passes_gate_d(run_dir: Path):
+    """NAMED LIMIT (expected PASS) --- a number built from a bare numeric LITERAL by
+    concatenation ("" + 8731 + " units") is not inside a string literal and is
+    not seen. The computed/concatenated residual, kept on purpose."""
+    gate = _gate(_verify(run_dir, F.with_script_concatenated_number()), "d")
+    assert gate.passed, gate.findings
+
+
+def test_clean_deck_detail_counts_the_script_body(run_dir: Path):
+    """The gate-d detail line names how many inline script bodies were scanned."""
+    gate = _gate(_verify(run_dir, F.clean_deck()), "d")
+    assert "inline script body(ies)" in gate.detail

--- a/skills/attractor-scout/tests/test_skill_doc_claims.py
+++ b/skills/attractor-scout/tests/test_skill_doc_claims.py
@@ -91,3 +91,43 @@ def test_skill_percentages_are_all_accounted_for():
         f"SKILL.md contains unpinned percentage(s) {sorted(unexpected)}. Pin each to "
         f"evals/README.md (add to PINNED_CLAIMS) or remove it."
     )
+
+
+# --------------------------------------------------------------------------
+# Step 10 (deck mode) claims, pinned to the CODE that makes them true.
+# Same doctrine as above, but the source of truth is the implementation, not
+# evals/README.md: step 10 describes gate behaviour, so a claim that drifts
+# from the code must break this test rather than mislead a reader.
+# --------------------------------------------------------------------------
+
+#: (phrase that must appear in SKILL.md, substring that must source it, source file)
+STEP10_PINNED_CLAIMS = [
+    ("attractor-scout-deck.html", 'DECK_FILENAME = f"{SKILL_NAME}-deck.html"', "scripts/attractor_scout/naming.py"),
+    ("exit 3", "return 3", "scripts/attractor_scout_cli.py"),
+    ("deck verify", "def cmd_deck", "scripts/attractor_scout_cli.py"),
+    ("deck brief", 'action == "brief"', "scripts/attractor_scout_cli.py"),
+    # The 600 s provider-timeout rationale for staged delegation (FOLD 6).
+    ("600 s", "DECK_MAX_ATTEMPTS", "scripts/attractor_scout/deck.py"),
+]
+
+
+def test_step10_claims_are_sourced_in_code():
+    skill = _strip_emphasis(SKILL_MD.read_text(encoding="utf-8"))
+    for phrase, source, relpath in STEP10_PINNED_CLAIMS:
+        assert _strip_emphasis(phrase) in skill, f"SKILL.md no longer contains the step-10 claim {phrase!r}"
+        code = (SKILL_DIR / relpath).read_text(encoding="utf-8")
+        assert source in code, (
+            f"SKILL.md's step-10 claim {phrase!r} is not sourced by {source!r} in {relpath} \u2014 "
+            f"the code moved; re-check the claim or update the pin."
+        )
+
+
+def test_step10_names_all_five_gates():
+    """Step 10 must describe every deterministic deck gate (a)-(e) by letter.
+
+    Guards against a future edit silently dropping a gate description from the
+    guidance while the gate still runs in code.
+    """
+    skill = SKILL_MD.read_text(encoding="utf-8")
+    for letter in "abcde":
+        assert f"**({letter})**" in skill, f"SKILL.md step 10 no longer names deck gate ({letter})"


### PR DESCRIPTION
## Summary
**Deck mode** for `skills/attractor-scout/` — an opt-in step 10 that turns the skill's verified mining data into a deck-grade, personalized, educational HTML artifact (the house deck style: section arc, inline-SVG diagram grammar, `<dialog>` deep-dives, dark editorial aesthetic), with the trust discipline enforced by code: a deterministic `deck brief` (house style/technique contract + hard constraints + the run's REAL data and demo `.dot` files inlined) feeds ONE bounded fresh-context `reasoning` delegation (budget 2; driven across resumed turns — a whole-deck single request exceeds provider timeouts, now stated in SKILL.md), and a `deck verify` subcommand gates the result: (a) parse, (b) self-containment, (c) dialog↔trigger pairing, (d) ★ deck-wide number re-verification — every digit-run in visible text AND in inline-script string literals must resolve against the run data or a declared-derived JSON block whose entries require non-empty `inputs` that each resolve against the run data and a `from` referencing them, (e) diagram fidelity — `data-node`/`data-edge` vs the real `.dot` node set + edge multiset. **Gate-failed decks never publish.** Optional vision rung after verify (honest `NOT RUN` label when unavailable). Depth rule: every ranked opportunity and every honest-NO gets its own modal — depth scales with findings, no numeric quota (a quota invites the padding gates (d)/(e) exist to prevent).

**Method provenance:** the generation recipe was recovered by transcript replay from the sessions that built the approved house decks (exemplar-techniques brief + real-data-inlined + scripted verification + vision QA), then hardened here into shipped mechanism. Design doc: `docs/designs/2026-08-19-attractor-scout-deck-mode.md`.

**Decision-matrix tier: Uncharted (extension), purely additive** — zero engine/module/contract changes (diff confined to `skills/attractor-scout/` + `docs/designs/`); steps 1–9 untouched; no-deck runs byte-unaffected. **EXTENSIONS entry — N/A:** no observable pipeline contract touched.

## Verification checklist
- [x] Unit tests — suite **398 passed / 52 skipped** (was 308/47): gate red/green fixtures per class, brief-mandate assembly, doc-claims pins for step 10
- [x] Live pipeline run — real-data live proof: 1 authoring attempt, all 5 gates green (218 numeric tokens re-verified vs 946 supplied values, 0 unresolved; 2/2 diagrams exact node set + edge multiset), 60,661 B deck published beside the report (artifacts outside the repo)
- [x] Independent adversarial review — **MERGE-AFTER-FIX, all findings closed**: it broke every gate independently, then found 3 real bypasses (below), each now a RED test; both existing decks re-verify green against the hardened gates
- [x] Guidance-surface toll — fresh-session walk-through: a general-role session given only the SKILL.md body executed step 10 unaided, all gates green, honest `vision QA: NOT RUN` stamp; no SKILL.md fix needed
- [x] Pre-publication leak review (§7) — new public content class (a new artifact type reaches users): outsider-brief read by the independent reviewer + deterministic guards green; a template example that carried real mined aggregates was replaced with synthetic numbers
- [x] Doc-claim guards — step-10 claims pinned in `test_skill_doc_claims.py`
- [x] CI green before merge — will confirm

## Required disclosures
1. **Three gate bypasses found by review, fixed + RED-tested:** (i) derived-values self-dealing — `inputs` was optional, so a fabricated number with a junk `from` passed gate (d); now mandatory, each input must resolve against run data, `from` must reference them; (ii) gate (b) was a blocklist missing `<object data=>`, SVG `xlink:href`, `<video><source src=>` (+ embed/track/use now covered; detail line made truthful); (iii) gate (d) was silently blind to script-injected text — inline-script string literals are now scanned; the residual (computed/concatenated strings) is a NAMED limit.
2. **Whitelist saturation** (measured on real data): 1–2-digit numbers are largely free (0–9: 100%, 10–99: ~94% coverage by supplied values); 3-digit ~14%. The gate's teeth are strongest on the distinctive numbers; stated in the design doc.
3. **Named declarative limit:** derived-value arithmetic is validated for provenance, not recomputed — fabrication is bounded to combinations of real values.
4. **Live-proof inputs not preserved** (the run's intermediates were transient); the walk-through deck is the fully reproducible proof and was independently re-verified by the reviewer.
5. Gate (c) is total-surjection (multiple triggers may open one dialog — the house prototype does this), not strict bijection.
