### PR TITLE
docs: migrate DirectProviderBackend references to the worker-registry API (attractor-1dm)

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,13 +333,14 @@ Best for analysis/reasoning pipelines where nodes only need to generate text
 ```python
 import asyncio
 import tempfile
+import unified_llm
 from amplifier_module_loop_pipeline.dot_parser import parse_dot
 from amplifier_module_loop_pipeline.engine import PipelineEngine
 from amplifier_module_loop_pipeline.context import PipelineContext
 from amplifier_module_loop_pipeline.handlers import HandlerRegistry
 from amplifier_module_loop_pipeline.transforms import apply_transforms
 from amplifier_module_loop_pipeline.validation import validate_or_raise
-from amplifier_module_loop_pipeline import DirectProviderBackend
+from amplifier_module_loop_pipeline.backend import AmplifierBackend
 
 DOT = """
 digraph {
@@ -358,8 +359,15 @@ async def main():
     apply_transforms(graph, context)
     validate_or_raise(graph)
 
-    # provider=None auto-creates unified_llm.Client from env vars
-    backend = DirectProviderBackend(provider=None)
+    # unified_llm.Client.from_env() reads ANTHROPIC_API_KEY / OPENAI_API_KEY /
+    # GEMINI_API_KEY (GOOGLE_API_KEY as a Gemini alias). No coordinator -> the
+    # worker registry's `direct` worker handles every node (EXTENSIONS.md
+    # Sec40 in amplifier-bundle-dot-runner). `provider=` and `unified_client=`
+    # take the SAME client: `provider` is only a truthiness flag that enables
+    # the `direct` dispatch branch, `unified_client` is what actually makes
+    # the calls.
+    client = unified_llm.Client.from_env()
+    backend = AmplifierBackend(provider=client, unified_client=client, default_worker="direct")
     engine = PipelineEngine(
         graph=graph, context=context,
         handler_registry=HandlerRegistry(backend=backend),
@@ -435,14 +443,17 @@ async def main():
 asyncio.run(main())
 ```
 
-The key difference: with `session.spawn` registered, the `AmplifierBackend` kicks
-in and each pipeline node gets a full child session with tools (filesystem, bash,
-search). Without it, you get `DirectProviderBackend`, which runs a per-node agentic
-tool loop and passes through whatever tools the host has mounted -- so a node is
-tool-free only when the host mounts none, which is the case in the bare
-programmatic path above. See [Backend Selection](#backend-selection) for the full
-contract (`DirectProviderBackend` also requires an explicit `llm_model` on every
-node; there is no default).
+The key difference: `AmplifierBackend` is the single adapter class in both cases --
+what changes is which registered **worker** it dispatches to per node (see
+[Backend Selection / Worker Selection](#backend-selection--worker-selection)). With
+`session.spawn` registered, the `spawn` worker kicks in and each pipeline node
+gets a full child session with tools (filesystem, bash, search). Without it (the
+bare programmatic path above), the `direct` worker runs a per-node agentic tool
+loop and passes through whatever tools the host has mounted -- so a node is
+tool-free only when the host mounts none. See
+[Backend Selection / Worker Selection](#backend-selection--worker-selection) for
+the full contract (the `direct` worker also requires an explicit `llm_model` on
+every node; there is no default).
 
 See [`amplifier-foundation/examples/07_full_workflow.py`](https://github.com/microsoft/amplifier-foundation/blob/main/examples/07_full_workflow.py) for the reference
 `register_spawn_capability()` implementation. For a comprehensive guide,

--- a/agents/attractor-expert.md
+++ b/agents/attractor-expert.md
@@ -45,7 +45,7 @@ meta:
     user: 'How do I run an Attractor pipeline from my Python application?'
     assistant: 'I will delegate to attractor:attractor-expert for programmatic integration guidance.'
     <commentary>
-    Integration questions need knowledge of DirectProviderBackend vs AmplifierBackend paths.
+    Integration questions need knowledge of AmplifierBackend's `direct` worker vs its `spawn` worker paths.
     </commentary>
     </example>
 
@@ -395,10 +395,11 @@ confidently wrong about the running engine.**
   variable expansion, model stylesheets, fidelity modes
 - **Pipeline patterns**: Linear, conditional routing, retry/fallback, parallel
   fan-out/fan-in, human gates, manager-supervisor, multi-provider
-- **Programmatic integration**: DirectProviderBackend (per-node agentic tool loop
-  via `unified_llm` -- whatever tools the host mounts are passed through; node
-  tools are absent only when the host mounts none) vs AmplifierBackend (full
-  sub-sessions with delegation), PreparedBundle lifecycle, spawn capability
+- **Programmatic integration**: `AmplifierBackend`'s `direct` worker (per-node
+  agentic tool loop via `unified_llm` -- whatever tools the host mounts are
+  passed through; node tools are absent only when the host mounts none) vs its
+  `spawn` worker (full sub-sessions with delegation), PreparedBundle lifecycle,
+  spawn capability
 - **Configuration**: Bundle entry points, profile selection, orchestrator config
 - **Debugging**: Edge selection algorithm, condition evaluation, fidelity
   resolution, backend selection logic

--- a/context/system-attractor-expert.md
+++ b/context/system-attractor-expert.md
@@ -169,11 +169,11 @@ the caller the exact command.
   nothing -- see the authoring contract above for what you owe on every file.
 - **Pipeline patterns**: linear, conditional routing, retry/fallback, parallel
   fan-out/fan-in, human gates, manager–supervisor, multi-provider.
-- **Programmatic integration**: DirectProviderBackend (a per-node agentic tool
-  loop via `unified_llm` -- whatever tools the host mounts are passed through;
-  node tools are absent only when the host mounts none) vs AmplifierBackend (full
-  sub-sessions with delegation), the prepare / create_session lifecycle, and the
-  spawn capability.
+- **Programmatic integration**: `AmplifierBackend`'s `direct` worker (a
+  per-node agentic tool loop via `unified_llm` -- whatever tools the host
+  mounts are passed through; node tools are absent only when the host mounts
+  none) vs its `spawn` worker (full sub-sessions with delegation), the
+  prepare / create_session lifecycle, and the spawn capability.
 - **Configuration**: bundle entry points, profile selection, orchestrator
   config, and the per-node provider/profile routing.
 - **Debugging**: the edge-selection algorithm, condition evaluation, fidelity

--- a/docs/APP-INTEGRATION-GUIDE.md
+++ b/docs/APP-INTEGRATION-GUIDE.md
@@ -6,10 +6,10 @@ How to use Attractor pipelines from a custom Python application.
 
 There are two execution paths for running Attractor pipelines programmatically:
 
-| Path | Backend | Tools? | Best For |
+| Path | Backend / Worker | Tools? | Best For |
 |------|---------|--------|----------|
-| **A: Direct LLM** | `DirectProviderBackend` | Whatever you mount -- none in this guide's example | Analysis, reasoning, planning; also tool work, if you mount the tools yourself |
-| **B: Amplifier Session** | `AmplifierBackend` | Yes -- the bundle's toolset | Coding pipelines -- file edits, shell commands, full agent loop |
+| **A: Direct LLM** | `AmplifierBackend` (`direct` worker) | Whatever you mount -- none in this guide's example | Analysis, reasoning, planning; also tool work, if you mount the tools yourself |
+| **B: Amplifier Session** | `AmplifierBackend` (`spawn` worker via `session.spawn`) | Yes -- the bundle's toolset | Coding pipelines -- file edits, shell commands, full agent loop |
 
 Both paths use the same DOT graph format and pipeline engine. The difference is
 what happens at each LLM node: Path A runs the call -- and any tool rounds it
@@ -19,13 +19,13 @@ backend; Path B spawns a full Amplifier child session with the bundle's tools.
 See [examples/programmatic_usage.py](../examples/programmatic_usage.py) for a
 complete, runnable example covering both paths.
 
-## Path A: DirectProviderBackend (No Session)
+## Path A: AmplifierBackend's `direct` worker (No Session)
 
 Best for analysis and reasoning pipelines where nodes only generate text. No
 Amplifier session. The example below mounts *no tools*, so its nodes do no file
 operations -- but that is a property of the example, not of the backend:
-`DirectProviderBackend` accepts a `tools` mapping and hands every tool in it to
-the provider (see [Limitations](#limitations) below).
+`AmplifierBackend`'s `direct` worker accepts a `tools` mapping and hands every
+tool in it to the provider (see [Limitations](#limitations) below).
 
 ### Complete Working Example
 
@@ -33,7 +33,8 @@ the provider (see [Limitations](#limitations) below).
 import asyncio
 import tempfile
 
-from amplifier_module_loop_pipeline import DirectProviderBackend
+import unified_llm
+from amplifier_module_loop_pipeline.backend import AmplifierBackend
 from amplifier_module_loop_pipeline.context import PipelineContext
 from amplifier_module_loop_pipeline.dot_parser import parse_dot
 from amplifier_module_loop_pipeline.engine import PipelineEngine
@@ -65,8 +66,17 @@ async def main():
     # 3. Validate structure (start/exit nodes, edges, attributes)
     validate_or_raise(graph)
 
-    # 4. Create backend -- provider=None auto-creates unified_llm.Client from env vars
-    backend = DirectProviderBackend(provider=None)
+    # 4. Create backend -- unified_llm.Client.from_env() reads ANTHROPIC_API_KEY /
+    #    OPENAI_API_KEY / GEMINI_API_KEY (GOOGLE_API_KEY as a Gemini alias) and
+    #    raises unified_llm.ConfigurationError if none is set. No coordinator ->
+    #    the worker registry's `direct` worker handles every node
+    #    (EXTENSIONS.md Sec40). `provider=` and `unified_client=` both take the
+    #    SAME client: `provider` is only a truthiness flag that enables the
+    #    `direct` worker's dispatch branch; `unified_client` is what actually
+    #    makes the calls (see amplifier-bundle-dot-runner's pipeline-runner
+    #    `_bootstrap_direct_provider()` for the reference pattern this mirrors).
+    client = unified_llm.Client.from_env()
+    backend = AmplifierBackend(provider=client, unified_client=client, default_worker="direct")
 
     # 5. Build and run the engine
     engine = PipelineEngine(
@@ -108,13 +118,13 @@ Plus at least one API key: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or `GEMINI_API
 
 ### Limitations
 
-- No tools *as constructed above* -- `DirectProviderBackend(provider=None)`
-  passes no `tools` mapping, so these nodes cannot read/write files or run
-  shell commands. This is a property of the call, not of the backend: pass
-  `DirectProviderBackend(provider=None, tools={...})` and every tool in that
-  mapping is handed to the provider, with `unified-llm-client` driving the
-  call -> tool -> call rounds internally (capped by the node's
-  `max_agent_turns`).
+- No tools *as constructed above* -- the example above passes no `tools`
+  mapping, so these nodes cannot read/write files or run shell commands. This
+  is a property of the call, not of the backend: pass
+  `AmplifierBackend(provider=client, unified_client=client, tools={...},
+  default_worker="direct")` and every tool in that mapping is handed to the
+  `direct` worker, which drives the call -> tool -> call rounds internally
+  (capped by the node's `max_agent_turns`).
 - No Amplifier child session -- no bundle toolset mounted for you, no agent
   profile, no per-node session state. Path B remains the answer for coding
   pipelines.
@@ -295,18 +305,20 @@ fails to wire its modules. Always go through `prepare()`; use
 
 ### How Backend Selection Works
 
-The pipeline orchestrator auto-selects the backend at runtime:
+`AmplifierBackend` is the single adapter class constructed in every case; what
+varies is which registered **worker** it dispatches to per node
+(amplifier-bundle-dot-runner's `specs/EXTENSIONS.md` Sec40):
 
-1. If `session.spawn` capability is registered --> **AmplifierBackend** (full
+1. If `session.spawn` capability is registered --> the **`spawn`** worker (full
    child sessions per node with tools)
-2. Else if a provider is available --> **DirectProviderBackend** (a per-node
+2. Else if a provider is available --> the **`direct`** worker (a per-node
    agentic tool loop via `unified-llm-client`; whatever tools are mounted are
    passed through, so nodes are toolless only when the host mounts none -- as
    in the bare programmatic path above)
 3. Otherwise --> simulation mode (for testing)
 
 This means: if you forget to call `register_spawn_capability()`, the pipeline
-silently falls back to DirectProviderBackend. Nodes still run, and still use
+silently falls back to the `direct` worker. Nodes still run, and still use
 whatever tools are mounted, but each node is a direct provider call rather than
 a full Amplifier child session -- no agent profile, no per-node session state.
 
@@ -494,7 +506,7 @@ When composing bundles for isolated execution, follow these rules:
 | Limitation | Impact | Workaround |
 |-----------|--------|------------|
 | `last_response` truncated to 200 chars | Nodes lose full prior output under `compact`/`truncate` fidelity | Use `fidelity="full"` for nodes needing complete prior context |
-| `DirectProviderBackend` nodes only get the tools the host mounts | With none mounted (the bare Path A example) nodes cannot read/write files or run commands | Pass a `tools` mapping to the backend, or use Path B (AmplifierSession) for full coding pipelines |
+| The `direct` worker's nodes only get the tools the host mounts | With none mounted (the bare Path A example) nodes cannot read/write files or run commands | Pass a `tools` mapping to the backend, or use Path B (AmplifierSession) for full coding pipelines |
 | Provider model in global settings overrides bundle | Unexpected model selection | Use project-level `.amplifier/settings.yaml` |
 | `PreparedBundle.spawn()` returns string | Requires JSON-in-string parsing for structured results | The engine handles this internally |
 | Box node whose final assistant message is only tool-calls returns empty | The engine sees an empty result and treats it as a silent failure / fallback | Nudge the node prompt so the final message is non-empty text (e.g. "After running tools, end with a one-line summary -- the final message must not be empty") |

--- a/docs/attractor-explained.html
+++ b/docs/attractor-explained.html
@@ -726,7 +726,7 @@ footer .fine{font-size:12.5px;line-height:1.6;color:var(--faint);max-width:600px
   <figure>
     <svg class="dg" viewBox="0 0 960 420" role="img" aria-labelledby="d8t d8d" xmlns="http://www.w3.org/2000/svg">
       <title id="d8t">Architecture: orchestrator, sub-session, backend selection</title>
-      <desc id="d8d">The loop-pipeline orchestrator reads the dot file, spawns a loop-agent sub-session per LLM node, and receives a report_outcome back. Backends are auto-selected: AmplifierBackend if session spawn is available, otherwise DirectProviderBackend. With no backend at all, LLM nodes fail loud and only model-free graphs still walk.</desc>
+      <desc id="d8d">The loop-pipeline orchestrator reads the dot file, spawns a loop-agent sub-session per LLM node, and receives a report_outcome back. AmplifierBackend auto-selects a worker per node: the spawn worker if session spawn is available, otherwise the direct worker. With no backend at all, LLM nodes fail loud and only model-free graphs still walk.</desc>
 
       <path class="n-q" d="M 20 78 h 122 l 28 26 v 58 h -150 z"/>
       <path class="e-m" d="M 142 78 v 26 h 28" style="stroke-dasharray:none"/>
@@ -763,7 +763,7 @@ footer .fine{font-size:12.5px;line-height:1.6;color:var(--faint);max-width:600px
       <text class="el" x="20" y="344">else: provider configured</text>
       <line class="e" x1="250" y1="338" x2="288" y2="338" marker-end="url(#ar)"/>
       <rect class="n" x="296" y="320" width="624" height="36" rx="2"/>
-      <text class="nl-s" x="312" y="343" style="fill:#1b1813">DirectProviderBackend &mdash; a per-node agentic tool loop; needs an explicit llm_model</text>
+      <text class="nl-s" x="312" y="343" style="fill:#1b1813">AmplifierBackend's direct worker &mdash; a per-node agentic tool loop; needs an explicit llm_model</text>
       <text class="el" x="20" y="392">else</text>
       <line class="e" x1="250" y1="386" x2="288" y2="386" marker-end="url(#ar)"/>
       <rect class="n-q" x="296" y="368" width="624" height="36" rx="2"/>

--- a/examples/programmatic_usage.py
+++ b/examples/programmatic_usage.py
@@ -3,7 +3,7 @@
 
 Two modes of operation:
 
-  Option A: DirectProviderBackend (no Amplifier session)
+  Option A: AmplifierBackend's `direct` worker (no Amplifier session)
     - Just LLM calls via unified_llm. No tools.
     - Good for analysis, reasoning, and writing pipelines.
     - Requirements: pip install amplifier-module-loop-pipeline unified-llm-client
@@ -62,13 +62,15 @@ digraph {
 # OPTION A: Direct LLM calls (no Amplifier session, no tools)
 # ===================================================================
 
+
 async def run_direct(dot_source: str) -> None:
-    """Run a pipeline using DirectProviderBackend.
+    """Run a pipeline using AmplifierBackend's `direct` worker.
 
     This is the simplest integration. No Amplifier session, no tools.
     Each pipeline node makes a direct LLM call via unified_llm.
     """
-    from amplifier_module_loop_pipeline import DirectProviderBackend
+    import unified_llm
+    from amplifier_module_loop_pipeline.backend import AmplifierBackend
     from amplifier_module_loop_pipeline.context import PipelineContext
     from amplifier_module_loop_pipeline.dot_parser import parse_dot
     from amplifier_module_loop_pipeline.engine import PipelineEngine
@@ -82,8 +84,28 @@ async def run_direct(dot_source: str) -> None:
     apply_transforms(graph, context)
     validate_or_raise(graph)
 
-    # provider=None -> auto-creates unified_llm.Client from env vars
-    backend = DirectProviderBackend(provider=None)
+    try:
+        # unified_llm.Client.from_env() reads ANTHROPIC_API_KEY / OPENAI_API_KEY
+        # / GEMINI_API_KEY (GOOGLE_API_KEY accepted as a Gemini alias) and
+        # raises ConfigurationError if none is set.
+        client = unified_llm.Client.from_env()
+    except unified_llm.ConfigurationError:
+        print(
+            "No provider API key set (ANTHROPIC_API_KEY / OPENAI_API_KEY / "
+            "GEMINI_API_KEY) -- skipping the direct-call example."
+        )
+        return
+
+    # No coordinator -> the worker registry's `direct` worker handles every
+    # node (specs/EXTENSIONS.md Sec40 in amplifier-bundle-dot-runner).
+    # `provider=` and `unified_client=` both take the SAME client: `provider`
+    # is only a truthiness flag that enables the `direct` worker's dispatch
+    # branch, `unified_client` is what actually makes the LLM calls (mirrors
+    # amplifier-bundle-dot-runner's pipeline-runner
+    # `_bootstrap_direct_provider()` reference pattern).
+    backend = AmplifierBackend(
+        provider=client, unified_client=client, default_worker="direct"
+    )
     engine = PipelineEngine(
         graph=graph,
         context=context,
@@ -181,10 +203,12 @@ async def run_with_session(dot_source: str) -> None:
     bundle = await load_bundle(ATTRACTOR_BUNDLE)
     overlay = Bundle(
         name="programmatic-run",
-        session={"orchestrator": {
-            "module": "loop-pipeline",
-            "config": {"dot_source": dot_source},
-        }},
+        session={
+            "orchestrator": {
+                "module": "loop-pipeline",
+                "config": {"dot_source": dot_source},
+            }
+        },
     )
     composed = bundle.compose(overlay)
 

--- a/tests/e2e/docker_pipeline_test.py
+++ b/tests/e2e/docker_pipeline_test.py
@@ -1,7 +1,7 @@
 """E2E test: run an attractor pipeline with output verified inside a Docker container.
 
 This test creates a real Docker container, runs a 2-node pipeline via
-DirectProviderBackend where the LLM generates a Python script, then
+AmplifierBackend's direct worker where the LLM generates a Python script, then
 verifies the output exists ONLY in the container (not on the host).
 
 Prerequisites:
@@ -95,7 +95,8 @@ def teardown_container() -> None:
 
 async def run_pipeline_in_docker() -> dict:
     """Run the pipeline and capture the LLM output, then write it to the container."""
-    from amplifier_module_loop_pipeline import DirectProviderBackend
+    import unified_llm
+    from amplifier_module_loop_pipeline.backend import AmplifierBackend
     from amplifier_module_loop_pipeline.context import PipelineContext
     from amplifier_module_loop_pipeline.dot_parser import parse_dot
     from amplifier_module_loop_pipeline.engine import PipelineEngine
@@ -109,8 +110,17 @@ async def run_pipeline_in_docker() -> dict:
     apply_transforms(graph, context)
     validate_or_raise(graph)
 
-    # Create backend (auto-creates unified_llm.Client from env)
-    backend = DirectProviderBackend(provider=None, tools={}, hooks=None)
+    # Create backend -- unified_llm.Client.from_env() auto-creates the client
+    # from env; no coordinator means the `direct` worker handles every node
+    # (EXTENSIONS.md Sec40).
+    client = unified_llm.Client.from_env()
+    backend = AmplifierBackend(
+        provider=client,
+        tools={},
+        hooks=None,
+        unified_client=client,
+        default_worker="direct",
+    )
 
     # Create engine
     logs_root = tempfile.mkdtemp(prefix="docker-e2e-")
@@ -128,7 +138,7 @@ async def run_pipeline_in_docker() -> dict:
     elapsed = time.time() - start_time
 
     # Get the implement node's response from status.json
-    # (DirectProviderBackend returns Outcome directly, so response.md is not written;
+    # (AmplifierBackend's direct worker returns Outcome directly, so response.md is not written;
     #  the response text lives in status.json's "notes" field)
     import os
 

--- a/tests/e2e/live_pipeline_test.py
+++ b/tests/e2e/live_pipeline_test.py
@@ -1,4 +1,5 @@
 """Live end-to-end DOT pipeline test against real APIs."""
+
 import asyncio
 import sys
 import tempfile
@@ -62,18 +63,20 @@ digraph MultiProvider {
 }
 """
 
+
 async def run_pipeline(name, dot_source):
-    from amplifier_module_loop_pipeline.dot_parser import parse_dot
-    from amplifier_module_loop_pipeline.transforms import apply_transforms
-    from amplifier_module_loop_pipeline.validation import validate_or_raise
+    import unified_llm
+    from amplifier_module_loop_pipeline.backend import AmplifierBackend
     from amplifier_module_loop_pipeline.context import PipelineContext
+    from amplifier_module_loop_pipeline.dot_parser import parse_dot
     from amplifier_module_loop_pipeline.engine import PipelineEngine
     from amplifier_module_loop_pipeline.handlers import HandlerRegistry
-    from amplifier_module_loop_pipeline import DirectProviderBackend
+    from amplifier_module_loop_pipeline.transforms import apply_transforms
+    from amplifier_module_loop_pipeline.validation import validate_or_raise
 
-    print(f"\n{'='*60}")
+    print(f"\n{'=' * 60}")
     print(f"  PIPELINE: {name}")
-    print(f"{'='*60}")
+    print(f"{'=' * 60}")
 
     # 1. Parse and validate
     graph = parse_dot(dot_source)
@@ -82,8 +85,17 @@ async def run_pipeline(name, dot_source):
     validate_or_raise(graph)
     print(f"✓ Parsed {len(graph.nodes)} nodes, {len(graph.edges)} edges")
 
-    # 2. Create backend (provider=None lets it auto-create unified_llm.Client.from_env())
-    backend = DirectProviderBackend(provider=None, tools={}, hooks=None)
+    # 2. Create backend -- unified_llm.Client.from_env() auto-creates the client
+    #    from env vars; no coordinator means the `direct` worker handles every
+    #    node (EXTENSIONS.md Sec40).
+    client = unified_llm.Client.from_env()
+    backend = AmplifierBackend(
+        provider=client,
+        tools={},
+        hooks=None,
+        unified_client=client,
+        default_worker="direct",
+    )
 
     # 3. Build engine
     logs_root = tempfile.mkdtemp(prefix=f"pipeline-{name}-")
@@ -111,8 +123,10 @@ async def run_pipeline(name, dot_source):
         elapsed = time.time() - start_time
         print(f"✗ FAILED after {elapsed:.1f}s: {type(e).__name__}: {e}")
         import traceback
+
         traceback.print_exc()
         return False
+
 
 async def main():
     results = {}
@@ -124,15 +138,17 @@ async def main():
     results["multi_provider"] = await run_pipeline("multi_provider", DOT_MULTI_PROVIDER)
 
     # Test 3: Multi-stage pipeline (plan -> implement -> validate)
-    results["plan_implement_review"] = await run_pipeline("plan_implement_review", DOT_PLAN_IMPLEMENT_REVIEW)
+    results["plan_implement_review"] = await run_pipeline(
+        "plan_implement_review", DOT_PLAN_IMPLEMENT_REVIEW
+    )
 
     # Test 4: Conditional routing with retry loop
     results["conditional"] = await run_pipeline("conditional", DOT_CONDITIONAL)
 
     # Summary
-    print(f"\n{'='*60}")
-    print(f"  RESULTS")
-    print(f"{'='*60}")
+    print(f"\n{'=' * 60}")
+    print("  RESULTS")
+    print(f"{'=' * 60}")
     for name, passed in results.items():
         status = "✓ PASS" if passed else "✗ FAIL"
         print(f"  {status}: {name}")
@@ -140,6 +156,7 @@ async def main():
     all_passed = all(results.values())
     print(f"\n  {'ALL PASSED' if all_passed else 'SOME FAILED'}")
     return 0 if all_passed else 1
+
 
 if __name__ == "__main__":
     sys.exit(asyncio.run(main()))

--- a/tests/e2e/test_gemini_pipeline.py
+++ b/tests/e2e/test_gemini_pipeline.py
@@ -1,4 +1,4 @@
-"""E2E test for a Gemini-based pipeline via the Python API (DirectProviderBackend).
+"""E2E test for a Gemini-based pipeline via the Python API (AmplifierBackend's direct worker).
 
 Unlike the CLI-based approach, this test drives loop-pipeline directly through
 the Python API, avoiding workspace settings interference and remote module
@@ -32,9 +32,9 @@ pytestmark = [
 PIPELINE_TIMEOUT = 600  # seconds
 
 # Inline DOT: simple single-node pipeline using Gemini.
-# No tools registered — DirectProviderBackend has tools={}.
+# No tools registered — AmplifierBackend's direct worker has tools={}.
 # goal_gate is intentionally omitted: goal_gate=true requires a report_outcome
-# tool call that agents make; DirectProviderBackend just runs LLM text generation.
+# tool call that agents make; the direct worker just runs LLM text generation.
 # The model generates a text response and the pipeline completes with SUCCESS.
 DOT_GEMINI_SIMPLE = r"""
 digraph simple_gemini_test {
@@ -53,21 +53,44 @@ async def _run_pipeline(dot_source: str) -> object:
     """Run a DOT pipeline via the Python API and return the final Outcome."""
     # Imports are inside the function so pyright doesn't see them as possibly
     # unbound, and because this function is only called when HAS_PIPELINE=True.
-    from amplifier_module_loop_pipeline import DirectProviderBackend  # type: ignore[import-untyped]
-    from amplifier_module_loop_pipeline.context import PipelineContext  # type: ignore[import-untyped]
-    from amplifier_module_loop_pipeline.dot_parser import parse_dot  # type: ignore[import-untyped]
-    from amplifier_module_loop_pipeline.engine import PipelineEngine  # type: ignore[import-untyped]
-    from amplifier_module_loop_pipeline.handlers import HandlerRegistry  # type: ignore[import-untyped]
-    from amplifier_module_loop_pipeline.transforms import apply_transforms  # type: ignore[import-untyped]
-    from amplifier_module_loop_pipeline.validation import validate_or_raise  # type: ignore[import-untyped]
+    import unified_llm  # type: ignore[import-untyped]
+    from amplifier_module_loop_pipeline.backend import (
+        AmplifierBackend,  # type: ignore[import-untyped]
+    )
+    from amplifier_module_loop_pipeline.context import (
+        PipelineContext,  # type: ignore[import-untyped]
+    )
+    from amplifier_module_loop_pipeline.dot_parser import (
+        parse_dot,  # type: ignore[import-untyped]
+    )
+    from amplifier_module_loop_pipeline.engine import (
+        PipelineEngine,  # type: ignore[import-untyped]
+    )
+    from amplifier_module_loop_pipeline.handlers import (
+        HandlerRegistry,  # type: ignore[import-untyped]
+    )
+    from amplifier_module_loop_pipeline.transforms import (
+        apply_transforms,  # type: ignore[import-untyped]
+    )
+    from amplifier_module_loop_pipeline.validation import (
+        validate_or_raise,  # type: ignore[import-untyped]
+    )
 
     graph = parse_dot(dot_source)
     context = PipelineContext()
     apply_transforms(graph, context)
     validate_or_raise(graph)
 
-    # provider=None → auto-creates unified_llm.Client.from_env(), picks up GOOGLE_API_KEY
-    backend = DirectProviderBackend(provider=None, tools={}, hooks=None)
+    # unified_llm.Client.from_env() picks up GOOGLE_API_KEY; no coordinator means
+    # the `direct` worker handles every node (EXTENSIONS.md Sec40).
+    client = unified_llm.Client.from_env()
+    backend = AmplifierBackend(
+        provider=client,
+        tools={},
+        hooks=None,
+        unified_client=client,
+        default_worker="direct",
+    )
     logs_root = tempfile.mkdtemp(prefix="pipeline-gemini-e2e-")
     registry = HandlerRegistry(backend=backend)
     engine = PipelineEngine(
@@ -84,7 +107,7 @@ def test_gemini_pipeline_simple(tmp_path):
 
     Graph: start -> implement -> done
     The implement node is assigned llm_provider="gemini" with goal_gate=true.
-    DirectProviderBackend drives the LLM call directly (no CLI, no workspace interference).
+    AmplifierBackend's direct worker drives the LLM call directly (no CLI, no workspace interference).
     """
     outcome = asyncio.run(_run_pipeline(DOT_GEMINI_SIMPLE))
 


### PR DESCRIPTION
## Summary

The engine repo ([amplifier-bundle-dot-runner](https://github.com/microsoft/amplifier-bundle-dot-runner)) deleted the standalone `DirectProviderBackend` class in its worker-registry work (DESIGN-worker-registry-core-split.md P1, merged). The replacement is `AmplifierBackend` constructed with `default_worker="direct"` (the registry's `direct` worker; run-level `worker`/`default_worker` config, `specs/EXTENSIONS.md` §40). A `DeprecationWarning` shim in `amplifier_module_loop_pipeline.__init__.DirectProviderBackend` preserves the old import path through a compat window, but this repo's docs/examples still taught the dead pattern and will break when that shim retires.

This PR migrates all of it to the registry-era API:

- `README.md` — Option A code sample + "Backend Selection / Worker Selection" prose
- `examples/programmatic_usage.py` — `run_direct()` now constructs `AmplifierBackend(provider=client, unified_client=client, default_worker="direct")` where `client = unified_llm.Client.from_env()`, mirroring `amplifier-bundle-dot-runner`'s `pipeline-runner._bootstrap_direct_provider()` reference pattern. Also now genuinely runnable standalone: guards the missing-API-key case via `unified_llm.ConfigurationError` instead of crashing.
- `docs/APP-INTEGRATION-GUIDE.md` — Path A section, backend/worker table, "How Backend Selection Works", and the known-limitations row
- Stragglers found via a repo-wide grep: `context/system-attractor-expert.md`, `agents/attractor-expert.md`, `docs/attractor-explained.html` (SVG explainer diagram), `tests/e2e/*.py`

**Left untouched by design:**
- `modules/` and `specs/` (byte-untouched compat window — this is where the actual shim/deprecated class lives)
- Historical archives: `docs/reports/`, `docs/designs/`, `docs/plans/`, `SPEC_CONFORMANCE.md`'s dated changelog entry, `context/engine-semantics.md`'s "the old X mode is closed" historical note, and `.github/capsule-pipeline/proposals/*` (frozen proposal-review artifacts bound to historical line numbers/diffs)

## Verification

- API verified against `amplifier-bundle-dot-runner@main` (19ad0e7): read the `DirectProviderBackend` shim's own deprecation message, `AmplifierBackend`'s real home (`amplifier_module_loop_pipeline.backend`), the worker registry (`workers/direct_worker.py`, `workers/registry.py`), `specs/EXTENSIONS.md` §40, and pipeline-runner's `_bootstrap_direct_provider()` (the real from-env provider-bootstrap pattern this PR's examples mirror).
- `examples/programmatic_usage.py` actually executes end-to-end in a throwaway venv (editable-installed from this repo's own `modules/unified-llm-client` + `modules/loop-pipeline`, no API key set): parses/validates the DOT graph, then hits the new `unified_llm.ConfigurationError` guard and exits 0 with an honest message — confirming import-time and no-key-path correctness.
- Root opinionated-guard suite: `python -m pytest tests/ -q --ignore=tests/e2e` → 192 passed, 2 skipped (both with and without this change — none of the touched files are exercised by that suite's collection).
- `git diff --stat` confirms `modules/` and `specs/` have zero touched lines.

This clears a P4b-slim precondition (dead-pattern docs cleanup ahead of the shim's eventual retirement).

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>