### PR TITLE
feat: P4 pattern-layer flip — attractor consumes the moved modules from dot-runner + explicit worker declaration (program P4, ungated half)

### DIFF
--- a/.github/capsule-pipeline/attractor-pipeline-dual.yaml
+++ b/.github/capsule-pipeline/attractor-pipeline-dual.yaml
@@ -15,6 +15,16 @@
 # blind re-sync would silently revert the engine repo split for BOTH
 # workflows that mount this bundle.
 #
+# FURTHER LEDGERED DIVERGENCE (P4, second extraction consumer flip): the
+# loop-agent orchestrator source (3x, one per child agent) and the three
+# hooks: sources (hooks-tool-truncation, hooks-pipeline-progress,
+# hooks-pipeline-observability) were likewise flipped from
+# amplifier-bundle-attractor to amplifier-bundle-dot-runner -- those modules
+# moved there too (DESIGN-worker-registry-core-split.md P2). A run-level
+# `worker: "spawn"` was also added to the pipeline orchestrator config,
+# citing dot-runner EXTENSIONS.md §40 (see the inline comment below). A
+# future re-sync MUST re-apply both flips and the worker declaration.
+#
 # UNCONDITIONALLY WIRED INTO BOTH WORKFLOWS (OPENAI_API_KEY exists as a
 # proven repo secret; issue #155 closed the conditional-fallback trap):
 # - .github/workflows/capsule-implement.yml mounts this bundle via
@@ -80,6 +90,10 @@ session:
     module: loop-pipeline
     source: git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/loop-pipeline
     config:
+      # Explicit worker-selection declaration (dot-runner EXTENSIONS.md §40).
+      # "spawn" is the reserved sentinel reaching the loop-agent child agents
+      # below via the profiles map -- declared rather than left implicit.
+      worker: "spawn"
       profiles:
         anthropic: attractor-agent-anthropic
         openai: attractor-agent-openai
@@ -105,11 +119,11 @@ tools:
 
 hooks:
   - module: hooks-tool-truncation
-    source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/hooks-tool-truncation
+    source: git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/hooks-tool-truncation
   - module: hooks-pipeline-progress
-    source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/hooks-pipeline-progress
+    source: git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/hooks-pipeline-progress
   - module: hooks-pipeline-observability
-    source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/hooks-pipeline-observability
+    source: git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/hooks-pipeline-observability
 
 # --- Child agents (one per provider, spawned by the pipeline engine) ---------
 # IMPORTANT: inline session.orchestrator is REQUIRED (loop-pipeline recursion
@@ -122,7 +136,7 @@ agents:
     session:
       orchestrator:
         module: loop-agent
-        source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
+        source: git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/loop-agent
         config:
           max_tool_rounds_per_input: 50
           default_command_timeout_ms: 120000
@@ -133,7 +147,7 @@ agents:
     session:
       orchestrator:
         module: loop-agent
-        source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
+        source: git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/loop-agent
         config:
           max_tool_rounds_per_input: 50
           default_command_timeout_ms: 10000
@@ -155,7 +169,7 @@ agents:
     session:
       orchestrator:
         module: loop-agent
-        source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
+        source: git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/loop-agent
         config:
           max_tool_rounds_per_input: 50
           default_command_timeout_ms: 10000

--- a/README.md
+++ b/README.md
@@ -77,6 +77,25 @@ The agent can generate pipelines on-the-fly or use any of the included examples.
 
 **4. Or run an example directly from the CLI:**
 
+**Two CLIs exist, and they are not the same thing.** `attractor` is this
+bundle's opinionated wrapper -- it auto-loads the attractor pipeline bundle
+(`loop-agent` default worker, the three-provider profile map, capsule-lane
+integration) so `attractor run`/`attractor lint`/`attractor resume` keep
+working exactly as documented below. It ships today from
+[`amplifier-bundle-dot-runner`](https://github.com/microsoft/amplifier-bundle-dot-runner)'s
+`pipeline-runner` module as a **deprecation-window** entry point (prints a
+one-line stderr notice) -- the engine-native default it will eventually fall
+back to is deliberately NOT this bundle. The engine's OWN command,
+`dot-runner`, has zero reach into this repo: engine-native defaults
+(`direct` worker, provider bootstrap from env keys), no attractor bundle,
+no capsule lanes. Use `attractor` for the opinionated coding-agent
+experience this README describes; use `dot-runner` if you want the bare
+engine with no pattern-layer opinions. This bundle does not ship its own
+`attractor` console script (that would collide with the one above during
+the deprecation window) -- only bundle-level wiring (the explicit `worker:
+"spawn"` + `profiles` declarations described under
+[Backend Selection / Worker Selection](#backend-selection--worker-selection)).
+
 The `attractor run` CLI executes a `.dot` with no config file. The
 `bug-fix` / `refactor` / `test-gen` [practical examples](examples/pipelines/practical/)
 ship a runnable sample target, so they work walk-up. From a clone of this repo:
@@ -523,13 +542,29 @@ amplifier-bundle-attractor/
 | `tool-dashboard-query` | tool | Pipeline status queries and management via HTTP API |
 | `tool-pipeline-status` | tool | Returns pipeline execution state |
 
-### Backend Selection
+### Backend Selection / Worker Selection
 
-The pipeline orchestrator auto-selects the execution backend:
+The pipeline orchestrator (`loop-pipeline`, now living in
+[`amplifier-bundle-dot-runner`](https://github.com/microsoft/amplifier-bundle-dot-runner))
+resolves ONE adapter class (`AmplifierBackend`) that internally dispatches
+per node to a named **worker** (dot-runner `specs/EXTENSIONS.md` §40):
 
-1. If `session.spawn` capability is registered --> `AmplifierBackend` (full sub-sessions per node, tools included)
-2. Else if a provider is available --> `DirectProviderBackend` (per-node **agentic tool loop** via `unified_llm` -- whatever tools are mounted are passed through, and `unified-llm-client` drives the call -> tool -> call rounds internally. Node tools are only absent when the host mounts none, e.g. the bare programmatic path above. Requires an explicit `llm_model` on every node; there is no default)
-3. Otherwise --> simulation mode (for testing)
+1. The node's own `worker=` attribute, if set.
+2. The run-level default -- this bundle's pipeline orchestrators declare it
+   EXPLICITLY as `config.worker: "spawn"` (see `bundles/attractor-pipeline.yaml`,
+   `agents/pipeline-runner.yaml`, `bundle.md`) rather than relying on
+   capability-fallback.
+3. Capability fallback (unchanged): `"spawn"` if `session.spawn` resolved for
+   this run, else `"direct"`.
+
+`"spawn"` reaches a hosted child-agent session (full sub-session per node,
+tools included) via the `profiles` map, spawning `loop-agent` by default in
+this bundle. `"direct"` is a single in-process agentic tool loop against a
+provider with no hosted session -- requires an explicit `llm_model` on every
+node; there is no default. See the
+[DOT Authoring Guide's Worker Selection section](docs/DOT-AUTHORING-GUIDE.md#worker-selection)
+for the full picture, including `llm_provider` (model family) vs `worker`
+(execution mechanism).
 
 </details>
 

--- a/agents/attractor-agent-anthropic-isolated.yaml
+++ b/agents/attractor-agent-anthropic-isolated.yaml
@@ -33,7 +33,7 @@ session:
     # made these relative:  "loop-agent: File not found:
     # .../amplifier_app_cli/_bundle/behaviors/modules/loop-agent" -- and the session
     # refused to start.  See docs/designs/2026-08-15-composition-fix.md.
-    source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
+    source: git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/loop-agent
     config:
       max_tool_rounds_per_input: 50
       default_command_timeout_ms: 120000

--- a/agents/attractor-agent-anthropic.yaml
+++ b/agents/attractor-agent-anthropic.yaml
@@ -32,7 +32,7 @@ session:
     # made these relative:  "loop-agent: File not found:
     # .../amplifier_app_cli/_bundle/behaviors/modules/loop-agent" -- and the session
     # refused to start.  See docs/designs/2026-08-15-composition-fix.md.
-    source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
+    source: git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/loop-agent
     config:
       max_tool_rounds_per_input: 50
       default_command_timeout_ms: 120000

--- a/agents/attractor-agent-gemini-isolated.yaml
+++ b/agents/attractor-agent-gemini-isolated.yaml
@@ -35,7 +35,7 @@ session:
     # made these relative:  "loop-agent: File not found:
     # .../amplifier_app_cli/_bundle/behaviors/modules/loop-agent" -- and the session
     # refused to start.  See docs/designs/2026-08-15-composition-fix.md.
-    source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
+    source: git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/loop-agent
     config:
       max_tool_rounds_per_input: 50
       default_command_timeout_ms: 120000

--- a/agents/attractor-agent-gemini.yaml
+++ b/agents/attractor-agent-gemini.yaml
@@ -32,7 +32,7 @@ session:
     # made these relative:  "loop-agent: File not found:
     # .../amplifier_app_cli/_bundle/behaviors/modules/loop-agent" -- and the session
     # refused to start.  See docs/designs/2026-08-15-composition-fix.md.
-    source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
+    source: git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/loop-agent
     config:
       max_tool_rounds_per_input: 50
       default_command_timeout_ms: 10000

--- a/agents/attractor-agent-openai-isolated.yaml
+++ b/agents/attractor-agent-openai-isolated.yaml
@@ -33,7 +33,7 @@ session:
     # made these relative:  "loop-agent: File not found:
     # .../amplifier_app_cli/_bundle/behaviors/modules/loop-agent" -- and the session
     # refused to start.  See docs/designs/2026-08-15-composition-fix.md.
-    source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
+    source: git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/loop-agent
     config:
       max_tool_rounds_per_input: 50
       default_command_timeout_ms: 120000

--- a/agents/attractor-agent-openai.yaml
+++ b/agents/attractor-agent-openai.yaml
@@ -32,7 +32,7 @@ session:
     # made these relative:  "loop-agent: File not found:
     # .../amplifier_app_cli/_bundle/behaviors/modules/loop-agent" -- and the session
     # refused to start.  See docs/designs/2026-08-15-composition-fix.md.
-    source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
+    source: git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/loop-agent
     config:
       max_tool_rounds_per_input: 50
       default_command_timeout_ms: 10000

--- a/agents/attractor-expert.md
+++ b/agents/attractor-expert.md
@@ -73,7 +73,7 @@ session:
     # through the attractor namespace) but MAIN's Layer-1 persona, because loop-agent
     # anchors a relative `system_prompt_file` on its own installed location.
     # See docs/designs/2026-08-15-composition-fix.md, "Two resolution classes".
-    source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
+    source: git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/loop-agent
     config:
       # Layer-1 base prompt.  attractor-expert is provider-agnostic (a consultant,
       # not a coding agent), so it gets its OWN persona base rather than a provider

--- a/agents/pipeline-runner.yaml
+++ b/agents/pipeline-runner.yaml
@@ -40,6 +40,12 @@ session:
     # refused to start.  See docs/designs/2026-08-15-composition-fix.md.
     source: git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/loop-pipeline
     config:
+      # Explicit worker-selection declaration (dot-runner EXTENSIONS.md §40).
+      # "spawn" is the reserved sentinel the adapter recognizes for the
+      # hosted session.spawn path that reaches the loop-agent child agents
+      # below via the profiles map -- declared here rather than left to
+      # capability-fallback.
+      worker: "spawn"
       # Profiles map llm_provider values to child agent names.
       profiles:
         anthropic: attractor-agent-anthropic
@@ -72,7 +78,7 @@ agents:
     session:
       orchestrator:
         module: loop-agent
-        source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
+        source: git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/loop-agent
         config:
           max_tool_rounds_per_input: 50
           default_command_timeout_ms: 120000
@@ -83,7 +89,7 @@ agents:
     session:
       orchestrator:
         module: loop-agent
-        source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
+        source: git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/loop-agent
         config:
           max_tool_rounds_per_input: 50
           default_command_timeout_ms: 10000
@@ -94,7 +100,7 @@ agents:
     session:
       orchestrator:
         module: loop-agent
-        source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
+        source: git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/loop-agent
         config:
           max_tool_rounds_per_input: 50
           default_command_timeout_ms: 10000

--- a/behaviors/attractor-core.yaml
+++ b/behaviors/attractor-core.yaml
@@ -46,11 +46,11 @@ tools:
 
 hooks:
   - module: hooks-tool-truncation
-    source: ../modules/hooks-tool-truncation
+    source: git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/hooks-tool-truncation
   - module: hooks-pipeline-progress
-    source: ../modules/hooks-pipeline-progress
+    source: git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/hooks-pipeline-progress
   - module: hooks-pipeline-observability
-    source: ../modules/hooks-pipeline-observability
+    source: git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/hooks-pipeline-observability
 
 agents:
   # ONE expert, ONE definition.  agents/attractor-expert.md carries its own metadata,

--- a/bundle.md
+++ b/bundle.md
@@ -67,7 +67,7 @@ agents:
     session:
       orchestrator:
         module: loop-agent
-        source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
+        source: git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/loop-agent
         config:
           default_command_timeout_ms: 120000
   attractor-profile-openai:
@@ -75,7 +75,7 @@ agents:
     session:
       orchestrator:
         module: loop-agent
-        source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
+        source: git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/loop-agent
         config:
           default_command_timeout_ms: 10000
   attractor-profile-gemini:
@@ -83,7 +83,7 @@ agents:
     session:
       orchestrator:
         module: loop-agent
-        source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
+        source: git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/loop-agent
         config:
           default_command_timeout_ms: 10000
   attractor-pipeline-runner:
@@ -93,6 +93,12 @@ agents:
         module: loop-pipeline
         source: git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/loop-pipeline
         config:
+          # Explicit worker-selection declaration (dot-runner EXTENSIONS.md
+          # §40). "spawn" is the reserved sentinel the adapter recognizes for
+          # the hosted session.spawn path that reaches the loop-agent child
+          # agents below via the profiles map -- declared here rather than
+          # left to capability-fallback.
+          worker: "spawn"
           profiles:
             anthropic: attractor-agent-anthropic
             openai: attractor-agent-openai

--- a/bundles/attractor-agent.yaml
+++ b/bundles/attractor-agent.yaml
@@ -33,7 +33,7 @@ session:
     # made these relative:  "loop-agent: File not found:
     # .../amplifier_app_cli/_bundle/behaviors/modules/loop-agent" -- and the session
     # refused to start.  See docs/designs/2026-08-15-composition-fix.md.
-    source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
+    source: git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/loop-agent
     config:
       default_command_timeout_ms: 120000
 

--- a/bundles/attractor-interactive.yaml
+++ b/bundles/attractor-interactive.yaml
@@ -38,7 +38,7 @@ session:
     # made these relative:  "loop-agent: File not found:
     # .../amplifier_app_cli/_bundle/behaviors/modules/loop-agent" -- and the session
     # refused to start.  See docs/designs/2026-08-15-composition-fix.md.
-    source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
+    source: git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/loop-agent
     config:
       max_tool_rounds_per_input: 50
       default_command_timeout_ms: 120000
@@ -93,6 +93,12 @@ agents:
         module: loop-pipeline
         source: git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/loop-pipeline
         config:
+          # Explicit worker-selection declaration (dot-runner EXTENSIONS.md
+          # §40). "spawn" is the reserved sentinel the adapter recognizes for
+          # the hosted session.spawn path that reaches the loop-agent child
+          # agents below via the profiles map -- declared here rather than
+          # left to capability-fallback.
+          worker: "spawn"
           profiles:
             anthropic: attractor-agent-anthropic
             openai: attractor-agent-openai
@@ -104,7 +110,7 @@ agents:
     session:
       orchestrator:
         module: loop-agent
-        source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
+        source: git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/loop-agent
         config:
           max_tool_rounds_per_input: 50
           default_command_timeout_ms: 120000
@@ -115,7 +121,7 @@ agents:
     session:
       orchestrator:
         module: loop-agent
-        source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
+        source: git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/loop-agent
         config:
           max_tool_rounds_per_input: 50
           default_command_timeout_ms: 10000
@@ -126,7 +132,7 @@ agents:
     session:
       orchestrator:
         module: loop-agent
-        source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
+        source: git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/loop-agent
         config:
           max_tool_rounds_per_input: 50
           default_command_timeout_ms: 10000

--- a/bundles/attractor-pipeline.yaml
+++ b/bundles/attractor-pipeline.yaml
@@ -34,6 +34,16 @@ session:
     # refused to start.  See docs/designs/2026-08-15-composition-fix.md.
     source: git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/loop-pipeline
     config:
+      # Explicit worker-selection declaration (dot-runner EXTENSIONS.md §40).
+      # The registry itself only names "direct"; "spawn" is the reserved
+      # sentinel the adapter recognizes for the hosted session.spawn path,
+      # which is what actually reaches the loop-agent-orchestrated child
+      # agents below via the profiles map. Before this entry the same
+      # routing happened by capability-fallback (spawn selected because
+      # session.spawn resolves for this composition) -- this makes the
+      # attractor layer's policy choice a declared value, not an implicit
+      # side effect of which capabilities happen to be mounted.
+      worker: "spawn"
       # Maps llm_provider values in DOT node attributes to agent names.
       # The model stylesheet sets llm_provider per node; the engine looks
       # up this map to spawn the correct child agent session.
@@ -75,7 +85,7 @@ agents:
     session:
       orchestrator:
         module: loop-agent
-        source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
+        source: git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/loop-agent
         config:
           max_tool_rounds_per_input: 50
           default_command_timeout_ms: 120000
@@ -86,7 +96,7 @@ agents:
     session:
       orchestrator:
         module: loop-agent
-        source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
+        source: git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/loop-agent
         config:
           max_tool_rounds_per_input: 50
           default_command_timeout_ms: 10000
@@ -97,7 +107,7 @@ agents:
     session:
       orchestrator:
         module: loop-agent
-        source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
+        source: git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/loop-agent
         config:
           max_tool_rounds_per_input: 50
           default_command_timeout_ms: 10000

--- a/docs/DOT-AUTHORING-GUIDE.md
+++ b/docs/DOT-AUTHORING-GUIDE.md
@@ -881,7 +881,8 @@ Every node in a DOT pipeline can have these attributes:
 | `thread_id` | String | derived | Thread identifier for session reuse under `full` fidelity. |
 | `class` | String | `""` | Comma-separated CSS classes for model stylesheet targeting. |
 | `llm_model` | String | inherited | LLM model identifier. Overrides stylesheet. |
-| `llm_provider` | String | auto | Provider key (`anthropic`, `openai`, `gemini`). |
+| `llm_provider` | String | auto | Provider key (`anthropic`, `openai`, `gemini`). Selects a MODEL FAMILY only -- orthogonal to `worker` below, which selects the EXECUTION MECHANISM. |
+| `worker` | String | unset (falls through to the run-level default, then capability-fallback) | Which registered worker executes this node -- see [Worker Selection](#worker-selection) below. A conformant `.dot` file never needs this: it is fully defaulted. |
 | `reasoning_effort` | String | unset (provider default) | `low`, `medium`, or `high`. No engine default is injected: unset means the provider's own default applies. The canonical spec's `high` default deliberately does not hold here — set it per node, via `model_stylesheet`, or in a profile (`specs/EXTENSIONS.md` §39, ledger ATX-14). |
 | `timeout` | Duration | unset | Max execution time (e.g., `900s`, `15m`). |
 | `auto_status` | Boolean | `false` | Auto-generate SUCCESS if handler writes no status. |
@@ -1017,6 +1018,73 @@ graph [model_stylesheet="
     #final_check { llm_model: claude-opus-*; reasoning_effort: high; }
 "]
 ```
+
+## Worker Selection
+
+A **worker** is the mechanism that actually executes an LLM (codergen) node --
+distinct from `llm_provider`, which only picks the model family. Selection
+precedence (highest to lowest), per dot-runner `specs/EXTENSIONS.md` §40:
+
+1. The node's own `worker=` attribute, if set (e.g. `worker="direct"`).
+2. The run-level default, set via the pipeline orchestrator's
+   `config.worker` key (e.g. `worker: "spawn"`).
+3. Capability fallback (unchanged): `"spawn"` if `session.spawn` resolved
+   for this run, else `"direct"`.
+
+An unrecognized value at either level raises `ValueError` naming every known
+worker -- never a silent fallback. **A conformant `.dot` file never needs
+`worker=`**: it is defaulted at every level, and the run-level default is the
+primary control surface for an opinionated layer (like this one) that wants
+to pin a mechanism without touching individual nodes.
+
+**What the two names mean:**
+
+- **`direct`** -- the one worker the engine registers by name today: a single
+  in-process tool-loop against a provider, no hosted session, no spawn.
+  Cheapest, no sub-agent identity, no Amplifier-specific capabilities.
+- **`"spawn"`** -- a reserved sentinel, not a registry entry. It tells the
+  adapter to reach a hosted child agent session via `session.spawn`, using
+  the (unchanged) `profiles` map to pick which agent to spawn per node's
+  `llm_provider`. Which orchestrator that spawned agent itself runs under
+  (`loop-agent`, `loop-amplifier-agent`, or a bespoke profile) is decided
+  entirely by that agent's own `session.orchestrator.module` -- the registry
+  has no opinion on it.
+- **`loop-agent`** -- the general Amplifier agent-loop orchestrator,
+  reachable ONLY as a spawned child agent's own orchestrator (never a
+  registry name). This is what the attractor layer's spawned coding agents
+  run today.
+- **`amplifier-agent`** -- the opt-in adapter over the standalone
+  `amplifier-agent` peer library. Also reachable only as a spawned child
+  agent's orchestrator, and never pulled in by a root bundle -- explicitly
+  opt-in via a behavior partial (e.g.
+  `behaviors/dot-runner-amplifier-agent.yaml` in dot-runner).
+
+**What this layer declares.** The attractor bundles (`bundles/*.yaml`,
+`agents/pipeline-runner.yaml`, `bundle.md`) declare their pipeline
+orchestrator's worker EXPLICITLY, rather than relying on the
+capability-fallback tier:
+
+```yaml
+session:
+  orchestrator:
+    module: loop-pipeline
+    source: git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/loop-pipeline
+    config:
+      worker: "spawn"       # explicit -- see specs/EXTENSIONS.md §40
+      profiles:
+        anthropic: attractor-agent-anthropic
+        openai: attractor-agent-openai
+        gemini: attractor-agent-gemini
+```
+
+Each spawned child agent (`attractor-agent-{anthropic,openai,gemini}`, one
+per profile) in turn declares an explicit inline `session.orchestrator:
+module: loop-agent` -- required regardless of the `worker` declaration
+above, so the spawned child does not inherit the parent's `loop-pipeline`
+orchestrator and recurse. The `worker: "spawn"` declaration and the
+per-child `loop-agent` orchestrator answer two different questions: the
+former picks the MECHANISM the pipeline uses to reach a node's agent; the
+latter picks what THAT AGENT runs once reached.
 
 ## Graph-Level Attributes
 

--- a/profiles/attractor-e2e-anthropic.yaml
+++ b/profiles/attractor-e2e-anthropic.yaml
@@ -25,7 +25,7 @@ session:
     # made these relative:  "loop-agent: File not found:
     # .../amplifier_app_cli/_bundle/behaviors/modules/loop-agent" -- and the session
     # refused to start.  See docs/designs/2026-08-15-composition-fix.md.
-    source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
+    source: git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/loop-agent
     config:
       max_tool_rounds_per_input: 20
       reasoning_effort: high
@@ -47,4 +47,4 @@ tools:
 
 hooks:
   - module: hooks-tool-truncation
-    source: ../modules/hooks-tool-truncation
+    source: git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/hooks-tool-truncation

--- a/profiles/attractor-e2e-gemini.yaml
+++ b/profiles/attractor-e2e-gemini.yaml
@@ -20,7 +20,7 @@ session:
     # made these relative:  "loop-agent: File not found:
     # .../amplifier_app_cli/_bundle/behaviors/modules/loop-agent" -- and the session
     # refused to start.  See docs/designs/2026-08-15-composition-fix.md.
-    source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
+    source: git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/loop-agent
     config:
       max_tool_rounds_per_input: 20
   context:
@@ -43,4 +43,4 @@ tools:
 
 hooks:
   - module: hooks-tool-truncation
-    source: ../modules/hooks-tool-truncation
+    source: git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/hooks-tool-truncation

--- a/profiles/attractor-e2e-pipeline-anthropic.yaml
+++ b/profiles/attractor-e2e-pipeline-anthropic.yaml
@@ -24,7 +24,7 @@ agents:
         # made these relative:  "loop-agent: File not found:
         # .../amplifier_app_cli/_bundle/behaviors/modules/loop-agent" -- and the session
         # refused to start.  See docs/designs/2026-08-15-composition-fix.md.
-        source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
+        source: git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/loop-agent
         config:
           default_command_timeout_ms: 120000
 
@@ -41,6 +41,10 @@ session:
     module: loop-pipeline
     source: git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/loop-pipeline
     config:
+      # Explicit worker-selection declaration (dot-runner EXTENSIONS.md §40).
+      # "spawn" is the reserved sentinel reaching the loop-agent child agent
+      # below via the profiles map -- declared rather than left implicit.
+      worker: "spawn"
       dot_file: ./tests/e2e/fixtures/simple_file_creation.dot
       profiles:
         anthropic: attractor-anthropic

--- a/profiles/attractor-e2e-pipeline-gemini.yaml
+++ b/profiles/attractor-e2e-pipeline-gemini.yaml
@@ -24,7 +24,7 @@ agents:
         # made these relative:  "loop-agent: File not found:
         # .../amplifier_app_cli/_bundle/behaviors/modules/loop-agent" -- and the session
         # refused to start.  See docs/designs/2026-08-15-composition-fix.md.
-        source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
+        source: git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/loop-agent
         config:
           default_command_timeout_ms: 120000
 
@@ -41,6 +41,10 @@ session:
     module: loop-pipeline
     source: git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/loop-pipeline
     config:
+      # Explicit worker-selection declaration (dot-runner EXTENSIONS.md §40).
+      # "spawn" is the reserved sentinel reaching the loop-agent child agent
+      # below via the profiles map -- declared rather than left implicit.
+      worker: "spawn"
       dot_file: ./tests/e2e/fixtures/simple_file_creation_gemini.dot
       profiles:
         gemini: attractor-gemini

--- a/profiles/attractor-profile-anthropic.yaml
+++ b/profiles/attractor-profile-anthropic.yaml
@@ -24,7 +24,7 @@ session:
     # made these relative:  "loop-agent: File not found:
     # .../amplifier_app_cli/_bundle/behaviors/modules/loop-agent" -- and the session
     # refused to start.  See docs/designs/2026-08-15-composition-fix.md.
-    source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
+    source: git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/loop-agent
     config:
       default_command_timeout_ms: 120000
   # session.context is REQUIRED by core 1.6.0 ("Configuration must specify

--- a/profiles/attractor-profile-gemini.yaml
+++ b/profiles/attractor-profile-gemini.yaml
@@ -24,7 +24,7 @@ session:
     # made these relative:  "loop-agent: File not found:
     # .../amplifier_app_cli/_bundle/behaviors/modules/loop-agent" -- and the session
     # refused to start.  See docs/designs/2026-08-15-composition-fix.md.
-    source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
+    source: git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/loop-agent
     config:
       default_command_timeout_ms: 10000
   # session.context is REQUIRED by core 1.6.0 ("Configuration must specify

--- a/profiles/attractor-profile-openai.yaml
+++ b/profiles/attractor-profile-openai.yaml
@@ -24,7 +24,7 @@ session:
     # made these relative:  "loop-agent: File not found:
     # .../amplifier_app_cli/_bundle/behaviors/modules/loop-agent" -- and the session
     # refused to start.  See docs/designs/2026-08-15-composition-fix.md.
-    source: git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=modules/loop-agent
+    source: git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/loop-agent
     config:
       default_command_timeout_ms: 10000
   # session.context is REQUIRED by core 1.6.0 ("Configuration must specify
@@ -36,7 +36,7 @@ session:
 
 tools:
   - module: tool-apply-patch
-    source: ../modules/tool-apply-patch
+    source: git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/tool-apply-patch
   - module: tool-filesystem
     source: git+https://github.com/microsoft/amplifier-module-tool-filesystem@main
     config:


### PR DESCRIPTION
## Summary

Phase 4's **ungated half** of the maintainer-ratified worker-registry + core/pattern split program (design: `DESIGN-worker-registry-core-split.md` at the workspace root; Phases 1-3 already merged in dot-runner as PRs #10/#11/#12).

### 1. Pattern layer's own consumer flip

23 files / 201 insertions - every bundle/behavior/profile/agent source for the P2-moved modules now points at `git+https://github.com/microsoft/amplifier-bundle-dot-runner@main#subdirectory=modules/<name>`:

- `loop-agent` - 20 files / 31 lines
- `hooks-tool-truncation` - 4 files
- `hooks-pipeline-progress` - 2 files
- `hooks-pipeline-observability` - 2 files
- `tool-apply-patch` - 1 file (while `agents/attractor-agent-openai.yaml`'s copy deliberately stays on `amplifier-bundle-filesystem`, guard-tested)
- `tool-dashboard-query` / `tool-pipeline-status` - zero consumer references existed (verified, no change needed)
- `tool-pipeline-run` - held back per the maintainer gate (item `attractor-24e`)

### 2. Explicit default-worker declaration (policy in the pattern layer)

`worker: "spawn"` added alongside the `profiles` map on all 7 parent loop-pipeline orchestrator configs.

Empirical proof the declaration is live, not inert (from the adversarial review): the orchestrator-config YAML key the engine reads IS `worker` (loop-pipeline `__init__.py:254` -> `AmplifierBackend(default_worker=...)`; the reviewer loaded the real flipped bundle.md config against the real `backend.py` - `_resolve_worker_name()` returns `"spawn"`, beating the fallback; invalid values raise a loud `ValueError`).

### 3. Wrapper honest-stop (disclosed)

No console script shipped - the design doc's P4 assigns none, and one would collide with dot-runner's still-live legacy `attractor` entry point through the deprecation window. Bundle-level wiring only.

### 4. Docs

- `DOT-AUTHORING-GUIDE` gains the `worker=` attr row + Worker Selection section (per-node attr is a ledgered extension - community `.dot` files never need it).
- `README` gains the Backend/Worker Selection rewrite + Two-CLIs paragraph.

### 5. What does NOT change

- `modules/` + `specs/` are byte-untouched (compat window holds until the gated slim - external consumer PRs #137/#319/#27).
- Reviewer confirmed diff = empty and all 13 entry-point closures are single-origin per package.
- Root suite: 196 passed / 3 skipped, IDENTICAL on branch and main. (Disclosure: the commit message says 192/2 - a stale count; zero regression either way, confirmed by re-running the suite on both branch and main.)

## Verification checklist

- [x] Adversarial review verdict: **MERGE**, no fixes required
- [x] Entry-point closures single-origin per package (13/13), reviewer-verified
- [x] Empirical proof of live `worker:` key - read against real `loop-pipeline/__init__.py` + `backend.py` (`_resolve_worker_name()` -> `"spawn"`)
- [x] `modules/` and `specs/` diff = empty (compat window intentionally untouched)
- [x] Root suite: 196 passed / 3 skipped on branch, identical on main (commit-message count of 192/2 disclosed as stale, no regression)
- [x] Guard tests green (attractor-agent-openai.yaml's deliberate `amplifier-bundle-filesystem` pin for `tool-apply-patch` covered)

## Program context

- Phases 1-3: merged in `amplifier-bundle-dot-runner` as PRs #10, #11, #12
- This PR: Phase 4, ungated half (pattern-layer consumer flip + policy declaration)
- Held back: `tool-pipeline-run` flip (maintainer gate, item `attractor-24e`); the gated slim of `modules/`+`specs/` (external consumer PRs #137/#319/#27 must land first)
