### PR TITLE
feat(skill): attractor-scout session provenance — deterministic human-vs-agent classification

### DIFF
--- a/docs/designs/2026-08-20-scout-session-provenance.md
+++ b/docs/designs/2026-08-20-scout-session-provenance.md
@@ -1,0 +1,263 @@
+# Design: attractor-scout session provenance — deterministic human-vs-agent classification
+
+**Status:** SHIPPED. Built and proved in the branch that lands this document.
+**Date:** 2026-08-20
+**Repo:** `amplifier-bundle-attractor`, `main` @ `7856305`
+**Scope:** a provenance layer in the `/attractor-scout` deterministic mining spine that decides,
+before anything downstream sees a session, whether that session was the user's own work or an
+agent's work on their behalf. Plus the policy that decides what is done with each answer.
+
+**Read against:** `skills/attractor-scout/` (SKILL.md, `scripts/attractor_scout/provenance.py`,
+`discover.py`, `extract.py`, `author.py`, `ranking.py`, `render.py`, `pipeline.py`,
+`fixtures/synthetic_corpus.py`, `tests/test_scenario11_session_provenance.py`),
+`docs/QUALITY_PROTOCOL.md` (§2 guidance toll, §7 leak defense),
+`docs/designs/2026-08-19-attractor-scout-demonstration-layer.md` (the additivity discipline this
+follows).
+
+---
+
+## 0. The complaint, and the one-sentence fix
+
+The maintainer's words about the personalized artifacts: they *"confuse things I did and things an
+agent did on my behalf."*
+
+They were right, and the cause was structural rather than incidental. Session selection admitted
+any root session carrying a `prompt:submit`, and **that event is byte-identical whether a person
+typed the prompt or a harness fired a single non-interactive run**. Everything downstream — the
+semantic clustering, the fit verdicts, the ranking, the artifact — inherited a pool that had never
+been filtered by authorship at all, and the one place that could still have caught it defaulted to
+`human` on missing information.
+
+What ships: a deterministic **R0–R5 provenance ladder** that classifies every mined session at
+mining time, records which rung fired and on what evidence, and a settled policy that mines
+opportunities from human-presumed sessions only, counting everything else out loud.
+
+---
+
+## 1. The investigation, generically
+
+Two independent investigations converged on the same map. Reported here without session ids,
+workspace names, paths, or any other identifying value — only shapes and measured rates.
+
+### 1.1 What is recorded, and what is not
+
+`session:start` carries a parent id, a redaction marker, a session id, and a timestamp. **That is
+all.** There is no argv, no run mode, no `stdin.isatty()`, no launching component, nothing that
+says a human was at a keyboard.
+
+The consequence is not a detail, it is the shape of the whole problem: **no positive human marker
+exists in the data.** Human authorship can only ever be *presumed* from behavioural shape. Every
+design instinct that wants a "human" default is therefore wrong, and the layer must be built so
+that an absence of evidence resolves to `UNKNOWN` and never to a person.
+
+### 1.2 The four leaks (each verified, each fixed)
+
+| # | Where | What was actually wrong |
+| --- | --- | --- |
+| 1 | qualification (`carries_prompt`) | Sole qualifier was "a `prompt:submit` exists". A harness-fired root emits the same event. **Zero discrimination.** |
+| 2 | `SessionRef` construction | `working_dir` — the single most discriminating field the corpus records — was read from `metadata.json` and then dropped on the floor. Nothing downstream could see it. |
+| 3 | `extract.machine_launched` | Measured **dead on the production path**: pipeline/recipe-start roots and prompt-carrying roots were disjoint sets, so the flag fired for **0** of the qualified roots it was scoring. It contributed a harness point that could never be earned. |
+| 4 | `ranking.apply_admission_gate` | `adjudicated or prior or author or HUMAN` — a **fail-open to human**. A unit with no author verdict at all was silently ranked as the user's own work. |
+
+A fifth, subtler one: the step-4 LLM author adjudication saw only ≤700 characters of
+noise-stripped prompt text. It could not see the working directory, the id shape, the session
+timing, or the prompt count — the facts that actually decide the question — and was being asked to
+recover an over-call using strictly less information than the deterministic layer already had.
+
+### 1.3 The signals, measured
+
+**Definitive (agent):**
+
+- a non-empty `parent_id`;
+- a delegate session-id shape (zero-filled prefix) or a composite `_<agent>` suffix;
+- a first event of `session:fork` — **2000/2000** sub-sessions vs **0/9,149** roots, a perfect
+  separator, and the reason the layer records which event came *first* rather than merely which
+  events occurred;
+- `pipeline:start` / `pipeline:node_start` / `recipe:start` / `recipe:loop_start`.
+
+**Strong structural heuristics:**
+
+- `working_dir` under a tmp root — **22/22** agent;
+- the wider ephemeral pattern set (scratch dirs, worktrees, lanes, compact-UTC-timestamped
+  basenames, mktemp-shaped basenames) — **39/40**;
+- a single templated long brief (≥1,200 chars, opening with a markdown title, a role preamble, or
+  an injected context file), never returned to — agent-leaning;
+- ≥2 prompts with at least one inter-prompt gap ≥45 s — **3/3** human, **0/9** agent.
+
+**False friends, measured and rejected** (named here so a future reader does not re-adopt one):
+
+- a `deprecation:warning` first event — a bundle/time artifact, and it hits sessions in the home
+  workspace band too;
+- `application_host` — constant across the corpus, so it separates nothing;
+- a UUID-shaped session id — thousands of UUID sessions carry parents, so the shape says nothing
+  about lineage.
+
+### 1.4 The honest residual
+
+The single-prompt band in a stable home workspace is **21–29% agent-contaminated** and genuinely
+undecidable from what is recorded. There is no clever reading of the available fields that
+resolves it. It gets `UNKNOWN`.
+
+---
+
+## 2. The ladder
+
+`scripts/attractor_scout/provenance.py`. Standard library only, in the deterministic layer, run
+during extraction — before clustering, before ranking, before any model sees a record. First rung
+that fires wins, so a definitive signal can never be overridden by a weaker one below it.
+
+| Rung | Verdict | Fires on |
+| --- | --- | --- |
+| **R0** | `agent` | definitive lineage: `parent_id`, delegate/composite id shape, `session:fork` opener |
+| **R1** | `agent` | definitive orchestration: a pipeline or recipe start event in the scan window |
+| **R2** | `agent` | structural path: an ephemeral or lane-shaped `working_dir` |
+| **R3** | `likely-agent` | exactly one prompt in the whole file **and** a templated long head |
+| **R4** | `human-presumed` | ≥2 prompts **and** ≥1 inter-prompt gap ≥ `HUMAN_GAP_MIN_S` |
+| **R5** | `unknown` | nothing decisive was recorded |
+
+Every threshold is a named module constant carrying its measured justification in a comment
+(`HUMAN_GAP_MIN_S = 45.0`, `TEMPLATED_PROMPT_MIN_CHARS = 1_200`, `ONE_SHOT_PROMPTS = 1`,
+`DELEGATE_SID_PREFIX`, `FORK_FIRST_EVENT`, `ORCHESTRATION_START_EVENTS`, and the R2 pattern set as
+one documented block). No threshold is inlined at a call site.
+
+**Every verdict is auditable.** `Provenance` records the verdict, the rung, the *named signal*
+that fired, and an evidence dict: `prompt_count`, `span_s`, `workspace_class`,
+`workspace_pattern`, `first_prompt_shape`, `first_prompt_chars`, `max_prompt_gap_s`,
+`first_event`. The evidence carries **classes and shapes, never values** — a workspace *class*,
+not a path; a prompt *shape*, not prompt text — which is what makes it safe to render in an
+artifact and safe to hand to an LLM tier.
+
+---
+
+## 3. The policy
+
+Settled exactly this way, and stated in SKILL.md, in `provenance.py`, and in the artifact:
+
+1. **Opportunities are mined from R4 (human-presumed) only.**
+2. **R5 UNKNOWN is excluded from ranked opportunities** — counted and sampled in the artifact's
+   provenance panel instead. The complaint being fixed *is* contamination, and a 21–29% agent
+   band is too wide to hand back to someone as "your recurring work". The panel says so, and names
+   the upstream change that would recover those sessions rather than pretending they are lost.
+3. **R0–R3 agent sessions are excluded from opportunities and counted**, surfaced as one
+   *already-automated footprint* section: what agents already do on your behalf. Context, not an
+   opportunity to act on.
+4. **The ranking fail-open is now fail-honest.** An absent author verdict routes a unit to a new
+   `unattributed` channel: excluded from the ranking, reported, and *not* relabelled harness
+   either — claiming it for the machine is the same unearned claim in the other direction.
+5. **The step-4 LLM adjudication now receives the deterministic verdict and its evidence**, bound
+   by one rule stated verbatim in the prompt: it may move a cluster *away* from human when the
+   prompt text shows machine authorship the ladder could not see, and it may **never** move a
+   cluster toward human. The adjudicator can tighten; it cannot launder an agent session into
+   human work.
+
+The enforcement point is a single named seam, `provenance.gate_units`, called by
+`pipeline.run` and by the CLI's `rank` command **after** cluster membership has been re-verified
+against the extract (so an invented member id is still caught by `--strict`) and **before**
+scoring (so no non-R4 session can reach a score). A unit that loses every member is not deleted:
+it is reported with its rung mix as already-automated or as unattributed.
+
+One consequence worth stating plainly, because it will be visible on first run: **the ranked list
+gets shorter.** That is the fix working. A smaller honest map beats a fuller one that mixes an
+agent's work in with the user's.
+
+---
+
+## 4. What changed, file by file
+
+| File | Change |
+| --- | --- |
+| `provenance.py` *(new)* | The ladder, the named constants, the evidence contract, `gate_units` (the mining boundary), `summarize` (the panel payload), and the fail-honest readers (`verdict_of`, `is_opportunity_eligible`). |
+| `discover.py` | `working_dir` plumbed onto `SessionRef` (leak 2). `carries_prompt` split into `scan_events` — one read that returns the first event and any orchestration starts alongside the prompt answer — with `carries_prompt` kept as a thin, documented "necessary, never sufficient" wrapper (leak 1). `qualify` stamps each qualified ref with that prescan. |
+| `extract.py` | Collects the first event, orchestration starts, and per-prompt timestamps; computes inter-prompt gaps; stamps `provenance` on every record. `machine_launched` **deleted** (leak 3). |
+| `author.py` | The dead `machine_launched` harness point replaced by the provenance rung (R0–R2 → +3, R3 → +2). Deliberately **no human-side counterpart**: there is no positive human marker to score. |
+| `ranking.py` | `apply_admission_gate` returns three channels and no longer defaults to human (leak 4); `rank` emits `unattributed` and `summary.n_unattributed`. |
+| `render.py` | Additive provenance panel: per-rung counts, sample evidence, the already-automated footprint, the honest UNKNOWN story, the upstream-fix note. Zero bytes — CSS included — when the ranked result carries no provenance data. |
+| `pipeline.py`, `attractor_scout_cli.py` | Wire the mining boundary and attach the panel payload; re-stamp records read back from an existing `extracts.jsonl`. |
+| `SKILL.md` | Step 1 names the provenance pass and the policy with the rung table; step 4 passes the verdict + evidence into the adjudication and states the never-promote-to-human rule verbatim; step 6 names both gates in order; step 7 and the Output section name the panel; one new hard rule. |
+
+---
+
+## 5. Tests
+
+`tests/test_scenario11_session_provenance.py`, over a new
+`fixtures/synthetic_corpus.build_provenance_corpus`. Every planted class runs the *same* shape of
+work at the *same* cost — a real loop, a terminal verification, one error it recovers from —
+differing only in its leading tool (so A-rung clustering separates them) and in its **provenance**.
+That isolation is the point: any difference in what reaches the ranking is caused by the ladder and
+by nothing else.
+
+The pinned verdict table: `human_multi_turn` → R4 · `delegate_sub_session` → R0 · `pipeline_root` →
+R1 · `harness_oneshot_tmp` → R2 · `goal_lane_worktree` → R2 · `templated_brief_root` → R3 ·
+`stable_single_prompt` → R5.
+
+Three RED proofs, because a gate that has never been shown failing is not a gate:
+
+1. **The leak, reproduced then closed.** The harness one-shot class is a prompt-carrying root in a
+   tmp workspace. The test asserts the old sole qualifier still admits it, strips the provenance
+   stamp to reproduce the pre-provenance world exactly (the author prior reads it as human and the
+   unit lands in the ranked opportunities), then shows the shipped path excluding it — *and*
+   counting it in the panel.
+2. **The fail-open regression.** A unit with no author verdict must not rank as human, must not be
+   relabelled harness, and must land in `unattributed` with `author == unknown`.
+3. **Renderer additivity, as a byte test.** No provenance data ⇒ byte-identical output, with a
+   marker sweep proving not one panel byte leaked into the frozen half.
+
+Plus: the false friends stay rejected; the R2 pattern set is parametrized including the
+timestamped and mktemp shapes; `gate_units` never mutates its input; gated-out units are reported
+with their rung mix; the two R4 thresholds (`HUMAN_GAP_MIN_S`, `HUMAN_MIN_PROMPTS`) are pinned by
+a scripted-cadence fixture that goes red if either is weakened; and the CLI `rank` path is
+guarded by its own end-to-end RED proof, independent of `pipeline.run`.
+
+**The leak scan runs over the SHIPPED artifact, not a vacuum.** The panel is summarized with the
+gate run over the *real* fixture corpus (a populated already-automated and unattributed set), then
+the full HTML is rendered and asserted to carry no session id, no workspace path, and no prompt
+text. One member-derived string does legitimately reach the HTML: a unit's **name**, printed in
+the unattributed table. That is intentional and safe — a unit name is an LLM-authored cluster
+*label*, never a path, id, or prompt body — and a dedicated test pins that channel so a future
+change that starts piping a path or an id into a name breaks loudly.
+
+Suite: **406 passed / 52 skipped → 454 passed / 54 skipped** (508 collected).
+
+---
+
+## 6. Named limits
+
+- **No positive human marker exists.** `R4` is `human-presumed`, and the name is the claim. If the
+  event schema ever records one, R4 should be re-derived from it rather than kept as a behavioural
+  proxy.
+- **The home-workspace single-prompt band is undecidable** at 21–29% agent contamination. Excluded
+  as `UNKNOWN`, never as human, never as agent.
+- **R2 is conservative by construction.** A workspace that merely looks unusual is left to R5. The
+  pattern set only contains shapes that cleared the measured bar.
+- **R4 needs timestamps.** A corpus whose prompt events carry no usable per-event timestamp cannot
+  express an inter-prompt gap, so it resolves to R5 across the board. That is the honest failure
+  mode: an empty ranking with a full panel, not a fabricated one.
+- **R4 has one residual bypass, and it is the ladder's honest ceiling.** A harness that paces its
+  prompts like a person — multiple turns with staged gaps ≥ `HUMAN_GAP_MIN_S` — running in a
+  stable workspace is indistinguishable from human work in today's data, so a few such runs may sit
+  inside the human-presumed pool. Nothing behavioural closes this: pacing and workspace are exactly
+  the signals a determined harness can mimic. **The upstream invocation-provenance marker (§7) is
+  what closes it** — a recorded "who launched this" needs no timing heuristic. Named here, and named
+  out loud in the artifact panel (`R4_RESIDUAL_NOTE`), rather than left as a silent hole in the one
+  pool the ranking actually trusts.
+- **`fold_children` remains a dead path.** `qualify` returns roots only, so a child session never
+  reaches `extract_all` and `_fold_into` never runs on the production path. Left in place and
+  noted rather than "fixed": making it live would change distinct-session reach for every existing
+  unit, which is a ranking-semantics decision, not a provenance one. Flagged for the orchestrator.
+
+---
+
+## 7. ★ The upstream fix this motivates
+
+**Record invocation provenance at `session:start`.** Four fields — `argv`, the run mode, whether
+`stdin` was a tty, and the launching component — would collapse rungs **R2 through R5 into one
+recorded boolean**. Every heuristic in this document exists solely because that boolean is not
+written down, and every one of them is a proxy that can only ever be *presumed*.
+
+This is not an attractor-scout change; it is an event-schema change in the context-intelligence
+writer, and it would pay off for every consumer of that corpus, not just this skill. The layer
+shipped here is deliberately built so that the day such a field appears, R2–R5 can be replaced by
+reading it, and R0/R1 remain useful as they are.
+
+Named here as an observation for the ecosystem rather than filed as a work item, because the
+decision about whether to record it belongs with whoever owns the writer.

--- a/skills/attractor-scout/SKILL.md
+++ b/skills/attractor-scout/SKILL.md
@@ -114,10 +114,37 @@ version-checks every `metadata.json` and **fails loud on a schema mismatch**,
 selects **prompt-carrying root sessions** (never top-N-by-workspace-size — the
 biggest recurring unit lives smeared across dozens of tiny workspaces and is
 invisible to size-ranked selection), reads errors from `tool:post.result.error`,
-folds children into their root via `parent_id`, keys on **full** session ids,
-and caps span at 7,200 s. It **fails loud on an empty root** with the exact
-message `looked in <root>, found 0` — if you see that, STOP and report it; do
-not fabricate a count from a shallower glob.
+keys on **full** session ids, and caps span at 7,200 s. It **fails loud on an
+empty root** with the exact message `looked in <root>, found 0` — if you see
+that, STOP and report it; do not fabricate a count from a shallower glob.
+
+**The same pass classifies PROVENANCE — whose work each session is.** A
+`prompt:submit` proves a prompt was submitted and nothing whatsoever about who
+submitted it: a harness firing one non-interactive run emits a byte-identical
+event. So every mined session is put through a deterministic ladder
+(`scripts/attractor_scout/provenance.py`) before anything downstream sees it:
+
+| Rung | Verdict | What fires it |
+| --- | --- | --- |
+| `R0` | agent | a parent session id, a delegate id shape, or a `session:fork` opener |
+| `R1` | agent | a pipeline or recipe start event |
+| `R2` | agent | an ephemeral or lane-shaped `working_dir` (tmp, scratch, worktree, lane) |
+| `R3` | likely-agent | a one-shot templated long brief |
+| `R4` | human-presumed | two or more prompts with a real gap between them |
+| `R5` | unknown | nothing decisive was recorded |
+
+Each verdict records **which rung fired, on what signal, with its evidence**,
+and that record is rendered in the artifact.
+
+**The policy, and it is not negotiable inside a run: opportunities are mined
+from `R4` only.** `R0`–`R3` are excluded and counted as an already-automated
+footprint (context — what agents already do for you — never an opportunity to
+hand back). `R5` is excluded and counted too: nothing recorded at session start
+says who launched a run, so a single-prompt session in a normal workspace
+genuinely cannot be told apart from an agent one-shot, and the contamination in
+that band is exactly the complaint this pass exists to fix. **`UNKNOWN` never
+silently becomes human.** Say the exclusion out loud when you report; do not
+present a shrunken ranking as if nothing was held back.
 
 **2 — Semantic label + cluster (`fast` role).** The deterministic spine dedups
 by tool-signature, but the large majority of real opportunities are found ONLY
@@ -142,13 +169,30 @@ labels; reasoning judges.
 
 **4 — Author adjudication (`general` role).** The deterministic spine already
 carries an author *prior* (harness / human / mixed) from fingerprints,
-sentinels, and machine-launch metadata. That prior **over-calls human**,
+sentinels, and the step-1 provenance verdict. That prior **over-calls human**,
 because it cannot read intent from prompt text — a templated autonomous "lane"
 mission looks human to it but is machine-launched. So adjudicate author at the
 **cluster level, reading the prompt text**, with a `general`-role sub-agent
 (the author-gate A/B, Gate 2 in `evals/README.md`, built this step: it admitted
 **0 of 2** harness clusters in **10/10** trials). The adjudicated label
 overrides the prior.
+
+**Give the adjudicator the provenance verdict, and bind it with one rule.**
+Each member record carries `provenance.rung`, `provenance.signal` and
+`provenance.evidence` (prompt count, session span, workspace class, first-prompt
+shape). Pass those into the adjudication prompt alongside the text — they are
+facts the prompt text cannot show, and withholding them is what made this step
+guess. State this rule verbatim in the prompt you send:
+
+> *You are given a deterministic provenance verdict per session. You may move a
+> cluster AWAY from human — to mixed or harness — when the prompt text shows
+> machine authorship the ladder could not see. You may NEVER move a cluster
+> toward human: a rung of R0, R1, R2 or R3 is evidence a machine started that
+> work, and no reading of prompt text overrides it. If the verdicts disagree
+> with each other inside one cluster, say mixed.*
+
+The adjudicator can tighten; it cannot launder an agent session into human
+work.
 
 After steps 2–4, write `$WORK/clusters.json` in exactly this shape — one entry
 per global cluster, carrying the fast-tier members and the reasoning/general
@@ -184,15 +228,22 @@ than no ranking. Re-run the label/cluster pass or fix the cluster JSON first.
 **6 — Rank (inside the same `rank` call).** `score = n_sessions × leverage ×
 fit / 100`, where `leverage = med_tool_calls + med_llm_cycles +
 med_span_capped/60 + 2·errs/n` (median within cluster, never p75; `n_prompts`
-carries zero signal and is dropped). Fit is binary {0,1}. **The author
-admission gate runs BEFORE scoring: only human/mixed units are ranked**; harness
-ceremony is routed to a separate waste-findings channel — reported (it is time
-you could reclaim), not offered as an opportunity to act on.
+carries zero signal and is dropped). Fit is binary {0,1}. **Two gates run
+BEFORE scoring, in this order.** First the provenance boundary narrows every
+unit's membership to its `R4` sessions; a unit left with none is reported in
+the provenance panel (as already-automated, or as unattributed) instead of
+ranked. Then the author admission gate admits **only human/mixed units**;
+harness ceremony is routed to the waste-findings channel — reported (it is time
+you could reclaim), not offered as an opportunity to act on. A unit carrying no
+author verdict at all is **not** treated as yours: it lands in `unattributed`,
+reported and unranked, because an absent verdict is an absence of evidence.
 
 **7 — Render (NO LLM).** The bundled deterministic renderer turns the ranked
 JSON into ONE self-contained HTML file — a sampled simple→complex range across
 the top, in-page modal deep-dives into the full list, honest-NOs shown with
-verdict and remediation, waste-findings in their own channel:
+verdict and remediation, waste-findings in their own channel, and a
+**provenance panel** carrying the per-rung counts, sample evidence, the
+already-automated footprint, and the honest UNKNOWN story:
 
 ```bash
 $CLI render --ranked "$WORK/ranked.json" --out "$OUTPUT_PATH"
@@ -382,6 +433,15 @@ Same ladder philosophy as the demo lint rung: a rung that could not run is
   (Tier A/B) is an *optional sharpener* for counts and joins; it is **never a
   precondition**. If no graph answers, run at Tier C and say so with an honest
   one-line note. Never let the graph become required for a rung to appear.
+- **Whose work it is is PRESUMED, never asserted — and never presumed to be
+  yours.** Nothing in the session record positively marks a human: there is no
+  argv, no mode, no tty flag, no launcher recorded at session start, so
+  `human-presumed` (`R4`) is the strongest claim the data supports and
+  `unknown` (`R5`) is a real answer, not a soft yes. Only `R4` sessions feed
+  the ranking; `R0`–`R3` and `R5` are counted in the provenance panel and kept
+  out of it. A unit with no author verdict is `unattributed`, never human. When
+  you report, name what was held back — a smaller, honest map beats a fuller
+  one that mixes an agent's work in with the user's.
 - **Honest-NOs are first-class output**, never dropped, never padded into the
   opportunity list to lengthen it. Each carries its verdict, the sub-test it
   failed (`recipe` / `one-shot` / `fragile`), and its remediation.
@@ -433,7 +493,10 @@ Same ladder philosophy as the demo lint rung: a rung that could not run is
 ## Output
 
 One **self-contained HTML** opportunity map (inlined CSS/JS, no network
-references), written to `$OUTPUT_PATH`. That is the current working directory
+references), written to `$OUTPUT_PATH`. It carries the ranked opportunities,
+the honest-NOs, the waste channel, and a **provenance panel**: how many of your
+sessions landed on each rung, sample evidence for each, the already-automated
+footprint, and the honest note about what could not be attributed and why. That is the current working directory
 by default, or an **`AGENTS.md`-guided output path** if the repo declares one.
 Never write the user's mined data into a shared repo — their session history
 belongs in their own artifact.

--- a/skills/attractor-scout/fixtures/synthetic_corpus.py
+++ b/skills/attractor-scout/fixtures/synthetic_corpus.py
@@ -62,15 +62,19 @@ def _iso(offset_s: float) -> str:
     return (BASE_TIME + timedelta(seconds=offset_s)).isoformat()
 
 
-def _line_format_b(event: str, data: dict) -> str:
-    """FORMAT B: data payload first, top-level `event` key LAST (E1 hazard)."""
+def _line_format_b(event: str, data: dict, at_s: float = 0.0) -> str:
+    """FORMAT B: data payload first, top-level `event` key LAST (E1 hazard).
+
+    `at_s` defaults to 0.0 so every corpus written before per-event timing
+    existed is still produced byte-for-byte identically.
+    """
     body = json.dumps(data, ensure_ascii=False)
-    return '{"data":' + body + ',"event":"' + event + '","timestamp":"' + _iso(0) + '"}'
+    return '{"data":' + body + ',"event":"' + event + '","timestamp":"' + _iso(at_s) + '"}'
 
 
-def _line_format_a(event: str, data: dict) -> str:
+def _line_format_a(event: str, data: dict, at_s: float = 0.0) -> str:
     """FORMAT A: `event` key early."""
-    return json.dumps({"ts": _iso(0), "lvl": "info", "event": event, "data": data}, ensure_ascii=False)
+    return json.dumps({"ts": _iso(at_s), "lvl": "info", "event": event, "data": data}, ensure_ascii=False)
 
 
 def write_session(
@@ -94,6 +98,10 @@ def write_session(
     llm_cycles: int | None = None,
     explicit_loop: bool = False,
     approval: bool = False,
+    working_dir: str | None = None,
+    prompt_offsets_s: list[float] | None = None,
+    first_event: str | None = None,
+    orchestration_events: list[str] | None = None,
 ) -> Path:
     """Write one synthetic session directory. Returns its path.
 
@@ -101,6 +109,22 @@ def write_session(
     is emitted after that call. `recover=True` re-invokes the SAME tool
     immediately after, which is exactly the error -> same-tool-retry shape
     4c reads.
+
+    The provenance parameters are all OPT-IN and default to off, so every
+    corpus written before the provenance layer existed is still produced
+    byte-for-byte identically:
+
+    * `working_dir` -- recorded in metadata.json. The single most
+      discriminating provenance field, and the R2 rung's only input.
+    * `prompt_offsets_s` -- per-prompt timestamps, relative to the session
+      start. Without them every prompt shares one timestamp and no
+      inter-prompt gap exists to measure, which is exactly what makes R4
+      (human-presumed) decline rather than guess.
+    * `first_event` -- overrides the opening `session:start`, so a
+      `session:fork` opener (the corpus's cleanest agent separator) can be
+      planted.
+    * `orchestration_events` -- emitted straight after the opener, so a
+      pipeline- or recipe-started session can be planted.
     """
     tools = list(tools or [])
     error_idx: set[int] = set(errors_at or [])
@@ -117,6 +141,8 @@ def write_session(
     }
     if parent_id:
         meta["parent_id"] = parent_id
+    if working_dir:
+        meta["working_dir"] = working_dir
     if source:
         # A NEUTRAL origin label under a forward-compatible key. Used only to
         # plant a foreign-source session the scoping gate must exclude; it is
@@ -124,13 +150,17 @@ def write_session(
         meta["source"] = source
     (sess_dir / "metadata.json").write_text(json.dumps(meta, indent=1), encoding="utf-8")
 
-    lines: list[str] = [_line_format_a("session:start", {"session_id": session_id})]
+    lines: list[str] = [_line_format_a(first_event or "session:start", {"session_id": session_id})]
+    for orchestration in orchestration_events or []:
+        lines.append(_line_format_a(orchestration, {"node": "synthetic"}))
     if big_config:
         # E2 hazard: a ~1 MB config line BEFORE the first prompt.
         lines.append(_line_format_b("session:config", {"blob": "c" * BIG_CONFIG_BYTES}))
-    for prompt in prompts:
+    for idx, prompt in enumerate(prompts):
         # E1 hazard: prompts always in FORMAT B.
-        lines.append(_line_format_b("prompt:submit", {"prompt": prompt}))
+        offsets = prompt_offsets_s or []
+        at_s = started_offset_s + offsets[idx] if idx < len(offsets) else 0.0
+        lines.append(_line_format_b("prompt:submit", {"prompt": prompt}, at_s))
     for _ in range(extra_marker_lines):
         lines.append(_line_format_b("llm:response", {"text": f"working on {UNIT_MARKER} ..."}))
 
@@ -657,4 +687,225 @@ def build_own_data_scope_corpus(root: str | Path) -> GroundTruth:
     return GroundTruth(
         root=root,
         expected={"own_ids": own, "foreign_ids": foreign, "blocked_endpoints": 2},
+    )
+
+
+# ------------------------------------------------------- Session provenance
+#: A stable, obviously-synthetic workspace path. The ladder reads the CLASS of
+#: a working directory, never the path itself, so the fixture only needs a
+#: path that is recognisably NOT ephemeral. No real user path ships here.
+STABLE_WORKDIR = "/synthetic-workspace/proj-alpha"
+
+#: An ephemeral harness workspace: a tmp root with a mktemp-shaped basename.
+HARNESS_TMP_WORKDIR = "/tmp/synthetic-run.k3f9zq"
+
+#: A templated machine brief: markdown-titled and long. Built from a repeated
+#: synthetic sentence so its length is a property of the fixture, not an
+#: accident of prose.
+TEMPLATED_BRIEF = "# Lane mission brief\n" + (
+    "Bring the synthetic module in line with its documented contract, add the regression "
+    "test that proves it, and drive the suite to green before reporting back. " * 12
+)
+
+
+#: Every planted class runs the SAME shape of work at the SAME cost -- a real
+#: loop (edit_file three times inside six calls), a terminal verification, and
+#: one error it recovers from -- differing only in its LEADING tool, so A-rung
+#: signature clustering gives each class its own unit. Same work, same cost,
+#: different PROVENANCE: any difference in what reaches the ranking is
+#: therefore attributable to provenance and to nothing else.
+def _prov_tools(lead: str) -> list[str]:
+    return [lead, "edit_file", "edit_file", "edit_file", "bash", "python_check"]
+
+
+def build_provenance_corpus(root: str | Path) -> GroundTruth:
+    """The six calibration classes of the provenance ladder, planted by construction.
+
+    Every class does the SAME shape of work with the SAME tools and the same
+    cost profile (a real loop, a terminal verification, an error it recovers
+    from). Only its provenance differs. That isolation is the point: any
+    difference in what reaches the ranking is caused by the ladder and by
+    nothing else.
+
+        human_multi_turn      R4  human-presumed  multi-prompt with real gaps
+        delegate_sub_session  R0  agent           parent_id + delegate id + fork
+        pipeline_root         R1  agent           orchestration start event
+        harness_oneshot_tmp   R2  agent           ephemeral tmp workspace
+        goal_lane_worktree    R2  agent           lane-shaped worktree path
+        templated_brief_root  R3  likely-agent    one-shot long templated brief
+        stable_single_prompt  R5  unknown         genuinely undecidable
+
+    `harness_oneshot_tmp` is the RED-PROOF class: it carries a `prompt:submit`
+    and is a root, so the pre-provenance qualifier admitted it as the user's
+    own work with zero discrimination.
+    """
+    root = Path(root)
+    classes: dict[str, dict] = {}
+
+    def _plant(name: str, rung: str, verdict: str, ids: list[str]) -> None:
+        classes[name] = {"ids": ids, "rung": rung, "verdict": verdict}
+
+    # R4 -- human: three turns, with real thinking gaps between them.
+    human_ids = []
+    for i in range(3):
+        sid = synth_id("synprovhum", i)
+        human_ids.append(sid)
+        write_session(
+            root,
+            "syn-prov-human",
+            sid,
+            prompts=[
+                "Can you help me line up the retry policy with what the contract says?",
+                "hmm that didn't work, try again",
+                "ok now verify the tests pass",
+            ],
+            prompt_offsets_s=[0.0, 180.0, 420.0],
+            tools=_prov_tools("read_file"),
+            errors_at=[2],
+            recover=True,
+            span_s=900,
+            started_offset_s=i * 7200,
+            working_dir=STABLE_WORKDIR,
+        )
+    _plant("human_multi_turn", "R4", "human-presumed", human_ids)
+
+    # R0 -- delegate sub-sessions: a parent, a delegate id shape, and a fork
+    # opener. Each of the three is independently conclusive.
+    delegate_ids = []
+    for i in range(2):
+        sid = f"0000000000000000-syndelegate{i:02d}"
+        delegate_ids.append(sid)
+        write_session(
+            root,
+            "syn-prov-delegate",
+            sid,
+            prompts=["Carry out the delegated leg of the task."],
+            prompt_offsets_s=[0.0],
+            tools=_prov_tools("glob"),
+            parent_id=human_ids[i],
+            first_event="session:fork",
+            span_s=300,
+            started_offset_s=i * 3600,
+            working_dir=STABLE_WORKDIR,
+        )
+    _plant("delegate_sub_session", "R0", "agent", delegate_ids)
+
+    # R1 -- a session an orchestrator started.
+    pipeline_ids = []
+    for i in range(2):
+        sid = synth_id("synprovpipe", i)
+        pipeline_ids.append(sid)
+        write_session(
+            root,
+            "syn-prov-pipeline",
+            sid,
+            prompts=["Advance the node."],
+            prompt_offsets_s=[0.0],
+            tools=_prov_tools("grep"),
+            errors_at=[2],
+            recover=True,
+            orchestration_events=["pipeline:start", "pipeline:node_start"],
+            span_s=400,
+            started_offset_s=i * 3600,
+            working_dir=STABLE_WORKDIR,
+        )
+    _plant("pipeline_root", "R1", "agent", pipeline_ids)
+
+    # R2 (RED PROOF) -- a harness one-shot in an ephemeral tmp workspace. A
+    # prompt-carrying root, indistinguishable from human work to the old
+    # qualifier, and deliberately given the full opportunity shape (loop +
+    # gate + recovery) so that nothing BUT provenance keeps it out.
+    harness_ids = []
+    for i in range(3):
+        sid = synth_id("synprovtmp", i)
+        harness_ids.append(sid)
+        write_session(
+            root,
+            "syn-prov-harness",
+            sid,
+            prompts=["Run the scheduled check and repair what it reports."],
+            prompt_offsets_s=[0.0],
+            tools=_prov_tools("todo"),
+            errors_at=[2],
+            recover=True,
+            span_s=500,
+            started_offset_s=i * 3600,
+            working_dir=HARNESS_TMP_WORKDIR,
+        )
+    _plant("harness_oneshot_tmp", "R2", "agent", harness_ids)
+
+    # R2 -- an autonomous goal lane running in its own worktree.
+    lane_ids = []
+    for i in range(2):
+        sid = synth_id("synprovlane", i)
+        lane_ids.append(sid)
+        write_session(
+            root,
+            "syn-prov-lane",
+            sid,
+            prompts=["Lane mission: bring the module to green.", "keep going"],
+            prompt_offsets_s=[0.0, 600.0],
+            tools=_prov_tools("web_search"),
+            errors_at=[2],
+            recover=True,
+            span_s=1200,
+            started_offset_s=i * 3600,
+            working_dir=f"{STABLE_WORKDIR}/worktrees/lane-{i}",
+        )
+    _plant("goal_lane_worktree", "R2", "agent", lane_ids)
+
+    # R3 -- a one-shot templated brief: machine-assembled, long, and never
+    # returned to. Likely-agent, and treated as agent by the policy.
+    brief_ids = []
+    for i in range(2):
+        sid = synth_id("synprovbrief", i)
+        brief_ids.append(sid)
+        write_session(
+            root,
+            "syn-prov-brief",
+            sid,
+            prompts=[TEMPLATED_BRIEF],
+            prompt_offsets_s=[0.0],
+            tools=_prov_tools("write_file"),
+            errors_at=[2],
+            recover=True,
+            span_s=800,
+            started_offset_s=i * 3600,
+            working_dir=STABLE_WORKDIR,
+        )
+    _plant("templated_brief_root", "R3", "likely-agent", brief_ids)
+
+    # R5 -- the honest residual: one short prompt, a stable workspace, and
+    # nothing else recorded. Undecidable, and never guessed as human.
+    unknown_ids = []
+    for i in range(3):
+        sid = synth_id("synprovunk", i)
+        unknown_ids.append(sid)
+        write_session(
+            root,
+            "syn-prov-unknown",
+            sid,
+            prompts=["fix the failing check"],
+            prompt_offsets_s=[0.0],
+            tools=_prov_tools("python_check"),
+            errors_at=[2],
+            recover=True,
+            span_s=600,
+            started_offset_s=i * 3600,
+            working_dir=STABLE_WORKDIR,
+        )
+    _plant("stable_single_prompt", "R5", "unknown", unknown_ids)
+
+    return GroundTruth(
+        root=root,
+        expected={
+            "classes": classes,
+            "red_proof_class": "harness_oneshot_tmp",
+            "opportunity_class": "human_multi_turn",
+            "stable_workdir": STABLE_WORKDIR,
+        },
+        notes=[
+            "every class shares one tool signature and cost profile; only provenance differs",
+            "delegate sub-sessions are not roots, so they are reached via enumerate, not qualify",
+        ],
     )

--- a/skills/attractor-scout/scripts/attractor_scout/__init__.py
+++ b/skills/attractor-scout/scripts/attractor_scout/__init__.py
@@ -8,6 +8,7 @@ Public surface:
 
     discover.enumerate_sessions / qualify   discovery spine (E1/E2/E3, fail-loud)
     extract.extract_all                     per-session records
+    provenance.classify / gate_units        R0-R5 human-vs-agent ladder
     author.classify_authors                 S8 deterministic prior
     frequency_signature                     S1 (A-rung dedup floor)
     leverage                                S2 (cost-now toil)

--- a/skills/attractor-scout/scripts/attractor_scout/author.py
+++ b/skills/attractor-scout/scripts/attractor_scout/author.py
@@ -20,6 +20,8 @@ import hashlib
 import re
 from collections import Counter
 
+from . import provenance
+
 HARNESS = "harness"
 HUMAN = "human"
 MIXED = "mixed"
@@ -148,9 +150,19 @@ def _harness_score(rec: dict, src: str, n_exact: int, n_near: int) -> tuple[int,
     if rec.get("n_prompts", 0) <= 1:
         score += 1
         sig.append("single-shot")
-    if rec.get("machine_launched"):
+    # The deterministic provenance verdict (R0-R3) replaces the old
+    # `machine_launched` flag, which keyed on two orchestration events that
+    # were measured DEAD on the production path: pipeline-start roots and
+    # prompt-carrying roots were disjoint sets, so the signal never once fired
+    # for a session this prior actually scored. The ladder subsumes it and
+    # adds the lineage/path evidence the flag never had.
+    rung = (rec.get("provenance") or {}).get("rung")
+    if rung in (provenance.R0, provenance.R1, provenance.R2):
+        score += 3
+        sig.append(f"provenance-{rung}-agent")
+    elif rung == provenance.R3:
         score += 2
-        sig.append("machine-launched")
+        sig.append(f"provenance-{rung}-likely-agent")
     return score, sig
 
 

--- a/skills/attractor-scout/scripts/attractor_scout/clustering.py
+++ b/skills/attractor-scout/scripts/attractor_scout/clustering.py
@@ -79,6 +79,13 @@ def units_from_clusters(records: list[dict], clusters: list[dict]) -> tuple[list
         # prior when supplied. Fit verdicts from the reasoning tier likewise
         # override the deterministic detectors — that is the whole reason
         # those tiers exist.
+        #
+        # ADJUDICATION INVARIANT (mirrored verbatim in SKILL.md step 4): the
+        # general tier may move a cluster AWAY from human, and may NEVER move a
+        # cluster toward human. A supplied `author_adjudicated` label is
+        # trusted here, but the prompt that produces it is bound by that rule,
+        # so a session the provenance ladder called agent (R0-R3) cannot be
+        # laundered into human work by a re-reading of its prompt text.
         for key_in, key_out in (
             ("author", "author_adjudicated"),
             ("author_adjudicated", "author_adjudicated"),

--- a/skills/attractor-scout/scripts/attractor_scout/discover.py
+++ b/skills/attractor-scout/scripts/attractor_scout/discover.py
@@ -11,6 +11,11 @@ Responsibilities (design.md §1a):
   the #1 human opportunity lives across 66 workspaces of 1-5 sessions each
   and is invisible to any size-ranked selection.
 * **Fail loud on empty**: `looked in <root>, found 0`.
+* **Carry what decides PROVENANCE**: `working_dir` from the metadata, and the
+  first event / orchestration markers from the one qualification read. This
+  module never interprets them — `provenance.classify` is the only place that
+  decides what they mean — but it must not drop them, because a
+  `prompt:submit` alone says nothing about who submitted it.
 * Own-data scoping: own-source sessions only; a session whose metadata
   explicitly declares a DIFFERENT origin is honoured and excluded, and
   write-only / read-blocked endpoints are never touched. Counters are exposed
@@ -29,6 +34,7 @@ import re
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from . import provenance
 from .errors import EmptyCorpusError, JsonlSchemaMismatch
 
 REQUIRED_FORMAT = "context-intelligence"
@@ -108,8 +114,36 @@ class ScopeCounters:
 
 
 @dataclass
+class EventScan:
+    """What ONE qualification read of an events file saw.
+
+    Qualification used to answer a single question — "is there a
+    `prompt:submit` in here?" — and that question has ZERO discriminating
+    power: a harness-fired root emits a byte-identical event. The same read
+    now also returns the provenance markers that DO discriminate (which event
+    came first, and whether an orchestrator started this session), so the
+    qualifier can hand downstream a stamped session instead of an anonymous
+    one. Same file, same budget, one pass.
+    """
+
+    has_prompt: bool = False
+    first_event: str | None = None
+    orchestration_events: tuple[str, ...] = ()
+    n_prompts_in_window: int = 0
+    window_truncated: bool = False
+
+
+@dataclass
 class SessionRef:
-    """One discovered session directory."""
+    """One discovered session directory.
+
+    `working_dir` is carried deliberately: it is the single most discriminating
+    provenance field the corpus records, and dropping it here (as this class
+    used to) made every downstream stage blind to the difference between a
+    session you ran in your project and one a harness ran in a temp directory.
+    It is plumbed, never interpreted, here — the ladder in `provenance.py` is
+    the only place that decides what a path means.
+    """
 
     workspace: str
     session_dir: str
@@ -120,6 +154,9 @@ class SessionRef:
     status: str | None
     events_path: Path
     is_root: bool
+    working_dir: str | None = None
+    #: Filled in by `qualify` from the single qualification read (see EventScan).
+    prescan: EventScan | None = None
 
 
 @dataclass
@@ -209,6 +246,23 @@ def _load_endpoint_scope(root: Path, counters: ScopeCounters) -> None:
             counters.blocked_endpoints_declared += 1
 
 
+def working_dir_of(meta: dict) -> str | None:
+    """The session's recorded working directory, if the corpus carries one.
+
+    This is the single most discriminating provenance field available, and it
+    was being dropped on the floor here. Read under a small set of neutral,
+    forward-compatible keys for the same reason `_source_of` does: the schema
+    may name it differently in a later version, and an absent value must read
+    as ABSENT (never as a default path), because `provenance.classify_workspace`
+    treats an unrecorded workspace as evidence of nothing.
+    """
+    for key in ("working_dir", "cwd", "workdir"):
+        val = meta.get(key)
+        if isinstance(val, str) and val.strip():
+            return val
+    return None
+
+
 def _source_of(meta: dict) -> str:
     """Origin of a session's data — own vs a foreign source.
 
@@ -277,6 +331,7 @@ def enumerate_sessions(
                     status=meta.get("status"),
                     events_path=ci_dir / "events.jsonl",
                     is_root=_is_root(meta, sess.name),
+                    working_dir=working_dir_of(meta),
                 )
             )
             disc.workspaces[proj.name] = disc.workspaces.get(proj.name, 0) + 1
@@ -286,14 +341,23 @@ def enumerate_sessions(
     return disc
 
 
-def carries_prompt(events_path: Path) -> bool:
-    """Does this session actually carry a `prompt:submit`?
+def scan_events(events_path: Path) -> EventScan:
+    """ONE line-budgeted read that answers qualification AND provenance.
 
     LINE-budgeted (E2). Matches the top-level EVENT FIELD via `event_of`, not
     a raw substring, so a ~1 MB `session:config` payload that merely mentions
     the string cannot false-positive.
+
+    Beyond "is there a prompt", this records the FIRST event name and any
+    orchestration-start events inside the window. Those are what the
+    provenance ladder needs and what a prompt-only qualifier could never
+    supply: a `prompt:submit` proves a prompt was submitted, and nothing
+    whatsoever about who submitted it.
     """
+    scan = EventScan()
     read = 0
+    orchestration: list[str] = []
+    seen_events = 0
     try:
         with open(events_path, "rb") as fh:
             for _ in range(QUALIFY_MAX_LINES):
@@ -302,14 +366,37 @@ def carries_prompt(events_path: Path) -> bool:
                     break
                 read += len(line)
                 if read > QUALIFY_MAX_BYTES:
+                    scan.window_truncated = True
                     break
-                if b"prompt:submit" not in line:
+                name = event_of(line)
+                if not name:
                     continue
-                if event_of(line) == "prompt:submit":
-                    return True
+                seen_events += 1
+                if scan.first_event is None:
+                    scan.first_event = name
+                if name == "prompt:submit":
+                    scan.has_prompt = True
+                    scan.n_prompts_in_window += 1
+                elif name in provenance.ORCHESTRATION_START_EVENTS and name not in orchestration:
+                    orchestration.append(name)
+            else:
+                scan.window_truncated = True
     except OSError:
-        return False
-    return False
+        return EventScan()
+    scan.orchestration_events = tuple(orchestration)
+    return scan
+
+
+def carries_prompt(events_path: Path) -> bool:
+    """Does this session carry a `prompt:submit`?
+
+    NECESSARY, NEVER SUFFICIENT. This answers one narrow question and is kept
+    as its own name so nobody mistakes it for an authorship test: a harness
+    firing a single non-interactive run emits a byte-identical event to a
+    person typing. Selection uses it to find sessions with work in them;
+    `provenance.classify` decides whose work it was.
+    """
+    return scan_events(events_path).has_prompt
 
 
 def qualify(
@@ -338,7 +425,19 @@ def qualify(
     if selector != "prompt-carrying":
         raise ValueError(f"unknown selector: {selector!r}")
 
-    qualified = [r for r in roots if carries_prompt(r.events_path)]
+    qualified: list[SessionRef] = []
+    for ref in roots:
+        scan = scan_events(ref.events_path)
+        if not scan.has_prompt:
+            continue
+        # Stamp the provenance markers from the SAME read. Selection stays
+        # "prompt-carrying" (a session with no prompt has no work in it), but a
+        # qualified session is no longer anonymous: whoever consumes it can see
+        # what started it. Agent-authored roots are deliberately still
+        # qualified here — they are COUNTED downstream as an already-automated
+        # footprint, and dropping them at the door would make that count a lie.
+        ref.prescan = scan
+        qualified.append(ref)
     if not qualified:
         raise EmptyCorpusError(str(discovery.root), "prompt-carrying root sessions")
     return qualified

--- a/skills/attractor-scout/scripts/attractor_scout/extract.py
+++ b/skills/attractor-scout/scripts/attractor_scout/extract.py
@@ -29,7 +29,8 @@ from collections import Counter
 from datetime import datetime
 from pathlib import Path
 
-from .discover import Discovery, SessionRef, event_of, read_metadata
+from . import provenance
+from .discover import Discovery, SessionRef, event_of, read_metadata, working_dir_of
 
 MAX_LINE_BYTES = 150_000
 MAX_EVENTS_SCANNED = 6_000
@@ -46,6 +47,10 @@ SPAN_CAP_S = 7_200.0
 
 _PROMPT_RE = re.compile(r'"prompt"\s*:\s*"((?:[^"\\]|\\.){0,4000})')
 _TOOLNAME_RE = re.compile(r'"tool_name"\s*:\s*"([^"]{1,60})"')
+#: Per-event timestamp, under either of the two key orderings (`ts` in format
+#: A, `timestamp` in format B). Prompt timestamps are what make the R4
+#: inter-prompt gap measurable at all.
+_TS_RE = re.compile(r'"(?:timestamp|ts)"\s*:\s*"([^"]{4,40})"')
 _NOISE_RE = re.compile(
     r"<context_file\b.*?</context_file>|<system-reminder\b.*?</system-reminder>",
     re.DOTALL,
@@ -105,12 +110,26 @@ def _seq_signature(tool_all: list[str]) -> tuple[str | None, int]:
     return hashlib.sha1("|".join(collapsed).encode()).hexdigest()[:12], len(collapsed)
 
 
+def _note_event(state: dict, name: str) -> None:
+    """Record the provenance-relevant facts about an event's IDENTITY.
+
+    Two facts, both cheap: which event came FIRST (a `session:fork` opener is
+    the corpus's cleanest agent separator) and whether an orchestrator start
+    appeared at all.
+    """
+    if state["first_event"] is None:
+        state["first_event"] = name
+    if name in provenance.ORCHESTRATION_START_EVENTS and name not in state["orchestration_events"]:
+        state["orchestration_events"].append(name)
+
+
 def _handle_big_line(line: str, state: dict) -> None:
     """Oversized line: read the event field only, never json-parse ~1 MB."""
     name = event_of(line.encode("utf-8", "replace"))
     if not name:
         return
     state["ev_names"][name] += 1
+    _note_event(state, name)
     if name == "llm:response":
         state["n_llm_resp"] += 1
     elif name == "llm:request":
@@ -122,6 +141,11 @@ def _handle_big_line(line: str, state: dict) -> None:
             _record_tool(state, m.group(1)[:40])
     elif name == "prompt:submit":
         state["n_prompts"] += 1
+        # Format B puts the timestamp last, so look at the tail first; a
+        # format-A oversized line carries it in the head.
+        ts = _TS_RE.search(line[-400:]) or _TS_RE.search(line[:400])
+        if ts:
+            state["prompt_ts"].append(ts.group(1))
         m = _PROMPT_RE.search(line[:400_000])
         if m:
             try:
@@ -186,6 +210,11 @@ def extract_session(ref: SessionRef, *, strict_schema: bool = True) -> dict:
         "bash_cmds": [],
         "last_err_tool": None,
         "ev_names": Counter(),
+        # Provenance inputs. Collected here because this is the pass that
+        # already reads every line; the ladder itself lives in `provenance`.
+        "first_event": None,
+        "orchestration_events": [],
+        "prompt_ts": [],
     }
 
     scanned = 0
@@ -211,6 +240,30 @@ def extract_session(ref: SessionRef, *, strict_schema: bool = True) -> dict:
     seq_sig, seq_len = _seq_signature(state["tool_all"])
     later = " ".join(state["prompts"][1:])
     all_prompts = " ".join(state["prompts"])
+
+    # Provenance: computed HERE, in the deterministic layer, before any
+    # clustering, ranking or model pass can see this record. The qualifier's
+    # prescan is preferred for `first_event` only when this pass saw nothing
+    # (an unreadable or empty stream); otherwise the full-file read wins,
+    # because its window is a superset of the qualifier's.
+    prescan = ref.prescan
+    first_event = state["first_event"] or (prescan.first_event if prescan else None)
+    orchestration = tuple(state["orchestration_events"]) or (prescan.orchestration_events if prescan else ())
+    prompt_gaps = provenance.gaps_from_timestamps(state["prompt_ts"])
+    working_dir = ref.working_dir or working_dir_of(meta)
+    prov = provenance.classify(
+        provenance.SessionSignals(
+            session_id=ref.session_id,
+            parent_id=ref.parent_id,
+            working_dir=working_dir,
+            first_event=first_event,
+            orchestration_events=tuple(orchestration),
+            n_prompts=state["n_prompts"],
+            first_prompt=state["first_prompt_full"],
+            prompt_gaps_s=prompt_gaps,
+            span_s=span_capped,
+        )
+    )
 
     return {
         "session_id": ref.session_id,
@@ -245,7 +298,15 @@ def extract_session(ref: SessionRef, *, strict_schema: bool = True) -> dict:
         "seq_len": seq_len,
         "events_scanned": scanned,
         "scan_truncated": scanned > MAX_EVENTS_SCANNED,
-        "machine_launched": bool(state["ev_names"].get("recipe:start") or state["ev_names"].get("pipeline:node_start")),
+        # Provenance inputs, retained so a record read back from
+        # `extracts.jsonl` can be re-classified without re-reading the corpus.
+        "working_dir": working_dir,
+        "first_event": first_event,
+        "orchestration_events": list(orchestration),
+        "prompt_gaps_s": list(prompt_gaps),
+        # The verdict itself: which rung fired, on what signal, with the
+        # evidence that justified it. Auditable, and rendered in the artifact.
+        "provenance": prov.as_dict(),
     }
 
 
@@ -253,11 +314,15 @@ def _consume_event(ev: dict, state: dict) -> None:
     name = ev.get("event")
     if name:
         state["ev_names"][name] += 1
+        _note_event(state, name)
     raw_data = ev.get("data")
     data: dict = raw_data if isinstance(raw_data, dict) else {}
 
     if name == "prompt:submit":
         state["n_prompts"] += 1
+        stamp = ev.get("timestamp") or ev.get("ts")
+        if stamp:
+            state["prompt_ts"].append(stamp)
         _record_prompt(state, data.get("prompt") or "")
     elif name == "tool:pre":
         state["n_tools"] += 1
@@ -310,6 +375,14 @@ def extract_all(
     root rather than counting it as an additional distinct session — the C1
     join discipline. A child whose parent is not in the selection is kept as
     its own record (dropping it would silently lose work).
+
+    NOTE (honest, and deliberately not "fixed" here): on the PRODUCTION path
+    this fold never runs. `discover.qualify` returns root sessions only, so no
+    child ever reaches this function and `_fold_into` is dead code in the
+    shipped pipeline. It stays because it is correct and because the census /
+    re-analysis paths do pass children. Making it live would change the
+    distinct-session reach of every existing unit — a ranking-semantics
+    decision, not a provenance one, and not one to smuggle in here.
     """
     records: list[dict] = []
     seen: set[str] = set()

--- a/skills/attractor-scout/scripts/attractor_scout/pipeline.py
+++ b/skills/attractor-scout/scripts/attractor_scout/pipeline.py
@@ -18,7 +18,7 @@ import json
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from . import clustering, discover, extract, graph, ranking, render
+from . import clustering, discover, extract, graph, provenance, ranking, render
 
 
 @dataclass
@@ -76,6 +76,11 @@ def run(
         disc_root, n_disc, n_qual = str(disc.root), len(disc.sessions), len(refs)
         scope = disc.scope.as_dict()
 
+    # Provenance is stamped during extraction; a record read back from an
+    # existing extracts.jsonl (or produced by an older miner) is stamped here
+    # so nothing can reach the ranking unclassified.
+    provenance.ensure_stamped(records)
+
     unknown: list[str] = []
     if clusters_path:
         raw = json.loads(Path(clusters_path).read_text(encoding="utf-8"))
@@ -86,7 +91,13 @@ def run(
         units = clustering.units_from_signatures(records)
         source = "signatures"
 
-    ranked = ranking.rank(units)
+    # THE MINING BOUNDARY. Cluster membership has already been re-verified
+    # against the extract above, so an invented member id is still caught;
+    # only now is membership narrowed to R4 human-presumed sessions. Agent and
+    # unattributable sessions are counted in the panel, never ranked.
+    gate = provenance.gate_units(units)
+    ranked = ranking.rank(gate.admitted)
+    ranked["provenance"] = provenance.summarize(records, gate=gate)
     result = RunResult(
         root=disc_root,
         tier=decision.tier,

--- a/skills/attractor-scout/scripts/attractor_scout/provenance.py
+++ b/skills/attractor-scout/scripts/attractor_scout/provenance.py
@@ -1,0 +1,621 @@
+"""Session PROVENANCE — deterministic human-vs-agent classification, at mining time.
+
+The personalized artifact this skill produces is only worth reading if it
+separates **what you did** from **what an agent did on your behalf**. Before
+this module existed it could not: the qualifier admitted any session carrying a
+`prompt:submit`, and a harness-fired root emits a byte-identical event. This
+module is the discrimination that was missing, and it runs in the
+DETERMINISTIC layer — before clustering, before ranking, before any model sees
+anything.
+
+WHAT THE DATA ACTUALLY SUPPORTS (measured; do not re-derive downstream)
+----------------------------------------------------------------------
+* **No positive human marker exists.** `session:start` carries only
+  `parent_id` / `redaction` / `session_id` / `timestamp` — no argv, no mode,
+  no `isatty`, no `launched_by`. "Human" can therefore only ever be
+  PRESUMED from behavioural shape, never asserted from a recorded fact. The
+  ladder below never defaults to human, and `UNKNOWN` is a real answer.
+* **Definitive AGENT signals exist and are cheap**: a non-empty `parent_id`;
+  a delegate/composite session-id shape; a first event of `session:fork`
+  (measured 2000/2000 sub-sessions vs 0/9,149 roots — a perfect separator);
+  and pipeline/recipe start events.
+* **Strong structural heuristics**: an ephemeral or lane-shaped
+  `working_dir` (tmp / scratch / worktree / lane / timestamped / mktemp)
+  was agent-authored in 22/22 tmp cases and 39/40 across the wider pattern
+  set. A single templated long brief, one-shot, leans agent. Two or more
+  prompts with a real thinking gap between them was human in 3/3 and agent
+  in 0/9.
+* **False friends, deliberately NOT used**: a `deprecation:warning` first
+  event (a bundle/time artifact), `application_host` (constant across the
+  corpus), and UUID-shaped ids (thousands of UUID sessions carry parents).
+  Each was measured and rejected; naming them here stops a future reader
+  re-adopting one.
+* **Honest residual**: the stable-workspace single-prompt band is
+  contaminated with agent runs at a measured 21–29% and is genuinely
+  undecidable from what is recorded. It resolves to `UNKNOWN` — never to
+  human.
+
+THE LADDER (first rung that fires wins; every verdict records WHICH and WHY)
+---------------------------------------------------------------------------
+    R0  AGENT            definitive lineage — parent_id / sid shape / session:fork
+    R1  AGENT            definitive orchestration — pipeline/recipe start events
+    R2  AGENT            structural path — ephemeral / lane-shaped working_dir
+    R3  LIKELY-AGENT     one-shot templated long brief
+    R4  HUMAN-PRESUMED   multi-prompt with a real inter-prompt gap
+    R5  UNKNOWN          nothing decisive — carries its evidence, never guesses
+
+POLICY (settled; see docs/designs/2026-08-20-scout-session-provenance.md)
+------------------------------------------------------------------------
+Opportunities are mined from **R4 only**. R5 UNKNOWN is counted and sampled in
+the artifact's provenance panel but excluded from ranked opportunities — the
+complaint being fixed IS contamination, and the measured band is too wide to
+hand back as "your work". R0–R3 are excluded from opportunities, counted, and
+surfaced as an already-automated footprint: context about what agents already
+do for you, not an opportunity to act on.
+
+Every threshold below is a named constant carrying its measured justification.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from datetime import datetime
+from itertools import pairwise
+
+# --------------------------------------------------------------- verdicts
+AGENT = "agent"
+LIKELY_AGENT = "likely-agent"
+HUMAN_PRESUMED = "human-presumed"
+UNKNOWN = "unknown"
+
+#: Ordered rung ids. The ladder is evaluated in exactly this order and the
+#: FIRST rung that fires wins, so a definitive signal can never be overridden
+#: by a weaker one further down.
+R0 = "R0"
+R1 = "R1"
+R2 = "R2"
+R3 = "R3"
+R4 = "R4"
+R5 = "R5"
+RUNGS = (R0, R1, R2, R3, R4, R5)
+
+VERDICT_BY_RUNG = {
+    R0: AGENT,
+    R1: AGENT,
+    R2: AGENT,
+    R3: LIKELY_AGENT,
+    R4: HUMAN_PRESUMED,
+    R5: UNKNOWN,
+}
+
+RUNG_LABEL = {
+    R0: "R0 agent — definitive lineage (parent / delegate id shape / fork)",
+    R1: "R1 agent — definitive orchestration (pipeline or recipe start)",
+    R2: "R2 agent — structural path (ephemeral or lane-shaped workspace)",
+    R3: "R3 likely-agent — one-shot templated brief",
+    R4: "R4 human-presumed — multi-prompt with a real thinking gap",
+    R5: "R5 unknown — nothing decisive was recorded",
+}
+
+#: Verdicts that are EXCLUDED from ranked opportunities. Everything except R4.
+NON_OPPORTUNITY_VERDICTS = frozenset({AGENT, LIKELY_AGENT, UNKNOWN})
+
+#: The one verdict opportunities may be mined from.
+OPPORTUNITY_VERDICT = HUMAN_PRESUMED
+
+# ------------------------------------------------------------ R0 constants
+#: Delegate sessions are written under a zero-filled id prefix. Measured: this
+#: prefix never appears on a session that also behaves like a root.
+DELEGATE_SID_PREFIX = "0000000000000000-"
+
+#: Composite delegate ids carry an `_<agent-name>` suffix after the id body.
+#: Anchored to the END of the id so an underscore inside a workspace name
+#: cannot false-positive.
+COMPOSITE_SID_SUFFIX_RE = re.compile(r"_[A-Za-z][\w.-]*$")
+
+#: First-event fork marker. Measured 2000/2000 sub-sessions vs 0/9,149 roots —
+#: the single cleanest separator in the corpus, and the reason the ladder
+#: bothers to record which event came FIRST rather than merely which occurred.
+FORK_FIRST_EVENT = "session:fork"
+
+# ------------------------------------------------------------ R1 constants
+#: Orchestration starts. A session carrying any of these was started BY a
+#: pipeline or recipe, not by a person typing. (`extract.machine_launched`
+#: previously keyed on a subset of these and was measured DEAD on the
+#: production path — pipeline-start roots and prompt-carrying roots were
+#: disjoint sets. The rung keeps the signal honestly instead of pretending
+#: a dead field earned its place in the author prior.)
+ORCHESTRATION_START_EVENTS = frozenset(
+    {
+        "pipeline:start",
+        "pipeline:node_start",
+        "recipe:start",
+        "recipe:loop_start",
+    }
+)
+
+# ------------------------------------------------------------ R2 constants
+WS_EPHEMERAL = "ephemeral"
+WS_STABLE = "stable"
+WS_UNRECORDED = "unrecorded"
+
+#: STRUCTURAL PATH PATTERNS — the R2 pattern set, deliberately conservative.
+#: Each entry is (name, predicate-kind, pattern). Measured: tmp roots were
+#: agent-authored in 22/22 cases, and the wider set held at 39/40. Anything
+#: that did not clear that bar is NOT in this list; a workspace that merely
+#: looks unusual is left to R5 rather than called agent on a hunch.
+_TMP_PREFIXES = ("/tmp/", "/var/tmp/", "/private/tmp/", "/private/var/tmp/")
+_EPHEMERAL_SEGMENTS = ("/.scratch/", "/worktrees/", "/lanes/", "/.worktrees/", "/.lanes/")
+#: A goal-lane / batch directory stamped with a compact UTC timestamp.
+_TIMESTAMPED_BASENAME_RE = re.compile(r".+-\d{8}T\d{6}Z$")
+#: A `mktemp -d`-shaped basename: a trailing dot plus exactly six token chars.
+_MKTEMP_BASENAME_RE = re.compile(r"\.\w{6}$")
+
+# ------------------------------------------------------------ R3 constants
+#: A templated brief is LONG. Below this length a "You are ..." opener is just
+#: as likely to be a person setting context, so the rung declines to fire.
+TEMPLATED_PROMPT_MIN_CHARS = 1_200
+
+#: Heads that mark a machine-assembled brief: a markdown title, a role
+#: preamble, or an injected context file. Anchored at the start of the prompt.
+TEMPLATED_HEAD_RE = re.compile(r"^(?:#\s|You are |<context_file)")
+
+#: R3 requires the session to be a true one-shot across the WHOLE file — a
+#: second prompt means somebody came back, which is not one-shot behaviour.
+ONE_SHOT_PROMPTS = 1
+
+# ------------------------------------------------------------ R4 constants
+#: A real human thinking gap between two prompts. Measured: >= 2 prompts with
+#: at least one gap this long was human in 3/3 cases and agent in 0/9. Below
+#: it, back-to-back prompts are indistinguishable from a scripted turn.
+HUMAN_GAP_MIN_S = 45.0
+
+#: Human presumption needs a genuine second turn — one prompt is never enough,
+#: because the corpus records nothing that could make a single prompt human.
+HUMAN_MIN_PROMPTS = 2
+
+# ------------------------------------------------------------ prompt shapes
+SHAPE_ABSENT = "absent"
+SHAPE_TEMPLATED_LONG = "templated-head-long"
+SHAPE_TEMPLATED_SHORT = "templated-head-short"
+SHAPE_FREEFORM = "freeform"
+
+#: Bound on per-rung samples surfaced in the artifact panel. Samples carry
+#: EVIDENCE ONLY — never a session id, path, or prompt body.
+MAX_SAMPLES_PER_RUNG = 3
+
+# ------------------------------------------------------------- panel prose
+#: Single home for the policy text, so SKILL.md, the renderer and the design
+#: doc cannot drift from what the code actually does.
+POLICY_NOTE = (
+    "Opportunities are mined from R4 (human-presumed) sessions only. Everything else is "
+    "counted here and kept out of the ranking."
+)
+
+UNKNOWN_NOTE = (
+    "UNKNOWN is an honest answer, not a soft human. Nothing recorded at session start says who "
+    "launched a run — no argv, no mode, no tty, no launcher — so a single-prompt session in a "
+    "stable workspace cannot be told apart from an agent one-shot. Those sessions are counted "
+    "here and excluded from the ranking rather than folded into your work."
+)
+
+ALREADY_AUTOMATED_NOTE = (
+    "Sessions an agent ran on your behalf. This is context — what is already automated — not an opportunity to act on."
+)
+
+UPSTREAM_FIX_NOTE = (
+    "Recording invocation provenance at session start (argv, mode, whether stdin was a tty, and "
+    "the launching component) would collapse rungs R2-R5 into one recorded boolean. That is an "
+    "upstream change to the event schema, not something this skill can infer."
+)
+
+#: The one bypass R4 cannot close from today's data. Named, not hidden.
+R4_RESIDUAL_NOTE = (
+    "A harness that paces its prompts like a person and runs in a stable workspace is "
+    "indistinguishable from human work in today's data, so a few such runs may sit inside the "
+    "human-presumed pool; the same upstream invocation-provenance marker is what closes this."
+)
+
+
+@dataclass(frozen=True)
+class SessionSignals:
+    """Everything the ladder is allowed to look at. Nothing else is consulted."""
+
+    session_id: str = ""
+    parent_id: str | None = None
+    working_dir: str | None = None
+    first_event: str | None = None
+    orchestration_events: tuple[str, ...] = ()
+    n_prompts: int = 0
+    first_prompt: str = ""
+    prompt_gaps_s: tuple[float, ...] = ()
+    span_s: float | None = None
+
+
+@dataclass(frozen=True)
+class Provenance:
+    """One auditable verdict: WHICH rung fired, WHY, and on what evidence."""
+
+    verdict: str
+    rung: str
+    signal: str
+    evidence: dict = field(default_factory=dict)
+
+    def as_dict(self) -> dict:
+        return {
+            "verdict": self.verdict,
+            "rung": self.rung,
+            "signal": self.signal,
+            "evidence": dict(self.evidence),
+        }
+
+
+def classify_workspace(working_dir: str | None) -> tuple[str, str | None]:
+    """Classify a `working_dir` into a workspace CLASS plus the pattern that fired.
+
+    Returns `(WS_UNRECORDED, None)` when there is no working_dir at all — the
+    absence of the field is never evidence of anything, and saying so
+    explicitly is what keeps R2 conservative.
+    """
+    if not working_dir or not isinstance(working_dir, str):
+        return WS_UNRECORDED, None
+    path = working_dir.strip()
+    if not path:
+        return WS_UNRECORDED, None
+    normalized = path.rstrip("/") or "/"
+    with_slash = normalized + "/"
+    for prefix in _TMP_PREFIXES:
+        if with_slash.startswith(prefix):
+            return WS_EPHEMERAL, "tmp-root"
+    for segment in _EPHEMERAL_SEGMENTS:
+        if segment in with_slash:
+            return WS_EPHEMERAL, segment.strip("/")
+    basename = normalized.rsplit("/", 1)[-1]
+    if _TIMESTAMPED_BASENAME_RE.match(basename):
+        return WS_EPHEMERAL, "timestamped-dir"
+    if _MKTEMP_BASENAME_RE.search(basename):
+        return WS_EPHEMERAL, "mktemp-dir"
+    return WS_STABLE, None
+
+
+def prompt_shape(text: str) -> str:
+    """Shape of the first prompt — a CLASS, never the prompt body."""
+    if not text or not isinstance(text, str) or not text.strip():
+        return SHAPE_ABSENT
+    stripped = text.lstrip()
+    if TEMPLATED_HEAD_RE.match(stripped):
+        return SHAPE_TEMPLATED_LONG if len(stripped) >= TEMPLATED_PROMPT_MIN_CHARS else SHAPE_TEMPLATED_SHORT
+    return SHAPE_FREEFORM
+
+
+def _evidence(sig: SessionSignals) -> dict:
+    """The evidence dict every verdict carries. Identity-free by construction.
+
+    `workspace_class` is a CLASS, not the path; `first_prompt_shape` is a
+    shape, not the text. That is what makes a verdict safe to render in an
+    artifact and safe to hand to the step-4 adjudication.
+    """
+    ws_class, ws_pattern = classify_workspace(sig.working_dir)
+    gaps = tuple(sig.prompt_gaps_s or ())
+    return {
+        "prompt_count": int(sig.n_prompts or 0),
+        "span_s": sig.span_s,
+        "workspace_class": ws_class,
+        "workspace_pattern": ws_pattern,
+        "first_prompt_shape": prompt_shape(sig.first_prompt),
+        "first_prompt_chars": len((sig.first_prompt or "").strip()),
+        "max_prompt_gap_s": round(max(gaps), 1) if gaps else None,
+        "first_event": sig.first_event,
+    }
+
+
+def _r0_signal(sig: SessionSignals) -> str | None:
+    """Definitive lineage. Any one of these is conclusive on its own."""
+    if sig.parent_id:
+        return "parent_id"
+    sid = str(sig.session_id or "")
+    if sid.startswith(DELEGATE_SID_PREFIX):
+        return "delegate-id-prefix"
+    if COMPOSITE_SID_SUFFIX_RE.search(sid):
+        return "composite-id-suffix"
+    if sig.first_event == FORK_FIRST_EVENT:
+        return "first-event-fork"
+    return None
+
+
+def _r1_signal(sig: SessionSignals) -> str | None:
+    """Definitive orchestration: a pipeline or recipe started this session."""
+    hits = sorted({str(e) for e in sig.orchestration_events if e in ORCHESTRATION_START_EVENTS})
+    return f"orchestration:{hits[0]}" if hits else None
+
+
+def _r2_signal(sig: SessionSignals) -> str | None:
+    ws_class, ws_pattern = classify_workspace(sig.working_dir)
+    return f"workspace:{ws_pattern}" if ws_class == WS_EPHEMERAL else None
+
+
+def _r3_signal(sig: SessionSignals) -> str | None:
+    if int(sig.n_prompts or 0) != ONE_SHOT_PROMPTS:
+        return None
+    return "one-shot-templated-brief" if prompt_shape(sig.first_prompt) == SHAPE_TEMPLATED_LONG else None
+
+
+def _r4_signal(sig: SessionSignals) -> str | None:
+    if int(sig.n_prompts or 0) < HUMAN_MIN_PROMPTS:
+        return None
+    gaps = tuple(sig.prompt_gaps_s or ())
+    if gaps and max(gaps) >= HUMAN_GAP_MIN_S:
+        return f"multi-prompt-gap>={HUMAN_GAP_MIN_S:g}s"
+    return None
+
+
+_LADDER = (
+    (R0, _r0_signal),
+    (R1, _r1_signal),
+    (R2, _r2_signal),
+    (R3, _r3_signal),
+    (R4, _r4_signal),
+)
+
+
+def classify(signals: SessionSignals) -> Provenance:
+    """Run the ladder. FIRST rung that fires wins; R5 UNKNOWN is the floor.
+
+    There is no path through this function that returns human on an absence
+    of evidence — that is the whole point of it.
+    """
+    evidence = _evidence(signals)
+    for rung, probe in _LADDER:
+        signal = probe(signals)
+        if signal:
+            return Provenance(verdict=VERDICT_BY_RUNG[rung], rung=rung, signal=signal, evidence=evidence)
+    return Provenance(verdict=UNKNOWN, rung=R5, signal="no-decisive-signal", evidence=evidence)
+
+
+def _parse_ts(value) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except (TypeError, ValueError):
+        return None
+
+
+def gaps_from_timestamps(stamps: list) -> tuple[float, ...]:
+    """Inter-prompt gaps, in seconds, from a list of prompt timestamps.
+
+    Unparseable stamps are dropped rather than guessed at. Fewer than two
+    parseable stamps means no gap can be claimed — which is a legitimate
+    reason for R4 to decline, not a reason to invent one.
+
+    ABS BY DESIGN — a named degradation, not a silent one. Each gap is the
+    ABSOLUTE difference between consecutive stamps, so an out-of-order or
+    clock-skewed pair still yields a positive magnitude rather than a negative
+    number that would silently fail the R4 `>= HUMAN_GAP_MIN_S` test. The
+    trade-off is deliberate and one-directional: it can only ever ADMIT a
+    session to the human-presumed pool that a strictly-ordered reading would
+    have declined, never exclude one it would have kept. Since R4 is the one
+    pool the ranking trusts, erring toward "look again, a human may be here"
+    on garbled timing is the safe direction; the paced-harness residual (see
+    module docstring) is the same class of limit and closes the same way.
+    """
+    parsed = [t for t in (_parse_ts(s) for s in stamps) if t is not None]
+    if len(parsed) < 2:
+        return ()
+    out: list[float] = []
+    for earlier, later in pairwise(parsed):
+        try:
+            out.append(abs((later - earlier).total_seconds()))
+        except (TypeError, ValueError):  # pragma: no cover - tz-mixed stamps
+            continue
+    return tuple(round(g, 1) for g in out)
+
+
+def signals_from_record(rec: dict) -> SessionSignals:
+    """Rebuild the ladder's inputs from an extract record.
+
+    Fields this library does not write (an `extracts.jsonl` from an older
+    miner) are simply absent, and their absence lands the record on R5 rather
+    than on a fabricated verdict.
+    """
+    return SessionSignals(
+        session_id=str(rec.get("session_id") or ""),
+        parent_id=(str(rec["parent_id"]) if rec.get("parent_id") else None),
+        working_dir=rec.get("working_dir"),
+        first_event=rec.get("first_event"),
+        orchestration_events=tuple(str(e) for e in (rec.get("orchestration_events") or ())),
+        n_prompts=int(rec.get("n_prompts") or 0),
+        first_prompt=str(rec.get("first_prompt") or ""),
+        prompt_gaps_s=tuple(float(g) for g in (rec.get("prompt_gaps_s") or ())),
+        span_s=rec.get("span_capped_s", rec.get("span_s")),
+    )
+
+
+def stamp_record(rec: dict) -> dict:
+    """Classify one extract record IN PLACE, writing `rec['provenance']`."""
+    rec["provenance"] = classify(signals_from_record(rec)).as_dict()
+    return rec
+
+
+def ensure_stamped(records: list[dict]) -> list[dict]:
+    """Stamp any record that does not already carry a verdict.
+
+    Idempotent, so re-reading an `extracts.jsonl` this library wrote does not
+    reclassify it, while an extract from another miner still gets an honest
+    (usually R5) verdict instead of silently bypassing the gate.
+    """
+    for rec in records:
+        prov = rec.get("provenance")
+        if not isinstance(prov, dict) or not prov.get("rung"):
+            stamp_record(rec)
+    return records
+
+
+def verdict_of(rec: dict) -> str:
+    """The record's verdict — FAIL-HONEST. An absent stamp reads UNKNOWN."""
+    prov = rec.get("provenance")
+    if isinstance(prov, dict):
+        verdict = prov.get("verdict")
+        if verdict in VERDICT_BY_RUNG.values():
+            return str(verdict)
+    return UNKNOWN
+
+
+def rung_of(rec: dict) -> str:
+    prov = rec.get("provenance")
+    if isinstance(prov, dict) and prov.get("rung") in RUNGS:
+        return str(prov["rung"])
+    return R5
+
+
+def is_opportunity_eligible(rec: dict) -> bool:
+    """Only R4 human-presumed sessions may feed a ranked opportunity."""
+    return verdict_of(rec) == OPPORTUNITY_VERDICT
+
+
+def partition_records(records: list[dict]) -> dict[str, list[dict]]:
+    """Split a corpus into the three policy pools. Nothing is discarded."""
+    pools: dict[str, list[dict]] = {"human_presumed": [], "unknown": [], "agent": []}
+    for rec in records:
+        verdict = verdict_of(rec)
+        if verdict == HUMAN_PRESUMED:
+            pools["human_presumed"].append(rec)
+        elif verdict == UNKNOWN:
+            pools["unknown"].append(rec)
+        else:
+            pools["agent"].append(rec)
+    return pools
+
+
+@dataclass
+class UnitGateResult:
+    """What the mining boundary admitted, and what it kept out — with reasons."""
+
+    admitted: list[dict] = field(default_factory=list)
+    already_automated: list[dict] = field(default_factory=list)
+    unattributed: list[dict] = field(default_factory=list)
+    n_members_dropped: int = 0
+
+    def as_dict(self) -> dict:
+        return {
+            "n_units_admitted": len(self.admitted),
+            "n_units_already_automated": len(self.already_automated),
+            "n_units_unattributed": len(self.unattributed),
+            "n_members_dropped": self.n_members_dropped,
+            "already_automated": list(self.already_automated),
+            "unattributed": list(self.unattributed),
+        }
+
+
+def _unit_rung_mix(members: list[dict]) -> dict[str, int]:
+    mix: dict[str, int] = {}
+    for member in members:
+        rung = rung_of(member)
+        mix[rung] = mix.get(rung, 0) + 1
+    return dict(sorted(mix.items()))
+
+
+def gate_units(units: list[dict]) -> UnitGateResult:
+    """THE MINING BOUNDARY: filter unit membership to R4 before ranking.
+
+    Applied AFTER cluster membership has been re-verified against the extract
+    (so a member id an LLM invented is still caught by the strict gate) and
+    BEFORE ranking, so no non-R4 session can reach a score. Input units are
+    never mutated — an admitted unit is a shallow copy carrying only its R4
+    members.
+
+    A unit that loses every member is not dropped: it is reported as either
+    an already-automated footprint (agent rungs dominate) or an unattributed
+    unit (UNKNOWN dominates), each with its rung mix.
+    """
+    result = UnitGateResult()
+    for unit in units:
+        members = list(unit.get("members") or [])
+        eligible = [m for m in members if is_opportunity_eligible(m)]
+        result.n_members_dropped += len(members) - len(eligible)
+        if eligible:
+            admitted = dict(unit)
+            admitted["members"] = eligible
+            admitted["provenance_mix"] = _unit_rung_mix(members)
+            # The unit that reaches ranking has DIFFERENT membership, so its
+            # deterministic author prior is recomputed over the members that
+            # survived. Leaving the prior computed over excluded sessions
+            # would let sessions that never reach the ranking decide how the
+            # ones that do get labelled. The ADJUDICATED label is left alone:
+            # it is a human-tier judgment, and this gate only ever removes
+            # members, never promotes them.
+            if "author_prior" in unit or "author_mix" in unit:
+                from . import author as author_mod  # local import keeps the module graph acyclic
+
+                prior = author_mod.cluster_author_prior(eligible)
+                admitted["author_prior"] = prior["author_prior"]
+                admitted["author_mix"] = prior["author_mix"]
+            result.admitted.append(admitted)
+            continue
+        mix = _unit_rung_mix(members)
+        summary = {
+            "unit_id": unit.get("unit_id") or unit.get("id"),
+            "name": unit.get("name"),
+            "n_sessions": len({str(m.get("session_id")) for m in members if m.get("session_id")}),
+            "provenance_mix": mix,
+        }
+        agent_n = sum(n for rung, n in mix.items() if rung in (R0, R1, R2, R3))
+        unknown_n = mix.get(R5, 0)
+        if agent_n >= unknown_n and agent_n > 0:
+            summary["note"] = ALREADY_AUTOMATED_NOTE
+            result.already_automated.append(summary)
+        else:
+            summary["note"] = UNKNOWN_NOTE
+            result.unattributed.append(summary)
+    return result
+
+
+def summarize(records: list[dict], *, gate: UnitGateResult | None = None) -> dict:
+    """The provenance panel payload: counts per rung, bounded evidence samples.
+
+    Contains NO session ids, NO paths and NO prompt bodies — only counts,
+    classes and shapes, so the panel is safe to render into an artifact that
+    a person may share.
+    """
+    by_rung: dict[str, int] = {rung: 0 for rung in RUNGS}
+    by_verdict: dict[str, int] = {AGENT: 0, LIKELY_AGENT: 0, HUMAN_PRESUMED: 0, UNKNOWN: 0}
+    samples: list[dict] = []
+    per_rung_sampled: dict[str, int] = {rung: 0 for rung in RUNGS}
+
+    for rec in records:
+        rung = rung_of(rec)
+        verdict = verdict_of(rec)
+        by_rung[rung] = by_rung.get(rung, 0) + 1
+        by_verdict[verdict] = by_verdict.get(verdict, 0) + 1
+        raw_prov = rec.get("provenance")
+        prov: dict = raw_prov if isinstance(raw_prov, dict) else {}
+        if per_rung_sampled[rung] < MAX_SAMPLES_PER_RUNG:
+            per_rung_sampled[rung] += 1
+            samples.append(
+                {
+                    "rung": rung,
+                    "verdict": verdict,
+                    "signal": prov.get("signal", "no-decisive-signal"),
+                    "evidence": dict(prov.get("evidence") or {}),
+                }
+            )
+
+    payload = {
+        "n_sessions": len(records),
+        "by_rung": by_rung,
+        "by_verdict": by_verdict,
+        "rung_labels": dict(RUNG_LABEL),
+        "opportunity_pool": by_verdict[HUMAN_PRESUMED],
+        "already_automated": by_verdict[AGENT] + by_verdict[LIKELY_AGENT],
+        "unknown_excluded": by_verdict[UNKNOWN],
+        "samples": samples,
+        "policy_note": POLICY_NOTE,
+        "unknown_note": UNKNOWN_NOTE,
+        "already_automated_note": ALREADY_AUTOMATED_NOTE,
+        "upstream_fix_note": UPSTREAM_FIX_NOTE,
+        "r4_residual_note": R4_RESIDUAL_NOTE,
+    }
+    if gate is not None:
+        payload["units"] = gate.as_dict()
+    return payload

--- a/skills/attractor-scout/scripts/attractor_scout/ranking.py
+++ b/skills/attractor-scout/scripts/attractor_scout/ranking.py
@@ -28,7 +28,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 
 from . import author as author_mod
-from . import frequency_signature, honest_no
+from . import frequency_signature, honest_no, provenance
 from . import leverage as leverage_mod
 
 SCORE_DIVISOR = 100.0
@@ -144,22 +144,36 @@ def classify_trajectory(
     return CHRONIC_STABLE
 
 
-def apply_admission_gate(units: list[dict]) -> tuple[list[dict], list[dict]]:
-    """Split units into (admitted, waste_findings) by AUTHOR, before scoring.
+def apply_admission_gate(units: list[dict]) -> tuple[list[dict], list[dict], list[dict]]:
+    """Split units into (admitted, waste_findings, unattributed) by AUTHOR, before scoring.
 
     A unit's authoritative author is `author_adjudicated` when the
     cluster-level adjudication supplied one, else the deterministic prior.
     The prior over-calls human by design; the adjudication is what recovers
     that, and this function deliberately prefers it when present rather than
     averaging the two into something neither measured.
+
+    **FAIL-HONEST, not fail-open.** This chain used to end in `or HUMAN`: a
+    unit that carried no author verdict at all was silently ranked as the
+    user's own work. That default is exactly backwards — nothing in the
+    corpus positively marks a session as human (see `provenance`), so an
+    absent verdict is an absence of evidence, not evidence of a person. Such
+    a unit is now routed to `unattributed`: excluded from the ranking,
+    reported, and never counted as harness ceremony either, because calling
+    it the machine's would be the same unearned claim in the other direction.
     """
     admitted: list[dict] = []
     waste: list[dict] = []
+    unattributed: list[dict] = []
     for unit in units:
-        label = unit.get("author_adjudicated") or unit.get("author_prior") or unit.get("author") or author_mod.HUMAN
+        label = unit.get("author_adjudicated") or unit.get("author_prior") or unit.get("author")
+        if not label:
+            unit["author"] = provenance.UNKNOWN
+            unattributed.append(unit)
+            continue
         unit["author"] = label
         (admitted if label in ADMITTED_AUTHORS else waste).append(unit)
-    return admitted, waste
+    return admitted, waste, unattributed
 
 
 def rank(
@@ -180,7 +194,7 @@ def rank(
     """
     from . import fit_cycle, fit_gate, fit_recovery
 
-    admitted, waste_units = apply_admission_gate(units)
+    admitted, waste_units, unattributed_units = apply_admission_gate(units)
 
     opportunities: list[RankedUnit] = []
     honest_nos: list[RankedUnit] = []
@@ -254,15 +268,31 @@ def rank(
         )
     waste.sort(key=lambda w: (-(w["n_sessions"] or 0), str(w["unit_id"])))
 
+    # Units with NO author verdict at all. Reported, never ranked, and never
+    # relabelled as harness: "we do not know" is the finding.
+    unattributed = [
+        {
+            "unit_id": unit.get("unit_id") or unit.get("id"),
+            "name": unit.get("name"),
+            "author": provenance.UNKNOWN,
+            "n_sessions": frequency_signature.count_distinct_sessions(unit.get("members") or []),
+            "note": "no author verdict was produced for this unit - excluded from the ranking rather than presumed human",
+        }
+        for unit in unattributed_units
+    ]
+    unattributed.sort(key=lambda u: (-(u["n_sessions"] or 0), str(u["unit_id"])))
+
     return {
         "opportunities": [u.as_dict() for u in opportunities],
         "honest_no": [u.as_dict() for u in honest_nos],
         "waste_findings": waste,
+        "unattributed": unattributed,
         "below_frequency_floor": below_floor,
         "summary": {
             "n_units_in": len(units),
             "n_admitted": len(admitted),
             "n_waste": len(waste),
+            "n_unattributed": len(unattributed),
             "n_opportunities": len(opportunities),
             "n_honest_no": len(honest_nos),
             "n_below_floor": len(below_floor),

--- a/skills/attractor-scout/scripts/attractor_scout/render.py
+++ b/skills/attractor-scout/scripts/attractor_scout/render.py
@@ -157,6 +157,19 @@ border-radius:0 6px 6px 0;margin-top:8px}
 """
 
 
+#: Appended to _CSS **only** when a provenance panel is rendered, so that a
+#: ranked result carrying no provenance data stays byte-identical to the
+#: pre-provenance-layer output. Same discipline as `_DEMO_CSS`.
+_PROVENANCE_CSS = """
+.prov{background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:16px 18px;margin-top:10px}
+.prov table{margin-top:6px}
+.prov .rung{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:12px;color:var(--dim)}
+.prov .honest{border-left:3px solid var(--acc);background:#1c2130;padding:10px 12px;
+border-radius:0 6px 6px 0;margin-top:12px}
+.prov .honest h4{margin:0 0 4px;font-size:13px}
+"""
+
+
 def _esc(value) -> str:
     return html.escape("" if value is None else str(value), quote=True)
 
@@ -382,6 +395,101 @@ def _demo_section(demo: dict) -> str:
     )
 
 
+def _provenance_rung_rows(panel: dict) -> str:
+    by_rung = panel.get("by_rung") or {}
+    labels = panel.get("rung_labels") or {}
+    rows = []
+    for rung in sorted(by_rung):
+        rows.append(
+            f'<tr><td class="rung">{_esc(rung)}</td>'
+            f"<td>{_esc(labels.get(rung, rung))}</td>"
+            f"<td>{_esc(by_rung.get(rung, 0))}</td></tr>"
+        )
+    return "\n".join(rows)
+
+
+def _provenance_sample_rows(panel: dict) -> str:
+    """Bounded evidence samples. Counts, classes and shapes only — never a path,
+    a session id, or a line of prompt text."""
+    rows = []
+    for sample in panel.get("samples") or []:
+        ev = sample.get("evidence") or {}
+        rows.append(
+            f'<tr><td class="rung">{_esc(sample.get("rung"))}</td>'
+            f"<td>{_esc(sample.get('signal'))}</td>"
+            f"<td>{_esc(ev.get('prompt_count'))}</td>"
+            f"<td>{_esc(ev.get('span_s'))}</td>"
+            f"<td>{_esc(ev.get('workspace_class'))}</td>"
+            f"<td>{_esc(ev.get('first_prompt_shape'))}</td></tr>"
+        )
+    return "\n".join(rows)
+
+
+def _unattributed_rows(units: list[dict]) -> str:
+    return "\n".join(
+        f"<tr><td>{_esc(u.get('name') or u.get('unit_id'))}</td>"
+        f"<td>{_esc(u.get('n_sessions'))}</td>"
+        f"<td>{_esc(u.get('note'))}</td></tr>"
+        for u in units
+    )
+
+
+def _provenance_block(result: dict) -> str:
+    """The provenance panel. Empty string when the run carried no provenance.
+
+    Additivity, same rule as the demonstration layer: a ranked result with no
+    provenance data (an older run, or a caller that never mined one) renders
+    the byte-identical artifact it rendered before this panel existed. Every
+    byte below — CSS included — is behind this guard.
+    """
+    panel = result.get("provenance") or {}
+    unattributed = result.get("unattributed") or []
+    if not panel and not unattributed:
+        return ""
+
+    parts = ["<h2>Session provenance &mdash; whose work this is</h2>"]
+    if panel:
+        parts.append(f'<p class="note">{_esc(panel.get("policy_note", ""))}</p>')
+        parts.append('<div class="prov">')
+        parts.append(
+            "<table><thead><tr><th>Rung</th><th>What fired</th><th>Sessions</th></tr></thead>"
+            f"<tbody>{_provenance_rung_rows(panel)}</tbody></table>"
+        )
+        parts.append(
+            f'<p class="note"><b>{_esc(panel.get("opportunity_pool", 0))}</b> session(s) qualified as '
+            f"human-presumed and fed the ranking. "
+            f"<b>{_esc(panel.get('already_automated', 0))}</b> ran as an already-automated footprint. "
+            f"<b>{_esc(panel.get('unknown_excluded', 0))}</b> could not be attributed.</p>"
+        )
+        parts.append(
+            f'<div class="honest"><h4>Already automated</h4>'
+            f'<p class="note">{_esc(panel.get("already_automated_note", ""))}</p></div>'
+        )
+        parts.append(
+            f'<div class="honest"><h4>What is still unknown</h4>'
+            f'<p class="note">{_esc(panel.get("unknown_note", ""))}</p>'
+            f'<p class="note">{_esc(panel.get("r4_residual_note", ""))}</p>'
+            f'<p class="note">{_esc(panel.get("upstream_fix_note", ""))}</p></div>'
+        )
+        sample_rows = _provenance_sample_rows(panel)
+        if sample_rows:
+            parts.append(
+                "<p class='note'>Sample evidence behind these verdicts (counts and classes only):</p>"
+                "<table><thead><tr><th>Rung</th><th>Signal</th><th>Prompts</th><th>Span (s)</th>"
+                "<th>Workspace</th><th>First prompt</th></tr></thead>"
+                f"<tbody>{sample_rows}</tbody></table>"
+            )
+        parts.append("</div>")
+    if unattributed:
+        parts.append(
+            "<p class='note'>Units held out of the ranking because no author verdict was produced for them &mdash; "
+            "reported here rather than presumed to be yours.</p>"
+            "<table><thead><tr><th>Unit</th><th>Sessions</th><th>Why it is not ranked</th></tr></thead>"
+            f"<tbody>{_unattributed_rows(unattributed)}</tbody></table>"
+        )
+    return "\n" + "\n".join(parts) + "\n"
+
+
 def _demos_block(demos: dict | None) -> str:
     """Primer + one section per demo. Empty string when nothing was supplied."""
     if not demos:
@@ -419,6 +527,10 @@ def render_html(
     # the artifact below is byte-identical to the pre-demo-layer output.
     demo_block = _demos_block(demos)
     demo_css = _DEMO_CSS if demo_block else ""
+    # Same additivity contract for the provenance panel: no provenance data in
+    # the ranked result => not one byte of it, CSS included.
+    provenance_block = _provenance_block(result)
+    provenance_css = _PROVENANCE_CSS if provenance_block else ""
     n_demonstrated = len((demos or {}).get("demos") or [])
     demo_count_note = f" &middot; {_esc(n_demonstrated)} demonstrated" if n_demonstrated else ""
     data_json = json.dumps({"units": _units_index(opportunities, honest_nos)}, sort_keys=True)
@@ -436,7 +548,7 @@ def render_html(
 <html lang="en"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>{_esc(SKILL_TITLE)} report</title>
-<style>{_CSS}{demo_css}</style></head><body><div class="wrap">
+<style>{_CSS}{demo_css}{provenance_css}</style></head><body><div class="wrap">
 <h1>{_esc(SKILL_TITLE)}</h1>
 <p class="sub">Generated {_esc(stamp)} &middot; own data only, computed locally &middot;
 {_esc(summary.get("n_opportunities", 0))} opportunities &middot;
@@ -464,7 +576,7 @@ that is a caveat on an opportunity, never a failure.</p>
 <p class="note">Recurring harness ceremony. Not opportunities to act on; time to reclaim.</p>
 <table><thead><tr><th>Unit</th><th>Sessions</th><th>Wall time</th><th>Author</th></tr></thead>
 <tbody>{waste_rows or '<tr><td colspan="4">none</td></tr>'}</tbody></table>
-
+{provenance_block}
 </div>
 <div class="modal" id="modal" onclick="if(event.target===this)closeModal()">
 <div class="modal-inner" id="modal-body"></div></div>

--- a/skills/attractor-scout/scripts/attractor_scout_cli.py
+++ b/skills/attractor-scout/scripts/attractor_scout_cli.py
@@ -47,6 +47,7 @@ from attractor_scout import (
     graph,
     honest_no,
     pipeline,
+    provenance,
     ranking,
     render,
 )
@@ -168,7 +169,7 @@ def cmd_detect(args) -> int:
 
 
 def cmd_rank(args) -> int:
-    records = extract.read_extracts(args.extracts)
+    records = provenance.ensure_stamped(extract.read_extracts(args.extracts))
     if args.clusters:
         raw = json.loads(Path(args.clusters).read_text(encoding="utf-8"))
         clusters = raw.get("clusters", raw) if isinstance(raw, dict) else raw
@@ -190,7 +191,16 @@ def cmd_rank(args) -> int:
                 )
     else:
         units = clustering.units_from_signatures(records)
-    _emit(ranking.rank(units), args.out)
+
+    # THE MINING BOUNDARY (skill step 1's provenance pass, enforced at the
+    # last moment before scoring): re-verification above has already checked
+    # every member id, so narrowing membership to R4 human-presumed sessions
+    # here cannot mask an invented count. Agent-authored and unattributable
+    # sessions are counted in the provenance panel instead of ranked.
+    gate = provenance.gate_units(units)
+    result = ranking.rank(gate.admitted)
+    result["provenance"] = provenance.summarize(records, gate=gate)
+    _emit(result, args.out)
     return 0
 
 

--- a/skills/attractor-scout/tests/test_scenario11_session_provenance.py
+++ b/skills/attractor-scout/tests/test_scenario11_session_provenance.py
@@ -1,0 +1,597 @@
+"""SCENARIO 11 — session PROVENANCE: whose work reached the ranking.
+
+The artifact this skill produces is only worth reading if it separates what
+the user did from what an agent did on their behalf. Before the provenance
+layer it could not: qualification's sole test was "a `prompt:submit` exists",
+and a harness-fired root emits a byte-identical event.
+
+Four things are machine-checked here.
+
+**The ladder lands where it was planted.** Every calibration class in
+`build_provenance_corpus` is pinned to its rung. The classes share one tool
+sequence and one cost profile, so any difference in what reaches the ranking
+is attributable to provenance and to nothing else.
+
+**The RED proofs.** A gate that has never been shown failing is not a gate:
+
+* `test_red_harness_root_previously_ranked_is_now_excluded` reproduces the OLD
+  behaviour on the same corpus (a tmp-workspace harness one-shot ranked as the
+  user's own work) and then shows the shipped path excluding it.
+* `test_red_ranking_fail_open_absent_author_never_ranks_as_human` pins the
+  `or HUMAN` fail-open that used to end the admission chain.
+* `test_red_renderer_stays_byte_identical_without_provenance` pins additivity.
+
+**Nothing is dropped.** Excluded sessions are counted and sampled, because
+"we excluded 40% of your history" is a finding, not a silence.
+
+**Nothing leaks.** The panel carries counts, classes and shapes — never a
+session id, a path, or a line of prompt text.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from attractor_scout import author as author_mod
+from attractor_scout import clustering, discover, extract, pipeline, provenance, ranking, render
+
+from fixtures.synthetic_corpus import build_provenance_corpus
+
+PINNED = "2020-01-01T00:00:00+00:00"
+
+SKILL_DIR = Path(__file__).resolve().parent.parent
+CLI = SKILL_DIR / "scripts" / "attractor_scout_cli.py"
+
+#: Substrings that exist ONLY because a provenance panel was rendered.
+PROVENANCE_MARKERS = (
+    "Session provenance",
+    'class="prov"',
+    ".prov{",
+    "Already automated",
+    "What is still unknown",
+    "human-presumed",
+)
+
+
+@pytest.fixture(scope="module")
+def planted(tmp_path_factory):
+    """The provenance corpus, mined through the real discovery/extract spine."""
+    root: Path = tmp_path_factory.mktemp("provenance") / "projects"
+    truth = build_provenance_corpus(root)
+    disc = discover.enumerate_sessions(root)
+    refs = discover.qualify(disc)
+    records = extract.extract_corpus(disc, refs)
+    return truth, disc, refs, records
+
+
+def _by_id(records: list[dict]) -> dict[str, dict]:
+    return {str(r["session_id"]): r for r in records}
+
+
+# --------------------------------------------------------------- the ladder
+@pytest.mark.parametrize(
+    "class_name",
+    [
+        "human_multi_turn",
+        "pipeline_root",
+        "harness_oneshot_tmp",
+        "goal_lane_worktree",
+        "templated_brief_root",
+        "stable_single_prompt",
+    ],
+)
+def test_each_planted_class_lands_on_its_rung(planted, class_name):
+    """The pinned verdict table. A rung that moves must move this test first."""
+    truth, _disc, _refs, records = planted
+    spec = truth.expected["classes"][class_name]
+    by_id = _by_id(records)
+    seen = [by_id[sid] for sid in spec["ids"] if sid in by_id]
+    assert seen, f"{class_name} did not survive qualification at all"
+    for rec in seen:
+        prov = rec["provenance"]
+        assert prov["rung"] == spec["rung"], f"{class_name}: expected {spec['rung']}, got {prov['rung']}"
+        assert prov["verdict"] == spec["verdict"]
+
+
+def test_delegate_sub_sessions_classify_r0_even_though_they_are_not_roots(planted):
+    """R0 fires on lineage alone — parent id, delegate id shape, fork opener.
+
+    Delegate sessions are not roots, so they never reach qualification. That
+    is not a reason for the ladder to have no answer about them: the fold and
+    census paths both see them.
+    """
+    truth, disc, _refs, _records = planted
+    spec = truth.expected["classes"]["delegate_sub_session"]
+    refs = [s for s in disc.sessions if s.session_id in set(spec["ids"])]
+    assert len(refs) == len(spec["ids"]), "the delegate sessions must still be DISCOVERED"
+    for ref in refs:
+        assert ref.is_root is False
+        rec = extract.extract_session(ref)
+        assert rec["provenance"]["rung"] == provenance.R0
+        assert rec["provenance"]["verdict"] == provenance.AGENT
+        assert rec["provenance"]["signal"] == "parent_id"
+
+
+def test_every_verdict_names_the_rung_that_fired_and_carries_its_evidence(planted):
+    _truth, _disc, _refs, records = planted
+    for rec in records:
+        prov = rec["provenance"]
+        assert prov["rung"] in provenance.RUNGS
+        assert prov["signal"], "a verdict with no named signal is not auditable"
+        for key in ("prompt_count", "span_s", "workspace_class", "first_prompt_shape"):
+            assert key in prov["evidence"], f"evidence is missing {key}"
+
+
+def test_r5_is_the_floor_and_never_resolves_to_human():
+    """No positive human marker exists, so absence of evidence is never human."""
+    bare = provenance.classify(provenance.SessionSignals(session_id="syn-bare"))
+    assert bare.rung == provenance.R5
+    assert bare.verdict == provenance.UNKNOWN
+
+    # Two prompts, but back to back: no thinking gap, so R4 must DECLINE
+    # rather than round up to human.
+    no_gap = provenance.classify(provenance.SessionSignals(session_id="syn-nogap", n_prompts=2, prompt_gaps_s=(1.0,)))
+    assert no_gap.verdict == provenance.UNKNOWN
+
+
+def test_r4_gap_threshold_is_pinned_scripted_band_stays_unknown(corpus_root: Path):
+    """RED-PROOF for `HUMAN_GAP_MIN_S`: a scripted-cadence multi-turn is NOT human.
+
+    Two workspaces, byte-identical work, differing ONLY in prompt cadence:
+
+    * scripted band — three prompts with gaps of 8 s (all <= 10 s). A machine
+      driving prompts back to back looks like this, and it must land on R5.
+    * human band — three prompts with gaps of 60 s and 120 s. A person
+      thinking between turns looks like this, and it must land on R4.
+
+    Weaken the constant (45.0 -> anything <= 8) and the scripted band starts
+    reading as human — this test goes RED. Verified red at 5.0 during
+    development, then restored.
+    """
+    from fixtures.synthetic_corpus import synth_id, write_session
+
+    for i in range(3):
+        write_session(
+            corpus_root,
+            "syn-prov-scripted",
+            synth_id("synscripted", i),
+            prompts=["kick off", "next step", "final step"],
+            prompt_offsets_s=[0.0, 8.0, 16.0],  # gaps: 8 s, 8 s
+            tools=["read_file", "edit_file", "edit_file", "edit_file", "bash", "python_check"],
+            span_s=600,
+            started_offset_s=i * 7200,
+            working_dir="/synthetic-workspace/proj-alpha",
+        )
+    for i in range(3):
+        write_session(
+            corpus_root,
+            "syn-prov-paced-human",
+            synth_id("synpaced", i),
+            prompts=["kick off", "next step", "final step"],
+            prompt_offsets_s=[0.0, 60.0, 180.0],  # gaps: 60 s, 120 s
+            tools=["read_file", "edit_file", "edit_file", "edit_file", "bash", "python_check"],
+            span_s=600,
+            started_offset_s=i * 7200,
+            working_dir="/synthetic-workspace/proj-alpha",
+        )
+
+    disc = discover.enumerate_sessions(corpus_root)
+    records = extract.extract_corpus(disc, discover.qualify(disc))
+    by_ws: dict[str, set[str]] = {}
+    for rec in records:
+        by_ws.setdefault(rec["workspace"], set()).add(rec["provenance"]["rung"])
+
+    assert by_ws["syn-prov-scripted"] == {provenance.R5}, "an <=10 s-cadence multi-turn must NOT be human-presumed"
+    assert by_ws["syn-prov-paced-human"] == {provenance.R4}, "a genuinely paced multi-turn must reach R4"
+
+
+def test_r4_min_prompts_is_pinned_a_single_prompt_is_never_human():
+    """RED-PROOF for `HUMAN_MIN_PROMPTS`: one prompt is never human, gap or not.
+
+    A single-prompt session cannot produce an inter-prompt gap from real data,
+    so this pins the guard directly at the classifier: even handed a gap value
+    that clears `HUMAN_GAP_MIN_S`, a one-prompt session must decline to R5.
+    Lower the constant (2 -> 1) and this reads R4 — RED.
+    """
+    one_prompt_with_gap = provenance.classify(
+        provenance.SessionSignals(
+            session_id="syn-oneprompt",
+            n_prompts=1,
+            prompt_gaps_s=(provenance.HUMAN_GAP_MIN_S + 100.0,),
+        )
+    )
+    assert one_prompt_with_gap.rung == provenance.R5
+    assert one_prompt_with_gap.verdict == provenance.UNKNOWN
+
+    # And the boundary itself: exactly HUMAN_MIN_PROMPTS prompts WITH a real
+    # gap is the smallest thing that earns R4, so the constant is the hinge.
+    at_boundary = provenance.classify(
+        provenance.SessionSignals(
+            session_id="syn-boundary",
+            n_prompts=provenance.HUMAN_MIN_PROMPTS,
+            prompt_gaps_s=(provenance.HUMAN_GAP_MIN_S,),
+        )
+    )
+    assert at_boundary.rung == provenance.R4
+
+
+def test_false_friends_are_not_treated_as_signals():
+    """Three measured-and-rejected signals must stay rejected.
+
+    A `deprecation:warning` first event (a bundle/time artifact), a
+    UUID-shaped id (thousands of which carry parents), and a session with a
+    constant host field are each NOT evidence of anything, and a session
+    carrying all three still resolves UNKNOWN.
+    """
+    verdict = provenance.classify(
+        provenance.SessionSignals(
+            session_id="synaaaa-bbbb-cccc-dddd-eeeeffff0000",
+            first_event="deprecation:warning",
+            n_prompts=1,
+            working_dir="/synthetic-workspace/proj-alpha",
+        )
+    )
+    assert verdict.rung == provenance.R5
+    assert verdict.verdict == provenance.UNKNOWN
+
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        ("/tmp/synthetic-run.k3f9zq", provenance.WS_EPHEMERAL),
+        ("/var/tmp/synthetic-run", provenance.WS_EPHEMERAL),
+        ("/synthetic-workspace/proj/.scratch/run", provenance.WS_EPHEMERAL),
+        ("/synthetic-workspace/proj/worktrees/lane-2", provenance.WS_EPHEMERAL),
+        ("/synthetic-workspace/proj/lanes/lane-2", provenance.WS_EPHEMERAL),
+        ("/synthetic-workspace/batch-20260814T091500Z", provenance.WS_EPHEMERAL),
+        ("/synthetic-workspace/proj.a1b2c3", provenance.WS_EPHEMERAL),
+        ("/synthetic-workspace/proj-alpha", provenance.WS_STABLE),
+        ("", provenance.WS_UNRECORDED),
+        (None, provenance.WS_UNRECORDED),
+    ],
+)
+def test_structural_path_pattern_set_is_documented_and_conservative(path, expected):
+    ws_class, _pattern = provenance.classify_workspace(path)
+    assert ws_class == expected
+
+
+# ------------------------------------------------------------ plumbing fixes
+def test_working_dir_is_plumbed_through_the_session_ref(planted):
+    """Leak #2: SessionRef used to DROP the most discriminating field it had."""
+    truth, disc, _refs, _records = planted
+    harness_ids = set(truth.expected["classes"]["harness_oneshot_tmp"]["ids"])
+    harness_refs = [s for s in disc.sessions if s.session_id in harness_ids]
+    assert harness_refs
+    for ref in harness_refs:
+        assert ref.working_dir, "working_dir must survive discovery"
+        assert provenance.classify_workspace(ref.working_dir)[0] == provenance.WS_EPHEMERAL
+
+
+def test_qualification_stamps_the_provenance_markers_it_reads(planted):
+    """Leak #1: the qualifier's single read now returns what discriminates."""
+    truth, _disc, refs, _records = planted
+    pipeline_ids = set(truth.expected["classes"]["pipeline_root"]["ids"])
+    stamped = [r for r in refs if r.session_id in pipeline_ids]
+    assert stamped
+    for ref in stamped:
+        assert ref.prescan is not None
+        assert ref.prescan.has_prompt is True
+        assert "pipeline:start" in ref.prescan.orchestration_events
+
+
+def test_extract_drops_the_dead_machine_launched_flag(planted):
+    """Leak #3: `machine_launched` was measured dead; the ladder subsumes it."""
+    _truth, _disc, _refs, records = planted
+    for rec in records:
+        assert "machine_launched" not in rec, "the dead flag must not come back"
+        assert "provenance" in rec
+
+
+def test_absent_provenance_reads_unknown_never_human():
+    """FAIL-HONEST at the record level: an unstamped record is not a person."""
+    assert provenance.verdict_of({}) == provenance.UNKNOWN
+    assert provenance.is_opportunity_eligible({}) is False
+    assert provenance.rung_of({}) == provenance.R5
+
+
+def test_ensure_stamped_classifies_records_read_back_from_disk(planted):
+    _truth, _disc, _refs, records = planted
+    stripped = [{k: v for k, v in rec.items() if k != "provenance"} for rec in records]
+    provenance.ensure_stamped(stripped)
+    original = {r["session_id"]: r["provenance"]["rung"] for r in records}
+    assert {r["session_id"]: r["provenance"]["rung"] for r in stripped} == original
+
+
+# ------------------------------------------------------------- the RED proofs
+def test_red_harness_root_previously_ranked_is_now_excluded(planted):
+    """RED PROOF 1 — the leak, reproduced, then closed.
+
+    The harness one-shot class is a prompt-carrying root running in a tmp
+    workspace. Stripping its provenance stamp reproduces the pre-provenance
+    world exactly: the author prior reads it as human and it lands in the
+    ranked opportunities. With the stamp, the mining boundary keeps it out.
+    """
+    truth, disc, _refs, records = planted
+    harness_ids = set(truth.expected["classes"]["harness_oneshot_tmp"]["ids"])
+
+    # (a) The OLD sole qualifier still admits it — that is the whole problem.
+    harness_refs = [s for s in disc.sessions if s.session_id in harness_ids]
+    assert harness_refs
+    for ref in harness_refs:
+        assert discover.carries_prompt(ref.events_path) is True
+
+    # (b) The pre-provenance world: no stamp, prior reads human, unit ranks.
+    before = copy.deepcopy(records)
+    for rec in before:
+        rec.pop("provenance", None)
+    author_mod.classify_authors(before)
+    before_by_id = _by_id(before)
+    assert all(before_by_id[sid]["author"] == author_mod.HUMAN for sid in harness_ids)
+    old_units = clustering.units_from_signatures(before)
+    old_result = ranking.rank(old_units)
+    old_ranked_members = {
+        sid for u in old_result["opportunities"] + old_result["honest_no"] for sid in u.get("members", [])
+    }
+    assert harness_ids & old_ranked_members, "fixture must reproduce the leak it is proving closed"
+
+    # (c) The shipped path: gate, then rank. The harness unit cannot reach it.
+    units = clustering.units_from_signatures(records)
+    gate = provenance.gate_units(units)
+    new_result = ranking.rank(gate.admitted)
+    new_ranked_members = {
+        sid for u in new_result["opportunities"] + new_result["honest_no"] for sid in u.get("members", [])
+    }
+    assert not (harness_ids & new_ranked_members), "an R2 agent session reached the ranking"
+
+    # (d) Excluded, but COUNTED — the exclusion is a finding, not a silence.
+    panel = provenance.summarize(records, gate=gate)
+    assert panel["by_rung"][provenance.R2] >= len(harness_ids)
+    assert panel["already_automated"] >= len(harness_ids)
+
+
+def test_red_ranking_fail_open_absent_author_never_ranks_as_human(planted):
+    """RED PROOF 2 — the `or HUMAN` fail-open at the end of the author chain.
+
+    A unit carrying no author verdict at all used to default to HUMAN and be
+    ranked as the user's own work. It must now be held out, and it must NOT
+    be relabelled harness either — the honest answer is "unattributed".
+    """
+    truth, _disc, _refs, records = planted
+    human_ids = truth.expected["classes"]["human_multi_turn"]["ids"]
+    by_id = _by_id(records)
+    members = [by_id[sid] for sid in human_ids]
+
+    unit = {"unit_id": "no-author", "name": "no author verdict", "members": members}
+    result = ranking.rank([unit])
+
+    ranked_ids = {u["unit_id"] for u in result["opportunities"]} | {u["unit_id"] for u in result["honest_no"]}
+    assert "no-author" not in ranked_ids, "an unattributed unit was ranked as human work"
+    assert {u["unit_id"] for u in result["waste_findings"]} == set(), "nor may it be called harness ceremony"
+    assert [u["unit_id"] for u in result["unattributed"]] == ["no-author"]
+    assert result["unattributed"][0]["author"] == provenance.UNKNOWN
+    assert result["summary"]["n_unattributed"] == 1
+
+    # The admission gate itself, directly: three channels, no default.
+    admitted, waste, unattributed = ranking.apply_admission_gate([{"unit_id": "x", "members": []}])
+    assert (admitted, waste) == ([], [])
+    assert unattributed[0]["author"] == provenance.UNKNOWN
+
+
+def test_red_renderer_stays_byte_identical_without_provenance(planted):
+    """RED PROOF 3 — additivity, the same discipline as the demos layer.
+
+    A ranked result with no provenance data renders the byte-identical
+    artifact it rendered before this panel existed; every new byte, CSS
+    included, is behind the guard.
+    """
+    truth, _disc, _refs, records = planted
+    human_ids = truth.expected["classes"]["human_multi_turn"]["ids"]
+    by_id = _by_id(records)
+    unit = {
+        "unit_id": "u1",
+        "name": "planted human unit",
+        "members": [by_id[sid] for sid in human_ids],
+        "author_adjudicated": author_mod.HUMAN,
+    }
+    baseline_result = ranking.rank([unit])
+    baseline_result.pop("unattributed", None)
+    baseline = render.render_html(baseline_result, generated_at=PINNED)
+
+    for marker in PROVENANCE_MARKERS:
+        assert marker not in baseline, f"a provenance marker leaked into the no-provenance artifact: {marker!r}"
+    assert render.render_html(dict(baseline_result), generated_at=PINNED) == baseline
+
+    # An explicitly-empty panel is still no panel: falsy means zero bytes.
+    empty = dict(baseline_result)
+    empty["provenance"] = {}
+    empty["unattributed"] = []
+    assert render.render_html(empty, generated_at=PINNED) == baseline
+
+    # ...and with a panel, the artifact grows and says the honest part out loud.
+    with_panel = dict(baseline_result)
+    with_panel["provenance"] = provenance.summarize(records)
+    rendered = render.render_html(with_panel, generated_at=PINNED)
+    assert rendered != baseline
+    for heading in (
+        "A range of what you already do",
+        "Ranked opportunities",
+        "Honest NOs",
+        "Waste findings",
+    ):
+        assert heading in rendered, f"the frozen half lost a section: {heading!r}"
+    assert rendered.index("Waste findings") < rendered.index("Session provenance"), (
+        "the panel is APPENDED, never interleaved"
+    )
+    assert provenance.UNKNOWN_NOTE in rendered
+    assert provenance.UPSTREAM_FIX_NOTE in rendered
+
+
+# ------------------------------------------------------------------- policy
+def test_opportunities_are_mined_from_r4_only(planted):
+    """The settled policy, end to end through the composed pipeline."""
+    truth, _disc, _refs, _records = planted
+    result = pipeline.run(root=truth.root, mode="jsonl")
+    human_ids = set(truth.expected["classes"]["human_multi_turn"]["ids"])
+
+    ranked_members = {
+        sid for u in result.ranked["opportunities"] + result.ranked["honest_no"] for sid in u.get("members", [])
+    }
+    assert ranked_members, "the human class must still produce a ranked unit"
+    assert ranked_members <= human_ids, f"non-R4 sessions reached the ranking: {sorted(ranked_members - human_ids)}"
+
+
+def test_agent_and_unknown_sessions_are_counted_never_silently_dropped(planted):
+    truth, _disc, _refs, records = planted
+    result = pipeline.run(root=truth.root, mode="jsonl")
+    panel = result.ranked["provenance"]
+
+    assert panel["n_sessions"] == len(records)
+    assert sum(panel["by_rung"].values()) == panel["n_sessions"]
+    assert panel["already_automated"] > 0, "the already-automated footprint must be surfaced"
+    assert panel["unknown_excluded"] > 0, "the honest UNKNOWN residual must be surfaced"
+    assert panel["opportunity_pool"] + panel["already_automated"] + panel["unknown_excluded"] == panel["n_sessions"], (
+        "every mined session must land in exactly one pool"
+    )
+    assert panel["samples"], "counts without samples are not auditable"
+
+
+def test_the_panel_carries_no_ids_paths_or_prompt_text(planted):
+    """§7: the SHIPPED artifact ships counts, classes and shapes — nothing identifying.
+
+    Non-vacuous by construction: the gate runs over the REAL fixture units (a
+    populated already-automated + unattributed set), the panel is summarized
+    with that real gate, and the assertion is made against the RENDERED HTML —
+    the thing that actually reaches disk — not just the summary dict.
+    """
+    truth, _disc, _refs, records = planted
+
+    units = clustering.units_from_signatures(records)
+    gate = provenance.gate_units(units)
+    assert gate.already_automated and gate.unattributed, "the leak scan must run over a POPULATED gate, not []"
+    panel = provenance.summarize(records, gate=gate)
+    result = ranking.rank(gate.admitted)
+    result["provenance"] = panel
+    html = render.render_html(result, generated_at=PINNED)
+
+    prompts = {"fix the failing check", "Run the scheduled check", "Lane mission", "kick off"}
+    for surface, label in ((json.dumps(panel), "panel dict"), (html, "rendered HTML")):
+        for spec in truth.expected["classes"].values():
+            for sid in spec["ids"]:
+                assert sid not in surface, f"{label} leaked a session id"
+        assert truth.expected["stable_workdir"] not in surface, f"{label} leaked a workspace path"
+        assert "/tmp/" not in surface, f"{label} leaked a tmp path"
+        for prompt in prompts:
+            assert prompt not in surface, f"{label} leaked prompt text: {prompt!r}"
+
+
+def test_unit_names_are_the_only_thing_that_reaches_the_html_and_they_are_labels(planted):
+    """DISCLOSURE (mirrored in design doc §5): a unit NAME reaches the HTML via
+    the unattributed table. That is intentional and safe — a name is an
+    LLM-authored cluster LABEL, never a path, id, or prompt body. This asserts
+    the channel exists and that what flows through it is a label, so a future
+    change that starts piping a path or id into a name breaks here.
+    """
+    truth, _disc, _refs, records = planted
+    human_members = [r for r in records if r["session_id"] in set(truth.expected["classes"]["human_multi_turn"]["ids"])]
+    # A unit with NO author verdict → ranking routes it to `unattributed`,
+    # whose NAME the renderer prints. Give it a label-shaped name on purpose.
+    label = "cross-workspace report handoff"
+    result = ranking.rank([{"unit_id": "u-unattr", "name": label, "members": human_members}])
+    assert [u["name"] for u in result["unattributed"]] == [label]
+    html = render.render_html(result, generated_at=PINNED)
+    assert label in html, "the unattributed unit name is expected to reach the HTML"
+    # ...and the name is the ONLY member-derived string that does: no id, path.
+    for member in human_members:
+        assert member["session_id"] not in html
+
+
+def test_gate_units_never_mutates_its_input(planted):
+    _truth, _disc, _refs, records = planted
+    units = clustering.units_from_signatures(records)
+    before = [len(u["members"]) for u in units]
+    provenance.gate_units(units)
+    assert [len(u["members"]) for u in units] == before
+
+
+def test_units_with_no_r4_member_are_reported_not_deleted(planted):
+    _truth, _disc, _refs, records = planted
+    units = clustering.units_from_signatures(records)
+    gate = provenance.gate_units(units)
+    reported = gate.already_automated + gate.unattributed
+    assert reported, "gated-out units must still be reported somewhere"
+    for entry in reported:
+        assert entry["n_sessions"] >= 1
+        assert entry["provenance_mix"], "an exclusion without its rung mix is not auditable"
+        assert entry["note"]
+
+
+# --------------------------------------------------------- the CLI boundary
+def _cli(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(CLI), *args],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+
+
+def test_red_cli_rank_enforces_the_mining_boundary(tmp_path: Path):
+    """RED PROOF 4 — the CLI `rank` path is gated too, not just `pipeline.run`.
+
+    `pipeline.run` and `cmd_rank` are two independent wirings of the mining
+    boundary, and only the first was guarded: mutating `cmd_rank`'s
+    `ranking.rank(gate.admitted)` back to `rank(units)` left the whole suite
+    green. This drives the real CLI (`extract` then `rank`) end to end over the
+    provenance corpus and pins the boundary there.
+
+    The load-bearing class is `stable_single_prompt` (R5, UNKNOWN): its author
+    PRIOR reads human (one unique prompt, no harness markers), so the author
+    admission gate would happily admit it. ONLY the provenance mining boundary
+    keeps it out — which is exactly why an ungated `cmd_rank` ranks it, and
+    this test goes red. Verified red against the mutated form during
+    development, then restored.
+    """
+    truth = build_provenance_corpus(tmp_path / "projects")
+    classes = truth.expected["classes"]
+    id2class = {sid: name for name, spec in classes.items() for sid in spec["ids"]}
+    human_ids = set(classes["human_multi_turn"]["ids"])
+
+    extracts = tmp_path / "ex.jsonl"
+    ranked = tmp_path / "ranked.json"
+    ex = _cli("--root", str(tmp_path / "projects"), "extract", "--out", str(extracts))
+    assert ex.returncode == 0, ex.stderr
+    rk = _cli("rank", "--extracts", str(extracts), "--out", str(ranked))
+    assert rk.returncode == 0, rk.stderr
+
+    result = json.loads(ranked.read_text(encoding="utf-8"))
+    ranked_members = {sid for u in result["opportunities"] + result["honest_no"] for sid in u.get("members", [])}
+    assert ranked_members, "the human class must still produce a ranked unit through the CLI"
+    leaked = {id2class.get(sid, sid) for sid in ranked_members - human_ids}
+    assert not leaked, f"non-R4 sessions reached the CLI ranking: {sorted(leaked)}"
+
+    # The UNKNOWN class was not merely absent from the ranking — it was
+    # positively counted in the panel the same run emits, so the exclusion is
+    # a visible finding and not a silence.
+    panel = result["provenance"]
+    assert panel["by_rung"][provenance.R5] >= len(classes["stable_single_prompt"]["ids"])
+    assert panel["unknown_excluded"] >= len(classes["stable_single_prompt"]["ids"])
+
+
+def test_the_unknown_class_authors_human_so_only_the_boundary_excludes_it(planted):
+    """The premise of RED PROOF 4, asserted directly: the author gate alone is
+    NOT enough. If the prior ever stops calling this class human, the CLI test
+    above would pass for the wrong reason — so pin the premise separately."""
+    truth, _disc, _refs, records = planted
+    by_id = _by_id(records)
+    for sid in truth.expected["classes"]["stable_single_prompt"]["ids"]:
+        rec = by_id[sid]
+        assert rec["provenance"]["rung"] == provenance.R5
+        assert rec["author"] == author_mod.HUMAN, (
+            "the UNKNOWN class must author HUMAN, or the CLI boundary test proves nothing"
+        )

--- a/skills/attractor-scout/tests/test_skill_doc_claims.py
+++ b/skills/attractor-scout/tests/test_skill_doc_claims.py
@@ -125,6 +125,58 @@ def test_step10_claims_are_sourced_in_code():
         )
 
 
+#: Step 1/4/6 provenance claims, pinned to the CODE that makes them true — same
+#: doctrine as the step-10 block above. A rung, a verdict name or a policy that
+#: drifts from `provenance.py` must break this test rather than mislead a reader.
+PROVENANCE_PINNED_CLAIMS = [
+    (
+        "scripts/attractor_scout/provenance.py",
+        'HUMAN_PRESUMED = "human-presumed"',
+        "scripts/attractor_scout/provenance.py",
+    ),
+    ("human-presumed", 'HUMAN_PRESUMED = "human-presumed"', "scripts/attractor_scout/provenance.py"),
+    ("likely-agent", 'LIKELY_AGENT = "likely-agent"', "scripts/attractor_scout/provenance.py"),
+    ("`session:fork` opener", 'FORK_FIRST_EVENT = "session:fork"', "scripts/attractor_scout/provenance.py"),
+    ("a pipeline or recipe start event", "ORCHESTRATION_START_EVENTS", "scripts/attractor_scout/provenance.py"),
+    ("`working_dir`", "def classify_workspace", "scripts/attractor_scout/provenance.py"),
+    (
+        "opportunities are mined\nfrom `R4` only",
+        "OPPORTUNITY_VERDICT = HUMAN_PRESUMED",
+        "scripts/attractor_scout/provenance.py",
+    ),
+    ("unattributed", 'unit["author"] = provenance.UNKNOWN', "scripts/attractor_scout/ranking.py"),
+    ("provenance panel", "def _provenance_block", "scripts/attractor_scout/render.py"),
+    # Step 4's never-promote-agent-to-human adjudication rule. Prose-only in
+    # SKILL.md, so pin it to the invariant comment at the seam that consumes
+    # the adjudicated label — a SKILL.md edit that drops the rule goes RED.
+    (
+        "may NEVER move a cluster",
+        "may NEVER move a\n        # cluster toward human",
+        "scripts/attractor_scout/clustering.py",
+    ),
+]
+
+
+def test_provenance_claims_are_sourced_in_code():
+    skill = _strip_emphasis(SKILL_MD.read_text(encoding="utf-8"))
+    for phrase, source, relpath in PROVENANCE_PINNED_CLAIMS:
+        assert _strip_emphasis(phrase) in skill, f"SKILL.md no longer contains the provenance claim {phrase!r}"
+        code = (SKILL_DIR / relpath).read_text(encoding="utf-8")
+        assert source in code, (
+            f"SKILL.md's provenance claim {phrase!r} is not sourced by {source!r} in {relpath} \u2014 "
+            f"the code moved; re-check the claim or update the pin."
+        )
+
+
+def test_skill_names_every_rung_of_the_ladder():
+    """All six rungs must be described in the guidance while all six run in code."""
+    skill = SKILL_MD.read_text(encoding="utf-8")
+    from attractor_scout import provenance
+
+    for rung in provenance.RUNGS:
+        assert f"`{rung}`" in skill, f"SKILL.md no longer names provenance rung {rung}"
+
+
 def test_step10_names_all_six_gates():
     """Step 10 must describe every deterministic deck gate (a)-(f) by letter.
 


### PR DESCRIPTION
## Summary
**Session provenance for `skills/attractor-scout/`** — deterministic human-vs-agent classification at mining time, fixing the maintainer-reported defect: personalized artifacts confused work the human did with work agents did on their behalf. Grounded in two independent forensic investigations of the real corpus (CI-graph + local-file), which converged on the headline: **no positive human marker exists in today's session data** — "human" can only ever be presumed, so the pipeline must never default to it.

**The ladder** (`scripts/attractor_scout/provenance.py`, stdlib, first-rung-wins, every verdict carries its rung + evidence): **R0 AGENT** (non-empty `parent_id` / delegate sid-prefix / composite `_<agent>` suffix / first-event `session:fork` — measured 2000/2000 vs 0/9,149 separation) · **R1 AGENT** (pipeline/recipe orchestration-start events) · **R2 AGENT** (working_dir under tmp/scratch/worktrees/lanes/timestamped/mktemp — measured 22/22, 39/40) · **R3 LIKELY-AGENT** (single templated long prompt) · **R4 HUMAN-PRESUMED** (≥2 prompts w/ ≥45s gap) · **R5 UNKNOWN** (floor — never silently human).

**The leak, closed at each site:** `carries_prompt` was the sole qualifier (a harness `amplifier run --mode single` root emits a byte-identical `prompt:submit`) → now a necessary-never-sufficient prescan; `SessionRef` dropped `working_dir` (the most discriminating available field) → plumbed; dead `machine_launched` deleted; `ranking.py`'s fail-open `or HUMAN` removed → fail-honest `unattributed` channel.

**Policy** (one seam, `provenance.gate_units`, after member re-verification, before scoring): opportunities are mined from **R4 only**; R0–R3 excluded + counted as an "already-automated footprint"; R5 UNKNOWN excluded from ranking but counted + sampled in a new artifact **provenance panel** (the measured ~21–29% agent contamination of the HOME one-shot band justifies exclusion); author prior recomputed over survivors; the step-4 LLM adjudication receives the deterministic verdict + evidence under a pinned never-promote-agent-to-human rule. Mixed-membership units survive with their R4 members (the human genuinely did that work).

**Decision-matrix tier: Uncharted (extension), additive** — diff confined to `skills/attractor-scout/` + `docs/designs/` (design doc: `docs/designs/2026-08-20-scout-session-provenance.md`). EXTENSIONS entry N/A: no pipeline contract touched. Renderer additivity pinned: no-provenance data ⇒ byte-identical artifact.

## Verification checklist
- [x] Unit tests — suite **454 passed / 54 skipped** (was 406/52): 7 pinned calibration-class fixtures (human multi-turn, delegate sub-session, pipeline root, harness one-shot in tmp, goal-lane worktree, templated-brief root, HOME one-shot UNKNOWN), threshold pins, CLI-boundary RED-proof, fail-open regression, panel-leak scan over rendered HTML, renderer byte-identity
- [x] Independent adversarial review — **MERGE-AFTER-FIX, all findings closed**: reviewer's mutations (R5→HUMAN, gate removal) went RED; two gaps it found (ungated `cmd_rank` path; unpinned R4 thresholds) now carry their own RED-proofs (verified red against the mutation, then restored)
- [x] Pre-publication leak review (§7) — evidence dicts carry classes/shapes only; panel HTML scanned for ids/paths/prompt text against real gated fixtures; design doc generic (no session ids, no identity values); 3-layer leak guard green
- [x] Byte-pins untouched; ruff clean (zero new); `git diff --check` clean
- [x] CI green before merge — will confirm

## Required disclosures
1. ★ **The residual bypass, named:** a harness that paces its prompts like a human (≥45s staged gaps) in a stable HOME workspace classifies R4 human-presumed — indistinguishable in today's data. Named in the design doc's limits AND in the artifact panel prose. The close is upstream: **record `argv` / `--mode` / `stdin.isatty()` / `launched_by_session_id` at `session:start`** — one boolean collapses R2–R5 into a definitive test (observation filed for the ecosystem).
2. R4 rests on a small calibration set (3/3 human, 0/9 agent) vs R0's 2000/2000 — thresholds are pinned constants with measured justifications, honest about their n.
3. Unit *names* (LLM-authored labels, never paths) reach the artifact HTML via the unattributed channel — disclosed in the design doc.
4. `gaps_from_timestamps` uses `abs()` — out-of-order timestamps degrade one-directionally (documented in the docstring).
5. `fold_children` remains dead-path (pre-existing; a ranking-semantics call, not provenance) — noted in-code.
