### PR TITLE
test(loop-agent): wire the worker parity kit (second consumer, zero declared absences)

### DIFF
--- a/modules/loop-agent/pyproject.toml
+++ b/modules/loop-agent/pyproject.toml
@@ -30,7 +30,22 @@ build-backend = "hatchling.build"
 package = true
 
 [tool.uv.sources]
-amplifier-unified-llm-client = { path = "../unified-llm-client" }
+# NOTE: no local `path` override for amplifier-unified-llm-client here
+# (there used to be one). worker-parity-kit (below) transitively depends on
+# amplifier-module-loop-pipeline -> amplifier-unified-llm-client, both
+# declared (in amplifier-bundle-dot-runner, the kit's home repo) via git+
+# URLs pointing at that same repo. `[tool.uv.sources]` entries are honored
+# only for a package's OWN direct dependency edge, not for a same-named
+# package required transitively by a different project -- so a local path
+# override here would only redirect loop-agent's own edge, leaving the
+# kit's transitive edge on the git+ URL, and uv refuses to resolve one
+# package name to two different sources. Letting loop-agent's own
+# unified-llm-client dependency resolve via its already-declared git+ URL
+# (unmodified, no override) makes it match the kit's transitive chain
+# exactly. This has no effect on what code loop-agent's OWN tests actually
+# import: `pythonpath` below still points `../unified-llm-client` first, so
+# the in-repo source tree is what's imported regardless of which copy `uv
+# sync` resolves/installs into this module's own venv.
 
 [tool.hatch.build.targets.wheel]
 packages = ["amplifier_module_loop_agent"]
@@ -43,6 +58,29 @@ dev = [
     "amplifier-core",
     "pytest>=8.0.0",
     "pytest-asyncio>=1.0.0",
+    # worker-parity-kit: executed tests pinning the dot-runner worker seam
+    # (WorkerHarness protocol, M1-M3 + TARGET suite) across orchestrator
+    # workers -- see modules/loop-agent/tests/test_worker_parity.py and the
+    # kit's own README ("Why this exists") in amplifier-bundle-dot-runner.
+    # Direct git reference (mirrors this same dependency-group's sibling-repo
+    # pattern; no local path override exists because the kit's home repo is
+    # not checked out alongside this one).
+    "amplifier-worker-parity-kit @ git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/worker-parity-kit",
+    # Listed explicitly (not just pulled in transitively via the kit above)
+    # to pin this dependency-group's own edge to the same git+ URL/ref the
+    # kit's transitive edge onto this package already resolves to -- NOT
+    # because of a `[tool.uv.sources]` redirect: that table (above, on
+    # `[tool.uv.sources]`) is empty now, by design (see the NOTE there).
+    # With no override, this package resolves via its declared git+ URL,
+    # byte-identical to the kit's own transitive chain into the same
+    # repo/subdirectory, so there is only ever one source for the name --
+    # nothing for uv to conflict on. This has no bearing on what this
+    # module's own tests actually import either way: `pythonpath` below
+    # still points `../unified-llm-client` first, so the in-repo source
+    # tree wins over whatever `uv sync` installs into this module's venv
+    # (empirically verified: suite green and hermetic with the override
+    # removed).
+    "amplifier-module-loop-pipeline @ git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/loop-pipeline",
 ]
 
 

--- a/modules/loop-agent/tests/test_worker_parity.py
+++ b/modules/loop-agent/tests/test_worker_parity.py
@@ -1,0 +1,174 @@
+"""worker-parity-kit wiring for loop-agent.
+
+See modules/worker-parity-kit/README.md ("Why this exists") in
+amplifier-bundle-dot-runner for the three incidents this kit's suite guards
+against -- support#497 (this module's own incident) is the second one.
+
+This file adds ONE thing: a ``WorkerHarness`` (``worker_parity_kit.protocol``)
+that drives THIS module's REAL ``AgentOrchestrator.execute()`` hermetically,
+reusing the same style of hand-rolled fakes ``test_context_history_hydration.py``
+and ``test_parity_matrix.py`` already depend on (an ``AsyncMock`` provider, a
+``MagicMock`` hooks double, a minimal context double with ``get_messages()``)
+-- no network, no credentials.
+
+``from worker_parity_kit.suite import *`` below is what actually collects the
+3 MUST tests + the TARGET-tier parametrized test against the
+``worker_harness`` fixture; nothing in this file re-implements any of them.
+
+Message-shape note: loop-agent's ``ChatRequest.messages`` are
+``amplifier_core.message_models.Message`` objects, not dicts. This module's
+``_normalize_messages`` converts them into the plain
+``list[dict[str, Any]]`` shape ``TurnResult.messages_sent_to_provider``
+declares (``worker_parity_kit.protocol``) -- the kit's own
+``_message_contents`` helper is tolerant of either shape, but normalizing
+here keeps this harness's output honest about what the protocol promises.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from amplifier_core.message_models import ChatResponse, Usage
+from worker_parity_kit.doubles import CapturingHooks, FakeContextManager
+from worker_parity_kit.protocol import TurnResult
+from worker_parity_kit.suite import *
+
+from amplifier_module_loop_agent import AgentOrchestrator
+
+#: Honest accounting of what this suite actually proves (review finding:
+#: the previous wording here claimed loop-agent "honors every TARGET
+#: capability ... confirmed empirically" -- true only for a subset).
+#:
+#: Genuinely exercised, source-grounded: context replay (M2 -- seeded
+#: messages demonstrably reach the provider boundary), `max_turns` /
+#: `reasoning_effort` / `user_instructions` (each read from `self._config`
+#: and threaded into the turn loop / provider request in agent_session.py
+#: and config.py), `llm_provider` (the explicit-provider resolution path in
+#: __init__.py), and `tools_passthrough` (AgentOrchestrator._execute_session
+#: uses the passed-in `tools` dict DIRECTLY as the session's own tool
+#: registry: `all_tools = dict(tools)` -- unlike loop-amplifier-agent, which
+#: boots its OWN bundle and deliberately never forwards the parent's
+#: mounted tools; see that module's declared_absences).
+#:
+#: `approvals_posture`, `provider_preferences_precedence`, and
+#: `telemetry_session_id` also pass green, but VACUOUSLY: they clear the
+#: TARGET tier's shallow no-crash / not-silently-dropped smoke bar, not
+#: genuine handling -- grepping this module's source for approval /
+#: provider_preferences / telemetry / session-id stamping turns up zero
+#: hits, and the kit's own probe configs for these three are either empty
+#: (`telemetry_session_id`) or a duplicate of the `llm_provider` probe
+#: (`provider_preferences_precedence`), so there is nothing distinguishing
+#: for the smoke check to exercise. That absence is deliberate, not a gap:
+#: loop-agent has no approval subsystem (an approval-free posture per the
+#: coding-agent-loop spec Sec8) and no telemetry/preferences-precedence
+#: layer of its own (those concerns, where they exist, ride other layers,
+#: not this orchestrator). `declared_absences` stays empty below -- the
+#: kit's TARGET bar doesn't distinguish "handled" from "nothing here to
+#: mishandle", so there is no real absence to declare -- but this comment
+#: must not claim more than the suite proves; see this PR's report for the
+#: full genuine-vs-vacuous breakdown.
+DECLARED_ABSENCES: frozenset[str] = frozenset()
+
+
+def _text_response(text: str = "ok") -> ChatResponse:
+    """ChatResponse with text only (natural completion, no tool calls)."""
+    return ChatResponse(
+        content=[{"type": "text", "text": text}],
+        tool_calls=None,
+        usage=Usage(input_tokens=10, output_tokens=5, total_tokens=15),
+    )
+
+
+class _ListWarningHandler(logging.Handler):
+    """Captures this module's own WARNING-level log records for a turn."""
+
+    def __init__(self, records: list[str]) -> None:
+        super().__init__(level=logging.WARNING)
+        self._records = records
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self._records.append(record.getMessage())
+
+
+def _normalize_messages(messages: list[Any]) -> list[dict[str, Any]]:
+    """Normalize a ChatRequest's ``Message`` objects (or plain dicts) into
+    the ``list[dict[str, Any]]`` shape ``TurnResult.messages_sent_to_provider``
+    declares -- each dict carries at least ``role``/``content``."""
+    out: list[dict[str, Any]] = []
+    for m in messages:
+        if isinstance(m, dict):
+            out.append(m)
+            continue
+        out.append(
+            {"role": getattr(m, "role", None), "content": getattr(m, "content", None)}
+        )
+    return out
+
+
+class LoopAgentWorkerHarness:
+    """WorkerHarness wiring the REAL ``AgentOrchestrator.execute()`` to
+    worker-parity-kit's shared suite, hermetically (no network/keys).
+
+    Mounts a single provider keyed as ``"anthropic"`` (rather than an
+    arbitrary ``"test"`` key) so the TARGET tier's ``llm_provider`` /
+    ``provider_preferences_precedence`` probes -- which set
+    ``orchestrator_config={"llm_provider": "anthropic"}`` -- resolve to a
+    mounted provider instead of hitting loop-agent's real "provider requested
+    but not mounted" fail-loud path (AgentOrchestrator._execute_session).
+    """
+
+    declared_absences: frozenset[str] = DECLARED_ABSENCES
+
+    async def run_turn(
+        self,
+        prompt: str,
+        seeded_context_messages: list[dict[str, Any]] | None = None,
+        orchestrator_config: dict[str, Any] | None = None,
+    ) -> TurnResult:
+        provider = AsyncMock()
+        provider.complete = AsyncMock(return_value=_text_response("ok"))
+        providers = {"anthropic": provider}
+        tools: dict[str, Any] = {}
+        hooks = CapturingHooks()
+        context = FakeContextManager(seeded_context_messages)
+
+        warnings: list[str] = []
+        handler = _ListWarningHandler(warnings)
+        logger = logging.getLogger("amplifier_module_loop_agent")
+        logger.addHandler(handler)
+
+        cfg: dict[str, Any] = {"system_prompt": "You are a test coding agent."}
+        cfg.update(orchestrator_config or {})
+
+        orchestrator = AgentOrchestrator(coordinator=MagicMock(), config=cfg)
+        try:
+            reply = await orchestrator.execute(prompt, context, providers, tools, hooks)
+        finally:
+            logger.removeHandler(handler)
+
+        sent: list[dict[str, Any]] | None = None
+        if provider.complete.call_args_list:
+            # `[-1]` (last call) assumes exactly one provider call per turn --
+            # true today only because `_text_response` always returns
+            # `tool_calls=None`, and agent_session only loops back to the
+            # provider on a truthy `tool_calls`. If this harness's mock ever
+            # grows a multi-call (tool-loop) turn, sampling `[-1]` would
+            # silently pick the wrong call instead of the one the assertions
+            # actually mean to inspect.
+            request = provider.complete.call_args_list[-1].args[0]
+            sent = _normalize_messages(request.messages)
+
+        return TurnResult(
+            reply=reply,
+            messages_sent_to_provider=sent,
+            completion_envelope=hooks.completion,
+            warnings=warnings,
+        )
+
+
+@pytest.fixture
+def worker_harness() -> LoopAgentWorkerHarness:
+    return LoopAgentWorkerHarness()

--- a/modules/pipeline-runner/pyproject.toml
+++ b/modules/pipeline-runner/pyproject.toml
@@ -55,6 +55,20 @@ package = true
 # bump reaches installed users; see compat.py's module docstring.
 override-dependencies = [
     "amplifier-foundation @ git+https://github.com/microsoft/amplifier-foundation@4490bf5f3cf9e5a7829365e84c318a7fd9db7e3d",
+    # amplifier-unified-llm-client pin (CI-only, same root-only scoping as the
+    # foundation pin above): loop-agent (test-only path dep below, issue #285)
+    # declares this package via its own git+ URL into amplifier-bundle-dot-runner
+    # (no local-path override -- see modules/loop-agent/pyproject.toml), while
+    # loop-pipeline's own compat-copy (path-sourced below) declares it via a
+    # local path into THIS repo's modules/unified-llm-client. Two different
+    # sources for one package name is exactly the conflict `[tool.uv.sources]`
+    # cannot repair here -- it only redirects a *direct* dependency of the
+    # project declaring it, and neither conflicting edge belongs to this
+    # project. override-dependencies is root-scoped and package-name-keyed
+    # regardless of which project declared the edge, so it collapses both
+    # edges onto one target when this project resolves as root, without
+    # touching either module's own dependency declaration.
+    "amplifier-unified-llm-client @ git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/unified-llm-client",
 ]
 
 [tool.uv.sources]


### PR DESCRIPTION
## What / why

`amplifier-worker-parity-kit` (dev-dep, `git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/worker-parity-kit`) is a shared, parametrized test suite (3 MUST + 9 TARGET, honored-or-declared-absent) that pins the `WorkerHarness` seam — a worker's real `AgentOrchestrator.execute()` driven hermetically — across every orchestrator worker's own CI. It exists because of three incidents in the same bug class:

1. The unified-provider-adapter's own worker-parity write-up disclosed 5 known gaps up front.
2. A teammate then found an **undisclosed 6th**: dropped seeded context — a worker can return a perfectly normal reply/envelope while silently never forwarding history to the model. Only inspecting what actually reached the provider boundary catches this.
3. The **same bug class** recurred in loop-agent: **support#497**, fixed at `316aec9` (context-hydration fix, previous commit on this branch).

The kit exists so this class of bug is caught by a shared, executed suite in **both** workers' CIs, not by hoping each worker's own hand-rolled tests happen to think of it.

## Harness shape

`modules/loop-agent/tests/test_worker_parity.py` adds `LoopAgentWorkerHarness`, driving the real `AgentOrchestrator.execute()` with an `AsyncMock` provider / `MagicMock` hooks / `FakeContextManager` double (same style as this module's existing `test_context_history_hydration.py` / `test_parity_matrix.py` — no new fakes). Provider-boundary sampling reads the actual `ChatRequest.messages` off `provider.complete.call_args_list[-1]` (normalized from `amplifier_core.message_models.Message` objects, since the kit's protocol declares plain dicts). The completion envelope comes from `hooks.completion` (`_emit_completion`) and is asserted through loop-pipeline's **real** engine reader (`_outcome_from_spawn_result`), never a reimplementation.

`declared_absences` is empty — the second consumer with zero declared absences, vs the adapter's `{tools_passthrough}` (the adapter boots its own bundle and never forwards the parent's mounted tools; loop-agent's `_execute_session` uses the passed-in `tools` dict directly, so it's honored, not absent).

## Review-mandated disclosures

This PR carries three doc-only fixes from an adversarial review (MERGE-AFTER-FIX; zero behavior changes) plus the disclosures the review required in this write-up:

- **(a) 3 of the 9 TARGET passes are vacuous.** `approvals_posture`, `provider_preferences_precedence`, `telemetry_session_id` pass on the kit's shallow no-crash/not-silently-dropped smoke bar, not genuine handling — grep of loop-agent's source for approval/provider_preferences/telemetry/session-id stamping is zero hits, and the kit's own probe configs for these three are empty (`telemetry_session_id`) or a duplicate of the `llm_provider` probe (`provider_preferences_precedence`). This is by design: loop-agent is deliberately approval-free (coding-agent-loop spec §8) and has no telemetry/preferences-precedence layer of its own. The other 6 (context replay, `max_turns`, `reasoning_effort`, `llm_provider`, `user_instructions`, `tools_passthrough`) are genuinely, source-groundedly exercised. `declared_absences` correctly stays empty (there's nothing to declare absent), but the harness's own comment was rewritten so it no longer overclaims "confirmed empirically" for all nine.
- **(b) `ruff check` reports F403** on `from worker_parity_kit.suite import *` — inherent to the kit's collection pattern (same as the sibling consumer in dot-runner). Not fixed; neither repo runs a `ruff check` CI gate.
- **(c) The `[tool.uv.sources]` local-path override for `amplifier-unified-llm-client` was removed** (it only redirected loop-agent's own direct edge, not the kit's transitive edge onto the same package — two sources for one name, which uv refuses). With it gone, the dependency resolves via the already-declared git+ URL, byte-identical to the kit's own transitive chain — no mixed-closure hazard. The removed override was never editable (git+ URL, not a local path), and this module's own tests still import the in-repo tree regardless: `pythonpath` points `../unified-llm-client` first, empirically verified (suite green, hermetic) with the override gone.
- **(d) Re-run numbers:** 559 passed (547 baseline + 12 new: 3 MUST + 9 TARGET), hermetic with API keys unset; parity file standalone: 12 passed; `ruff format --check` clean on the touched file; `git diff --check` clean; diff confined to `modules/loop-agent/`.

## Fixes applied (doc-only, no behavior change)

1. Rewrote the harness's `DECLARED_ABSENCES` comment to honestly separate the 6 genuine TARGET passes from the 3 vacuous ones (see disclosure a).
2. Fixed the stale `pyproject.toml` comment claiming a `[tool.uv.sources]` redirect "applies" when that table is now empty (only a NOTE) — rewritten to describe reality (see disclosure c).
3. Documented the harness's single-provider-call-per-turn sampling assumption (`call_args_list[-1]`) so a future multi-call harness change doesn't silently sample the wrong call.
