### PR TITLE
docs: strengthen nlspec gate to an evidence bar

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@
 
 ## Verification checklist
 
-- [ ] Checked what the strongdm/attractor nlspec says about this (cite section) — or N/A with reason
+- [ ] nlspec evidence: cited section(s) + holistic-context note (spec silence ≠ support; silence → extension process or design guidance)
 - [ ] Unit tests pass (`pytest modules/loop-pipeline/`)
 - [ ] Live pipeline run exercising changed code path — required when touching `engine.py` or any handler; paste `events.jsonl` analysis or test-run output in the section below
 - [ ] AGENTS.md reviewed; repo-specific gates met

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,13 @@ nlspec has to say about this first?"** This is "Walk upstream first"
    entry — both authoritative in `amplifier-bundle-dot-runner` now — are
    required. Not the wild-west; "the spec didn't anticipate this shape"
    files an entry, it doesn't skip one.
+5. **Evidence bar.** Cite the section(s) *and* state what the surrounding
+   context says — proof the nlspec was read holistically, not a
+   cherry-picked line wielded as leverage to push an agenda or design
+   change. Spec silence is not support for a change: it routes to point 3
+   above and to `amplifier-bundle-dot-runner`'s SPEC_CONFORMANCE rule 5 /
+   `specs/EXTENSIONS.md` (point 4), and the preferred first answer to "the
+   spec doesn't do X" is a different pipeline design, not a new feature.
 
 When behavior is ambiguous, the canonical spec is authoritative. Our
 implementation extends but does not contradict it. If you find yourself


### PR DESCRIPTION
## Summary

Strengthens the existing nlspec-first gate (updated in #325) into an explicit evidence bar, per maintainer directive (2026-08-29): issue reports, PRs, feature requests, and design-change proposals must cite the nlspec section(s) AND demonstrate holistic reading (what the surrounding context says) — spec silence is not support for a change, and routes to the `amplifier-bundle-dot-runner` compatibility doctrine / extension ledger rather than licensing a new feature.

## Changes

- `AGENTS.md`: new item 5, **Evidence bar**, under "Before you design, file, or submit" — cite section(s) + surrounding-context note; spec silence ≠ support; prefer a different pipeline design over a new feature when the spec doesn't do X.
- `.github/PULL_REQUEST_TEMPLATE.md`: checklist line upgraded from "checked what the nlspec says (cite section)" to the evidence form: `nlspec evidence: cited section(s) + holistic-context note (spec silence ≠ support; silence → extension process or design guidance)`.

Docs-only diff — no `modules/`, no `specs/`.

## Verification

- Reviewed rendered Markdown; wording matches existing doc voice and the dot-runner pointers already present in the gate section (SPEC_CONFORMANCE rule 5 / EXTENSIONS.md).
- No code paths touched.

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>