### PR TITLE
chore(repo-split): flip attractor's own engine consumption to amplifier-bundle-dot-runner

### DIFF
--- a/.github/capsule-pipeline/attractor-pipeline-dual.yaml
+++ b/.github/capsule-pipeline/attractor-pipeline-dual.yaml
@@ -6,6 +6,15 @@
 # byte-identical to the source file below this header -- do not hand-edit
 # the body; re-sync from source and re-apply this header instead.
 #
+# LEDGERED DIVERGENCE FROM THE PINNED SOURCE (2026-08-27, engine repo split):
+# the two module `source:` lines in the body below (loop-pipeline and
+# tool-report-outcome) were flipped from amplifier-bundle-attractor to
+# amplifier-bundle-dot-runner -- the engine now installs from its extracted
+# repo. Any future re-sync from the private source at d859909 MUST re-apply
+# this flip (or re-sync from a source commit that already carries it); a
+# blind re-sync would silently revert the engine repo split for BOTH
+# workflows that mount this bundle.
+#
 # UNCONDITIONALLY WIRED INTO BOTH WORKFLOWS (OPENAI_API_KEY exists as a
 # proven repo secret; issue #155 closed the conditional-fallback trap):
 # - .github/workflows/capsule-implement.yml mounts this bundle via
@@ -69,7 +78,7 @@ providers:
 session:
   orchestrator:
     module: loop-pipeline
-    source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-pipeline
+    source: git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/loop-pipeline
     config:
       profiles:
         anthropic: attractor-agent-anthropic
@@ -92,7 +101,7 @@ tools:
   # From attractor-core (inlined; no namespace include so this file is
   # loadable from any path):
   - module: tool-report-outcome
-    source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/tool-report-outcome
+    source: git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/tool-report-outcome
 
 hooks:
   - module: hooks-tool-truncation

--- a/.github/workflows/capsule-implement.yml
+++ b/.github/workflows/capsule-implement.yml
@@ -281,6 +281,15 @@ jobs:
           ENGINE_SRC="$RUNNER_TEMP/engine-src"
           rm -rf "$ENGINE_SRC"
           mkdir -p "$ENGINE_SRC"
+          # REPO-SPLIT FLIP: modules/ moved to microsoft/amplifier-bundle-dot-runner
+          # (Track B). bundles/ STAYS in this repo (opinionated layer), so it is still
+          # tar'd locally; modules/ is now fetched from the runner repo instead of the
+          # workspace checkout, matching what every other consumer's git+ pin does.
+          RUNNER_ENGINE_SOURCE="https://github.com/microsoft/amplifier-bundle-dot-runner"
+          git clone --quiet --depth 1 "$RUNNER_ENGINE_SOURCE" "$ENGINE_SRC/_runner_src"
+          RUNNER_SHA="$(git -C "$ENGINE_SRC/_runner_src" rev-parse HEAD)"
+          mv "$ENGINE_SRC/_runner_src/modules" "$ENGINE_SRC/modules"
+          rm -rf "$ENGINE_SRC/_runner_src"
           # tar, not `cp -a`: the exclusions apply at ARCHIVE time, so a
           # .venv/.git/__pycache__ that somehow already exists in the tree never
           # enters the snapshot at all rather than being copied in and then
@@ -290,10 +299,10 @@ jobs:
             --exclude='.git' \
             --exclude='__pycache__' \
             --exclude='*.pyc' \
-            modules bundles \
+            bundles \
           | tar -xf - -C "$ENGINE_SRC"
-          echo "engine snapshot: $GITHUB_WORKSPACE/{modules,bundles} -> $ENGINE_SRC/"
-          echo "engine snapshot provenance: base SHA $(git rev-parse HEAD)"
+          echo "engine snapshot: modules <- $RUNNER_ENGINE_SOURCE ; bundles <- $GITHUB_WORKSPACE/bundles -> $ENGINE_SRC/"
+          echo "engine snapshot provenance: base SHA $(git rev-parse HEAD); runner SHA $RUNNER_SHA"
           for required in \
             "modules/pipeline-runner/pyproject.toml" \
             "modules/loop-pipeline/pyproject.toml" \

--- a/.github/workflows/capsule-specify.yml
+++ b/.github/workflows/capsule-specify.yml
@@ -151,6 +151,15 @@ jobs:
           ENGINE_SRC="$RUNNER_TEMP/engine-src"
           rm -rf "$ENGINE_SRC"
           mkdir -p "$ENGINE_SRC"
+          # REPO-SPLIT FLIP: modules/ moved to microsoft/amplifier-bundle-dot-runner
+          # (Track B). bundles/ STAYS in this repo (opinionated layer), so it is still
+          # tar'd locally; modules/ is now fetched from the runner repo instead of the
+          # workspace checkout, matching what every other consumer's git+ pin does.
+          RUNNER_ENGINE_SOURCE="https://github.com/microsoft/amplifier-bundle-dot-runner"
+          git clone --quiet --depth 1 "$RUNNER_ENGINE_SOURCE" "$ENGINE_SRC/_runner_src"
+          RUNNER_SHA="$(git -C "$ENGINE_SRC/_runner_src" rev-parse HEAD)"
+          mv "$ENGINE_SRC/_runner_src/modules" "$ENGINE_SRC/modules"
+          rm -rf "$ENGINE_SRC/_runner_src"
           # tar, not `cp -a`: the exclusions apply at ARCHIVE time, so a
           # .venv/.git/__pycache__ that somehow already exists in the tree never
           # enters the snapshot at all rather than being copied in and then
@@ -160,10 +169,10 @@ jobs:
             --exclude='.git' \
             --exclude='__pycache__' \
             --exclude='*.pyc' \
-            modules bundles \
+            bundles \
           | tar -xf - -C "$ENGINE_SRC"
-          echo "engine snapshot: $GITHUB_WORKSPACE/{modules,bundles} -> $ENGINE_SRC/"
-          echo "engine snapshot provenance: base SHA $(git rev-parse HEAD)"
+          echo "engine snapshot: modules <- $RUNNER_ENGINE_SOURCE ; bundles <- $GITHUB_WORKSPACE/bundles -> $ENGINE_SRC/"
+          echo "engine snapshot provenance: base SHA $(git rev-parse HEAD); runner SHA $RUNNER_SHA"
           for required in \
             "modules/pipeline-runner/pyproject.toml" \
             "modules/loop-pipeline/pyproject.toml" \

--- a/.github/workflows/feature-specify.yml
+++ b/.github/workflows/feature-specify.yml
@@ -277,6 +277,15 @@ jobs:
           ENGINE_SRC="$RUNNER_TEMP/engine-src"
           rm -rf "$ENGINE_SRC"
           mkdir -p "$ENGINE_SRC"
+          # REPO-SPLIT FLIP: modules/ moved to microsoft/amplifier-bundle-dot-runner
+          # (Track B). bundles/ STAYS in this repo (opinionated layer), so it is still
+          # tar'd locally; modules/ is now fetched from the runner repo instead of the
+          # workspace checkout, matching what every other consumer's git+ pin does.
+          RUNNER_ENGINE_SOURCE="https://github.com/microsoft/amplifier-bundle-dot-runner"
+          git clone --quiet --depth 1 "$RUNNER_ENGINE_SOURCE" "$ENGINE_SRC/_runner_src"
+          RUNNER_SHA="$(git -C "$ENGINE_SRC/_runner_src" rev-parse HEAD)"
+          mv "$ENGINE_SRC/_runner_src/modules" "$ENGINE_SRC/modules"
+          rm -rf "$ENGINE_SRC/_runner_src"
           # tar, not `cp -a`: the exclusions apply at ARCHIVE time, so a
           # .venv/.git/__pycache__ that somehow already exists in the tree never
           # enters the snapshot at all rather than being copied in and then
@@ -286,10 +295,10 @@ jobs:
             --exclude='.git' \
             --exclude='__pycache__' \
             --exclude='*.pyc' \
-            modules bundles \
+            bundles \
           | tar -xf - -C "$ENGINE_SRC"
-          echo "engine snapshot: $GITHUB_WORKSPACE/{modules,bundles} -> $ENGINE_SRC/"
-          echo "engine snapshot provenance: base SHA $(git rev-parse HEAD)"
+          echo "engine snapshot: modules <- $RUNNER_ENGINE_SOURCE ; bundles <- $GITHUB_WORKSPACE/bundles -> $ENGINE_SRC/"
+          echo "engine snapshot provenance: base SHA $(git rev-parse HEAD); runner SHA $RUNNER_SHA"
           for required in \
             "modules/pipeline-runner/pyproject.toml" \
             "modules/loop-pipeline/pyproject.toml" \

--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ Requirements: install `amplifier-module-loop-pipeline` from the bundle (this pul
 `unified-llm-client` automatically):
 
 ```
-pip install "amplifier-module-loop-pipeline @ git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-pipeline"
+pip install "amplifier-module-loop-pipeline @ git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/loop-pipeline"
 ```
 
 Plus an API key in environment (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or `GEMINI_API_KEY`).

--- a/agents/pipeline-runner.yaml
+++ b/agents/pipeline-runner.yaml
@@ -38,7 +38,7 @@ session:
     # made these relative:  "loop-agent: File not found:
     # .../amplifier_app_cli/_bundle/behaviors/modules/loop-agent" -- and the session
     # refused to start.  See docs/designs/2026-08-15-composition-fix.md.
-    source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-pipeline
+    source: git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/loop-pipeline
     config:
       # Profiles map llm_provider values to child agent names.
       profiles:

--- a/bundle.md
+++ b/bundle.md
@@ -91,7 +91,7 @@ agents:
     session:
       orchestrator:
         module: loop-pipeline
-        source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-pipeline
+        source: git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/loop-pipeline
         config:
           profiles:
             anthropic: attractor-agent-anthropic

--- a/bundles/attractor-interactive.yaml
+++ b/bundles/attractor-interactive.yaml
@@ -91,7 +91,7 @@ agents:
     session:
       orchestrator:
         module: loop-pipeline
-        source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-pipeline
+        source: git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/loop-pipeline
         config:
           profiles:
             anthropic: attractor-agent-anthropic

--- a/bundles/attractor-pipeline.yaml
+++ b/bundles/attractor-pipeline.yaml
@@ -32,7 +32,7 @@ session:
     # made these relative:  "loop-agent: File not found:
     # .../amplifier_app_cli/_bundle/behaviors/modules/loop-agent" -- and the session
     # refused to start.  See docs/designs/2026-08-15-composition-fix.md.
-    source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-pipeline
+    source: git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/loop-pipeline
     config:
       # Maps llm_provider values in DOT node attributes to agent names.
       # The model stylesheet sets llm_provider per node; the engine looks

--- a/docs/APP-INTEGRATION-GUIDE.md
+++ b/docs/APP-INTEGRATION-GUIDE.md
@@ -87,14 +87,14 @@ asyncio.run(main())
 ### Requirements
 
 ```
-pip install "amplifier-module-loop-pipeline @ git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-pipeline"
+pip install "amplifier-module-loop-pipeline @ git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/loop-pipeline"
 ```
 
 This automatically installs `unified-llm-client` (bundled at `modules/unified-llm-client/`
 in the same repo). If you need `unified-llm-client` standalone:
 
 ```
-pip install "unified-llm-client @ git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/unified-llm-client"
+pip install "unified-llm-client @ git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/unified-llm-client"
 ```
 
 Plus at least one API key: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or `GEMINI_API_KEY`.

--- a/modules/loop-agent/pyproject.toml
+++ b/modules/loop-agent/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     # a direct reference keeps that collision-avoidance (uv never queries an
     # index for the name) while surviving `--no-sources`. The path source is
     # retained below for local editable development.
-    "amplifier-unified-llm-client @ git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/unified-llm-client",
+    "amplifier-unified-llm-client @ git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/unified-llm-client",
 ]
 
 [project.entry-points."amplifier.modules"]

--- a/modules/pipeline-runner/dtu/pipeline-runner.yaml
+++ b/modules/pipeline-runner/dtu/pipeline-runner.yaml
@@ -67,7 +67,7 @@ provision:
     # Install the attractor CLI (this module). It declares
     # amplifier-module-loop-pipeline as a real dependency, so a plain install
     # pulls the attractor engine.
-    - uv tool install -vv "git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/pipeline-runner"
+    - uv tool install -vv "git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/pipeline-runner"
 
     # Verify the CLI is on PATH
     - attractor doctor
@@ -76,12 +76,12 @@ provision:
     # Fixtures then live at /root/attractor-src/modules/pipeline-runner/tests/fixtures/
     # e.g. cd /root/attractor-src/modules/pipeline-runner/tests/fixtures
     #      attractor run fixture_box_writes_cwd.dot --cwd /root/attractor-out
-    - git clone --depth 1 https://github.com/microsoft/amplifier-bundle-attractor /root/attractor-src
+    - git clone --depth 1 https://github.com/microsoft/amplifier-bundle-dot-runner /root/attractor-src
 
 update:
   cmds:
     # Pull the latest published runner (and its @main deps).
-    - uv tool install --reinstall -vv "git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/pipeline-runner"
+    - uv tool install --reinstall -vv "git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/pipeline-runner"
     - attractor doctor
 
 readiness:

--- a/profiles/attractor-e2e-pipeline-anthropic.yaml
+++ b/profiles/attractor-e2e-pipeline-anthropic.yaml
@@ -39,7 +39,7 @@ providers:
 session:
   orchestrator:
     module: loop-pipeline
-    source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-pipeline
+    source: git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/loop-pipeline
     config:
       dot_file: ./tests/e2e/fixtures/simple_file_creation.dot
       profiles:

--- a/profiles/attractor-e2e-pipeline-gemini.yaml
+++ b/profiles/attractor-e2e-pipeline-gemini.yaml
@@ -39,7 +39,7 @@ providers:
 session:
   orchestrator:
     module: loop-pipeline
-    source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-pipeline
+    source: git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/loop-pipeline
     config:
       dot_file: ./tests/e2e/fixtures/simple_file_creation_gemini.dot
       profiles:

--- a/skills/attractor-scout/SKILL.md
+++ b/skills/attractor-scout/SKILL.md
@@ -313,7 +313,7 @@ If `attractor` is missing it will say so in the artifact rather than imply a
 pass. You may then ask the user ONCE whether to fetch the public linter via
 `uvx` — **an inbound package fetch; none of their mined data leaves the machine;
 never run it without their yes**. On yes, re-run assemble with
-`--lint-cmd "uvx --from git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/pipeline-runner attractor"`.
+`--lint-cmd "uvx --from git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/pipeline-runner attractor"`.
 If the gates reject the draft it exits non-zero and leaves the verbatim reports
 at `$WORK/demo/$SLUG/gate-report.txt`: re-delegate **ONCE** with those reports
 appended, and if it is still red, do not publish — say so and move on. Then

--- a/skills/attractor-scout/scripts/attractor_scout/demo_templates.py
+++ b/skills/attractor-scout/scripts/attractor_scout/demo_templates.py
@@ -39,13 +39,13 @@ EXPLAINER_URL = "https://microsoft.github.io/amplifier-bundle-attractor/attracto
 
 #: The single source of the install line, quoted in every demo's panel.
 CLI_INSTALL_CMD = (
-    'uv tool install "git+https://github.com/microsoft/amplifier-bundle-attractor'
+    'uv tool install "git+https://github.com/microsoft/amplifier-bundle-dot-runner'
     '@main#subdirectory=modules/pipeline-runner"'
 )
 
 #: The ASK-FIRST inbound fetch. Never run without an explicit yes (rung 2).
 UVX_LINT_CMD = (
-    "uvx --from git+https://github.com/microsoft/amplifier-bundle-attractor"
+    "uvx --from git+https://github.com/microsoft/amplifier-bundle-dot-runner"
     "@main#subdirectory=modules/pipeline-runner attractor"
 )
 


### PR DESCRIPTION
## Summary
The last consumer flip in the repo-split migration: **attractor's own consumption of the engine** now installs from the published `microsoft/amplifier-bundle-dot-runner@main` instead of this repo's in-repo copy. The in-repo engine copy under `modules/` **stays** as the compatibility window (nothing deleted — the "slim" is a separate, later PR gated on all consumer flips merging).

## What flipped (16 pins across 12 files + 3 workflows + review fixes)
1. **Orchestrator sources** — `bundles/attractor-pipeline.yaml`, `bundles/attractor-interactive.yaml`, `profiles/attractor-e2e-pipeline-{anthropic,gemini}.yaml`, `agents/pipeline-runner.yaml`, `bundle.md` → loop-pipeline from dot-runner.
2. **Capsule bundle** — `.github/capsule-pipeline/attractor-pipeline-dual.yaml` (loop-pipeline + tool-report-outcome), with a **ledgered divergence note added to its vendored-copy header** so a future blind re-sync from the pinned private source (d859909) cannot silently revert the flip.
3. **CI workflows restructured** — `capsule-specify.yml`, `feature-specify.yml`, `capsule-implement.yml`: the engine-snapshot step now clones `modules/` from dot-runner instead of tar'ing the local checkout (fails loud: `set -euo pipefail` + required-file checks).
4. **Stayed-module dep** — `modules/loop-agent/pyproject.toml` unified-llm-client → dot-runner (matches dot-runner's own internal sourcing; no mixed-URL closure).
5. **User-facing install strings** — README + APP-INTEGRATION-GUIDE quick-starts, attractor-scout skill (SKILL.md + demo_templates.py), and `modules/pipeline-runner/dtu/pipeline-runner.yaml` (review catch).

## Verification checklist
- [x] Root guard suite **192 passed / 2 skipped** (identical to baseline); OSP-001..003 accept the new URLs and the negative control still REDs with the exact PR #255 message
- [x] Conformance matrix untouched — `git diff origin/main -- specs/` empty; matrix suite green
- [x] loop-agent (stayed module, dep flipped) — `uv sync` + **538 passed**
- [x] Real resolution proof — `uv run --with` the flipped loop-pipeline URL cloned/built/installed from dot-runner; `uvx --from …dot-runner… attractor --help` works (skill-string check)
- [x] Mixed-URL closure check — dot-runner's modules self-reference dot-runner; attractor's flipped closure has no dual-source conflict for any package
- [x] Independent adversarial review — **MERGE-AFTER-FIX**; both required fixes applied (DTU profile pins; vendored-header ledger note)
- [x] Zero deletions under `modules/` (compat window intact); only the one loop-agent pyproject line changed there
- [x] Pre-publication leak review — zero identity values
- [x] CI green before merge — will confirm

## Disclosures
1. **Vendored-copy exception:** `attractor-pipeline-dual.yaml`'s body was hand-edited despite its header's re-sync discipline — recorded as a ledgered divergence in the header itself (the pinned source predates the repo split).
2. **Implicit-HEAD clone:** the workflows' `git clone --depth 1` of dot-runner floats its default branch (`main`) — equivalent drift profile to the `@main` pins used everywhere else.
3. **LEAVE-classed residuals:** old-URL mentions remain in dated design docs/plans/ledgers (historical prose) and in the vestigial in-repo engine modules' own self-referencing pyprojects (correct until the slim PR removes them).

Part of the repo-split migration (runner extracted → consumers flip independently → slim last). After this merges, the slim is gated only on the three external consumer PRs (#137, #319, #27).
