### PR TITLE
chore!: adopt the engine's 0.2.0 worker surface -- explicit --worker loop-agent in lanes; bundle vocabulary retired from docs

### DIFF
--- a/.github/workflows/capsule-implement.yml
+++ b/.github/workflows/capsule-implement.yml
@@ -261,9 +261,11 @@ jobs:
         # (`Path(__file__).resolve().parents[3] / "bundles" /
         # "attractor-pipeline.yaml"`). Moving the engine without that directory
         # would silently turn a local-sibling hit into a miss and push the
-        # engine onto its git fallback. These workflows all set
-        # ATTRACTOR_PIPELINE_BUNDLE explicitly, so that default is unreachable
-        # here -- but 20K of YAML is a cheap price for a snapshot that behaves
+        # engine onto its git fallback. WORKER-SURFACE FLIP (engine 0.2.0):
+        # this job no longer sets ATTRACTOR_PIPELINE_BUNDLE or
+        # DOT_RUNNER_BUNDLE (both --bundle forms are gone from the CLI), so
+        # this bare default-bundle path is the one every run actually takes
+        # -- but 20K of YAML is a cheap price for a snapshot that behaves
         # identically to the in-tree layout it replaces, and bundles/ is
         # engine-side content by the same rule as modules/.
         #
@@ -349,10 +351,12 @@ jobs:
         # 20+ minutes to say what could be said in one line at startup. The
         # vendored task-runner.dot's critique_b node HARD-DECLARES
         # llm_provider="openai" (restored to the pristine upstream shape;
-        # see that file's own header) and this job now unconditionally
-        # mounts attractor-pipeline-dual.yaml to serve it -- there is no
-        # more silent single-provider fallback at either layer. So: check
-        # the one precondition that makes that mount meaningful BEFORE
+        # see that file's own header). WORKER-SURFACE FLIP (engine 0.2.0):
+        # with `--worker loop-agent`, that attribute now flows straight
+        # through the named-worker path and is honored directly -- no
+        # dual-provider bundle mount required any more, and no more silent
+        # single-provider fallback at either layer. So: check the one
+        # precondition that makes that attribute serviceable BEFORE
         # spending any of the run's 30-90+ minute budget, and fail loudly,
         # naming exactly what's missing and what capability is lost, if it
         # isn't met.
@@ -361,7 +365,7 @@ jobs:
         run: |
           set -euo pipefail
           if [ -z "$OPENAI_API_KEY" ]; then
-            echo "::error::capsule-implement: OPENAI_API_KEY secret is missing. task-runner.dot's critique_b node requires llm_provider=\"openai\" (dual-family critique -- an independent, different-model-family reviewer is the point; see issue #155) and this job unconditionally mounts attractor-pipeline-dual.yaml to serve it. Without OPENAI_API_KEY that mount cannot serve a real OpenAI model, and running anyway would either crash the node every round (draining the whole iteration budget on a crash loop) or silently degrade to single-family review depending on engine version -- both are exactly the failure this preflight exists to prevent. Refusing to start. Provision OPENAI_API_KEY as a repo secret, then re-run." >&2
+            echo "::error::capsule-implement: OPENAI_API_KEY secret is missing. task-runner.dot's critique_b node requires llm_provider=\"openai\" (dual-family critique -- an independent, different-model-family reviewer is the point; see issue #155) and the engine cross-checks every declared provider at startup, refusing to start without a serviceable credential for it. Without OPENAI_API_KEY that check fails fast at startup (fail-loud, no crash-loop, no silent same-family substitution). Refusing to start here too, so the failure is visible before the run's 30-90+ minute budget is spent. Provision OPENAI_API_KEY as a repo secret, then re-run." >&2
             exit 1
           fi
           echo "OPENAI_API_KEY is present -- dual-family critique (Anthropic + OpenAI) can be honored. Proceeding."
@@ -484,25 +488,18 @@ jobs:
         continue-on-error: true
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          # DUAL-FAMILY CRITIQUE, UNCONDITIONALLY WIRED (issue #155): the
-          # vendored task-runner.dot's critique_b node declares
-          # llm_provider="openai" -- a design requirement, not optional --
-          # so this bundle is ALWAYS mounted; there is no single-provider
-          # fallback path any more. If OPENAI_API_KEY is unset, the
-          # "Preflight: dual-family critique is unserviceable without an
-          # OpenAI key" step below fails the job LOUDLY before this step
-          # (and the 30-90+ minute run it would otherwise start) ever runs.
+          # DUAL-FAMILY CRITIQUE, WORKER-SURFACE FLIP (engine 0.2.0, issue
+          # #155): the vendored task-runner.dot's critique_b node declares
+          # llm_provider="openai" -- a design requirement, not optional.
+          # `--worker loop-agent` below (the named-worker path) now honors
+          # that attribute directly -- the old ATTRACTOR_PIPELINE_BUNDLE/
+          # DOT_RUNNER_BUNDLE dual-bundle mount is retired from this job
+          # entirely; --bundle and DOT_RUNNER_BUNDLE are gone from the CLI
+          # as of 0.2.0 anyway. If OPENAI_API_KEY is unset, the "Preflight:
+          # dual-family critique is unserviceable without an OpenAI key"
+          # step below fails the job LOUDLY before this step (and the
+          # 30-90+ minute run it would otherwise start) ever runs.
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          ATTRACTOR_PIPELINE_BUNDLE: ${{ format('{0}/.github/capsule-pipeline/attractor-pipeline-dual.yaml', github.workspace) }}
-          # POST-RIP SEAM FIX (review-driven, cli-rename-sweep follow-up):
-          # amplifier-bundle-dot-runner's band-aid rip deleted the engine's
-          # ATTRACTOR_PIPELINE_BUNDLE auto-load entirely -- the var above is
-          # inert against the root-form `dot-runner` this job now installs.
-          # DOT_RUNNER_BUNDLE is the ONE env var the post-rip CLI actually
-          # reads (cli.py's --bundle fallback); same value, so the dual-family
-          # (openai critique) bundle keeps mounting instead of silently
-          # falling back to the engine-native `direct` worker.
-          DOT_RUNNER_BUNDLE: ${{ format('{0}/.github/capsule-pipeline/attractor-pipeline-dual.yaml', github.workspace) }}
         run: |
           set -uo pipefail
           mkdir -p "$RUNNER_TEMP/capsule-implement/logs"
@@ -536,6 +533,7 @@ jobs:
           # supposed to be the live one.
           uv run --project "$RUNNER_TEMP/engine-src/modules/pipeline-runner" dot-runner run \
             .github/capsule-pipeline/task-runner.dot \
+            --worker loop-agent \
             --cwd "$GITHUB_WORKSPACE" \
             --logs-root "$RUNNER_TEMP/capsule-implement/logs" \
             --on-human-gate auto-approve \

--- a/.github/workflows/capsule-specify.yml
+++ b/.github/workflows/capsule-specify.yml
@@ -132,9 +132,11 @@ jobs:
         # (`Path(__file__).resolve().parents[3] / "bundles" /
         # "attractor-pipeline.yaml"`). Moving the engine without that directory
         # would silently turn a local-sibling hit into a miss and push the
-        # engine onto its git fallback. These workflows all set
-        # ATTRACTOR_PIPELINE_BUNDLE explicitly, so that default is unreachable
-        # here -- but 20K of YAML is a cheap price for a snapshot that behaves
+        # engine onto its git fallback. WORKER-SURFACE FLIP (engine 0.2.0):
+        # this job no longer sets ATTRACTOR_PIPELINE_BUNDLE or
+        # DOT_RUNNER_BUNDLE (both --bundle forms are gone from the CLI), so
+        # this bare default-bundle path is the one every run actually takes
+        # -- but 20K of YAML is a cheap price for a snapshot that behaves
         # identically to the in-tree layout it replaces, and bundles/ is
         # engine-side content by the same rule as modules/.
         #
@@ -421,17 +423,19 @@ jobs:
         # capsule.dot's lean rebuild has exactly ONE judgment node,
         # `critique`, and it HARD-DECLARES llm_provider="openai" (a second
         # model family, deliberately -- the judge must not share the
-        # maker's family), and this job now unconditionally mounts
-        # attractor-pipeline-dual.yaml to serve it. So: check the one
-        # precondition that makes that mount meaningful BEFORE spending any
-        # of the run's multi-hour budget, and fail loudly, naming exactly
-        # what's missing and what capability is lost, if it isn't met.
+        # maker's family). WORKER-SURFACE FLIP (engine 0.2.0): with
+        # `--worker loop-agent`, that attribute now flows straight through
+        # the named-worker path and is honored directly -- no dual-provider
+        # bundle mount required any more. So: check the one precondition
+        # that makes that attribute serviceable BEFORE spending any of the
+        # run's multi-hour budget, and fail loudly, naming exactly what's
+        # missing and what capability is lost, if it isn't met.
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           set -euo pipefail
           if [ -z "$OPENAI_API_KEY" ]; then
-            echo "::error::capsule-specify: OPENAI_API_KEY secret is missing. capsule.dot's critique node (the lean rebuild's ONE judgment node) requires llm_provider=\"openai\" -- a second model family is the point: the judge must be independent of the maker's family (see issue #155 for the proven failure) -- and this job unconditionally mounts attractor-pipeline-dual.yaml to serve it. Without OPENAI_API_KEY that mount cannot serve a real OpenAI model, and running anyway would either crash the node every round (draining the whole iteration budget on a crash loop) or silently degrade the judge to the maker's own family depending on engine version -- both are exactly the failure this preflight exists to prevent. Refusing to start. Provision OPENAI_API_KEY as a repo secret, then re-run." >&2
+            echo "::error::capsule-specify: OPENAI_API_KEY secret is missing. capsule.dot's critique node (the lean rebuild's ONE judgment node) requires llm_provider=\"openai\" -- a second model family is the point: the judge must be independent of the maker's family (see issue #155 for the proven failure) -- and the engine cross-checks every declared provider at startup and refuses to start without a serviceable credential for it. Without OPENAI_API_KEY that check fails fast at startup (fail-loud, no crash-loop, no silent same-family substitution). Refusing to start here too, so the failure is visible before the run's multi-hour budget is spent. Provision OPENAI_API_KEY as a repo secret, then re-run." >&2
             exit 1
           fi
           echo "OPENAI_API_KEY is present -- the second-family critique judge (OpenAI) can be honored. Proceeding."
@@ -446,25 +450,18 @@ jobs:
         continue-on-error: true
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          # DUAL-FAMILY JUDGE, UNCONDITIONALLY WIRED (mirror of
+          # DUAL-FAMILY JUDGE, WORKER-SURFACE FLIP (engine 0.2.0, mirror of
           # capsule-implement.yml, issue #155): the vendored capsule.dot's
           # critique node declares llm_provider="openai" -- a design
-          # requirement, not optional -- so this bundle is ALWAYS mounted;
-          # there is no single-provider fallback path. If OPENAI_API_KEY is
-          # unset, the preflight step above fails the job LOUDLY before
-          # this step (and the multi-hour run it would otherwise start)
-          # ever runs.
+          # requirement, not optional. `--worker loop-agent` below (the
+          # named-worker path) now honors that attribute directly -- the
+          # old ATTRACTOR_PIPELINE_BUNDLE/DOT_RUNNER_BUNDLE dual-bundle
+          # mount is retired from this job entirely; --bundle and
+          # DOT_RUNNER_BUNDLE are gone from the CLI as of 0.2.0 anyway. If
+          # OPENAI_API_KEY is unset, the preflight step above fails the job
+          # LOUDLY before this step (and the multi-hour run it would
+          # otherwise start) ever runs.
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          ATTRACTOR_PIPELINE_BUNDLE: ${{ format('{0}/.github/capsule-pipeline/attractor-pipeline-dual.yaml', github.workspace) }}
-          # POST-RIP SEAM FIX (review-driven, cli-rename-sweep follow-up):
-          # amplifier-bundle-dot-runner's band-aid rip deleted the engine's
-          # ATTRACTOR_PIPELINE_BUNDLE auto-load entirely -- the var above is
-          # inert against the root-form `dot-runner` this job now installs.
-          # DOT_RUNNER_BUNDLE is the ONE env var the post-rip CLI actually
-          # reads (cli.py's --bundle fallback); same value, so the dual-family
-          # (openai critique) bundle keeps mounting instead of silently
-          # falling back to the engine-native `direct` worker.
-          DOT_RUNNER_BUNDLE: ${{ format('{0}/.github/capsule-pipeline/attractor-pipeline-dual.yaml', github.workspace) }}
         run: |
           set -uo pipefail
           mkdir -p "$RUNNER_TEMP/capsule-run/out" "$RUNNER_TEMP/capsule-run/logs"
@@ -476,6 +473,7 @@ jobs:
           # supposed to be the live one.
           uv run --project "$RUNNER_TEMP/engine-src/modules/pipeline-runner" dot-runner run \
             .github/capsule-pipeline/capsule.dot \
+            --worker loop-agent \
             --cwd "$GITHUB_WORKSPACE" \
             --logs-root "$RUNNER_TEMP/capsule-run/logs" \
             --param issue_file="${{ steps.issue.outputs.file }}" \

--- a/.github/workflows/feature-specify.yml
+++ b/.github/workflows/feature-specify.yml
@@ -257,9 +257,11 @@ jobs:
         # (`Path(__file__).resolve().parents[3] / "bundles" /
         # "attractor-pipeline.yaml"`). Moving the engine without that directory
         # would silently turn a local-sibling hit into a miss and push the
-        # engine onto its git fallback. These workflows all set
-        # ATTRACTOR_PIPELINE_BUNDLE explicitly, so that default is unreachable
-        # here -- but 20K of YAML is a cheap price for a snapshot that behaves
+        # engine onto its git fallback. WORKER-SURFACE FLIP (engine 0.2.0):
+        # this job no longer sets ATTRACTOR_PIPELINE_BUNDLE or
+        # DOT_RUNNER_BUNDLE (both --bundle forms are gone from the CLI), so
+        # this bare default-bundle path is the one every run actually takes
+        # -- but 20K of YAML is a cheap price for a snapshot that behaves
         # identically to the in-tree layout it replaces, and bundles/ is
         # engine-side content by the same rule as modules/.
         #
@@ -597,17 +599,19 @@ jobs:
         # capsule-implement.yml's (issue #155). feature-capsule.dot has
         # exactly ONE judgment node, `critique`, and -- like capsule.dot's --
         # it HARD-DECLARES llm_provider="openai": the judge must not share the
-        # maker's model family. This job unconditionally mounts
-        # attractor-pipeline-dual.yaml to serve it, so check the one
-        # precondition that makes that mount meaningful BEFORE spending any of
-        # the run's multi-hour budget, and fail loudly, naming exactly what's
+        # maker's model family. WORKER-SURFACE FLIP (engine 0.2.0): with
+        # `--worker loop-agent`, that attribute now flows straight through
+        # the named-worker path and is honored directly -- no dual-provider
+        # bundle mount required any more. So: check the one precondition
+        # that makes that attribute serviceable BEFORE spending any of the
+        # run's multi-hour budget, and fail loudly, naming exactly what's
         # missing and what capability is lost, if it isn't met.
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           set -euo pipefail
           if [ -z "$OPENAI_API_KEY" ]; then
-            echo "::error::feature-specify: OPENAI_API_KEY secret is missing. feature-capsule.dot's critique node (this pipeline's ONE judgment node) requires llm_provider=\"openai\" -- a second model family is the point: the judge must be independent of the maker's family (see issue #155 for the proven failure) -- and this job unconditionally mounts attractor-pipeline-dual.yaml to serve it. Without OPENAI_API_KEY that mount cannot serve a real OpenAI model, and running anyway would either crash the node every round (draining the whole iteration budget on a crash loop) or silently degrade the judge to the maker's own family depending on engine version -- both are exactly the failure this preflight exists to prevent. Refusing to start. Provision OPENAI_API_KEY as a repo secret, then re-run." >&2
+            echo "::error::feature-specify: OPENAI_API_KEY secret is missing. feature-capsule.dot's critique node (this pipeline's ONE judgment node) requires llm_provider=\"openai\" -- a second model family is the point: the judge must be independent of the maker's family (see issue #155 for the proven failure) -- and the engine cross-checks every declared provider at startup, refusing to start without a serviceable credential for it. Without OPENAI_API_KEY that check fails fast at startup (fail-loud, no crash-loop, no silent same-family substitution). Refusing to start here too, so the failure is visible before the run's multi-hour budget is spent. Provision OPENAI_API_KEY as a repo secret, then re-run." >&2
             exit 1
           fi
           echo "OPENAI_API_KEY is present -- the second-family critique judge (OpenAI) can be honored. Proceeding."
@@ -623,27 +627,17 @@ jobs:
         continue-on-error: true
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          # DUAL-FAMILY JUDGE, UNCONDITIONALLY WIRED -- the same bundle
-          # capsule-specify.yml mounts for capsule.dot's critique node, for
-          # the same reason: feature-capsule.dot's critique node likewise
-          # declares llm_provider="openai", and its header calls this out
-          # explicitly ("ATTRACTOR_PIPELINE_BUNDLE is REQUIRED -- the critique
-          # node pins a second model family, delivered by
-          # attractor-pipeline-dual.yaml exactly as capsule.dot's critique").
-          # There is no single-provider fallback path; the preflight step
+          # DUAL-FAMILY JUDGE, WORKER-SURFACE FLIP (engine 0.2.0) -- the same
+          # reason capsule-specify.yml flipped for capsule.dot's critique
+          # node: feature-capsule.dot's critique node likewise declares
+          # llm_provider="openai". `--worker loop-agent` below (the
+          # named-worker path) now honors that attribute directly -- the old
+          # ATTRACTOR_PIPELINE_BUNDLE/DOT_RUNNER_BUNDLE dual-bundle mount is
+          # retired from this job entirely; --bundle and DOT_RUNNER_BUNDLE
+          # are gone from the CLI as of 0.2.0 anyway. The preflight step
           # above fails the job LOUDLY before this step ever runs if
           # OPENAI_API_KEY is unset.
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          ATTRACTOR_PIPELINE_BUNDLE: ${{ format('{0}/.github/capsule-pipeline/attractor-pipeline-dual.yaml', github.workspace) }}
-          # POST-RIP SEAM FIX (review-driven, cli-rename-sweep follow-up):
-          # amplifier-bundle-dot-runner's band-aid rip deleted the engine's
-          # ATTRACTOR_PIPELINE_BUNDLE auto-load entirely -- the var above is
-          # inert against the root-form `dot-runner` this job now installs.
-          # DOT_RUNNER_BUNDLE is the ONE env var the post-rip CLI actually
-          # reads (cli.py's --bundle fallback); same value, so the dual-family
-          # (openai critique) bundle keeps mounting instead of silently
-          # falling back to the engine-native `direct` worker.
-          DOT_RUNNER_BUNDLE: ${{ format('{0}/.github/capsule-pipeline/attractor-pipeline-dual.yaml', github.workspace) }}
         run: |
           set -uo pipefail
           mkdir -p "$RUNNER_TEMP/capsule-run/out" "$RUNNER_TEMP/capsule-run/logs"
@@ -667,6 +661,7 @@ jobs:
           # supposed to be the live one.
           uv run --project "$RUNNER_TEMP/engine-src/modules/pipeline-runner" dot-runner run \
             .github/capsule-pipeline/feature-capsule.dot \
+            --worker loop-agent \
             --cwd "$GITHUB_WORKSPACE" \
             --logs-root "$RUNNER_TEMP/capsule-run/logs" \
             --on-human-gate auto-approve \

--- a/README.md
+++ b/README.md
@@ -102,9 +102,16 @@ cp -r examples/pipelines/practical/sample /tmp/attractor-demo
 cd /tmp/attractor-demo
 dot-runner run "$DOT" \
     --param goal="Fix the TypeError in get_display_name when a user's avatar is None" \
-    --bundle git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=bundles/attractor-pipeline.yaml \
+    --worker loop-agent \
     --cwd .
 ```
+
+`--worker loop-agent` runs box nodes as the full coding agent (tools, file edits, the
+works). Omit `--worker` and the CLI falls back to its own default ladder --
+`amplifier-agent` if it is installed, otherwise `direct` (plain LLM text, no tools) with
+a loud notice -- so pin `--worker` explicitly in anything unattended (CI) rather than
+relying on that ladder. Other valid names: `direct`, `amplifier-agent`. See `--worker`
+in `dot-runner run --help`.
 
 Then `pytest -v` in the copy to see the fix + regression test. The sample is
 copied to a temp dir so the committed fixture stays pristine; `$DOT` is captured

--- a/agents/attractor-expert.md
+++ b/agents/attractor-expert.md
@@ -565,12 +565,11 @@ time. Full patterns and compliant examples are in the companion context file.
 **Judge verdict contracts** (lint cannot see inside node prompts):
 - [ ] Every `goal_gate=true` LLM node has an explicit outcome instruction, in
   escalation order: write a verdict file that a downstream deterministic
-  `parallelogram` gate reads, write a node-written `status.json`, emit a
-  pure-JSON verdict, or (legacy compatibility window, not the taught
-  mechanism) call `report_outcome`. Prose verdicts are discarded under the
-  fail-closed contract (engine-semantics.md §5). Never leave a judge to prose,
-  and never let a `report_outcome` call stand in as the only channel -- a
-  tool call is still a self-report.
+  `parallelogram` gate reads, write a node-written `status.json`, or emit a
+  pure-JSON verdict. (`report_outcome` was a fourth, legacy rung; it is
+  removed in the engine's 0.2.0 repair release and is no longer callable.)
+  Prose verdicts are discarded under the fail-closed contract
+  (engine-semantics.md §5). Never leave a judge to prose.
 
 **Delta-assertion gates** (green tests on an unmodified tree prove nothing):
 - [ ] Work-completion gates anchor to a recorded base SHA and assert that

--- a/context/attractor-expert-defenses.md
+++ b/context/attractor-expert-defenses.md
@@ -92,14 +92,15 @@ is no longer the taught mechanism):**
    > "Respond with ONLY a JSON object: `{\"status\": \"success\"}` or
    > `{\"status\": \"fail\", \"reason\": \"...\"}`. No surrounding prose."
 
-4. **`report_outcome` tool call** (legacy compatibility window, not the taught
-   mechanism -- still honored, a node-written `status.json` wins over it on
-   conflict). A tool call is still a self-report from inside the same context
-   that produced the work: it is not an exemption from "verification inside
-   the context that produced the evidence is not verification"
-   (`context/dot-reference.md`). Machine evidence (patterns 1-2 above)
-   outranks it. See `docs/PIPELINE_PATTERNS.md` §6's anti-pattern catalog
-   ("`report_outcome`-as-primary", alongside "LLM-Emitted Routing Sentinel").
+4. ~~`report_outcome` tool call~~ -- **removed in the engine's 0.2.0 repair
+   release; no longer callable at all.** It was a legacy compatibility
+   window, never the taught mechanism, and even while it existed a tool call
+   was still a self-report from inside the same context that produced the
+   work: not an exemption from "verification inside the context that
+   produced the evidence is not verification" (`context/dot-reference.md`).
+   Only patterns 1-3 above remain. See `docs/PIPELINE_PATTERNS.md` §6's
+   anti-pattern catalog ("`report_outcome`-as-primary", alongside
+   "LLM-Emitted Routing Sentinel").
 
 **Cross-reference:** engine-semantics.md §5 (verdict-recovery ladder, fail-closed
 goal-gate contract, `is_explicit` field).

--- a/context/engine-semantics.md
+++ b/context/engine-semantics.md
@@ -19,7 +19,7 @@ Source: nlspec §2.8; `validation.py:24-34` (`SHAPE_TO_HANDLER`).
 |---|---|---|---|---|---|
 | `Mdiamond` | `start` | no | no | no (no-op SUCCESS) `handlers/start.py` | [NLSPEC] |
 | `Msquare` | `exit` | no | no | no (engine checks goal gates) `handlers/exit.py` | [NLSPEC] |
-| `box` | `codergen` | **yes** | no | **YES via backend** (JSON / `report_outcome`) `backend.py:604-637` | [NLSPEC] |
+| `box` | `codergen` | **yes** | no | **YES via backend** (JSON; `report_outcome` removed 0.2.0) `backend.py:604-637` | [NLSPEC] |
 | `diamond` | `conditional` | no | no | no-op SUCCESS; engine routes `handlers/conditional.py` | [NLSPEC] |
 | `hexagon` | `wait.human` | no | no | yes — `suggested_next_ids` + `human.gate.*` `handlers/human.py` | [NLSPEC] |
 | `component` | `parallel` | no (orchestrates) | no | emits `branch.{i}.outcome` `handlers/parallel.py` | [NLSPEC] |
@@ -53,9 +53,10 @@ wrong about the running engine.
 1. **`box`/codergen nodes CAN route and set context.** Spec §4.5 shows `CodergenHandler`
    returning hard-coded SUCCESS. SHIPPED: the backend maps the LLM result to a full
    `Outcome` (status, `context_updates`, `preferred_label`, `suggested_next_ids`) via
-   (a) a response that is entirely JSON → `_parse_outcome` (`backend.py:903`), or
-   (b) the child calling the **`report_outcome` tool** → `_find_report_outcome_call`
-   (`backend.py:621,827-890`). LLM nodes are NOT routing-inert.
+   a response that is entirely (or fenced, or embedded-trailing) JSON → `_parse_outcome`
+   (`backend.py:903`). (The former second path, the child calling a `report_outcome`
+   tool → `_find_report_outcome_call`, was removed in the engine's 0.2.0 repair release
+   -- no compat window, the tool module is gone.) LLM nodes are NOT routing-inert.
 
 2. **FAIL is fail-fast — it does NOT traverse plain edges.** Spec §3.2 pseudocode advances
    on any selected edge. SHIPPED (`edge_selection.py:79-101`): on `status==FAIL`, plain
@@ -159,8 +160,9 @@ Source: `backend.py:_parse_outcome, _outcome_from_spawn_result`; `outcome.py`.
 
 **The verdict-recovery ladder** (tried in order for every LLM response):
 
-1. **`report_outcome` tool call** — authoritative; checked before any text parsing (tool-loop
-   path: `backend.py:_find_report_outcome_call`; spawn path: `metadata["report_outcome"]`).
+1. ~~`report_outcome` tool call~~ — **removed in the engine's 0.2.0 repair release** (was
+   checked before any text parsing; the check and the tool module are both gone repo-wide,
+   no compat window).
 2. **Fenced JSON** — ` ```json … ``` ` stripped, then parsed as JSON.
 3. **Pure JSON** — entire stripped response starts with `{`, parsed, `status` field honored.
 4. **Embedded verdict recovery** — last balanced `{…}` in prose extracted; if it carries a
@@ -187,10 +189,11 @@ Graph-level retries of a FAIL are a separate mechanism: `retry_target` and
 `condition="outcome=fail"` edges.
 
 **`is_explicit` field on `Outcome`:** `outcome.is_explicit=True` means the status was asserted
-by an unambiguous mechanism: paths 1–4 above, a tool (parallelogram) node's exit code
-(0 = explicit success, nonzero = explicit fail; `handlers/tool.py`), **verdict-shaped**
-`response_schema` structured output (a captured `report_outcome` call or a `status` field
-with a recognized value — `backend._outcome_from_structured_output`), or a deterministic
+by an unambiguous mechanism: paths 2–4 above (path 1, `report_outcome`, is removed as of
+engine 0.2.0), a tool (parallelogram) node's exit code (0 = explicit success, nonzero =
+explicit fail; `handlers/tool.py`), **verdict-shaped** `response_schema` structured output
+(a `status` field with a recognized value — `backend._outcome_from_structured_output`), or
+a deterministic
 handler verdict that cannot be LLM-defaulted (human-gate selections/freeform input,
 start/exit/conditional structural SUCCESS, fan-in ranking, parallel join-policy results).
 `is_explicit=False` means the status was defaulted: plain-prose fallback, empty-response
@@ -204,7 +207,7 @@ field, serialized into every node `status.json` (flat and iteration-scoped) and 
 
 **The gate check enforces both flags:** `_check_goal_gates()` (`engine.py`) treats a goal gate
 as satisfied only when `outcome.is_success AND outcome.is_explicit`. A SUCCESS with
-`is_explicit=False` (e.g. a spawn wrapper's clean exit with no `report_outcome`, or a schema
+`is_explicit=False` (e.g. a spawn wrapper's clean exit with no recognized verdict, or a schema
 node whose output carried no recognized verdict) does NOT satisfy the gate. This centralized enforcement
 closes bypass paths that never go through `_parse_outcome`. The RETRY-from-`_parse_outcome`
 rule above is the belt; the gate's `is_explicit` requirement is the suspenders.
@@ -227,12 +230,13 @@ reach; each step down is more machine-checkable than the one above it:
 3. **A pure-JSON verdict** in the node's own LLM response (paths 2–4 of the recovery ladder
    above — fenced, bare, or an embedded trailing `{...}` carrying a recognized `status`;
    EXTENSIONS.md §25).
-4. **`report_outcome` is a legacy compatibility window, not the taught mechanism.** It still
-   works — `is_explicit=True`, and a node-written `status.json` wins over it on conflict —
-   but it is a self-report from inside the same context that produced the work. A tool call
-   is not an exemption from that: machine evidence (paths 1–2) outranks a self-reported
-   verdict regardless of which channel carries the self-report. See `PIPELINE_PATTERNS.md`
-   §6's anti-pattern catalog ("`report_outcome`-as-primary").
+4. ~~`report_outcome`~~ -- **removed in the engine's 0.2.0 repair release, no compat
+   window.** It was a legacy compatibility window, never the taught mechanism, and even
+   while it existed it was still a self-report from inside the same context that produced
+   the work -- a tool call was never an exemption from that: machine evidence (rungs 1-2)
+   outranked a self-reported verdict regardless of which channel carried the self-report.
+   Only rungs 1-3 above remain. See `PIPELINE_PATTERNS.md` §6's anti-pattern catalog
+   ("`report_outcome`-as-primary").
 
 Do not rely on bare prose regardless of channel — even prose that says "CONVERGED" will
 return RETRY under the fail-closed contract.
@@ -339,9 +343,9 @@ of injected critique per iteration — bounded regardless of iteration count.
 3. **Copy the nearest proven pipeline before inventing.** Simplicity applies to the proven
    pattern, not to a minimal node count built on a wrong engine model.
 4. **Route verdicts via an artifact file + tool exit code, or a node-written
-   `status.json`, not free-text JSON** (§5 bug). `report_outcome` still works as a
-   legacy compatibility window, but it is not the taught mechanism -- see §5's
-   escalation ladder.
+   `status.json`, not free-text JSON** (§5 bug). `report_outcome` was removed in the
+   engine's 0.2.0 repair release (no compat window) -- see §5's escalation ladder for
+   the mechanisms that remain.
 5. **Run `dot_graph validate` after every edit** — catches isolated nodes, stray quotes,
    missing fallback edges before an expensive rebuild.
 6. **Author for fail-loud:** explicit FAIL edges (§2 #2), explicit `llm_model`, explicit

--- a/context/system-anthropic.md
+++ b/context/system-anthropic.md
@@ -51,8 +51,8 @@ Find files by name pattern. Results are sorted by modification time (newest firs
 ### status.json (the taught verdict channel)
 If your instructions name a status.json contract path, write your verdict there as JSON (`outcome`/`preferred_label`/`suggested_next_ids`/`context_updates`/`notes`) when you finish or determine you cannot -- this is a spec-native audit trail the engine reads back, and the mechanism a spawned worker should use.
 
-### report_outcome (legacy compatibility window)
-When you have completed the task (or determined you cannot), you may also report the outcome with this tool. It still works, but a node-written status.json wins over it on conflict, and it is not the primary, taught mechanism.
+### report_outcome (removed)
+`report_outcome` was removed in the engine's 0.2.0 repair release -- no tool by that name ships any more. Use status.json above; it is now the only out-of-band verdict channel.
 
 ## Best Practices
 

--- a/context/system-gemini.md
+++ b/context/system-gemini.md
@@ -59,8 +59,8 @@ Fetch content from a URL. Use this to read documentation pages, API references, 
 ### status.json (the taught verdict channel)
 If your instructions name a status.json contract path, write your verdict there as JSON (`outcome`/`preferred_label`/`suggested_next_ids`/`context_updates`/`notes`) when you finish or determine you cannot -- this is a spec-native audit trail the engine reads back, and the mechanism a spawned worker should use.
 
-### report_outcome (legacy compatibility window)
-When you have completed the task (or determined you cannot), you may also report the outcome with this tool. It still works, but a node-written status.json wins over it on conflict, and it is not the primary, taught mechanism.
+### report_outcome (removed)
+`report_outcome` was removed in the engine's 0.2.0 repair release -- no tool by that name ships any more. Use status.json above; it is now the only out-of-band verdict channel.
 
 ## Project Instructions
 

--- a/context/system-openai.md
+++ b/context/system-openai.md
@@ -57,8 +57,8 @@ Find files by name pattern. Results are sorted by modification time (newest firs
 ### status.json (the taught verdict channel)
 If your instructions name a status.json contract path, write your verdict there as JSON (`outcome`/`preferred_label`/`suggested_next_ids`/`context_updates`/`notes`) when you finish or determine you cannot -- this is a spec-native audit trail the engine reads back, and the mechanism a spawned worker should use.
 
-### report_outcome (legacy compatibility window)
-When you have completed the task (or determined you cannot), you may also report the outcome with this tool. It still works, but a node-written status.json wins over it on conflict, and it is not the primary, taught mechanism.
+### report_outcome (removed)
+`report_outcome` was removed in the engine's 0.2.0 repair release -- no tool by that name ships any more. Use status.json above; it is now the only out-of-band verdict channel.
 
 ## Best Practices
 

--- a/docs/DOT-AUTHORING-GUIDE.md
+++ b/docs/DOT-AUTHORING-GUIDE.md
@@ -42,10 +42,11 @@ gated on `verdict_gate` output -- implementation completing earns nothing.
 **`goal_gate` nodes require an explicit verdict (fail-closed).** A goal gate is
 satisfied only by an explicit verdict, and the escalation ladder below is the
 taught order for producing one: a `parallelogram` tool node's exit code, a
-node-written `status.json` (canonical spec §4.5 / Appendix C), a pure or fenced
-JSON response with a `status` field, an embedded trailing JSON verdict, or --
-as a legacy compatibility window, not the taught mechanism -- a `report_outcome`
-tool call. A plain-prose response ("looks good, all done") returns RETRY instead
+node-written `status.json` (canonical spec §4.5 / Appendix C), or a pure or
+fenced JSON response with a `status` field, or an embedded trailing JSON
+verdict. (`report_outcome` was a legacy compatibility window, never the taught
+mechanism, and is now removed outright in the engine 0.2.0 repair release.) A
+plain-prose response ("looks good, all done") returns RETRY instead
 of SUCCESS, so the gate is never satisfied by a defaulted response; even prose
 that says "CONVERGED" does not count (`specs/EXTENSIONS.md` §25). Make the gate a
 parallelogram tool node whose exit code is the verdict, or have the node write
@@ -112,12 +113,13 @@ the frame every pattern below and every gate in this repo implements:
 3. **A pure-JSON verdict** in the node's own LLM response, when neither of the above fits and
    the node must self-describe (fenced or bare `{...}` with a `status` field -- EXTENSIONS.md
    §25's recovery ladder, paths 2-4).
-4. **`report_outcome`** -- a legacy compatibility window, still honored, but not the taught
-   mechanism. It is a tool call, but the verdict it carries is still self-reported from inside
-   the same context that produced the work; machine evidence (rungs 1-2) outranks it. See the
-   anti-pattern catalog entry ("`report_outcome`-as-primary", `PIPELINE_PATTERNS.md` §6) and
-   the existing self-report anti-pattern ("LLM-Emitted Routing Sentinel", same section) --
-   wrapping a self-report in a tool call does not make it evidence.
+4. ~~`report_outcome`~~ -- **removed in the engine 0.2.0 repair release, no compat window.**
+   It was a legacy compatibility window, never the taught mechanism, and even while it existed
+   the verdict it carried was still self-reported from inside the same context that produced
+   the work; machine evidence (rungs 1-2) outranked it. Only rungs 1-3 above remain callable.
+   See the anti-pattern catalog entry ("`report_outcome`-as-primary", `PIPELINE_PATTERNS.md`
+   §6) and the existing self-report anti-pattern ("LLM-Emitted Routing Sentinel", same
+   section) -- wrapping a self-report in a tool call never made it evidence.
 
 Pointers: `docs/PIPELINE_PATTERNS.md` (the layering discipline this section summarizes),
 `docs/ROUTING-REFERENCE.md` (the routing mechanics `status.json` / `report_outcome` feed),
@@ -235,13 +237,14 @@ gate -> deploy [condition="outcome=success && context.tests_passed=true"]
 ```
 
 Keys available in conditions:
-- `outcome` -- resolves to `preferred_label` if one was set (by a node-written
-  `status.json`, or -- legacy -- by the agent via `report_outcome`), otherwise falls
-  back to the raw status value (`success`, `fail`, etc.)
+- `outcome` -- resolves to `preferred_label` if one was set by a node-written
+  `status.json`, otherwise falls back to the raw status value (`success`, `fail`,
+  etc.). (`report_outcome` used to be an alternate way to set these fields; it is
+  removed in the engine 0.2.0 repair release.)
 - `preferred_label` -- the custom routing label set via a node-written `status.json`
-  or (legacy) `report_outcome` (null if not set)
+  (null if not set)
 - `context.<key>` -- any value in the pipeline context (set via `context_updates` in
-  a node-written `status.json` or, legacy, `report_outcome`)
+  a node-written `status.json`)
 
 **Dynamic routing: prefer evidence over self-report.** Nodes that make routing
 decisions (review gates, test runners) should route on a `preferred_label` set by the
@@ -250,9 +253,9 @@ an artifact file a downstream `parallelogram` gate greps and turns into
 `context.tool.last_line`, or a node-written `status.json` for out-of-band/spawned
 outcomes. For example, a review node with edges `condition="outcome=pass"` and
 `condition="outcome=retry"` should write a verdict file (or `status.json`) carrying
-`preferred_label="pass"` or `"retry"`. `report_outcome` still sets the same fields and
-is still honored, but it is a legacy compatibility window, not the taught mechanism --
-a self-reported tool call is still a self-report.
+`preferred_label="pass"` or `"retry"`. (`report_outcome` used to set the same fields
+as a legacy compatibility window; it is removed outright in the engine 0.2.0 repair
+release -- a self-reported tool call was never an exemption from self-report anyway.)
 
 > **Common mistake: escaped-quote delimiters** — Condition (and all attribute)
 > values must use **plain double-quotes** as delimiters.  Writing
@@ -936,7 +939,7 @@ Every node in a DOT pipeline can have these attributes:
 | `label` | String | node ID | Display name. Used as prompt fallback if `prompt` is empty. |
 | `prompt` | String | `""` | Primary instruction for LLM nodes. Supports `$goal` expansion. |
 | `type` | String | `""` | Explicit handler type override. Takes precedence over shape. |
-| `goal_gate` | Boolean | `false` | Node must succeed **with an explicit verdict** (tool exit code / node-written `status.json` / JSON -- `report_outcome` is a legacy compatibility window) before pipeline can exit. Plain prose returns RETRY (fail-closed, EXTENSIONS.md §25). |
+| `goal_gate` | Boolean | `false` | Node must succeed **with an explicit verdict** (tool exit code / node-written `status.json` / JSON -- `report_outcome` was removed in the engine 0.2.0 repair release) before pipeline can exit. Plain prose returns RETRY (fail-closed, EXTENSIONS.md §25). |
 | `max_retries` | Integer | `0` | Additional attempts beyond the first. `max_retries=3` = 4 total. |
 | `retry_target` | String | `""` | Node to jump to when retries exhausted. |
 | `fallback_retry_target` | String | `""` | Secondary retry target if primary is missing. |
@@ -1197,7 +1200,7 @@ Set these on the `graph` element:
 | `tool_command="cmd 2>&1 \| tail -N"` (pipe-masked exit code, CMD-001) | In `/bin/sh`, the pipeline's exit code is `tail`'s — always 0.  The gate records SUCCESS even when `cmd` failed. | Redirect instead: `cmd > out.log 2>&1`.  See CMD-001 below. |
 | `tool_command="cmd \| tail -N && echo TOKEN"` (always-true sentinel, CMD-002) | `tail` exits 0, so `&& echo TOKEN` fires unconditionally.  `tool.last_line` becomes the sentinel regardless of `cmd`'s result. | Use the honest token gate: `cmd && printf ok \|\| printf fail` (no pipe).  See CMD-002 below. |
 
-| `report_outcome`-as-primary: prompting a `goal_gate=true` node to "call `report_outcome`" as the verdict mechanism | A tool call is still a self-report from inside the same context that produced the work -- structurally the same hazard as the LLM-emitted-sentinel anti-pattern above, just wearing a tool-call costume. `report_outcome` is a legacy compatibility window, not the taught mechanism. | Climb the escalation ladder instead: artifact file + tool-node exit code first, node-written `status.json` for out-of-band/spawned outcomes, pure JSON only if neither fits. See ["Spec-Intended Pipeline Design"](#spec-intended-pipeline-design). |
+| `report_outcome`-as-primary: prompting a `goal_gate=true` node to "call `report_outcome`" as the verdict mechanism | A tool call was still a self-report from inside the same context that produced the work -- structurally the same hazard as the LLM-emitted-sentinel anti-pattern above, just wearing a tool-call costume. `report_outcome` was a legacy compatibility window, never the taught mechanism, and is now removed outright (engine 0.2.0 repair release) -- the call is not even available any more. | Climb the escalation ladder instead: artifact file + tool-node exit code first, node-written `status.json` for out-of-band/spawned outcomes, pure JSON only if neither fits. See ["Spec-Intended Pipeline Design"](#spec-intended-pipeline-design). |
 
 ## Complete Example: Feature Build Pipeline
 
@@ -1314,8 +1317,9 @@ gate -> done [condition="context.preferred_label=done"]
 
 Diamond nodes are pure routing hubs.  They do not execute logic and cannot
 observe upstream outcomes.  Use `context.preferred_label` (set via a node-written
-`status.json`, or legacy `report_outcome`) or `context.tool.last_line` (set by a
-tool node -- the preferred, machine-checked source) to route.
+`status.json` -- `report_outcome` is removed as of engine 0.2.0) or
+`context.tool.last_line` (set by a tool node -- the preferred, machine-checked
+source) to route.
 
 ---
 
@@ -1716,8 +1720,9 @@ means.  Canonical defines it as `outcome.status` only; this engine resolves it
 to **`preferred_label` first**, falling back to `status` only when no label is
 set.  That divergence is deliberate and ledgered — `specs/EXTENSIONS.md` §22,
 `SPEC_CONFORMANCE.md` ATX-5 (disposition DIVERGE, decided) — because it is how
-a node steers its own routing via `preferred_label`, whether that label was set by a
-node-written `status.json` or, legacy, `report_outcome`.  The trap is that
+a node steers its own routing via `preferred_label`, set by a node-written
+`status.json` (the only channel now that `report_outcome` is removed, engine
+0.2.0).  The trap is that
 `preferred_label` is free-form and the status words are exactly the words an
 author reaches for as a label.  When they overlap, the label silently wins:
 

--- a/docs/DOT-SYNTAX.md
+++ b/docs/DOT-SYNTAX.md
@@ -32,7 +32,7 @@ digraph {
 | Attribute | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `prompt` | string | -- | Instructions for the LLM. `$goal` and `$param` tokens are expanded. |
-| `goal_gate` | bool | false | Must succeed **with an explicit verdict** (tool exit code / node-written `status.json` / JSON -- `report_outcome` is a legacy compatibility window) for pipeline to complete; plain prose returns RETRY (fail-closed, `specs/EXTENSIONS.md` §25) |
+| `goal_gate` | bool | false | Must succeed **with an explicit verdict** (tool exit code / node-written `status.json` / JSON -- `report_outcome` was removed in the engine 0.2.0 repair release) for pipeline to complete; plain prose returns RETRY (fail-closed, `specs/EXTENSIONS.md` §25) |
 | `max_retries` | int | graph default | In-place re-attempts for RETRY-class outcomes, retryable exceptions, and `must_write=` violations. A plain FAIL is returned immediately, never retried (use `retry_target` / `outcome=fail` edges for that) |
 | `retry_target` | string | -- | Node to jump to on gate failure |
 | `fidelity` | string | "compact" | Context carryover mode |

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -63,11 +63,15 @@ cp -r examples/pipelines/practical/sample /tmp/attractor-demo
 cd /tmp/attractor-demo
 dot-runner run "$DOT" \
     --param goal="Fix the TypeError in get_display_name when avatar is None" \
-    --bundle git+https://github.com/microsoft/amplifier-bundle-attractor@main#subdirectory=bundles/attractor-pipeline.yaml \
+    --worker loop-agent \
     --cwd .
 ```
 
-The goal defaults to the graph's `goal=` attribute; override it with
+`--worker loop-agent` is the full coding agent (tools, file edits). Worker NAMES are
+the whole user surface now -- `direct`, `loop-agent`, `amplifier-agent` -- and there is
+no `--bundle`/`DOT_RUNNER_BUNDLE` any more (bundles are internal-only). Omit `--worker`
+and the CLI falls back to `amplifier-agent` if it's installed, else `direct` with a
+loud notice; pin it explicitly for anything unattended. The goal defaults to the graph's `goal=` attribute; override it with
 `--param goal="..."`. Run from a scratch dir whose path equals `--cwd` (box-node
 pipelines root their writes at the process cwd). See
 [examples/pipelines/](../examples/pipelines/) for the full run pattern and every

--- a/docs/PIPELINE_PATTERNS.md
+++ b/docs/PIPELINE_PATTERNS.md
@@ -295,14 +295,14 @@ judge [shape=box, goal_gate=true,
                if it passes, status=fail otherwise."]
 ```
 
-**Why it fails:** this looks more rigorous than AP-2's bare sentinel -- it is a structured tool
-call with a validated `status` enum, not a typed keyword -- but the verdict inside it is
+**Why it fails:** this looked more rigorous than AP-2's bare sentinel -- it was a structured tool
+call with a validated `status` enum, not a typed keyword -- but the verdict inside it was
 produced by the same node, in the same context, that did the work being judged. Wrapping a
-self-report in a tool call does not make it evidence: "verification inside the context that
-produced the evidence is not verification" (`context/dot-reference.md`) applies exactly as much
+self-report in a tool call did not make it evidence: "verification inside the context that
+produced the evidence is not verification" (`context/dot-reference.md`) applied exactly as much
 to a `report_outcome` call as to a plain-prose sentinel. As of the 2026-08-29 maintainer ruling,
-`report_outcome` is RETCONNED to a legacy compatibility window: still honored (a node-written
-`status.json` wins over it on conflict), but no longer the taught, primary mechanism.
+`report_outcome` was RETCONNED to a legacy compatibility window, and it is now **removed outright
+in the engine 0.2.0 repair release** -- no compat window, the tool module is gone repo-wide.
 
 **Measured:** across this repository's own shipped `.dot` corpus, **0 of 9** sampled
 community-style pipeline files ever instructed a worker to call `report_outcome` -- every one

--- a/docs/ROUTING-REFERENCE.md
+++ b/docs/ROUTING-REFERENCE.md
@@ -27,10 +27,11 @@ an artifact file read by a downstream tool-node exit code, and a node-written
 `status.json` (canonical spec §4.5 / Appendix C) for out-of-band or spawned
 outcomes -- see [DOT-AUTHORING-GUIDE.md's escalation
 ladder](DOT-AUTHORING-GUIDE.md#spec-intended-pipeline-design). The
-**`report_outcome` tool** (§2 below) provides the same envelope from inside an
-agent's own turn; it is a **legacy compatibility window**, not the taught
-mechanism -- a node-written `status.json` wins over it on conflict, and a
-self-reported tool call is still a self-report, not machine evidence.
+**`report_outcome` tool** (§2 below) used to provide the same envelope from inside
+an agent's own turn; it was a **legacy compatibility window**, never the taught
+mechanism, and it is **removed in the engine 0.2.0 repair release** -- no
+compat window, the tool module is gone. A node-written `status.json` is now
+the only out-of-band channel.
 
 **Edge conditions** — Each outgoing edge may carry a `condition` attribute
 containing a boolean expression evaluated against the outcome and the current
@@ -50,21 +51,24 @@ failure cases.
 
 ---
 
-## 2. The `report_outcome` Tool (legacy compatibility window)
+## 2. The `report_outcome` Tool (removed, engine 0.2.0)
 
-> **Not the taught mechanism.** `report_outcome` is RETCONNED as of the
-> 2026-08-29 maintainer ruling: the spec's own channels -- an artifact file +
-> tool-node exit code, and a node-written `status.json` (canonical spec §4.5 /
-> Appendix C) -- are what pipeline authors should reach for. `report_outcome`
-> is not deleted and still functions exactly as documented below; a
-> node-written `status.json` simply wins over it when both are present and
-> diverge. It remains here as full reference for pipelines and agent
-> integrations that already depend on it. See
-> [DOT-AUTHORING-GUIDE.md's escalation
+> **Removed, no compat window.** `report_outcome` was RETCONNED to a legacy
+> compatibility window as of the 2026-08-29 maintainer ruling, and then
+> removed outright in the engine 0.2.0 repair release: the tool module
+> is gone repo-wide, the tool-call check and the spawn-metadata precedence
+> read are both deleted, and no flag or env var brings it back. The spec's
+> own channels -- an artifact file + tool-node exit code, and a node-written
+> `status.json` (canonical spec §4.5 / Appendix C) -- are what pipeline
+> authors reach for now, and the only channels that remain. The rest of this
+> section is kept as historical reference for reading OLDER pipelines and
+> agent integrations that were written against it; do not write new ones
+> against it. See [DOT-AUTHORING-GUIDE.md's escalation
 > ladder](DOT-AUTHORING-GUIDE.md#spec-intended-pipeline-design) and
 > `PIPELINE_PATTERNS.md` §6's anti-pattern catalog ("`report_outcome`-as-primary")
-> for why: a tool call is still a self-report from inside the same context
-> that produced the work, and machine evidence outranks it.
+> for why it was never the taught mechanism even while it existed: a tool
+> call is still a self-report from inside the same context that produced the
+> work, and machine evidence outranks it.
 
 The agent calls `report_outcome` at the end of a node's execution to
 communicate the outcome back to the pipeline engine. The engine reads
@@ -156,7 +160,8 @@ Canonical §10.4 defines `outcome` as `outcome.status` **only**, with `preferred
 key. This engine resolves `outcome` to `preferred_label` when one is set, falling back to
 `status.value` — `conditions.py`, ledgered as `specs/EXTENSIONS.md` §22 / `SPEC_CONFORMANCE.md`
 ATX-5. It is load-bearing: it is how a node steers its own routing via `preferred_label`,
-whichever channel set it -- a node-written `status.json` (taught) or, legacy, `report_outcome`.
+whichever channel set it -- a node-written `status.json` is the only channel now that
+`report_outcome` is removed (engine 0.2.0).
 
 It is also **not behavior-neutral**, and that is the trap: one key, two meanings.
 
@@ -339,12 +344,13 @@ WARNING: Node "decide" has unrecognized type "stack.steer" -- defaulting to code
 
 ## 6. Common Patterns and Pitfalls
 
-> **A note on the examples below.** They show the `report_outcome` call because it is the
-> most compact way to illustrate which `preferred_label` / `context_updates` values make each
-> condition match -- the resolution mechanics are identical no matter which channel set those
-> fields. `report_outcome` itself is a legacy compatibility window (§2); the taught way to
-> produce the same fields is an artifact file + tool-node exit code, or a node-written
-> `status.json` for out-of-band/spawned outcomes -- see [DOT-AUTHORING-GUIDE.md's escalation
+> **A note on the examples below.** They show the `report_outcome` call, kept for
+> historical/illustrative purposes, because it is a compact way to illustrate which
+> `preferred_label` / `context_updates` values make each condition match -- the resolution
+> mechanics are identical no matter which channel set those fields. `report_outcome` itself
+> is **removed in the engine 0.2.0 repair release** (§2); the way to produce the same
+> fields today is an artifact file + tool-node exit code, or a node-written `status.json`
+> for out-of-band/spawned outcomes -- see [DOT-AUTHORING-GUIDE.md's escalation
 > ladder](DOT-AUTHORING-GUIDE.md#spec-intended-pipeline-design).
 
 ### Pattern: Pass/retry routing

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -126,14 +126,16 @@ a ledger row, not a vision. This page does not forge decisions the maintainer ha
   here unmodified; "an extension that breaks a conforming graph is a bug, not an extension."
 - **One command; opinion arrives by composition.** `dot-runner` is the only entry point. A
   bundle's opinion -- which worker runs a node, which model backs it -- reaches the engine through
-  composition (`--bundle`, config), never through a second command name. A second binary is not a
+  composition (`--worker`, config), never through a second command name; bundles themselves are
+  internal-only as of the engine's 0.2.0 repair release (`--bundle`/`DOT_RUNNER_BUNDLE` are removed
+  from the CLI surface -- worker NAMES are the whole user-facing concept). A second binary is not a
   feature; it is the `.dot` file losing its claim to be the complete, self-contained workflow
   definition (spec 1.2).
 - **The spec's own channels carry the outcome; extensions are retconned, not defended.** Artifact
   files, tool exit codes, and a node-written `status.json` (spec §4.5 / Appendix C) are the taught
   and implemented way a worker -- spawned or not -- delivers its verdict; a pure-JSON verdict is
-  the sharpest reading of that same channel, and a legacy report tool survives only as a dated
-  compatibility window, never as a parallel truth. When a deeper read of the nlspec shows a shipped
+  the sharpest reading of that same channel, and a legacy report tool was removed outright once its
+  compatibility window closed (engine 0.2.0 repair release), never kept on as a parallel truth. When a deeper read of the nlspec shows a shipped
   extension was never the right shape, the correct move is to undo it -- demote, back out,
   deprecate -- ledgered exactly as loudly as the extension itself was ledgered in. Shipping first
   earns no immunity from being retconned later.

--- a/docs/attractor-explained.html
+++ b/docs/attractor-explained.html
@@ -824,7 +824,7 @@ footer .fine{font-size:12.5px;line-height:1.6;color:var(--faint);max-width:600px
 review -&gt; Fix  [<span class="at">condition</span>=<span class="st">"outcome=retry"</span>]
 review -&gt; Test [<span class="at">condition</span>=<span class="st">"outcome!=retry"</span>, <span class="at">weight</span>=<span class="st">10</span>]</code></pre>
 
-    <h3>The verdict contract (<code>report_outcome</code> is now a legacy channel)</h3>
+    <h3>The verdict contract (<code>report_outcome</code> is removed, engine 0.2.0)</h3>
     <p>An LLM node communicates its result back to the orchestrator by calling a tool. This is the authoritative channel — everything else is recovery.</p>
 <pre><code>{
   <span class="at">"status"</span>: <span class="st">"success | fail | partial_success | retry"</span>,
@@ -840,7 +840,7 @@ review -&gt; Test [<span class="at">condition</span>=<span class="st">"outcome!=
   <figure>
     <svg class="dg" viewBox="0 0 960 330" role="img" aria-labelledby="d10t d10d" xmlns="http://www.w3.org/2000/svg">
       <title id="d10t">The verdict recovery ladder</title>
-      <desc id="d10d">Five fallbacks below the report_outcome tool call -- a legacy channel the engine still checks first internally, but no longer the taught, primary mechanism -- ending with plain prose which means success on ordinary nodes but retry on goal gate nodes, and an empty response which means fail.</desc>
+      <desc id="d10d">Five fallbacks below the report_outcome tool call -- removed outright in the engine 0.2.0 repair release, no longer checked at all -- ending with plain prose which means success on ordinary nodes but retry on goal gate nodes, and an empty response which means fail.</desc>
       <text class="cap" transform="rotate(-90 12 160)" x="12" y="160" text-anchor="middle">recovery order</text>
       <rect class="n-p" x="30" y="26" width="430" height="36" rx="2"/>
       <text class="nl-s" x="44" y="49" style="fill:#1b1813">report_outcome tool call</text>

--- a/examples/pipelines/03-conditional-routing.md
+++ b/examples/pipelines/03-conditional-routing.md
@@ -46,7 +46,7 @@ Key facts:
 - `shape=parallelogram` maps to the `tool` handler, which runs `tool_command` as a shell command
 - The last non-empty stdout line is stored in `context["tool.last_line"]` automatically
 - Route on `context.tool.last_line`, never on `tool.output` (full stdout never matches a condition exactly)
-- A diamond is only correct when routing on `context.*` keys set by *earlier* nodes (e.g., a `preferred_label` set by a node-written `status.json`, or legacy `report_outcome`) -- never on `outcome=` of the node before it
+- A diamond is only correct when routing on `context.*` keys set by *earlier* nodes (e.g., a `preferred_label` set by a node-written `status.json` -- `report_outcome` is removed as of the engine\047s 0.2.0 repair release) -- never on `outcome=` of the node before it
 
 ## Pipeline Structure
 


### PR DESCRIPTION
## Upstream breaking release

`amplifier-bundle-dot-runner` PR #22 (main @ `d81f25f`, **v0.2.0 "repair release"**):

1. `--bundle` flag AND `DOT_RUNNER_BUNDLE` env are **removed** from the dot-runner CLI (bundles are internal-only now).
2. Worker **names** are the user surface: `--worker direct|loop-agent|amplifier-agent` (+ node `worker=` attr). Default ladder when no explicit worker is given: `amplifier-agent`-if-installed, else `direct` + a one-line stderr notice.
3. Per-node `llm_provider`/`llm_model` now flow correctly through the named-worker path (e2e-proven upstream) — the dual-provider critique nodes work **without** the old dual bundle.
4. `report_outcome` is fully **removed** upstream (tool module gone; `status.json`/§41 + returned `Outcome`s + exit codes are the channels).

## The silent-regression window this closes

`amplifier-agent` is **not installed** in this repo's CI. Every `dot-runner run`/`resume` invocation that omitted `--worker` was silently falling through the default ladder to `direct` instead of `loop-agent` — box nodes losing tool access with no error, no warning that survives CI log noise. This PR pins `--worker loop-agent` explicitly everywhere, so CI never depends on the default ladder again.

## Flip inventory

**CI workflows** (`capsule-specify.yml`, `capsule-implement.yml`, `feature-specify.yml`):
- Removed the now-inert `ATTRACTOR_PIPELINE_BUNDLE`/`DOT_RUNNER_BUNDLE` env lines and their dual-bundle-mount comments from all 3 `dot-runner run` steps.
- Added explicit `--worker loop-agent` to all 3 invocations.
- OPENAI_API_KEY preflight steps **stay** — the critique nodes' `llm_provider="openai"` now flows natively through the named-worker path (upstream capability #3), so the key is still required, just no longer via a bundle mount.
- The dual bundle **file** (`.github/capsule-pipeline/attractor-pipeline-dual.yaml`) stays in-tree for now — **retirement candidate** now that nothing in the workflows references it any more.

**Docs**: `README.md`, `docs/GETTING-STARTED.md` quickstarts flipped from `--bundle git+...` to `--worker loop-agent`, noting `amplifier-agent` as the default-when-installed. `docs/VISION.md`'s "one command; opinion by composition" principle now names `--worker`; its `report_outcome` principle line reworded from "survives as a compat window" to "removed" (changelog/ledger entries untouched).

**`report_outcome` residue**: agent system prompts (`context/system-{anthropic,openai,gemini}.md`), `context/engine-semantics.md`, `context/attractor-expert-defenses.md`, `agents/attractor-expert.md`, `docs/ROUTING-REFERENCE.md`, `docs/DOT-AUTHORING-GUIDE.md`, `docs/DOT-SYNTAX.md`, `docs/PIPELINE_PATTERNS.md` (AP-4), `docs/attractor-explained.html`, `examples/pipelines/03-conditional-routing.md` — every "still works"/"legacy compatibility window"/"not deleted" current-state claim updated to state removal in the engine's 0.2.0 repair release. Anti-pattern catalog entries kept, reworded past-tense. Ledger-style archives (VISION.md changelog, PRINCIPLES.md deltas) untouched.

**Confirmed false positives, left alone**: `bundles/attractor-agent.yaml`'s `amplifier run --bundle` (a different tool's flag entirely) and `evals/guidance/harness`'s `--bundle-repo`/`--bundle-branch`/`--bundle-sha` (the eval harness's own source-checkout args, never passed to `dot-runner`).

## Smoke results

Scratch env, `uv tool install git+https://github.com/microsoft/amplifier-bundle-dot-runner@main` (installed @ `d81f25f`):
- `dot-runner lint .github/capsule-pipeline/task-runner.dot` → exit 0 (1 pre-existing CMD-001 warning on `ship_check`, unrelated to this diff).
- `dot-runner run --help` → shows `--worker NAME` documenting `direct`/`loop-agent`/`amplifier-agent`; **never** mentions `--bundle`.
- `DOT_RUNNER_BUNDLE=x dot-runner run --help` → exit 0 (inert env confirmed harmless).

## Verification

- `bash -n` on all 43 workflow run-blocks: clean. `actionlint`: clean except 2 pre-existing SC2012 shellcheck info-nits (unrelated `ls` usage, untouched by this diff).
- **Worker attack**: grep-proof confirms all 3 `dot-runner run`/`resume` invocations in workflows carry an explicit `--worker`; zero rely on the default ladder.
- Root suite: **192 passed, 2 skipped** (all doc guards included, green — no guard expectations needed updating). `tests/e2e`: 4 passed, 1 skipped.
- Final grep-proof: zero current-state `--bundle`/`DOT_RUNNER_BUNDLE` teachings and zero "report_outcome still works" phrasings outside frozen dirs (`modules/`, `specs/`, `docs/reports|designs|plans/`, `proposals/`).

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>
