### PR TITLE
Run attractor on any mounted provider (GitHub Copilot included)

### DIFF
--- a/agents/attractor-agent-anthropic.yaml
+++ b/agents/attractor-agent-anthropic.yaml
@@ -2,6 +2,11 @@
 # Uses edit_file with old_string/new_string, 120s shell timeout.
 # Shared definition — referenced by attractor-pipeline, attractor-interactive,
 # and pipeline-runner bundles.
+#
+# Everything identical across the four provider agents (attractor-core, the
+# loop-agent orchestrator + its load-bearing @main self-pin,
+# max_tool_rounds_per_input, context-simple, tool-search) lives in
+# behaviors/attractor-agent-base.yaml.  Only this provider's residue is below.
 
 bundle:
   name: attractor-agent-anthropic
@@ -11,7 +16,7 @@ bundle:
     Uses edit_file with old_string/new_string, 120s shell timeout.
 
 includes:
-  - bundle: attractor:behaviors/attractor-core
+  - bundle: attractor:behaviors/attractor-agent-base
 
 providers:
   - module: provider-anthropic
@@ -22,23 +27,12 @@ providers:
       timeout: 600
 
 session:
+  # Deep-merged OVER attractor-agent-base's session.orchestrator (foundation
+  # composes includes first, then this file; session is deep-merged, later wins
+  # for scalars).  module/source/max_tool_rounds_per_input come from the base.
   orchestrator:
-    module: loop-agent
-    # NOTE: the same-repo `@main` pin is DELIBERATE, and cannot currently be removed.
-    # Unlike tools:/hooks:/providers: sources (resolved at PARSE time against this file's
-    # own directory), a session.orchestrator `source:` is resolved LATE against the
-    # COMPOSED ROOT's base_path -- which in a real amplifier session is the APP's own
-    # bundle directory, not this bundle's.  Measured, from a DTU install of a branch that
-    # made these relative:  "loop-agent: File not found:
-    # .../amplifier_app_cli/_bundle/behaviors/modules/loop-agent" -- and the session
-    # refused to start.  See docs/designs/2026-08-15-composition-fix.md.
-    source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
     config:
-      max_tool_rounds_per_input: 50
       default_command_timeout_ms: 120000
-  context:
-    module: context-simple
-    source: git+https://github.com/microsoft/amplifier-module-context-simple@main
 
 tools:
   - module: tool-filesystem

--- a/agents/attractor-agent-copilot.yaml
+++ b/agents/attractor-agent-copilot.yaml
@@ -1,0 +1,58 @@
+# GitHub Copilot coding agent (Claude Code aligned)
+# Uses edit_file with old_string/new_string, 120s shell timeout.
+# Shared definition -- referenced by attractor-pipeline, attractor-interactive,
+# and pipeline-runner bundles.
+
+bundle:
+  name: attractor-agent-copilot
+  version: 0.1.0
+  description: >
+    GitHub Copilot coding agent (Claude Code aligned).
+    Uses edit_file with old_string/new_string, 120s shell timeout.
+
+includes:
+  - bundle: attractor:behaviors/attractor-core
+
+providers:
+  - module: provider-github-copilot
+    source: git+https://github.com/microsoft/amplifier-module-provider-github-copilot@main
+    config:
+      default_model: claude-sonnet-4.6
+      timeout: 600
+
+session:
+  orchestrator:
+    module: loop-agent
+    # NOTE: the same-repo `@main` pin is DELIBERATE, and cannot currently be removed.
+    # Unlike tools:/hooks:/providers: sources (resolved at PARSE time against this file's
+    # own directory), a session.orchestrator `source:` is resolved LATE against the
+    # COMPOSED ROOT's base_path -- which in a real amplifier session is the APP's own
+    # bundle directory, not this bundle's.  Measured, from a DTU install of a branch that
+    # made these relative:  "loop-agent: File not found:
+    # .../amplifier_app_cli/_bundle/behaviors/modules/loop-agent" -- and the session
+    # refused to start.  See docs/designs/2026-08-15-composition-fix.md.
+    source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
+    config:
+      max_tool_rounds_per_input: 50
+      default_command_timeout_ms: 120000
+      # INTERIM PIN (issue #0 workaround): loop-agent derives the Layer-1 base
+      # prompt via canonical_provider(provider_name), which returns None for
+      # "github-copilot" and RAISES at every spawn. Pinning an explicit
+      # system_prompt_file bypasses that lookup entirely. This hand-pins ONE
+      # prompt family (anthropic's) for every node using this agent -- it is
+      # not provider-accurate, just unblocking -- until canonical_provider
+      # gains a github-copilot->family mapping (deferred fix).
+      system_prompt_file: context/system-anthropic.md
+  context:
+    module: context-simple
+    source: git+https://github.com/microsoft/amplifier-module-context-simple@main
+
+tools:
+  - module: tool-filesystem
+    source: git+https://github.com/microsoft/amplifier-module-tool-filesystem@main
+  - module: tool-bash
+    source: git+https://github.com/microsoft/amplifier-module-tool-bash@main
+    config:
+      timeout: 120
+  - module: tool-search
+    source: git+https://github.com/microsoft/amplifier-module-tool-search@main

--- a/agents/attractor-agent-copilot.yaml
+++ b/agents/attractor-agent-copilot.yaml
@@ -2,6 +2,11 @@
 # Uses edit_file with old_string/new_string, 120s shell timeout.
 # Shared definition -- referenced by attractor-pipeline, attractor-interactive,
 # and pipeline-runner bundles.
+#
+# Everything identical across the four provider agents (attractor-core, the
+# loop-agent orchestrator + its load-bearing @main self-pin,
+# max_tool_rounds_per_input, context-simple, tool-search) lives in
+# behaviors/attractor-agent-base.yaml.  Only this provider's residue is below.
 
 bundle:
   name: attractor-agent-copilot
@@ -11,7 +16,7 @@ bundle:
     Uses edit_file with old_string/new_string, 120s shell timeout.
 
 includes:
-  - bundle: attractor:behaviors/attractor-core
+  - bundle: attractor:behaviors/attractor-agent-base
 
 providers:
   - module: provider-github-copilot
@@ -21,31 +26,23 @@ providers:
       timeout: 600
 
 session:
+  # Deep-merged OVER attractor-agent-base's session.orchestrator (foundation
+  # composes includes first, then this file; session is deep-merged, later wins
+  # for scalars).  module/source/max_tool_rounds_per_input come from the base.
   orchestrator:
-    module: loop-agent
-    # NOTE: the same-repo `@main` pin is DELIBERATE, and cannot currently be removed.
-    # Unlike tools:/hooks:/providers: sources (resolved at PARSE time against this file's
-    # own directory), a session.orchestrator `source:` is resolved LATE against the
-    # COMPOSED ROOT's base_path -- which in a real amplifier session is the APP's own
-    # bundle directory, not this bundle's.  Measured, from a DTU install of a branch that
-    # made these relative:  "loop-agent: File not found:
-    # .../amplifier_app_cli/_bundle/behaviors/modules/loop-agent" -- and the session
-    # refused to start.  See docs/designs/2026-08-15-composition-fix.md.
-    source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
     config:
-      max_tool_rounds_per_input: 50
       default_command_timeout_ms: 120000
-      # INTERIM PIN (issue #0 workaround): loop-agent derives the Layer-1 base
-      # prompt via canonical_provider(provider_name), which returns None for
-      # "github-copilot" and RAISES at every spawn. Pinning an explicit
-      # system_prompt_file bypasses that lookup entirely. This hand-pins ONE
-      # prompt family (anthropic's) for every node using this agent -- it is
-      # not provider-accurate, just unblocking -- until canonical_provider
-      # gains a github-copilot->family mapping (deferred fix).
-      system_prompt_file: context/system-anthropic.md
-  context:
-    module: context-simple
-    source: git+https://github.com/microsoft/amplifier-module-context-simple@main
+      # Layer-1 base prompt selection follows the MOUNTED TOOLSET, not the
+      # provider/model: context/system-<name>.md files are toolset prompts
+      # (anthropic = edit_file toolset, openai = apply_patch toolset,
+      # gemini = web-tools toolset), not model-family prompts.
+      # canonical_provider("github-copilot") returns None (Copilot can run
+      # several underlying model families, so it can't be derived from the
+      # provider name alone) -- this agent declares prompt_profile: anthropic
+      # because it mounts the SAME toolset (tool-filesystem full + tool-bash +
+      # tool-search) as the anthropic agent. This is an accurate declaration
+      # of what this agent mounts, not a workaround.
+      prompt_profile: anthropic
 
 tools:
   - module: tool-filesystem

--- a/agents/attractor-agent-gemini.yaml
+++ b/agents/attractor-agent-gemini.yaml
@@ -2,6 +2,11 @@
 # Uses edit_file, includes web tools for grounding.
 # Shared definition — referenced by attractor-pipeline, attractor-interactive,
 # and pipeline-runner bundles.
+#
+# Everything identical across the four provider agents (attractor-core, the
+# loop-agent orchestrator + its load-bearing @main self-pin,
+# max_tool_rounds_per_input, context-simple, tool-search) lives in
+# behaviors/attractor-agent-base.yaml.  Only this provider's residue is below.
 
 bundle:
   name: attractor-agent-gemini
@@ -11,7 +16,7 @@ bundle:
     Uses edit_file, includes web tools for grounding.
 
 includes:
-  - bundle: attractor:behaviors/attractor-core
+  - bundle: attractor:behaviors/attractor-agent-base
 
 providers:
   - module: provider-gemini
@@ -22,23 +27,12 @@ providers:
       timeout: 600
 
 session:
+  # Deep-merged OVER attractor-agent-base's session.orchestrator (foundation
+  # composes includes first, then this file; session is deep-merged, later wins
+  # for scalars).  module/source/max_tool_rounds_per_input come from the base.
   orchestrator:
-    module: loop-agent
-    # NOTE: the same-repo `@main` pin is DELIBERATE, and cannot currently be removed.
-    # Unlike tools:/hooks:/providers: sources (resolved at PARSE time against this file's
-    # own directory), a session.orchestrator `source:` is resolved LATE against the
-    # COMPOSED ROOT's base_path -- which in a real amplifier session is the APP's own
-    # bundle directory, not this bundle's.  Measured, from a DTU install of a branch that
-    # made these relative:  "loop-agent: File not found:
-    # .../amplifier_app_cli/_bundle/behaviors/modules/loop-agent" -- and the session
-    # refused to start.  See docs/designs/2026-08-15-composition-fix.md.
-    source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
     config:
-      max_tool_rounds_per_input: 50
       default_command_timeout_ms: 10000
-  context:
-    module: context-simple
-    source: git+https://github.com/microsoft/amplifier-module-context-simple@main
 
 tools:
   - module: tool-filesystem

--- a/agents/attractor-agent-openai.yaml
+++ b/agents/attractor-agent-openai.yaml
@@ -2,6 +2,11 @@
 # Uses native apply_patch (Responses API built-in), restricted filesystem, 10s shell timeout.
 # Shared definition — referenced by attractor-pipeline, attractor-interactive,
 # and pipeline-runner bundles.
+#
+# Everything identical across the four provider agents (attractor-core, the
+# loop-agent orchestrator + its load-bearing @main self-pin,
+# max_tool_rounds_per_input, context-simple, tool-search) lives in
+# behaviors/attractor-agent-base.yaml.  Only this provider's residue is below.
 
 bundle:
   name: attractor-agent-openai
@@ -11,7 +16,7 @@ bundle:
     Uses native apply_patch (Responses API built-in), restricted filesystem, 10s shell timeout.
 
 includes:
-  - bundle: attractor:behaviors/attractor-core
+  - bundle: attractor:behaviors/attractor-agent-base
 
 providers:
   - module: provider-openai
@@ -22,23 +27,12 @@ providers:
       timeout: 600
 
 session:
+  # Deep-merged OVER attractor-agent-base's session.orchestrator (foundation
+  # composes includes first, then this file; session is deep-merged, later wins
+  # for scalars).  module/source/max_tool_rounds_per_input come from the base.
   orchestrator:
-    module: loop-agent
-    # NOTE: the same-repo `@main` pin is DELIBERATE, and cannot currently be removed.
-    # Unlike tools:/hooks:/providers: sources (resolved at PARSE time against this file's
-    # own directory), a session.orchestrator `source:` is resolved LATE against the
-    # COMPOSED ROOT's base_path -- which in a real amplifier session is the APP's own
-    # bundle directory, not this bundle's.  Measured, from a DTU install of a branch that
-    # made these relative:  "loop-agent: File not found:
-    # .../amplifier_app_cli/_bundle/behaviors/modules/loop-agent" -- and the session
-    # refused to start.  See docs/designs/2026-08-15-composition-fix.md.
-    source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
     config:
-      max_tool_rounds_per_input: 50
       default_command_timeout_ms: 10000
-  context:
-    module: context-simple
-    source: git+https://github.com/microsoft/amplifier-module-context-simple@main
 
 tools:
   - module: tool-apply-patch

--- a/behaviors/attractor-agent-base.yaml
+++ b/behaviors/attractor-agent-base.yaml
@@ -1,0 +1,67 @@
+# Shared skeleton for the four per-provider attractor coding agents.
+#
+# agents/attractor-agent-{anthropic,openai,gemini,copilot}.yaml were ~90%
+# byte-identical copies of each other.  Everything that was IDENTICAL across all
+# four now lives here, once; each agent keeps only its real per-provider residue
+# (its provider module + config, its shell timeouts, its mounted toolset, and --
+# for copilot -- its prompt_profile declaration).
+#
+# HOW THIS COMPOSES (foundation, verified against the installed foundation source):
+#   amplifier_foundation/registry.py:_load_includes --
+#     "Compose: includes first, then current bundle overrides (order matters here)"
+#     result = included[0].compose(included[1])... ; return result.compose(bundle)
+#   amplifier_foundation/bundle/_dataclass.py:Bundle.compose --
+#     "session/spawn: deep merge (nested dicts merged, later wins for scalars)"
+#     result.session = deep_merge(result.session, other.session)
+# So the `session.orchestrator` block declared HERE is the parent layer, and each
+# including agent's own `session.orchestrator.config` is deep-merged OVER it --
+# which is exactly how `default_command_timeout_ms` (and copilot's
+# `prompt_profile`) stay per-agent while `module`/`source`/
+# `max_tool_rounds_per_input` are stated once.
+#
+# This file is NOT a general-purpose behavior: it is the agents' shared base and
+# is included ONLY by agents/attractor-agent-*.yaml.  Do not include it from a
+# pipeline or root composition -- it would install loop-agent as that
+# composition's orchestrator.
+
+bundle:
+  name: attractor-agent-base
+  version: 0.1.0
+  description: >
+    Shared base for the per-provider attractor coding agents: attractor-core,
+    the loop-agent orchestrator (with its load-bearing self-pin), and the
+    context-simple context module.  Tools stay per-agent (see the tools note
+    below) to keep the composed tool order byte-identical.
+
+includes:
+  - bundle: attractor:behaviors/attractor-core
+
+session:
+  orchestrator:
+    module: loop-agent
+    # NOTE: the same-repo `@main` pin is DELIBERATE, and cannot currently be removed.
+    # Unlike tools:/hooks:/providers: sources (resolved at PARSE time against this file's
+    # own directory), a session.orchestrator `source:` is resolved LATE against the
+    # COMPOSED ROOT's base_path -- which in a real amplifier session is the APP's own
+    # bundle directory, not this bundle's.  Measured, from a DTU install of a branch that
+    # made these relative:  "loop-agent: File not found:
+    # .../amplifier_app_cli/_bundle/behaviors/modules/loop-agent" -- and the session
+    # refused to start.  See docs/designs/2026-08-15-composition-fix.md.
+    source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
+    config:
+      # Identical across all four provider agents.  Per-agent knobs
+      # (default_command_timeout_ms, copilot's prompt_profile) are deep-merged
+      # over this by the including agent.
+      max_tool_rounds_per_input: 50
+  context:
+    module: context-simple
+    source: git+https://github.com/microsoft/amplifier-module-context-simple@main
+
+# NOTE: `tools:` is intentionally NOT deduplicated here.  Every provider agent
+# mounts tool-search, but foundation's merge_module_lists is parent-first, so a
+# tool-search entry declared in this base would compose in BEFORE each agent's
+# tool-filesystem/tool-bash instead of after them -- reordering the composed
+# tools list and changing the tool-schema order presented to the model.  This
+# refactor is pure relocation with ZERO behavioral delta, so tool-search stays
+# in each agent file at its original (last) position.  The dedup win here is the
+# session.orchestrator self-pin + max_tool_rounds_per_input + context-simple.

--- a/bundles/attractor-pipeline-copilot.yaml
+++ b/bundles/attractor-pipeline-copilot.yaml
@@ -1,0 +1,127 @@
+bundle:
+  name: attractor-pipeline-copilot
+  version: 0.1.0
+  description: >
+    GitHub Copilot variant of the Attractor pipeline, for key-free runs where
+    auth is a GitHub token instead of Anthropic/OpenAI/Gemini API keys. All
+    worker nodes route to Copilot by default.
+
+    Provide a DOT graph via orchestrator config:
+      config.dot_file:   path to a .dot file
+      config.dot_source: inline DOT digraph string
+
+includes:
+  - bundle: attractor:behaviors/attractor-core
+
+# --- Pipeline orchestrator provider (used for orchestrator reasoning) -------
+providers:
+  - module: provider-github-copilot
+    source: git+https://github.com/microsoft/amplifier-module-provider-github-copilot@main
+    config:
+      default_model: claude-sonnet-4.6
+
+# --- Pipeline orchestrator session ------------------------------------------
+session:
+  orchestrator:
+    module: loop-pipeline
+    # NOTE: the same-repo `@main` pin is DELIBERATE, and cannot currently be removed.
+    # Unlike tools:/hooks:/providers: sources (resolved at PARSE time against this file's
+    # own directory), a session.orchestrator `source:` is resolved LATE against the
+    # COMPOSED ROOT's base_path -- which in a real amplifier session is the APP's own
+    # bundle directory, not this bundle's.  Measured, from a DTU install of a branch that
+    # made these relative:  "loop-agent: File not found:
+    # .../amplifier_app_cli/_bundle/behaviors/modules/loop-agent" -- and the session
+    # refused to start.  See docs/designs/2026-08-15-composition-fix.md.
+    source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-pipeline
+    config:
+      # Maps llm_provider values in DOT node attributes to agent names.
+      # The model stylesheet sets llm_provider per node; the engine looks
+      # up this map to spawn the correct child agent session.
+      profiles:
+        anthropic: attractor-agent-anthropic
+        openai: attractor-agent-openai
+        gemini: attractor-agent-gemini
+        github-copilot: attractor-agent-copilot
+      # User must provide one of:
+      #   dot_file:   ./path/to/pipeline.dot
+      #   dot_source: "digraph { ... }"
+  context:
+    module: context-simple
+    source: git+https://github.com/microsoft/amplifier-module-context-simple@main
+
+# --- Pipeline orchestrator tools (filesystem access for the orchestrator) ----
+tools:
+  - module: tool-filesystem
+    source: git+https://github.com/microsoft/amplifier-module-tool-filesystem@main
+  - module: tool-bash
+    source: git+https://github.com/microsoft/amplifier-module-tool-bash@main
+    config:
+      timeout: 120
+  - module: tool-search
+    source: git+https://github.com/microsoft/amplifier-module-tool-search@main
+
+# --- Child agents (one per provider, spawned by the pipeline engine) ---------
+# IMPORTANT: inline session.orchestrator is REQUIRED here.  The spawn capability merges
+# the agent's session: key onto the parent config; without an explicit session.orchestrator
+# the child inherits the parent's loop-pipeline orchestrator and recurses.
+agents:
+  # Inline session.orchestrator is REQUIRED (passes the loop-pipeline recursion
+  # guard, which checks orchestrator.module). The Layer-1 base prompt is supplied
+  # by loop-agent's provider default (context/system-<provider>.md), so no
+  # per-agent system_prompt_file is needed here.
+  attractor-agent-anthropic:
+    description: >
+      Anthropic coding agent (Claude Code aligned).
+      Uses edit_file with old_string/new_string, 120s shell timeout.
+    session:
+      orchestrator:
+        module: loop-agent
+        source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
+        config:
+          max_tool_rounds_per_input: 50
+          default_command_timeout_ms: 120000
+  attractor-agent-openai:
+    description: >
+      OpenAI coding agent (codex-rs aligned).
+      Uses native apply_patch (Responses API built-in), restricted filesystem, 10s shell timeout.
+    session:
+      orchestrator:
+        module: loop-agent
+        source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
+        config:
+          max_tool_rounds_per_input: 50
+          default_command_timeout_ms: 10000
+  attractor-agent-gemini:
+    description: >
+      Gemini coding agent (gemini-cli aligned).
+      Uses edit_file, includes web tools for grounding.
+    session:
+      orchestrator:
+        module: loop-agent
+        source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
+        config:
+          max_tool_rounds_per_input: 50
+          default_command_timeout_ms: 10000
+  attractor-agent-copilot:
+    description: >
+      GitHub Copilot coding agent (Claude Code aligned).
+      Uses edit_file with old_string/new_string, 120s shell timeout.
+    session:
+      orchestrator:
+        module: loop-agent
+        source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
+        config:
+          max_tool_rounds_per_input: 50
+          default_command_timeout_ms: 120000
+          # Layer-1 base prompt selection follows the MOUNTED TOOLSET, not
+          # the provider/model: context/system-<name>.md files are toolset
+          # prompts (anthropic = edit_file toolset, openai = apply_patch
+          # toolset, gemini = web-tools toolset), not model-family prompts.
+          # canonical_provider("github-copilot") returns None (Copilot can
+          # run several underlying model families, so it can't be derived
+          # from the provider name alone) -- this agent declares
+          # prompt_profile: anthropic because it mounts the SAME toolset
+          # (tool-filesystem full + tool-bash + tool-search) as the
+          # anthropic agent. This is an accurate declaration of what this
+          # agent mounts, not a workaround.
+          prompt_profile: anthropic

--- a/bundles/attractor-pipeline.yaml
+++ b/bundles/attractor-pipeline.yaml
@@ -41,6 +41,7 @@ session:
         anthropic: attractor-agent-anthropic
         openai: attractor-agent-openai
         gemini: attractor-agent-gemini
+        github-copilot: attractor-agent-copilot
       # User must provide one of:
       #   dot_file:   ./path/to/pipeline.dot
       #   dot_source: "digraph { ... }"
@@ -101,3 +102,23 @@ agents:
         config:
           max_tool_rounds_per_input: 50
           default_command_timeout_ms: 10000
+  attractor-agent-copilot:
+    description: >
+      GitHub Copilot coding agent (Claude Code aligned).
+      Uses edit_file with old_string/new_string, 120s shell timeout.
+    session:
+      orchestrator:
+        module: loop-agent
+        source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
+        config:
+          max_tool_rounds_per_input: 50
+          default_command_timeout_ms: 120000
+          # INTERIM PIN (issue #0 workaround): loop-agent derives the Layer-1
+          # base prompt via canonical_provider(provider_name), which returns
+          # None for "github-copilot" and RAISES at every spawn. Pinning an
+          # explicit system_prompt_file bypasses that lookup entirely. This
+          # hand-pins ONE prompt family (anthropic's) for every node using
+          # this agent -- not provider-accurate, just unblocking -- until
+          # canonical_provider gains a github-copilot->family mapping
+          # (deferred fix).
+          system_prompt_file: context/system-anthropic.md

--- a/bundles/attractor-pipeline.yaml
+++ b/bundles/attractor-pipeline.yaml
@@ -113,12 +113,15 @@ agents:
         config:
           max_tool_rounds_per_input: 50
           default_command_timeout_ms: 120000
-          # INTERIM PIN (issue #0 workaround): loop-agent derives the Layer-1
-          # base prompt via canonical_provider(provider_name), which returns
-          # None for "github-copilot" and RAISES at every spawn. Pinning an
-          # explicit system_prompt_file bypasses that lookup entirely. This
-          # hand-pins ONE prompt family (anthropic's) for every node using
-          # this agent -- not provider-accurate, just unblocking -- until
-          # canonical_provider gains a github-copilot->family mapping
-          # (deferred fix).
-          system_prompt_file: context/system-anthropic.md
+          # Layer-1 base prompt selection follows the MOUNTED TOOLSET, not
+          # the provider/model: context/system-<name>.md files are toolset
+          # prompts (anthropic = edit_file toolset, openai = apply_patch
+          # toolset, gemini = web-tools toolset), not model-family prompts.
+          # canonical_provider("github-copilot") returns None (Copilot can
+          # run several underlying model families, so it can't be derived
+          # from the provider name alone) -- this agent declares
+          # prompt_profile: anthropic because it mounts the SAME toolset
+          # (tool-filesystem full + tool-bash + tool-search) as the
+          # anthropic agent. This is an accurate declaration of what this
+          # agent mounts, not a workaround.
+          prompt_profile: anthropic

--- a/modules/loop-agent/amplifier_module_loop_agent/__init__.py
+++ b/modules/loop-agent/amplifier_module_loop_agent/__init__.py
@@ -150,7 +150,7 @@ class AgentOrchestrator:
     def _resolve_base_prompt(
         self, config_dict: dict[str, Any], provider_name: str
     ) -> str:
-        """Resolve the Layer-1 base prompt with a 4-step precedence.
+        """Resolve the Layer-1 base prompt with a 5-step precedence.
 
         Precedence (first that applies wins):
           1. explicit ``system_prompt`` in config        -> used as-is
@@ -159,11 +159,25 @@ class AgentOrchestrator:
              resolver), where ``<provider>`` is the canonical provider derived
              from the agent's own mounted provider — the same provider used for
              the actual completion, so the base always matches the model called.
-          4. unknown provider, or a configured/default file that does not exist
-             -> a CLEAR, ACTIONABLE error (never a silent wrong/empty base).
+          4. opt-in ``prompt_profile`` in config, consulted ONLY when the
+             provider name does not map to a known family (step 3 is None) ->
+             ``context/system-<prompt_profile>.md``, loaded the same way as
+             ``system_prompt_file``. This is NOT a model/provider guess: the
+             ``system-<name>.md`` files are TOOLSET prompts (anthropic =
+             edit_file toolset, openai = apply_patch toolset, gemini = web-tools
+             toolset), not model-family prompts. A multi-family provider (e.g.
+             "github-copilot", which can run several underlying model families)
+             cannot be resolved from its provider name alone, so its agent
+             declares which toolset prompt matches what it actually MOUNTS
+             (e.g. ``prompt_profile: anthropic`` when it mounts the same
+             tool-filesystem/tool-bash/tool-search set as the anthropic agent).
+          5. unknown provider with no declared ``prompt_profile``, or a
+             configured/default file that does not exist -> a CLEAR, ACTIONABLE
+             error (never a silent wrong/empty base).
 
-        Explicit config (1, 2) always overrides the provider default (3), so a
-        non-coding agent (e.g. attractor-expert) can pin its own persona base.
+        Explicit config (1, 2) always overrides the provider default (3) and the
+        opt-in profile (4), so a non-coding agent (e.g. attractor-expert) can pin
+        its own persona base.
 
         See docs/designs/layer-1-profile-owned-system-prompt.md §Mechanism.
         """
@@ -172,25 +186,40 @@ class AgentOrchestrator:
         if existing:
             return existing
 
-        # (2) explicit system_prompt_file, else (3) provider default.
+        # (2) explicit system_prompt_file, else (3) provider default, else (4)
+        # opt-in prompt_profile.
         spf = config_dict.get("system_prompt_file", "")
         if not spf:
             canonical = canonical_provider(provider_name)
             if canonical is None:
-                # (4) unknown provider — do NOT guess a base; fail loud and clear.
-                raise RuntimeError(
-                    f"loop-agent cannot select a Layer-1 base prompt: no "
-                    f"system_prompt or system_prompt_file is configured, and the "
-                    f"provider {provider_name!r} is not one of the known providers "
-                    f"{KNOWN_PROVIDERS} (so no default context/system-<provider>.md "
-                    f"applies). Set an explicit system_prompt_file in "
-                    f"session.orchestrator.config, or run under a known provider. "
-                    f"See docs/designs/layer-1-profile-owned-system-prompt.md."
-                )
-            spf = f"context/system-{canonical}.md"
+                # (4) opt-in prompt_profile: the agent declares which toolset
+                # prompt it mounts, for providers whose name doesn't map to a
+                # known family (e.g. "github-copilot").
+                declared = config_dict.get("prompt_profile")
+                if not declared:
+                    # (5) unknown provider, no declared profile — do NOT guess
+                    # a base; fail loud and clear.
+                    raise RuntimeError(
+                        f"loop-agent cannot select a Layer-1 base prompt: no "
+                        f"system_prompt or system_prompt_file is configured, and "
+                        f"the provider {provider_name!r} is not one of the known "
+                        f"providers {KNOWN_PROVIDERS} (so no default "
+                        f"context/system-<provider>.md applies). Set an explicit "
+                        f"system_prompt_file in session.orchestrator.config, run "
+                        f"under a known provider, or — for multi-family "
+                        f"providers like 'github-copilot' that mount an existing "
+                        f"toolset — set prompt_profile to the toolset prompt "
+                        f"this agent's mounted tools match, e.g. "
+                        f"prompt_profile: anthropic. "
+                        f"See docs/designs/layer-1-profile-owned-system-prompt.md."
+                    )
+                spf = f"context/system-{declared}.md"
+            else:
+                spf = f"context/system-{canonical}.md"
 
-        # (2)/(3) load via the robust, CWD-independent resolver. A missing file
-        # raises a clear FileNotFoundError naming the value and path tried — (4).
+        # (2)/(3)/(4) load via the robust, CWD-independent resolver. A missing
+        # file raises a clear FileNotFoundError naming the value and path
+        # tried — (5).
         return _resolve_system_prompt_file(spf).read_text(encoding="utf-8")
 
     async def _execute_session(

--- a/modules/loop-agent/tests/test_system_prompt_wiring.py
+++ b/modules/loop-agent/tests/test_system_prompt_wiring.py
@@ -1060,3 +1060,151 @@ async def test_magicmock_coordinator_not_coerced_to_string():
         f"Working directory value is not an absolute path: {wd_value!r} — "
         "MagicMock was coerced to string instead of falling back to os.getcwd()"
     )
+
+
+# ---------------------------------------------------------------------------
+# Opt-in prompt_profile fallback (FIX #0): multi-family providers like
+# "github-copilot" don't map to a known KNOWN_PROVIDERS family via
+# canonical_provider(), so an agent can declare which TOOLSET prompt it
+# mounts via prompt_profile, instead of loop-agent raising.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unknown_provider_with_prompt_profile_loads_declared_toolset_prompt():
+    """Unknown provider + prompt_profile: anthropic -> loads system-anthropic.md, no raise.
+
+    This is the core FIX #0 behavior: "github-copilot" does not canonicalize
+    (canonical_provider returns None), but the agent declares prompt_profile:
+    anthropic because it mounts the same edit_file toolset as the anthropic
+    agent. loop-agent must resolve context/system-anthropic.md and must NOT
+    raise.
+    """
+    context = MagicMock()
+    provider = AsyncMock()
+    provider.complete = AsyncMock(return_value=_text_response("done"))
+    hooks = _make_hooks()
+    coordinator = MagicMock()
+    coordinator.register_capability = MagicMock()
+
+    orch = AgentOrchestrator(
+        coordinator=coordinator,
+        config={
+            "prompt_profile": "anthropic",
+            "max_tool_rounds_per_input": 1,
+        },
+    )
+    # "github-copilot" is not a KNOWN_PROVIDERS family -> canonical_provider()
+    # returns None -> prompt_profile must be consulted instead of raising.
+    await orch.execute(
+        "hello", context, {"github-copilot": provider}, {}, hooks
+    )
+
+    request = provider.complete.call_args[0][0]
+    system_content = request.messages[0].content
+    assert "Anthropic Profile" in system_content or "Claude Code" in system_content, (
+        f"prompt_profile did not load the declared toolset prompt. "
+        f"Got: {system_content[:200]}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_unknown_provider_without_prompt_profile_still_raises():
+    """Unknown provider + no prompt_profile (and no explicit base) still raises loud.
+
+    prompt_profile is opt-in: an unknown provider that does NOT declare one
+    must keep failing loud rather than silently picking a base.
+    """
+    context = MagicMock()
+    provider = AsyncMock()
+    provider.complete = AsyncMock(return_value=_text_response("done"))
+    hooks = _make_hooks()
+    coordinator = MagicMock()
+    coordinator.register_capability = MagicMock()
+
+    orch = AgentOrchestrator(
+        coordinator=coordinator,
+        config={"max_tool_rounds_per_input": 1},  # no prompt_profile set
+    )
+    with pytest.raises(RuntimeError, match="not one of the known providers"):
+        await orch.execute(
+            "hello", context, {"github-copilot": provider}, {}, hooks
+        )
+
+
+@pytest.mark.asyncio
+async def test_system_prompt_file_overrides_prompt_profile():
+    """Explicit system_prompt_file still overrides prompt_profile (precedence 2 > 4).
+
+    prompt_profile sits at the same layer as the provider-name default: it is
+    only consulted when there is no explicit system_prompt / system_prompt_file
+    AND canonical_provider() returns None. An explicit system_prompt_file must
+    win outright, even when prompt_profile is also set.
+    """
+    FILE_SENTINEL = "SYSTEM-PROMPT-FILE-WINS-OVER-PROFILE"
+    context = MagicMock()
+    provider = AsyncMock()
+    provider.complete = AsyncMock(return_value=_text_response("done"))
+    hooks = _make_hooks()
+    coordinator = MagicMock()
+    coordinator.register_capability = MagicMock()
+
+    import os
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp:
+        prompt_file = os.path.join(tmp, "base.md")
+        with open(prompt_file, "w", encoding="utf-8") as f:
+            f.write(f"# Explicit File\n\n{FILE_SENTINEL}")
+
+        orch = AgentOrchestrator(
+            coordinator=coordinator,
+            config={
+                "system_prompt_file": prompt_file,
+                # Deliberately also set, to prove it's ignored when
+                # system_prompt_file is present.
+                "prompt_profile": "anthropic",
+                "max_tool_rounds_per_input": 1,
+            },
+        )
+        await orch.execute(
+            "hello", context, {"github-copilot": provider}, {}, hooks
+        )
+
+        request = provider.complete.call_args[0][0]
+        system_content = request.messages[0].content
+        assert FILE_SENTINEL in system_content, (
+            f"system_prompt_file not used. Got: {system_content[:200]}"
+        )
+        assert "Anthropic Profile" not in system_content, (
+            "prompt_profile leaked through despite system_prompt_file being set"
+        )
+
+
+@pytest.mark.asyncio
+async def test_known_provider_path_unchanged_by_prompt_profile():
+    """A known provider (anthropic) still resolves its own default, ignoring
+    prompt_profile even if (incorrectly) set -- prompt_profile is only
+    consulted when canonical_provider() returns None (precedence 3 beats 4)."""
+    context = MagicMock()
+    provider = AsyncMock()
+    provider.complete = AsyncMock(return_value=_text_response("done"))
+    hooks = _make_hooks()
+    coordinator = MagicMock()
+    coordinator.register_capability = MagicMock()
+
+    orch = AgentOrchestrator(
+        coordinator=coordinator,
+        config={
+            "prompt_profile": "gemini",  # must be ignored: anthropic canonicalizes
+            "max_tool_rounds_per_input": 1,
+        },
+    )
+    await orch.execute("hello", context, {"anthropic": provider}, {}, hooks)
+
+    request = provider.complete.call_args[0][0]
+    system_content = request.messages[0].content
+    assert "Anthropic Profile" in system_content or "Claude Code" in system_content, (
+        f"known-provider default not loaded; prompt_profile wrongly took over. "
+        f"Got: {system_content[:200]}"
+    )

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/__init__.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/__init__.py
@@ -52,12 +52,21 @@ class DirectProviderBackend:
         hooks: Any = None,
         coordinator: Any = None,
         unified_client: Any | None = None,
+        *,
+        default_provider: str | None = None,
+        mounted_providers: tuple[str, ...] = (),
     ) -> None:
         self._provider = provider
         self._tools = tools or {}
         self._hooks = hooks
         self._coordinator = coordinator
         self._unified_client = unified_client
+        # Engine-resolved default llm_provider for bare nodes (sole mounted
+        # provider, or None when zero/multiple are mounted -- see
+        # _resolve_default_provider() below and _resolve_node_provider() in
+        # .backend, the single shared resolution rule for both backends).
+        self._default_provider = default_provider
+        self._mounted_providers = mounted_providers
         # Fidelity state (H-9): track completed nodes and message history
         self._completed_nodes: dict[str, Any] = {}
         self._message_pools: dict[str, list] = {}  # thread_key -> unified_llm Messages
@@ -88,6 +97,7 @@ class DirectProviderBackend:
             _parse_outcome,
             _resolve_concrete_model,
             _resolve_model,
+            _resolve_node_provider,
             _STATUS_MAP,
             _MAX_TOOL_LOOP_ROUNDS,
         )
@@ -104,10 +114,8 @@ class DirectProviderBackend:
             )
 
         # Resolve model, provider, tools, reasoning, max_agent_turns
-        provider_name = (
-            node.llm_provider
-            if hasattr(node, "llm_provider") and node.llm_provider
-            else node.attrs.get("llm_provider", "anthropic")
+        provider_name = _resolve_node_provider(
+            node, self._default_provider, self._mounted_providers
         )
         model = await _resolve_concrete_model(
             provider_name, _resolve_model(node), emit=self._emit
@@ -486,6 +494,20 @@ def _spawn_resolvable_agents(coordinator: Any | None) -> frozenset[str] | None:
     return frozenset(str(name) for name in agents)
 
 
+def _resolve_default_provider(providers: dict[str, Any]) -> str | None:
+    """Engine default llm_provider when a node declares none.
+
+    Sole-mounted -> that provider (provider-agnostic completion of engine intent;
+    also byte-for-byte legacy behavior for shipped single-orchestrator-provider bundles).
+    >1 mounted and unspecified is ambiguous -> None here, resolution sites raise.
+    Zero mounted -> None -> simulation mode.
+    """
+    if not providers:
+        return None
+    names = list(providers.keys())
+    return names[0] if len(names) == 1 else None
+
+
 def _build_backend(
     providers: dict[str, Any],
     tools: dict[str, Any],
@@ -506,6 +528,8 @@ def _build_backend(
        simulation mode).
     """
     first_provider = next(iter(providers.values()), None) if providers else None
+    default_provider = _resolve_default_provider(providers)
+    mounted_names = tuple(providers.keys())
 
     # Try the full spawn-based backend first
     if coordinator is not None:
@@ -541,12 +565,21 @@ def _build_backend(
                 provider=first_provider,
                 tools=tools,
                 hooks=hooks,
+                default_provider=default_provider,
+                mounted_providers=mounted_names,
             )
 
     # Fall back to direct provider tool loop
     if first_provider is not None:
         logger.info("Using DirectProviderBackend (direct provider tool loop)")
-        return DirectProviderBackend(first_provider, tools, hooks, coordinator)
+        return DirectProviderBackend(
+            first_provider,
+            tools,
+            hooks,
+            coordinator,
+            default_provider=default_provider,
+            mounted_providers=mounted_names,
+        )
 
     logger.warning(
         "No providers available \u2014 codergen nodes will run in simulation mode"

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/backend.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/backend.py
@@ -76,6 +76,38 @@ _STATUS_MAP: dict[str, StageStatus] = {s.value: s for s in StageStatus}
 _MAX_TOOL_LOOP_ROUNDS = 20
 
 
+def _resolve_node_provider(
+    node: Any,
+    default_provider: str | None,
+    mounted_providers: tuple[str, ...],
+) -> str:
+    """Resolve the llm_provider a bare (unannotated) node should run on.
+
+    Shared by both backends (``AmplifierBackend`` and ``DirectProviderBackend``)
+    so the rule lives in exactly one place (EXTENSIONS.md \u00a736 extension):
+
+    1. Explicit ``node.llm_provider`` or ``node.attrs["llm_provider"]`` wins.
+    2. Else the engine-resolved default (the sole mounted provider \u2014 see
+       ``_resolve_default_provider`` in ``__init__.py``).
+    3. Else (no default resolvable \u2014 zero or >1 mounted providers with no
+       explicit declaration) fail loud naming the mounted providers, rather
+       than silently picking one family (the issue #155 anti-pattern this
+       repo explicitly forbids).
+    """
+    explicit = getattr(node, "llm_provider", None) or node.attrs.get("llm_provider")
+    if explicit:
+        return explicit
+    if default_provider is not None:
+        return default_provider
+    raise ValueError(
+        f"Node '{node.id}' declares no llm_provider and the engine cannot pick "
+        f"a default: {len(mounted_providers)} providers are mounted "
+        f"({sorted(mounted_providers) or 'none'}). Set the node's llm_provider, "
+        f"add a model_stylesheet '* {{ llm_provider: <name> }}' default, or mount "
+        f"a single provider. Refusing to silently pick one family (issue #155)."
+    )
+
+
 class AmplifierBackend:
     """CodergenBackend implementation using Amplifier session spawning.
 
@@ -103,6 +135,9 @@ class AmplifierBackend:
         tools: dict[str, Any] | None = None,
         unified_client: Any | None = None,
         hooks: Any | None = None,
+        *,
+        default_provider: str | None = None,
+        mounted_providers: tuple[str, ...] = (),
     ) -> None:
         """Initialize the backend.
 
@@ -116,6 +151,15 @@ class AmplifierBackend:
             unified_client: Optional ``unified_llm.Client`` for LLM calls.
                             Created lazily via ``Client.from_env()`` if not provided.
             hooks: Optional HookRegistry for emitting provider-level events.
+            default_provider: Engine-resolved default llm_provider for bare
+                nodes (the sole mounted provider, or ``None`` when zero or
+                more than one provider is mounted). See
+                ``_resolve_default_provider`` in ``__init__.py`` and
+                ``_resolve_node_provider`` above. Keyword-only and defaulted
+                so existing positional call sites keep compiling.
+            mounted_providers: Names of all mounted providers, used only to
+                compose a clear error message when ``default_provider`` is
+                ``None`` and a bare node needs one.
         """
         self._coordinator = coordinator
         self._profiles = profiles
@@ -123,6 +167,8 @@ class AmplifierBackend:
         self._tools = tools or {}
         self._unified_client = unified_client
         self._hooks = hooks
+        self._default_provider = default_provider
+        self._mounted_providers = mounted_providers
         self._spawn_fn: Any | None = None
         self._spawn_checked = False
         # _thread_transcripts: thread_key → list of (node_id, instruction, output) triples.
@@ -151,6 +197,8 @@ class AmplifierBackend:
         new._provider = self._provider
         new._unified_client = self._unified_client
         new._hooks = self._hooks
+        new._default_provider = self._default_provider
+        new._mounted_providers = self._mounted_providers
 
         # Copy tools: stateless tools are shared across clones (safe); stateful tools
         # (those exposing last_outcome) get an independent shallow copy with last_outcome
@@ -238,7 +286,9 @@ class AmplifierBackend:
             self._spawn_checked = True
 
         # 2. Resolve provider and profile from node attributes
-        provider = node.attrs.get("llm_provider", "anthropic")
+        provider = _resolve_node_provider(
+            node, self._default_provider, self._mounted_providers
+        )
         model = node.attrs.get("llm_model")
         model = await _resolve_concrete_model(provider, model, emit=self._emit)
         reasoning_effort = node.attrs.get("reasoning_effort")
@@ -707,7 +757,9 @@ class AmplifierBackend:
         import unified_llm
 
         client = self._get_or_create_unified_client()
-        provider_name = node.llm_provider or node.attrs.get("llm_provider", "anthropic")
+        provider_name = _resolve_node_provider(
+            node, self._default_provider, self._mounted_providers
+        )
         model = await _resolve_concrete_model(
             provider_name, _resolve_model(node), emit=self._emit
         )

--- a/modules/loop-pipeline/amplifier_module_loop_pipeline/preflight.py
+++ b/modules/loop-pipeline/amplifier_module_loop_pipeline/preflight.py
@@ -25,11 +25,18 @@ still statically, still with no live call and no spawn.
 Scope decisions (deliberate, documented):
 
 - **Declared providers only.**  A node with no ``llm_provider`` uses the
-  engine default (``"anthropic"``, see ``backend.py``).  The implicit default
-  is NOT policed here: policing it would make simulation mode (no providers
-  mounted at all -- a documented degraded mode used heavily by tests) and
-  mock-provider harnesses unreachable.  The CLI separately preflights the
-  default provider's credential before any run (``pipeline-runner cli.py``).
+  engine-resolved default: the SOLE mounted provider when exactly one is
+  mounted, ``None`` (simulation mode) when zero are mounted, and -- when
+  more than one provider is mounted and the node names none -- a fail-loud
+  ``ValueError`` at resolution time rather than a silent pick of one family
+  (see ``_resolve_default_provider()`` in ``__init__.py`` and
+  ``_resolve_node_provider()`` in ``backend.py``).  The implicit default is
+  NOT policed by this *startup* preflight: policing it would make simulation
+  mode (no providers mounted at all -- a documented degraded mode used
+  heavily by tests) and mock-provider harnesses unreachable.  The >1-mounted
+  ambiguous case instead fails loud per-node at resolution time, not here.
+  The CLI separately preflights the default provider's credential before any
+  run (``pipeline-runner cli.py``).
 - **Root graph only.**  Nested ``dot_file`` child pipelines are loaded
   mid-walk by the pipeline handler; their nodes are not visible at startup.
   A child graph's unserviceable declaration fails loud at its first

--- a/modules/loop-pipeline/tests/test_backend.py
+++ b/modules/loop-pipeline/tests/test_backend.py
@@ -358,6 +358,10 @@ async def test_backend_default_provider_is_anthropic():
     backend = AmplifierBackend(
         coordinator=coordinator,
         profiles={"anthropic": "attractor-anthropic"},
+        # Sole mounted provider is anthropic -- engine-resolved default routes
+        # the bare node to it (see _resolve_default_provider/_resolve_node_provider).
+        default_provider="anthropic",
+        mounted_providers=("anthropic",),
     )
     node = _make_node(attrs={})  # No llm_provider
     await backend.run(node, "task", _make_context())
@@ -374,6 +378,8 @@ async def test_backend_passes_parent_session():
     backend = AmplifierBackend(
         coordinator=coordinator,
         profiles={"anthropic": "attractor-anthropic"},
+        default_provider="anthropic",
+        mounted_providers=("anthropic",),
     )
     await backend.run(_make_node(attrs={}), "task", _make_context())
     assert "parent_session" in coordinator.last_spawn_kwargs
@@ -398,6 +404,8 @@ async def test_backend_passes_agent_configs():
     backend = AmplifierBackend(
         coordinator=coordinator,
         profiles={"anthropic": "attractor-anthropic"},
+        default_provider="anthropic",
+        mounted_providers=("anthropic",),
     )
     await backend.run(_make_node(attrs={}), "task", _make_context())
     assert coordinator.last_spawn_kwargs.get("agent_configs") == agents
@@ -431,6 +439,8 @@ async def test_recursion_guard_raises_on_missing_session_orchestrator():
     backend = AmplifierBackend(
         coordinator=coordinator,
         profiles={"anthropic": "attractor-anthropic"},
+        default_provider="anthropic",
+        mounted_providers=("anthropic",),
     )
     with pytest.raises(ValueError, match="recursion guard"):
         await backend.run(_make_node(attrs={}), "task", _make_context())
@@ -456,6 +466,8 @@ async def test_recursion_guard_raises_on_loop_pipeline_module():
     backend = AmplifierBackend(
         coordinator=coordinator,
         profiles={"anthropic": "attractor-anthropic"},
+        default_provider="anthropic",
+        mounted_providers=("anthropic",),
     )
     with pytest.raises(ValueError, match="recursion guard"):
         await backend.run(_make_node(attrs={}), "task", _make_context())
@@ -481,6 +493,8 @@ async def test_recursion_guard_passes_on_non_pipeline_module():
     backend = AmplifierBackend(
         coordinator=coordinator,
         profiles={"anthropic": "attractor-anthropic"},
+        default_provider="anthropic",
+        mounted_providers=("anthropic",),
     )
     # Must not raise; spawn must be called normally.
     result = await backend.run(_make_node(attrs={}), "task", _make_context())

--- a/modules/loop-pipeline/tests/test_default_provider_resolution.py
+++ b/modules/loop-pipeline/tests/test_default_provider_resolution.py
@@ -1,0 +1,322 @@
+"""Tests for the engine-resolved default llm_provider (FIX 1).
+
+Prior behavior: the engine hardcoded ``"anthropic"`` as the default
+``llm_provider`` for any node that declared none, at three literal call
+sites (``backend.py:241``, ``backend.py:710``, ``__init__.py``). A
+single-provider session mounting anything other than anthropic (e.g. only
+github-copilot) hard-failed asking for an unmounted anthropic provider.
+
+Fix: the default is now RESOLVED from the mounted provider set, computed in
+``_build_backend()`` (the only place the full ``providers`` dict is visible)
+and threaded into both backends as ``default_provider=``/``mounted_providers=``.
+Per-node resolution (``_resolve_node_provider()`` in ``backend.py``, shared by
+both backends) follows:
+
+1. Explicit ``node.llm_provider`` / ``node.attrs["llm_provider"]`` wins.
+2. Else the engine default -- the SOLE mounted provider.
+3. Else (zero mounted) -> ``None`` -- simulation mode, unaffected here.
+4. Else (>1 mounted, node names none) -> fail loud with a ``ValueError``
+   naming the mounted providers, rather than silently picking one family
+   (the issue #155 anti-pattern this repo explicitly forbids).
+
+Covers:
+- (a) sole-mounted non-anthropic provider routes a bare node to that provider
+- (b) >1 mounted + bare node raises the ambiguous ValueError
+- (c) single-anthropic-mount legacy behavior is unchanged
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+unified_llm = pytest.importorskip("unified_llm")
+
+from amplifier_module_loop_pipeline import (  # noqa: E402
+    DirectProviderBackend,
+    _build_backend,
+    _resolve_default_provider,
+)
+from amplifier_module_loop_pipeline.backend import (  # noqa: E402
+    AmplifierBackend,
+    _resolve_node_provider,
+)
+from amplifier_module_loop_pipeline.context import PipelineContext  # noqa: E402
+from amplifier_module_loop_pipeline.graph import Node  # noqa: E402
+from amplifier_module_loop_pipeline.outcome import StageStatus  # noqa: E402
+
+
+def _make_node(**kwargs: Any) -> Node:
+    defaults = {"id": "codegen", "prompt": "do the thing"}
+    defaults.update(kwargs)
+    return Node(**defaults)
+
+
+def _make_generate_result(text: str) -> "unified_llm.GenerateResult":
+    usage = unified_llm.Usage(input_tokens=1, output_tokens=1, total_tokens=2)
+    response = unified_llm.Response(
+        id="resp-mock",
+        model="test-model",
+        provider="test",
+        message=unified_llm.Message.assistant(text),
+        finish_reason=unified_llm.FinishReason(reason="stop"),
+        usage=usage,
+    )
+    return unified_llm.GenerateResult(
+        text=text,
+        finish_reason=unified_llm.FinishReason(reason="stop"),
+        usage=usage,
+        total_usage=usage,
+        steps=[],
+        response=response,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _resolve_default_provider() -- computed from the mounted provider set
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_default_provider_zero_mounted_is_none():
+    assert _resolve_default_provider({}) is None
+
+
+def test_resolve_default_provider_sole_mounted_non_anthropic():
+    """A single mounted github-copilot provider becomes the default -- not anthropic."""
+    assert _resolve_default_provider({"github-copilot": object()}) == "github-copilot"
+
+
+def test_resolve_default_provider_sole_mounted_anthropic_unchanged():
+    assert _resolve_default_provider({"anthropic": object()}) == "anthropic"
+
+
+def test_resolve_default_provider_multiple_mounted_is_ambiguous_none():
+    providers = {"anthropic": object(), "openai": object()}
+    assert _resolve_default_provider(providers) is None
+
+
+# ---------------------------------------------------------------------------
+# _resolve_node_provider() -- shared per-node resolution rule
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_node_provider_explicit_field_wins_over_default():
+    node = _make_node(llm_provider="openai")
+    assert _resolve_node_provider(node, "anthropic", ("anthropic", "openai")) == "openai"
+
+
+def test_resolve_node_provider_explicit_attrs_wins_over_default():
+    node = _make_node(attrs={"llm_provider": "gemini"})
+    assert _resolve_node_provider(node, "anthropic", ("anthropic",)) == "gemini"
+
+
+def test_resolve_node_provider_bare_node_uses_sole_mounted_default():
+    node = _make_node()
+    assert (
+        _resolve_node_provider(node, "github-copilot", ("github-copilot",))
+        == "github-copilot"
+    )
+
+
+def test_resolve_node_provider_bare_node_ambiguous_raises_value_error():
+    """>1 mounted, node names none -> fail loud, never silently pick one (issue #155)."""
+    node = _make_node(id="critique_b")
+    with pytest.raises(ValueError, match="critique_b") as excinfo:
+        _resolve_node_provider(node, None, ("anthropic", "openai"))
+    message = str(excinfo.value)
+    assert "anthropic" in message
+    assert "openai" in message
+    assert "2 providers are mounted" in message
+
+
+def test_resolve_node_provider_zero_mounted_and_no_default_raises():
+    """Zero mounted with a non-None default never happens in practice, but a bare
+    node with no default and zero mounted providers still fails loud rather than
+    crashing obscurely -- simulation mode is handled upstream by never invoking
+    this resolver (backend is None), not by this function returning a sentinel.
+    """
+    node = _make_node(id="lonely")
+    with pytest.raises(ValueError, match="lonely"):
+        _resolve_node_provider(node, None, ())
+
+
+# ---------------------------------------------------------------------------
+# _build_backend() wiring -- default_provider/mounted_providers threaded through
+# ---------------------------------------------------------------------------
+
+
+def _make_coordinator_no_spawn() -> Any:
+    coordinator = MagicMock()
+    coordinator.get_capability = MagicMock(return_value=None)
+    coordinator.config = {}
+    return coordinator
+
+
+def _make_coordinator_with_spawn(agents: dict | None = None) -> Any:
+    coordinator = MagicMock()
+    coordinator.get_capability = MagicMock(return_value=MagicMock())
+    coordinator.config = {"agents": agents or {}}
+    return coordinator
+
+
+def test_build_backend_threads_sole_provider_default_into_direct_backend():
+    coordinator = _make_coordinator_no_spawn()
+    providers = {"github-copilot": object()}
+
+    backend = _build_backend(providers, {}, None, coordinator, {})
+
+    assert isinstance(backend, DirectProviderBackend)
+    assert backend._default_provider == "github-copilot"
+    assert backend._mounted_providers == ("github-copilot",)
+
+
+def test_build_backend_threads_none_default_when_multiple_providers_mounted():
+    coordinator = _make_coordinator_no_spawn()
+    providers = {"anthropic": object(), "openai": object()}
+
+    backend = _build_backend(providers, {}, None, coordinator, {})
+
+    assert isinstance(backend, DirectProviderBackend)
+    assert backend._default_provider is None
+    assert set(backend._mounted_providers) == {"anthropic", "openai"}
+
+
+def test_build_backend_threads_default_into_amplifier_backend():
+    coordinator = _make_coordinator_with_spawn(
+        agents={"attractor-anthropic": {"session": {"orchestrator": {}}}}
+    )
+    providers = {"anthropic": object()}
+
+    backend = _build_backend(providers, {}, None, coordinator, {})
+
+    assert isinstance(backend, AmplifierBackend)
+    assert backend._default_provider == "anthropic"
+    assert backend._mounted_providers == ("anthropic",)
+
+
+def test_build_backend_no_providers_returns_none_backend():
+    """Zero mounted providers still falls through to simulation mode (unchanged)."""
+    coordinator = _make_coordinator_no_spawn()
+    backend = _build_backend({}, {}, None, coordinator, {})
+    assert backend is None
+
+
+# ---------------------------------------------------------------------------
+# AmplifierBackend.clone() copies the new fields (else test_backend_clone.py
+# style AttributeError on a cloned branch)
+# ---------------------------------------------------------------------------
+
+
+def test_amplifier_backend_clone_copies_default_provider_fields():
+    coordinator = _make_coordinator_with_spawn()
+    backend = AmplifierBackend(
+        coordinator,
+        profiles={},
+        provider=object(),
+        default_provider="github-copilot",
+        mounted_providers=("github-copilot",),
+    )
+    clone = backend.clone()
+    assert clone._default_provider == "github-copilot"
+    assert clone._mounted_providers == ("github-copilot",)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end-ish: DirectProviderBackend.run() actually routes a bare node
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_direct_backend_bare_node_routes_to_sole_mounted_non_anthropic(
+    monkeypatch,
+):
+    """(a) Sole-mounted non-anthropic provider routes a bare node to that provider."""
+    captured_kwargs: dict[str, Any] = {}
+
+    async def _fake_generate(**kwargs):
+        captured_kwargs.update(kwargs)
+        return _make_generate_result(json.dumps({"status": "success"}))
+
+    monkeypatch.setattr(unified_llm, "generate", _fake_generate)
+
+    backend = DirectProviderBackend(
+        provider=object(),  # truthy sentinel
+        unified_client=object(),
+        default_provider="github-copilot",
+        mounted_providers=("github-copilot",),
+    )
+    # Bare node: no llm_provider attribute or attrs key at all.
+    node = _make_node(attrs={"llm_model": "some-model"})
+
+    result = await backend.run(node, "task", PipelineContext())
+
+    assert result.status == StageStatus.SUCCESS
+    assert captured_kwargs.get("provider") == "github-copilot"
+
+
+@pytest.mark.asyncio
+async def test_direct_backend_bare_node_ambiguous_multi_provider_raises(monkeypatch):
+    """(b) >1 mounted + bare node raises the ambiguous ValueError, never picks one."""
+
+    async def _fake_generate(**kwargs):  # pragma: no cover - must not be reached
+        raise AssertionError("generate() must not be called when resolution fails")
+
+    monkeypatch.setattr(unified_llm, "generate", _fake_generate)
+
+    backend = DirectProviderBackend(
+        provider=object(),
+        unified_client=object(),
+        default_provider=None,  # >1 mounted -> ambiguous, per _resolve_default_provider
+        mounted_providers=("anthropic", "openai"),
+    )
+    node = _make_node(id="critique_b", attrs={"llm_model": "some-model"})
+
+    with pytest.raises(ValueError, match="critique_b"):
+        await backend.run(node, "task", PipelineContext())
+
+
+@pytest.mark.asyncio
+async def test_direct_backend_bare_node_single_anthropic_mount_unchanged(monkeypatch):
+    """(c) Single anthropic mount: bare node still routes to anthropic (legacy behavior)."""
+    captured_kwargs: dict[str, Any] = {}
+
+    async def _fake_generate(**kwargs):
+        captured_kwargs.update(kwargs)
+        return _make_generate_result(json.dumps({"status": "success"}))
+
+    monkeypatch.setattr(unified_llm, "generate", _fake_generate)
+
+    backend = DirectProviderBackend(
+        provider=object(),
+        unified_client=object(),
+        default_provider="anthropic",
+        mounted_providers=("anthropic",),
+    )
+    node = _make_node(attrs={"llm_model": "some-model"})
+
+    result = await backend.run(node, "task", PipelineContext())
+
+    assert result.status == StageStatus.SUCCESS
+    assert captured_kwargs.get("provider") == "anthropic"
+
+
+@pytest.mark.asyncio
+async def test_direct_backend_defaults_are_backward_compatible_when_omitted(monkeypatch):
+    """Constructing DirectProviderBackend without the new kwargs at all (positional-only
+    legacy call sites) must still work -- and a bare node then hits the ambiguous/no-default
+    path (None, ()) rather than silently defaulting to anthropic.
+    """
+
+    async def _fake_generate(**kwargs):  # pragma: no cover
+        raise AssertionError("generate() must not be called when resolution fails")
+
+    monkeypatch.setattr(unified_llm, "generate", _fake_generate)
+
+    backend = DirectProviderBackend(object(), {}, None, None, unified_client=object())
+    node = _make_node(attrs={"llm_model": "some-model"})
+
+    with pytest.raises(ValueError):
+        await backend.run(node, "task", PipelineContext())

--- a/modules/loop-pipeline/tests/test_dot_integration.py
+++ b/modules/loop-pipeline/tests/test_dot_integration.py
@@ -210,6 +210,11 @@ def _make_integration_engine(
         provider=object(),  # truthy sentinel
         unified_client=mock_client,
         hooks=hooks,
+        # These fixtures' nodes declare no llm_provider -- a sole mounted
+        # "test" provider makes the engine-resolved default route bare
+        # nodes to it (see _resolve_default_provider/_resolve_node_provider).
+        default_provider="test",
+        mounted_providers=("test",),
     )
 
     # Engine passes itself to handlers via execute(engine=...) — no closure needed.
@@ -841,6 +846,9 @@ def _make_production_engine(
         provider=object(),  # truthy sentinel
         unified_client=mock_client,
         hooks=hooks,
+        # See _make_integration_engine above for the same rationale.
+        default_provider="test",
+        mounted_providers=("test",),
     )
 
     # Engine passes itself to handlers via execute(engine=...) — no closure needed.

--- a/modules/loop-pipeline/tests/test_execution_environment.py
+++ b/modules/loop-pipeline/tests/test_execution_environment.py
@@ -298,6 +298,10 @@ def _make_backend_with_mock_spawn():
     backend = AmplifierBackend(
         coordinator=coordinator,
         profiles={"anthropic": "test-profile"},
+        # Sole mounted provider is anthropic -- engine-resolved default routes
+        # the bare node to it (see _resolve_default_provider/_resolve_node_provider).
+        default_provider="anthropic",
+        mounted_providers=("anthropic",),
     )
     return backend, mock_spawn
 

--- a/modules/loop-pipeline/tests/test_response_schema.py
+++ b/modules/loop-pipeline/tests/test_response_schema.py
@@ -475,6 +475,8 @@ class TestBackendToolLoopWiring:
             profiles={},
             provider=MagicMock(),
             unified_client=mock_client,
+            default_provider="anthropic",
+            mounted_providers=("anthropic",),
         )
 
         await backend._run_with_tool_loop(
@@ -507,6 +509,8 @@ class TestBackendToolLoopWiring:
             profiles={},
             provider=MagicMock(),
             unified_client=mock_client,
+            default_provider="anthropic",
+            mounted_providers=("anthropic",),
         )
 
         await backend._run_with_tool_loop(
@@ -537,6 +541,8 @@ class TestBackendToolLoopWiring:
             profiles={},
             provider=MagicMock(),
             unified_client=mock_client,
+            default_provider="anthropic",
+            mounted_providers=("anthropic",),
         )
 
         outcome = await backend._run_with_tool_loop(
@@ -573,6 +579,8 @@ class TestBackendToolLoopWiring:
             profiles={},
             provider=MagicMock(),
             unified_client=mock_client,
+            default_provider="anthropic",
+            mounted_providers=("anthropic",),
         )
 
         outcome = await backend._run_with_tool_loop(
@@ -605,6 +613,8 @@ class TestBackendSpawnPathFail:
         backend = AmplifierBackend(
             coordinator=coordinator,
             profiles={"anthropic": "attractor-anthropic"},
+            default_provider="anthropic",
+            mounted_providers=("anthropic",),
         )
         backend.ensure_spawn_resolved()
 
@@ -629,6 +639,8 @@ class TestBackendSpawnPathFail:
         backend = AmplifierBackend(
             coordinator=coordinator,
             profiles={"anthropic": "attractor-anthropic"},
+            default_provider="anthropic",
+            mounted_providers=("anthropic",),
         )
         backend.ensure_spawn_resolved()
 
@@ -660,6 +672,8 @@ class TestDirectProviderBackendWiring:
         backend = DirectProviderBackend(
             provider=MagicMock(),
             unified_client=mock_client,
+            default_provider="anthropic",
+            mounted_providers=("anthropic",),
         )
 
         outcome = await backend.run(node, "Extract please", _make_context())
@@ -687,6 +701,8 @@ class TestDirectProviderBackendWiring:
         backend = DirectProviderBackend(
             provider=MagicMock(),
             unified_client=mock_client,
+            default_provider="anthropic",
+            mounted_providers=("anthropic",),
         )
 
         await backend.run(node, "Do work", _make_context())
@@ -712,6 +728,8 @@ def _make_tool_loop_backend(text: str) -> "AmplifierBackend":
         profiles={},
         provider=MagicMock(),
         unified_client=_MockUnifiedClient(text=text),
+        default_provider="anthropic",
+        mounted_providers=("anthropic",),
     )
 
 
@@ -808,6 +826,8 @@ class TestStructuredOutputVerdictPolicy:
             unified_client=_MockUnifiedClient(
                 text=json.dumps({"assessment": "NOT CONVERGED"})
             ),
+            default_provider="anthropic",
+            mounted_providers=("anthropic",),
         )
         node = _make_node_with_schema(_INLINE_SCHEMA_DICT)
         outcome = await backend.run(node, "Judge", _make_context())
@@ -820,6 +840,8 @@ class TestStructuredOutputVerdictPolicy:
             unified_client=_MockUnifiedClient(
                 text=json.dumps({"status": "success", "notes": "converged"})
             ),
+            default_provider="anthropic",
+            mounted_providers=("anthropic",),
         )
         outcome2 = await backend2.run(node, "Judge", _make_context())
         assert outcome2.status == StageStatus.SUCCESS
@@ -843,6 +865,8 @@ class TestGoalGateStructuredOutput:
         backend = DirectProviderBackend(
             provider=MagicMock(),
             unified_client=_MockUnifiedClient(text=response_text),
+            default_provider="anthropic",
+            mounted_providers=("anthropic",),
         )
         return PipelineEngine(
             graph=graph,

--- a/modules/loop-pipeline/tests/test_spawn_suggested_next_ids_coercion.py
+++ b/modules/loop-pipeline/tests/test_spawn_suggested_next_ids_coercion.py
@@ -143,6 +143,10 @@ def _make_backend(coordinator: _SequencedSpawnCoordinator) -> AmplifierBackend:
     return AmplifierBackend(
         coordinator=coordinator,
         profiles={"anthropic": "attractor-anthropic"},
+        # Sole mounted provider is anthropic -- engine-resolved default routes
+        # bare nodes to it (see _resolve_default_provider/_resolve_node_provider).
+        default_provider="anthropic",
+        mounted_providers=("anthropic",),
     )
 
 

--- a/modules/loop-pipeline/tests/test_tool_extraction_regression.py
+++ b/modules/loop-pipeline/tests/test_tool_extraction_regression.py
@@ -142,6 +142,10 @@ def _make_amplifier_backend(
         profiles={},
         provider=MagicMock(),
         unified_client=unified_client,
+        # Sole mounted provider is anthropic -- engine-resolved default routes
+        # bare nodes to it (see _resolve_default_provider/_resolve_node_provider).
+        default_provider="anthropic",
+        mounted_providers=("anthropic",),
     )
 
 
@@ -155,6 +159,8 @@ def _make_direct_backend(
         hooks=None,
         coordinator=None,
         unified_client=unified_client,
+        default_provider="anthropic",
+        mounted_providers=("anthropic",),
     )
 
 

--- a/modules/pipeline-runner/amplifier_module_pipeline_runner/cli.py
+++ b/modules/pipeline-runner/amplifier_module_pipeline_runner/cli.py
@@ -235,18 +235,12 @@ def cmd_run(args: argparse.Namespace) -> int:
         print(f"attractor: {e}", file=sys.stderr)
         return 1
 
-    # --- Fail loud: unknown --provider is a CLI-argument error ---
-    if args.provider not in runner.PROVIDER_KEY_ENV:
-        print(
-            f"attractor: unknown provider {args.provider!r}. Known providers: "
-            f"{', '.join(sorted(runner.PROVIDER_KEY_ENV))}",
-            file=sys.stderr,
-        )
-        return 1
-
-    # --- Fail loud: provider API key must be present BEFORE we run anything ---
-    key_env = runner.PROVIDER_KEY_ENV[args.provider]
-    if not os.environ.get(key_env):
+    # --- Fail loud on a missing key ONLY for providers with a known key env.
+    # A provider whose credential is a token, not a <X>_API_KEY (e.g.
+    # github-copilot), has no env to check here -- defer auth to the provider
+    # module, which fails loud at composition if it cannot authenticate.
+    key_env = runner.PROVIDER_KEY_ENV.get(args.provider)
+    if key_env is not None and not os.environ.get(key_env):
         print(
             f"attractor: missing API key -- set {key_env} for provider {args.provider!r}",
             file=sys.stderr,
@@ -391,16 +385,12 @@ def cmd_resume(args: argparse.Namespace) -> int:
         print(f"attractor resume: {e}", file=sys.stderr)
         return 1
 
-    if args.provider not in runner.PROVIDER_KEY_ENV:
-        print(
-            f"attractor resume: unknown provider {args.provider!r}. Known providers: "
-            f"{', '.join(sorted(runner.PROVIDER_KEY_ENV))}",
-            file=sys.stderr,
-        )
-        return 1
-
-    key_env = runner.PROVIDER_KEY_ENV[args.provider]
-    if not os.environ.get(key_env):
+    # Fail loud on a missing key ONLY for providers with a known key env.
+    # A provider whose credential is a token, not a <X>_API_KEY (e.g.
+    # github-copilot), has no env to check here -- defer auth to the provider
+    # module, which fails loud at composition if it cannot authenticate.
+    key_env = runner.PROVIDER_KEY_ENV.get(args.provider)
+    if key_env is not None and not os.environ.get(key_env):
         print(
             f"attractor resume: missing API key -- set {key_env} for provider "
             f"{args.provider!r}",

--- a/modules/pipeline-runner/amplifier_module_pipeline_runner/runner.py
+++ b/modules/pipeline-runner/amplifier_module_pipeline_runner/runner.py
@@ -52,6 +52,7 @@ DEFAULT_PROFILES: dict[str, str] = {
     "anthropic": "attractor-agent-anthropic",
     "openai": "attractor-agent-openai",
     "gemini": "attractor-agent-gemini",
+    "github-copilot": "attractor-agent-copilot",   # provided by FIX 3
 }
 
 # Env var name per provider -- used by the CLI's fail-loud preflight check

--- a/modules/pipeline-runner/amplifier_module_pipeline_runner/runner.py
+++ b/modules/pipeline-runner/amplifier_module_pipeline_runner/runner.py
@@ -354,6 +354,39 @@ async def drive_engine(
         # ``hooks is not None`` guard preserves an explicit caller override.
         effective_hooks = hooks if hooks is not None else getattr(coordinator, "hooks", None)
 
+        # FIX A: thread the MOUNTED provider set into AmplifierBackend so a
+        # bare node (no explicit llm_provider) can resolve the engine default
+        # exactly as the mounted-orchestrator path does (FIX 1,
+        # `_resolve_default_provider` below). Before this fix, drive_engine
+        # constructed AmplifierBackend with `default_provider`/
+        # `mounted_providers` left at their keyword-only defaults
+        # (`None`/`()`) -- i.e. "0 mounted" from the backend's point of view
+        # -- so EVERY bare node hit the ">1 mounted OR unknown" ambiguous
+        # branch and raised, for any provider, on the standalone-CLI path.
+        #
+        # The mounted set comes from `coordinator.get("providers")` -- the
+        # SAME mount point amplifier_core's own module-execute dispatch reads
+        # (see e.g. `coordinator.get("providers") or {}` in amplifier_core's
+        # `_session_exec.py`/`session.py`), which is how the
+        # mounted-orchestrator path (`PipelineOrchestrator.execute()`)
+        # receives its `providers` argument. It is deliberately NOT
+        # `--provider` (that CLI arg is only a preflight/provenance flag, not
+        # a mount-time provider set) and NOT `resolved_profiles.keys()`
+        # (those are routable profile targets, not what is actually mounted).
+        #
+        # `getattr(coordinator, "get", None)` + a `callable()` guard keeps
+        # bare test-stub coordinators (which may not implement `.get()` at
+        # all -- see e.g. `_StubCoordinator` in
+        # test_provider_preflight_drive_engine.py) safe, mirroring the
+        # `effective_hooks` guard just above; `or {}` covers a real
+        # coordinator whose "providers" mount point is empty or absent.
+        from amplifier_module_loop_pipeline import _resolve_default_provider
+
+        _get_mount_point = getattr(coordinator, "get", None)
+        _mounted_providers = (
+            _get_mount_point("providers") if callable(_get_mount_point) else None
+        ) or {}
+
         backend = AmplifierBackend(
             # The SAME coordinator the preflight above read
             # `config["agents"]` from, and the SAME profiles dict it judged:
@@ -363,6 +396,8 @@ async def drive_engine(
             # Nothing between that call and this one mutates either.
             coordinator=coordinator,
             profiles=resolved_profiles,
+            default_provider=_resolve_default_provider(_mounted_providers),
+            mounted_providers=tuple(_mounted_providers.keys()),
         )
         registry = HandlerRegistry(
             HandlerContext(

--- a/modules/pipeline-runner/tests/test_default_provider_threading_drive_engine.py
+++ b/modules/pipeline-runner/tests/test_default_provider_threading_drive_engine.py
@@ -1,0 +1,179 @@
+"""FIX A: drive_engine must thread the MOUNTED provider set into AmplifierBackend.
+
+FIX 1 (see ``modules/loop-pipeline/tests/test_default_provider_resolution.py``)
+made the loop-pipeline engine resolve a bare node's (no explicit
+``llm_provider``) default from the MOUNTED provider set via
+``_resolve_default_provider`` / ``_resolve_node_provider``, threaded into
+``AmplifierBackend`` as ``default_provider=``/``mounted_providers=``.
+
+But the standalone-CLI path (``drive_engine`` in runner.py) constructed
+``AmplifierBackend(coordinator=..., profiles=...)`` WITHOUT passing those two
+kwargs. They are keyword-only with defaults ``None``/``()``, so the CLI path
+always saw "0 mounted" and EVERY bare node hit the ambiguous-resolution
+``ValueError`` -- for any provider, regardless of what was actually mounted.
+Confirmed live in a DTU.
+
+These tests pin the fix at the ``drive_engine`` seam (mirroring the style of
+``test_provider_preflight_drive_engine.py``):
+
+(a) sole-mounted provider -> ``default_provider``/``mounted_providers`` are
+    threaded into ``AmplifierBackend`` exactly as the mounted-orchestrator
+    path would, and the bare node reaches execution (a real spawn) instead
+    of raising.
+(b) >1 mounted provider + a bare node -> still fails loud, per-node, at
+    resolution time (the #155 anti-pattern this repo forbids: never silently
+    pick one family).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+from amplifier_module_loop_pipeline.backend import AmplifierBackend
+from amplifier_module_pipeline_runner.runner import drive_engine
+
+# A BARE node: no llm_provider attribute at all. Must inherit the engine
+# default rather than raise (sole-mounted case) or must raise loud (ambiguous
+# multi-mounted case) -- never silently pick a provider.
+_DOT_BARE_NODE = """\
+digraph bare {
+    graph [goal="bare-node provider inheritance fixture"]
+    start [shape=Mdiamond]
+    codegen [shape=box, prompt="do the work"]
+    done [shape=Msquare]
+    start -> codegen -> done
+}
+"""
+
+_LOOP_AGENT: dict[str, Any] = {"session": {"orchestrator": {"module": "loop-agent"}}}
+
+
+class _ProvidersCoordinator:
+    """Coordinator stub exposing a ``.get("providers")`` mount point --
+    the SAME mount point amplifier_core's own module-execute dispatch reads
+    (see e.g. ``coordinator.get("providers") or {}`` in amplifier_core's
+    ``_session_exec.py``/``session.py``) -- plus a recording spawn
+    capability, mirroring ``_AgentsCoordinator`` in
+    ``test_provider_preflight_drive_engine.py``.
+    """
+
+    def __init__(
+        self, providers: dict[str, Any], agent_names: tuple[str, ...]
+    ) -> None:
+        self._providers = providers
+        self.spawn_calls: list[str] = []
+        self.session = None
+        self.hooks = None
+        self.config: dict[str, Any] = {
+            "agents": {name: dict(_LOOP_AGENT) for name in agent_names}
+        }
+
+    def get(self, key: str, default: Any = None) -> Any:
+        if key == "providers":
+            return self._providers
+        return default
+
+    def get_capability(self, name: str):
+        return self._spawn_fn if name == "session.spawn" else None
+
+    async def _spawn_fn(self, **kwargs):
+        self.spawn_calls.append(str(kwargs.get("agent_name")))
+        return {
+            "output": json.dumps({"status": "success", "notes": "stub"}),
+            "session_id": "child-1",
+        }
+
+
+def test_drive_engine_threads_sole_mounted_provider_into_backend(
+    tmp_path, monkeypatch
+) -> None:
+    """(a) Sole-mounted provider (e.g. "github-copilot") -> default_provider
+    threaded == that provider, mounted_providers == ("github-copilot",), and
+    the bare node reaches execution rather than raising.
+
+    Against the pre-fix runner this configuration raised the ambiguous
+    ``ValueError`` for the "codegen" node on EVERY run, regardless of the
+    fact that exactly one provider was mounted.
+    """
+    captured_kwargs: dict[str, Any] = {}
+    original_init = AmplifierBackend.__init__
+
+    def _spy_init(self, *args, **kwargs):
+        captured_kwargs.update(kwargs)
+        original_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(AmplifierBackend, "__init__", _spy_init)
+
+    coordinator = _ProvidersCoordinator(
+        providers={"github-copilot": object()},
+        agent_names=("attractor-github-copilot",),
+    )
+
+    outcome = asyncio.run(
+        drive_engine(
+            _DOT_BARE_NODE,
+            coordinator,
+            cwd=tmp_path,
+            logs_root=tmp_path / "logs",
+            profiles={"github-copilot": "attractor-github-copilot"},
+            transform=True,
+        )
+    )
+
+    assert captured_kwargs.get("default_provider") == "github-copilot"
+    assert captured_kwargs.get("mounted_providers") == ("github-copilot",)
+    assert outcome.status.value == "success", outcome
+    assert coordinator.spawn_calls == ["attractor-github-copilot"], (
+        "the bare node must actually reach spawn/execution, not raise"
+    )
+
+
+def test_drive_engine_ambiguous_multi_mounted_bare_node_still_fails_loud(
+    tmp_path,
+) -> None:
+    """(b) >1 mounted provider + a bare node -> still fails loud, per-node.
+
+    The fix must not paper over genuine ambiguity: with two providers
+    mounted and the node naming none, resolution must still fail, naming
+    the failing node and the mounted providers -- never silently pick one
+    family (issue #155's forbidden anti-pattern).
+
+    ``_resolve_node_provider``'s ``ValueError`` is raised inside node
+    execution (``AmplifierBackend.run``), which the engine's own node
+    handler catches and converts into a failed ``Outcome`` (never a bare
+    node-loss of the exception all the way out of ``drive_engine``) -- so
+    the pinned assertion is on the returned ``Outcome``, not a raised
+    exception. ``test_resolve_node_provider_bare_node_ambiguous_raises_value_error``
+    in ``modules/loop-pipeline/tests/test_default_provider_resolution.py``
+    already pins the raw resolver's raise; this test pins that the SAME
+    failure reaches the CLI/``drive_engine`` seam undegraded.
+    """
+    coordinator = _ProvidersCoordinator(
+        providers={"anthropic": object(), "openai": object()},
+        agent_names=("attractor-anthropic", "attractor-openai"),
+    )
+
+    outcome = asyncio.run(
+        drive_engine(
+            _DOT_BARE_NODE,
+            coordinator,
+            cwd=tmp_path,
+            logs_root=tmp_path / "logs",
+            profiles={
+                "anthropic": "attractor-anthropic",
+                "openai": "attractor-openai",
+            },
+            transform=True,
+        )
+    )
+
+    assert outcome.status.value == "fail", outcome
+    msg = outcome.failure_reason or ""
+    assert "codegen" in msg  # the failing (bare) node
+    assert "anthropic" in msg
+    assert "openai" in msg
+    assert not coordinator.spawn_calls, (
+        "ambiguous resolution must fail before any spawn is issued"
+    )

--- a/profiles/attractor-profile-copilot.yaml
+++ b/profiles/attractor-profile-copilot.yaml
@@ -1,0 +1,57 @@
+bundle:
+  name: attractor-profile-copilot
+  version: 1.0.0
+  description: >
+    GitHub Copilot coding agent profile (Claude Code aligned).
+    Uses edit_file with old_string/new_string for edits, 120s default
+    shell timeout, and a system prompt mirroring Claude Code conventions.
+
+includes:
+  - bundle: attractor:behaviors/attractor-core
+
+providers:
+  - module: provider-github-copilot
+    source: git+https://github.com/microsoft/amplifier-module-provider-github-copilot@main
+    config:
+      default_model: claude-sonnet-4.6
+      timeout: 600
+
+session:
+  orchestrator:
+    module: loop-agent
+    # NOTE: the same-repo `@main` pin is DELIBERATE, and cannot currently be removed.
+    # Unlike tools:/hooks:/providers: sources (resolved at PARSE time against this file's
+    # own directory), a session.orchestrator `source:` is resolved LATE against the
+    # COMPOSED ROOT's base_path -- which in a real amplifier session is the APP's own
+    # bundle directory, not this bundle's.  Measured, from a DTU install of a branch that
+    # made these relative:  "loop-agent: File not found:
+    # .../amplifier_app_cli/_bundle/behaviors/modules/loop-agent" -- and the session
+    # refused to start.  See docs/designs/2026-08-15-composition-fix.md.
+    source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
+    config:
+      default_command_timeout_ms: 120000
+      # INTERIM PIN (issue #0 workaround): loop-agent derives the Layer-1 base
+      # prompt via canonical_provider(provider_name), which returns None for
+      # "github-copilot" and RAISES at every spawn. Pinning an explicit
+      # system_prompt_file bypasses that lookup entirely. This hand-pins ONE
+      # prompt family (anthropic's) for every node using this agent -- it is
+      # not provider-accurate, just unblocking -- until canonical_provider
+      # gains a github-copilot->family mapping (deferred fix).
+      system_prompt_file: context/system-anthropic.md
+  # session.context is REQUIRED by core 1.6.0 ("Configuration must specify
+  # session.context"). This profile only includes attractor-core (which provides
+  # no context module) -- unlike attractor-agent.yaml which pulls it from
+  # amplifier-foundation -- so it must be declared explicitly here.
+  context:
+    module: context-simple
+    source: git+https://github.com/microsoft/amplifier-module-context-simple@main
+
+tools:
+  - module: tool-filesystem
+    source: git+https://github.com/microsoft/amplifier-module-tool-filesystem@main
+  - module: tool-bash
+    source: git+https://github.com/microsoft/amplifier-module-tool-bash@main
+    config:
+      timeout: 120
+  - module: tool-search
+    source: git+https://github.com/microsoft/amplifier-module-tool-search@main

--- a/specs/EXTENSIONS.md
+++ b/specs/EXTENSIONS.md
@@ -2298,10 +2298,15 @@ never a drained budget or a silent substitution):**
 
 **Deliberate scope boundaries (documented in `preflight.py`):**
 
-- **Declared providers only.** A node with no `llm_provider` uses the engine default
-  (`"anthropic"`); the implicit default is NOT policed by the preflight — policing it would make
-  simulation mode (no providers mounted; a documented degraded mode) and mock-provider harnesses
-  unreachable. The CLI separately preflights the default provider's credential (`cli.py`).
+- **Declared providers only.** A node with no `llm_provider` uses the engine-resolved default: the
+  SOLE mounted provider when exactly one is mounted, `None` (simulation mode) when zero are
+  mounted, and — when more than one provider is mounted and the node names none — a fail-loud
+  `ValueError` at resolution time rather than a silent pick of one family (the issue #155
+  anti-pattern; see `_resolve_default_provider()` in `__init__.py` and `_resolve_node_provider()`
+  in `backend.py`). The implicit default is NOT policed by the *startup* preflight — policing it
+  would make simulation mode (no providers mounted; a documented degraded mode) and mock-provider
+  harnesses unreachable — the ambiguous->1-mounted case instead fails loud per-node at resolution
+  time. The CLI separately preflights the default provider's credential (`cli.py`).
 - **Root graph only.** Nested `dot_file` children are loaded mid-walk; their unserviceable
   declarations fail loud at first execution via change 2 rather than at startup.
 - **Injected backends skip the preflight.** `execute(..., backend=...)` is the invoker taking
@@ -2320,12 +2325,21 @@ disease, not a remedy).
 **Implementation locations:**
 
 - `modules/loop-pipeline/amplifier_module_loop_pipeline/preflight.py` — the check + refusal
-- `modules/loop-pipeline/amplifier_module_loop_pipeline/__init__.py` — orchestrator wiring (step 5b)
+- `modules/loop-pipeline/amplifier_module_loop_pipeline/__init__.py` — orchestrator wiring (step
+  5b); `_resolve_default_provider()` computes the engine default from the MOUNTED provider set
+  (the only place that set is visible) and `_build_backend()` threads it (plus the mounted-name
+  tuple) into both backend constructors as `default_provider=`/`mounted_providers=`
 - `modules/pipeline-runner/amplifier_module_pipeline_runner/runner.py` — `drive_engine` wiring
-- `modules/loop-pipeline/amplifier_module_loop_pipeline/backend.py` — no-fallback profile resolution
+- `modules/loop-pipeline/amplifier_module_loop_pipeline/backend.py` — no-fallback profile
+  resolution; `_resolve_node_provider()` is the single shared per-node resolution rule (explicit
+  attr > engine default > fail loud), consumed by both `AmplifierBackend.run()` and
+  `AmplifierBackend._run_with_tool_loop()`, and by `DirectProviderBackend.run()` in `__init__.py`
 - `modules/loop-pipeline/tests/test_provider_preflight.py`,
   `modules/pipeline-runner/tests/test_provider_preflight_drive_engine.py` — contract + regression
   tests (including the provider-not-in-profiles class, ruling R5)
+- `modules/loop-pipeline/tests/test_default_provider_resolution.py` — sole-mounted-provider
+  default routing, >1-mounted ambiguity fail-loud, and single-anthropic-mount legacy-behavior
+  regression
 
 *Addendum (2026-08-17): the "never a drained budget" claim above OVERSTATED what change 1
 guaranteed, and issue #195 named the residual. A profile is a STRING naming an agent, and the


### PR DESCRIPTION
## Summary

Attractor runs on Anthropic, OpenAI, or Gemini today. Each path assumes an API key in the
environment and a provider name that maps one-to-one to a model family. GitHub Copilot breaks
both. It authenticates with a GitHub token, has no `*_API_KEY`, and serves several model
families through one provider. A Copilot-only run fails four different ways before it does any
work.

This branch makes attractor run on any mounted provider, Copilot included, with no
Anthropic/OpenAI/Gemini keys set. The existing three-provider behavior is unchanged.

Four small fixes and one cleanup.

- The engine no longer defaults a bare node's provider to the literal "anthropic". It resolves
  the default from the mounted provider set. Sole mounted wins, and more than one mounted with
  none named is ambiguous and fails loud rather than guessing. The standalone CLI builds the
  backend on its own path and had missed the same wiring, so a bare node broke there for every
  provider. Fixed too.
- The CLI stops rejecting any provider that isn't in a hardcoded three-key map. It requires an
  API key only for providers that actually have one, and otherwise leaves auth to the provider
  module. The key check for anthropic/openai/gemini is untouched.
- A new opt-in `prompt_profile` config key. loop-agent chose its base prompt from the provider
  name, which returns nothing for a one-to-many provider and then raises. The `context/system-*.md`
  files are toolset prompts, not model-family prompts. anthropic is the edit_file toolset, openai
  the apply_patch toolset, gemini the web-tools one. So the honest thing for an agent to declare
  is which toolset it mounts. Copilot mounts the same tools as anthropic, so it declares
  `prompt_profile: anthropic`.
- A Copilot agent profile plus a Copilot-only pipeline bundle, so a key-free run needs no
  anthropic mount anywhere.
- Cleanup. The four provider agents were about 90 percent copy-paste. The shared parts, including
  the one self-pin, now live in a single `attractor-agent-base` behavior. Composition is
  byte-identical, verified against the real registry.

## Change tier

Toward the nlspec, not away. The canonical spec says `llm_provider` is auto-detected and the
provider set is open ("etc"), so the hardcoded "anthropic" default was an implementation choice,
not a spec requirement. The engine-default change is observable, so `specs/EXTENSIONS.md` section
36 and the preflight docstring now describe the sole-mounted rule and the fail-loud behavior.

## Verification

Unit and guard suites pass per module with all provider keys unset, which is the repo's own rule.
New tests cover the default-provider resolution, the CLI-path threading, and the `prompt_profile`
fallback. No existing test needed to change.

I ran it e2e, before and after, in two Digital Twin Universes that differ only in the bundle
commit. Both Copilot-only, GitHub token for auth, every `*_API_KEY` unset, both substrates proven
healthy first so the results are about the code.

Before, on baseline main, all four failures reproduce. unknown provider at the CLI, "provider
'anthropic' not mounted" for a bare node, the base-prompt raise once a Copilot profile exists, and
no Copilot profile in the tree at all.

After, on this branch, a seven-node convergence pipeline ships on Copilot alone. One critic ran on
claude-sonnet-4.6 and the other on gpt-5.6-sol, both through github-copilot, confirmed from each
child session's provider mount rather than a token-header guess. The anthropic-without-key path
still fails loud, so the guard wasn't quietly removed. I can paste the convergence record and the
per-node model breakdown into the PR body, and there's a dashboard in the run tree.

## Notes

- `prompt_profile: anthropic` names Copilot's toolset, not the family of the model answering. A
  gpt critic reads the edit_file toolset prompt. That is correct for tools and is not a claim
  about model-idiom prompting.
- The end state where one generic agent serves any provider with no per-provider files still needs
  the toolset-declaration idea carried further. This branch shrinks the per-provider files and
  names the concept, it does not finish that.
- The convergence loop did not iterate in the run because the task shipped first pass. The
  back-edges exist, they just weren't exercised.
- GPT-family critic nodes can hit the documented empty-final-message trap when they end on a tool
  call. That is a graph-authoring note, not an engine change here.
