### PR TITLE
fix(skill): attractor-scout labeller — batch-boundary id validation, fail-loud counter

### DIFF
--- a/skills/attractor-scout/SKILL.md
+++ b/skills/attractor-scout/SKILL.md
@@ -154,10 +154,23 @@ sessions**, run in **waves of 5 batches in series**. Those two numbers are the
 calibrated shape: ~40 keeps a batch inside one workspace's coherence so a
 cluster is not split across unrelated work, and 5-at-a-time in series stays
 under provider rate limits on a corpus of any size. The `fast`
-role does this reliably at scale — every batch measured in this build placed
-every session with **zero invented ids**. Each batch returns cluster
-assignments as JSON; collect them into an intermediate `$WORK/fast-clusters.json`
-(the verdict-carrying `$WORK/clusters.json` is assembled in step 4).
+role does this reliably at scale but **not perfectly**: a full-corpus run
+measured it returning a small number of session ids that were in no supplied
+batch. So the discipline is ENFORCED rather than assumed — **every id a batch
+returns is checked against the ids THAT batch was handed; one that is not is
+dropped, counted, and reported as `invented_ids_rejected` in the run summary.**
+Write each batch's response next to the ids that batch was handed, and collect
+them THROUGH that check into `$WORK/fast-clusters.json` (the verdict-carrying
+`$WORK/clusters.json` is assembled in step 4):
+
+```json
+{"batch_id": "b07", "session_ids": ["<sid>", "<sid>"],
+ "clusters": [{"id": "b07-c1", "name": "short label", "members": ["<sid>"]}]}
+```
+
+```bash
+$CLI label-merge --batches "$WORK/label-batches" --out "$WORK/fast-clusters.json"
+```
 
 **3 — Merge + fit verdicts (`reasoning` role).** Merge the per-batch clusters
 (staged: batch → regional → global) and assign each cluster its **fit verdict**

--- a/skills/attractor-scout/scripts/attractor_scout/clustering.py
+++ b/skills/attractor-scout/scripts/attractor_scout/clustering.py
@@ -16,16 +16,170 @@ This module never calls a model. It only ATTACHES member records to
 cluster definitions and re-verifies membership deterministically — which is
 the whole point of the seam: everything the LLM pass produces gets checked
 against `extracts.jsonl` before it can influence a ranking.
+
+There are TWO id checks here, at two different boundaries, and they are not
+redundant:
+
+* `validate_batch_labels` — THE BATCH BOUNDARY, run as each `fast`-tier
+  labelling batch comes back. An id is admissible only against the ~40 ids
+  THAT batch was handed. This is the tightest set the id can be checked
+  against, and it is checked at the moment the model emits it.
+* `units_from_clusters` — the corpus boundary, run at rank time against the
+  whole extract. Wider by construction, and later.
 """
 
 from __future__ import annotations
 
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+
 from . import author as author_mod
 from . import frequency_signature
+from .errors import AttractorScoutError
 
 
 def _index(records: list[dict]) -> dict[str, dict]:
     return {str(r["session_id"]): r for r in records if r.get("session_id")}
+
+
+def _expand(sid: str, candidates: Iterable[str]) -> list[str]:
+    """Resolve one labeller-emitted id against a candidate id set.
+
+    Full id first. A short id is resolved by unique-prefix expansion, and an
+    AMBIGUOUS prefix expands to ALL matches — the measured 3.0% collision rate
+    means a prefix key would otherwise silently merge distinct sessions. An
+    empty list means the id is not in this set at all.
+
+    An empty/whitespace id resolves to NOTHING rather than to everything: `""`
+    is a prefix of every id, so treating it as a prefix would launder a blank
+    into the whole corpus.
+    """
+    if not sid.strip():
+        return []
+    if sid in candidates:
+        return [sid]
+    return [full for full in candidates if full.startswith(sid)]
+
+
+# ------------------------------------------------------- THE BATCH BOUNDARY
+@dataclass
+class BatchLabelMerge:
+    """What the labelling pass actually produced, and what it invented.
+
+    `invented_ids_rejected` is the fail-loud counter: it is emitted on every
+    merge, including the clean case (as `0`), because a counter that only
+    appears when it is non-zero is a counter nobody is watching.
+    """
+
+    clusters: list[dict] = field(default_factory=list)
+    n_batches: int = 0
+    n_ids_supplied: int = 0
+    n_ids_placed: int = 0
+    invented_ids_rejected: int = 0
+    rejected_by_batch: dict[str, list[str]] = field(default_factory=dict)
+    n_clusters_emptied: int = 0
+
+    def as_dict(self) -> dict:
+        return {
+            "n_batches": self.n_batches,
+            "n_ids_supplied": self.n_ids_supplied,
+            "n_ids_placed": self.n_ids_placed,
+            "invented_ids_rejected": self.invented_ids_rejected,
+            "n_clusters_emptied": self.n_clusters_emptied,
+            "rejected_by_batch": {k: list(v) for k, v in self.rejected_by_batch.items()},
+        }
+
+
+def validate_batch_labels(supplied_ids: Iterable[str], clusters: list[dict]) -> tuple[list[dict], list[str]]:
+    """Hold ONE labelling batch to its OWN supplied id set.
+
+    Returns `(kept_clusters, rejected_ids)`. Every member id the `fast` tier
+    returned must resolve against `supplied_ids` — the ids that batch was
+    actually handed. An id that does not is DROPPED from the cluster and
+    RETURNED for counting; it is never passed downstream and never silently
+    swallowed.
+
+    This is deterministic containment at the earliest possible moment. A live
+    run of 2,299 sessions across 64 batches saw the fast tier return 4 ids
+    (0.17%) that were in no supplied batch — downstream gates caught them, but
+    only after they had travelled through the merge. Here they do not travel.
+    """
+    # An ORDERED de-duplicating set: prefix expansion must land in the order
+    # the batch supplied its ids, or two identical runs disagree.
+    supplied: dict[str, None] = {}
+    for raw_id in supplied_ids:
+        sid = str(raw_id)
+        if sid.strip():
+            supplied.setdefault(sid, None)
+    if not supplied:
+        raise AttractorScoutError(
+            "batch-boundary validation was asked to check a batch with an EMPTY supplied id set. "
+            "Every id would be rejected, which is a broken caller, not a labelling failure. "
+            "Record the ids each batch was handed alongside its response."
+        )
+
+    kept: list[dict] = []
+    rejected: list[str] = []
+    for cluster in clusters or []:
+        members: list[str] = []
+        seen: set[str] = set()
+        for raw in cluster.get("members") or []:
+            sid = str(raw)
+            matches = _expand(sid, supplied)
+            if not matches:
+                rejected.append(sid)
+                continue
+            for full in matches:
+                if full not in seen:
+                    seen.add(full)
+                    members.append(full)
+        out = dict(cluster)
+        out["members"] = members
+        kept.append(out)
+    return kept, rejected
+
+
+def merge_fast_batches(batches: list[dict]) -> BatchLabelMerge:
+    """Collect the `fast` tier's per-batch responses THROUGH the batch boundary.
+
+    Each batch is `{"batch_id": ..., "session_ids": [...supplied...],
+    "clusters": [...returned...]}` (`supplied_ids`/`ids` and `assignments` are
+    accepted as aliases). Clusters left with no surviving member are dropped
+    and counted in `n_clusters_emptied` — an all-invented cluster is not a
+    cluster, and shipping it as an empty one would put a fabricated name into
+    the merge.
+    """
+    merged = BatchLabelMerge()
+    for index, batch in enumerate(batches or [], start=1):
+        if not isinstance(batch, dict):
+            raise AttractorScoutError(f"labelling batch #{index} is {type(batch).__name__}, expected an object")
+        batch_id = str(batch.get("batch_id") or batch.get("id") or f"batch-{index}")
+        supplied = batch.get("session_ids")
+        if supplied is None:
+            supplied = batch.get("supplied_ids")
+        if supplied is None:
+            supplied = batch.get("ids")
+        raw_clusters = batch.get("clusters")
+        if raw_clusters is None:
+            raw_clusters = batch.get("assignments")
+        try:
+            kept, rejected = validate_batch_labels(supplied or [], raw_clusters or [])
+        except AttractorScoutError as exc:
+            raise AttractorScoutError(f"labelling batch {batch_id!r}: {exc}") from exc
+
+        merged.n_batches += 1
+        merged.n_ids_supplied += len({str(s) for s in (supplied or []) if str(s).strip()})
+        for cluster in kept:
+            if not cluster["members"]:
+                merged.n_clusters_emptied += 1
+                continue
+            cluster.setdefault("batch_id", batch_id)
+            merged.n_ids_placed += len(cluster["members"])
+            merged.clusters.append(cluster)
+        if rejected:
+            merged.rejected_by_batch[batch_id] = rejected
+            merged.invented_ids_rejected += len(rejected)
+    return merged
 
 
 def units_from_clusters(records: list[dict], clusters: list[dict]) -> tuple[list[dict], list[str]]:
@@ -33,13 +187,13 @@ def units_from_clusters(records: list[dict], clusters: list[dict]) -> tuple[list
 
     Returns `(units, unknown_member_ids)`. Member ids that do not resolve are
     REPORTED, never silently dropped — an invented id is the exact failure
-    mode the deterministic re-verification exists to catch (the calibration
-    run measured 0 invented ids across 57 batches; this is how we keep
-    knowing that).
+    mode the deterministic re-verification exists to catch, and a live run of
+    64 batches proved the fast tier does invent them (4 ids, 0.17%). This is
+    the corpus-wide backstop; `validate_batch_labels` is the tight one.
 
-    Member ids are matched on the FULL session id first. A short id is
-    resolved by unique-prefix expansion, and an AMBIGUOUS prefix expands to
-    ALL matches — the measured 3.0% collision rate means a prefix key would
+    Member ids are matched by `_expand`: FULL session id first, then
+    unique-prefix expansion, with an AMBIGUOUS prefix expanding to ALL
+    matches — the measured 3.0% collision rate means a prefix key would
     otherwise silently merge distinct sessions.
     """
     by_id = _index(records)
@@ -51,12 +205,7 @@ def units_from_clusters(records: list[dict], clusters: list[dict]) -> tuple[list
         seen: set[str] = set()
         for raw in cluster.get("members") or []:
             sid = str(raw)
-            if sid in by_id:
-                if sid not in seen:
-                    seen.add(sid)
-                    members.append(by_id[sid])
-                continue
-            matches = [full for full in by_id if full.startswith(sid)]
+            matches = _expand(sid, by_id)
             if not matches:
                 unknown.append(sid)
                 continue

--- a/skills/attractor-scout/scripts/attractor_scout/pipeline.py
+++ b/skills/attractor-scout/scripts/attractor_scout/pipeline.py
@@ -34,6 +34,14 @@ class RunResult:
     ranked: dict = field(default_factory=dict)
     artifact: str | None = None
     source: str = "signatures"
+    #: The batch-boundary ledger carried on the clusters file by `label-merge`.
+    #: Empty when no labelling pass ran (the deterministic A-rung floor).
+    labelling: dict = field(default_factory=dict)
+
+    @property
+    def invented_ids_rejected(self) -> int:
+        """Ids the fast tier returned that were in no supplied batch."""
+        return int(self.labelling.get("invented_ids_rejected", 0) or 0)
 
     def as_dict(self) -> dict:
         return {
@@ -45,6 +53,10 @@ class RunResult:
             "n_sessions_qualified": self.n_sessions_qualified,
             "n_records": self.n_records,
             "unknown_cluster_members": self.unknown_cluster_members,
+            # The fail-loud counter, ALWAYS emitted - a counter that only shows
+            # up when it is non-zero is a counter nobody is watching.
+            "invented_ids_rejected": self.invented_ids_rejected,
+            "labelling": self.labelling,
             "own_data_scope": self.scope,
             "artifact": self.artifact,
             **self.ranked,
@@ -82,9 +94,15 @@ def run(
     provenance.ensure_stamped(records)
 
     unknown: list[str] = []
+    labelling: dict = {}
     if clusters_path:
         raw = json.loads(Path(clusters_path).read_text(encoding="utf-8"))
         clusters = raw.get("clusters", raw) if isinstance(raw, dict) else raw
+        # The batch-boundary ledger `label-merge` stamped on this file, carried
+        # into the run summary so `invented_ids_rejected` survives the hand-off
+        # between the labelling pass and the report.
+        if isinstance(raw, dict) and isinstance(raw.get("labelling"), dict):
+            labelling = raw["labelling"]
         units, unknown = clustering.units_from_clusters(records, clusters)
         source = "semantic-clusters"
     else:
@@ -109,6 +127,7 @@ def run(
         scope=scope,
         ranked=ranked,
         source=source,
+        labelling=labelling,
     )
     if render_to is not None:
         result.artifact = str(render.write_report(ranked, render_to, tier_note=decision.note))

--- a/skills/attractor-scout/scripts/attractor_scout_cli.py
+++ b/skills/attractor-scout/scripts/attractor_scout_cli.py
@@ -168,11 +168,70 @@ def cmd_detect(args) -> int:
     raise ValueError(f"unknown signal: {args.signal!r}")
 
 
+def _load_batches(paths: list[str]) -> list[dict]:
+    """Read the `fast` tier's per-batch responses from files and/or directories."""
+    files: list[Path] = []
+    for raw in paths:
+        path = Path(raw)
+        if path.is_dir():
+            files.extend(sorted(path.glob("*.json")))
+        elif path.is_file():
+            files.append(path)
+        else:
+            raise AttractorScoutError(f"--batches path does not exist: {path}")
+    if not files:
+        raise AttractorScoutError(f"--batches matched 0 JSON files under: {', '.join(paths)}")
+
+    batches: list[dict] = []
+    for path in files:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(payload, dict) and isinstance(payload.get("batches"), list):
+            found = payload["batches"]
+        elif isinstance(payload, list):
+            found = payload
+        else:
+            found = [payload]
+        for item in found:
+            if isinstance(item, dict):
+                item.setdefault("batch_id", path.stem)
+            batches.append(item)
+    return batches
+
+
+def cmd_label_merge(args) -> int:
+    """Collect the fast-tier labelling batches THROUGH the batch boundary.
+
+    Every id a batch returns must be one of the ids THAT batch was handed.
+    Invented ids are dropped, counted, and printed - a live 64-batch run
+    measured 4 of them, so this counter is load-bearing, not decorative.
+    """
+    merged = clustering.merge_fast_batches(_load_batches(args.batches))
+    summary = merged.as_dict()
+    _emit({"clusters": merged.clusters, "labelling": summary}, args.out)
+    print(
+        f"labelling: batches={summary['n_batches']} ids_supplied={summary['n_ids_supplied']} "
+        f"ids_placed={summary['n_ids_placed']} invented_ids_rejected={summary['invented_ids_rejected']}",
+        file=sys.stderr,
+    )
+    if summary["invented_ids_rejected"]:
+        for batch_id, ids in summary["rejected_by_batch"].items():
+            print(f"  REJECTED (not in batch {batch_id}): {', '.join(ids[:10])}", file=sys.stderr)
+        if args.strict:
+            raise AttractorScoutError(
+                f"batch-boundary validation rejected {summary['invented_ids_rejected']} invented id(s). "
+                f"--strict was given, so this is fatal: re-run the labelling pass."
+            )
+    return 0
+
+
 def cmd_rank(args) -> int:
     records = provenance.ensure_stamped(extract.read_extracts(args.extracts))
+    labelling: dict | None = None
     if args.clusters:
         raw = json.loads(Path(args.clusters).read_text(encoding="utf-8"))
         clusters = raw.get("clusters", raw) if isinstance(raw, dict) else raw
+        if isinstance(raw, dict) and isinstance(raw.get("labelling"), dict):
+            labelling = raw["labelling"]
         units, unknown = clustering.units_from_clusters(records, clusters)
         if unknown:
             # Deterministic re-verification (skill step 5): a member id the LLM
@@ -200,6 +259,15 @@ def cmd_rank(args) -> int:
     gate = provenance.gate_units(units)
     result = ranking.rank(gate.admitted)
     result["provenance"] = provenance.summarize(records, gate=gate)
+    if labelling is not None:
+        # Carry the batch-boundary counter forward into the run summary. It is
+        # a fact ABOUT this ranking's inputs; a reader who never saw the merge
+        # step's stderr still gets `invented_ids_rejected` here.
+        result["labelling"] = labelling
+        print(
+            f"labelling (from {args.clusters}): invented_ids_rejected={labelling.get('invented_ids_rejected', 0)}",
+            file=sys.stderr,
+        )
     _emit(result, args.out)
     return 0
 
@@ -378,6 +446,24 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--extracts", default="extracts.jsonl")
     p.add_argument("--out")
     p.set_defaults(func=cmd_detect)
+
+    p = sub.add_parser(
+        "label-merge",
+        help="collect the fast-tier labelling batches through the batch boundary (skill step 2)",
+    )
+    p.add_argument(
+        "--batches",
+        nargs="+",
+        required=True,
+        help="per-batch response JSON files and/or directories of them; each carries its supplied session_ids",
+    )
+    p.add_argument("--out", default=None, help="fast-clusters.json to write (default: stdout)")
+    p.add_argument(
+        "--strict",
+        action="store_true",
+        help="batch-boundary rejection is FATAL: exit 2 if the labeller returned any id outside its own batch",
+    )
+    p.set_defaults(func=cmd_label_merge)
 
     p = sub.add_parser("rank")
     p.add_argument("--extracts", default="extracts.jsonl")

--- a/skills/attractor-scout/tests/test_scenario12_batch_boundary.py
+++ b/skills/attractor-scout/tests/test_scenario12_batch_boundary.py
@@ -1,0 +1,337 @@
+"""SCENARIO 12 — THE BATCH BOUNDARY: the labeller does not get to invent ids.
+
+The `fast`-tier label/cluster pass is the only place in this skill where a
+model produces session ids rather than consuming them. A live run of 2,299
+sessions across 64 batches measured it returning **4 ids (0.17%) that were in
+no supplied batch**. Downstream gates contained all four — but only after they
+had travelled through the merge, and the discipline SKILL.md pinned ("zero
+invented ids") was simply not what the machine measured.
+
+This file is the enforcement of the replacement discipline: **an id the
+labeller returns is admissible only against the ids THAT batch was handed**,
+and the ones that are not are dropped, counted, and said out loud.
+
+Three layers.
+
+Layer 1 — THE RED PROOFS. A gate that has never been shown failing is not a
+gate:
+
+* `test_red_unvalidated_collect_carries_an_invented_id_into_the_merge`
+  reproduces the OLD step-2 behaviour (plain concatenation of batch responses)
+  on the same fixture and shows the invented id sailing through, then shows
+  the shipped path rejecting it.
+* `test_red_an_id_real_elsewhere_but_not_in_this_batch_is_still_rejected` is
+  the exact shape the live run hit: the id is well-formed and plausible, and
+  the corpus-wide check would have admitted it. The batch boundary does not.
+* `test_red_a_blank_id_resolves_to_nothing_not_to_everything` pins the prefix
+  rule's own failure mode — `""` is a prefix of every id.
+
+Layer 2 — CONTAINMENT IS COUNTED, NEVER SILENT. The counter is emitted on
+every merge, including the clean case as `0`, and it survives the hand-off
+into `rank` and into the run summary.
+
+Layer 3 — NO FALSE POSITIVES. A clean batch is byte-identical to the
+unvalidated collect, and legitimate short/prefix ids still resolve.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from attractor_scout import clustering, pipeline
+from attractor_scout.errors import AttractorScoutError
+
+SKILL_DIR = Path(__file__).resolve().parent.parent
+CLI = [sys.executable, str(SKILL_DIR / "scripts" / "attractor_scout_cli.py")]
+
+
+def _sid(prefix: str, n: int) -> str:
+    """A deterministic synthetic session id. Never a real UUID."""
+    return f"{prefix}-{n:04d}-4000-8000-{n:012d}"
+
+
+BATCH_A_IDS = [_sid("synbatcha", i) for i in range(1, 5)]
+BATCH_B_IDS = [_sid("synbatchb", i) for i in range(1, 5)]
+
+#: Shaped exactly like a real id, supplied by NO batch. This is the artefact.
+INVENTED_ID = _sid("syninvent", 9)
+
+
+def _clean_batch_a() -> dict:
+    return {
+        "batch_id": "batch-a",
+        "session_ids": list(BATCH_A_IDS),
+        "clusters": [
+            {"id": "a1", "name": "report handoff", "members": [BATCH_A_IDS[0], BATCH_A_IDS[1]]},
+            {"id": "a2", "name": "flaky retry loop", "members": [BATCH_A_IDS[2], BATCH_A_IDS[3]]},
+        ],
+    }
+
+
+def _clean_batch_b() -> dict:
+    return {
+        "batch_id": "batch-b",
+        "session_ids": list(BATCH_B_IDS),
+        "clusters": [{"id": "b1", "name": "doc sweep", "members": list(BATCH_B_IDS)}],
+    }
+
+
+def _unvalidated_collect(batches: list[dict]) -> list[dict]:
+    """THE OLD STEP 2, reproduced: concatenate what every batch returned.
+
+    This is what "collect them into an intermediate fast-clusters.json" meant
+    before the batch boundary existed — no check at all between the model's
+    output and the merge.
+    """
+    out: list[dict] = []
+    for batch in batches:
+        out.extend(copy.deepcopy(batch.get("clusters") or []))
+    return out
+
+
+# ------------------------------------------------------------------ layer 1
+def test_red_unvalidated_collect_carries_an_invented_id_into_the_merge():
+    """RED: the pre-fix path admits an id no batch ever supplied."""
+    dirty = _clean_batch_a()
+    dirty["clusters"][0]["members"].append(INVENTED_ID)
+
+    old = _unvalidated_collect([dirty])
+    old_members = [m for cluster in old for m in cluster["members"]]
+    assert INVENTED_ID in old_members, (
+        "RED proof is not proving anything: the unvalidated collect must carry the invented id"
+    )
+
+    merged = clustering.merge_fast_batches([dirty])
+    new_members = [m for cluster in merged.clusters for m in cluster["members"]]
+    assert INVENTED_ID not in new_members, "the batch boundary must not pass an unsupplied id downstream"
+    assert merged.invented_ids_rejected == 1
+    assert merged.rejected_by_batch == {"batch-a": [INVENTED_ID]}
+
+
+def test_red_an_id_real_elsewhere_but_not_in_this_batch_is_still_rejected():
+    """RED: the corpus-wide check would admit this id. The batch check will not.
+
+    This is the live failure shape — a returned id that is a perfectly real
+    session, just not one THIS batch was handed. Only the tighter boundary
+    catches it, which is why the two checks are not redundant.
+    """
+    bleed = _clean_batch_a()
+    borrowed = BATCH_B_IDS[0]
+    bleed["clusters"][1]["members"].append(borrowed)
+
+    # The corpus-wide backstop resolves it happily: it IS in the extract.
+    records = [{"session_id": sid} for sid in BATCH_A_IDS + BATCH_B_IDS]
+    _, unknown = clustering.units_from_clusters(records, _unvalidated_collect([bleed]))
+    assert unknown == [], "the corpus-wide check cannot see a batch-bleed - that is the point"
+
+    merged = clustering.merge_fast_batches([bleed])
+    assert merged.invented_ids_rejected == 1
+    assert merged.rejected_by_batch == {"batch-a": [borrowed]}
+
+
+def test_red_a_blank_id_resolves_to_nothing_not_to_everything():
+    """RED: `""` is a prefix of every id; prefix expansion must not launder it."""
+    blank = _clean_batch_a()
+    blank["clusters"] = [{"id": "a1", "name": "blank", "members": ["", "   ", BATCH_A_IDS[0]]}]
+
+    merged = clustering.merge_fast_batches([blank])
+    assert merged.clusters[0]["members"] == [BATCH_A_IDS[0]], "a blank id must not expand to the whole batch"
+    assert merged.invented_ids_rejected == 2
+
+
+# ------------------------------------------------------------------ layer 2
+def test_invented_ids_are_dropped_counted_and_named_per_batch():
+    a, b = _clean_batch_a(), _clean_batch_b()
+    a["clusters"][0]["members"].append(INVENTED_ID)
+    b["clusters"][0]["members"].append(_sid("syninvent", 7))
+
+    merged = clustering.merge_fast_batches([a, b])
+    assert merged.invented_ids_rejected == 2
+    assert sorted(merged.rejected_by_batch) == ["batch-a", "batch-b"]
+    assert merged.n_ids_placed == len(BATCH_A_IDS) + len(BATCH_B_IDS)
+    assert merged.n_ids_supplied == len(BATCH_A_IDS) + len(BATCH_B_IDS)
+
+
+def test_the_counter_is_emitted_even_when_it_is_zero():
+    """A counter that only appears when non-zero is a counter nobody watches."""
+    summary = clustering.merge_fast_batches([_clean_batch_a(), _clean_batch_b()]).as_dict()
+    assert summary["invented_ids_rejected"] == 0
+    assert "invented_ids_rejected" in summary
+    assert summary["rejected_by_batch"] == {}
+    assert summary["n_batches"] == 2
+
+
+def test_a_wholly_invented_cluster_is_dropped_and_counted_not_shipped_empty():
+    ghost = _clean_batch_a()
+    ghost["clusters"].append({"id": "a3", "name": "ghost unit", "members": [INVENTED_ID, _sid("syninvent", 8)]})
+
+    merged = clustering.merge_fast_batches([ghost])
+    assert [c["id"] for c in merged.clusters] == ["a1", "a2"], "an all-invented cluster is not a cluster"
+    assert merged.n_clusters_emptied == 1
+    assert merged.invented_ids_rejected == 2
+
+
+def test_a_batch_with_no_supplied_id_set_is_fail_loud():
+    """Vacuous validation would reject everything - that is a broken caller."""
+    with pytest.raises(AttractorScoutError) as exc:
+        clustering.merge_fast_batches([{"batch_id": "batch-a", "clusters": _clean_batch_a()["clusters"]}])
+    assert "batch-a" in str(exc.value)
+    assert "EMPTY supplied id set" in str(exc.value)
+
+
+# ------------------------------------------------------------------ layer 3
+def test_a_clean_batch_rejects_nothing_and_matches_the_unvalidated_collect():
+    """No false positives: validation is invisible when the labeller behaved."""
+    batches = [_clean_batch_a(), _clean_batch_b()]
+    merged = clustering.merge_fast_batches(batches)
+
+    assert merged.invented_ids_rejected == 0
+    assert merged.n_clusters_emptied == 0
+    old = _unvalidated_collect(batches)
+    assert [c["id"] for c in merged.clusters] == [c["id"] for c in old]
+    for got, want in zip(merged.clusters, old, strict=True):
+        assert got["members"] == want["members"], "a clean batch must pass through unchanged"
+        assert got["name"] == want["name"]
+
+
+def test_a_legitimate_short_id_still_resolves_by_prefix_expansion():
+    short = _clean_batch_a()
+    short["clusters"] = [{"id": "a1", "name": "short", "members": [BATCH_A_IDS[0][:14]]}]
+
+    merged = clustering.merge_fast_batches([short])
+    assert merged.invented_ids_rejected == 0
+    assert merged.clusters[0]["members"] == [BATCH_A_IDS[0]]
+
+
+def test_an_ambiguous_prefix_expands_to_every_match_rather_than_merging_silently():
+    ambiguous = _clean_batch_a()
+    ambiguous["clusters"] = [{"id": "a1", "name": "ambiguous", "members": ["synbatcha-"]}]
+
+    merged = clustering.merge_fast_batches([ambiguous])
+    assert merged.invented_ids_rejected == 0
+    assert merged.clusters[0]["members"] == BATCH_A_IDS
+
+
+# ------------------------------------------------------------ the CLI seam
+def _write_batches(tmp_path: Path, batches: list[dict]) -> Path:
+    batch_dir = tmp_path / "label-batches"
+    batch_dir.mkdir(parents=True, exist_ok=True)
+    for batch in batches:
+        (batch_dir / f"{batch['batch_id']}.json").write_text(json.dumps(batch), encoding="utf-8")
+    return batch_dir
+
+
+def _label_merge(
+    tmp_path: Path, batches: list[dict], *, strict: bool = False
+) -> tuple[subprocess.CompletedProcess, Path]:
+    batch_dir = _write_batches(tmp_path, batches)
+    out = tmp_path / "fast-clusters.json"
+    argv = [*CLI, "label-merge", "--batches", str(batch_dir), "--out", str(out)]
+    if strict:
+        argv.append("--strict")
+    return subprocess.run(argv, capture_output=True, text=True, cwd=SKILL_DIR, check=False), out
+
+
+def test_cli_label_merge_surfaces_the_counter_on_stderr_and_in_the_file(tmp_path: Path):
+    dirty = _clean_batch_a()
+    dirty["clusters"][0]["members"].append(INVENTED_ID)
+    proc, out = _label_merge(tmp_path, [dirty, _clean_batch_b()])
+
+    assert proc.returncode == 0, proc.stderr
+    assert "invented_ids_rejected=1" in proc.stderr, "the counter must be said out loud, not buried in a file"
+    assert "REJECTED (not in batch batch-a)" in proc.stderr
+
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["labelling"]["invented_ids_rejected"] == 1
+    assert payload["labelling"]["rejected_by_batch"] == {"batch-a": [INVENTED_ID]}
+    assert INVENTED_ID not in json.dumps(payload["clusters"])
+
+
+def test_cli_label_merge_is_quietly_zero_on_a_clean_run(tmp_path: Path):
+    proc, out = _label_merge(tmp_path, [_clean_batch_a(), _clean_batch_b()])
+    assert proc.returncode == 0, proc.stderr
+    assert "invented_ids_rejected=0" in proc.stderr
+    assert json.loads(out.read_text(encoding="utf-8"))["labelling"]["invented_ids_rejected"] == 0
+
+
+def test_cli_label_merge_strict_is_fatal(tmp_path: Path):
+    dirty = _clean_batch_a()
+    dirty["clusters"][0]["members"].append(INVENTED_ID)
+    proc, _ = _label_merge(tmp_path, [dirty], strict=True)
+    assert proc.returncode == 2, "--strict must exit 2, the same posture as `rank --strict`"
+    assert "FAIL-LOUD" in proc.stderr
+
+
+# ------------------------------------------------- it reaches the run summary
+def _write_extracts(tmp_path: Path, ids: list[str]) -> Path:
+    path = tmp_path / "extracts.jsonl"
+    lines = [
+        json.dumps(
+            {
+                "session_id": sid,
+                "workspace": "syn-ws-001",
+                "n_prompts": 2,
+                "n_tool_calls": 4,
+                "tool_seq": ["read_file", "edit_file"],
+                "tool_all": ["read_file", "edit_file"],
+                "tool_tail": ["edit_file"],
+                "author": "human",
+            }
+        )
+        for sid in ids
+    ]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+def test_rank_carries_the_labelling_ledger_into_its_own_output(tmp_path: Path):
+    dirty = _clean_batch_a()
+    dirty["clusters"][0]["members"].append(INVENTED_ID)
+    _, clusters_path = _label_merge(tmp_path, [dirty])
+    extracts = _write_extracts(tmp_path, BATCH_A_IDS)
+    ranked = tmp_path / "ranked.json"
+
+    proc = subprocess.run(
+        [
+            *CLI,
+            "rank",
+            "--strict",
+            "--extracts",
+            str(extracts),
+            "--clusters",
+            str(clusters_path),
+            "--out",
+            str(ranked),
+        ],
+        capture_output=True,
+        text=True,
+        cwd=SKILL_DIR,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "invented_ids_rejected=1" in proc.stderr
+    payload = json.loads(ranked.read_text(encoding="utf-8"))
+    assert payload["labelling"]["invented_ids_rejected"] == 1
+
+
+def test_the_run_summary_always_carries_invented_ids_rejected(tmp_path: Path):
+    dirty = _clean_batch_a()
+    dirty["clusters"][0]["members"].append(INVENTED_ID)
+    _, clusters_path = _label_merge(tmp_path, [dirty])
+    extracts = _write_extracts(tmp_path, BATCH_A_IDS)
+
+    result = pipeline.run(extracts_path=extracts, clusters_path=clusters_path)
+    summary = result.as_dict()
+    assert summary["invented_ids_rejected"] == 1
+    assert summary["labelling"]["rejected_by_batch"] == {"batch-a": [INVENTED_ID]}
+
+    # And the A-rung floor, where no labelling pass ran at all, still reports
+    # the counter rather than omitting it.
+    floor = pipeline.run(extracts_path=extracts).as_dict()
+    assert floor["invented_ids_rejected"] == 0
+    assert floor["labelling"] == {}

--- a/skills/attractor-scout/tests/test_skill_doc_claims.py
+++ b/skills/attractor-scout/tests/test_skill_doc_claims.py
@@ -168,6 +168,53 @@ def test_provenance_claims_are_sourced_in_code():
         )
 
 
+#: Step 2 (fast-tier labelling) claims, pinned to the CODE that makes them
+#: true. The pin here USED to read "zero invented ids" - a live 64-batch run
+#: disproved it, so the claim was replaced with the containment that is
+#: actually enforced. This guard's contract is doc-follows-reality: if the
+#: batch boundary is ever removed, the SKILL.md sentence describing it must go
+#: RED rather than keep promising a check that no longer runs.
+LABELLING_PINNED_CLAIMS = [
+    (
+        "checked against the ids THAT batch was handed",
+        "def validate_batch_labels",
+        "scripts/attractor_scout/clustering.py",
+    ),
+    (
+        "`invented_ids_rejected` in the run summary",
+        '"invented_ids_rejected": self.invented_ids_rejected',
+        "scripts/attractor_scout/pipeline.py",
+    ),
+    ("label-merge", "def cmd_label_merge", "scripts/attractor_scout_cli.py"),
+]
+
+
+def test_labelling_claims_are_sourced_in_code():
+    skill = _strip_emphasis(SKILL_MD.read_text(encoding="utf-8"))
+    for phrase, source, relpath in LABELLING_PINNED_CLAIMS:
+        assert _strip_emphasis(phrase) in skill, f"SKILL.md no longer contains the labelling claim {phrase!r}"
+        code = (SKILL_DIR / relpath).read_text(encoding="utf-8")
+        assert source in code, (
+            f"SKILL.md's labelling claim {phrase!r} is not sourced by {source!r} in {relpath} \u2014 "
+            f"the code moved; re-check the claim or update the pin."
+        )
+
+
+def test_the_retired_zero_invented_ids_pin_never_comes_back():
+    """The old step-2 pin claimed a property the machine did not have.
+
+    A full-corpus run measured the fast tier returning session ids that were
+    in no supplied batch. "Zero" was therefore never a discipline this skill
+    could keep - only a containment it could enforce. Re-asserting the old
+    wording would be a doc claiming a guarantee the code does not give.
+    """
+    skill = _strip_emphasis(SKILL_MD.read_text(encoding="utf-8"))
+    assert "zero invented ids" not in skill.lower(), (
+        "SKILL.md re-asserted 'zero invented ids'. The enforced truth is that invented ids are "
+        "REJECTED at the batch boundary and COUNTED - say that instead."
+    )
+
+
 def test_skill_names_every_rung_of_the_ladder():
     """All six rungs must be described in the guidance while all six run in code."""
     skill = SKILL_MD.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
Closes the fast-tier labeller's invented-id hole (#310): during a full live mining run, 4 of 2,299 session ids returned by the labelling tier existed in no supplied batch. Containment held (provenance gate + `rank --strict` member re-verification — nothing reached output), but the skill's own "zero invented ids" pin was factually unmet. **Provenance note:** the issue was fired through the capsule pipeline first (run 32436606840) — it refused honestly (non-convergence, comment on the issue); this is the pre-chartered hand-fix fallback.

**The fix (deterministic, batch-boundary):** `validate_batch_labels` holds each batch response to that batch's own supplied id set — an id not in the set is DROPPED + COUNTED + SURFACED as `invented_ids_rejected` (stderr, `fast-clusters.json` labelling block, forwarded through `rank`, and always present in the run summary — including as `0`). The corpus-wide expansion stays as backstop (it cannot see a batch-bleed; the boundary check can). `--strict` → exit 2. SKILL.md pin reworded to the enforced truth: "every id a batch returns is checked against the ids THAT batch was handed; one that is not is dropped, counted, and reported."

## Verification checklist
- [x] Unit tests — suite **475 passed / 55 skipped** (was 454/54): new `test_scenario12_batch_boundary.py` (15 tests, ALL proven RED against the unfixed tree then GREEN — incl. the real-elsewhere-but-not-this-batch case and blank-id-resolves-to-nothing), doc-claims guard gains `LABELLING_PINNED_CLAIMS` + a retired-pin tripwire (the old "zero invented ids" wording can never silently return)
- [x] Live pipeline run — N/A: deterministic validation in the skill's stdlib layer; the RED fixtures reproduce the live run's exact failure shape
- [x] EXTENSIONS entry — N/A: no pipeline contract touched (diff confined to `skills/attractor-scout/`)
- [x] Pre-publication leak review — no identity values; the private 4/2,299 figure kept out of shipped text
- [x] Ruff clean (zero new); `git diff --check` clean
- [x] CI green before merge — will confirm

Fixes #310
