### PR TITLE
fix(tool-pipeline-run): the module names no bundle; the bundle names itself (attractor-24e stage 1)

### DIFF
--- a/bundles/attractor-interactive.yaml
+++ b/bundles/attractor-interactive.yaml
@@ -62,7 +62,16 @@ tools:
   - module: tool-pipeline-run
     source: ../modules/tool-pipeline-run
     config:
+      # This bundle names ITSELF here. The module's own defaults are
+      # namespace-neutral by design (attractor-24e stage 1) -- it knows
+      # nothing about "attractor", so the runner agent and the @mention
+      # example its tool shows the LLM are ours to supply. Dropping either
+      # key does not fall back to these values; it falls back to a neutral
+      # placeholder, and the LLM would be taught a mention that resolves
+      # nowhere. tests/test_pipeline_run_namespace_neutrality.py guards
+      # exactly that.
       runner_agent: attractor-pipeline-runner
+      mention_example: "@attractor:examples/pipelines/01-simple-linear.dot"
       profiles:
         anthropic: attractor-agent-anthropic
         openai: attractor-agent-openai

--- a/modules/tool-pipeline-run/README.md
+++ b/modules/tool-pipeline-run/README.md
@@ -7,28 +7,47 @@ return a structured result.
 ## Config
 
 Mounted like any other Amplifier module, with a `config` dict supplied at
-mount time. All keys are optional; every default below reproduces this
-module's pre-existing (attractor-bundle) behavior exactly, so an
-unconfigured mount is unaffected by anything in this section.
+mount time. All keys are optional. **The defaults name no bundle** -- this
+module knows nothing about the bundle mounting it, so a bundle that wants
+its own runner agent or its own `@mention` namespace advertised to the LLM
+supplies them here.
 
 | Key | Type | Default | Purpose |
 |-----|------|---------|---------|
-| `runner_agent` | `str` | `"attractor-pipeline-runner"` | Name of the agent `session.spawn` is called with to actually execute the pipeline. |
+| `runner_agent` | `str` | `"pipeline-runner"` | Name of the agent `session.spawn` is called with to actually execute the pipeline. |
 | `profiles` | `dict[str, str]` | `{}` (unset) | Maps required `llm_provider` names (parsed from the pipeline's DOT source) to the agent name that provides them, for pre-spawn provider-availability validation. Forwarded to the spawned child's `orchestrator_config["profiles"]`. |
-| `mention_example` | `str` | `"@attractor:examples/pipelines/01-simple-linear.dot"` | Illustrative `@mention` example shown in this tool's own `description` and `input_schema["dot_file"]["description"]` (i.e. what the calling LLM sees). Purely cosmetic -- it does not affect actual `@mention` resolution, which is generic and handled by the coordinator's `mention_resolver` capability regardless of namespace. Only the text before the first `:` (the namespace) is reused in the shorter `description` form. |
+| `mention_example` | `str` | `"@<bundle>:path/to/pipeline.dot"` | Illustrative `@mention` example shown in this tool's own `description` and `input_schema["dot_file"]["description"]` (i.e. what the calling LLM sees). Purely cosmetic -- it does not affect actual `@mention` resolution, which is generic and handled by the coordinator's `mention_resolver` capability regardless of namespace. Only the text before the first `:` (the namespace) is reused in the shorter `description` form. |
 
-### Why `mention_example` exists
+A mounting bundle typically sets both name-bearing keys:
 
-This module is a sanctioned exception to the compat-window freeze ahead of
-its planned move to a namespace-neutral module (see
-`DESIGN-worker-registry-core-split.md` §6.3). Before that move, every
-hard-coded reference to the `attractor` bundle name had to be pulled out of
-the module's source so mounting it from a differently-named bundle would
-not show that bundle's LLM a `run_pipeline` tool that advertises an
-`@attractor:...` mention no such bundle has registered. The `runner_agent`
-and `profiles` keys were already config-driven before this change; only
-their *default values* remain attractor-specific, by design, so today's
-attractor bundles keep working unconfigured.
+```yaml
+  - module: tool-pipeline-run
+    config:
+      runner_agent: my-pipeline-runner
+      mention_example: "@my-bundle:pipelines/01-simple-linear.dot"
+```
+
+### Why the defaults name no bundle
+
+This module's source used to carry one specific bundle's name in two
+places: the `@mention` namespace in the LLM-facing text above, and the
+spawn default for `runner_agent`. Neither is resolution logic -- `@mention`
+resolution is generic -- but LLM-facing text that confidently names a
+namespace the mounting bundle has not registered is how a tool teaches its
+caller to write a mention that resolves nowhere, and it fails at resolution
+time rather than at read time.
+
+The defaults are therefore neutral, and the placeholder default for
+`mention_example` is deliberately an *obvious* placeholder: an unconfigured
+mount should read as unconfigured. Bundles that relied on the old
+bundle-specific defaults pass those same values as config instead and get
+byte-identical behavior (pinned by
+`test_prior_consumer_config_reproduces_its_llm_text_byte_identical` and
+`test_prior_consumer_config_still_spawns_its_own_runner_agent`).
+
+This is stage 1 of the module's planned move to a namespace-neutral home
+(see `DESIGN-worker-registry-core-split.md` §6.3): de-attractorize in
+place first, so the move itself can ride byte-identical.
 
 ## Tests
 

--- a/modules/tool-pipeline-run/amplifier_module_tool_pipeline_run/__init__.py
+++ b/modules/tool-pipeline-run/amplifier_module_tool_pipeline_run/__init__.py
@@ -42,12 +42,21 @@ class PipelineRunTool:
     # input_schema (below) -- purely illustrative text for the calling LLM,
     # not resolution logic (mention_resolver.resolve() handles any namespace
     # generically; see _resolve_dot_file_path). Hard-coding a bundle-specific
-    # namespace here is nonetheless real coupling: a non-"attractor" bundle
-    # mounting this tool unconfigured would show its LLM an example mention
-    # that resolves nowhere. Config-worthy -- see "mention_example" in the
-    # module README. Default preserves today's exact text for existing
-    # (attractor) consumers.
-    _DEFAULT_MENTION_EXAMPLE = "@attractor:examples/pipelines/01-simple-linear.dot"
+    # namespace here is real coupling: a bundle of any other name mounting
+    # this tool unconfigured would show its LLM an example mention that
+    # resolves nowhere while *looking* real. The default is therefore an
+    # obvious placeholder -- an unconfigured mount reads as unconfigured
+    # instead of pointing confidently at some other bundle's namespace.
+    # Mounting bundles set "mention_example" to a path under their own
+    # registered namespace; see the module README.
+    _DEFAULT_MENTION_EXAMPLE = "@<bundle>:path/to/pipeline.dot"
+
+    # Default agent name `session.spawn` is called with to execute the
+    # pipeline. Namespace-neutral for the same reason as above: a bundle
+    # names its own runner agent via the "runner_agent" config key, and a
+    # bundle-specific default here would send every unconfigured mount
+    # looking for an agent only one bundle defines.
+    _DEFAULT_RUNNER_AGENT = "pipeline-runner"
 
     def __init__(self, config: dict[str, Any], coordinator: Any = None) -> None:
         self.config = config
@@ -450,7 +459,7 @@ class PipelineRunTool:
             )
 
         # --- Resolve runner agent name ---
-        runner_agent = self.config.get("runner_agent", "attractor-pipeline-runner")
+        runner_agent = self.config.get("runner_agent", self._DEFAULT_RUNNER_AGENT)
 
         # --- Build orchestrator config for the child session ---
         orchestrator_config: dict[str, Any] = {

--- a/modules/tool-pipeline-run/tests/test_pipeline_run.py
+++ b/modules/tool-pipeline-run/tests/test_pipeline_run.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from amplifier_module_tool_pipeline_run import PipelineRunTool
+from amplifier_module_tool_pipeline_run import PipelineRunTool, mount
 
 
 # ---------------------------------------------------------------------------
@@ -741,19 +741,32 @@ async def test_no_params_omits_key_from_orchestrator_config():
 
 
 # ---------------------------------------------------------------------------
-# De-attractorization: "mention_example" config (attractor-24e stage 1)
+# Namespace neutrality: "mention_example" + "runner_agent" config
+# (attractor-24e stage 1)
 #
-# The tool's own `description` and `input_schema["dot_file"]["description"]`
-# used to hard-code the "@attractor:" mention namespace as an illustrative
-# example for the calling LLM. That's real coupling (a non-"attractor"
-# bundle mounting this tool unconfigured would show its LLM an example
-# mention that resolves nowhere), even though it never touched actual
-# @mention *resolution* logic (mention_resolver.resolve() handles any
-# namespace generically -- see test_resolve_at_mention_path above, which is
-# unaffected by any of this). "mention_example" makes the illustrative
-# text configurable; its default preserves today's exact "attractor" text
-# byte-for-byte for existing (attractor) consumers.
+# This module used to name one specific bundle in its own source: the
+# mention namespace shown to the calling LLM (in `description` and
+# `input_schema["dot_file"]["description"]`) and the agent name spawned to
+# execute the pipeline. Both are now parameters whose DEFAULTS name no
+# bundle at all; a mounting bundle supplies its own values.
+#
+# None of this ever touched @mention *resolution* -- mention_resolver
+# .resolve() handles any namespace generically (see
+# test_resolve_at_mention_path above, and
+# test_configured_namespace_resolves_end_to_end below, which proves it with
+# a namespace this module has never heard of). The coupling was in
+# LLM-facing text and in a spawn default, and text that confidently names
+# some other bundle's namespace is exactly how a tool teaches its caller to
+# write a mention that resolves nowhere.
 # ---------------------------------------------------------------------------
+
+# The exact LLM-facing text and runner agent this module produced for its
+# original consumer, back when both were baked into the source. That
+# consumer now passes these same values as config (see the tool-pipeline-run
+# mount in bundles/attractor-interactive.yaml), so this pair is the
+# consumer-compat proof: same values in, byte-identical behavior out.
+PRIOR_CONSUMER_MENTION_EXAMPLE = "@attractor:examples/pipelines/01-simple-linear.dot"
+PRIOR_CONSUMER_RUNNER_AGENT = "attractor-pipeline-runner"
 
 
 def test_custom_mention_example_lands_in_input_schema():
@@ -782,13 +795,67 @@ def test_custom_mention_example_lands_in_tool_description():
     assert "attractor" not in tool.description.lower()
 
 
-def test_default_mention_example_matches_todays_text_byte_identical():
-    """Unconfigured mount reproduces today's exact @attractor: example text.
+def test_default_mention_example_names_no_bundle():
+    """An unconfigured mount advertises a placeholder, never a real namespace.
 
-    Pins both surfaces byte-for-byte so an unconfigured (existing attractor)
-    consumer sees zero behavior change.
+    The de-attractorization pin. An unconfigured mount must read as
+    unconfigured: a default that named a real bundle would point every
+    other bundle's LLM at a namespace it has not registered, and the
+    resulting mention fails at resolution time rather than at read time.
+
+    RED pre-change: the default was
+    "@attractor:examples/pipelines/01-simple-linear.dot", so both the
+    placeholder assertions and the "names no bundle" assertions failed.
     """
     tool = PipelineRunTool(config={})
+    schema_description = tool.input_schema["properties"]["dot_file"]["description"]
+
+    assert "@<bundle>:path/to/pipeline.dot" in schema_description
+    assert "@<bundle>:... mentions" in tool.description
+
+    # Two-sided: no bundle name may creep back into either surface.
+    assert "attractor" not in tool.description.lower()
+    assert "attractor" not in schema_description.lower()
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_default_runner_agent_names_no_bundle():
+    """An unconfigured mount spawns the neutral runner name, not a bundle's.
+
+    RED pre-change: the default was "attractor-pipeline-runner".
+    """
+    spawn_kwargs_capture = {}
+
+    async def mock_spawn(**kwargs):
+        spawn_kwargs_capture.update(kwargs)
+        return {
+            "output": '{"status": "success"}',
+            "session_id": "child-default-runner",
+        }
+
+    mock_coordinator = MagicMock()
+    mock_coordinator.get_capability = lambda name: (
+        mock_spawn if name == "session.spawn" else None
+    )
+    mock_coordinator.config = {"agents": {"pipeline-runner": {}}}
+    mock_coordinator.session = MagicMock()
+
+    tool = PipelineRunTool(config={}, coordinator=mock_coordinator)
+    result = await tool.execute({"goal": "test goal", "dot_source": SIMPLE_DOT})
+
+    assert result.success
+    assert spawn_kwargs_capture["agent_name"] == "pipeline-runner"
+    assert "attractor" not in spawn_kwargs_capture["agent_name"]
+
+
+def test_prior_consumer_config_reproduces_its_llm_text_byte_identical():
+    """The original consumer's values reproduce its original text exactly.
+
+    Consumer-compat proof for the LLM-facing half: the bundle that used to
+    get this text from the module's baked-in defaults now passes the same
+    values as config, and gets the same two strings byte-for-byte.
+    """
+    tool = PipelineRunTool(config={"mention_example": PRIOR_CONSUMER_MENTION_EXAMPLE})
     assert tool.description == (
         "Run a DOT graph pipeline. Provide a pipeline definition via "
         "'dot_file' (path to a .dot file, supports @attractor:... mentions) "
@@ -804,12 +871,12 @@ def test_default_mention_example_matches_todays_text_byte_identical():
 
 
 @pytest.mark.asyncio(loop_scope="session")
-async def test_default_runner_agent_matches_todays_value_when_unconfigured():
-    """Unconfigured mount still spawns the pre-existing default runner agent.
+async def test_prior_consumer_config_still_spawns_its_own_runner_agent():
+    """The original consumer's runner_agent value still reaches session.spawn.
 
-    "runner_agent" was already config-driven before this change (only its
-    *default* is attractor-specific); this pins that default explicitly so
-    a future stage-2 move can prove it never silently changed.
+    Consumer-compat proof for the spawn half. That bundle already passed
+    runner_agent explicitly before this change, so this asserts the path it
+    depends on is the one that survived when the default moved.
     """
     spawn_kwargs_capture = {}
 
@@ -817,31 +884,93 @@ async def test_default_runner_agent_matches_todays_value_when_unconfigured():
         spawn_kwargs_capture.update(kwargs)
         return {
             "output": '{"status": "success"}',
-            "session_id": "child-default-runner",
+            "session_id": "child-prior-consumer",
         }
 
     mock_coordinator = MagicMock()
     mock_coordinator.get_capability = lambda name: (
         mock_spawn if name == "session.spawn" else None
     )
-    mock_coordinator.config = {"agents": {"attractor-pipeline-runner": {}}}
+    mock_coordinator.config = {"agents": {PRIOR_CONSUMER_RUNNER_AGENT: {}}}
     mock_coordinator.session = MagicMock()
 
-    tool = PipelineRunTool(config={}, coordinator=mock_coordinator)
-    result = await tool.execute(
-        {
-            "goal": "test goal",
-            "dot_source": SIMPLE_DOT,
-        }
+    tool = PipelineRunTool(
+        config={"runner_agent": PRIOR_CONSUMER_RUNNER_AGENT},
+        coordinator=mock_coordinator,
     )
+    result = await tool.execute({"goal": "test goal", "dot_source": SIMPLE_DOT})
 
     assert result.success
-    assert spawn_kwargs_capture["agent_name"] == "attractor-pipeline-runner"
+    assert spawn_kwargs_capture["agent_name"] == PRIOR_CONSUMER_RUNNER_AGENT
+    assert result.output["runner_agent"] == PRIOR_CONSUMER_RUNNER_AGENT
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_configured_namespace_resolves_end_to_end():
+    """A mount configured for a foreign namespace resolves mentions in it.
+
+    The parameterization proof end-to-end: mount() with a namespace this
+    module has never heard of, hand the mounted tool a dot_file in that
+    namespace, and the file behind it is what reaches the spawned pipeline
+    -- while the tool advertises that same namespace to its own LLM.
+
+    RED pre-change: the advertised-example assertion failed (the mounted
+    tool advertised "@attractor:..." regardless of the namespace in play),
+    which is the whole hazard -- resolution worked while the text told the
+    LLM to write a mention into a bundle that was not there.
+    """
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".dot", delete=False) as f:
+        f.write(SIMPLE_DOT)
+        f.flush()
+        tmp_path = f.name
+    try:
+        mention = "@neutral-bundle:pipelines/demo.dot"
+
+        mock_resolver = MagicMock()
+        mock_resolver.resolve.return_value = Path(tmp_path)
+
+        spawn_kwargs_capture = {}
+
+        async def mock_spawn(**kwargs):
+            spawn_kwargs_capture.update(kwargs)
+            return {
+                "output": '{"status": "success"}',
+                "session_id": "child-neutral-namespace",
+            }
+
+        capabilities = {
+            "mention_resolver": mock_resolver,
+            "session.spawn": mock_spawn,
+        }
+        mock_coordinator = MagicMock()
+        mock_coordinator.get_capability = capabilities.get
+        mock_coordinator.config = {"agents": {"neutral-runner": {}}}
+        mock_coordinator.session = MagicMock()
+        mock_coordinator.mount = AsyncMock()
+
+        await mount(
+            mock_coordinator,
+            {"mention_example": mention, "runner_agent": "neutral-runner"},
+        )
+        tool = mock_coordinator.mount.call_args[0][1]
+
+        # What the mounted tool tells its LLM to write ...
+        assert mention in tool.input_schema["properties"]["dot_file"]["description"]
+
+        # ... is what it then resolves and runs.
+        result = await tool.execute({"goal": "test goal", "dot_file": mention})
+
+        assert result.success
+        mock_resolver.resolve.assert_called_once_with(mention)
+        assert spawn_kwargs_capture["orchestrator_config"]["dot_source"] == SIMPLE_DOT
+        assert spawn_kwargs_capture["agent_name"] == "neutral-runner"
+    finally:
+        os.unlink(tmp_path)
 
 
 @pytest.mark.asyncio(loop_scope="session")
 async def test_custom_runner_agent_lands_in_spawn_call():
-    """A configured runner_agent (not the attractor default) is what gets spawned."""
+    """A configured runner_agent overrides the neutral default at spawn."""
     spawn_kwargs_capture = {}
 
     async def mock_spawn(**kwargs):

--- a/tests/test_pipeline_run_namespace_neutrality.py
+++ b/tests/test_pipeline_run_namespace_neutrality.py
@@ -119,6 +119,21 @@ def test_prn_001_module_source_names_no_bundle():
     )
 
 
+def _required_config_value(key: str) -> str:
+    """Fetch a name-bearing config value, failing (not erroring) when absent.
+
+    PRN-003/PRN-004 read what PRN-002 asserts is present. When the key is
+    missing they should report that plainly and point at PRN-002, rather
+    than surfacing a KeyError that names nothing.
+    """
+    config = _pipeline_run_mount_config()
+    assert key in config, (
+        f"'{key}' is absent from {CONSUMER_BUNDLE.name}'s tool-pipeline-run "
+        "mount -- see PRN-002, which is the check that owns this."
+    )
+    return config[key]
+
+
 @pytest.mark.parametrize("key", ["runner_agent", "mention_example"])
 def test_prn_002_consumer_supplies_both_name_bearing_keys(key):
     """PRN-002: this bundle passes its own names instead of inheriting a default."""
@@ -134,7 +149,7 @@ def test_prn_002_consumer_supplies_both_name_bearing_keys(key):
 
 def test_prn_003_advertised_mention_example_is_ours_and_exists():
     """PRN-003: the advertised @mention names this bundle and points at a real file."""
-    mention = _pipeline_run_mount_config()["mention_example"]
+    mention = _required_config_value("mention_example")
     bundle_name = _bundle_name()
 
     assert mention.startswith("@"), f"mention_example {mention!r} is not an @mention"
@@ -154,7 +169,7 @@ def test_prn_003_advertised_mention_example_is_ours_and_exists():
 
 def test_prn_004_configured_runner_agent_is_registered_here():
     """PRN-004: the runner_agent spawned is an agent this repo actually declares."""
-    runner_agent = _pipeline_run_mount_config()["runner_agent"]
+    runner_agent = _required_config_value("runner_agent")
 
     assert AGENTS_DIR.is_dir(), f"{AGENTS_DIR} not found. {RE_AIM}"
     declared = set()

--- a/tests/test_pipeline_run_namespace_neutrality.py
+++ b/tests/test_pipeline_run_namespace_neutrality.py
@@ -1,0 +1,171 @@
+"""The bundle names itself; the module does not -- PRN-001..PRN-004.
+
+`modules/tool-pipeline-run` used to carry this bundle's name in its own
+source: the `@attractor:` mention namespace it showed the calling LLM, and
+an `attractor-pipeline-runner` spawn default (attractor-24e stage 1). Both
+are now config keys whose defaults name no bundle, and THIS bundle supplies
+its own values at the mount in `bundles/attractor-interactive.yaml`.
+
+That split is only stable if both halves are held. Each half fails silently
+on its own:
+
+  * Put a bundle name back in the module and nothing breaks here -- it
+    breaks for whoever mounts the module next, as an `@mention` their
+    bundle never registered, at resolution time rather than read time.
+  * Drop a key from the mount and nothing breaks loudly either: the module
+    falls back to a neutral *placeholder*, so this bundle's agent would be
+    told to write `@<bundle>:path/to/pipeline.dot`.
+
+So the guard is two-sided by construction, and neither side is a
+restatement of the other: PRN-001 reads the module's source, PRN-002..004
+read the composition surfaces and the files they point at.
+
+Checks:
+
+  PRN-001  `modules/tool-pipeline-run`'s module source
+           -> contains no occurrence of this bundle's name, in any case
+  PRN-002  the `tool-pipeline-run` mount in `bundles/attractor-interactive.yaml`
+           -> supplies BOTH name-bearing keys (`runner_agent`,
+              `mention_example`) rather than inheriting a default
+  PRN-003  the advertised `mention_example`
+           -> its namespace is this repo's own bundle name (`bundle.md`),
+              and the path behind it exists on disk
+  PRN-004  the configured `runner_agent`
+           -> names an agent this repo actually registers under `agents/`
+
+Honest limits:
+
+  * PRN-001 is a substring scan, not a semantic one. It catches the failure
+    that actually happened (a bundle name baked into source) and would not
+    catch a bundle-specific assumption expressed without the name.
+  * PRN-003 checks that the advertised path exists in THIS repo; it does not
+    execute foundation's mention resolver, which is the module's own
+    concern and is tested there
+    (`test_configured_namespace_resolves_end_to_end`).
+  * Every check asserts its target exists first. If `modules/tool-pipeline-run`
+    later leaves this repo (the stage-2 move), these fail loudly rather than
+    passing vacuously -- re-aim or retire this guard deliberately at that
+    point, which is the whole reason it fails instead of skipping.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+MODULE_SOURCE = (
+    REPO_ROOT
+    / "modules"
+    / "tool-pipeline-run"
+    / "amplifier_module_tool_pipeline_run"
+    / "__init__.py"
+)
+CONSUMER_BUNDLE = REPO_ROOT / "bundles" / "attractor-interactive.yaml"
+ROOT_BUNDLE_DOC = REPO_ROOT / "bundle.md"
+AGENTS_DIR = REPO_ROOT / "agents"
+
+RE_AIM = (
+    "If tool-pipeline-run has moved out of this repo, re-aim or retire this "
+    "guard deliberately (tests/test_pipeline_run_namespace_neutrality.py) -- "
+    "do not let it pass vacuously."
+)
+
+
+def _bundle_name() -> str:
+    """This repo's own bundle name, from bundle.md's frontmatter."""
+    text = ROOT_BUNDLE_DOC.read_text(encoding="utf-8")
+    assert text.startswith("---\n"), f"{ROOT_BUNDLE_DOC} has no YAML frontmatter"
+    frontmatter = text.split("---\n", 2)[1]
+    name = yaml.safe_load(frontmatter)["bundle"]["name"]
+    assert name, f"{ROOT_BUNDLE_DOC} frontmatter declares no bundle.name"
+    return name
+
+
+def _pipeline_run_mount_config() -> dict:
+    """The `config:` block of the tool-pipeline-run mount in the consumer bundle."""
+    assert CONSUMER_BUNDLE.exists(), f"{CONSUMER_BUNDLE} not found. {RE_AIM}"
+    doc = yaml.safe_load(CONSUMER_BUNDLE.read_text(encoding="utf-8"))
+    mounts = [
+        entry
+        for entry in (doc.get("tools") or [])
+        if entry.get("module") == "tool-pipeline-run"
+    ]
+    assert len(mounts) == 1, (
+        f"expected exactly one tool-pipeline-run mount in {CONSUMER_BUNDLE.name}, "
+        f"found {len(mounts)}. {RE_AIM}"
+    )
+    return mounts[0].get("config") or {}
+
+
+def test_prn_001_module_source_names_no_bundle():
+    """PRN-001: the module carries no reference to this bundle's name."""
+    assert MODULE_SOURCE.exists(), f"{MODULE_SOURCE} not found. {RE_AIM}"
+
+    bundle_name = _bundle_name()
+    source = MODULE_SOURCE.read_text(encoding="utf-8")
+
+    offenders = [
+        f"{lineno}: {line.strip()}"
+        for lineno, line in enumerate(source.splitlines(), start=1)
+        if bundle_name.lower() in line.lower()
+    ]
+    assert not offenders, (
+        f"{MODULE_SOURCE.relative_to(REPO_ROOT)} names the '{bundle_name}' bundle. "
+        "Its defaults must name no bundle -- the mounting bundle supplies its own "
+        "runner_agent / mention_example (see the module README). Offending lines:\n"
+        + "\n".join(offenders)
+    )
+
+
+@pytest.mark.parametrize("key", ["runner_agent", "mention_example"])
+def test_prn_002_consumer_supplies_both_name_bearing_keys(key):
+    """PRN-002: this bundle passes its own names instead of inheriting a default."""
+    config = _pipeline_run_mount_config()
+    assert key in config, (
+        f"{CONSUMER_BUNDLE.name}'s tool-pipeline-run mount does not set '{key}'. "
+        "The module's default for it names no bundle, so dropping this key does "
+        "not restore this bundle's behavior -- it substitutes a neutral "
+        "placeholder into what the agent is told."
+    )
+    assert config[key], f"'{key}' is set but empty in {CONSUMER_BUNDLE.name}"
+
+
+def test_prn_003_advertised_mention_example_is_ours_and_exists():
+    """PRN-003: the advertised @mention names this bundle and points at a real file."""
+    mention = _pipeline_run_mount_config()["mention_example"]
+    bundle_name = _bundle_name()
+
+    assert mention.startswith("@"), f"mention_example {mention!r} is not an @mention"
+    namespace, _, path = mention[1:].partition(":")
+    assert path, f"mention_example {mention!r} has no path after its namespace"
+
+    assert namespace == bundle_name, (
+        f"mention_example advertises '@{namespace}:' but this repo's bundle is "
+        f"'{bundle_name}' (bundle.md). The agent would be taught a mention that "
+        "resolves nowhere."
+    )
+    assert (REPO_ROOT / path).exists(), (
+        f"mention_example points at '{path}', which does not exist in this repo. "
+        "An example the agent copies must be a file it can actually reach."
+    )
+
+
+def test_prn_004_configured_runner_agent_is_registered_here():
+    """PRN-004: the runner_agent spawned is an agent this repo actually declares."""
+    runner_agent = _pipeline_run_mount_config()["runner_agent"]
+
+    assert AGENTS_DIR.is_dir(), f"{AGENTS_DIR} not found. {RE_AIM}"
+    declared = set()
+    for agent_file in sorted(AGENTS_DIR.glob("*.yaml")):
+        doc = yaml.safe_load(agent_file.read_text(encoding="utf-8")) or {}
+        name = (doc.get("bundle") or {}).get("name")
+        if name:
+            declared.add(name)
+
+    assert declared, f"no agent bundle names found under {AGENTS_DIR}. {RE_AIM}"
+    assert runner_agent in declared, (
+        f"tool-pipeline-run is configured to spawn '{runner_agent}', which no "
+        f"agent under agents/ declares. Declared: {sorted(declared)}"
+    )


### PR DESCRIPTION
## Summary

`modules/tool-pipeline-run` carried this bundle's name in its own source. An earlier pass (2a2a1f8) made the LLM-facing mention example *configurable* but left both name-bearing **defaults** baked in: `"@attractor:examples/pipelines/01-simple-linear.dot"` and an `"attractor-pipeline-runner"` spawn default. Those defaults are the coupling -- any other bundle mounting this module unconfigured gets a `run_pipeline` tool that advertises a namespace it never registered, and that failure lands at *resolution* time rather than at read time. This PR finishes stage 1 of attractor-24e: the module's defaults now name no bundle, and this bundle names itself at the mount. **Stage 2 -- the history-preserving move plus its `HISTORY-MAP` entry -- is a separate follow-up PR and is deliberately not in this diff** (moves ride byte-identical; changes come as separate reviewed commits).

**Decision-matrix tier: not spec-relevant.** The nlspec's subject is graph-as-program execution -- DOT nodes as computation, edges as dispatch, clusters as subgraphs. Amplifier module *mount configuration* is outside that subject entirely, which is a different thing from "the spec is silent about a graph behavior we want to add" (the Uncharted row). The diff touches no parser, engine, handler, dispatch, or event surface -- no file under `modules/loop-pipeline/` or `specs/` -- so no spec-conformant graph behaves differently, and the full `loop-pipeline` suite (2488 tests) plus the live-graph gate are unchanged. No ledger entry; and the "no observable change" reason on the checklist below is scoped precisely rather than waved through: the module's *defaults* did change, loudly and on purpose, and that is stated in full below.

## Before / after config surface

| Key | Default before | Default after | This bundle's mount |
|---|---|---|---|
| `mention_example` | `"@attractor:examples/pipelines/01-simple-linear.dot"` | `"@<bundle>:path/to/pipeline.dot"` | now passes the old default explicitly |
| `runner_agent` | `"attractor-pipeline-runner"` | `"pipeline-runner"` | already passed it explicitly; unchanged |
| `profiles` | `{}` (unset) | `{}` (unset) -- never name-bearing | unchanged |

The `mention_example` default is deliberately an *obvious* placeholder rather than a plausible-looking name: an unconfigured mount should read as unconfigured, instead of pointing confidently at some other bundle's namespace.

`grep -i attractor modules/tool-pipeline-run/amplifier_module_tool_pipeline_run/__init__.py` -> no matches. The module's tests and README keep the name as an example *value*, which is what it now is.

## Consumer-compat proof

This bundle's behavior is unchanged byte-for-byte. `bundles/attractor-interactive.yaml` already passed `runner_agent`; it now also passes `mention_example`, and two tests pin that the same values in produce the same behavior out:

- `test_prior_consumer_config_reproduces_its_llm_text_byte_identical` -- asserts `tool.description` and `input_schema["dot_file"]["description"]` equal the exact pre-change strings, character for character.
- `test_prior_consumer_config_still_spawns_its_own_runner_agent` -- asserts the configured runner still reaches `session.spawn` and echoes back in the tool result.

The parameterization is proven in the other direction, end-to-end, by `test_configured_namespace_resolves_end_to_end`: it `mount()`s with `@neutral-bundle:` -- a namespace this module has never heard of -- asserts the mounted tool *advertises* that namespace to its LLM, then follows the same mention through `mention_resolver.resolve()` into the spawned `orchestrator_config["dot_source"]`.

## Verification evidence

**Every module suite, run the way CI runs it** (per-module `uv sync && uv run pytest -q`, provider keys unset via `env -u ANTHROPIC_API_KEY -u OPENAI_API_KEY -u GEMINI_API_KEY -u GOOGLE_API_KEY` -- AGENTS.md's shared-venv pitfall):

```
hooks-pipeline-observability :: 87 passed
hooks-pipeline-progress      :: 26 passed
hooks-tool-truncation        :: 34 passed
loop-agent                   :: 559 passed
loop-pipeline                :: 2488 passed, 27 skipped
pipeline-runner              :: 91 passed, 1 skipped
remote-source                :: 48 passed, 1 skipped
tool-apply-patch             :: 23 passed
tool-dashboard-query         :: 19 passed
tool-pipeline-run            :: 54 passed      (main: 51)
tool-pipeline-status         :: 15 passed
tool-report-outcome          :: 21 passed
unified-llm-client           :: 770 passed, 13 deselected
```

Zero failures anywhere, so the "failing list identical to `main`" comparison is empty on both sides rather than merely matching.

**Root guard suite:** `python -m pytest tests/ -q --ignore=tests/e2e` -> `198 passed, 2 skipped` (main: `193 passed, 2 skipped` -- same two skips, +5 new).

**Lint, against a `main` baseline of the same files:** `ruff check --statistics` reports `3 I001 + 2 BLE001` on **both** `main` and this branch -- identical profile, all pre-existing. The new guard file adds zero findings. `ruff format --check` on all three touched Python files: `3 files already formatted`.

### RED proofs

Every new test was broken deliberately and observed failing for the right reason, then restored.

**1. Revert both module defaults to their pre-change (bundle-named) values:**

```
FAILED test_pipeline_run.py::test_default_mention_example_names_no_bundle
  AssertionError: assert '@<bundle>:path/to/pipeline.dot' in 'Path to a .dot pipeline file.
  Supports @mention syntax (e.g. @attractor:examples/pipelines/01-simple-linear.dot).'
FAILED test_pipeline_run.py::test_default_runner_agent_names_no_bundle
  AssertionError: assert 'attractor-pipeline-runner' == 'pipeline-runner'
FAILED tests/test_pipeline_run_namespace_neutrality.py::test_prn_001_module_source_names_no_bundle
  AssertionError: modules/tool-pipeline-run/.../__init__.py names the 'attractor' bundle. ...
  Offending lines:
    52: _DEFAULT_MENTION_EXAMPLE = "@attractor:examples/pipelines/01-simple-linear.dot"
    59: _DEFAULT_RUNNER_AGENT = "attractor-pipeline-runner"
```

**2a. `_mention_example()` ignores config** -> `4 failed`, including `test_prior_consumer_config_reproduces_its_llm_text_byte_identical` and `test_configured_namespace_resolves_end_to_end`.

**2b. Spawn site ignores `runner_agent` config** -> `5 failed`, including `test_prior_consumer_config_still_spawns_its_own_runner_agent` and the two pre-existing spawn tests.

**2c. Mangle the namespace handed to the resolver** (`resolve("@attractor:" + path)` instead of `resolve(dot_file)`) -> **exactly one** test catches it:

```
FAILED test_pipeline_run.py::test_configured_namespace_resolves_end_to_end
  AssertionError: expected call not found.
```

That one is worth naming: the pre-existing `test_resolve_at_mention_path` uses `@attractor:` as its fixture, so a bug that *forces* the attractor namespace passes it silently. The new end-to-end test is what makes that break visible.

**3. Root guard, one break per check** (each restored after):

| Break | Failure |
|---|---|
| drop `mention_example` from the mount | PRN-002[mention_example]: "...does not set 'mention_example'. The module's default for it names no bundle, so dropping this key does not restore this bundle's behavior -- it substitutes a neutral placeholder into what the agent is told." |
| drop `runner_agent` from the mount | PRN-002[runner_agent], same shape |
| advertise `@some-other-bundle:` | PRN-003: "...but this repo's bundle is 'attractor' (bundle.md). The agent would be taught a mention that resolves nowhere." |
| advertise a path that does not exist | PRN-003: "...points at 'examples/pipelines/does-not-exist.dot', which does not exist in this repo." |
| `runner_agent: ghost-pipeline-runner` | PRN-004: "...which no agent under agents/ declares. Declared: [...]" |

## Notes for reviewers

- **The guard is two-sided on purpose.** Each half fails silently alone: put a bundle name back in the module and nothing breaks *here* (it breaks for whoever mounts it next); drop a key from the mount and the module falls back to a neutral placeholder rather than to this bundle's values. PRN-001 reads the module's source; PRN-002..004 read the composition surfaces and the files they point at, so neither side is a restatement of the other.
- **The guard fails loudly if the module leaves this repo** rather than skipping -- the stage-2 move must re-aim or retire it deliberately. That is stated in its docstring and in its assertion messages, and it is the same reasoning the `opinionated-guards` job itself exists for: a guard that silently stops running is worse than no guard.
- **Deliberately not changed:** the missing-providers error still says "Configure the missing providers in the pipeline-runner agent" rather than naming the *configured* `runner_agent`. It names no bundle, so it is out of scope here; folding it in would have meant hoisting the runner resolution above the provider check for a cosmetic gain.
- **Left alone deliberately:** `docs/plans/tool-pipeline-run-plan.md` still describes the original `"attractor-pipeline-runner"` default. It is an implementation-plan record of what was planned then, not living documentation of what the code does now -- rewriting past plans to match present code is how a record becomes fiction. No guard reads `docs/plans/`.
- **Observations:** none arose against `docs/VISION.md` during this work.

## Verification checklist

- [x] nlspec evidence -- see the tier paragraph above. The nlspec governs DOT graph execution semantics; Amplifier module mount config is outside its subject, and the diff touches no parser/engine/handler/dispatch/event surface. Read holistically: the silence here is silence about a different domain, not silence about a graph behavior.
- [x] Unit tests pass -- all 13 module suites plus the root guard suite, listed above with counts.
- [x] Live pipeline run -- N/A per the verification gradient: no `engine.py` or handler code is touched. The automated live-graph gate runs in CI regardless.
- [x] AGENTS.md reviewed; repo-specific gates met (per-module isolated runs with provider keys unset; no cross-module imports added).
- [x] Backward-compat path unchanged -- byte-identical for this bundle, proven by the two `test_prior_consumer_config_*` tests.
- [x] Observable contract -- module mount-config defaults only; no dispatch, event, or admission behavior changes, so no `specs/EXTENSIONS.md` entry. The default change itself is declared in full in the table above rather than hidden behind this box.
- [x] Doc claims guarded -- `modules/tool-pipeline-run/README.md`'s defaults table is pinned to code by `test_default_mention_example_names_no_bundle` and `test_default_runner_agent_names_no_bundle`, which read the values from the module rather than from the page.
- [x] Pre-publication leak review -- N/A: no new public content class (one new file inside the existing `tests/` harness; no run artifacts, no new fixture corpus, no real-run evidence).
- [x] PR body includes verification evidence, not just "tests pass".
- [x] CI green before merge -- `gh pr checks` confirmed for `CI Gate (all checks passed)` before any merge.