### PR TITLE
docs!: retcon — the spec's own outcome channels are the taught way; report_outcome demoted to legacy window

### DIFF
--- a/agents/attractor-expert.md
+++ b/agents/attractor-expert.md
@@ -563,11 +563,14 @@ time. Full patterns and compliant examples are in the companion context file.
   or use the honest token gate idiom.
 
 **Judge verdict contracts** (lint cannot see inside node prompts):
-- [ ] Every `goal_gate=true` LLM node has an explicit outcome instruction:
-  call `report_outcome`, emit a pure-JSON verdict, or write a verdict file
-  that a downstream deterministic `parallelogram` gate reads. Prose verdicts
-  are discarded under the fail-closed contract (engine-semantics.md §5).
-  Never leave a judge to prose.
+- [ ] Every `goal_gate=true` LLM node has an explicit outcome instruction, in
+  escalation order: write a verdict file that a downstream deterministic
+  `parallelogram` gate reads, write a node-written `status.json`, emit a
+  pure-JSON verdict, or (legacy compatibility window, not the taught
+  mechanism) call `report_outcome`. Prose verdicts are discarded under the
+  fail-closed contract (engine-semantics.md §5). Never leave a judge to prose,
+  and never let a `report_outcome` call stand in as the only channel -- a
+  tool call is still a self-report.
 
 **Delta-assertion gates** (green tests on an unmodified tree prove nothing):
 - [ ] Work-completion gates anchor to a recorded base SHA and assert that

--- a/context/attractor-expert-defenses.md
+++ b/context/attractor-expert-defenses.md
@@ -67,18 +67,11 @@ degrade to FAIL — the replan loop never fires as intended.
 **Self-check question:** Does every `goal_gate=true` node have an explicit
 outcome instruction in its prompt?
 
-**Three compliant patterns:**
+**Compliant patterns, in escalation order (RETCON, 2026-08-29 -- `report_outcome`
+is no longer the taught mechanism):**
 
-1. **`report_outcome` tool call** (most explicit — authoritative):
-   > "You MUST report your verdict by calling the `report_outcome` tool with
-   > `status: success` or `status: fail`. Prose verdicts are discarded."
-
-2. **Pure JSON response**:
-   > "Respond with ONLY a JSON object: `{\"status\": \"success\"}` or
-   > `{\"status\": \"fail\", \"reason\": \"...\"}`. No surrounding prose."
-
-3. **Verdict file + deterministic gate** (route on evidence, not typed
-   sentinels — preferred for complex judges):
+1. **Verdict file + deterministic gate** (route on evidence, not typed
+   sentinels -- preferred for complex judges, and the default choice):
    ```dot
    judge [shape=box, prompt="... Write verdict to .ai/verdict.txt: first
        line must be exactly CONVERGED or NOT_CONVERGED."]
@@ -88,6 +81,25 @@ outcome instruction in its prompt?
    verdict_gate -> done  [condition="tool.last_line=ok"]
    verdict_gate -> fix   [condition="tool.last_line=fail"]
    ```
+
+2. **Node-written `status.json`** (canonical spec §4.5 / Appendix C), for
+   out-of-band or spawned-worker outcomes -- the engine reads it back and now
+   auto-injects the path + envelope into every spawned worker's instruction:
+   > "Write your verdict to the status.json contract path given in your
+   > instructions, with `outcome: success` or `outcome: fail`."
+
+3. **Pure JSON response**:
+   > "Respond with ONLY a JSON object: `{\"status\": \"success\"}` or
+   > `{\"status\": \"fail\", \"reason\": \"...\"}`. No surrounding prose."
+
+4. **`report_outcome` tool call** (legacy compatibility window, not the taught
+   mechanism -- still honored, a node-written `status.json` wins over it on
+   conflict). A tool call is still a self-report from inside the same context
+   that produced the work: it is not an exemption from "verification inside
+   the context that produced the evidence is not verification"
+   (`context/dot-reference.md`). Machine evidence (patterns 1-2 above)
+   outranks it. See `docs/PIPELINE_PATTERNS.md` §6's anti-pattern catalog
+   ("`report_outcome`-as-primary", alongside "LLM-Emitted Routing Sentinel").
 
 **Cross-reference:** engine-semantics.md §5 (verdict-recovery ladder, fail-closed
 goal-gate contract, `is_explicit` field).

--- a/context/engine-semantics.md
+++ b/context/engine-semantics.md
@@ -209,10 +209,33 @@ node whose output carried no recognized verdict) does NOT satisfy the gate. This
 closes bypass paths that never go through `_parse_outcome`. The RETRY-from-`_parse_outcome`
 rule above is the belt; the gate's `is_explicit` requirement is the suspenders.
 
-**Author guidance:** For `goal_gate=true` nodes, always call the **`report_outcome` tool** or
-emit a pure JSON response (or use a parallelogram tool node — its exit code is the verdict).
-Do not rely on prose output — even prose that says "CONVERGED" will return RETRY under the
-fail-closed contract. The recovery ladder (paths 2–4) is a safety net, not a contract.
+**Author guidance — the escalation ladder (RETCON, 2026-08-29 maintainer ruling):**
+`report_outcome` is no longer the taught, primary mechanism for delivering a `goal_gate=true`
+node's explicit verdict. Reach for the mechanism **lowest** on this list that the node can
+reach; each step down is more machine-checkable than the one above it:
+
+1. **Artifact file + tool-node exit code, first.** Have the node write its verdict to a file;
+   a downstream `parallelogram` node greps it and its exit code (`context.tool.last_line`)
+   becomes the routing signal. Deterministic evidence, checked outside the worker's own
+   context — the strongest signal available.
+2. **Node-written `status.json`, for out-of-band or spawned-worker outcomes.** The engine
+   reads a node's stage-directory `status.json` back (canonical spec §4.5 / Appendix C —
+   the `outcome`/`preferred_label`/`suggested_next_ids`/`context_updates`/`notes` envelope)
+   and now auto-injects the absolute path plus that envelope contract into every SPAWNED
+   worker's instruction, so a spawned child always has a reachable, spec-native channel
+   without needing to be told separately.
+3. **A pure-JSON verdict** in the node's own LLM response (paths 2–4 of the recovery ladder
+   above — fenced, bare, or an embedded trailing `{...}` carrying a recognized `status`;
+   EXTENSIONS.md §25).
+4. **`report_outcome` is a legacy compatibility window, not the taught mechanism.** It still
+   works — `is_explicit=True`, and a node-written `status.json` wins over it on conflict —
+   but it is a self-report from inside the same context that produced the work. A tool call
+   is not an exemption from that: machine evidence (paths 1–2) outranks a self-reported
+   verdict regardless of which channel carries the self-report. See `PIPELINE_PATTERNS.md`
+   §6's anti-pattern catalog ("`report_outcome`-as-primary").
+
+Do not rely on bare prose regardless of channel — even prose that says "CONVERGED" will
+return RETRY under the fail-closed contract.
 
 **Plain-edge hazard:** RETRY (like FAIL) does not traverse plain unconditional edges — it
 routes only via `condition="outcome=fail"`, `retry_target`, or `runs_on=always|failure` nodes.
@@ -315,7 +338,10 @@ of injected critique per iteration — bounded regardless of iteration count.
 2. **Code nodes (`parallelogram`/tool) are glue only** — shell/IO/orchestration, not inference.
 3. **Copy the nearest proven pipeline before inventing.** Simplicity applies to the proven
    pattern, not to a minimal node count built on a wrong engine model.
-4. **Route verdicts via the `report_outcome` tool, not free-text JSON** (§5 bug).
+4. **Route verdicts via an artifact file + tool exit code, or a node-written
+   `status.json`, not free-text JSON** (§5 bug). `report_outcome` still works as a
+   legacy compatibility window, but it is not the taught mechanism -- see §5's
+   escalation ladder.
 5. **Run `dot_graph validate` after every edit** — catches isolated nodes, stray quotes,
    missing fallback edges before an expensive rebuild.
 6. **Author for fail-loud:** explicit FAIL edges (§2 #2), explicit `llm_model`, explicit

--- a/context/system-anthropic.md
+++ b/context/system-anthropic.md
@@ -48,8 +48,11 @@ Search file contents using regex patterns. Supports output modes: `content` (mat
 ### glob
 Find files by name pattern. Results are sorted by modification time (newest first).
 
-### report_outcome
-When you have completed the task (or determined you cannot), report the outcome with a status and notes.
+### status.json (the taught verdict channel)
+If your instructions name a status.json contract path, write your verdict there as JSON (`outcome`/`preferred_label`/`suggested_next_ids`/`context_updates`/`notes`) when you finish or determine you cannot -- this is a spec-native audit trail the engine reads back, and the mechanism a spawned worker should use.
+
+### report_outcome (legacy compatibility window)
+When you have completed the task (or determined you cannot), you may also report the outcome with this tool. It still works, but a node-written status.json wins over it on conflict, and it is not the primary, taught mechanism.
 
 ## Best Practices
 

--- a/context/system-gemini.md
+++ b/context/system-gemini.md
@@ -56,8 +56,11 @@ Search the web for information. Use this when you need documentation, examples, 
 ### web_fetch
 Fetch content from a URL. Use this to read documentation pages, API references, or other web content.
 
-### report_outcome
-When you have completed the task (or determined you cannot), report the outcome with a status and notes.
+### status.json (the taught verdict channel)
+If your instructions name a status.json contract path, write your verdict there as JSON (`outcome`/`preferred_label`/`suggested_next_ids`/`context_updates`/`notes`) when you finish or determine you cannot -- this is a spec-native audit trail the engine reads back, and the mechanism a spawned worker should use.
+
+### report_outcome (legacy compatibility window)
+When you have completed the task (or determined you cannot), you may also report the outcome with this tool. It still works, but a node-written status.json wins over it on conflict, and it is not the primary, taught mechanism.
 
 ## Project Instructions
 

--- a/context/system-openai.md
+++ b/context/system-openai.md
@@ -54,8 +54,11 @@ Search file contents using regex patterns. Use `glob_filter` to narrow by file t
 ### glob
 Find files by name pattern. Results are sorted by modification time (newest first).
 
-### report_outcome
-When you have completed the task (or determined you cannot), report the outcome with a status and notes.
+### status.json (the taught verdict channel)
+If your instructions name a status.json contract path, write your verdict there as JSON (`outcome`/`preferred_label`/`suggested_next_ids`/`context_updates`/`notes`) when you finish or determine you cannot -- this is a spec-native audit trail the engine reads back, and the mechanism a spawned worker should use.
+
+### report_outcome (legacy compatibility window)
+When you have completed the task (or determined you cannot), you may also report the outcome with this tool. It still works, but a node-written status.json wins over it on conflict, and it is not the primary, taught mechanism.
 
 ## Best Practices
 

--- a/docs/DOT-AUTHORING-GUIDE.md
+++ b/docs/DOT-AUTHORING-GUIDE.md
@@ -40,19 +40,26 @@ Shipped positive example: `examples/pipelines/practical/bug-fix.dot`'s exit is
 gated on `verdict_gate` output -- implementation completing earns nothing.
 
 **`goal_gate` nodes require an explicit verdict (fail-closed).** A goal gate is
-satisfied only by an explicit verdict: a `report_outcome` tool call, a pure or
-fenced JSON response with a `status` field, an embedded trailing JSON verdict,
-or -- for `shape=parallelogram` tool nodes -- the command's exit code. A
-plain-prose response ("looks good, all done") returns RETRY instead of SUCCESS,
-so the gate is never satisfied by a defaulted response; even prose that says
-"CONVERGED" does not count (`specs/EXTENSIONS.md` §25). Prompt your gate nodes
-to call `report_outcome` (or emit pure JSON), or make the gate a parallelogram
-tool node whose exit code is the verdict:
+satisfied only by an explicit verdict, and the escalation ladder below is the
+taught order for producing one: a `parallelogram` tool node's exit code, a
+node-written `status.json` (canonical spec §4.5 / Appendix C), a pure or fenced
+JSON response with a `status` field, an embedded trailing JSON verdict, or --
+as a legacy compatibility window, not the taught mechanism -- a `report_outcome`
+tool call. A plain-prose response ("looks good, all done") returns RETRY instead
+of SUCCESS, so the gate is never satisfied by a defaulted response; even prose
+that says "CONVERGED" does not count (`specs/EXTENSIONS.md` §25). Make the gate a
+parallelogram tool node whose exit code is the verdict, or have the node write
+`status.json` directly:
 
 ```dot
 judge [shape=box, goal_gate=true, retry_target="implement",
-    prompt="Evaluate the work against the criteria. You MUST call the report_outcome tool with status=success only if all criteria pass; otherwise status=retry with what is missing."]
+    prompt="Evaluate the work against the criteria. Write your verdict to the
+    status.json contract path given in your instructions with status=success only
+    if all criteria pass; otherwise status=retry with what is missing."]
 ```
+
+See ["Spec-Intended Pipeline Design"](#spec-intended-pipeline-design) below for the
+full escalation ladder and why files-as-interface sits above self-report.
 
 **Recipes vs. attractor pipelines.** Recipes are for staged sequential workflows
 with human approval gates; attractor pipelines are for machine-verified
@@ -68,6 +75,54 @@ pipelines are legitimate -- the "probably" is load-bearing.)
 - Prefer fewer, well-prompted nodes over many thin ones
 - Use `goal_gate` on evidence-bearing nodes (test gates, acceptance checks, human gates)
 - Use conditional routing to handle success/failure paths explicitly
+
+## Spec-Intended Pipeline Design
+
+The spec's own shape for a node's outcome channel, restated as design discipline -- this is
+the frame every pattern below and every gate in this repo implements:
+
+- **Files-as-interface.** The durable handoff between a worker and the graph is a file the
+  worker wrote, not a claim the worker made about its own work. Prompts should tell a node to
+  *write evidence*, not to *announce a verdict*.
+- **Gates check artifacts via exit codes / `tool.last_line`.** A `parallelogram` node greps or
+  validates the artifact and turns the result into an exit code; `context.tool.last_line`
+  carries the routing token. This is machine evidence, produced outside the worker's own
+  context -- the worker cannot grade its own homework.
+- **Context is for routing scalars, not payloads.** `context_updates` / `preferred_label` carry
+  small, closed-vocabulary routing decisions (`"pass"`, `"retry"`, a lane name) between nodes.
+  They are not where a verdict's *evidence* lives -- the evidence lives in the file the gate
+  actually checked.
+- **Nodes are stateless between visits.** A node's prompt should not depend on the engine
+  remembering that node's own prior self-assessment; it depends on the file(s) on disk and the
+  context keys explicitly carried forward. Re-entry (`loop_restart`) is designed to reset
+  exactly this kind of accumulated, ungrounded state.
+- **`status.json` is the spec-native envelope for out-of-band and spawned outcomes** (canonical
+  spec §4.5 / Appendix C): `outcome` / `preferred_label` / `suggested_next_ids` /
+  `context_updates` / `notes`. The engine reads a node's stage-directory `status.json` back and
+  auto-injects the absolute path plus this envelope into every SPAWNED worker's instruction, so
+  a spawned child (which cannot return a Python `Outcome` in-process) always has a reachable
+  channel.
+
+**The escalation ladder this implies, in taught order:**
+
+1. **Artifact file + tool-node exit code, first.** The default answer for "how does this node's
+   result reach the graph."
+2. **Node-written `status.json`**, when the outcome is produced out-of-band or by a spawned
+   worker with no other channel back.
+3. **A pure-JSON verdict** in the node's own LLM response, when neither of the above fits and
+   the node must self-describe (fenced or bare `{...}` with a `status` field -- EXTENSIONS.md
+   §25's recovery ladder, paths 2-4).
+4. **`report_outcome`** -- a legacy compatibility window, still honored, but not the taught
+   mechanism. It is a tool call, but the verdict it carries is still self-reported from inside
+   the same context that produced the work; machine evidence (rungs 1-2) outranks it. See the
+   anti-pattern catalog entry ("`report_outcome`-as-primary", `PIPELINE_PATTERNS.md` §6) and
+   the existing self-report anti-pattern ("LLM-Emitted Routing Sentinel", same section) --
+   wrapping a self-report in a tool call does not make it evidence.
+
+Pointers: `docs/PIPELINE_PATTERNS.md` (the layering discipline this section summarizes),
+`docs/ROUTING-REFERENCE.md` (the routing mechanics `status.json` / `report_outcome` feed),
+`context/dot-reference.md` (the self-report doctrine at the authoring-review layer),
+`context/engine-semantics.md` §5 (the full verdict-recovery ladder and fail-closed contract).
 
 ## Pipeline Patterns
 
@@ -180,16 +235,24 @@ gate -> deploy [condition="outcome=success && context.tests_passed=true"]
 ```
 
 Keys available in conditions:
-- `outcome` -- resolves to `preferred_label` if set by the agent via `report_outcome`, otherwise falls back to the raw status value (`success`, `fail`, etc.)
-- `preferred_label` -- the custom routing label set via `report_outcome` (null if not set)
-- `context.<key>` -- any value in the pipeline context (set via `context_updates` in `report_outcome`)
+- `outcome` -- resolves to `preferred_label` if one was set (by a node-written
+  `status.json`, or -- legacy -- by the agent via `report_outcome`), otherwise falls
+  back to the raw status value (`success`, `fail`, etc.)
+- `preferred_label` -- the custom routing label set via a node-written `status.json`
+  or (legacy) `report_outcome` (null if not set)
+- `context.<key>` -- any value in the pipeline context (set via `context_updates` in
+  a node-written `status.json` or, legacy, `report_outcome`)
 
-**Dynamic routing with `report_outcome`:** Nodes that make routing decisions
-(review gates, test runners) should call the `report_outcome` tool with a
-`preferred_label` that matches their outgoing edge conditions. For example,
-a review node with edges `condition="outcome=pass"` and `condition="outcome=retry"`
-should call `report_outcome(status="success", preferred_label="pass")` or
-`report_outcome(status="fail", preferred_label="retry")`.
+**Dynamic routing: prefer evidence over self-report.** Nodes that make routing
+decisions (review gates, test runners) should route on a `preferred_label` set by the
+escalation ladder in ["Spec-Intended Pipeline Design"](#spec-intended-pipeline-design):
+an artifact file a downstream `parallelogram` gate greps and turns into
+`context.tool.last_line`, or a node-written `status.json` for out-of-band/spawned
+outcomes. For example, a review node with edges `condition="outcome=pass"` and
+`condition="outcome=retry"` should write a verdict file (or `status.json`) carrying
+`preferred_label="pass"` or `"retry"`. `report_outcome` still sets the same fields and
+is still honored, but it is a legacy compatibility window, not the taught mechanism --
+a self-reported tool call is still a self-report.
 
 > **Common mistake: escaped-quote delimiters** — Condition (and all attribute)
 > values must use **plain double-quotes** as delimiters.  Writing
@@ -873,7 +936,7 @@ Every node in a DOT pipeline can have these attributes:
 | `label` | String | node ID | Display name. Used as prompt fallback if `prompt` is empty. |
 | `prompt` | String | `""` | Primary instruction for LLM nodes. Supports `$goal` expansion. |
 | `type` | String | `""` | Explicit handler type override. Takes precedence over shape. |
-| `goal_gate` | Boolean | `false` | Node must succeed **with an explicit verdict** (report_outcome / JSON / tool exit code) before pipeline can exit. Plain prose returns RETRY (fail-closed, EXTENSIONS.md §25). |
+| `goal_gate` | Boolean | `false` | Node must succeed **with an explicit verdict** (tool exit code / node-written `status.json` / JSON -- `report_outcome` is a legacy compatibility window) before pipeline can exit. Plain prose returns RETRY (fail-closed, EXTENSIONS.md §25). |
 | `max_retries` | Integer | `0` | Additional attempts beyond the first. `max_retries=3` = 4 total. |
 | `retry_target` | String | `""` | Node to jump to when retries exhausted. |
 | `fallback_retry_target` | String | `""` | Secondary retry target if primary is missing. |
@@ -1134,6 +1197,8 @@ Set these on the `graph` element:
 | `tool_command="cmd 2>&1 \| tail -N"` (pipe-masked exit code, CMD-001) | In `/bin/sh`, the pipeline's exit code is `tail`'s — always 0.  The gate records SUCCESS even when `cmd` failed. | Redirect instead: `cmd > out.log 2>&1`.  See CMD-001 below. |
 | `tool_command="cmd \| tail -N && echo TOKEN"` (always-true sentinel, CMD-002) | `tail` exits 0, so `&& echo TOKEN` fires unconditionally.  `tool.last_line` becomes the sentinel regardless of `cmd`'s result. | Use the honest token gate: `cmd && printf ok \|\| printf fail` (no pipe).  See CMD-002 below. |
 
+| `report_outcome`-as-primary: prompting a `goal_gate=true` node to "call `report_outcome`" as the verdict mechanism | A tool call is still a self-report from inside the same context that produced the work -- structurally the same hazard as the LLM-emitted-sentinel anti-pattern above, just wearing a tool-call costume. `report_outcome` is a legacy compatibility window, not the taught mechanism. | Climb the escalation ladder instead: artifact file + tool-node exit code first, node-written `status.json` for out-of-band/spawned outcomes, pure JSON only if neither fits. See ["Spec-Intended Pipeline Design"](#spec-intended-pipeline-design). |
+
 ## Complete Example: Feature Build Pipeline
 
 This pipeline demonstrates multiple patterns working together:
@@ -1248,8 +1313,9 @@ gate -> done [condition="context.preferred_label=done"]
 ```
 
 Diamond nodes are pure routing hubs.  They do not execute logic and cannot
-observe upstream outcomes.  Use `context.preferred_label` (set via
-`report_outcome`) or `context.tool.last_line` (set by a tool node) to route.
+observe upstream outcomes.  Use `context.preferred_label` (set via a node-written
+`status.json`, or legacy `report_outcome`) or `context.tool.last_line` (set by a
+tool node -- the preferred, machine-checked source) to route.
 
 ---
 
@@ -1650,7 +1716,8 @@ means.  Canonical defines it as `outcome.status` only; this engine resolves it
 to **`preferred_label` first**, falling back to `status` only when no label is
 set.  That divergence is deliberate and ledgered — `specs/EXTENSIONS.md` §22,
 `SPEC_CONFORMANCE.md` ATX-5 (disposition DIVERGE, decided) — because it is how
-a node steers its own routing through `report_outcome`.  The trap is that
+a node steers its own routing via `preferred_label`, whether that label was set by a
+node-written `status.json` or, legacy, `report_outcome`.  The trap is that
 `preferred_label` is free-form and the status words are exactly the words an
 author reaches for as a label.  When they overlap, the label silently wins:
 

--- a/docs/DOT-SYNTAX.md
+++ b/docs/DOT-SYNTAX.md
@@ -32,7 +32,7 @@ digraph {
 | Attribute | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `prompt` | string | -- | Instructions for the LLM. `$goal` and `$param` tokens are expanded. |
-| `goal_gate` | bool | false | Must succeed **with an explicit verdict** (report_outcome / JSON / tool exit code) for pipeline to complete; plain prose returns RETRY (fail-closed, `specs/EXTENSIONS.md` §25) |
+| `goal_gate` | bool | false | Must succeed **with an explicit verdict** (tool exit code / node-written `status.json` / JSON -- `report_outcome` is a legacy compatibility window) for pipeline to complete; plain prose returns RETRY (fail-closed, `specs/EXTENSIONS.md` §25) |
 | `max_retries` | int | graph default | In-place re-attempts for RETRY-class outcomes, retryable exceptions, and `must_write=` violations. A plain FAIL is returned immediately, never retried (use `retry_target` / `outcome=fail` edges for that) |
 | `retry_target` | string | -- | Node to jump to on gate failure |
 | `fidelity` | string | "compact" | Context carryover mode |

--- a/docs/PIPELINE_PATTERNS.md
+++ b/docs/PIPELINE_PATTERNS.md
@@ -286,6 +286,50 @@ hierarchy of right and wrong.
 
 ---
 
+### AP-4: `report_outcome`-as-primary
+
+```dot
+// PROBLEM: the tool call is treated as sufficient verdict evidence
+judge [shape=box, goal_gate=true,
+       prompt="Evaluate the work. Call the report_outcome tool with status=success
+               if it passes, status=fail otherwise."]
+```
+
+**Why it fails:** this looks more rigorous than AP-2's bare sentinel -- it is a structured tool
+call with a validated `status` enum, not a typed keyword -- but the verdict inside it is
+produced by the same node, in the same context, that did the work being judged. Wrapping a
+self-report in a tool call does not make it evidence: "verification inside the context that
+produced the evidence is not verification" (`context/dot-reference.md`) applies exactly as much
+to a `report_outcome` call as to a plain-prose sentinel. As of the 2026-08-29 maintainer ruling,
+`report_outcome` is RETCONNED to a legacy compatibility window: still honored (a node-written
+`status.json` wins over it on conflict), but no longer the taught, primary mechanism.
+
+**Measured:** across this repository's own shipped `.dot` corpus, **0 of 9** sampled
+community-style pipeline files ever instructed a worker to call `report_outcome` -- every one
+gates on files, exit codes, or a prose convention a downstream `parallelogram` node checks. The
+anti-pattern is one this repo's own guidance used to teach and its own graphs never practiced.
+
+**Fix:** climb the escalation ladder in
+[DOT-AUTHORING-GUIDE.md's "Spec-Intended Pipeline Design"](DOT-AUTHORING-GUIDE.md#spec-intended-pipeline-design):
+
+```dot
+// FIX: verdict is a file; a parallelogram outside the worker's context checks it
+judge      [shape=box, prompt="Evaluate the work. Write your verdict to verdict.txt:
+                                first line must be exactly PASS or FAIL."]
+judge_gate [shape=parallelogram, goal_gate=true, max_retries=0,
+            tool_command="head -n1 verdict.txt | grep -qx PASS && printf ok || printf fail"]
+judge -> judge_gate
+judge_gate -> done [condition="context.tool.last_line=ok"]
+judge_gate -> fix  [condition="context.tool.last_line=fail"]
+```
+
+Or, for an out-of-band / spawned worker with no other channel back, a node-written
+`status.json` (canonical spec §4.5 / Appendix C) -- the engine reads it back and now injects
+the contract path directly into a spawned worker's instruction, so this is reachable without
+extra prompting.
+
+---
+
 ### AP-3: Prompt/Validator Drift
 
 ```dot

--- a/docs/ROUTING-REFERENCE.md
+++ b/docs/ROUTING-REFERENCE.md
@@ -19,11 +19,18 @@ Complete reference for the Attractor pipeline engine's routing system.
 The routing system determines which node executes next after each node
 completes. Three mechanisms work together to produce a routing decision:
 
-**`report_outcome` tool** — The executing agent calls this at the end of a
-node's work to signal the outcome. It carries the `status`, an optional
-`preferred_label` routing signal, optional `suggested_next_ids`, and optional
-`context_updates` that are merged into the pipeline context before edge
-selection runs.
+**An explicit-verdict channel** — something on the node's path writes the
+`status`, an optional `preferred_label` routing signal, optional
+`suggested_next_ids`, and optional `context_updates` that are merged into the
+pipeline context before edge selection runs. The taught, primary channels are
+an artifact file read by a downstream tool-node exit code, and a node-written
+`status.json` (canonical spec §4.5 / Appendix C) for out-of-band or spawned
+outcomes -- see [DOT-AUTHORING-GUIDE.md's escalation
+ladder](DOT-AUTHORING-GUIDE.md#spec-intended-pipeline-design). The
+**`report_outcome` tool** (§2 below) provides the same envelope from inside an
+agent's own turn; it is a **legacy compatibility window**, not the taught
+mechanism -- a node-written `status.json` wins over it on conflict, and a
+self-reported tool call is still a self-report, not machine evidence.
 
 **Edge conditions** — Each outgoing edge may carry a `condition` attribute
 containing a boolean expression evaluated against the outcome and the current
@@ -43,7 +50,21 @@ failure cases.
 
 ---
 
-## 2. The `report_outcome` Tool
+## 2. The `report_outcome` Tool (legacy compatibility window)
+
+> **Not the taught mechanism.** `report_outcome` is RETCONNED as of the
+> 2026-08-29 maintainer ruling: the spec's own channels -- an artifact file +
+> tool-node exit code, and a node-written `status.json` (canonical spec §4.5 /
+> Appendix C) -- are what pipeline authors should reach for. `report_outcome`
+> is not deleted and still functions exactly as documented below; a
+> node-written `status.json` simply wins over it when both are present and
+> diverge. It remains here as full reference for pipelines and agent
+> integrations that already depend on it. See
+> [DOT-AUTHORING-GUIDE.md's escalation
+> ladder](DOT-AUTHORING-GUIDE.md#spec-intended-pipeline-design) and
+> `PIPELINE_PATTERNS.md` §6's anti-pattern catalog ("`report_outcome`-as-primary")
+> for why: a tool call is still a self-report from inside the same context
+> that produced the work, and machine evidence outranks it.
 
 The agent calls `report_outcome` at the end of a node's execution to
 communicate the outcome back to the pipeline engine. The engine reads
@@ -134,7 +155,8 @@ stripped before comparison. An empty condition is always eligible.
 Canonical §10.4 defines `outcome` as `outcome.status` **only**, with `preferred_label` as a separate
 key. This engine resolves `outcome` to `preferred_label` when one is set, falling back to
 `status.value` — `conditions.py`, ledgered as `specs/EXTENSIONS.md` §22 / `SPEC_CONFORMANCE.md`
-ATX-5. It is load-bearing: it is how a node steers its own routing through `report_outcome`.
+ATX-5. It is load-bearing: it is how a node steers its own routing via `preferred_label`,
+whichever channel set it -- a node-written `status.json` (taught) or, legacy, `report_outcome`.
 
 It is also **not behavior-neutral**, and that is the trap: one key, two meanings.
 
@@ -316,6 +338,14 @@ WARNING: Node "decide" has unrecognized type "stack.steer" -- defaulting to code
 ---
 
 ## 6. Common Patterns and Pitfalls
+
+> **A note on the examples below.** They show the `report_outcome` call because it is the
+> most compact way to illustrate which `preferred_label` / `context_updates` values make each
+> condition match -- the resolution mechanics are identical no matter which channel set those
+> fields. `report_outcome` itself is a legacy compatibility window (§2); the taught way to
+> produce the same fields is an artifact file + tool-node exit code, or a node-written
+> `status.json` for out-of-band/spawned outcomes -- see [DOT-AUTHORING-GUIDE.md's escalation
+> ladder](DOT-AUTHORING-GUIDE.md#spec-intended-pipeline-design).
 
 ### Pattern: Pass/retry routing
 

--- a/docs/attractor-explained.html
+++ b/docs/attractor-explained.html
@@ -824,7 +824,7 @@ footer .fine{font-size:12.5px;line-height:1.6;color:var(--faint);max-width:600px
 review -&gt; Fix  [<span class="at">condition</span>=<span class="st">"outcome=retry"</span>]
 review -&gt; Test [<span class="at">condition</span>=<span class="st">"outcome!=retry"</span>, <span class="at">weight</span>=<span class="st">10</span>]</code></pre>
 
-    <h3>The <code>report_outcome</code> contract</h3>
+    <h3>The verdict contract (<code>report_outcome</code> is now a legacy channel)</h3>
     <p>An LLM node communicates its result back to the orchestrator by calling a tool. This is the authoritative channel — everything else is recovery.</p>
 <pre><code>{
   <span class="at">"status"</span>: <span class="st">"success | fail | partial_success | retry"</span>,
@@ -840,7 +840,7 @@ review -&gt; Test [<span class="at">condition</span>=<span class="st">"outcome!=
   <figure>
     <svg class="dg" viewBox="0 0 960 330" role="img" aria-labelledby="d10t d10d" xmlns="http://www.w3.org/2000/svg">
       <title id="d10t">The verdict recovery ladder</title>
-      <desc id="d10d">Five fallbacks below the authoritative report_outcome tool call, ending with plain prose which means success on ordinary nodes but retry on goal gate nodes, and an empty response which means fail.</desc>
+      <desc id="d10d">Five fallbacks below the report_outcome tool call -- a legacy channel the engine still checks first internally, but no longer the taught, primary mechanism -- ending with plain prose which means success on ordinary nodes but retry on goal gate nodes, and an empty response which means fail.</desc>
       <text class="cap" transform="rotate(-90 12 160)" x="12" y="160" text-anchor="middle">recovery order</text>
       <rect class="n-p" x="30" y="26" width="430" height="36" rx="2"/>
       <text class="nl-s" x="44" y="49" style="fill:#1b1813">report_outcome tool call</text>

--- a/examples/pipelines/03-conditional-routing.md
+++ b/examples/pipelines/03-conditional-routing.md
@@ -46,7 +46,7 @@ Key facts:
 - `shape=parallelogram` maps to the `tool` handler, which runs `tool_command` as a shell command
 - The last non-empty stdout line is stored in `context["tool.last_line"]` automatically
 - Route on `context.tool.last_line`, never on `tool.output` (full stdout never matches a condition exactly)
-- A diamond is only correct when routing on `context.*` keys set by *earlier* nodes (e.g., a `report_outcome` `preferred_label`) -- never on `outcome=` of the node before it
+- A diamond is only correct when routing on `context.*` keys set by *earlier* nodes (e.g., a `preferred_label` set by a node-written `status.json`, or legacy `report_outcome`) -- never on `outcome=` of the node before it
 
 ## Pipeline Structure
 


### PR DESCRIPTION
## Ruling

Per the 2026-08-29 maintainer ruling, `report_outcome` is RETCONNED from the taught,
primary verdict mechanism to a **legacy compatibility window**. It is not deleted and
not removed — it still works exactly as documented, and a node-written `status.json`
simply wins over it on conflict (strictly-later, out-of-band correction). Pipeline
authors should teach the spec's own outcome channels instead.

## The escalation ladder (taught order)

1. **Artifact file + tool-node exit code** — a downstream `parallelogram` greps the
   artifact; its exit code (`context.tool.last_line`) becomes the routing signal.
   Deterministic evidence, checked outside the worker's own context.
2. **Node-written `status.json`**, for out-of-band or spawned-worker outcomes
   (canonical spec §4.5 / Appendix C). The engine reads it back and now
   auto-injects the absolute contract path + envelope into every spawned worker's
   instruction.
3. **A pure-JSON verdict** in the node's own LLM response (EXTENSIONS.md §25's
   recovery ladder, paths 2-4).
4. **`report_outcome`** — legacy compatibility window, not the taught mechanism. A
   tool call is still a self-report from inside the same context that produced the
   work; machine evidence (rungs 1-2) outranks it.

## Evidence

- **0-of-9 community evidence**: across this repo's own shipped `.dot` corpus, 0 of 9
  sampled community-style pipeline files ever instructed a worker to call
  `report_outcome` — gating is already done on files/exit codes/prose-checked-downstream.
- **Zero-graph-edits finding**: full audit of every non-proposal `.dot` in the repo
  (independently re-run: repo-wide `grep report_outcome *.dot` = 0 matches, including
  outside the original 36-file sample) confirms no shipped graph teaches the old
  pattern. No `.dot` edits were needed.
- **Grep-proof**: remaining `report_outcome` mentions across the 12 touched files are
  code citations, legacy-labeled reference material, or anti-pattern-catalog entries —
  none instruct "always call report_outcome" as primary.

## Files changed (12, +252/-61)

`context/engine-semantics.md`, `docs/DOT-AUTHORING-GUIDE.md` (+ new "Spec-Intended
Pipeline Design" section), `docs/ROUTING-REFERENCE.md`, `docs/DOT-SYNTAX.md`,
`docs/PIPELINE_PATTERNS.md` (+ new AP-4 "report_outcome-as-primary" anti-pattern),
`context/attractor-expert-defenses.md`, `agents/attractor-expert.md`,
`context/system-{anthropic,gemini,openai}.md`,
`examples/pipelines/03-conditional-routing.md`, `docs/attractor-explained.html`.

## Review findings (compact adversarial pass)

- Diff stats verified exact (12 files, +252/-61).
- Root suite (`tests/ --ignore=tests/e2e`): 192 passed / 2 skipped, identical at base
  `d1ab6d8` and this branch — no regression from the doc changes.
- `modules/loop-pipeline` text-anchored doc-guard twins: 7 passed, 0 failed.
- All 63 git-tracked `.dot` files render clean under `dot -Tsvg` (superset of the
  claimed 36; render-gate scope).
- Graph audit re-run independently: repo-wide `report_outcome` grep across every
  `*.dot` = 0 matches. No guard test pins the old "always call report_outcome"
  wording (grepped; none found — and the guard suite passes against the new text).
- Engine facts spot-checked against a scratch clone of `amplifier-bundle-dot-runner`
  @ `56744d0`: auto-injection of the `status.json` contract into spawned-worker
  instructions (`status_contract.py` + `backend.py::_run_with_spawn`), the §41
  read-side (`status_file.py`, explicitly cited), and status.json-wins-on-conflict
  precedence over `report_outcome` are all confirmed in code, matching the docs'
  claims verbatim.
- AP-4 anti-pattern wording checked for honesty: consistently frames `report_outcome`
  as "still works" / "legacy compatibility window," never "removed" or "broken."
- `docs/attractor-explained.html` parses cleanly; the "verdict recovery ladder" deck
  section and its accessibility `<desc>` were updated consistently with the ladder.
- Frozen dirs (`modules/`, `specs/`) diff against base = 0; no engine/spec changes
  smuggled into a docs PR.

No structural problems found. Small numeric drift only (self-reported "196/3"/"81
mentions" vs. this review's own re-measured "192/2"/"~76"): immaterial to
correctness, does not block merge.
