### PR TITLE
fix(unified-llm-client): support anthropic SDK 1.0.0 via extra_body relocation (supersedes #313)

### DIFF
--- a/modules/unified-llm-client/pyproject.toml
+++ b/modules/unified-llm-client/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 dependencies = [
     "openai>=1.0.0",
-    "anthropic>=0.40.0",
+    "anthropic>=1.0.0,<2.0.0",
     "google-genai>=1.40.0",
     "pydantic>=2.0",
 ]

--- a/modules/unified-llm-client/tests/adapter/test_anthropic.py
+++ b/modules/unified-llm-client/tests/adapter/test_anthropic.py
@@ -236,7 +236,12 @@ class TestRequestTranslation:
         assert kwargs["tool_choice"] == {"type": "tool", "name": "get_weather"}
 
     def test_generation_params_passed(self) -> None:
-        """temperature, top_p, stop_sequences forwarded."""
+        """temperature/top_p travel in extra_body; stop_sequences stays typed.
+
+        anthropic 1.0.0 dropped temperature/top_p from the typed Messages
+        surface, so the adapter relocates them into ``extra_body`` (the API
+        still honours them there).  stop_sequences is still typed.
+        """
         adapter = _make_adapter()
         request = Request(
             model="claude-sonnet-4-20250514",
@@ -246,8 +251,10 @@ class TestRequestTranslation:
             stop_sequences=["END"],
         )
         kwargs = adapter._translate_request(request)
-        assert kwargs["temperature"] == 0.7
-        assert kwargs["top_p"] == 0.9
+        assert "temperature" not in kwargs
+        assert "top_p" not in kwargs
+        assert kwargs["extra_body"]["temperature"] == 0.7
+        assert kwargs["extra_body"]["top_p"] == 0.9
         assert kwargs["stop_sequences"] == ["END"]
 
     def test_provider_options_passthrough(self) -> None:
@@ -854,7 +861,10 @@ class TestCompleteIntegration:
             call_kwargs = mock_client.messages.with_raw_response.create.call_args[1]
             assert call_kwargs["model"] == "claude-sonnet-4-20250514"
             assert call_kwargs["max_tokens"] == 1024
-            assert call_kwargs["temperature"] == 0.5
+            # anthropic 1.0.0 dropped temperature from the typed surface — it
+            # rides in extra_body now, never as a top-level kwarg.
+            assert "temperature" not in call_kwargs
+            assert call_kwargs["extra_body"]["temperature"] == 0.5
             assert "system" in call_kwargs
 
     def test_complete_translates_api_errors(self) -> None:
@@ -1341,3 +1351,150 @@ class TestPromptCaching:
         beta = kwargs["extra_headers"]["anthropic-beta"]
         assert "prompt-caching-2024-07-31" in beta
         assert "max-tokens-3-5-sonnet-2024-07-15" in beta
+
+
+# ---------------------------------------------------------------------------
+# anthropic 1.0.0: wire-only param relocation (regression guard)
+# ---------------------------------------------------------------------------
+
+
+class TestWireOnlyParamRelocation:
+    """anthropic 1.0.0 removed temperature/top_p/top_k from the typed surface.
+
+    Passing them as top-level kwargs to ``messages.create``/``.stream`` raises
+    ``TypeError: got an unexpected keyword argument``.  The adapter must
+    relocate them into ``extra_body``, which the SDK forwards verbatim onto
+    the wire.  These tests fail RED against the pre-fix adapter.
+    """
+
+    def test_installed_sdk_messages_create_rejects_wire_only_params(self) -> None:
+        """Real-signature guard: document WHY the relocation is needed.
+
+        Introspects the *installed* SDK rather than trusting a changelog.  If
+        a future SDK restores these as typed params this test goes red and the
+        relocation can be revisited.
+        """
+        import inspect
+
+        from anthropic.resources.messages import AsyncMessages
+
+        typed_params = set(inspect.signature(AsyncMessages.create).parameters)
+        for removed in ("temperature", "top_p", "top_k"):
+            assert removed not in typed_params, (
+                f"{removed!r} is a typed param of AsyncMessages.create in "
+                f"anthropic {anthropic.__version__} — the extra_body relocation "
+                "may no longer be necessary."
+            )
+        # extra_body IS accepted — that is where the relocated params land.
+        assert "extra_body" in typed_params
+
+    def test_complete_never_passes_temperature_or_top_p_as_kwargs(self) -> None:
+        """complete(): temperature/top_p reach the SDK via extra_body only."""
+        with patch(
+            "unified_llm.adapters.anthropic.anthropic.AsyncAnthropic"
+        ) as mock_cls:
+            adapter = AnthropicAdapter(api_key="test-key")
+            mock_client = mock_cls.return_value
+            _mock_raw = MagicMock()
+            _mock_raw.parse.return_value = _mock_anthropic_response()
+            _mock_raw.headers = {}
+            mock_client.messages.with_raw_response.create = AsyncMock(
+                return_value=_mock_raw
+            )
+
+            request = Request(
+                model="claude-sonnet-4-20250514",
+                messages=[Message.user("Hi")],
+                temperature=0.3,
+                top_p=0.8,
+            )
+            asyncio.run(adapter.complete(request))
+
+            call_kwargs = mock_client.messages.with_raw_response.create.call_args[1]
+            assert "temperature" not in call_kwargs, (
+                "temperature must not be a top-level kwarg — anthropic 1.0.0 "
+                "raises TypeError for it"
+            )
+            assert "top_p" not in call_kwargs, (
+                "top_p must not be a top-level kwarg — anthropic 1.0.0 raises "
+                "TypeError for it"
+            )
+            # ...but the values must still travel on the wire.
+            assert call_kwargs["extra_body"]["temperature"] == 0.3
+            assert call_kwargs["extra_body"]["top_p"] == 0.8
+
+    def test_stream_never_passes_temperature_or_top_p_as_kwargs(self) -> None:
+        """stream(): temperature/top_p reach the SDK via extra_body only."""
+        adapter = _make_adapter()
+        request = Request(
+            model="claude-sonnet-4-20250514",
+            messages=[Message.user("Hi")],
+            temperature=0.3,
+            top_p=0.8,
+        )
+        mock_create = AsyncMock(
+            return_value=_MockAsyncStream(_make_stream_events_text())
+        )
+        with patch.object(adapter._client.messages, "create", mock_create):
+
+            async def run() -> None:
+                async for _ in adapter.stream(request):
+                    pass
+
+            asyncio.run(run())
+
+        call_kwargs = mock_create.call_args[1]
+        assert "temperature" not in call_kwargs
+        assert "top_p" not in call_kwargs
+        assert call_kwargs["extra_body"]["temperature"] == 0.3
+        assert call_kwargs["extra_body"]["top_p"] == 0.8
+        assert call_kwargs["stream"] is True
+
+    def test_thinking_temperature_override_relocated(self) -> None:
+        """The extended-thinking temperature=1.0 constraint rides extra_body."""
+        adapter = _make_adapter()
+        request = Request(
+            model="claude-sonnet-4-20250514",
+            messages=[Message.user("Hi")],
+            temperature=0.2,
+            reasoning_effort="high",
+            max_tokens=20000,
+        )
+        kwargs = adapter._translate_request(request)
+        assert "temperature" not in kwargs
+        assert kwargs["extra_body"]["temperature"] == 1.0
+
+    def test_top_k_from_provider_options_relocated(self) -> None:
+        """top_k (also removed in 1.0.0) is relocated from provider_options."""
+        adapter = _make_adapter()
+        request = Request(
+            model="claude-sonnet-4-20250514",
+            messages=[Message.user("Hi")],
+            provider_options={"anthropic": {"top_k": 40}},
+        )
+        kwargs = adapter._translate_request(request)
+        assert "top_k" not in kwargs
+        assert kwargs["extra_body"]["top_k"] == 40
+
+    def test_caller_supplied_extra_body_wins(self) -> None:
+        """A key already in extra_body is never clobbered by the relocation."""
+        adapter = _make_adapter()
+        request = Request(
+            model="claude-sonnet-4-20250514",
+            messages=[Message.user("Hi")],
+            temperature=0.7,
+            provider_options={"anthropic": {"extra_body": {"temperature": 0.1}}},
+        )
+        kwargs = adapter._translate_request(request)
+        assert "temperature" not in kwargs
+        assert kwargs["extra_body"]["temperature"] == 0.1
+
+    def test_no_generation_params_leaves_extra_body_absent(self) -> None:
+        """No wire-only params → no spurious empty extra_body is added."""
+        adapter = _make_adapter()
+        request = Request(
+            model="claude-sonnet-4-20250514",
+            messages=[Message.user("Hi")],
+        )
+        kwargs = adapter._translate_request(request)
+        assert "extra_body" not in kwargs

--- a/modules/unified-llm-client/tests/adapter/test_ulm_7_9_10.py
+++ b/modules/unified-llm-client/tests/adapter/test_ulm_7_9_10.py
@@ -71,7 +71,13 @@ class TestULM7AnthropicReasoning:
         assert thinking["budget_tokens"] < kwargs["max_tokens"], (
             "budget_tokens must be strictly less than max_tokens"
         )
-        assert kwargs["temperature"] == 1.0, (
+        # Anthropic requires temperature=1.0 when thinking is enabled, but
+        # anthropic 1.0.0 removed temperature from the typed Messages surface,
+        # so the adapter sends it via extra_body instead of as a kwarg.
+        assert "temperature" not in kwargs, (
+            "temperature must not be a top-level kwarg under anthropic 1.0.0"
+        )
+        assert kwargs["extra_body"]["temperature"] == 1.0, (
             "Anthropic requires temperature=1.0 when thinking is enabled"
         )
 

--- a/modules/unified-llm-client/unified_llm/adapters/anthropic.py
+++ b/modules/unified-llm-client/unified_llm/adapters/anthropic.py
@@ -58,6 +58,49 @@ def _effort_to_budget(effort: str) -> int:
     return _EFFORT_TO_BUDGET.get(effort.lower(), 8000)
 
 
+# ---------------------------------------------------------------------------
+# anthropic 1.0.0: wire-only params
+# ---------------------------------------------------------------------------
+
+# Params the Anthropic Messages API still accepts ON THE WIRE but the SDK no
+# longer exposes as typed keyword arguments on Messages.create/.stream.
+#
+#   temperature / top_p / top_k
+#       Removed from the typed Messages surface in anthropic 1.0.0.  Verified
+#       by introspecting both SDKs: present in 0.100.0's
+#       ``AsyncMessages.create`` signature, absent from 1.0.0's.  The API
+#       still honours all three; only the SDK signature dropped them.
+#   speed
+#       Never present in the typed surface on any 0.x or 1.x release, though
+#       the API accepts it when the fast-mode beta header is sent.  Listed
+#       here to match the sibling ``provider-anthropic`` module so a caller
+#       may pass it through ``provider_options`` without a TypeError.
+#
+# Passing any of these as a top-level keyword under 1.0.0 raises
+# ``TypeError: ... got an unexpected keyword argument 'temperature'``.  They
+# must instead travel in ``extra_body``, which the SDK forwards verbatim into
+# the request body — identical bytes on the wire, just relocated off the
+# typed surface.
+_WIRE_ONLY_PARAMS: tuple[str, ...] = ("temperature", "top_p", "top_k", "speed")
+
+
+def _relocate_wire_only_params(kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Move wire-only params off the typed surface into ``extra_body``.
+
+    Mutates and returns ``kwargs``.  A key already present in ``extra_body``
+    wins — an explicit caller-supplied override (via ``provider_options``) is
+    never clobbered by the value this adapter derived.
+    """
+    for key in _WIRE_ONLY_PARAMS:
+        if key not in kwargs:
+            continue
+        value = kwargs.pop(key)
+        extra_body = dict(kwargs.get("extra_body") or {})
+        extra_body.setdefault(key, value)
+        kwargs["extra_body"] = extra_body
+    return kwargs
+
+
 def _serialize_raw(obj: Any) -> dict[str, Any] | None:
     """Defensively serialize a provider SDK response to a JSON-serializable dict.
 
@@ -491,6 +534,13 @@ class AnthropicAdapter:
 
         if auto_cache:
             self._inject_cache_control(kwargs)
+
+        # anthropic 1.0.0 removed temperature/top_p/top_k from the typed
+        # Messages surface.  Relocate them (and anything else wire-only that
+        # arrived via provider_options) into extra_body LAST, so this catches
+        # every producer above — the generation params, the extended-thinking
+        # temperature=1.0 override, and the provider_options escape hatch.
+        _relocate_wire_only_params(kwargs)
 
         return kwargs
 


### PR DESCRIPTION
## Summary
Migrates `modules/unified-llm-client`'s anthropic adapter to **anthropic SDK 1.0.0**. 1.0.0 removed `temperature`, `top_p`, and `top_k` from the typed `Messages.create()`/`.stream()` surface, so the adapter's kwargs caused a `TypeError` at runtime whenever a caller set those params. The current uncapped `anthropic>=0.40.0` resolves to 1.0.0, so main is broken today (masked by tests that mocked the SDK and asserted the old surface).

**The fix** mirrors the sibling `microsoft/amplifier-module-provider-anthropic` (already migrated): a `_relocate_wire_only_params()` helper moves those params off the typed surface into `extra_body`, where the SDK forwards them on the wire verbatim. Wired as the last statement of `_translate_request()` so it covers all producers (generation params, the extended-thinking `temperature=1.0` override, and the `provider_options` escape hatch). `setdefault` never clobbers a caller-supplied `extra_body` key.

**Cap:** `anthropic>=0.40.0` → `>=1.0.0,<2.0.0`, byte-identical to provider-anthropic so both modules resolve to one anthropic in a shared venv.

**Supersedes external PR #313.** #313 tried to cap `anthropic<1.0.0`, but the attractor bundles (`attractor-agent`/`-interactive`/`-pipeline`) mount provider-anthropic, which requires `>=1.0.0`. `<1.0.0` + `>=1.0.0` are disjoint → the cap would make those bundles unresolvable. Supporting 1.0.0 is the correct fix.

## Verification checklist
- [x] Unit tests — unified-llm-client **766 passed / 13 deselected** (+7 new); new `TestWireOnlyParamRelocation` RED-proven (6 fail against the pre-fix adapter) then GREEN; a signature guard introspects the installed SDK and asserts temperature/top_p/top_k are absent from the typed surface
- [x] Type check — pyright `unified_llm/` (the module's real CI gate): **0 errors, 0 warnings**
- [x] ★ Wire-fidelity confirmed — `extra_body` merges into the JSON body verbatim (SDK `_merge_mappings`); an httpx capture shows `temperature`/`top_p`/`top_k` land top-level in the request body, identical to 0.x. `setdefault` reproduces the pre-fix wire precedence (extra_json already beat typed kwargs).
- [x] Independent adversarial review — **MERGE, no required fixes**: relocation verified via mock (params in extra_body, not top-level), extended-thinking override relocates, don't-clobber invariant holds, provider_options merges once (not doubled), cap coexistence byte-identical to provider-anthropic
- [x] EXTENSIONS entry — N/A: dependency + adapter internals, no pipeline contract touched
- [x] Pre-publication leak review — zero identity values
- [x] CI green before merge — will confirm

## Disclosures
1. `loop-pipeline` shows 4 failures on some hosts — a broken local `pytest` shim on PATH, not this branch (the file imports neither `unified_llm` nor `anthropic`; passes 18/18 with `.venv/bin` prepended).
2. `speed` is carried in the wire-only list to match provider-anthropic exactly; it is unreachable from `Request` (provider_options only) and untested.
3. The signature guard hard-fails under anthropic 0.x by design — it couples the suite to the installed SDK so a future SDK change forces a revisit.

Fixes #313 concerns (superseded).
