### PR TITLE
feat(skill): attractor-scout deck mode — house-style uplift + modal depth gate

### DIFF
--- a/docs/designs/2026-08-19-attractor-scout-deck-mode.md
+++ b/docs/designs/2026-08-19-attractor-scout-deck-mode.md
@@ -253,3 +253,129 @@ byte-pinned `authoring_contract.py`, and every pre-existing test.
 - **Any edit to the deterministic renderer's output.** `render.py` is untouched; a deck is a
   sibling file, never a modification of the map.
 - **Shipping the exemplar.** No sentence of it is committed. Only the method is.
+
+---
+
+# Addendum — 2026-08-20: the style uplift and the structural depth gate (gate f)
+
+**Status:** SHIPPED. Built and live-proved on the branch that lands this addendum.
+**Repo:** `amplifier-bundle-attractor`, branched from `main` @ `4e1ba02`.
+**Decision-matrix tier:** still an **additive extension**. One new gate, one new mandate, a
+rewritten style contract. No CLI surface changed; steps 1–9 remain byte-untouched in behaviour.
+
+## A.0 What was wrong
+
+The shipped deck mode produced *correct* pages that did not read like the house decks they were
+meant to sit beside. Reviewing a real generated deck against the two reference decks turned up a
+consistent set of misses, and every one of them was an **absence in the brief**, not an author
+failure — the style contract described a section *arc* and a diagram *grammar* and left everything
+between them to taste:
+
+| Axis | Reference decks do | The shipped contract said | Result |
+|---|---|---|---|
+| Type | three stacks; a serif carries every heading, pull quote, card title and stat value | "system fonts only" | sans-only, report-flavoured |
+| Colour | every semantic hue is a **triad** (stroke / lighter text sibling / dark tint fill), plus a separate focus hue | "typographic hierarchy carries the structure" | a flat palette, no tints, no focus token |
+| Width | **two** measures — narrow for prose, wide for figures | (unstated) | one width for everything; dense |
+| Nav | fixed scroll-progress bar, sticky top bar, numbered section nav, `IntersectionObserver` current-section highlight | (unstated) | **no navigation of any kind** |
+| Section furniture | eyebrow → claim heading → standfirst → figure with title+caption → pull quote → openers → doctrine strip | "a kicker, a headline, a deck line, then body" | no captions, no pull quotes, no closing strip |
+| Modals | sticky header with kicker + serif title over a scrolling body; `<h4>` sub-sections; inset evidence blocks; focus return; reduced-motion | "depth lives in a MODAL per card" | a floated close button and three flat paragraphs |
+| Modal count | ~3.5–4.5 per section, across every finding class | "every opportunity + every honest-NO" | modals on opportunities only; demos and waste had none |
+
+## A.1 The approach: a technique sheet, not a template
+
+The original design's §4 records why the exemplar itself is not shipped ("only the method is").
+That still holds — and it is exactly why the fix is **not** "give the author a better exemplar."
+The fix is to make the method *concrete enough to reproduce*.
+
+So `STYLE_CONTRACT` was rewritten as a five-part **technique sheet**: the design tokens with the
+rules they encode, the nav spec, the section furniture in order, the modal machinery, and only then
+the section arc. It carries literal token values (a hex ramp is a design token, not prose) and
+literal structural instructions, and it carries **no sentence of any reference deck**. The leak
+guard's Layer-1/2 scan covers the shipped file as it covers every other; the discipline the
+addendum adds on top is editorial — *techniques, not sentences* — and it is checked by reading, the
+same way §4's "no exemplar sentence ships" is.
+
+The bet: an author who is told "the serif carries every heading, `font-weight:600`, negative
+tracking near -.035em on the h1" will produce the house look from scratch, where an author told
+"typographic hierarchy carries the structure" will produce something reasonable and generic. That
+is a claim about briefs, and the live proof in §A.4 is what tests it.
+
+## A.2 The new mandate, and why it is structural
+
+**Mandate 5 — every modal is structured, not a paragraph dump.** Dissecting ten representative
+modals (five per reference deck) showed one invariant shape, not a length: an unheaded lede, two or
+more sub-section heads, at least one *inset* that quotes evidence, a reading of what it means, and
+somewhere to go. Length varied 5–14 block elements; **structure did not vary at all**.
+
+So the contract mandates the parts, by name, with marker classes the gate can count:
+
+| Part | Marker | Minimum |
+|---|---|---|
+| title | `<h3>` | 1 |
+| kicker | `class="m-kick"` | 1 |
+| sub-sections | `<h4>` | **2** |
+| evidence (the reader's own verified data, quoted) | `class="evidence"` | **1** |
+| why-it-matters | `class="why"` | 1 |
+| entry point | `class="entry"` | 1 |
+
+These live as constants in `deck_templates.py` (`MODAL_*`), quoted by the brief and read by the
+gate — the same single-source discipline `DERIVED_BLOCK_ID` already uses for the numbers gate, and
+for the same reason: a contract stated in two places drifts.
+
+**Why structure and not a length quota.** A byte or word minimum is trivially satisfiable by
+padding, and padding is the failure mode a deck-grade page most needs protection from. A structure
+check inverts that: a hollow modal cannot pass by growing, and a genuinely short modal that has the
+parts passes untouched. `test_gate_f_is_structural_not_a_length_check` asserts both halves
+directly — a padded hollow modal fails, a trimmed conforming one passes.
+
+## A.3 Gate (f), and its named limits
+
+`gate_modal_depth` counts the parts above per `<dialog>` and fails naming the dialog id and exactly
+which parts are absent. It is stdlib, deterministic, and O(document) — it rides the existing
+`HTMLParser` pass, adding a dialog stack and six counters. Fixtures: `with_hollow_modal` (the RED
+proof — a modal gutted to two flat paragraphs while every other gate stays green),
+`with_modal_missing_evidence`, `with_modal_one_subsection`; the clean fixture's modal was rebuilt
+to the contract and is the GREEN baseline.
+
+Named limits, documented rather than closed, each with a test:
+
+1. **It counts presence, not quality.** Two `<h4>`s reading "Details" and "More details" pass.
+   Judging whether a sub-section *earns* its heading is exactly the taste question a deterministic
+   gate must not pretend to answer; the brief tells the author what the sub-sections are for, and
+   the gate only ensures the slots exist. Same posture as gate (d)'s refusal to recompute
+   arithmetic (§3.4).
+2. **`class="evidence"` is a claim, not a proof.** The gate checks that an evidence inset exists;
+   it does not verify that what is inside it came from the run. It does not need to — every number
+   in it is already subject to gate (d), which is the check that actually binds. The residual is an
+   evidence block with no numbers in it at all.
+3. **Class tokens are matched exactly, never as substrings.** `class="whyever"` is not a `why`
+   block (`test_gate_f_class_token_is_matched_exactly`). A token may sit beside others.
+4. **Nesting is stack-based but flat in practice.** Dialogs do not nest in any real deck; the
+   parser keeps a stack anyway so a malformed document degrades to a named failure rather than a
+   miscount.
+5. **The gate cannot see a modal that is never opened.** It counts structure inside `<dialog>`
+   elements; gate (c) is what guarantees each of them is reachable. The two are complementary and
+   neither subsumes the other.
+
+## A.4 What the technique sheet does NOT close
+
+- **Nav is mandated in the brief, not gated.** A deck could ship without the sticky bar and still
+  pass every gate. Gating "has a top bar" would be checkable, but it is a *taste* mandate wearing
+  machine clothes, and the deck's trust story is about honesty, not chrome. Named, not closed.
+- **Diagrams still do not appear inside modals.** The reference decks do not do it; the contract
+  says so explicitly so an author does not go looking for the pattern and invent one.
+- **Token adoption is unenforced.** The contract states the hex ramp; nothing checks that the
+  author used it. A colour gate would fight legitimate variation for no honesty gain.
+
+## A.5 Files
+
+**Changed:** `scripts/attractor_scout/deck_templates.py` (the technique sheet; `MODAL_*` constants;
+Mandate 5), `scripts/attractor_scout/deck.py` (`DeckDialog`, dialog-structure parsing,
+`gate_modal_depth`, docstring), `fixtures/deck_fixture.py` (conforming clean modal + three
+mutations), `tests/test_scenario9_deck_gates.py` (+8 gate-f tests),
+`tests/test_scenario10_deck_brief.py` (six gates, five mandates),
+`tests/test_skill_doc_claims.py` (gate (f) pinned to `gate_modal_depth`), `SKILL.md` (step 10 names
+gate (f)).
+
+**Unchanged:** every module of the mining spine, `demo.py`, `demo_templates.py`, `render.py`, the
+byte-pinned `authoring_contract.py`, and the CLI's surface and exit codes.

--- a/skills/attractor-scout/SKILL.md
+++ b/skills/attractor-scout/SKILL.md
@@ -323,7 +323,7 @@ $CLI deck verify --deck "$WORK/deck/deck.html" \
 ```
 
 `deck verify` is deterministic and it is the only thing that decides whether the
-deck publishes. Five gates: **(a)** the HTML parses; **(b)** the page is
+deck publishes. Six gates: **(a)** the HTML parses; **(b)** the page is
 self-contained — no `<img>`/`<link>`/`<script src>`/`@import`/`<iframe>`/
 `srcset`, `url(` only as `url(#…)`, exactly two https links, zero `file://`;
 **(c)** every modal has a trigger and every trigger has a modal; **(d)** every
@@ -332,8 +332,13 @@ derivation the deck itself declares, with provenance, in its
 `<script type="application/json" id="derived-values">` block — **an undeclared
 number is FATAL, same as step 5**; **(e)** every pipeline diagram matches its
 real `.dot` node-for-node and edge-for-edge (an edge MULTISET comparison, so a
-back-edge quietly not drawn is caught). Exit 0 means all five passed; **exit 3
-means a gate came back red and the deck must NOT be published**.
+back-edge quietly not drawn is caught); **(f)** the **structural depth gate** —
+every `<dialog>` carries the five parts the style contract mandates (a title and
+kicker, at least two `<h4>` sub-sections, an `evidence` inset quoting the
+reader's own verified data, a `why`, and an `entry` point). It counts structure,
+never length, so padding cannot buy a pass and an honest short modal is never
+punished. Exit 0 means all six passed; **exit 3 means a gate came back red and
+the deck must NOT be published**.
 
 If it exits 3, re-delegate **ONCE** with `$WORK/deck/deck-gate-report.txt`
 appended verbatim, then re-verify. Still red? **Do not publish.** Say which

--- a/skills/attractor-scout/fixtures/deck_fixture.py
+++ b/skills/attractor-scout/fixtures/deck_fixture.py
@@ -304,10 +304,30 @@ CLEAN_DECK = f"""<!doctype html>
 
 <dialog id="m-unit" aria-labelledby="h-unit">
   <div class="mbox" tabindex="-1">
-    <h3 id="h-unit">The repair loop</h3>
-    <p>Seven distinct sessions. A median of twelve tool calls and four LLM cycles per session, over
-    a median span of nine hundred and thirty seconds, with about a third of an error per session.</p>
-    <button class="m-close" type="button" aria-label="Close">Close</button>
+    <div class="mhead">
+      <div class="mh-b">
+        <p class="m-kick">The strongest fit</p>
+        <h3 id="h-unit">The repair loop</h3>
+      </div>
+      <button class="m-close" type="button" aria-label="Close">Close</button>
+    </div>
+    <div class="mbody">
+      <p>The one unit in this run that cleared all three questions.</p>
+      <h4>What it is</h4>
+      <p>A generated report comes back wrong, you repair it, and you run the check again until the
+      check stops complaining.</p>
+      <div class="evidence">
+        <span class="lbl">Your own numbers</span>
+        <p>Seven distinct sessions. A median of twelve tool calls and four LLM cycles per session,
+        over a median span of nine hundred and thirty seconds, with about a third of an error per
+        session.</p>
+      </div>
+      <h4>Why it recurs</h4>
+      <p class="why">Every one of those sessions ended when a check you already run agreed with
+      you. That agreement is the evidence gate; nothing about it needs a person.</p>
+      <p class="entry">Smallest next step: name the command you already run at the end, and let a
+      loop run it instead.</p>
+    </div>
   </div>
 </dialog>
 
@@ -367,6 +387,49 @@ def with_orphan_dialog() -> str:
         '<script type="application/json" id="derived-values">',
         1,
     )
+
+
+#: The conforming modal body from CLEAN_DECK, sliced out once so the hollow
+#: mutation below can replace exactly it and nothing else.
+_CONFORMING_MBODY_START = '    <div class="mbody">'
+_CONFORMING_MBODY_END = "    </div>\n  </div>\n</dialog>"
+
+#: A modal that says a true thing in two flat paragraphs and carries not one
+#: of the five mandated structural parts. This is the shape gate (f) exists to
+#: catch: readable, honest, and hollow.
+_HOLLOW_MBODY = """\
+    <div class="mbody">
+      <p>The repair loop shows up in seven distinct sessions.</p>
+      <p>It is worth automating.</p>
+"""
+
+
+def with_hollow_modal() -> str:
+    """Gate (f): a modal with a title but none of the mandated structure.
+
+    Everything else about the deck is unchanged --- it still parses, is still
+    self-contained, its numbers still resolve. Only the modal's INSIDE is
+    gutted, which is precisely the failure a length check would miss and a
+    structure check catches.
+    """
+    start = CLEAN_DECK.index(_CONFORMING_MBODY_START)
+    end = CLEAN_DECK.index(_CONFORMING_MBODY_END, start)
+    return CLEAN_DECK[:start] + _HOLLOW_MBODY + CLEAN_DECK[end:]
+
+
+def with_modal_missing_evidence() -> str:
+    """Gate (f): every part present EXCEPT the reader's own data, quoted.
+
+    The narrow case: a modal that has a heading, sub-sections, a why and an
+    entry point, and still never shows the reader a number of their own. The
+    gate must name the missing evidence block specifically, not just fail.
+    """
+    return CLEAN_DECK.replace('<div class="evidence">', '<div class="aside">', 1)
+
+
+def with_modal_one_subsection() -> str:
+    """Gate (f): one sub-section where the contract mandates two."""
+    return CLEAN_DECK.replace("<h4>Why it recurs</h4>", "<p><strong>Why it recurs</strong></p>", 1)
 
 
 def with_fabricated_number() -> str:
@@ -555,9 +618,12 @@ __all__ = [
     "with_external_resource",
     "with_fabricated_number",
     "with_from_not_referencing_inputs",
+    "with_hollow_modal",
     "with_inputless_derivation",
     "with_local_use_href",
     "with_media_source",
+    "with_modal_missing_evidence",
+    "with_modal_one_subsection",
     "with_node_added",
     "with_object_data",
     "with_orphan_dialog",

--- a/skills/attractor-scout/scripts/attractor_scout/deck.py
+++ b/skills/attractor-scout/scripts/attractor_scout/deck.py
@@ -8,7 +8,7 @@ file, with its own layout and its own prose --- and buys the trust back with
 gates instead.
 
 That is the whole design: **what the renderer guaranteed by construction, the
-gates here guarantee by inspection.** Five of them, all deterministic, all
+gates here guarantee by inspection.** Six of them, all deterministic, all
 stdlib, run over the candidate deck plus the run's own data:
 
   a. **It parses.** Container elements nest and close.
@@ -29,6 +29,13 @@ stdlib, run over the candidate deck plus the run's own data:
      MULTISET, read off `data-node`/`data-edge` attributes, must equal the
      `.dot`'s. A diagram that quietly drops the awkward back-edge is a diagram
      that teaches the wrong shape.
+  f. **Every modal carries the mandated structure.** A deck's depth lives in
+     its modals, so a hollow modal is a hollow deck. Each `<dialog>` must
+     carry a title and kicker, at least two `<h4>` sub-sections, an
+     `evidence` inset quoting the reader's own verified data, a `why`, and an
+     `entry` point --- names the style contract mandates and this gate counts.
+     It is a STRUCTURE check, never a length check: padding buys nothing, and
+     a genuinely short modal that has the parts passes.
 
 `verify_deck` returns a report; the CLI exits 0 only when every gate passed.
 **A gate-failed deck is never published** --- the same posture as
@@ -220,6 +227,43 @@ class DeckSvg:
     edges: list[str] = field(default_factory=list)
 
 
+@dataclass
+class DeckDialog:
+    """One `<dialog>`, counted against the modal-structure contract.
+
+    Every field is a COUNT of a structural part the style contract mandates by
+    name (see `deck_templates`'s Mandate 5). Counting, rather than measuring
+    length, is the whole design: a modal cannot pad its way past this.
+    """
+
+    dialog_id: str
+    titles: int = 0  # <h3> --- the modal title
+    kickers: int = 0  # class="m-kick" --- the label above it
+    subsections: int = 0  # <h4> --- the sub-section spine
+    evidence: int = 0  # class="evidence" --- the reader's own data, quoted
+    why: int = 0  # class="why" --- why it matters for them
+    entry: int = 0  # class="entry" --- where they can go next
+
+    def missing(self) -> list[str]:
+        """The mandated parts this dialog does not have. Empty == conforming."""
+        gaps: list[str] = []
+        if self.titles < 1:
+            gaps.append("no <h3> title")
+        if self.kickers < 1:
+            gaps.append(f"no class={DT.MODAL_KICKER_CLASS!r} kicker")
+        if self.subsections < DT.MODAL_MIN_SUBSECTIONS:
+            gaps.append(
+                f"{self.subsections} <{DT.MODAL_SUBSECTION_TAG}> sub-section(s); {DT.MODAL_MIN_SUBSECTIONS} required"
+            )
+        if self.evidence < DT.MODAL_MIN_EVIDENCE:
+            gaps.append(f"{self.evidence} class={DT.MODAL_EVIDENCE_CLASS!r} block(s); {DT.MODAL_MIN_EVIDENCE} required")
+        if self.why < 1:
+            gaps.append(f"no class={DT.MODAL_WHY_CLASS!r} why-it-matters")
+        if self.entry < 1:
+            gaps.append(f"no class={DT.MODAL_ENTRY_CLASS!r} entry point")
+        return gaps
+
+
 class _DeckParser(HTMLParser):
     """Structural read of a candidate deck. Never raises on content."""
 
@@ -230,11 +274,13 @@ class _DeckParser(HTMLParser):
         self.text_parts: list[str] = []
         self.dialog_ids: list[str] = []
         self.trigger_targets: list[str] = []
+        self.dialogs: list[DeckDialog] = []
         self.svgs: list[DeckSvg] = []
         self.json_blocks: dict[str, list[str]] = {}
         self.script_bodies: list[str] = []
         self.meta_description: str | None = None
         self._svg_stack: list[DeckSvg] = []
+        self._dialog_stack: list[DeckDialog] = []
         self._suppress_text = 0
         self._json_block_id: str | None = None
         self._capturing_js = False
@@ -253,8 +299,31 @@ class _DeckParser(HTMLParser):
                 current.nodes.append(adict[DT.NODE_ATTR])
             if DT.EDGE_ATTR in adict:
                 current.edges.append(adict[DT.EDGE_ATTR])
-        if tag == "dialog" and adict.get("id"):
-            self.dialog_ids.append(adict["id"])
+        if tag == "dialog":
+            if adict.get("id"):
+                self.dialog_ids.append(adict["id"])
+            record = DeckDialog(dialog_id=adict.get("id") or "(unnamed dialog)")
+            self.dialogs.append(record)
+            self._dialog_stack.append(record)
+        elif self._dialog_stack:
+            # Structural parts of the modal-depth contract, counted by NAME
+            # against the constants the brief also quotes. A class token may
+            # sit alongside others, so the class attribute is split, never
+            # substring-matched --- `class="whyever"` must not count as `why`.
+            current = self._dialog_stack[-1]
+            if tag == "h3":
+                current.titles += 1
+            elif tag == DT.MODAL_SUBSECTION_TAG:
+                current.subsections += 1
+            tokens = set(adict.get("class", "").split())
+            if DT.MODAL_KICKER_CLASS in tokens:
+                current.kickers += 1
+            if DT.MODAL_EVIDENCE_CLASS in tokens:
+                current.evidence += 1
+            if DT.MODAL_WHY_CLASS in tokens:
+                current.why += 1
+            if DT.MODAL_ENTRY_CLASS in tokens:
+                current.entry += 1
         if adict.get("data-modal"):
             self.trigger_targets.append(adict["data-modal"])
         if tag == "meta" and adict.get("name", "").lower() == "description":
@@ -293,6 +362,8 @@ class _DeckParser(HTMLParser):
         tag = tag.lower()
         if tag == "svg" and self._svg_stack:
             self._svg_stack.pop()
+        if tag == "dialog" and self._dialog_stack:
+            self._dialog_stack.pop()
         if tag in ("style", "script"):
             self._suppress_text = max(0, self._suppress_text - 1)
             self._json_block_id = None
@@ -686,6 +757,39 @@ def gate_dialogs(doc: DeckDocument) -> GateResult:
     )
 
 
+def gate_modal_depth(doc: DeckDocument) -> GateResult:
+    """Gate (f): every modal carries the five mandated structural parts.
+
+    Cheap and structural on purpose. It counts named parts --- a title, a
+    kicker, `<h4>` sub-sections, an evidence inset, a why-it-matters, an entry
+    point --- and never looks at length. A hollow modal cannot pass by being
+    padded, and an honest short modal that HAS the parts is never punished for
+    being short. The names come from `deck_templates`, which is also what the
+    brief quotes, so the author and the gate read one contract.
+    """
+    dialogs = doc.parser.dialogs
+    findings: list[str] = []
+    conforming = 0
+    for dialog in dialogs:
+        gaps = dialog.missing()
+        if gaps:
+            findings.append(f"{dialog.dialog_id}: {'; '.join(gaps)}")
+        else:
+            conforming += 1
+    total_sub = sum(d.subsections for d in dialogs)
+    total_ev = sum(d.evidence for d in dialogs)
+    return GateResult(
+        letter="f",
+        name="every modal carries the mandated structure",
+        passed=not findings,
+        detail=(
+            f"{conforming}/{len(dialogs)} dialog(s) conforming; "
+            f"{total_sub} sub-section(s) and {total_ev} evidence block(s) across the deck"
+        ),
+        findings=findings,
+    )
+
+
 def gate_numbers(doc: DeckDocument, whitelist: set[str]) -> GateResult:
     declared, problems = read_derived_declarations(doc)
     findings = list(problems)
@@ -857,6 +961,7 @@ def verify_deck(
         gate_dialogs(doc),
         gate_numbers(doc, whitelist),
         gate_diagram_fidelity(doc, demos),
+        gate_modal_depth(doc),
     ]
     return DeckReport(deck_path=str(deck_file), gates=gates)
 
@@ -1099,6 +1204,7 @@ __all__ = [
     "dot_graph_counts",
     "gate_diagram_fidelity",
     "gate_dialogs",
+    "gate_modal_depth",
     "gate_numbers",
     "gate_parses",
     "gate_self_contained",

--- a/skills/attractor-scout/scripts/attractor_scout/deck_templates.py
+++ b/skills/attractor-scout/scripts/attractor_scout/deck_templates.py
@@ -53,6 +53,44 @@ EDGE_ATTR = "data-edge"
 #: the recovered exemplar verifies. When present the mapping is explicit.
 DIAGRAM_ATTR = "data-diagram"
 
+# --------------------------------------------------------------------------
+# The modal STRUCTURE contract --- the second machine-readable seam.
+#
+# The style contract below tells the author to build every modal out of these
+# named parts; `deck.gate_modal_depth` counts exactly these names. One set of
+# constants, so the brief and the gate can never drift apart --- the same
+# single-source discipline `DERIVED_BLOCK_ID` uses for the numbers gate.
+#
+# These are STRUCTURE mandates, not length quotas. A modal cannot satisfy them
+# by being long; it satisfies them by having a heading, real sub-sections, a
+# block that quotes the reader's own verified data, a why-this-matters, and a
+# way in. Padding does not help, which is the entire point.
+# --------------------------------------------------------------------------
+
+#: The tiny uppercase label above a modal's title. Part of the heading pattern.
+MODAL_KICKER_CLASS = "m-kick"
+
+#: A modal sub-section head. Plain `<h4>` inside the modal body --- no class
+#: needed, because the tag alone is unambiguous at this depth.
+MODAL_SUBSECTION_TAG = "h4"
+
+#: The inset that quotes THIS reader's own verified data back to them ---
+#: their counts, medians, trend, or a machine verdict relayed verbatim.
+MODAL_EVIDENCE_CLASS = "evidence"
+
+#: The block that says why the evidence matters *for this reader*.
+MODAL_WHY_CLASS = "why"
+
+#: The closing line: the smallest next step, or (for an honest NO) what would
+#: change the answer. Every modal ends somewhere the reader can go.
+MODAL_ENTRY_CLASS = "entry"
+
+#: How many `<h4>` sub-sections a conforming modal carries, at minimum.
+MODAL_MIN_SUBSECTIONS = 2
+
+#: How many evidence insets a conforming modal carries, at minimum.
+MODAL_MIN_EVIDENCE = 1
+
 #: The two links the footer carries, and the only two the gate permits.
 FOOTER_LINKS: tuple[tuple[str, str], ...] = (
     ("the published explainer", T.EXPLAINER_URL),
@@ -67,7 +105,7 @@ ALLOWED_HTTPS_HREFS = len(FOOTER_LINKS)
 # (a) The house style / technique contract --- the section arc, as TEXT.
 # --------------------------------------------------------------------------
 
-STYLE_CONTRACT = """\
+STYLE_CONTRACT = f"""\
 THE HOUSE DECK IDIOM (learn the TECHNIQUES; write FRESH content)
 
 This is a DECK, not a report. A report enumerates; a deck argues. Every section
@@ -75,6 +113,232 @@ opens on a claim a reader can disagree with, then pays it off with the run's own
 verified evidence. Write for one specific reader --- the person whose work this
 run mined --- in second person, in their vocabulary, with no internal jargon and
 no meta-commentary about being a language model.
+
+What follows is a TECHNIQUE SHEET, not a template: concrete tokens, a concrete
+nav spec, and a concrete modal-structure contract, extracted from the house
+decks this one has to sit beside. Reproduce the TECHNIQUES exactly. Write every
+sentence yourself, from the data below.
+
+=========================================================================
+PART 1 --- THE DESIGN TOKENS (declare these verbatim in :root)
+=========================================================================
+
+  --bg:#0d1117;      --bg2:#11171e;     --surface:#171e26; --surface2:#1e262f;
+  --track:#232c36;   --line:#2a3540;    --line2:#3a4753;
+  --ink:#eef2f6;     --ink2:#c3ccd6;    --muted:#93a1af;   --faint:#8593a1;
+  --accent:#ff7a45;  --accent2:#ffa27a; --accent-tint:#2b1a12;
+  --pass:#4ade80;    --pass2:#86efac;   --pass-tint:#102a1c;
+  --focus:#7cc4ff;
+  --wide:1040px;     --col:760px;
+
+THE RULES THOSE TOKENS ENCODE --- follow them, do not just paste them:
+
+  * EVERY SEMANTIC COLOUR IS A TRIAD: a saturated hue for strokes/borders
+    (`--accent`, `--pass`), a LIGHTER sibling for text on dark (`--accent2`,
+    `--pass2`), and a very dark TINT for filled shapes (`--accent-tint`,
+    `--pass-tint`). Never set accent-hue text directly on the page background;
+    always use the lighter sibling. Accent = attention, a gate, a control node.
+    Pass/green = the passing edge and the single exit door. Nothing else gets
+    a colour.
+  * FOCUS IS ITS OWN HUE, outside both families, so a keyboard ring can never
+    be mistaken for an accent: `:focus-visible {{ outline:2px solid var(--focus);
+    outline-offset:3px }}` declared once, globally, for links, buttons and
+    anything with a tabindex.
+  * SURFACES GO LIGHTER, INSETS GO DARKER. A card/panel sits ABOVE the page
+    (`--surface`, hover `--surface2`); a quoted/evidence inset sits BELOW it
+    (`--bg2`). That inversion is what makes quoted material read as quoted.
+  * FLAT, NOT GLOSSY. No gradients anywhere. Exactly ONE shadow in the whole
+    document, on the dialog: `0 26px 70px rgba(0,0,0,.62)`. Everything else is
+    a 1px `--line` border.
+
+TYPOGRAPHY --- three stacks, and the split between them is the signature:
+
+  --sans:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,
+         "Helvetica Neue",sans-serif;
+  --serif:"Iowan Old Style","Palatino Linotype",Palatino,"Book Antiqua",
+          Georgia,"Times New Roman",serif;
+  --mono:ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,
+         "Liberation Mono",monospace;
+
+  * SERIF carries every h1/h2/h3, the hero sub-line, every pull quote, every
+    doctrine strip, every card title, and every big stat value. SANS carries
+    body copy and the tiny uppercase labels. MONO carries counters, diagram
+    edge labels, code, and stat figures inside modals. A deck that sets its
+    headings in the body sans is the single most obvious way to miss this
+    house style.
+  * WEIGHT AND TRACKING: headings are `font-weight:600` with NEGATIVE tracking
+    (h1 about -.035em, h2/h3 about -.02em) and tight leading (h1 near .98).
+    Heavy 800-weight headings are wrong here; the serif does the work.
+  * SCALE: body 17px/1.6. h1 `clamp(44px,7.4vw,82px)`.
+    h2 `clamp(32px,4.8vw,50px)`. h3 about 21px. A serif deck-line under the
+    hero headline at `clamp(20px,2.6vw,27px)`. A sans standfirst at 19px/1.45.
+    A muted lede at 16px.
+  * THE MICRO-LABEL RHYTHM (this recurs in ~8 places and is the second
+    signature): 10.5-11px, `font-weight:700`, `letter-spacing:.16em-.2em`,
+    `text-transform:uppercase`, coloured `--accent` when it labels a section
+    or a modal, `--faint` when it labels a figure or an inset. Use it for the
+    hero kicker, the section eyebrow, the figure title, the modal kicker, and
+    every inset's label.
+
+LAYOUT RHYTHM:
+
+  * TWO WIDTHS, deliberately different: `--col:760px` for PROSE, `--wide:1040px`
+    for FIGURES and the top bar. Prose narrower than diagrams is what makes the
+    page feel airy instead of like a report.
+  * `main > section {{ padding:76px 0 34px; scroll-margin-top:70px;
+    border-top:1px solid var(--line) }}`, and the hero section drops the top
+    border. Sections are separated by a hairline, never by a colour change.
+  * RADII BY ROLE: 5px insets/notes, 6px cards and diagram nodes, 10px dialog,
+    999px pill buttons, 50% circular counters and the modal close button.
+  * THE 3px LEFT STRIPE is the house emphasis device. A doctrine strip, a
+    pull-out note, an evidence inset, and a card all carry
+    `border-left:3px solid <a semantic hue>` --- accent for attention, pass for
+    "what changes", faint for "what we cannot see".
+
+=========================================================================
+PART 2 --- THE NAV SPEC (build all four pieces; they are not optional)
+=========================================================================
+
+  1. SCROLL PROGRESS. A fixed 3px bar across the top of the viewport
+     (`position:fixed;top:0;left:0;right:0;z-index:80`, `aria-hidden="true"`)
+     whose inner element's width is set from the scroll fraction by the inline
+     script, on a passive scroll listener plus resize.
+  2. STICKY TOP BAR. `position:sticky;top:0;z-index:60`, background the page
+     colour at ~92% alpha with `backdrop-filter:saturate(150%) blur(10px)`, a
+     1px bottom border, about 54px tall, its contents laid out at `--wide`.
+     It carries a BRAND word-mark (12.5px, 700, .16em tracking, uppercase, one
+     word inside it in `--accent`) and, optionally, one bordered mono pill
+     tagging what this document is.
+  3. NUMBERED SECTION NAV. Inside the bar, `<nav aria-label="Sections">` with
+     one anchor per non-hero section, each labelled with a zero-padded ordinal
+     and a two-or-three-word name (`01 The shape`, `02 What is already
+     loop-shaped`, ...). 12px, `--muted`, transparent bottom border; on hover
+     and when current, an `--accent` bottom border. The bar scrolls
+     horizontally on narrow screens with the scrollbar hidden.
+  4. CURRENT-SECTION HIGHLIGHT. An `IntersectionObserver` over the section
+     elements with a `rootMargin` that narrows the trigger band to the middle
+     of the viewport (about `-45% 0px -50% 0px`), setting `aria-current="true"`
+     on the matching anchor and removing it from the others. Guard the whole
+     block with a feature check so a browser without it simply gets no
+     highlight. Pair it with `html {{ scroll-behavior:smooth }}` and the
+     `scroll-margin-top` above, so a jumped-to heading is never hidden under
+     the sticky bar.
+
+=========================================================================
+PART 3 --- THE SECTION FURNITURE (what a section is made of, in order)
+=========================================================================
+
+  HERO: a `--col` block holding a kicker micro-label, a serif h1 that is ONE
+  declarative sentence ending in a full stop, a serif deck-line, and a muted
+  lede that says how to read the page (that cards, nodes and numbers open
+  detail). Then, immediately, a full-`--wide` `<figure>` carrying the hero
+  diagram. No top border.
+
+  EVERY OTHER SECTION, in this order:
+    a. `--col` block: eyebrow micro-label with the ordinal in its own <span>,
+       then a claim-shaped serif h2, then a sans standfirst.
+    b. full-`--wide` `<figure>`: a figure-title micro-label, the inline SVG,
+       and a `<figcaption>` (14px, `--muted`, top-bordered, capped near 660px)
+       that opens with a bold lead-in clause and then says what the diagram
+       MEANS --- never what it depicts.
+    c. `--col` block again: a serif PULL QUOTE (`clamp(20px,2.4vw,25px)`, with
+       one clause in accent italics), then the section's content grid (cards,
+       stat tiles, numbered rows, or chips), then a cluster of PILL OPENER
+       buttons that open modals, then optionally one bordered NOTE block.
+    d. a full-width DOCTRINE STRIP closing the section: a single serif line at
+       `clamp(21px,2.8vw,28px)` in `--accent2`, with a 3px accent left rule and
+       about 22px of left padding. One per section. It is the deck's
+       punctuation --- the last thing a skimmer reads before the next hairline.
+
+  FOOTER: `--bg2` background, its heading deliberately set in SANS at 14px
+  uppercase `--faint` (breaking the serif rule to de-emphasise), a flex row of
+  mono links, and one closing paragraph.
+
+  TRIGGER SPECIES --- use several, not one. The house decks open modals from
+  FIVE different kinds of element, and that variety is most of why the page
+  feels alive: (i) grid CARDS with a mono index line, a serif title, a muted
+  description, a mono stat line and an uppercase go-line; (ii) big STAT TILES
+  whose value is serif at ~54px in `--accent2`; (iii) NUMBERED ROWS with a
+  circular mono counter; (iv) PILL OPENERS prefixed with a `+` in accent;
+  (v) SVG HOTSPOTS --- a `<g>` with `role="button" tabindex="0"` and a `+`
+  glyph, carrying its own focus ring rect that appears only on
+  `:focus-visible`. Every one of them carries `data-modal`.
+
+  DENSITY: one idea per screen, one diagram per section, prose capped at
+  `--col`, grids on `repeat(auto-fit,minmax(230-300px,1fr))`. Hover states lift
+  a card by 2px and change its border; all of it opts out under
+  `prefers-reduced-motion`.
+
+=========================================================================
+PART 4 --- THE MODAL MACHINERY AND ITS DEPTH CONTRACT
+=========================================================================
+
+MACHINERY (build exactly this):
+
+  * Native `<dialog id="m-slug" aria-labelledby="h-slug">`, opened with
+    `showModal()` from a delegated handler bound to every `[data-modal]`
+    element --- buttons AND SVG groups. Non-button triggers additionally
+    handle Enter and Space. Keep a `setAttribute("open")` fallback for engines
+    without `showModal`.
+  * Inside the dialog: ONE scroll box (`max-height:86vh; overflow-y:auto`,
+    `tabindex="-1"`, its own outline suppressed) containing a STICKY HEADER and
+    a BODY. On open, reset the box's `scrollTop` to 0 and focus it.
+  * The sticky header carries the modal kicker micro-label and the serif h3
+    (`clamp(23px,3.4vw,30px)`), plus a circular close button that inverts to
+    accent on hover. It stays put while the body scrolls.
+  * Backdrop: `dialog::backdrop {{ background:rgba(5,8,12,.76) }}`. Close on a
+    click OUTSIDE the dialog's own bounding rect --- compute it from
+    `getBoundingClientRect()`, and skip the check when a click reports
+    coordinates of exactly 0,0 (that is a keyboard-synthesised click, and
+    treating it as a backdrop hit closes the dialog the instant it opens).
+  * On the dialog's `close` event, return focus to the trigger that opened it.
+    Escape is native; the `close` event fires for every path, which is why the
+    focus return belongs there and nowhere else.
+  * Motion: `dialog[open]` gets a ~.18s ease-out fade-and-rise, and the
+    `prefers-reduced-motion` block turns that animation off along with every
+    hover transform.
+
+DEPTH --- WHAT A MODAL CONTAINS (this is Mandate 5; the gate counts it):
+
+  A modal is a DEEP-DIVE, not a tooltip. Every dialog in this deck is built
+  from these named parts, and `deck verify` checks for them by name:
+
+    * HEADING PATTERN --- the sticky header's `<p class="{MODAL_KICKER_CLASS}">`
+      kicker plus an `<h3>` title (the one `aria-labelledby` points at).
+    * AT LEAST {MODAL_MIN_SUBSECTIONS} SUB-SECTIONS --- plain `<{MODAL_SUBSECTION_TAG}>`
+      heads inside the modal body, each naming a distinct move: what it is,
+      why it recurs, what changes, what is still unknown, what it is NOT.
+      Set them in the micro-label rhythm (uppercase, tracked, `--faint`).
+    * AT LEAST {MODAL_MIN_EVIDENCE} EVIDENCE BLOCK --- an inset carrying
+      `class="{MODAL_EVIDENCE_CLASS}"` that quotes THIS reader's own verified
+      data back to them: their session count, their medians, their trend, the
+      machine verdict relayed verbatim. Give it the darker inset background,
+      a 3px left stripe, and an uppercase label of its own. A grid of stat
+      tiles (a mono figure over a small caption) is the densest form and is
+      encouraged wherever several of the reader's numbers belong together.
+      Numbers inside it are subject to Mandate 1 exactly like any other text.
+    * A WHY-IT-MATTERS --- one element carrying `class="{MODAL_WHY_CLASS}"`
+      that says what the evidence means FOR THIS READER, in their vocabulary.
+      Not what an attractor is in general; what this specific piece of their
+      week costs them, or buys them.
+    * AN ENTRY POINT --- one element carrying `class="{MODAL_ENTRY_CLASS}"`
+      that closes the modal on somewhere to go: the smallest next step for an
+      opportunity, what would change the answer for an honest NO, what to stop
+      doing for a waste finding, how to run it for a demonstration.
+
+  A conforming modal lands at roughly five to fourteen block elements. That is
+  a consequence of having the parts, NOT a quota --- padding a thin modal with
+  filler paragraphs satisfies nothing and is worse than a short honest one.
+  Optionally close on a serif accent pull-quote with a left rule, the same
+  device as the section doctrine strips.
+
+  A KNOWN LIMIT, stated so you do not go looking for it: the house decks do
+  NOT put diagrams inside modals. Diagrams live in section figures; modals
+  carry stat tiles and quoted verdicts instead. Follow that.
+
+=========================================================================
+PART 5 --- THE SECTION ARC
+=========================================================================
 
 THE SECTION ARC (six sections, in this order; each is one <section> element):
 
@@ -106,16 +370,21 @@ THE SECTION ARC (six sections, in this order; each is one <section> element):
      gated for this run, drawn as INLINE SVG in the house diagram grammar (see
      below). Each diagram is the real graph, node for node and edge for edge.
      Quote the machine verdicts verbatim. Say which checks did NOT run. Never
-     vouch for the pipeline yourself.
+     vouch for the pipeline yourself. EVERY demonstration gets its own modal
+     too, built to the same structure contract --- its evidence block is the
+     machine verdict relayed verbatim, and its entry point is how to run it.
 
   5. HONEST NOES AND WASTE --- the units that recur and cost real effort and are
      still NOT worth automating, each with the sub-test it failed and what would
      change the answer; plus the waste channel (ceremony that cost time but is
-     not an opportunity to act on). Give EVERY honest-NO in the data its own
-     modal too, the same as the opportunities --- the credibility of this
-     section is that it withholds nothing; depth scales with the findings, to no
-     fixed quota. This section is the deck's credibility: a deck that only sells
-     is an advertisement.
+     not an opportunity to act on). Give EVERY honest-NO AND EVERY waste finding
+     its own modal too, the same depth as the opportunities --- the credibility
+     of this section is that it withholds nothing, and a finding demoted to a
+     table row is a finding the deck is quietly embarrassed by. Depth scales
+     with the findings, to no fixed quota. An honest-NO modal's entry point is
+     what would change the answer; a waste finding's is what to stop doing.
+     This section is the deck's credibility: a deck that only sells is an
+     advertisement.
 
   6. GOING FORWARD --- the entry points, ordered by how much the reader has to
      commit. Smallest first. End on the smallest possible next step.
@@ -195,7 +464,7 @@ HARD CONSTRAINTS (verbatim --- a violation fails the deck):
 # --------------------------------------------------------------------------
 
 MANDATES = f"""\
-THE FOUR MANDATES (machine-enforced by `deck verify`; a violation means the
+THE FIVE MANDATES (machine-enforced by `deck verify`; a violation means the
 deck is NOT published --- these are not style advice, they are the gate):
 
   ** MANDATE 1 --- EVERY DISPLAYED NUMBER RESOLVES. **
@@ -268,6 +537,41 @@ deck is NOT published --- these are not style advice, they are the gate):
   what happened before the artifact was written --- label it as TESTIMONY
   ("reported, not recovered from a file"), distinctly from anything quoted from
   a real artifact. A reader must always be able to tell which is which.
+
+  ** MANDATE 5 --- EVERY MODAL IS STRUCTURED, NOT A PARAGRAPH DUMP. **
+  A modal is where this deck earns the word "deck-grade". Every single
+  `<dialog>` in the document --- an opportunity, an honest NO, a waste finding,
+  a demonstration, a methodology aside, all of them --- must carry ALL FIVE of
+  the following, and `deck verify` counts them:
+
+    1. An `<h3>` title (the one `aria-labelledby` points at), preceded by a
+       kicker element carrying `class="{MODAL_KICKER_CLASS}"`.
+    2. At least {MODAL_MIN_SUBSECTIONS} `<{MODAL_SUBSECTION_TAG}>` sub-section
+       heads inside the modal body. Each names a distinct move --- what it is,
+       why it recurs, what changes, what is still unknown --- not "Details" and
+       "More details".
+    3. At least {MODAL_MIN_EVIDENCE} element carrying
+       `class="{MODAL_EVIDENCE_CLASS}"`: the inset that quotes THIS reader's
+       own verified data back to them (their counts, their medians, their
+       trend, a machine verdict relayed verbatim). Numbers inside it obey
+       Mandate 1 like everything else.
+    4. One element carrying `class="{MODAL_WHY_CLASS}"` --- why that evidence
+       matters for this reader specifically.
+    5. One element carrying `class="{MODAL_ENTRY_CLASS}"` --- where they can go
+       next: the smallest next step, or what would change the answer, or what
+       to stop doing, or how to run it.
+
+  The class name may sit alongside others (`class="inset {MODAL_EVIDENCE_CLASS}"`
+  is fine); the gate looks for the token. A dialog missing any of the five
+  fails, and the failure names the dialog's id and exactly which parts are
+  absent.
+
+  This is a STRUCTURE mandate and deliberately not a length one. There is no
+  word count to hit and no reward for padding: a modal passes by having a
+  heading, real sub-sections, the reader's own evidence, a reason it matters,
+  and a way in. If a finding genuinely does not support five parts, that is
+  worth saying inside the modal --- but say it in the parts, not by omitting
+  them.
 """
 
 
@@ -297,8 +601,14 @@ When you are done, the orchestrating session runs `deck verify` over it. That
 gate is deterministic and it is the only thing that decides whether the deck is
 published. It checks, in order: that the HTML parses; that the page is fully
 self-contained; that every modal has a trigger and every trigger has a modal;
-that every displayed number resolves (Mandate 1/2); and that every pipeline
-diagram matches its real `.dot` node-for-node and edge-for-edge (Mandate 3).
+that every displayed number resolves (Mandate 1/2); that every pipeline diagram
+matches its real `.dot` node-for-node and edge-for-edge (Mandate 3); and that
+every modal carries the five structural parts (Mandate 5).
+
+Write the modals to the structure contract on the FIRST pass. Retro-fitting
+five structural parts into a page of finished paragraphs is far more work than
+writing them that way to begin with, and the structural gate is the one most
+likely to catch a draft that read fine to its author.
 """
 
 

--- a/skills/attractor-scout/tests/test_scenario10_deck_brief.py
+++ b/skills/attractor-scout/tests/test_scenario10_deck_brief.py
@@ -58,7 +58,7 @@ def test_brief_is_written_and_deterministic(run_dir: Path):
     assert second.read_text(encoding="utf-8") == text_a, "the same run must always produce the same brief"
 
 
-def test_brief_carries_all_four_mandates(run_dir: Path):
+def test_brief_carries_all_five_mandates(run_dir: Path):
     """★ Without these, the gates are unpassable by an author who cannot see them."""
     brief = deck_mod.build_deck_brief(
         ranked_path=run_dir / "ranked.json", demos_path=run_dir / "demos.json", workdir=run_dir / "deck"
@@ -68,6 +68,7 @@ def test_brief_carries_all_four_mandates(run_dir: Path):
         "MANDATE 2 --- DECLARE EVERY DERIVED VALUE",
         "MANDATE 3 --- DIAGRAM FIDELITY IS CHECKED",
         "MANDATE 4 --- ABSENT DATA GETS AN HONEST NOTE",
+        "MANDATE 5 --- EVERY MODAL IS STRUCTURED",
     ):
         assert mandate in brief, f"the brief must state {mandate!r}"
     assert DT.DERIVED_BLOCK_ID in brief
@@ -228,7 +229,7 @@ def test_cli_verify_writes_a_machine_readable_report(run_dir: Path):
     assert proc.returncode == 0, proc.stderr
     payload = json.loads((run_dir / "gates.json").read_text(encoding="utf-8"))
     assert payload["ok"] is True
-    assert len(payload["gates"]) == 5
+    assert len(payload["gates"]) == 6
 
 
 def test_cli_fails_loud_on_a_missing_deck(run_dir: Path):

--- a/skills/attractor-scout/tests/test_scenario9_deck_gates.py
+++ b/skills/attractor-scout/tests/test_scenario9_deck_gates.py
@@ -49,11 +49,11 @@ def _gate(report: deck_mod.DeckReport, letter: str) -> deck_mod.GateResult:
 
 # --------------------------------------------------------------------- GREEN
 def test_clean_deck_passes_every_gate(run_dir: Path):
-    """★ The green baseline: a minimal clean deck clears all five gates."""
+    """★ The green baseline: a minimal clean deck clears all six gates."""
     report = _verify(run_dir, F.clean_deck())
     failing = [f"{g.letter}: {g.findings}" for g in report.gates if not g.passed]
     assert report.ok, f"the clean fixture deck must pass every gate; failures: {failing}"
-    assert [g.letter for g in report.gates] == ["a", "b", "c", "d", "e"]
+    assert [g.letter for g in report.gates] == ["a", "b", "c", "d", "e", "f"]
 
 
 def test_clean_deck_report_reports_real_numbers(run_dir: Path):
@@ -335,6 +335,101 @@ def test_diagram_with_no_demonstration_to_check_against_is_red(tmp_path: Path):
     assert "no demonstration bundle was supplied" in " ".join(gate.findings)
 
 
+# ------------------------------------------- (f) every modal has the depth
+def test_clean_deck_modal_conforms_to_the_structure_contract(run_dir: Path):
+    """★ GREEN: the fixture's one modal carries all five mandated parts."""
+    gate = _gate(_verify(run_dir, F.clean_deck()), "f")
+    assert gate.passed, gate.findings
+    assert "1/1 dialog(s) conforming" in gate.detail
+    assert "sub-section(s)" in gate.detail and "evidence block(s)" in gate.detail
+
+
+def test_red_hollow_modal_fails_gate_f(run_dir: Path):
+    """★ RED: a modal that is two flat paragraphs and nothing else.
+
+    Everything else about the deck is untouched, so this proves the gate is
+    reading modal STRUCTURE and not riding some other gate's failure.
+    """
+    report = _verify(run_dir, F.with_hollow_modal())
+    assert not report.ok
+    gate = _gate(report, "f")
+    assert not gate.passed
+    joined = " ".join(gate.findings)
+    assert "m-unit" in joined, gate.findings
+    for expected in ("sub-section", "evidence", "why", "entry"):
+        assert expected in joined, f"the finding must name the missing {expected!r}: {gate.findings}"
+    for other in ("a", "b", "c", "d", "e"):
+        assert _gate(report, other).passed, f"gate {other} must be unaffected: {_gate(report, other).findings}"
+
+
+def test_red_modal_without_evidence_fails_gate_f(run_dir: Path):
+    """RED: heading, sub-sections, why and entry --- but never the reader's own data."""
+    report = _verify(run_dir, F.with_modal_missing_evidence())
+    gate = _gate(report, "f")
+    assert not gate.passed
+    joined = " ".join(gate.findings)
+    assert DT.MODAL_EVIDENCE_CLASS in joined, gate.findings
+    assert "sub-section" not in joined, f"only the evidence gap should be named: {gate.findings}"
+
+
+def test_red_modal_with_one_subsection_fails_gate_f(run_dir: Path):
+    """RED: the sub-section minimum is a real threshold, not a presence check."""
+    gate = _gate(_verify(run_dir, F.with_modal_one_subsection()), "f")
+    assert not gate.passed
+    joined = " ".join(gate.findings)
+    assert f"1 <{DT.MODAL_SUBSECTION_TAG}> sub-section(s)" in joined, gate.findings
+    assert str(DT.MODAL_MIN_SUBSECTIONS) in joined
+
+
+def test_gate_f_is_structural_not_a_length_check(run_dir: Path):
+    """A SHORT modal that has every part passes; a LONG one missing parts fails.
+
+    The whole design intent of gate (f), asserted directly: padding buys
+    nothing and brevity costs nothing. Structure is the only currency.
+    """
+    filler = "<p>The same point, restated at length, again and again.</p>\n" * 30
+    padded_hollow = F.with_hollow_modal().replace(
+        "<p>It is worth automating.</p>", "<p>It is worth automating.</p>\n" + filler, 1
+    )
+    assert not _gate(_verify(run_dir, padded_hollow), "f").passed
+
+    trimmed = F.clean_deck().replace(
+        "A generated report comes back wrong, you repair it, and you run the check again until the\n"
+        "      check stops complaining.",
+        "It repeats.",
+        1,
+    )
+    assert len(trimmed) < len(F.clean_deck())
+    assert _gate(_verify(run_dir, trimmed), "f").passed
+
+
+def test_gate_f_class_token_is_matched_exactly(run_dir: Path):
+    """`class="whyever"` is not a why-block --- the gate splits, never substrings."""
+    html = F.clean_deck().replace('<p class="why">', '<p class="whyever">', 1)
+    gate = _gate(_verify(run_dir, html), "f")
+    assert not gate.passed
+    assert DT.MODAL_WHY_CLASS in " ".join(gate.findings)
+
+
+def test_gate_f_accepts_a_class_token_beside_others(run_dir: Path):
+    """A mandated class may sit alongside styling classes --- the token is what counts."""
+    html = F.clean_deck().replace('<div class="evidence">', '<div class="inset evidence wide">', 1)
+    assert _gate(_verify(run_dir, html), "f").passed
+
+
+def test_gate_f_names_an_unnamed_dialog_rather_than_crashing(run_dir: Path):
+    """A <dialog> with no id still gets counted and still gets named in the finding."""
+    html = F.clean_deck().replace(
+        '<script type="application/json" id="derived-values">',
+        '<dialog><div class="mbox"><h3>No id at all</h3></div></dialog>\n\n'
+        '<script type="application/json" id="derived-values">',
+        1,
+    )
+    gate = _gate(_verify(run_dir, html), "f")
+    assert not gate.passed
+    assert "(unnamed dialog)" in " ".join(gate.findings), gate.findings
+
+
 # ------------------------------------------------------------ report shape
 def test_failures_name_the_file_and_the_reason(run_dir: Path):
     report = _verify(run_dir, F.with_fabricated_number(), name="candidate-deck.html")
@@ -349,7 +444,7 @@ def test_report_round_trips_as_json(run_dir: Path):
     report = _verify(run_dir, F.clean_deck())
     payload = json.loads(json.dumps(report.as_dict()))
     assert payload["ok"] is True
-    assert [g["letter"] for g in payload["gates"]] == ["a", "b", "c", "d", "e"]
+    assert [g["letter"] for g in payload["gates"]] == ["a", "b", "c", "d", "e", "f"]
 
 
 # ===================================================================

--- a/skills/attractor-scout/tests/test_skill_doc_claims.py
+++ b/skills/attractor-scout/tests/test_skill_doc_claims.py
@@ -108,6 +108,9 @@ STEP10_PINNED_CLAIMS = [
     ("deck brief", 'action == "brief"', "scripts/attractor_scout_cli.py"),
     # The 600 s provider-timeout rationale for staged delegation (FOLD 6).
     ("600 s", "DECK_MAX_ATTEMPTS", "scripts/attractor_scout/deck.py"),
+    # The structural depth gate (f) and the class tokens it counts.
+    ("structural depth gate", "def gate_modal_depth", "scripts/attractor_scout/deck.py"),
+    ("`evidence` inset", 'MODAL_EVIDENCE_CLASS = "evidence"', "scripts/attractor_scout/deck_templates.py"),
 ]
 
 
@@ -122,12 +125,12 @@ def test_step10_claims_are_sourced_in_code():
         )
 
 
-def test_step10_names_all_five_gates():
-    """Step 10 must describe every deterministic deck gate (a)-(e) by letter.
+def test_step10_names_all_six_gates():
+    """Step 10 must describe every deterministic deck gate (a)-(f) by letter.
 
     Guards against a future edit silently dropping a gate description from the
     guidance while the gate still runs in code.
     """
     skill = SKILL_MD.read_text(encoding="utf-8")
-    for letter in "abcde":
+    for letter in "abcdef":
         assert f"**({letter})**" in skill, f"SKILL.md step 10 no longer names deck gate ({letter})"


### PR DESCRIPTION
## Summary
Deck-mode **style + depth uplift** per maintainer direction: the personalized content stays, but the deck now carries the styling, nav design, modal machinery, overall feel, and modal-content depth of the two reference decks. The brief's style contract in `deck_templates.py` was rewritten from an extracted **technique sheet**: 23 design tokens verbatim (surface/ink ramps, accent triads w/ a separate focus hue), the serif/sans split that is the family signature, the micro-label rhythm, the full nav spec (fixed scroll-progress bar, sticky blurred topbar, numbered section nav w/ IntersectionObserver `aria-current`), section furniture order (eyebrow → claim → standfirst → figure → pull quote → pills → grid → doctrine strip), five trigger species, and the sticky-mhead modal machinery incl. the keyboard-synthesized-click guard. **New Mandate 5** modal-structure contract (every dialog: h3 + kicker, ≥2 h4 sub-sections, ≥1 `.evidence` inset quoting the reader's own verified data, one `.why`, one `.entry`) enforced by **new gate (f) `gate_modal_depth`** in `deck verify` — structure, never length (pinned by `test_gate_f_is_structural_not_a_length_check`). Gates (a)–(e) behaviorally unchanged (A/B-verified against base code by the review).

**Live proof on real data:** regenerated the maintainer's deck — 1 authoring attempt, **all six gates green** (769 numeric tokens re-verified/0 unresolved; 83/83 modals conforming, 171 sub-sections, 83 evidence blocks; 2/2 diagram fidelity). Vision QA vs the reference deck: one fix round (nav clipping, missing figures) → "same design family." Result: 204,817 B, 6 sections / 83 modals / 8 SVGs — beats the 174KB hand-built benchmark on modal count (83 v 44), sub-sections (171 v 46), and token fidelity (23/23 v 3/23). Artifacts live outside the repo.

**Decision-matrix tier: Uncharted (extension), additive** — diff confined to `skills/attractor-scout/` + `docs/designs/` (dated design-doc addendum). EXTENSIONS entry N/A: no pipeline contract touched.

## Verification checklist
- [x] Unit tests — suite **406 passed / 52 skipped** (was 398/52; +8 incl. gate-f RED fixtures: hollow modal / missing evidence / one subsection)
- [x] Independent adversarial review — **MERGE outright**: reviewer re-ran `deck verify` on v2 (all six green), on the old v1 deck (gate f correctly FAILS it 0/9 — predates the mandate), and on a gutted-modal mutation (f RED naming the modal, a–e unaffected); confirmed `MODAL_*` constants genuinely shared brief↔gate (single source); 5,512 added 7-word runs vs both reference decks → **0 prose overlap**
- [x] Byte-pin (vendored checker) untouched; `git diff --check` clean
- [x] Pre-publication leak review — techniques encoded, zero copied sentences, zero identity values
- [x] CI green before merge — will confirm

## Required disclosures
1. **Gate (f) checks structural presence, not content**: an empty `.evidence` div would pass — disclosed in the design doc as a named limit (the digit gates still bind any numbers inside; an evidence block with no numbers is the residual).
2. **Nav is mandated in the brief but not gated** — "has a topbar" is taste wearing machine clothes; named open limit rather than a fake gate.
3. The shared `_DeckParser` gained additive fields (gate a–e verdicts A/B-verified identical against base code).
4. Ruff correction: base and branch are both fully clean (an earlier "6 pre-existing errors" report was not reproducible).
5. Provenance: this commit was briefly cherry-picked across branches during a concurrent-session collision; the review verified the diff byte-identical and both branches residue-free.
