### PR TITLE
docs: close four verified Layer-3 drift findings; refute the fifth's severity

### DIFF
--- a/SPEC_CONFORMANCE.md
+++ b/SPEC_CONFORMANCE.md
@@ -17,8 +17,15 @@ Maintainer ruling, 2026-08-14. The four rules that decide every disposition in t
 1. **Honor the nlspec design where possible.** The upstream natural-language spec is the design of
    record; "we'd have done it differently" is not a reason to diverge.
 2. **100% support for community `.dot` files built against the nlspec.** A graph written to the
-   canonical spec must run on this engine unmodified. This is the hard constraint — an extension
-   that breaks a conforming graph is a bug, not an extension.
+   canonical spec must run on this engine unmodified. This is the hard constraint **on
+   extensions** — an extension that breaks a conforming graph is a bug, not an extension. It is
+   not a claim that *nothing* can require an edit: the decided **divergences** under rule 4 are
+   the enumerated exceptions, and each one names the graph shape it refuses and the one-line
+   remedy. Today the divergences that can require touching a conforming graph are `EXTENSIONS.md`
+   §16 (fail-fast routing — a graph relying on canonical "continue past FAIL on the best
+   unconditional edge" must add `runs_on=always` or `continue_on_fail` to the intended successor)
+   and §38 / ATX-13 (unknown-shape hard-fail — a decorative out-of-table shape must carry an
+   explicit `type=`). Rule 2 bounds what an *extension* may do; it does not repeal rule 4.
 3. **Extensions must be additive and non-interfering.** New attributes, shapes, and semantics may
    only add reachable behavior; they may not change what a spec-conformant graph does.
 4. **Divergences only for safety, backed by measured evidence, and always LOUD.** A divergence must
@@ -127,11 +134,20 @@ keys. Do not mark "live" until exercised against real providers (e.g. in a DTU w
 | ATX-13 | Unknown node shape hard-fails at dispatch instead of falling back to the default handler: `HandlerRegistry.get()` raises `ValueError` naming the shape, the node, the supported set, and the remedy | `§4.2 :603-607` (resolution order ends "3. Default handler (the codergen/LLM handler)"); `:628-629` (`RETURN default_handler`) | `handlers/__init__.py:116-121`; behavior contract `tests/test_no_silent_fallback.py`; both halves asserted by matrix row `ATX-M-F01` (`specs/conformance/attractor-matrix.yaml`) | **DONE — DECIDED** | DIVERGE (decided; ledgered — `specs/EXTENSIONS.md` §38; closes issue #234 F1) |
 | ATX-14 | `reasoning_effort` unset-passthrough: no engine-injected default anywhere, so Appendix A's `"high"` does not hold — an omitted attribute reaches the provider as no reasoning parameter at all, and node attr / `model_stylesheet` / profile are the only value sources | `§2.6 :162` and Appendix A `:2020` (default `"high"`) | `graph.py:251` (`Node.reasoning_effort = None`), `backend.py:244` + `__init__.py:114` (None passthrough; spawn path omits the key), `transforms.py`/`stylesheet.py` (explicit resolution surface); asserted by matrix row `ATX-M-F04`; authoring-guide claim pinned by `tests/test_doc_consistency.py` D-243 | **DONE — DECIDED** | DIVERGE (decided; ledgered — `specs/EXTENSIONS.md` §39; closes issue #234 F4) |
 
-**Shipped extensions (IMPROVE — fold into `specs/EXTENSIONS.md`):** fail-fast edge routing with
-`runs_on`/`continue_on_fail`; skip-propagation contracts (`requires=`/`outputs=`/`failed_outputs`,
+**Shipped extensions (IMPROVE — ledgered in `specs/EXTENSIONS.md`):** skip-propagation contracts
+(`requires=`/`outputs=`/`failed_outputs`,
 `PIPELINE_NODE_SKIPPED`/`PIPELINE_NODE_CONTRACT_VIOLATION`); parallel `k_of_n`/`quorum`/`error_policy`;
 human `freeform` mode + attachments; tool `parse_json`/`tool_env`/`tool.last_line`; `$param`/`${key}`
-substitution beyond `$goal`.
+substitution beyond `$goal`. These are additive: they add reachable behavior without changing what a
+spec-conformant graph does (doctrine rule 3).
+
+**Fail-fast edge routing (`runs_on`/`continue_on_fail`) is a DIVERGE, not an IMPROVE.** It changes
+what a conforming graph does on a FAIL outcome — canonical §3.3 step 4 selects the best unconditional
+edge regardless of outcome status; this engine stops unless the target declares
+`runs_on` ∈ {`always`, `failure`} or `continue_on_fail`. The load-bearing classification is
+conformance-matrix row `ATX-M-016` (`specs/conformance/attractor-matrix.yaml`),
+`disposition: DIVERGE-DECIDED`, ledgered at `specs/EXTENSIONS.md` §16 and asserted by
+`tests/test_edge_selection_no_silent_fallthrough.py`.
 
 ---
 

--- a/context/engine-semantics.md
+++ b/context/engine-semantics.md
@@ -28,8 +28,19 @@ Source: nlspec §2.8; `validation.py:24-34` (`SHAPE_TO_HANDLER`).
 | `house` | `stack.manager_loop` | no | orchestrates child | experimental ("future form TBD" `validation.py:33`) | [EXTENSION] |
 | `folder` | `pipeline` | no (runs child graph) | no | yes — merges child `outputs=` back `handlers/pipeline.py` | [EXTENSION] |
 
-Handler resolution: explicit `type` attr → shape mapping → default `codergen` (nlspec §4.2;
-`node_outputs.py:83-89`).
+Handler resolution (dispatch): explicit `type` attr → `node_type` attr → shape mapping →
+**hard-fail**. There is NO default-handler fallback: a shape outside the table above makes
+`HandlerRegistry.get()` raise `ValueError` naming the shape, the node id, the full supported-shape
+set, and the remedy (`shape=box` for an LLM node) — `handlers/__init__.py`. This is a **DECIDED
+DIVERGENCE** from nlspec §4.2, whose resolution order ends "3. Default handler (the codergen/LLM
+handler)": an unrecognized shape must never silently become an LLM session. Ledgered at
+`specs/EXTENSIONS.md` §38 and `SPEC_CONFORMANCE.md` ATX-13; both halves asserted by matrix row
+`ATX-M-F01`.
+
+The spec-literal `SHAPE_TO_HANDLER.get(shape, "codergen")` fallback survives only in **non-dispatch**
+helpers — lint classification (`validation.py`), output-table prediction
+(`node_outputs.py:83-89`), and preflight's effective-handler estimate
+(`preflight.py:80`). None of these selects an executing handler.
 
 ---
 

--- a/docs/DOT-AUTHORING-GUIDE.md
+++ b/docs/DOT-AUTHORING-GUIDE.md
@@ -223,7 +223,7 @@ unsatisfied goal-gate exit (spec §3.4), not on per-node failure.
 digraph {
     graph [
         goal="Generate an RFC 5322 email validation regex",
-        default_max_retry=3
+        default_max_retries=3
     ]
 
     start [shape=Mdiamond]
@@ -267,7 +267,7 @@ that can change the cause, not always back to a single generic attempt node.
 digraph ConvergencePipeline {
     graph [
         goal="Build, test, and security-scan a feature branch",
-        default_max_retry=2,
+        default_max_retries=2,
         // graph-level targets fire on unsatisfied goal-gate exit (spec §3.4),
         // NOT on per-node failure (spec §3.7). Per-node failure uses node-level
         // retry_target or a conditional edge.
@@ -1028,7 +1028,7 @@ Set these on the `graph` element:
 | `label` | String | `""` | Display name for the pipeline. |
 | `model_stylesheet` | String | `""` | CSS-like model assignment rules. |
 | `default_fidelity` | String | `compact` | Default context fidelity for all nodes. |
-| `default_max_retry` | Integer | `0` | Global retry ceiling. |
+| `default_max_retries` | Integer | `0` | Global retry ceiling. Legacy alias: `default_max_retry`. |
 | `retry_target` | String | `""` | Global retry target when exit has unsatisfied goal gates. |
 | `fallback_retry_target` | String | `""` | Global fallback retry target when exit has unsatisfied goal gates. |
 
@@ -1075,7 +1075,7 @@ digraph FeatureBuild {
     graph [
         goal="$goal",
         label="Feature Build Pipeline",
-        default_max_retry=2,
+        default_max_retries=2,
         default_fidelity="full",
         default_thread_id="feature-build"
     ]

--- a/docs/DOT-SYNTAX.md
+++ b/docs/DOT-SYNTAX.md
@@ -62,7 +62,7 @@ digraph {
 |-----------|------|-------------|
 | `goal` | string | Pipeline objective. Expands `$goal` in prompts. |
 | `default_fidelity` | string | Default fidelity for all nodes |
-| `default_max_retry` | int | Default retry count for all nodes |
+| `default_max_retries` | int | Default retry count for all nodes (default `0`). Legacy alias `default_max_retry` is accepted and maps to the same behavior (`dot_parser.py` `_set_graph_attr`) |
 | `retry_target` | string | Retry target when exit has unsatisfied goal gates (spec §3.4); not consulted on per-node failure |
 | `max_pipeline_duration` | string | Timeout for entire pipeline (e.g. "10m") |
 | `model_stylesheet` | string | CSS-like rules for model/provider config |
@@ -114,7 +114,7 @@ digraph {
 ### Retry Loop
 ```dot
 digraph {
-    graph [default_max_retry=3]
+    graph [default_max_retries=3]
     start [shape=Mdiamond]; done [shape=Msquare]
     do_work [prompt="$goal", goal_gate=true, retry_target="do_work"]
     verify [prompt="Verify the work"]

--- a/examples/pipelines/02-plan-implement-test.md
+++ b/examples/pipelines/02-plan-implement-test.md
@@ -80,7 +80,7 @@ meaningful in both contexts.
 - **`goal_gate` + `retry_target`**: the gate survives to the exit node check;
   `retry_target` names where to resume
 - **Iteration budget**: `max_pipeline_duration=300000` (5 minutes) is the
-  duration cap the engine actually enforces on this graph. Note: `default_max_retry`
+  duration cap the engine actually enforces on this graph. Note: `default_max_retries`
   bounds handler retries on individual nodes, not graph traversal through
   `loop_restart` edges — a loop without a real bound is a different foot-gun,
   not a fix. Use `max_pipeline_duration` for a duration cap the engine enforces.

--- a/examples/pipelines/04-retry-with-fallback.dot
+++ b/examples/pipelines/04-retry-with-fallback.dot
@@ -68,7 +68,7 @@ digraph RetryWithFallback {
     graph [
         goal="Generate a complex regex pattern that validates email addresses per RFC 5322",
         label="Retry with Fallback Pipeline",
-        default_max_retry=3,
+        default_max_retries=3,
         default_fidelity="full",
         default_thread_id="retry-with-fallback"
     ]

--- a/examples/pipelines/04-retry-with-fallback.md
+++ b/examples/pipelines/04-retry-with-fallback.md
@@ -72,7 +72,7 @@ committed at
 - **`retry_target`** (node-level): When `implement` exhausts retries, jump back to `plan` for a fresh approach (spec §3.7 step 2)
 - **`fallback_retry_target`** (node-level on `implement`): If no drawn edge matches a FAIL outcome, the engine would consult `retry_target` then `fallback_retry_target` as a belt-and-suspenders chain (spec §3.7 steps 2-3). The drawn edge `implement -> renegotiate` **is** the engine mechanism in this graph — it is selected at spec §3.3 Step 1 on any FAIL outcome, before the engine reaches `_resolve_failure_retry_target`. The attributes are present to demonstrate the retry-ladder API; they are not the active routing mechanism here.
 - **Fail-edge**: `validate_gate -> implement [condition="context.tool.last_line=gate_fail"]` — explicit per-node failure routing
-- **Graph-level `default_max_retry`**: Sets the global retry ceiling to 3
+- **Graph-level `default_max_retries`**: Sets the global retry ceiling to 3
 - **`goal_gate` + retry interaction**: Both `implement` and `simple_implement` are goal gates — the pipeline cannot exit until at least one succeeds
 - **`allow_partial`**: `simple_implement` accepts PARTIAL_SUCCESS when retries exhaust, treating it as good enough for the relaxed criteria
 

--- a/examples/pipelines/10-full-attractor.dot
+++ b/examples/pipelines/10-full-attractor.dot
@@ -13,7 +13,7 @@ digraph FullAttractor {
         goal="Build a user notifications feature with real-time WebSocket delivery, email fallback, and a React notification center UI",
         label="Full Attractor Kitchen Sink",
         default_fidelity="compact",
-        default_max_retry=3,
+        default_max_retries=3,
         retry_target="plan",
         fallback_retry_target="plan",
         model_stylesheet="

--- a/examples/pipelines/10-full-attractor.md
+++ b/examples/pipelines/10-full-attractor.md
@@ -48,7 +48,7 @@ This is a realistic "build a feature" pipeline that exercises **every Attractor 
 | **Class attribute** | `.planning`, `.code`, `.fast` on various nodes |
 | **Join policy** | `wait_all` on parallel_impl |
 | **Error policy** | `continue` on parallel_impl |
-| **Graph-level defaults** | `default_fidelity`, `default_max_retry`, `retry_target`, `fallback_retry_target` |
+| **Graph-level defaults** | `default_fidelity`, `default_max_retries`, `retry_target`, `fallback_retry_target` |
 
 ## Pipeline Structure
 

--- a/examples/pipelines/12-graph-resume.dot
+++ b/examples/pipelines/12-graph-resume.dot
@@ -37,7 +37,7 @@ digraph GraphResume {
         label="Graph-Level Resume Pattern",
         default_fidelity="full",
         default_thread_id="graph-resume",
-        default_max_retry=2
+        default_max_retries=2
     ]
     rankdir=LR
 

--- a/examples/pipelines/practical/feature-build.dot
+++ b/examples/pipelines/practical/feature-build.dot
@@ -7,7 +7,7 @@ digraph FeatureBuild {
     graph [
         goal="$goal",
         label="Feature Build Pipeline",
-        default_max_retry=2,
+        default_max_retries=2,
         default_fidelity="full",
         default_thread_id="feature-build"
     ]

--- a/examples/pipelines/practical/refactor.dot
+++ b/examples/pipelines/practical/refactor.dot
@@ -8,7 +8,7 @@ digraph Refactor {
     graph [
         goal="$goal",
         label="Safe Refactoring Pipeline",
-        default_max_retry=3,
+        default_max_retries=3,
         default_fidelity="full",
         default_thread_id="refactor"
     ]

--- a/examples/pipelines/practical/refactor.md
+++ b/examples/pipelines/practical/refactor.md
@@ -65,4 +65,4 @@ fire, and the pipeline would proceed to diff review even when tests are failing.
 gate runs `pytest` directly and routes on the actual exit code.
 
 **FAIL routing**: `snapshot_tests` has `retry_target="snapshot_tests"`. If any LLM node crashes
-(hard FAIL), the engine's `default_max_retry=3` provides retry before fail-fast termination.
+(hard FAIL), the engine's `default_max_retries=3` provides retry before fail-fast termination.

--- a/examples/pipelines/practical/test-gen.dot
+++ b/examples/pipelines/practical/test-gen.dot
@@ -7,7 +7,7 @@ digraph TestGen {
     graph [
         goal="$goal",
         label="Test Generation Pipeline",
-        default_max_retry=3,
+        default_max_retries=3,
         default_fidelity="full",
         default_thread_id="test-gen"
     ]

--- a/examples/pipelines/practical/test-gen.md
+++ b/examples/pipelines/practical/test-gen.md
@@ -59,7 +59,7 @@ would never fire, and the pipeline would report success with failing tests. The 
 gate runs `pytest` directly and routes on the actual exit code.
 
 **FAIL routing**: `write_tests` has `retry_target="fix_failures"`. If any LLM node crashes
-(hard FAIL), the engine's `default_max_retry=3` provides retry before fail-fast termination.
+(hard FAIL), the engine's `default_max_retries=3` provides retry before fail-fast termination.
 
 ## Models
 

--- a/modules/loop-pipeline/tests/test_doc_consistency.py
+++ b/modules/loop-pipeline/tests/test_doc_consistency.py
@@ -77,12 +77,18 @@ def test_spec_default_max_retry_table_is_zero():
 
 
 def test_authoring_guide_default_max_retry_is_zero():
-    """DOT-AUTHORING-GUIDE.md table row for default_max_retry must show default 0 (D-135)."""
+    """DOT-AUTHORING-GUIDE.md table row for the retry ceiling must show default 0 (D-135).
+
+    Accepts BOTH spellings, for the same reason the canonical-spec check above
+    does: canonical names the attribute ``default_max_retries`` and keeps the
+    singular only as a legacy alias, so this guard is anchored on the documented
+    default *value*, not on which of the two names the row happens to use.
+    """
     content = _read("docs/DOT-AUTHORING-GUIDE.md")
     matches = re.findall(
-        r"\|\s*`default_max_retry`\s*\|\s*Integer\s*\|\s*`(\d+)`", content
+        r"\|\s*`default_max_retr(?:y|ies)`\s*\|\s*Integer\s*\|\s*`(\d+)`", content
     )
-    assert matches, "default_max_retry table row not found in DOT-AUTHORING-GUIDE.md"
+    assert matches, "default_max_retries table row not found in DOT-AUTHORING-GUIDE.md"
     for val in matches:
         assert val == "0", (
             f"DOT-AUTHORING-GUIDE.md: default_max_retry table default is '{val}', expected '0' (D-135)"


### PR DESCRIPTION
## Summary
Closes the five Layer-3 drift-review findings surfaced by the #304 toll run — after verify-first discipline (findings are claims; each was verified against primary sources before any fix). Verdicts: **3 REAL, 2 PARTIAL** (each partial had a refuted half, documented below). 16 files, +60/−27, docs/exemplar-prose/tests only — zero engine/module behavior changes.

1. **DR-GUIDE-001 (REAL):** `context/engine-semantics.md` taught dispatch falling back to "default `codergen`"; engine truth is `HandlerRegistry.get()` raises on unknown shapes (ledgered §38/ATX-13, matrix `ATX-M-F01`). Rewritten to teach the hard-fail; the surviving spec-literal fallback is scoped to its three **non-dispatch** helpers (`validation.py` lint, `node_outputs.py` output prediction, `preflight.py:80` effective-handler estimate — the third site was caught by the independent review).
2. **DR-LEDGER-001 (REAL):** `SPEC_CONFORMANCE.md:19`'s unqualified "canonical graphs run unmodified" was false vs §16 (`runs_on=always`) and §38 (explicit `type=` for decorative shapes); now scoped with the rule-4 divergences as enumerated exceptions.
3. **DR-CORE-001 (PARTIAL):** the "legacy attr" half is real — docs taught only `default_max_retry`; **refuted half:** the legacy spelling is NOT ignored (`dot_parser.py:451` accepts both spellings into one field). Docs now teach `default_max_retries` primary + truthful alias note.
4. **DR-EX-001 (PARTIAL):** the ★"silently-dead attributes" theory is **REFUTED** (see #3) — this was a consistency sweep, not a defect fix: 6 exemplar `.dot` + 5 companion `.md` moved to the primary spelling. Two loop-pipeline fixtures **deliberately keep the legacy spelling** so the alias path retains asserted test coverage (`test_dot_parser.py:346`, `test_validation.py:638`).
5. **DR-LEDGER-002 (REAL):** `SPEC_CONFORMANCE.md:130` filed fail-fast routing under IMPROVE; matrix row `ATX-M-016` records DIVERGE-DECIDED; cell aligned.

## Verification checklist
- [x] Unit tests — guard batteries (engine-semantics doc-guard, ledger integrity, conformance matrix, quality-protocol, doc-consistency) + examples batteries: reviewer's independent re-run **262 passed/24 skipped + 442 passed**; full loop-pipeline **2558 passed/25 skipped**
- [x] `attractor lint` — 0 ERROR on all 6 edited exemplars; full 33-graph sweep 0 ERROR
- [x] **Live pipeline run — SUBSTITUTED, disclosed as a caller decision:** §2's exemplar row asks for a live convergence run w/ gates RED and GREEN. Supplied instead: an **in-process engine-equivalence probe** — both spellings parse to the same `Graph.default_max_retry` field and produce identical `max_attempts` (3→4; absent→1), plus identical lint output on `04-retry-with-fallback.dot` under both spellings. The independent review re-ran the probe, confirmed it, and ruled the substitution SOUND ("an equivalence proof is strictly stronger than one stochastic sample" for a pure attribute-spelling swap that touches zero nodes/edges/conditions/gates).
- [x] Independent adversarial review — **MERGE-AFTER-FIX**: sole required fix (the `preflight.py:80` third fallback site) applied; all 5 verdicts re-verified against primary sources
- [x] EXTENSIONS entry — N/A: no observable pipeline contract touched (docs realigned TO the ledger)
- [x] Pre-publication leak review — docs/prose diff, zero identity values
- [x] CI green before merge — will confirm

## Notes for reviewers
- Test change: D-135's authoring-guide guard re-anchored to `default_max_retr(?:y|ies)` (matches its canonical-spec sibling); still pins the expected count.
- 13 singular-spelling snippets survive in frozen `docs/plans/` archives — deliberately untouched (historical documents).
- Latent, not fixed here (engine question, filed in review notes): `dot_parser.py`'s `_KNOWN_GRAPH_ATTRS`/`_GRAPH_FIELD_ATTRS` are dead constants listing only the singular spelling — harmless today, a trap if ever wired up.
