### PR TITLE
fix(loop-agent): stop discarding tool:post hook output on truncation

### DIFF
--- a/modules/loop-agent/amplifier_module_loop_agent/agent_session.py
+++ b/modules/loop-agent/amplifier_module_loop_agent/agent_session.py
@@ -912,15 +912,29 @@ class AgentSession:
             # If a hook modified the result (e.g. truncation), use the
             # modified output for the LLM while preserving full output
             # in the event stream.
+            #
+            # NOTE: we deliberately do NOT gate this on
+            # `post_result.action == "modify"`. Per amplifier-core's
+            # HookRegistry.emit() (crates/amplifier-core/src/hooks.rs),
+            # `Modify` is a handler-to-handler data-chaining mechanism only:
+            # each handler's returned `data` is merged into the data passed
+            # to the *next* handler, but the terminal HookResult returned to
+            # the caller always carries `action=Continue` (the merged data
+            # is preserved; the action is not). A caller-side check for
+            # `action == "modify"` can therefore never be true and silently
+            # discards any hook-modified output -- which is exactly what
+            # happened here, disabling tool-output truncation in
+            # production. The merged `data` dict IS the contract; `action`
+            # is not. Since the input payload already included
+            # `"result": raw_output`, `post_result.data["result"]` is always
+            # present -- either unchanged (no hook modified it) or replaced
+            # by a hook. The `isinstance`/`!=` guards make this a provable
+            # no-op whenever no hook modifies the result.
             llm_output = raw_output
-            if (
-                hasattr(post_result, "action")
-                and post_result.action == "modify"
-                and hasattr(post_result, "data")
-                and post_result.data
-                and "result" in post_result.data
-            ):
-                llm_output = post_result.data["result"]
+            if post_result.data:
+                modified = post_result.data.get("result")
+                if isinstance(modified, str) and modified != raw_output:
+                    llm_output = modified
 
             # Emit tool output delta for UI streaming (spec TOOL_CALL_OUTPUT_DELTA)
             await self._hooks.emit(

--- a/modules/loop-agent/tests/test_truncation_wiring.py
+++ b/modules/loop-agent/tests/test_truncation_wiring.py
@@ -2,16 +2,29 @@
 
 Verifies that when hooks-tool-truncation is active, the agent loop:
 1. Emits tool:post after tool execution
-2. Reads back HookResult(action="modify") data
+2. Reads back the tool:post hook's (merged) output data
 3. Uses truncated output for the ToolResult sent to LLM
 4. Preserves full output in agent:tool_call_end event
+
+IMPORTANT: these tests wrap a REAL ``amplifier_core.HookRegistry`` (the
+Rust-backed engine), not a hand-rolled fake. A prior version of this file
+used a bare ``MagicMock`` whose fake ``emit()`` directly fabricated
+``HookResult(action="modify", ...)`` -- something the real registry's
+``emit()`` never returns to a caller (see hooks.rs: ``Modify`` only chains
+data between handlers; the terminal result returned to the caller always
+carries ``action=Continue``, with the merged data preserved). That fake let
+`test_truncated_output_sent_to_llm` pass while production discarded every
+hook-truncated tool output. Routing every emit through the real registry
+means these tests now exercise the actual merge-and-collapse contract.
 """
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock
 
+from amplifier_core import HookRegistry, HookResult
+from amplifier_core.events import TOOL_POST
 from amplifier_core.message_models import ChatResponse, ToolCall, Usage
-from amplifier_core.models import HookResult, ToolResult
+from amplifier_core.models import ToolResult
+from unittest.mock import AsyncMock, MagicMock
 
 from amplifier_module_loop_agent.agent_session import AgentSession
 from amplifier_module_loop_agent.config import SessionConfig
@@ -42,15 +55,42 @@ def _make_mock_tool(name: str, output: str = "ok") -> MagicMock:
     return tool
 
 
-def _make_hooks():
-    hooks = MagicMock()
-    hooks._emitted = []
+class RecordingHookRegistry:
+    """Thin recorder around a REAL ``amplifier_core.HookRegistry``.
 
-    async def _emit(event, data):
-        hooks._emitted.append((event, data))
-        return MagicMock(action="continue")
+    This is deliberately NOT a ``MagicMock``. ``.emit()`` below delegates to
+    the actual Rust-backed ``HookRegistry.emit()``, so whatever that engine
+    truly returns to a caller (merged ``data``, collapsed ``action``) is what
+    ``AgentSession`` sees -- exactly like production. Handlers are attached
+    via the real registry's own ``.register()``. ``.emitted`` additionally
+    records every ``(event, data)`` pair passed through, purely so these
+    tests can assert on emission the same way the old MagicMock-based tests
+    did -- it plays no part in computing the returned HookResult.
+    """
 
-    hooks.emit = AsyncMock(side_effect=_emit)
+    def __init__(self) -> None:
+        self._registry = HookRegistry()
+        self.emitted: list[tuple[str, dict]] = []
+
+    def register(self, event: str, handler) -> None:
+        self._registry.register(event, handler)
+
+    async def emit(self, event: str, data: dict):
+        self.emitted.append((event, dict(data)))
+        return await self._registry.emit(event, data)
+
+
+def _make_truncating_hooks(truncated: str) -> RecordingHookRegistry:
+    """Real HookRegistry with a tool:post handler that truncates `result`."""
+    hooks = RecordingHookRegistry()
+
+    async def truncate_handler(event: str, data: dict) -> HookResult:
+        return HookResult(
+            action="modify",
+            data={"result": truncated, "full_output": data.get("result")},
+        )
+
+    hooks.register(TOOL_POST, truncate_handler)
     return hooks
 
 
@@ -66,22 +106,7 @@ async def test_tool_post_emitted_after_execution():
         _text_response("done."),
     ])
 
-    emitted_events: list[tuple[str, dict]] = []
-
-    async def recording_emit(event: str, data: dict):
-        emitted_events.append((event, data))
-        if event == "tool:post":
-            return HookResult(
-                action="modify",
-                data={
-                    "result": "truncated_output",
-                    "full_output": data.get("result"),
-                },
-            )
-        return MagicMock(action="continue")
-
-    hooks = MagicMock()
-    hooks.emit = AsyncMock(side_effect=recording_emit)
+    hooks = _make_truncating_hooks("truncated_output")
 
     session = AgentSession(
         config=SessionConfig(system_prompt="You are a test coding agent."),
@@ -92,7 +117,7 @@ async def test_tool_post_emitted_after_execution():
     await session.process_input("read big.txt")
 
     # Verify tool:post was emitted
-    post_events = [(e, d) for e, d in emitted_events if e == "tool:post"]
+    post_events = [(e, d) for e, d in hooks.emitted if e == "tool:post"]
     assert len(post_events) == 1
     assert post_events[0][1]["tool_name"] == "read_file"
     assert post_events[0][1]["result"] == big_output
@@ -100,7 +125,15 @@ async def test_tool_post_emitted_after_execution():
 
 @pytest.mark.asyncio
 async def test_truncated_output_sent_to_llm():
-    """When tool:post returns modify, the LLM sees truncated output."""
+    """When tool:post's handler modifies `result`, the LLM sees the modified output.
+
+    This is the test that a fabricated ``MagicMock`` HookResult let pass
+    while production shipped with truncation silently disabled. It now runs
+    against the real ``amplifier_core.HookRegistry``, so it fails on the old
+    (buggy) `agent_session.py` gate of `post_result.action == "modify"` --
+    that condition is never true from the real engine -- and passes once the
+    caller instead reads the merged `data["result"]`.
+    """
     big_output = "x" * 100_000
     truncated = "truncated_version"
     tool = _make_mock_tool("read_file", output=big_output)
@@ -111,16 +144,7 @@ async def test_truncated_output_sent_to_llm():
         _text_response("done."),
     ])
 
-    async def truncating_emit(event: str, data: dict):
-        if event == "tool:post":
-            return HookResult(
-                action="modify",
-                data={"result": truncated, "full_output": data.get("result")},
-            )
-        return MagicMock(action="continue")
-
-    hooks = MagicMock()
-    hooks.emit = AsyncMock(side_effect=truncating_emit)
+    hooks = _make_truncating_hooks(truncated)
 
     session = AgentSession(
         config=SessionConfig(system_prompt="You are a test coding agent."),
@@ -150,19 +174,7 @@ async def test_full_output_in_tool_call_end_event():
         _text_response("done."),
     ])
 
-    emitted_events: list[tuple[str, dict]] = []
-
-    async def recording_emit(event: str, data: dict):
-        emitted_events.append((event, data))
-        if event == "tool:post":
-            return HookResult(
-                action="modify",
-                data={"result": "short", "full_output": data.get("result")},
-            )
-        return MagicMock(action="continue")
-
-    hooks = MagicMock()
-    hooks.emit = AsyncMock(side_effect=recording_emit)
+    hooks = _make_truncating_hooks("short")
 
     session = AgentSession(
         config=SessionConfig(system_prompt="You are a test coding agent."),
@@ -173,7 +185,7 @@ async def test_full_output_in_tool_call_end_event():
     await session.process_input("read big.txt")
 
     # agent:tool_call_end should have the FULL output
-    end_events = [(e, d) for e, d in emitted_events
+    end_events = [(e, d) for e, d in hooks.emitted
                   if e == "agent:tool_call_end"]
     assert len(end_events) == 1
     assert end_events[0][1]["output"] == big_output
@@ -181,7 +193,13 @@ async def test_full_output_in_tool_call_end_event():
 
 @pytest.mark.asyncio
 async def test_no_truncation_when_hook_continues():
-    """When tool:post returns action=continue, output is unchanged."""
+    """When no tool:post handler modifies `result`, output is unchanged.
+
+    No handler is registered on the real registry at all here: an
+    unregistered event naturally collapses to `action=continue` with the
+    input data unchanged, which is precisely the "nothing modified this"
+    case the fix must leave as a no-op.
+    """
     tool = _make_mock_tool("read_file", output="small output")
 
     provider = AsyncMock()
@@ -190,11 +208,7 @@ async def test_no_truncation_when_hook_continues():
         _text_response("done."),
     ])
 
-    async def passthrough_emit(event: str, data: dict):
-        return MagicMock(action="continue")
-
-    hooks = MagicMock()
-    hooks.emit = AsyncMock(side_effect=passthrough_emit)
+    hooks = RecordingHookRegistry()
 
     session = AgentSession(
         config=SessionConfig(system_prompt="You are a test coding agent."),


### PR DESCRIPTION
## Summary

Fixes microsoft-amplifier/amplifier-support#485.

`agent_session.py`'s tool-execution path emits `tool:post` (so hooks like
`hooks-tool-truncation` can shrink oversized tool output) and then gates
using the hook's result on `post_result.action == "modify"`. That condition
is **never true** in production: `amplifier-core`'s `HookRegistry.emit()`
(`crates/amplifier-core/src/hooks.rs`) treats `Modify` purely as a
handler-to-handler data-chaining mechanism -- each handler's `data` is
merged into what the *next* handler sees, but the terminal `HookResult`
returned to the caller always carries `action=Continue` (the merged data
survives; the action does not). The gate was dead code from the day it was
written, so every configured `char_limits` truncation was silently a no-op:
truncation hooks computed correctly and were then thrown away.

**Production incident:** a `grep` tool call whose raw output was ~7 MB
reached the model, producing a 4,223,547-token prompt against a 1,000,000
token ceiling. The run's own `events.jsonl` recorded the tool result at
20,128 bytes -- exactly the configured `grep: 20_000` cap plus a truncation
warning header -- proving the truncation hook ran and computed the right
answer, while the model still received the untruncated ~7 MB payload.

## Does `amplifier-core` need to change? No.

`hooks.rs` is self-consistent and intentional: `Modify` is documented and
implemented as a *data-chaining* action between handlers in the same chain,
not a signal that survives to the caller. Renaming/repurposing `action` on
return would be a bigger, riskier change to a used contract for no benefit
-- the merged `data` already carries everything the caller needs. The bug
is entirely in `loop-agent`'s caller-side assumption that `action` reflects
what a handler did, when the contract never promised that.

## The fix

```python
llm_output = raw_output
if post_result.data:
    modified = post_result.data.get("result")
    if isinstance(modified, str) and modified != raw_output:
        llm_output = modified
```

The `tool:post` payload always includes `"result": raw_output`, and
`HookRegistry.emit()` returns the merged `data`, so `post_result.data["result"]`
is *always* present -- either untouched (no hook modified it) or replaced by
a hook (e.g. truncation). This reads the merged `data`, which **is** the
contract, instead of `action`, which is not. The `isinstance` guard avoids a
non-string payload replacing a string; the `!=` comparison guarantees
byte-identical behavior whenever no hook changed the value (a provable
no-op in the untouched case, sidestepping any serde JSON round-trip
concern).

## Test fix: the mock that let this ship

`modules/loop-agent/tests/test_truncation_wiring.py` used a bare
`MagicMock` for `hooks`, whose fake `emit()` directly fabricated
`HookResult(action="modify", data={...})`. That is exactly what the real
Rust-backed `HookRegistry.emit()` never returns to a caller, so
`test_truncated_output_sent_to_llm` passed against the buggy code while
production truncated nothing.

Replaced with a thin recorder wrapping a **real** `amplifier_core.HookRegistry`
(the Rust-backed engine is installed as a normal dependency of `loop-agent`,
so it's constructible directly in-process -- no fake substitute was needed).
Handlers are registered via the real registry's own `.register()`, and
`.emit()` delegates to the real `HookRegistry.emit()`; a small `.emitted`
list on the wrapper is retained only so the other three tests can still
assert on emission history, exactly like the old MagicMock-based tests did.
The wrapper computes nothing about the returned `HookResult` itself.

**Confirmed the new test is a real regression guard**, not just a
rewrite: reverting only `agent_session.py` to its pre-fix state (keeping the
new test file) makes `test_truncated_output_sent_to_llm` fail --
`tool_messages[0].content` is the raw 100,000-char output instead of the
truncated string -- while the other three tests in the file still pass.
Restoring the fix turns all 4 green again.

## End-to-end verification (real `HookRegistry`, not inference)

```python
from amplifier_core import HookRegistry, HookResult
import asyncio

async def main():
    hr = HookRegistry()

    async def handler(event, data):
        return HookResult(action="modify",
                           data={"result": "TRUNCATED", "full_output": data.get("result")})

    hr.register(hr.TOOL_POST, handler)
    res = await hr.emit(hr.TOOL_POST, {"tool_name": "grep", "result": "x" * 100})
    print("action=", res.action)   # -> continue (NEVER "modify")
    print("data=", res.data)       # -> {'result': 'TRUNCATED', 'full_output': 'xxxx...'}
```

Observed output:
```
action= continue
data= {'result': 'TRUNCATED', 'full_output': 'xxxxxxxxxxxx...'}
```

This is the exact shape of the bug: `action` is always `continue`, and the
truncated value is sitting right there in `data["result"]`, discarded by
the old gate. Before the fix, `AgentSession` would use `raw_output`
(untruncated); after the fix, it correctly picks up `"TRUNCATED"` from the
merged `data`.

## Blast radius

Every consumer of the attractor pipeline (loop-agent / loop-pipeline) that
relies on `hooks-tool-truncation`'s `char_limits` config has been running
with tool-output truncation **silently disabled** since this wiring
shipped -- any tool that can produce large output (`grep`, `read_file`,
broad file listings, etc.) can blow past the model's context ceiling with
no warning, as it did in the incident that prompted this fix. This is a
correctness fix with no config or API surface change; existing
`char_limits` configuration now actually takes effect.

## Test results

`modules/loop-agent` (`uv run pytest -q`):
- **Before** (repo `HEAD`, `cea283d`): 533 collected, 1 pre-existing failure
  unrelated to this change (`test_system_prompt_wiring.py::test_capability_fallback_to_getcwd_when_no_capability`,
  a `/private/var` vs `/var` macOS symlink-resolution mismatch -- reproduced
  identically on `HEAD` before touching anything), 532 passed.
- **After this fix**: same 532 passed, same 1 pre-existing unrelated
  failure. `test_truncation_wiring.py` itself: 4/4 passed (was 4/4 passed
  before too, but against a mock that fabricated the wrong contract --
  see "Test fix" above for the reversion proof that the new version
  actually catches the bug).

`modules/hooks-tool-truncation` (the module that computes the truncation
data being discarded) is unaffected by this change: 34/34 passed, untouched.

## Lint / type-check

This repo's CI (`.github/workflows/ci.yml`) runs `uv sync && uv run pytest -q`
per module and does not run a lint step. The `type-check` job runs `pyright`
against `unified-llm-client` only -- `loop-agent` is explicitly excluded
there today (10 pre-existing findings, per that job's own comment). Ran
`pyright` against `loop-agent` informally anyway: 11 pre-existing errors,
all `reportAttributeAccessIssue` on unrelated `amplifier_core.events` import
symbols (`CONTENT_BLOCK_END`, `PROVIDER_ERROR`, etc.), none touching the
lines changed here. This PR does not add or worsen any of them.

## Not committed

`modules/loop-agent/uv.lock` and `.venv/` (created by `uv sync` while
running tests) -- both are `.gitignore`d in this repo and were not staged.

Branch: `fix/tool-truncation-output-discarded`, one commit.
