### PR TITLE
docs: nlspec-first gate in contributor conventions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,6 +3,7 @@
 
 ## Verification checklist
 
+- [ ] Checked what the strongdm/attractor nlspec says about this (cite section) — or N/A with reason
 - [ ] Unit tests pass (`pytest modules/loop-pipeline/`)
 - [ ] Live pipeline run exercising changed code path — required when touching `engine.py` or any handler; paste `events.jsonl` analysis or test-run output in the section below
 - [ ] AGENTS.md reviewed; repo-specific gates met

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,9 +68,38 @@ This ecosystem has five documented recurring bug species: incomplete assembly, l
 - **Designing a change**: read [`docs/designs/RECURRING-BUG-CLASSES.md`](docs/designs/RECURRING-BUG-CLASSES.md).
 - **Reviewing a PR**: read [`docs/designs/CODE-REVIEW-CHECKLIST.md`](docs/designs/CODE-REVIEW-CHECKLIST.md).
 
-## Spec authority
+## Before you design, file, or submit
 
-When behavior is ambiguous, the canonical spec at `github.com/strongdm/attractor` is authoritative. Our implementation extends but does not contradict the spec. If you find yourself "fixing" something that is spec-conformant, stop and check `specs/` first.
+Before any design proposal, issue report, or code change touching engine or
+spec-adjacent behavior, ask: **"Did you check what the strongdm/attractor
+nlspec has to say about this first?"** This is "Walk upstream first"
+(`PRINCIPLES.md`) made explicit as a gate:
+
+1. **Check the nlspec first.** The canonical, pinned copies and the
+   compatibility doctrine now live in
+   [`amplifier-bundle-dot-runner`](https://github.com/microsoft/amplifier-bundle-dot-runner)
+   (`specs/canonical/`) — this repo's own `specs/` copy is a temporary
+   compat window, not the source of truth. Cite the section in your issue,
+   PR, or design doc.
+2. **Conform-fixes are easy yeses.** If the nlspec clearly defines the
+   behavior and we implement it wrong or not at all, that's a "yes, fix it"
+   (recent examples: support#497, support#498 — both spec-behavior holes,
+   both sailed through review).
+3. **Need it at all?** If the nlspec is silent, ask whether the need can be
+   met *outside* the engine first: an extension/wrapper, pre/post-processing,
+   or composing pipelines into something larger. Prefer those.
+4. **True extensions/divergences face the hard bar.**
+   [`SPEC_CONFORMANCE.md`](https://github.com/microsoft/amplifier-bundle-dot-runner/blob/main/SPEC_CONFORMANCE.md)'s
+   Compatibility doctrine (including rule 5, "Anchoring survives scope")
+   plus a ledgered
+   [`specs/EXTENSIONS.md`](https://github.com/microsoft/amplifier-bundle-dot-runner/blob/main/specs/EXTENSIONS.md)
+   entry — both authoritative in `amplifier-bundle-dot-runner` now — are
+   required. Not the wild-west; "the spec didn't anticipate this shape"
+   files an entry, it doesn't skip one.
+
+When behavior is ambiguous, the canonical spec is authoritative. Our
+implementation extends but does not contradict it. If you find yourself
+"fixing" something that is spec-conformant, stop and check first.
 
 ## Dependency awareness rule
 


### PR DESCRIPTION
## What

Integrates the maintainer's **nlspec-first gate** into this repo's existing contributor conventions, strengthening what was already there rather than duplicating it.

- **`AGENTS.md`** — the existing "Spec authority" section (which already said "check `specs/` first") is expanded into **"Before you design, file, or submit"**: the gate question plus a 4-rung decision ladder. Paths are adjusted for the post-repo-split world: `specs/canonical/`, `SPEC_CONFORMANCE.md`, and `specs/EXTENSIONS.md` are now authoritative in `amplifier-bundle-dot-runner` (linked); this repo's own `specs/` copy is called out as the temporary compat window. "Walk upstream first" (`PRINCIPLES.md`) is cross-referenced, not restated.
- **`.github/PULL_REQUEST_TEMPLATE.md`** — added one line, first in the existing "Verification checklist": "Checked what the strongdm/attractor nlspec says about this (cite section) — or N/A with reason".
- Issue templates (`.github/ISSUE_TEMPLATE/`) — left untouched; out of scope for this PR.

## The gate

> Did you check what the strongdm/attractor nlspec has to say about this first?

1. Check the nlspec first (now in `amplifier-bundle-dot-runner`'s `specs/canonical/`, cite the section).
2. Conform-fixes are easy yeses (recent examples: support#497, support#498).
3. If the nlspec is silent, ask whether the need can be met outside the engine (extension/wrapper, pre/post-processing, composition) first.
4. True extensions/divergences meet the hard bar: dot-runner's `SPEC_CONFORMANCE.md` Compatibility doctrine (rule 5, "Anchoring survives scope") + a ledgered `specs/EXTENSIONS.md` entry.

## Scope

Docs-only: `AGENTS.md` and `.github/PULL_REQUEST_TEMPLATE.md`. No `specs/`, `modules/`, or conformance-matrix content touched — `git diff --stat` confirms exactly these two files.

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>