### PR TITLE
refactor(tool-pipeline-run): parameterize attractor-pattern coupling (attractor-24e stage 1)

### DIFF
--- a/modules/tool-pipeline-run/README.md
+++ b/modules/tool-pipeline-run/README.md
@@ -1,0 +1,39 @@
+# tool-pipeline-run
+
+Agent-facing `run_pipeline` tool: lets an interactive session invoke a DOT
+graph pipeline at runtime via `session.spawn`, wait for completion, and
+return a structured result.
+
+## Config
+
+Mounted like any other Amplifier module, with a `config` dict supplied at
+mount time. All keys are optional; every default below reproduces this
+module's pre-existing (attractor-bundle) behavior exactly, so an
+unconfigured mount is unaffected by anything in this section.
+
+| Key | Type | Default | Purpose |
+|-----|------|---------|---------|
+| `runner_agent` | `str` | `"attractor-pipeline-runner"` | Name of the agent `session.spawn` is called with to actually execute the pipeline. |
+| `profiles` | `dict[str, str]` | `{}` (unset) | Maps required `llm_provider` names (parsed from the pipeline's DOT source) to the agent name that provides them, for pre-spawn provider-availability validation. Forwarded to the spawned child's `orchestrator_config["profiles"]`. |
+| `mention_example` | `str` | `"@attractor:examples/pipelines/01-simple-linear.dot"` | Illustrative `@mention` example shown in this tool's own `description` and `input_schema["dot_file"]["description"]` (i.e. what the calling LLM sees). Purely cosmetic -- it does not affect actual `@mention` resolution, which is generic and handled by the coordinator's `mention_resolver` capability regardless of namespace. Only the text before the first `:` (the namespace) is reused in the shorter `description` form. |
+
+### Why `mention_example` exists
+
+This module is a sanctioned exception to the compat-window freeze ahead of
+its planned move to a namespace-neutral module (see
+`DESIGN-worker-registry-core-split.md` §6.3). Before that move, every
+hard-coded reference to the `attractor` bundle name had to be pulled out of
+the module's source so mounting it from a differently-named bundle would
+not show that bundle's LLM a `run_pipeline` tool that advertises an
+`@attractor:...` mention no such bundle has registered. The `runner_agent`
+and `profiles` keys were already config-driven before this change; only
+their *default values* remain attractor-specific, by design, so today's
+attractor bundles keep working unconfigured.
+
+## Tests
+
+```bash
+cd modules/tool-pipeline-run
+uv sync
+uv run pytest -q
+```

--- a/modules/tool-pipeline-run/amplifier_module_tool_pipeline_run/__init__.py
+++ b/modules/tool-pipeline-run/amplifier_module_tool_pipeline_run/__init__.py
@@ -37,17 +37,41 @@ class PipelineRunTool:
     """
 
     name = "run_pipeline"
-    description = (
-        "Run a DOT graph pipeline. Provide a pipeline definition via "
-        "'dot_file' (path to a .dot file, supports @attractor:... mentions) "
-        "or 'dot_source' (inline DOT digraph string), plus a 'goal' "
-        "describing the task. The pipeline executes as a child session "
-        "and returns the result when complete."
-    )
+
+    # Default @mention example shown in this tool's own description and
+    # input_schema (below) -- purely illustrative text for the calling LLM,
+    # not resolution logic (mention_resolver.resolve() handles any namespace
+    # generically; see _resolve_dot_file_path). Hard-coding a bundle-specific
+    # namespace here is nonetheless real coupling: a non-"attractor" bundle
+    # mounting this tool unconfigured would show its LLM an example mention
+    # that resolves nowhere. Config-worthy -- see "mention_example" in the
+    # module README. Default preserves today's exact text for existing
+    # (attractor) consumers.
+    _DEFAULT_MENTION_EXAMPLE = "@attractor:examples/pipelines/01-simple-linear.dot"
 
     def __init__(self, config: dict[str, Any], coordinator: Any = None) -> None:
         self.config = config
         self.coordinator = coordinator
+
+    def _mention_example(self) -> str:
+        """Return the configured (or default) @mention example path."""
+        return self.config.get("mention_example", self._DEFAULT_MENTION_EXAMPLE)
+
+    def _mention_namespace_prefix(self) -> str:
+        """Return just the '@namespace:' prefix of the mention example."""
+        return self._mention_example().split(":", 1)[0]
+
+    @property
+    def description(self) -> str:
+        """Return the tool description shown to the calling LLM."""
+        return (
+            "Run a DOT graph pipeline. Provide a pipeline definition via "
+            "'dot_file' (path to a .dot file, supports "
+            f"{self._mention_namespace_prefix()}:... mentions) "
+            "or 'dot_source' (inline DOT digraph string), plus a 'goal' "
+            "describing the task. The pipeline executes as a child session "
+            "and returns the result when complete."
+        )
 
     @property
     def input_schema(self) -> dict:
@@ -59,7 +83,7 @@ class PipelineRunTool:
                     "type": "string",
                     "description": (
                         "Path to a .dot pipeline file. Supports @mention "
-                        "syntax (e.g. @attractor:examples/pipelines/01-simple-linear.dot)."
+                        f"syntax (e.g. {self._mention_example()})."
                     ),
                 },
                 "dot_source": {

--- a/modules/tool-pipeline-run/tests/test_pipeline_run.py
+++ b/modules/tool-pipeline-run/tests/test_pipeline_run.py
@@ -738,3 +738,137 @@ async def test_no_params_omits_key_from_orchestrator_config():
 
     orch_config = spawn_kwargs_capture["orchestrator_config"]
     assert "params" not in orch_config
+
+
+# ---------------------------------------------------------------------------
+# De-attractorization: "mention_example" config (attractor-24e stage 1)
+#
+# The tool's own `description` and `input_schema["dot_file"]["description"]`
+# used to hard-code the "@attractor:" mention namespace as an illustrative
+# example for the calling LLM. That's real coupling (a non-"attractor"
+# bundle mounting this tool unconfigured would show its LLM an example
+# mention that resolves nowhere), even though it never touched actual
+# @mention *resolution* logic (mention_resolver.resolve() handles any
+# namespace generically -- see test_resolve_at_mention_path above, which is
+# unaffected by any of this). "mention_example" makes the illustrative
+# text configurable; its default preserves today's exact "attractor" text
+# byte-for-byte for existing (attractor) consumers.
+# ---------------------------------------------------------------------------
+
+
+def test_custom_mention_example_lands_in_input_schema():
+    """A configured mention_example overrides the dot_file schema description.
+
+    RED pre-change: input_schema's dot_file description was a fixed string
+    hard-coding "@attractor:examples/pipelines/01-simple-linear.dot" with no
+    config indirection at all, so this assertion could not pass no matter
+    what config was supplied.
+    """
+    tool = PipelineRunTool(config={"mention_example": "@my-bundle:pipelines/demo.dot"})
+    schema = tool.input_schema
+    description = schema["properties"]["dot_file"]["description"]
+    assert "@my-bundle:pipelines/demo.dot" in description
+    assert "attractor" not in description.lower()
+
+
+def test_custom_mention_example_lands_in_tool_description():
+    """A configured mention_example's namespace overrides the tool description.
+
+    RED pre-change: `description` was a class-level constant hard-coding
+    "@attractor:... mentions", unreachable via config.
+    """
+    tool = PipelineRunTool(config={"mention_example": "@my-bundle:pipelines/demo.dot"})
+    assert "@my-bundle:... mentions" in tool.description
+    assert "attractor" not in tool.description.lower()
+
+
+def test_default_mention_example_matches_todays_text_byte_identical():
+    """Unconfigured mount reproduces today's exact @attractor: example text.
+
+    Pins both surfaces byte-for-byte so an unconfigured (existing attractor)
+    consumer sees zero behavior change.
+    """
+    tool = PipelineRunTool(config={})
+    assert tool.description == (
+        "Run a DOT graph pipeline. Provide a pipeline definition via "
+        "'dot_file' (path to a .dot file, supports @attractor:... mentions) "
+        "or 'dot_source' (inline DOT digraph string), plus a 'goal' "
+        "describing the task. The pipeline executes as a child session "
+        "and returns the result when complete."
+    )
+    schema = tool.input_schema
+    assert schema["properties"]["dot_file"]["description"] == (
+        "Path to a .dot pipeline file. Supports @mention "
+        "syntax (e.g. @attractor:examples/pipelines/01-simple-linear.dot)."
+    )
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_default_runner_agent_matches_todays_value_when_unconfigured():
+    """Unconfigured mount still spawns the pre-existing default runner agent.
+
+    "runner_agent" was already config-driven before this change (only its
+    *default* is attractor-specific); this pins that default explicitly so
+    a future stage-2 move can prove it never silently changed.
+    """
+    spawn_kwargs_capture = {}
+
+    async def mock_spawn(**kwargs):
+        spawn_kwargs_capture.update(kwargs)
+        return {
+            "output": '{"status": "success"}',
+            "session_id": "child-default-runner",
+        }
+
+    mock_coordinator = MagicMock()
+    mock_coordinator.get_capability = lambda name: (
+        mock_spawn if name == "session.spawn" else None
+    )
+    mock_coordinator.config = {"agents": {"attractor-pipeline-runner": {}}}
+    mock_coordinator.session = MagicMock()
+
+    tool = PipelineRunTool(config={}, coordinator=mock_coordinator)
+    result = await tool.execute(
+        {
+            "goal": "test goal",
+            "dot_source": SIMPLE_DOT,
+        }
+    )
+
+    assert result.success
+    assert spawn_kwargs_capture["agent_name"] == "attractor-pipeline-runner"
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_custom_runner_agent_lands_in_spawn_call():
+    """A configured runner_agent (not the attractor default) is what gets spawned."""
+    spawn_kwargs_capture = {}
+
+    async def mock_spawn(**kwargs):
+        spawn_kwargs_capture.update(kwargs)
+        return {
+            "output": '{"status": "success"}',
+            "session_id": "child-custom-runner",
+        }
+
+    mock_coordinator = MagicMock()
+    mock_coordinator.get_capability = lambda name: (
+        mock_spawn if name == "session.spawn" else None
+    )
+    mock_coordinator.config = {"agents": {"my-custom-pipeline-runner": {}}}
+    mock_coordinator.session = MagicMock()
+
+    tool = PipelineRunTool(
+        config={"runner_agent": "my-custom-pipeline-runner"},
+        coordinator=mock_coordinator,
+    )
+    result = await tool.execute(
+        {
+            "goal": "test goal",
+            "dot_source": SIMPLE_DOT,
+        }
+    )
+
+    assert result.success
+    assert spawn_kwargs_capture["agent_name"] == "my-custom-pipeline-runner"
+    assert result.output["runner_agent"] == "my-custom-pipeline-runner"


### PR DESCRIPTION
## Why

`modules/tool-pipeline-run` was held back from the P2 module-extraction wave because it still carried hard-coded `attractor`-bundle coupling: an illustrative `@attractor:...` mention example baked into the tool's own `description` and `input_schema`. That's real coupling — a non-attractor bundle mounting this tool unconfigured would show its calling LLM an example mention that resolves nowhere.

This PR cleans that up **in place**, with zero behavior change for existing (attractor) consumers. Stage 2 — the history-preserved move of this module to the engine repo (dot-runner) — is a separate follow-up PR.

## Config surface (new/documented)

| Key | Type | Default | Purpose |
|---|---|---|---|
| `mention_example` | `str` | `"@attractor:examples/pipelines/01-simple-linear.dot"` | Illustrative `@mention` example shown in `description` / `input_schema["dot_file"]["description"]`. Purely cosmetic — actual `@mention` resolution is generic (`mention_resolver`) regardless of namespace. |
| `runner_agent` | `str` | `"attractor-pipeline-runner"` | Agent name `session.spawn` invokes to run the pipeline. Was already config-driven; only the *default* is attractor-specific (unchanged, now pinned by test). |
| `profiles` | — | (pre-existing) | Documented alongside the above for a complete config-surface picture. |

README.md now documents all three.

## Zero-behavior-change proof

- Defaults are **byte-identical** to pre-change text: verified independently (not just via the pinning tests) by instantiating `PipelineRunTool({})` against both `origin/main` and this branch and diffing `.description` / `.input_schema` — identical, 285 bytes each.
- `bundles/attractor-interactive.yaml` already passes `runner_agent: attractor-pipeline-runner` explicitly (matches the preserved default) — no bundle YAML changes needed.

## RED-proofs (fail pre-change, pass post-change)

- `test_custom_mention_example_lands_in_input_schema` — re-verified: reverting only the source change (keeping tests) makes this fail with the old hard-coded string, confirming it's a real regression test, not vacuous.
- `test_custom_mention_example_lands_in_tool_description` — same re-verification, same result.

## Defaults-unchanged pins

- `test_default_mention_example_matches_todays_text_byte_identical`
- `test_default_runner_agent_matches_todays_value_when_unconfigured`
- Plus `test_custom_runner_agent_lands_in_spawn_call` (custom `runner_agent` actually gets spawned).

## Suite

51 passed (46 pre-existing + 5 new), `uv run pytest -q` in `modules/tool-pipeline-run`. `ruff` clean on touched files. Only `modules/tool-pipeline-run/` touched (diff against `origin/main` outside that path is empty).

Rebased onto `origin/main` @ `1223e6d` (PR #327, docs-only — no conflicts).
