### PR TITLE
fix(loop-agent): hydrate SessionHistory from seeded context — fidelity="full" continuity

### DIFF
--- a/modules/loop-agent/amplifier_module_loop_agent/__init__.py
+++ b/modules/loop-agent/amplifier_module_loop_agent/__init__.py
@@ -344,6 +344,16 @@ class AgentOrchestrator:
                 follow_up_queue=self._follow_up_queue,
                 coordinator=self._coordinator,
                 provider_name=provider_name,
+                # support#497: the mounted context (Orchestrator protocol's
+                # `context` param). For a fidelity="full" spawn, foundation's
+                # spawn path seeds prior-turn messages onto THIS session's own
+                # mounted context (child_context.set_messages(parent_messages))
+                # BEFORE execute() is ever called -- see
+                # AgentSession._hydrate_history_from_context, which reads it
+                # back once, before turn 1, so the seeded history actually
+                # reaches _convert_history_to_messages (and thus the provider
+                # request) instead of sitting inert on the mount.
+                context=context,
             )
             # Register subagent depth on coordinator for tool-delegate
             self._coordinator.register_capability(

--- a/modules/loop-agent/amplifier_module_loop_agent/agent_session.py
+++ b/modules/loop-agent/amplifier_module_loop_agent/agent_session.py
@@ -132,6 +132,7 @@ class AgentSession:
         coordinator: Any = None,
         provider_name: str = "",
         model: str = "",
+        context: Any = None,
     ) -> None:
         self._config = config
         self._provider = provider
@@ -164,6 +165,17 @@ class AgentSession:
         # every process_input() so a prior invocation's ending can never
         # classify this one's lifecycle status.
         self._termination_reason = "natural"
+        # support#497: the Orchestrator protocol's ``context`` argument (the
+        # PARENT session's mounted ContextManager). For a fidelity="full" spawn,
+        # foundation's spawn path seeds prior-turn messages onto THIS session's
+        # own mounted context via ``set_messages`` BEFORE execute() is ever
+        # called (see AgentOrchestrator._execute_session, which threads it
+        # through here). Stored, not consumed yet -- ``_hydrate_history_from_context``
+        # reads it back exactly once, from the top of the first process_input()
+        # call, so seeded history always precedes turn 1's own UserTurn. See
+        # that method for the full mechanism and the system-message decision.
+        self._context = context
+        self._context_hydrated = False
 
     # ------------------------------------------------------------------
     # Streaming detection
@@ -344,6 +356,15 @@ class AgentSession:
         execution, and returns the final text response.  The loop exits
         on natural completion (no tool calls), round limit, or turn limit.
         """
+        # support#497: hydrate seeded cross-node history from the mounted
+        # context BEFORE anything else this invocation does -- in particular
+        # before the current prompt's own UserTurn is appended below, so
+        # seeded history always precedes it.  Runs at most once per session
+        # (see _hydrate_history_from_context's own guard), so a session
+        # reused across several process_input() calls (follow-ups, steering,
+        # resume_with_input) never re-seeds on turn 2+.
+        await self._hydrate_history_from_context()
+
         # EXTENSIONS.md 35: per-invocation reset -- a prior invocation's
         # terminal condition must never classify this one.
         self._termination_reason = "natural"
@@ -678,6 +699,127 @@ class AgentSession:
             project_docs=project_docs,
             user_override=user_override,
         )
+
+    # ------------------------------------------------------------------
+    # Seeded cross-node history (support#497)
+    # ------------------------------------------------------------------
+
+    async def _hydrate_history_from_context(self) -> None:
+        """Replay prior-turn messages seeded on the mounted context, once.
+
+        THE BUG (support#497): for a ``fidelity="full"`` spawn, the
+        loop-pipeline engine's backend carries a thread's prior (instruction,
+        output) exchanges and hands them to foundation's spawn path, which
+        seeds them onto THIS session's own mounted context via
+        ``child_context.set_messages(parent_messages)`` -- BEFORE this
+        orchestrator's ``execute()`` is ever called
+        (``amplifier_foundation.bundle._prepared.PreparedBundle.spawn``).
+        AgentSession, however, keeps its own independent ``SessionHistory``
+        and never read that mounted context back -- ``coordinator.get("context")``
+        / ``context.get_messages()`` appeared nowhere -- so the seeded messages
+        were vestigial: they reached the mount, never the provider request
+        built by ``_convert_history_to_messages``. Live evidence from the
+        ticket: "Restored 2 messages to context" followed by "Final message
+        count for API: 1".
+
+        THE FIX: read them back here and replay them into ``self._history``
+        as ordinary turns, so they flow through the exact same
+        ``_convert_history_to_messages`` path every other turn does.
+
+        Runs AT MOST ONCE per session (``self._context_hydrated`` guard) --
+        called from the top of every ``process_input()``, but a session
+        persists across multiple calls (follow-ups, steering,
+        ``resume_with_input``) and seeded history belongs only at turn 1,
+        before the first prompt's own ``UserTurn``.
+
+        System-message handling: loop-agent rebuilds its OWN 5-layer system
+        prompt fresh on EVERY request (spec PROV-002) and
+        ``_convert_history_to_messages`` already strips ANY ``role="system"``
+        message out of the assembled list before prepending that fresh one
+        (see below) -- a replayed system message would be silently discarded
+        downstream regardless. Skipping it HERE instead is the honest
+        choice: it documents the decision at the point it's made, and avoids
+        burning a ``SessionHistory`` slot (and ``max_turns`` / turn-count
+        budget) on a turn that could never surface to the model.
+
+        Honest failure: a context present but whose ``get_messages()`` raises,
+        or returns something other than a list, is logged as a loud warning
+        and treated as "nothing to replay" -- degraded continuity, never a
+        crashed node. A per-message shape that cannot be safely replayed
+        (missing/unknown role, non-dict entry) is skipped individually and
+        counted, rather than fabricated or allowed to raise.
+        """
+        if self._context_hydrated:
+            return
+        self._context_hydrated = True  # exactly once, success or failure
+
+        context = self._context
+        if context is None or not hasattr(context, "get_messages"):
+            return
+
+        try:
+            messages = await context.get_messages()
+        except Exception:
+            logger.warning(
+                "loop-agent: context.get_messages() raised while seeding "
+                "cross-node history (fidelity='full' continuity) -- "
+                "proceeding without seeded history for this node.",
+                exc_info=True,
+            )
+            return
+
+        if not isinstance(messages, list) or not messages:
+            return
+
+        seeded = 0
+        skipped = 0
+        for message in messages:
+            if not isinstance(message, dict):
+                skipped += 1
+                continue
+            role = message.get("role")
+            content = message.get("content", "")
+            if not isinstance(content, str):
+                content = str(content)
+            if role == "system":
+                # Own Layer-1 framing is rebuilt fresh every request and any
+                # stored system message is stripped before the request is
+                # built (see _convert_history_to_messages) -- replaying it
+                # would be inert at best. Skip explicitly rather than
+                # silently round-tripping a turn that can never surface.
+                continue
+            if role == "user":
+                self._history.append(UserTurn(content=content))
+                seeded += 1
+            elif role == "assistant":
+                # Only text is replayed -- never a seeded message's tool_calls
+                # (if present): this session has no correlated ToolResultsTurn
+                # to pair with a replayed tool call, and fabricating one would
+                # hand the provider a dangling tool_use with no result.
+                self._history.append(AssistantTurn(content=content))
+                seeded += 1
+            else:
+                # tool-role (or any other/unknown role) entries cannot be
+                # safely replayed without a correlated tool_call_id from a
+                # matching AssistantTurn in THIS session's own history --
+                # never fabricate one. Degraded continuity, not a crash.
+                skipped += 1
+
+        if skipped:
+            logger.warning(
+                "loop-agent: %d seeded context message(s) could not be "
+                "replayed into session history (unsupported role/shape); "
+                "%d replayed.",
+                skipped,
+                seeded,
+            )
+        if seeded:
+            logger.info(
+                "loop-agent: seeded %d prior-turn message(s) from the "
+                "mounted context into session history before turn 1 "
+                "(fidelity='full' continuity, support#497).",
+                seeded,
+            )
 
     # ------------------------------------------------------------------
     # History -> Messages conversion

--- a/modules/loop-agent/tests/test_context_history_hydration.py
+++ b/modules/loop-agent/tests/test_context_history_hydration.py
@@ -1,0 +1,341 @@
+"""Tests for seeded cross-node history hydration (support#497).
+
+Independent re-review found the REAL support#497 fix belongs here, not in
+the loop-amplifier-agent adapter: loop-agent's AgentSession kept its own
+SessionHistory and never read the mounted ``context`` the Orchestrator
+protocol hands ``execute()`` -- so a fidelity="full" spawn's seeded
+``parent_messages`` (delivered via foundation's
+``child_context.set_messages(parent_messages)`` before ``execute()`` runs)
+never reached ``_convert_history_to_messages()``, and thus never reached the
+provider request. Ticket's live evidence: "Restored 2 messages to context"
+followed by "Final message count for API: 1".
+
+These tests exercise the fix end-to-end through the public
+``AgentOrchestrator.execute()`` seam (mirroring test_agent_session.py's own
+harness style) so a RED run against the pre-fix code path fails for the
+right reason: the seeded messages never reaching ``provider.complete``'s
+request, not merely "some attribute wasn't set".
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from amplifier_core.message_models import ChatResponse, Usage
+from amplifier_module_loop_agent import AgentOrchestrator
+
+# ---------------------------------------------------------------------------
+# Test helpers (mirrors tests/test_agent_session.py's _make_harness style)
+# ---------------------------------------------------------------------------
+
+
+def _text_response(text: str) -> ChatResponse:
+    """ChatResponse with text only (natural completion)."""
+    return ChatResponse(
+        content=[{"type": "text", "text": text}],
+        tool_calls=None,
+        usage=Usage(input_tokens=10, output_tokens=5, total_tokens=15),
+    )
+
+
+class FakeContext:
+    """Minimal double for the mounted ContextManager (support#497 seam).
+
+    Mirrors the ONLY two behaviors the fix depends on: an async
+    ``get_messages()`` returning ``list[dict]`` (or raising, for the
+    honest-failure negative).
+    """
+
+    def __init__(
+        self,
+        messages: list[dict[str, Any]] | None = None,
+        *,
+        raises: Exception | None = None,
+    ) -> None:
+        self._messages = list(messages) if messages is not None else []
+        self._raises = raises
+        self.call_count = 0
+
+    async def get_messages(self) -> list[dict[str, Any]]:
+        self.call_count += 1
+        if self._raises is not None:
+            raise self._raises
+        return list(self._messages)
+
+
+def _make_harness(
+    config: dict | None = None,
+    responses: list[ChatResponse] | None = None,
+):
+    """Build an orchestrator + mocks, mirroring test_agent_session.py.
+
+    Returns (orchestrator, providers, tools, hooks).
+    """
+    defaults = {"system_prompt": "You are a test coding agent."}
+    cfg = {**defaults, **(config or {})}
+
+    provider = AsyncMock()
+    provider.complete = AsyncMock(side_effect=responses or [_text_response("done")])
+    providers = {"test": provider}
+
+    tools: dict[str, Any] = {}
+
+    hooks = MagicMock()
+
+    async def _recording_emit(event: str, data: dict):
+        return MagicMock(action="continue")
+
+    hooks.emit = AsyncMock(side_effect=_recording_emit)
+
+    orchestrator = AgentOrchestrator(coordinator=MagicMock(), config=cfg)
+    return orchestrator, providers, tools, hooks
+
+
+def _sent_messages(provider: AsyncMock, call_index: int = 0) -> list[Any]:
+    """The `messages` list of the ChatRequest built for provider.complete's
+    call_index'th invocation."""
+    request = provider.complete.call_args_list[call_index].args[0]
+    return request.messages
+
+
+# ---------------------------------------------------------------------------
+# 1. RED-proof: seeded history must reach the built provider request.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_seeded_context_history_reaches_provider_request():
+    """RED-proof (support#497): against the pre-fix loop-agent, `context` was
+    accepted by execute() and silently dropped -- the built ChatRequest carried
+    only the system message + the current prompt (ticket's "Final message
+    count for API: 1"), no matter what the mounted context held. Post-fix,
+    the seeded prior-turn messages are replayed into session history BEFORE
+    the loop runs, so they appear in the request sent to provider.complete().
+    """
+    orch, provs, tools, hooks = _make_harness(
+        responses=[_text_response("The secret code is ZEBRA-42.")]
+    )
+    seeded = [
+        {"role": "user", "content": "The secret code is ZEBRA-42."},
+        {"role": "assistant", "content": "Understood, I will remember it."},
+    ]
+    context = FakeContext(seeded)
+
+    result = await orch.execute(
+        "What was the secret code?", context, provs, tools, hooks
+    )
+    assert result == "The secret code is ZEBRA-42."
+
+    sent = _sent_messages(provs["test"])
+    contents = [getattr(m, "content", None) for m in sent]
+    assert "The secret code is ZEBRA-42." in contents
+    assert "Understood, I will remember it." in contents
+    # The seeded turns precede the current prompt (order preserved).
+    idx_seed_user = contents.index("The secret code is ZEBRA-42.")
+    idx_seed_assistant = contents.index("Understood, I will remember it.")
+    idx_prompt = contents.index("What was the secret code?")
+    assert idx_seed_user < idx_seed_assistant < idx_prompt
+
+
+@pytest.mark.asyncio
+async def test_message_count_signature_inverted():
+    """The ticket's own failure signature, inverted: 2 seeded messages + 1
+    prompt must yield MORE than one non-system message in the built request
+    (pre-fix: exactly the fresh system message + the bare prompt, i.e. the
+    conversation carried only 1 non-system message)."""
+    orch, provs, tools, hooks = _make_harness(responses=[_text_response("ok")])
+    seeded = [
+        {"role": "user", "content": "turn one"},
+        {"role": "assistant", "content": "turn one reply"},
+    ]
+    context = FakeContext(seeded)
+
+    await orch.execute("turn two prompt", context, provs, tools, hooks)
+
+    sent = _sent_messages(provs["test"])
+    non_system = [m for m in sent if m.role != "system"]
+    assert len(non_system) > 1, (
+        f"expected >1 non-system message (2 seeded + 1 prompt), got "
+        f"{len(non_system)}: {non_system!r}"
+    )
+    assert len(non_system) == 3
+
+
+# ---------------------------------------------------------------------------
+# 2. Negatives: context=None, empty context, get_messages() raises.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_context_none_is_a_noop():
+    """context=None must behave exactly like today: no seeded history, no crash."""
+    orch, provs, tools, hooks = _make_harness(responses=[_text_response("ok")])
+
+    result = await orch.execute("hello", None, provs, tools, hooks)
+    assert result == "ok"
+
+    sent = _sent_messages(provs["test"])
+    non_system = [m for m in sent if m.role != "system"]
+    assert len(non_system) == 1
+    assert non_system[0].content == "hello"
+
+
+@pytest.mark.asyncio
+async def test_empty_context_history_is_a_noop():
+    """A present context whose get_messages() returns [] seeds nothing."""
+    orch, provs, tools, hooks = _make_harness(responses=[_text_response("ok")])
+    context = FakeContext([])
+
+    result = await orch.execute("hello", context, provs, tools, hooks)
+    assert result == "ok"
+    assert context.call_count == 1
+
+    sent = _sent_messages(provs["test"])
+    non_system = [m for m in sent if m.role != "system"]
+    assert len(non_system) == 1
+    assert non_system[0].content == "hello"
+
+
+@pytest.mark.asyncio
+async def test_context_without_get_messages_is_a_noop():
+    """A context object that doesn't even expose get_messages() must not crash."""
+    orch, provs, tools, hooks = _make_harness(responses=[_text_response("ok")])
+    context = object()  # no get_messages attribute at all
+
+    result = await orch.execute("hello", context, provs, tools, hooks)
+    assert result == "ok"
+
+
+@pytest.mark.asyncio
+async def test_context_get_messages_raises_warns_and_proceeds(
+    caplog: pytest.LogCaptureFixture,
+):
+    """A context whose get_messages() raises must NOT crash the node -- log a
+    loud warning and proceed as if there were nothing to replay (degraded
+    continuity, never a dead node)."""
+    orch, provs, tools, hooks = _make_harness(responses=[_text_response("ok")])
+    context = FakeContext(raises=RuntimeError("context store unavailable"))
+
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        result = await orch.execute("hello", context, provs, tools, hooks)
+
+    assert result == "ok"
+    assert any(
+        "context.get_messages() raised" in rec.getMessage() for rec in caplog.records
+    )
+
+    sent = _sent_messages(provs["test"])
+    non_system = [m for m in sent if m.role != "system"]
+    assert len(non_system) == 1
+    assert non_system[0].content == "hello"
+
+
+# ---------------------------------------------------------------------------
+# 3. System-prompt survival.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_own_system_framing_survives_hydration_exactly_once():
+    """loop-agent's own Layer-1..5 system prompt must appear EXACTLY ONCE in
+    the built request after hydration -- neither displaced nor duplicated --
+    even when the seeded context itself carries a role="system" message."""
+    orch, provs, tools, hooks = _make_harness(
+        config={"system_prompt": "OWN SYSTEM FRAMING MARKER"},
+        responses=[_text_response("ok")],
+    )
+    seeded = [
+        {"role": "system", "content": "a DIFFERENT node's stale system prompt"},
+        {"role": "user", "content": "prior turn"},
+        {"role": "assistant", "content": "prior reply"},
+    ]
+    context = FakeContext(seeded)
+
+    await orch.execute("current prompt", context, provs, tools, hooks)
+
+    sent = _sent_messages(provs["test"])
+    system_messages = [m for m in sent if m.role == "system"]
+    assert len(system_messages) == 1, (
+        f"expected exactly one system message, got {len(system_messages)}: "
+        f"{system_messages!r}"
+    )
+    assert "OWN SYSTEM FRAMING MARKER" in system_messages[0].content
+    assert "a DIFFERENT node's stale system prompt" not in system_messages[0].content
+    # The system message always leads (messages.py: system-first ordering).
+    assert sent[0] is system_messages[0]
+    # The seeded user/assistant turns still made it through.
+    contents = [getattr(m, "content", None) for m in sent]
+    assert "prior turn" in contents
+    assert "prior reply" in contents
+
+
+# ---------------------------------------------------------------------------
+# 4. Hydrate once, before turn 1 -- not re-seeded on a later process_input().
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_hydration_runs_once_not_on_every_invocation():
+    """A session persists across multiple execute() calls (follow-ups,
+    steering). Seeded history belongs only at turn 1 -- a second execute()
+    call on the SAME session/context must not replay the seeded messages a
+    second time."""
+    orch, provs, tools, hooks = _make_harness(
+        responses=[_text_response("first"), _text_response("second")]
+    )
+    seeded = [{"role": "user", "content": "seed-once"}]
+    context = FakeContext(seeded)
+
+    await orch.execute("prompt one", context, provs, tools, hooks)
+    await orch.execute("prompt two", context, provs, tools, hooks)
+
+    # get_messages() is only even consulted once (hydration guard trips
+    # before the second call ever reads the context again).
+    assert context.call_count == 1
+
+    sent_second = _sent_messages(provs["test"], call_index=1)
+    seed_occurrences = [
+        m for m in sent_second if getattr(m, "content", None) == "seed-once"
+    ]
+    assert len(seed_occurrences) == 1, (
+        "seeded message replayed more than once across invocations -- "
+        f"found {len(seed_occurrences)} occurrences"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. Unsupported roles in seeded history are skipped, not crashed on.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unsupported_role_in_seeded_history_is_skipped_not_fatal(
+    caplog: pytest.LogCaptureFixture,
+):
+    """A seeded 'tool'-role (or otherwise-shaped) entry cannot be safely
+    replayed without a correlated tool_call_id -- it must be skipped with a
+    warning, never fabricated, and never crash the node."""
+    orch, provs, tools, hooks = _make_harness(responses=[_text_response("ok")])
+    seeded = [
+        {"role": "user", "content": "kept turn"},
+        {"role": "tool", "content": "orphaned tool result"},
+        "not-even-a-dict",
+    ]
+    context = FakeContext(seeded)
+
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        result = await orch.execute("hello", context, provs, tools, hooks)
+
+    assert result == "ok"
+    assert any("could not be replayed" in rec.getMessage() for rec in caplog.records)
+
+    sent = _sent_messages(provs["test"])
+    contents = [getattr(m, "content", None) for m in sent]
+    assert "kept turn" in contents
+    assert "orphaned tool result" not in contents


### PR DESCRIPTION
## Summary
Fixes the actual field incident behind microsoft-amplifier/amplifier-support#497 (referenced without a closing keyword — the ticket is managed manually): **`loop-agent`, the default node worker, kept its own `SessionHistory` and never read the mounted context.** The engine's backend builds `parent_messages` for `fidelity="full"` and foundation's spawn seeds them into the child session's context via `set_messages()` *before* `execute()` runs — but nothing on the loop-agent side ever consumed them. The ticket's own live evidence shows the result: *"Final message count for API: 1"* despite *"Restored 2 messages to context."* Cross-node continuity never reached the model.

## The fix
`AgentSession` gains a `context` param; `_hydrate_history_from_context()` runs once at the top of `process_input()`, converting seeded user/assistant messages through the **same Turn taxonomy every other turn uses** (no parallel conversion path):
1. **System messages filtered at hydration** — loop-agent builds its own 5-layer system prompt per request (PROV-002), and the engine's `_append_to_transcript` strips system roles from transcripts anyway; the filter is documented belt-and-braces.
2. **Seeded `tool_calls` / `role=tool` entries dropped with a counted, logged warning** — never replayed with fabricated `tool_call_id` pairing (disclosed limitation).
3. **Read-only toward the mounted context** — only `get_messages()` is ever called; the seeded context is never mutated.
4. **Idempotence guarded** — `_context_hydrated` is set synchronously before any `await`; hydration cannot run twice.
5. **Honest failure** — a raising `get_messages()` logs a loud warning and degrades (no history), never crashes the node, never fabricates.

## Verification checklist
- [x] 9 new tests; **RED-proven** — 7/9 fail against pre-fix loop-agent (stash/run/restore; independently reproduced by the adversarial reviewer), the 2 pass-either-way cases are true no-ops (context=None / missing `get_messages`)
- [x] Suite **538 → 547 passed / 0 failed**
- [x] Negatives: `context=None` / empty / missing method / raising `get_messages`
- [x] System-framing survival: own system prompt present **exactly once** post-hydration
- [x] Message-count proof: 2 seeded + 1 prompt → >1 messages in the built request (the #497 signature, inverted)
- [x] Engine + specs untouched: `git diff origin/main -- modules/loop-pipeline specs/` = empty (conformance matrix byte-frozen)
- [x] Independent adversarial review: **MERGE** — hydration taxonomy fidelity, ordering, idempotence, and read-only posture all verified; system-filter judgment confirmed grounded (backend strips system roles from transcripts, so the filter is belt-and-braces, not information loss)
- [x] EXTENSIONS entry: N/A — this *implements* the already-ledgered §12 mechanism at the worker; a §12 wording refinement ("restores the spec-mandated behavior" was only true to the spawn boundary until now) is flagged as a docs follow-up, deliberately not bundled here
- [x] Pre-publication leak review: clean
- [x] CI green before merge — will confirm

## Disclosures
1. **No live continuity test — honest stop.** loop-agent has no key-gated live harness; building one here was disproportionate. The message-count and RED proofs pin the behavior; the sibling seam has a live secret-recall test in the adapter.
2. **Companion fix:** the analogous latent bug in the `loop-amplifier-agent` adapter was fixed via dot-runner PR #3 (adopted from @kenotron-ms with changes, merged @ 86e712e). Both workers now honor seeded context — the forthcoming worker parity kit will pin this class in both CIs.
3. Seeded tool-call/tool-role entries are dropped-with-warning rather than replayed (no fabricated pairing).
