### PR TITLE
fix(unified-llm-client): await AsyncAPIResponse.parse in anthropic complete() (SDK 1.0.0)

### DIFF
--- a/modules/unified-llm-client/tests/adapter/test_anthropic.py
+++ b/modules/unified-llm-client/tests/adapter/test_anthropic.py
@@ -517,6 +517,23 @@ def _mock_anthropic_response(
     )
 
 
+def _mock_raw_http(
+    parsed: SimpleNamespace,
+    headers: dict[str, str] | None = None,
+) -> MagicMock:
+    """Mock the object ``messages.with_raw_response.create`` resolves to.
+
+    On anthropic 1.0.0 that is an ``AsyncAPIResponse``, whose ``.parse()`` is a
+    **coroutine function** — so the mock uses ``AsyncMock``.  Stubbing it with a
+    plain sync ``MagicMock`` (as these tests used to) models a surface the SDK
+    no longer has and hides a missing ``await`` in the adapter.
+    """
+    raw_http = MagicMock()
+    raw_http.parse = AsyncMock(return_value=parsed)
+    raw_http.headers = headers if headers is not None else {}
+    return raw_http
+
+
 class TestResponseTranslation:
     """Task 23: Verify Anthropic response → unified Response."""
 
@@ -813,11 +830,11 @@ class TestCompleteIntegration:
         ) as mock_cls:
             adapter = AnthropicAdapter(api_key="test-key")
             mock_client = mock_cls.return_value
-            _mock_raw = MagicMock()
-            _mock_raw.parse.return_value = _mock_anthropic_response(
-                content=[SimpleNamespace(type="text", text="Hello from Claude!")],
+            _mock_raw = _mock_raw_http(
+                _mock_anthropic_response(
+                    content=[SimpleNamespace(type="text", text="Hello from Claude!")],
+                )
             )
-            _mock_raw.headers = {}
             mock_client.messages.with_raw_response.create = AsyncMock(
                 return_value=_mock_raw
             )
@@ -840,9 +857,7 @@ class TestCompleteIntegration:
         ) as mock_cls:
             adapter = AnthropicAdapter(api_key="test-key")
             mock_client = mock_cls.return_value
-            _mock_raw = MagicMock()
-            _mock_raw.parse.return_value = _mock_anthropic_response()
-            _mock_raw.headers = {}
+            _mock_raw = _mock_raw_http(_mock_anthropic_response())
             mock_client.messages.with_raw_response.create = AsyncMock(
                 return_value=_mock_raw
             )
@@ -912,19 +927,19 @@ class TestCompleteIntegration:
         ) as mock_cls:
             adapter = AnthropicAdapter(api_key="test-key")
             mock_client = mock_cls.return_value
-            _mock_raw = MagicMock()
-            _mock_raw.parse.return_value = _mock_anthropic_response(
-                content=[
-                    SimpleNamespace(
-                        type="tool_use",
-                        id="toolu_1",
-                        name="get_weather",
-                        input={"city": "SF"},
-                    ),
-                ],
-                stop_reason="tool_use",
+            _mock_raw = _mock_raw_http(
+                _mock_anthropic_response(
+                    content=[
+                        SimpleNamespace(
+                            type="tool_use",
+                            id="toolu_1",
+                            name="get_weather",
+                            input={"city": "SF"},
+                        ),
+                    ],
+                    stop_reason="tool_use",
+                )
             )
-            _mock_raw.headers = {}
             mock_client.messages.with_raw_response.create = AsyncMock(
                 return_value=_mock_raw
             )
@@ -1395,9 +1410,7 @@ class TestWireOnlyParamRelocation:
         ) as mock_cls:
             adapter = AnthropicAdapter(api_key="test-key")
             mock_client = mock_cls.return_value
-            _mock_raw = MagicMock()
-            _mock_raw.parse.return_value = _mock_anthropic_response()
-            _mock_raw.headers = {}
+            _mock_raw = _mock_raw_http(_mock_anthropic_response())
             mock_client.messages.with_raw_response.create = AsyncMock(
                 return_value=_mock_raw
             )
@@ -1498,3 +1511,145 @@ class TestWireOnlyParamRelocation:
         )
         kwargs = adapter._translate_request(request)
         assert "extra_body" not in kwargs
+
+
+# ---------------------------------------------------------------------------
+# anthropic 1.0.0: AsyncAPIResponse.parse is a coroutine (regression guard)
+# ---------------------------------------------------------------------------
+
+
+class TestRawResponseParseIsAwaited:
+    """anthropic 1.0.0 removed the legacy *sync* raw-response surface.
+
+    ``with_raw_response.create`` on an async client now resolves to
+    ``AsyncAPIResponse``, whose ``.parse()`` is a **coroutine function**.
+    Calling it without ``await`` yields a coroutine object, and the very next
+    attribute access (``raw.content``, inside ``_translate_response``) raises
+    ``AttributeError: 'coroutine' object has no attribute 'content'``.
+
+    The pre-existing mocks were blind to exactly this: they stubbed ``.parse``
+    with a *sync* ``MagicMock`` returning a plain object — a surface the 1.0.0
+    SDK no longer has — so the un-awaited call looked fine under test and blew
+    up against the real API.  The mocks below are ``AsyncMock``, matching the
+    installed SDK, and fail RED against the pre-fix adapter.
+    """
+
+    def test_installed_sdk_async_raw_response_parse_is_coroutine(self) -> None:
+        """Real-signature guard: document WHY the ``await`` is needed.
+
+        Introspects the *installed* SDK rather than trusting a changelog.  If a
+        future SDK makes ``parse`` sync again — or restores the legacy sync
+        response class that ``with_raw_response`` used to return — this goes
+        red and the ``await`` must be revisited.
+        """
+        import inspect
+
+        from anthropic._response import AsyncAPIResponse
+
+        assert inspect.iscoroutinefunction(AsyncAPIResponse.parse), (
+            "AsyncAPIResponse.parse is not a coroutine function in anthropic "
+            f"{anthropic.__version__} — the `await` in complete() may no "
+            "longer be correct."
+        )
+        # The legacy sync raw-response surface is gone in 1.0.0.  While it is
+        # absent, with_raw_response can only resolve to AsyncAPIResponse.
+        assert not hasattr(anthropic._response, "LegacyAPIResponse"), (
+            "LegacyAPIResponse is back in anthropic "
+            f"{anthropic.__version__} — re-check which response class "
+            "with_raw_response.create returns before trusting the `await`."
+        )
+
+    def test_complete_awaits_raw_response_parse(self) -> None:
+        """★ complete() must ``await`` the coroutine returned by ``.parse()``.
+
+        RED against the pre-fix adapter with:
+            AttributeError: 'coroutine' object has no attribute 'content'
+        """
+        with patch(
+            "unified_llm.adapters.anthropic.anthropic.AsyncAnthropic"
+        ) as mock_cls:
+            adapter = AnthropicAdapter(api_key="test-key")
+            mock_client = mock_cls.return_value
+            _mock_raw = MagicMock()
+            # Matches anthropic 1.0.0: AsyncAPIResponse.parse is a coroutine fn.
+            _mock_raw.parse = AsyncMock(
+                return_value=_mock_anthropic_response(
+                    content=[SimpleNamespace(type="text", text="Awaited!")],
+                )
+            )
+            _mock_raw.headers = {}
+            mock_client.messages.with_raw_response.create = AsyncMock(
+                return_value=_mock_raw
+            )
+
+            request = Request(
+                model="claude-sonnet-4-20250514",
+                messages=[Message.user("Hi")],
+            )
+            response = asyncio.run(adapter.complete(request))
+
+            # The parsed Message — not a coroutine — reached translation.
+            assert response.text == "Awaited!"
+            _mock_raw.parse.assert_awaited_once()
+
+    def test_complete_serializes_the_awaited_message_not_a_coroutine(self) -> None:
+        """The awaited object must also reach ``_serialize_raw``/``response.raw``.
+
+        ``complete()`` consumes ``raw`` twice — ``_translate_response(raw)`` and
+        ``_serialize_raw(raw)``.  Both must see the resolved Message.
+        """
+        with patch(
+            "unified_llm.adapters.anthropic.anthropic.AsyncAnthropic"
+        ) as mock_cls:
+            adapter = AnthropicAdapter(api_key="test-key")
+            mock_client = mock_cls.return_value
+            _mock_raw = MagicMock()
+            _mock_raw.parse = AsyncMock(return_value=_mock_anthropic_response())
+            _mock_raw.headers = {}
+            mock_client.messages.with_raw_response.create = AsyncMock(
+                return_value=_mock_raw
+            )
+
+            response = asyncio.run(
+                adapter.complete(
+                    Request(
+                        model="claude-sonnet-4-20250514",
+                        messages=[Message.user("Hi")],
+                    )
+                )
+            )
+
+            assert isinstance(response.raw, dict)
+            assert response.raw["id"] == "msg_test123"
+
+    def test_adapter_never_calls_parse_without_await(self) -> None:
+        """Structural guard: every ``.parse()`` in the adapter is awaited.
+
+        The DTU reported ``stream()`` as fine, but a second un-awaited site
+        anywhere in the module would fail the same way and be equally
+        invisible to mocked tests.  This walks the module's AST instead of
+        trusting a grep, so any future ``.parse()`` added without ``await``
+        goes red here.
+        """
+        import ast
+        import inspect
+
+        import unified_llm.adapters.anthropic as anthropic_adapter
+
+        tree = ast.parse(inspect.getsource(anthropic_adapter))
+        awaited = {
+            id(node.value) for node in ast.walk(tree) if isinstance(node, ast.Await)
+        }
+        unawaited = [
+            node.lineno
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "parse"
+            and id(node) not in awaited
+        ]
+        assert not unawaited, (
+            f"un-awaited .parse() call(s) at line(s) {unawaited} of "
+            "unified_llm/adapters/anthropic.py — AsyncAPIResponse.parse is a "
+            "coroutine function in anthropic 1.0.0"
+        )

--- a/modules/unified-llm-client/tests/adapter/test_ulm5_raw_and_ulm6_rate_limit.py
+++ b/modules/unified-llm-client/tests/adapter/test_ulm5_raw_and_ulm6_rate_limit.py
@@ -225,7 +225,7 @@ class TestULM5ResponseRaw:
         raw = _anthropic_raw()
 
         mock_raw_http = MagicMock()
-        mock_raw_http.parse.return_value = raw
+        mock_raw_http.parse = AsyncMock(return_value=raw)
         mock_raw_http.headers = _mock_headers(include_rate_limits=False)
         adapter._client.messages.with_raw_response.create = AsyncMock(  # type: ignore[attr-defined]
             return_value=mock_raw_http
@@ -248,7 +248,7 @@ class TestULM5ResponseRaw:
         raw = _anthropic_raw()
 
         mock_raw_http = MagicMock()
-        mock_raw_http.parse.return_value = raw
+        mock_raw_http.parse = AsyncMock(return_value=raw)
         mock_raw_http.headers = _mock_headers(include_rate_limits=False)
         adapter._client.messages.with_raw_response.create = AsyncMock(  # type: ignore[attr-defined]
             return_value=mock_raw_http
@@ -416,7 +416,7 @@ class TestULM6RateLimit:
         headers = _mock_headers(include_rate_limits=True)
 
         mock_raw_http = MagicMock()
-        mock_raw_http.parse.return_value = raw
+        mock_raw_http.parse = AsyncMock(return_value=raw)
         mock_raw_http.headers = headers
         adapter._client.messages.with_raw_response.create = AsyncMock(  # type: ignore[attr-defined]
             return_value=mock_raw_http
@@ -441,7 +441,7 @@ class TestULM6RateLimit:
         raw = _anthropic_raw()
 
         mock_raw_http = MagicMock()
-        mock_raw_http.parse.return_value = raw
+        mock_raw_http.parse = AsyncMock(return_value=raw)
         mock_raw_http.headers = _mock_headers(include_rate_limits=False)
         adapter._client.messages.with_raw_response.create = AsyncMock(  # type: ignore[attr-defined]
             return_value=mock_raw_http

--- a/modules/unified-llm-client/tests/dod/test_8_2_provider_adapters.py
+++ b/modules/unified-llm-client/tests/dod/test_8_2_provider_adapters.py
@@ -160,7 +160,7 @@ class TestCompleteReturnsResponse:
             usage=SimpleNamespace(input_tokens=10, output_tokens=3),
         )
         _mock_raw_http = MagicMock()
-        _mock_raw_http.parse.return_value = mock_raw
+        _mock_raw_http.parse = AsyncMock(return_value=mock_raw)
         _mock_raw_http.headers = {}
         adapter._client.messages.with_raw_response.create = AsyncMock(
             return_value=_mock_raw_http

--- a/modules/unified-llm-client/tests/dod/test_8_9_cross_provider_parity.py
+++ b/modules/unified-llm-client/tests/dod/test_8_9_cross_provider_parity.py
@@ -161,7 +161,7 @@ def _setup_complete_mock(adapter: Any, provider: str, response: Any) -> None:
         )
     elif provider == "anthropic":
         _raw_http = MagicMock()
-        _raw_http.parse.return_value = response
+        _raw_http.parse = AsyncMock(return_value=response)
         _raw_http.headers = {}
         adapter._client.messages.with_raw_response.create = AsyncMock(
             return_value=_raw_http

--- a/modules/unified-llm-client/unified_llm/adapters/anthropic.py
+++ b/modules/unified-llm-client/unified_llm/adapters/anthropic.py
@@ -251,7 +251,10 @@ class AnthropicAdapter:
             # ULM-5/ULM-6: use with_raw_response to access HTTP headers for
             # rate-limit info while still getting the parsed SDK object.
             raw_http = await self._client.messages.with_raw_response.create(**kwargs)
-            raw = raw_http.parse()
+            # anthropic 1.0.0 dropped the legacy sync raw-response surface:
+            # with_raw_response on an async client yields AsyncAPIResponse,
+            # whose .parse() is a coroutine function and MUST be awaited.
+            raw = await raw_http.parse()
             headers = raw_http.headers
             response = self._translate_response(raw)
             response.raw = _serialize_raw(raw)


### PR DESCRIPTION
## Summary
Fixes a second anthropic SDK 1.0.0 break, **found in a live DTU run against the real API** (PR #315's mocked tests were blind to it). `modules/unified-llm-client/unified_llm/adapters/anthropic.py:254` did `raw = raw_http.parse()` with no `await`. On SDK 1.0.0, `AsyncAPIResponse.parse` is a **coroutine function** (the legacy sync path was removed), so `raw.content` raised `AttributeError: 'coroutine' object has no attribute 'content'` on the non-streaming `complete()` path. `stream()` was unaffected.

**Fix:** `raw = await raw_http.parse()` (one logical line). `complete()` now returns the real response on 1.0.0.

**openai / openai_compat adapters left unchanged — verified correct:** their `with_raw_response` uses `LegacyAPIResponse` whose `.parse` is NOT a coroutine on openai 3.3.1 (introspected the installed package); adding `await` there would break them.

**Why mocked tests missed it:** the old `.parse()` mocks were sync `MagicMock`, modeling a surface 1.0.0 deleted. Converted all anthropic `.parse` mocks to `AsyncMock`, matching the real 1.0.0 shape.

## Verification checklist
- [x] Unit tests — unified-llm-client **770 passed / 13 deselected** (+4 new). New `TestRawResponseParseIsAwaited`: `test_complete_awaits_raw_response_parse` (RED-proven — reverting only the `await` with async mocks reproduces the coroutine AttributeError; GREEN after), an AST guard `test_adapter_never_calls_parse_without_await` (fires when a second un-awaited `.parse()` is planted), and an SDK-coroutine guard introspecting the installed 1.0.0
- [x] ★ Live-verified in a DTU — real anthropic 1.0.0 API: `complete()` with `temperature=0.5` set returns the response, temperature top-level on the wire (httpx capture); pre-fix line reproduces the exact live AttributeError
- [x] Independent adversarial review — **MERGE, no code fixes**: openai non-change confirmed correct by introspection, new-test RED/GREEN reproduced, AST guard fires on a planted un-awaited call
- [x] Type check — pyright `unified_llm/` **0 errors** (note: pyright was blind pre-fix — `_translate_response(raw: Any)` erases the coroutine type; only a real/async-mock call surfaces it)
- [x] EXTENSIONS entry — N/A: adapter internals, no pipeline contract touched
- [x] Pre-publication leak review — zero identity values
- [x] CI green before merge — will confirm

## Disclosures
1. `loop-pipeline` shows 4 failures on some hosts (pre-existing at origin/main, an env/pytest-target quirk; the changed module isn't imported by those tests).
2. Cross-module `.venv`s hold a vendored non-editable `unified_llm` — they don't exercise this branch; the real proof is the unified-llm-client suite + the live DTU run.

Follow-up to #315 (SDK 1.0.0 `extra_body` relocation); together they make non-streaming + streaming anthropic work on 1.0.0.
