### PR TITLE
fix(loop-agent): honor tool:post hook modifications — spec §5.1 truncation was a silent no-op

### DIFF
--- a/SPEC_CONFORMANCE.md
+++ b/SPEC_CONFORMANCE.md
@@ -63,7 +63,7 @@ Maintainer ruling, 2026-08-14. The four rules that decide every disposition in t
 | Spec | Areas reviewed | Off-spec gaps | Resolved | Open |
 |------|----------------|---------------|----------|------|
 | unified-llm | ~35 | 13 | 4 (structured output, all providers) | 9 |
-| coding-agent-loop | ~17 | 9 | 2 (bugs CAL-1, CAL-2) | 7 |
+| coding-agent-loop | ~17 | 10 | 3 (bugs CAL-1, CAL-2, CAL-10) | 7 |
 | attractor | ~30 | 12 | 9 (ATX-1, ATX-2, ATX-4, ATX-5, ATX-10, ATX-11, ATX-12, ATX-13, ATX-14) | 3 (ATX-3, ATX-6, ATX-7) |
 
 The engine layer (attractor) is the strongest — substantially a **superset** of the spec. The
@@ -114,6 +114,7 @@ keys. Do not mark "live" until exercised against real providers (e.g. in a DTU w
 | CAL-7 | System prompt: recent commit messages + knowledge-cutoff line (§6.4) | `:1036`, `:1025` | omitted | OPEN | ALIGN (cheap) |
 | CAL-8 | Subagents: start-then-`wait` semantics, default unlimited turns | `:1069`, `:1075` | lazy spawn, default 50, host-dependent | OPEN | DIVERGE-or-ALIGN |
 | CAL-9 | Graceful shutdown closes active subagents + cancels in-flight stream | `:1436-1449` | partial | OPEN | ALIGN |
+| CAL-10 | Tool output truncation (§5.1 MUST) silently discarded: `tool:post` hook `Modify` results (e.g. `hooks-tool-truncation`) never reached the LLM because the consumer gated on `post_result.action == "modify"`, a value amplifier-core's `HookRegistry.emit()` (`hooks.rs`) never returns to its caller (Modify only chains data between handlers inside `emit()`'s own dispatch loop; the returned action always collapses to `continue`) | `:852-854` (§5.1: truncation MUST happen before the LLM sees oversized output) | `agent_session.py:912-945` (fixed); `loop-pipeline/hook_bridge.py:190-224` (`wrap_tool_with_hooks`, same discard-class, unwired/dead in production) | **DONE — PROVEN (RED→GREEN)** | ALIGN |
 
 ---
 
@@ -226,6 +227,41 @@ are the current state; these are the reasoning behind it.
 ---
 
 ## Changelog
+
+### 2026-08-26 — CAL-10 DONE: tool:post hook modifications (truncation) reach the LLM again (amplifier-support#485)
+
+- **CAL-10 NEW → DONE — ALIGN.** §5.1's MUST ("tool output exceeds the configured limit, it MUST be
+  truncated before being sent to the LLM") was silently unmet in production: `agent_session.py`'s
+  tool:post consumer gated on `post_result.action == "modify"`, a value amplifier-core's
+  `HookRegistry.emit()` (`hooks.rs`) never returns to its caller — Modify only chains `current_data`
+  between handlers *inside* `emit()`'s own dispatch loop; the action returned to the caller always
+  collapses to `continue` (or deny/ask_user/inject_context if some handler in the chain requested one
+  of those). Dead since `fc85653`. Every `hooks-tool-truncation` modification was a no-op; the LLM
+  always received the raw, untruncated output.
+  - **Fix (toward-spec, decision-matrix tier):** read `post_result.data` directly — it is the merged
+    (possibly hook-modified) event data, delivered under `action="continue"` in the normal case — and
+    guard for `"result"` being a `str` that differs from the raw output before using it, because
+    Modify *replaces* `current_data` rather than merging it, so `"result"` is not guaranteed present.
+    Fixed at both sites in the same class found by grep: `agent_session.py:912-945` (loop-agent's
+    live tool-call path) and `loop-pipeline/hook_bridge.py:190-224`'s `wrap_tool_with_hooks` (same
+    discard, more severe — it never read `post_result` at all; currently unwired in production, fixed
+    as defense-in-depth so it isn't a landmine if wired in later).
+  - **Loudness:** both sites now `logger.debug` original→modified char counts whenever a modification
+    is actually applied — the incident was a modifier silently no-op'ing for months undetected.
+  - **Tests:** `test_truncation_wiring.py` fakes rewritten to be faithful to the real kernel contract
+    (`action="continue"`, data replaced) instead of fabricating `action="modify"` back to the caller —
+    the old fakes are what let this bug ship silently; `test_tool_post_modification_reaches_llm` is
+    RED at `origin/main` (proven: fails against the pre-fix file) and GREEN after the fix; 3 new guard
+    tests (missing `"result"`, non-str `"result"`, identical `"result"` → no spurious log). New
+    `test_truncation_e2e_real_hook.py` mounts the REAL `hooks-tool-truncation` module on a REAL
+    `amplifier_core.HookRegistry` (not a fake) and proves oversized output is truncated to the
+    configured `char_limit` before reaching the LLM.
+  - **Live-run evidence:** a real `AgentSession` run against a live provider, oversized `bash` output,
+    truncation hook mounted — event-stream slice saved outside the repo (see PR notes / report).
+  - **EXTENSIONS.md:** not touched — this is a bug fix restoring documented §5.1 behavior, not a new
+    or changed behavior surface.
+  - loop-agent suite, hooks-tool-truncation suite, loop-pipeline suite, pipeline-runner suite all green
+    after the fix (see PR notes for exact counts).
 
 ### 2026-08-16 — issue #234 decided: ATX-13 + ATX-14 ledgered as divergences (F1/F4 from the matrix build)
 

--- a/modules/loop-agent/amplifier_module_loop_agent/agent_session.py
+++ b/modules/loop-agent/amplifier_module_loop_agent/agent_session.py
@@ -912,15 +912,42 @@ class AgentSession:
             # If a hook modified the result (e.g. truncation), use the
             # modified output for the LLM while preserving full output
             # in the event stream.
+            #
+            # amplifier-core's HookRegistry.emit() (hooks.rs) never returns
+            # action="modify" to *this* caller: Modify is a handler-to-handler
+            # chaining mechanism only -- inside emit()'s dispatch loop, each
+            # Modify result's data REPLACES current_data for the next handler,
+            # but the action returned to the caller of emit() always collapses
+            # to "continue" (or deny/ask_user/inject_context, if some handler
+            # in the chain requested one of those). Gating on
+            # `post_result.action == "modify"` here can therefore never fire
+            # -- it is what silently discarded every hooks-tool-truncation
+            # modification since fc85653 (amplifier-support#485, PR #318).
+            #
+            # The correct read: post_result.data IS the (possibly
+            # hook-modified) merged event data, delivered under action=
+            # "continue" in the normal case. Because Modify REPLACES
+            # current_data rather than merging it, a hook that returns a
+            # partial data dict can drop "result" entirely -- it is NOT
+            # guaranteed present, so this must be a guarded read, not a
+            # dict index.
             llm_output = raw_output
-            if (
-                hasattr(post_result, "action")
-                and post_result.action == "modify"
-                and hasattr(post_result, "data")
-                and post_result.data
-                and "result" in post_result.data
-            ):
-                llm_output = post_result.data["result"]
+            modified_result = (
+                post_result.data.get("result")
+                if isinstance(post_result.data, dict)
+                else None
+            )
+            if isinstance(modified_result, str) and modified_result != raw_output:
+                llm_output = modified_result
+                # Loudness: a hook silently no-op'ing here (as it did for
+                # months, undetected) is the actual incident. Make every
+                # real application of a tool:post modification observable.
+                logger.debug(
+                    "tool:post hook modified output for %s: %d -> %d chars",
+                    tool_call.name,
+                    len(raw_output),
+                    len(modified_result),
+                )
 
             # Emit tool output delta for UI streaming (spec TOOL_CALL_OUTPUT_DELTA)
             await self._hooks.emit(

--- a/modules/loop-agent/pyproject.toml
+++ b/modules/loop-agent/pyproject.toml
@@ -51,4 +51,8 @@ dev = [
 testpaths = ["tests"]
 addopts = "--import-mode=importlib"
 asyncio_mode = "strict"
-pythonpath = [".", "../unified-llm-client"]
+# ../hooks-tool-truncation: test_truncation_e2e_real_hook.py mounts the real
+# hooks-tool-truncation module on a real amplifier_core.HookRegistry to prove
+# the tool:post wiring fix end-to-end (amplifier-support#485), not just
+# against a fake hook double.
+pythonpath = [".", "../unified-llm-client", "../hooks-tool-truncation"]

--- a/modules/loop-agent/tests/test_truncation_e2e_real_hook.py
+++ b/modules/loop-agent/tests/test_truncation_e2e_real_hook.py
@@ -1,0 +1,143 @@
+"""End-to-end wiring test with the REAL hooks-tool-truncation module mounted
+on a REAL amplifier_core.HookRegistry (not a fake hook double).
+
+This proves the fix at the integration boundary the regression test in
+test_truncation_wiring.py cannot: that the actual kernel (amplifier-core's
+Rust HookRegistry, via its Python binding) really does collapse a Modify
+result to action="continue" on return, and that AgentSession's tool:post
+consumer really does read the truncated output back out of it.
+
+Only the LLM provider and the tool are mocked; hooks-tool-truncation and
+the HookRegistry it mounts on are the real, shipped modules.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from amplifier_core import HookRegistry
+from amplifier_core.message_models import ChatResponse, ToolCall, Usage
+from amplifier_core.models import ToolResult
+from amplifier_module_hooks_tool_truncation import mount as mount_truncation_hook
+from amplifier_module_loop_agent.agent_session import AgentSession
+from amplifier_module_loop_agent.config import SessionConfig
+
+
+def _text_response(text: str) -> ChatResponse:
+    return ChatResponse(
+        content=[{"type": "text", "text": text}],
+        tool_calls=None,
+        usage=Usage(input_tokens=10, output_tokens=5, total_tokens=15),
+    )
+
+
+def _tool_response(call_id: str, tool_name: str, args: dict) -> ChatResponse:
+    return ChatResponse(
+        content=[],
+        tool_calls=[ToolCall(id=call_id, name=tool_name, arguments=args)],
+        usage=Usage(input_tokens=10, output_tokens=5, total_tokens=15),
+    )
+
+
+def _make_mock_tool(name: str, output: str) -> MagicMock:
+    tool = MagicMock()
+    tool.name = name
+    tool.description = f"Mock {name}"
+    tool.input_schema = {"type": "object", "properties": {}}
+    tool.execute = AsyncMock(return_value=ToolResult(success=True, output=output))
+    return tool
+
+
+@pytest.mark.asyncio
+async def test_real_truncation_hook_output_reaches_llm():
+    """Oversized tool output, real hooks-tool-truncation mounted on a real
+    HookRegistry: the LLM-bound content must be truncated to the configured
+    char_limit (not the raw, oversized output).
+    """
+    char_limit = 500
+    real_hooks = HookRegistry()
+
+    # coordinator duck-type: hooks-tool-truncation's mount() only calls
+    # coordinator.get("hooks").
+    coordinator = SimpleNamespace(
+        get=lambda key: real_hooks if key == "hooks" else None
+    )
+    cleanup = await mount_truncation_hook(
+        coordinator,
+        config={"char_limits": {"bash": char_limit}, "line_limits": {}, "modes": {}},
+    )
+    assert cleanup is not None
+
+    big_output = "L" * 50_000
+    tool = _make_mock_tool("bash", output=big_output)
+
+    provider = AsyncMock()
+    provider.complete = AsyncMock(
+        side_effect=[
+            _tool_response("tc1", "bash", {"command": "cat huge.log"}),
+            _text_response("done."),
+        ]
+    )
+
+    session = AgentSession(
+        config=SessionConfig(system_prompt="You are a test coding agent."),
+        provider=provider,
+        tools={"bash": tool},
+        hooks=real_hooks,
+    )
+    await session.process_input("cat huge.log")
+
+    second_request = provider.complete.call_args_list[1][0][0]
+    tool_messages = [m for m in second_request.messages if m.role == "tool"]
+    assert len(tool_messages) == 1
+    llm_content = tool_messages[0].content
+
+    # The money proof: LLM-bound content is NOT the raw 50,000-char output,
+    # IS bounded near the configured 500-char limit (plus marker overhead),
+    # and carries the truncation warning the spec (§5.1) requires.
+    assert llm_content != big_output
+    assert len(llm_content) < len(big_output)
+    assert len(llm_content) <= char_limit + 500  # allow marker overhead
+    assert "[WARNING: Tool output was truncated" in llm_content
+
+    cleanup()
+
+
+@pytest.mark.asyncio
+async def test_real_truncation_hook_leaves_small_output_untouched():
+    """Under the configured limit: real hooks-tool-truncation is a no-op,
+    and the exact original string reaches the LLM.
+    """
+    real_hooks = HookRegistry()
+    coordinator = SimpleNamespace(
+        get=lambda key: real_hooks if key == "hooks" else None
+    )
+    cleanup = await mount_truncation_hook(
+        coordinator,
+        config={"char_limits": {"bash": 30_000}, "line_limits": {}, "modes": {}},
+    )
+
+    small_output = "all good, 3 files changed"
+    tool = _make_mock_tool("bash", output=small_output)
+
+    provider = AsyncMock()
+    provider.complete = AsyncMock(
+        side_effect=[
+            _tool_response("tc1", "bash", {"command": "git status"}),
+            _text_response("done."),
+        ]
+    )
+
+    session = AgentSession(
+        config=SessionConfig(system_prompt="You are a test coding agent."),
+        provider=provider,
+        tools={"bash": tool},
+        hooks=real_hooks,
+    )
+    await session.process_input("git status")
+
+    second_request = provider.complete.call_args_list[1][0][0]
+    tool_messages = [m for m in second_request.messages if m.role == "tool"]
+    assert tool_messages[0].content == small_output
+
+    cleanup()

--- a/modules/loop-agent/tests/test_truncation_wiring.py
+++ b/modules/loop-agent/tests/test_truncation_wiring.py
@@ -2,17 +2,32 @@
 
 Verifies that when hooks-tool-truncation is active, the agent loop:
 1. Emits tool:post after tool execution
-2. Reads back HookResult(action="modify") data
+2. Reads back the hook-modified event data
 3. Uses truncated output for the ToolResult sent to LLM
 4. Preserves full output in agent:tool_call_end event
+
+Regression coverage for amplifier-support#485 / PR #318: amplifier-core's
+HookRegistry.emit() (hooks.rs) never returns action="modify" to its caller
+-- Modify only chains data between handlers *inside* emit()'s own dispatch
+loop; the action returned to the caller always collapses to "continue"
+(or deny/ask_user/inject_context, if some handler in the chain requested
+one of those). A consumer that gates on `post_result.action == "modify"`
+is dead code that can never fire.
+
+The test doubles below model that REAL kernel contract: a "modifying" hook
+double returns `HookResult(action="continue", data=<replaced dict>)`, never
+`action="modify"`. A double that fabricates `action="modify"` back to the
+caller (as this file's fakes used to) is unfaithful to the kernel and can
+mask a broken consumer -- which is exactly how this bug went undetected in
+production.
 """
 
-import pytest
+import logging
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
 from amplifier_core.message_models import ChatResponse, ToolCall, Usage
 from amplifier_core.models import HookResult, ToolResult
-
 from amplifier_module_loop_agent.agent_session import AgentSession
 from amplifier_module_loop_agent.config import SessionConfig
 
@@ -43,12 +58,40 @@ def _make_mock_tool(name: str, output: str = "ok") -> MagicMock:
 
 
 def _make_hooks():
+    """A hook double with no registered handlers: always action=continue."""
     hooks = MagicMock()
     hooks._emitted = []
 
     async def _emit(event, data):
         hooks._emitted.append((event, data))
-        return MagicMock(action="continue")
+        return HookResult(action="continue", data=dict(data))
+
+    hooks.emit = AsyncMock(side_effect=_emit)
+    return hooks
+
+
+def _make_modifying_hooks(replacement_result):
+    """A hook double faithful to the REAL kernel contract for a modifying hook.
+
+    amplifier-core's HookRegistry.emit() (hooks.rs) folds a handler's
+    Modify result into `current_data` and returns it to the caller under
+    action="continue" -- never "modify". This is what hooks-tool-truncation
+    (and any other tool:post modifier) actually looks like from the
+    consumer's point of view.
+    """
+    hooks = MagicMock()
+    hooks._emitted = []
+
+    async def _emit(event, data):
+        hooks._emitted.append((event, data))
+        if event == "tool:post":
+            modified = {
+                **data,
+                "result": replacement_result,
+                "full_output": data.get("result"),
+            }
+            return HookResult(action="continue", data=modified)
+        return HookResult(action="continue", data=dict(data))
 
     hooks.emit = AsyncMock(side_effect=_emit)
     return hooks
@@ -61,27 +104,14 @@ async def test_tool_post_emitted_after_execution():
     tool = _make_mock_tool("read_file", output=big_output)
 
     provider = AsyncMock()
-    provider.complete = AsyncMock(side_effect=[
-        _tool_response("tc1", "read_file", {"path": "big.txt"}),
-        _text_response("done."),
-    ])
+    provider.complete = AsyncMock(
+        side_effect=[
+            _tool_response("tc1", "read_file", {"path": "big.txt"}),
+            _text_response("done."),
+        ]
+    )
 
-    emitted_events: list[tuple[str, dict]] = []
-
-    async def recording_emit(event: str, data: dict):
-        emitted_events.append((event, data))
-        if event == "tool:post":
-            return HookResult(
-                action="modify",
-                data={
-                    "result": "truncated_output",
-                    "full_output": data.get("result"),
-                },
-            )
-        return MagicMock(action="continue")
-
-    hooks = MagicMock()
-    hooks.emit = AsyncMock(side_effect=recording_emit)
+    hooks = _make_modifying_hooks("truncated_output")
 
     session = AgentSession(
         config=SessionConfig(system_prompt="You are a test coding agent."),
@@ -91,36 +121,42 @@ async def test_tool_post_emitted_after_execution():
     )
     await session.process_input("read big.txt")
 
-    # Verify tool:post was emitted
-    post_events = [(e, d) for e, d in emitted_events if e == "tool:post"]
+    # Verify tool:post was emitted with the raw (pre-hook) event data
+    post_events = [(e, d) for e, d in hooks._emitted if e == "tool:post"]
     assert len(post_events) == 1
     assert post_events[0][1]["tool_name"] == "read_file"
     assert post_events[0][1]["result"] == big_output
 
 
 @pytest.mark.asyncio
-async def test_truncated_output_sent_to_llm():
-    """When tool:post returns modify, the LLM sees truncated output."""
+async def test_tool_post_modification_reaches_llm():
+    """REGRESSION (amplifier-support#485): a tool:post hook's modified
+    `result` must reach the LLM payload.
+
+    This is the dead-branch proof. amplifier-core's real dispatch semantics
+    (hooks.rs) return `action="continue"` to the caller even when a handler
+    requested Modify -- so a consumer gated on
+    `post_result.action == "modify"` NEVER applies the modification. At
+    origin/main (agent_session.py:918, pre-fix) this test fails: the fake
+    hook below returns exactly what the kernel really returns
+    (action="continue", data with a replaced "result"), and the dead branch
+    ignores it, so the LLM sees the raw, untruncated output. After the fix
+    (reading post_result.data directly, guarded by isinstance/!=), the
+    modified output reaches the LLM and this test passes.
+    """
     big_output = "x" * 100_000
     truncated = "truncated_version"
     tool = _make_mock_tool("read_file", output=big_output)
 
     provider = AsyncMock()
-    provider.complete = AsyncMock(side_effect=[
-        _tool_response("tc1", "read_file", {"path": "big.txt"}),
-        _text_response("done."),
-    ])
+    provider.complete = AsyncMock(
+        side_effect=[
+            _tool_response("tc1", "read_file", {"path": "big.txt"}),
+            _text_response("done."),
+        ]
+    )
 
-    async def truncating_emit(event: str, data: dict):
-        if event == "tool:post":
-            return HookResult(
-                action="modify",
-                data={"result": truncated, "full_output": data.get("result")},
-            )
-        return MagicMock(action="continue")
-
-    hooks = MagicMock()
-    hooks.emit = AsyncMock(side_effect=truncating_emit)
+    hooks = _make_modifying_hooks(truncated)
 
     session = AgentSession(
         config=SessionConfig(system_prompt="You are a test coding agent."),
@@ -145,24 +181,14 @@ async def test_full_output_in_tool_call_end_event():
     tool = _make_mock_tool("read_file", output=big_output)
 
     provider = AsyncMock()
-    provider.complete = AsyncMock(side_effect=[
-        _tool_response("tc1", "read_file", {"path": "big.txt"}),
-        _text_response("done."),
-    ])
+    provider.complete = AsyncMock(
+        side_effect=[
+            _tool_response("tc1", "read_file", {"path": "big.txt"}),
+            _text_response("done."),
+        ]
+    )
 
-    emitted_events: list[tuple[str, dict]] = []
-
-    async def recording_emit(event: str, data: dict):
-        emitted_events.append((event, data))
-        if event == "tool:post":
-            return HookResult(
-                action="modify",
-                data={"result": "short", "full_output": data.get("result")},
-            )
-        return MagicMock(action="continue")
-
-    hooks = MagicMock()
-    hooks.emit = AsyncMock(side_effect=recording_emit)
+    hooks = _make_modifying_hooks("short")
 
     session = AgentSession(
         config=SessionConfig(system_prompt="You are a test coding agent."),
@@ -173,28 +199,25 @@ async def test_full_output_in_tool_call_end_event():
     await session.process_input("read big.txt")
 
     # agent:tool_call_end should have the FULL output
-    end_events = [(e, d) for e, d in emitted_events
-                  if e == "agent:tool_call_end"]
+    end_events = [(e, d) for e, d in hooks._emitted if e == "agent:tool_call_end"]
     assert len(end_events) == 1
     assert end_events[0][1]["output"] == big_output
 
 
 @pytest.mark.asyncio
 async def test_no_truncation_when_hook_continues():
-    """When tool:post returns action=continue, output is unchanged."""
+    """When no hook modifies the result, output is unchanged."""
     tool = _make_mock_tool("read_file", output="small output")
 
     provider = AsyncMock()
-    provider.complete = AsyncMock(side_effect=[
-        _tool_response("tc1", "read_file", {}),
-        _text_response("done."),
-    ])
+    provider.complete = AsyncMock(
+        side_effect=[
+            _tool_response("tc1", "read_file", {}),
+            _text_response("done."),
+        ]
+    )
 
-    async def passthrough_emit(event: str, data: dict):
-        return MagicMock(action="continue")
-
-    hooks = MagicMock()
-    hooks.emit = AsyncMock(side_effect=passthrough_emit)
+    hooks = _make_hooks()
 
     session = AgentSession(
         config=SessionConfig(system_prompt="You are a test coding agent."),
@@ -208,3 +231,132 @@ async def test_no_truncation_when_hook_continues():
     tool_messages = [m for m in second_request.messages if m.role == "tool"]
     assert len(tool_messages) == 1
     assert "small output" in tool_messages[0].content
+
+
+# ---------------------------------------------------------------------------
+# Guard cases (3c): the consumer must not crash or spuriously log when the
+# hook-modified data doesn't look like a real modification.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_missing_result_key_no_crash_raw_preserved():
+    """post_result.data without a "result" key: no crash, raw output used.
+
+    Modify REPLACES current_data rather than merging it, so a hook that
+    returns a partial data dict can legitimately drop "result" entirely.
+    """
+    tool = _make_mock_tool("read_file", output="raw output")
+
+    provider = AsyncMock()
+    provider.complete = AsyncMock(
+        side_effect=[
+            _tool_response("tc1", "read_file", {}),
+            _text_response("done."),
+        ]
+    )
+
+    async def _emit(event, data):
+        if event == "tool:post":
+            # A hook that replaced current_data with something that has no
+            # "result" key at all (e.g. it only cared about a side-channel
+            # field). This must not be treated as a crash or as raw==None.
+            return HookResult(action="continue", data={"call_id": data.get("call_id")})
+        return HookResult(action="continue", data=dict(data))
+
+    hooks = MagicMock()
+    hooks.emit = AsyncMock(side_effect=_emit)
+
+    session = AgentSession(
+        config=SessionConfig(system_prompt="You are a test coding agent."),
+        provider=provider,
+        tools={"read_file": tool},
+        hooks=hooks,
+    )
+    # Must not raise
+    await session.process_input("read")
+
+    second_request = provider.complete.call_args_list[1][0][0]
+    tool_messages = [m for m in second_request.messages if m.role == "tool"]
+    assert len(tool_messages) == 1
+    assert tool_messages[0].content == "raw output"
+
+
+@pytest.mark.asyncio
+async def test_non_string_result_ignored():
+    """A non-string "result" in post_result.data must be ignored, not sent to the LLM."""
+    tool = _make_mock_tool("read_file", output="raw output")
+
+    provider = AsyncMock()
+    provider.complete = AsyncMock(
+        side_effect=[
+            _tool_response("tc1", "read_file", {}),
+            _text_response("done."),
+        ]
+    )
+
+    async def _emit(event, data):
+        if event == "tool:post":
+            # Misbehaving/foreign hook returns a non-string "result".
+            return HookResult(action="continue", data={**data, "result": 12345})
+        return HookResult(action="continue", data=dict(data))
+
+    hooks = MagicMock()
+    hooks.emit = AsyncMock(side_effect=_emit)
+
+    session = AgentSession(
+        config=SessionConfig(system_prompt="You are a test coding agent."),
+        provider=provider,
+        tools={"read_file": tool},
+        hooks=hooks,
+    )
+    await session.process_input("read")
+
+    second_request = provider.complete.call_args_list[1][0][0]
+    tool_messages = [m for m in second_request.messages if m.role == "tool"]
+    assert len(tool_messages) == 1
+    assert tool_messages[0].content == "raw output"
+
+
+@pytest.mark.asyncio
+async def test_identical_result_no_spurious_modification_log(caplog):
+    """A hook that echoes back an identical "result" must not log a modification."""
+    tool = _make_mock_tool("read_file", output="unchanged output")
+
+    provider = AsyncMock()
+    provider.complete = AsyncMock(
+        side_effect=[
+            _tool_response("tc1", "read_file", {}),
+            _text_response("done."),
+        ]
+    )
+
+    async def _emit(event, data):
+        if event == "tool:post":
+            # Hook ran, decided nothing needed truncating, echoed "result"
+            # back unchanged (as hooks-tool-truncation's action="continue"
+            # short path effectively does).
+            return HookResult(
+                action="continue", data={**data, "result": data.get("result")}
+            )
+        return HookResult(action="continue", data=dict(data))
+
+    hooks = MagicMock()
+    hooks.emit = AsyncMock(side_effect=_emit)
+
+    session = AgentSession(
+        config=SessionConfig(system_prompt="You are a test coding agent."),
+        provider=provider,
+        tools={"read_file": tool},
+        hooks=hooks,
+    )
+
+    with caplog.at_level(
+        logging.DEBUG, logger="amplifier_module_loop_agent.agent_session"
+    ):
+        await session.process_input("read")
+
+    second_request = provider.complete.call_args_list[1][0][0]
+    tool_messages = [m for m in second_request.messages if m.role == "tool"]
+    assert tool_messages[0].content == "unchanged output"
+    assert not any("hook modified output" in rec.message for rec in caplog.records)

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/hook_bridge.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/hook_bridge.py
@@ -189,7 +189,7 @@ def wrap_tool_with_hooks(tool: Any, hooks: Any) -> Any:
 
         result = await original_execute(**kwargs)
 
-        await hooks.emit(
+        post_result = await hooks.emit(
             "tool:post",
             {
                 "tool_name": tool.name,
@@ -197,6 +197,30 @@ def wrap_tool_with_hooks(tool: Any, hooks: Any) -> Any:
                 "node_id": node_ctx.get("node_id"),
             },
         )
+
+        # Honor a tool:post hook modification (e.g. hooks-tool-truncation).
+        #
+        # amplifier-core's HookRegistry.emit() (hooks.rs) never returns
+        # action="modify" to this caller -- Modify only chains data between
+        # handlers inside emit()'s own dispatch loop; the action returned
+        # here always collapses to "continue" (same defect class as
+        # amplifier-support#485 in loop-agent's agent_session.py). Read
+        # post_result.data directly instead of gating on action, and guard
+        # for "result" being absent (Modify REPLACES the data dict, so a
+        # partial-data hook can drop it) or non-string.
+        modified_result = (
+            post_result.data.get("result")
+            if isinstance(post_result.data, dict)
+            else None
+        )
+        if isinstance(modified_result, str) and modified_result != result:
+            logger.debug(
+                "tool:post hook modified output for %s: %d -> %d chars",
+                tool.name,
+                len(result) if isinstance(result, str) else -1,
+                len(modified_result),
+            )
+            return modified_result
 
         return result
 

--- a/modules/loop-pipeline/tests/test_hook_bridge.py
+++ b/modules/loop-pipeline/tests/test_hook_bridge.py
@@ -4,6 +4,7 @@ Validates that create_hook_bridge() returns a middleware function that
 bridges unified-llm-client middleware to Amplifier's hook system.
 """
 
+import logging
 import sys
 import types
 from dataclasses import dataclass, field
@@ -73,32 +74,64 @@ def test_create_hook_bridge_returns_callable():
 
 
 class RecordingHooks:
-    """Records emitted events and returns configurable HookResults."""
+    """Records emitted events and returns configurable, kernel-faithful HookResults.
+
+    amplifier-core's HookRegistry.emit() (hooks.rs:230-274) never returns
+    action="modify" to its caller -- Modify only chains `current_data`
+    between handlers *inside* emit()'s own dispatch loop; the action
+    returned to the caller always collapses to "continue" (or deny/
+    ask_user/inject_context, per hooks.rs's documented precedence) once no
+    handler requests one of those. A double that fabricates action="modify"
+    back to the caller is unfaithful to the kernel and can mask a broken
+    consumer -- which is the exact anti-pattern amplifier-support#485 /
+    PR #318 indicts (and which this class's own now-removed `set_modify()`
+    used to model).
+
+    For a "no handler touched this event" default, emit() echoes the event
+    data back unchanged under action="continue" -- the real no-op shape.
+    Use `set_deny()` for deny, or `set_tool_post_data()` to model a tool:post
+    handler that replaced `current_data` (mirrors
+    modules/loop-agent/tests/test_truncation_wiring.py's
+    `_make_modifying_hooks`).
+    """
 
     def __init__(self, action: str = "continue"):
         self.events: list[tuple[str, dict]] = []
         self._action = action
         self._reason: str | None = None
-        self._modified_data: dict | None = None
+        self._tool_post_data: dict | None = None
 
     def set_deny(self, reason: str = "blocked"):
         self._action = "deny"
         self._reason = reason
 
-    def set_modify(self, data: dict):
-        self._action = "modify"
-        self._modified_data = data
+    def set_tool_post_data(self, data: dict) -> None:
+        """Model a tool:post handler that returned Modify.
+
+        Kernel-faithful: the caller-visible action is still "continue" --
+        only the returned `data` for the tool:post event differs from what
+        was emitted (current_data is REPLACED by the handler's dict, not
+        merged with the emitted event data).
+        """
+        self._tool_post_data = data
 
     async def emit(self, event: str, data: dict) -> Any:
         self.events.append((event, data))
+        if self._action == "deny":
+            return type(
+                "HookResult",
+                (),
+                {"action": "deny", "data": dict(data), "reason": self._reason},
+            )()
+        result_data = (
+            self._tool_post_data
+            if event == "tool:post" and self._tool_post_data is not None
+            else dict(data)
+        )
         return type(
             "HookResult",
             (),
-            {
-                "action": self._action,
-                "data": self._modified_data,
-                "reason": self._reason,
-            },
+            {"action": "continue", "data": result_data, "reason": None},
         )()
 
     @property
@@ -371,6 +404,107 @@ async def test_wrap_tool_with_no_execute_returns_none():
     )
     wrapped = wrap_tool_with_hooks(original_tool, hooks)
     assert wrapped.execute is None
+
+
+# ---------------------------------------------------------------------------
+# wrap_tool_with_hooks honors a tool:post hook modification
+# (amplifier-support#485 / PR #318 -- same defect class as loop-agent's
+# agent_session.py, but more severe here: pre-fix, wrap_tool_with_hooks
+# never read post_result at all). Doubles are kernel-faithful
+# (action="continue", data replaced) -- see RecordingHooks above and
+# modules/loop-agent/tests/test_truncation_wiring.py's `_make_modifying_hooks`,
+# whose pattern this copies.
+# ---------------------------------------------------------------------------
+
+
+async def _wrap_and_run(
+    hooks: RecordingHooks, raw_output: Any, **exec_kwargs: Any
+) -> Any:
+    """Build a wrapped tool returning `raw_output` and execute it once."""
+    original_tool = unified_llm.Tool(
+        name="read_file",
+        description="Read a file",
+        parameters={},
+        execute=None,
+    )
+
+    async def original_execute(**kwargs):
+        return raw_output
+
+    original_tool.execute = original_execute
+
+    token = set_node_context({"node_id": "step1"})
+    try:
+        wrapped = wrap_tool_with_hooks(original_tool, hooks)
+        return await wrapped.execute(**exec_kwargs)
+    finally:
+        _current_node_context.reset(token)
+
+
+@pytest.mark.asyncio
+async def test_wrap_tool_post_modification_reaches_output():
+    """REGRESSION (amplifier-support#485): a tool:post hook's modified
+    `result` must reach wrap_tool_with_hooks's returned output.
+
+    This is the dead-branch proof for wrap_tool_with_hooks specifically:
+    pre-fix, the wrapper never read `post_result` at all (unlike
+    agent_session.py, it wasn't even gated on the wrong action -- it simply
+    discarded the hook's return value), so the raw, untruncated output was
+    always what the caller received. After the fix (reading
+    `post_result.data` directly, guarded by isinstance/!=), a kernel-faithful
+    modification reaches the output.
+    """
+    big_output = "x" * 100_000
+    truncated = "truncated_version"
+    hooks = RecordingHooks()
+    hooks.set_tool_post_data(
+        {"tool_name": "read_file", "node_id": "step1", "result": truncated}
+    )
+
+    result = await _wrap_and_run(hooks, big_output, path="/tmp/big.txt")
+
+    assert result == truncated
+
+
+@pytest.mark.asyncio
+async def test_wrap_tool_post_missing_result_key_no_crash_raw_preserved():
+    """post_result.data without a "result" key: no crash, raw output used.
+
+    Modify REPLACES current_data rather than merging it, so a hook that
+    returns a partial data dict can legitimately drop "result" entirely.
+    """
+    hooks = RecordingHooks()
+    hooks.set_tool_post_data({"tool_name": "read_file"})  # no "result" key at all
+
+    result = await _wrap_and_run(hooks, "raw output")
+
+    assert result == "raw output"
+
+
+@pytest.mark.asyncio
+async def test_wrap_tool_post_non_string_result_ignored():
+    """A non-string "result" in post_result.data must be ignored, not returned."""
+    hooks = RecordingHooks()
+    hooks.set_tool_post_data({"tool_name": "read_file", "result": 12345})
+
+    result = await _wrap_and_run(hooks, "raw output")
+
+    assert result == "raw output"
+
+
+@pytest.mark.asyncio
+async def test_wrap_tool_post_identical_result_no_spurious_log(caplog):
+    """A hook that echoes back an identical "result" must not log a modification."""
+    hooks = RecordingHooks()
+    hooks.set_tool_post_data({"tool_name": "read_file", "result": "unchanged output"})
+
+    with caplog.at_level(
+        logging.DEBUG, logger="amplifier_module_loop_pipeline.hook_bridge"
+    ):
+        result = await _wrap_and_run(hooks, "unchanged output")
+
+    assert result == "unchanged output"
+    assert not any("modified output" in rec.message for rec in caplog.records)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Fixes a silently-dead consumer path: `hooks-tool-truncation` computes a spec-mandated truncation on every `tool:post` and returns `HookResult(action="modify", data=...)` — but the kernel's hook dispatch collapses the caller-visible action to `continue` (Modify only chains `current_data` between handlers, REPLACING it). The consumer in `modules/loop-agent/.../agent_session.py` gated on `post_result.action == "modify"` — a branch that can never fire — so **every tool:post modification, including the coding-agent-loop spec's §5.1 MUST truncation, was silently discarded**.

**Credit:** reported by @samueljklee (amplifier-support#485, PR #318). This is a fresh implementation superseding #318 — same defect, plus the same-class fix in `loop-pipeline/hook_bridge.py`, kernel-faithful test doubles, loudness, ledger row, and live-run evidence.

## The fix
1. **`agent_session.py`** — honor a hook-modified result: if `post_result.data` carries a `"result"` that is a `str` and differs from the raw output, it becomes the LLM-bound output. Comment written to the real kernel semantics (Modify REPLACES `current_data`; `"result"` not guaranteed present; caller sees `continue`).
2. **`loop-pipeline/hook_bridge.py`** — same dead-consumer class fixed (verified unwired in production; defense-in-depth), now with its own kernel-faithful tests.
3. **Loudness** — when a modification applies, a debug log records original→modified char counts (lengths only, never content).
4. **Test doubles de-fabricated** — the old doubles modeled a friendlier kernel (`action="modify"`) than the real one; that is exactly why the dead branch stayed green. Doubles now mirror `hooks.rs` semantics (`continue` + replaced data); the fabricating `set_modify()` helper is removed.

## nlspec alignment
`specs/canonical/coding-agent-loop-spec-canonical.md` §5.1: truncation before the LLM sees oversized output is a **MUST**; §5.2 gives the limits. The hook already implemented the algorithm correctly — the gap was purely consumer wiring. Decision-matrix tier: **toward-spec (ALIGN)**. `SPEC_CONFORMANCE.md` gains **CAL-10** (DONE — PROVEN, ALIGN) + dated changelog. EXTENSIONS.md deliberately untouched (restores documented behavior; adds none).

## Verification checklist
- [x] RED-proof — `test_tool_post_modification_reaches_llm` fails at origin/main (raw untruncated output reaches the LLM), passes after; hook_bridge regression test RED-proven the same way (reverting only that file)
- [x] End-to-end — real `hooks-tool-truncation` on a real `HookRegistry`: oversized output → LLM-bound content truncated to configured limits
- [x] Live-run evidence — real 100,092-char tool output → 11,567 chars after real kernel dispatch → identical 11,567-char string in the real outbound LLM request (evidence dir retained locally, outside the repo)
- [x] Guard cases — missing `"result"` (raw preserved), non-str ignored, identical result (no spurious log), empty-string modification honored
- [x] Suites — loop-pipeline **2667 passed / 25 skipped / 0 failed**, loop-agent **538**, hooks-tool-truncation **34**, pipeline-runner **91 / 1**; ruff clean on touched files
- [x] Independent adversarial review — MERGE-AFTER-FIX; both required fixes applied (see disclosures)
- [x] Zero amplifier-core changes (kernel read-only; consumer-side fix only)
- [x] Pre-publication leak review — zero identity values
- [x] CI green before merge — will confirm

## Disclosures (required by review)
1. **A false claim was corrected pre-merge:** an earlier commit body said "4 pre-existing failures in test_exemplar_terminals.py, confirmed unrelated." Not true — the real baseline is 0 failed; the 4 failures were an artifact of a broken local `pytest` shim (dead shebang) on the build sandbox. The commit body now states this and retracts the claim.
2. **hook_bridge.py initially shipped untested** — the review caught it; kernel-faithful tests (4) were added and RED-proven before this PR opened.
3. **Follow-up candidates (not in scope):** multi-handler B-clobbers-A chaining is real kernel behavior with no exercising test (currently benign — only one modifying tool:post hook ships); a mount-time "modifier had no observable effect" loudness guard; 3 unrelated pre-existing unified-llm-client adapter bugs surfaced during live evidence (to be filed separately).

## Observations
The disease pattern here — a test double modeling a friendlier contract than the real kernel, keeping a dead branch green — is the same class our gate-hardening doctrine calls fabricated evidence. The doubles are now pinned to the kernel's actual semantics.
