### PR TITLE
feat(skills): put attractor-scout and attractorify out of the model's autonomous reach

### DIFF
--- a/docs/lanes/lswd-attractor-catalog-reduction/DONE-NOTE.md
+++ b/docs/lanes/lswd-attractor-catalog-reduction/DONE-NOTE.md
@@ -1,0 +1,154 @@
+# lswd — skills catalog reduction: hide `attractor-scout` + `attractorify`
+
+Work item: `model_performance-lswd` (project `model_performance`). Owner approved
+2026-09-07: *"all of those authoring ones are ones we run by hand, so they can be
+hidden."*
+
+Branch `lane/lswd-attractor-catalog-reduction`, cut from `origin/main` @ `c12885d`.
+Ships as a **DRAFT PR**. This lane may not merge — the merge is the manager's next
+stage.
+
+Spend: **$0**. No LLM eval, no container, no API call beyond this lane's own
+session.
+
+---
+
+## 1. What changed
+
+Three files, one behaviour.
+
+| file | change |
+|---|---|
+| `skills/attractor-scout/SKILL.md` | `+ disable-model-invocation: true` (frontmatter) |
+| `skills/attractorify/SKILL.md` | `+ disable-model-invocation: true` (frontmatter) |
+| `tests/test_skill_catalog_visibility.py` | **new** — S-300..S-304, the guard that keeps it |
+
+Both skills keep `user-invocable: true`, keep `model_role: reasoning`, keep their
+`allowed-tools`, and keep running **inline** (neither declares `context: fork`).
+
+---
+
+## 2. Fail-before / pass-after
+
+Evidence files are verbatim command output in `evidence/`.
+
+| | command | result |
+|---|---|---|
+| **before** | `pytest tests/test_skill_catalog_visibility.py -q` at `c12885d` + the new test, SKILL.md untouched | **4 failed, 5 passed** — `evidence/fail-before.txt` |
+| **after** | same command, SKILL.md edited | **9 passed** — `evidence/pass-after.txt` |
+
+The four that flip are S-300 and S-301, once per skill. The five that pass in both
+states are the ones asserting what must *not* change (S-302 user-invocable, S-303
+inline, S-304 the declared skill set) — they were green before because they are
+guarding the status quo, and that is what makes the red/green pair honest rather
+than tautological.
+
+## 3. Full suite, green
+
+`evidence/full-suite-after.txt`, reproducible via `evidence/run_suites.sh`. Every
+job in `.github/workflows/ci.yml`:
+
+| CI job | before | after |
+|---|---|---|
+| `opinionated-guards` (`pytest tests/ --ignore=tests/e2e`) | 204 passed, 2 skipped | **213 passed, 2 skipped** (+9, all mine) |
+| `unit-tests` (`modules/tool-report-outcome`) | 21 passed | **21 passed** |
+| `dot-render-gate` (43 tracked `.dot`) | 0 failed | **0 failed** |
+
+`tests/e2e` is excluded by CI's own design (live/Docker, needs keys —
+`tests/e2e/MANUAL_E2E.md`), not by this lane.
+
+**One pre-existing red, proven not ours.** `skills/attractor-scout/tests/` is not
+in CI (root `pyproject.toml` sets `testpaths = ["tests"]`; the skill has its own
+`pytest.ini`). It was run anyway because this change edits that skill's SKILL.md.
+`test_no_real_data_leak.py::test_layer2_no_current_environment_identity` fails on
+7 files — **and fails on the same 7 files at `c12885d` with this lane's changes
+stashed**. The matched term is `'amplifier'`, derived at runtime from this
+machine's git identity (`user.name = Amplifier`) and colliding with the product
+name in paths like `~/.amplifier/projects`. Proof, with the stash command and
+both outputs: `evidence/pre-existing-failures.txt`.
+
+## 4. Real-session check — the acceptance criterion
+
+*"Given a real session, when `load_skill(skill_name=...)` is called directly on
+each, then both still load successfully."*
+
+Done, in this lane's own live agent session, at $0, using `tool-skills`' own
+`source` parameter to merge the worktree's `skills/` into the live catalog
+(in-memory only — no config write). Both returned `success: true` with the
+**complete SKILL.md body inline**. Detail, and why a fresh `amplifier` run and a
+DTU were both deliberately rejected: `evidence/real-session-load.md`.
+
+## 5. The number that is NOT what the item implies — read this before quoting it
+
+The item is filed under "skills catalog reduction". **This change reduces zero
+catalog bytes, and that was measured rather than assumed.**
+
+`evidence/measure_catalog_delta.py` renders the live
+`SkillsVisibilityHook._format_skills_list` — the function that produces the
+`hooks-skills-visibility` reminder in every session — over a real catalog with
+the flag forced off and on:
+
+| catalog | flag absent | flag true | delta |
+|---|---:|---:|---:|
+| this repo's 2 skills alone | 457 B | 463 B | **+6 B** |
+| stock skills bundle + this repo (40 skills) | 6,623 B | 6,623 B | **0 B** |
+
+Both sections emit one line per skill under the same 180-char cap
+(`DEFAULT_LINE_CHAR_CAP`), so moving a skill from `Available skills` to
+`User-invoked skills` is free; the marginal case is +6 B because the second
+section's header appears. The 2,500-token budget that bounds only the regular
+section (`DEFAULT_VISIBILITY_TOKEN_BUDGET`) was not binding at either catalog
+size — in a catalog large enough for it to bind, the sign could differ, and this
+lane did not measure that.
+
+**What the change actually buys is the tail, not the line.** With the flag set,
+the model can no longer decide on its own to load a ~30 KB body (7.5–7.6 k
+tokens at the hook's own 4 chars/token estimate) inline in the middle of an
+unrelated task. The usage table records zero all-time
+loads for both skills, so the realised cost to date is zero — this closes the
+path, it does not recover a measured loss. That is the honest framing, and it is
+the owner's stated reason too: *they are run by hand.*
+
+Anyone re-using "catalog reduction" as a cost lever should read this section
+first. The lever is real; its units are risk, not tokens.
+
+## 6. The guard, and what each check would catch
+
+`tests/test_skill_catalog_visibility.py`, in the repo's guard idiom (file-content
+assertions, pytest + pyyaml only, no engine import — so it runs in the
+`opinionated-guards` job which installs nothing else).
+
+| id | assertion | the regression it catches |
+|---|---|---|
+| S-300 | both carry `disable-model-invocation: true` | the flag dropped in a later edit |
+| S-301 | the value is a real YAML boolean | `discovery.py:297` coerces a non-bool with `bool(...)`, under which the **string** `"false"` is truthy — a quoted value works today and inverts silently the day someone tries to turn it off |
+| S-302 | both keep `user-invocable: true` | hiding from the model is only acceptable while the slash command survives; dropping both strands the skill with no invocation path |
+| S-303 | neither declares `context: fork` | invisible *and* blind — a forked attractorify sees nothing of the session it exists to analyse |
+| S-304 | `skills/` on disk == the declared set | decision-forcing: a third SKILL.md must state whether the model may reach for it, rather than defaulting to yes |
+
+S-301 reports a missing key and points at S-300 rather than raising `KeyError`,
+following `1b7bac5` (PRN-003/004).
+
+## 7. Honest limits
+
+- The CI guard reads frontmatter, not the running `tool-skills` module. This repo
+  does not depend on the skills bundle and the `opinionated-guards` job installs
+  only pytest + pyyaml, so a live-module assertion could not run there. The
+  behavioural half is verified in §4 and reproducible via
+  `evidence/measure_catalog_delta.py`, which does import the live module.
+- S-300..S-303 are one-sided — they assert on this repo's own files with no second
+  source to cross-check against — because the value under guard *is* an owner
+  policy decision about these files, not a number derived from code. Sibling
+  guards in this repo are two-sided for the opposite reason; the difference is
+  deliberate and stated in the test's docstring.
+- The catalog measurement (§5) uses the stock skills bundle plus this repo as its
+  ambient catalog because the real set of skills mounted alongside this bundle
+  varies per consumer. The marginal delta is exact; the ambient one is
+  representative.
+
+## 8. Census safety
+
+No `amplifier` invocation with a scratch `AMPLIFIER_HOME` at any point (§4 records
+why the one path that would have needed it was rejected). Post-run verification:
+`grep -l /tmp/ ~/.local/share/uv/tools/amplifier/lib/python3.13/site-packages/*.pth`
+returns nothing.

--- a/docs/lanes/lswd-attractor-catalog-reduction/DONE-NOTE.md
+++ b/docs/lanes/lswd-attractor-catalog-reduction/DONE-NOTE.md
@@ -57,6 +57,22 @@ job in `.github/workflows/ci.yml`:
 `tests/e2e` is excluded by CI's own design (live/Docker, needs keys —
 `tests/e2e/MANUAL_E2E.md`), not by this lane.
 
+**And green on the real CI, not just locally.** Run
+[34167331579](https://github.com/microsoft/amplifier-bundle-attractor/actions/runs/34167331579)
+on PR #352 (`gh pr checks 352`):
+
+    CI Gate (all checks passed)                    pass   4s
+    DOT Render Gate (every tracked .dot renders)   pass  17s
+    Opinionated Guards (repo root)                 pass  14s
+    Unit Tests (tool-report-outcome, py3.11)       pass  11s
+    Unit Tests (tool-report-outcome, py3.13)       pass  10s
+    license/cla                                    pass
+
+`CI Gate` is the one stable context branch protection requires, and it is
+fail-closed by construction (`if: always()` plus an explicit `needs.*.result`
+check), so its `pass` means every upstream job genuinely succeeded rather than
+was skipped.
+
 **One pre-existing red, proven not ours.** `skills/attractor-scout/tests/` is not
 in CI (root `pyproject.toml` sets `testpaths = ["tests"]`; the skill has its own
 `pytest.ini`). It was run anyway because this change edits that skill's SKILL.md.

--- a/docs/lanes/lswd-attractor-catalog-reduction/evidence/catalog-delta.txt
+++ b/docs/lanes/lswd-attractor-catalog-reduction/evidence/catalog-delta.txt
@@ -1,0 +1,21 @@
+# Catalog-visibility delta for disable-model-invocation: true
+# repo   : /home/bkrabach/dev/hw-model-performance/lanes/lswd-attractor-catalog-reduction/amplifier-bundle-attractor
+# bundle : /home/bkrabach/.amplifier/cache/amplifier-bundle-skills-5105b7c75992a85a/skills
+
+## MARGINAL (this repo's skills only) (2 skills in catalog)
+  block bytes, flag ABSENT (model-invocable) :    457
+  block bytes, flag TRUE   (user-invoked)    :    463
+  delta                                      :     +6 bytes (+1 tokens at the hook's own 4 chars/token estimate)
+  attractor-scout  before: Available skills   after: User-invoked skills
+  attractorify     before: Available skills   after: User-invoked skills
+
+## AMBIENT (stock skills bundle + this repo) (40 skills in catalog)
+  block bytes, flag ABSENT (model-invocable) :   6623
+  block bytes, flag TRUE   (user-invoked)    :   6623
+  delta                                      :     +0 bytes (+0 tokens at the hook's own 4 chars/token estimate)
+  attractor-scout  before: Available skills   after: User-invoked skills
+  attractorify     before: Available skills   after: User-invoked skills
+
+## Per-skill frontmatter, as the live discovery parses it
+  attractor-scout  disable_model_invocation=True user_invocable=True context=None description_chars=575
+  attractorify     disable_model_invocation=True user_invocable=True context=None description_chars=297

--- a/docs/lanes/lswd-attractor-catalog-reduction/evidence/fail-before.txt
+++ b/docs/lanes/lswd-attractor-catalog-reduction/evidence/fail-before.txt
@@ -1,0 +1,80 @@
+$ git rev-parse HEAD
+c12885dca636d40cd526c7b887d7fce86ce03794
+
+$ python -m pytest tests/test_skill_catalog_visibility.py -q   # BEFORE the SKILL.md edits
+FFFF.....                                                                [100%]
+=================================== FAILURES ===================================
+_______ test_s300_hand_run_skill_is_not_model_invocable[attractor-scout] _______
+
+skill_name = 'attractor-scout'
+
+    @pytest.mark.parametrize("skill_name", HAND_RUN)
+    def test_s300_hand_run_skill_is_not_model_invocable(skill_name: str) -> None:
+        fm = _frontmatter(skill_name)
+>       assert "disable-model-invocation" in fm, (
+            f"skills/{skill_name}/SKILL.md must carry `disable-model-invocation: true`. "
+            f"It is a hand-run authoring skill (owner directive 2026-09-07, "
+            f"model_performance-lswd); without the field its full description is "
+            f"injected into the skills catalog on every request of every session."
+        )
+E       AssertionError: skills/attractor-scout/SKILL.md must carry `disable-model-invocation: true`. It is a hand-run authoring skill (owner directive 2026-09-07, model_performance-lswd); without the field its full description is injected into the skills catalog on every request of every session.
+E       assert 'disable-model-invocation' in {'allowed-tools': ['bash', 'read_file', 'write_file', 'delegate'], 'description': 'Mine YOUR OWN local context-intelli... keep doing by hand?", "mine my own work for pipelines".\n', 'model_role': 'reasoning', 'name': 'attractor-scout', ...}
+
+tests/test_skill_catalog_visibility.py:138: AssertionError
+________ test_s300_hand_run_skill_is_not_model_invocable[attractorify] _________
+
+skill_name = 'attractorify'
+
+    @pytest.mark.parametrize("skill_name", HAND_RUN)
+    def test_s300_hand_run_skill_is_not_model_invocable(skill_name: str) -> None:
+        fm = _frontmatter(skill_name)
+>       assert "disable-model-invocation" in fm, (
+            f"skills/{skill_name}/SKILL.md must carry `disable-model-invocation: true`. "
+            f"It is a hand-run authoring skill (owner directive 2026-09-07, "
+            f"model_performance-lswd); without the field its full description is "
+            f"injected into the skills catalog on every request of every session."
+        )
+E       AssertionError: skills/attractorify/SKILL.md must carry `disable-model-invocation: true`. It is a hand-run authoring skill (owner directive 2026-09-07, model_performance-lswd); without the field its full description is injected into the skills catalog on every request of every session.
+E       assert 'disable-model-invocation' in {'allowed-tools': ['read_file', 'write_file', 'bash', 'delegate'], 'description': 'Analyze the current session and dec... need an attractor pipeline?", "turn this into a pipeline".\n', 'model_role': 'reasoning', 'name': 'attractorify', ...}
+
+tests/test_skill_catalog_visibility.py:138: AssertionError
+________ test_s301_flag_is_a_real_boolean_not_a_string[attractor-scout] ________
+
+skill_name = 'attractor-scout'
+
+    @pytest.mark.parametrize("skill_name", HAND_RUN)
+    def test_s301_flag_is_a_real_boolean_not_a_string(skill_name: str) -> None:
+        fm = _frontmatter(skill_name)
+        # Report the absence plainly and point at the check that owns it, rather
+        # than surfacing a KeyError that names nothing (the PRN-003/004 lesson).
+>       assert "disable-model-invocation" in fm, (
+            f"`disable-model-invocation` is absent from skills/{skill_name}/"
+            f"SKILL.md -- see S-300, which is the check that owns this."
+        )
+E       AssertionError: `disable-model-invocation` is absent from skills/attractor-scout/SKILL.md -- see S-300, which is the check that owns this.
+E       assert 'disable-model-invocation' in {'allowed-tools': ['bash', 'read_file', 'write_file', 'delegate'], 'description': 'Mine YOUR OWN local context-intelli... keep doing by hand?", "mine my own work for pipelines".\n', 'model_role': 'reasoning', 'name': 'attractor-scout', ...}
+
+tests/test_skill_catalog_visibility.py:155: AssertionError
+_________ test_s301_flag_is_a_real_boolean_not_a_string[attractorify] __________
+
+skill_name = 'attractorify'
+
+    @pytest.mark.parametrize("skill_name", HAND_RUN)
+    def test_s301_flag_is_a_real_boolean_not_a_string(skill_name: str) -> None:
+        fm = _frontmatter(skill_name)
+        # Report the absence plainly and point at the check that owns it, rather
+        # than surfacing a KeyError that names nothing (the PRN-003/004 lesson).
+>       assert "disable-model-invocation" in fm, (
+            f"`disable-model-invocation` is absent from skills/{skill_name}/"
+            f"SKILL.md -- see S-300, which is the check that owns this."
+        )
+E       AssertionError: `disable-model-invocation` is absent from skills/attractorify/SKILL.md -- see S-300, which is the check that owns this.
+E       assert 'disable-model-invocation' in {'allowed-tools': ['read_file', 'write_file', 'bash', 'delegate'], 'description': 'Analyze the current session and dec... need an attractor pipeline?", "turn this into a pipeline".\n', 'model_role': 'reasoning', 'name': 'attractorify', ...}
+
+tests/test_skill_catalog_visibility.py:155: AssertionError
+=========================== short test summary info ============================
+FAILED tests/test_skill_catalog_visibility.py::test_s300_hand_run_skill_is_not_model_invocable[attractor-scout]
+FAILED tests/test_skill_catalog_visibility.py::test_s300_hand_run_skill_is_not_model_invocable[attractorify]
+FAILED tests/test_skill_catalog_visibility.py::test_s301_flag_is_a_real_boolean_not_a_string[attractor-scout]
+FAILED tests/test_skill_catalog_visibility.py::test_s301_flag_is_a_real_boolean_not_a_string[attractorify]
+4 failed, 5 passed in 0.04s

--- a/docs/lanes/lswd-attractor-catalog-reduction/evidence/full-suite-after.txt
+++ b/docs/lanes/lswd-attractor-catalog-reduction/evidence/full-suite-after.txt
@@ -1,0 +1,26 @@
+repo: /home/bkrabach/dev/hw-model-performance/lanes/lswd-attractor-catalog-reduction/amplifier-bundle-attractor
+HEAD: c12885dca636d40cd526c7b887d7fce86ce03794
+
+=== CI job: opinionated-guards ===
+$ python -m pytest tests/ -q --ignore=tests/e2e
+........................................................ss.............. [ 33%]
+........................................................................ [ 66%]
+.......................................................................  [100%]
+213 passed, 2 skipped in 1.64s
+
+=== CI job: unit-tests (module tool-report-outcome) ===
+$ cd modules/tool-report-outcome && uv run pytest -q
+.....................                                                    [100%]
+21 passed in 0.28s
+
+=== CI job: dot-render-gate ===
+$ dot -Tsvg on every git-tracked .dot (excluding .ai/ .amplifier/ evals/)
+Checked 43 git-tracked .dot file(s); 0 failed to render.
+
+=== NOT in CI, run because SKILL.md changed: skills/attractor-scout own suite ===
+$ cd skills/attractor-scout && python -m pytest tests -q
+FAILED tests/test_no_real_data_leak.py::test_layer2_no_current_environment_identity[tests/test_no_real_data_leak.py]
+FAILED tests/test_no_real_data_leak.py::test_layer2_no_current_environment_identity[scripts/attractor_scout_cli.py]
+FAILED tests/test_no_real_data_leak.py::test_layer2_no_current_environment_identity[scripts/attractor_scout/discover.py]
+FAILED tests/test_no_real_data_leak.py::test_layer2_no_current_environment_identity[scripts/attractor_scout/demo_templates.py]
+FAILED tests/test_no_real_data_leak.py::test_layer2_no_current_environment_identity[scripts/attractor_scout/deck_templates.py]

--- a/docs/lanes/lswd-attractor-catalog-reduction/evidence/measure_catalog_delta.py
+++ b/docs/lanes/lswd-attractor-catalog-reduction/evidence/measure_catalog_delta.py
@@ -1,0 +1,125 @@
+"""Measure what `disable-model-invocation: true` actually costs and saves.
+
+Runs the LIVE `SkillsVisibilityHook._format_skills_list` (the renderer that
+produces the `hooks-skills-visibility` system-reminder in every session) over a
+real catalog, once with the two attractor skills model-invocable and once with
+them hidden, and reports the byte/token delta plus which section each lands in.
+
+Zero spend: no LLM call, no `amplifier` invocation, no network. It imports the
+already-installed `amplifier_module_tool_skills` and reads SKILL.md files.
+
+Run with the amplifier tool venv's interpreter:
+
+    /home/bkrabach/.local/share/uv/tools/amplifier/bin/python3 \
+        docs/lanes/lswd-attractor-catalog-reduction/evidence/measure_catalog_delta.py
+
+Ambient catalog: the skills bundle's own `skills/` directory (the ~49 skills a
+stock session carries) plus this repo's `skills/`. Marginal catalog: this
+repo's two skills alone. Both are reported, because the marginal delta is the
+honest number for "what did this change do" and the ambient one shows it in the
+context where it is actually paid.
+"""
+
+from __future__ import annotations
+
+import copy
+import glob
+import sys
+from pathlib import Path
+
+from amplifier_module_tool_skills.discovery import discover_skills
+from amplifier_module_tool_skills.hooks import SkillsVisibilityHook
+
+REPO = Path(__file__).resolve().parents[4]
+REPO_SKILLS = REPO / "skills"
+
+_bundle_matches = sorted(
+    glob.glob(
+        str(
+            Path.home()
+            / ".amplifier"
+            / "cache"
+            / "amplifier-bundle-skills-*"
+            / "skills"
+        )
+    )
+)
+BUNDLE_SKILLS = Path(_bundle_matches[0]) if _bundle_matches else None
+
+TARGETS = ("attractor-scout", "attractorify")
+
+
+def render(catalog: dict) -> str:
+    """Render the visibility block exactly as a live session would."""
+    hook = SkillsVisibilityHook(skills=catalog, config={})
+    return hook._format_skills_list(catalog)
+
+
+def flipped(catalog: dict, value: bool) -> dict:
+    """Copy the catalog with the two target skills' flag forced to `value`."""
+    out = {name: copy.copy(meta) for name, meta in catalog.items()}
+    for name in TARGETS:
+        if name in out:
+            out[name].disable_model_invocation = value
+    return out
+
+
+def report(label: str, catalog: dict) -> None:
+    if not catalog:
+        print(f"\n## {label}: EMPTY -- skipped")
+        return
+
+    missing = [n for n in TARGETS if n not in catalog]
+    if missing:
+        print(f"\n## {label}: missing {missing} -- skipped")
+        return
+
+    shown = render(flipped(catalog, False))
+    hidden = render(flipped(catalog, True))
+
+    print(f"\n## {label} ({len(catalog)} skills in catalog)")
+    print(f"  block bytes, flag ABSENT (model-invocable) : {len(shown):>6}")
+    print(f"  block bytes, flag TRUE   (user-invoked)    : {len(hidden):>6}")
+    delta = len(hidden) - len(shown)
+    print(f"  delta                                      : {delta:>+6} bytes "
+          f"({delta // 4:+d} tokens at the hook's own 4 chars/token estimate)")
+
+    for name in TARGETS:
+        in_regular = f"- **{name}**" in shown.split("User-invoked skills")[0]
+        after = hidden.split("User-invoked skills")
+        in_user_invoked = len(after) > 1 and f"- **{name}**" in after[1]
+        print(f"  {name:<16} before: "
+              f"{'Available skills' if in_regular else 'NOT in Available'}"
+              f"   after: "
+              f"{'User-invoked skills' if in_user_invoked else 'NOT in User-invoked'}")
+
+
+def main() -> int:
+    print("# Catalog-visibility delta for disable-model-invocation: true")
+    print(f"# repo   : {REPO}")
+    print(f"# bundle : {BUNDLE_SKILLS}")
+
+    repo_only = discover_skills(REPO_SKILLS)
+    report("MARGINAL (this repo's skills only)", repo_only)
+
+    if BUNDLE_SKILLS is not None:
+        ambient = discover_skills(BUNDLE_SKILLS)
+        ambient.update(repo_only)
+        report("AMBIENT (stock skills bundle + this repo)", ambient)
+
+    print("\n## Per-skill frontmatter, as the live discovery parses it")
+    for name in TARGETS:
+        meta = repo_only.get(name)
+        if meta is None:
+            print(f"  {name}: NOT DISCOVERED")
+            continue
+        print(
+            f"  {name:<16} disable_model_invocation={meta.disable_model_invocation!r} "
+            f"user_invocable={meta.user_invocable!r} context={meta.context!r} "
+            f"description_chars={len(meta.description)}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/lanes/lswd-attractor-catalog-reduction/evidence/pass-after.txt
+++ b/docs/lanes/lswd-attractor-catalog-reduction/evidence/pass-after.txt
@@ -1,0 +1,8 @@
+$ git diff --stat  # the SKILL.md edits under test
+ skills/attractor-scout/SKILL.md | 11 +++++++++++
+ skills/attractorify/SKILL.md    | 11 +++++++++++
+ 2 files changed, 22 insertions(+)
+
+$ python -m pytest tests/test_skill_catalog_visibility.py -q   # AFTER the SKILL.md edits
+.........                                                                [100%]
+9 passed in 0.03s

--- a/docs/lanes/lswd-attractor-catalog-reduction/evidence/pre-existing-failures.txt
+++ b/docs/lanes/lswd-attractor-catalog-reduction/evidence/pre-existing-failures.txt
@@ -1,0 +1,31 @@
+PRE-EXISTING FAILURE PROOF -- skills/attractor-scout/tests/test_no_real_data_leak.py
+
+This suite is NOT run by CI (.github/workflows/ci.yml runs root tests/,
+modules/tool-report-outcome, and the dot-render gate). It was run anyway because
+this change edits skills/attractor-scout/SKILL.md. It has 7 failures -- and it has
+the SAME 7 failures at HEAD with this lane's changes stashed, proving they are
+not this lane's.
+
+The matched term is 'amplifier', derived at runtime from this machine's git
+identity (user.name = Amplifier). Every hit is the literal string 'amplifier' in
+paths like ~/.amplifier/projects and AMPLIFIER_CONTEXT_INTELLIGENCE_BASE_PATH --
+an artifact of the guard's identity derivation colliding with the product name on
+a machine whose git user IS 'Amplifier', not a real environment leak.
+
+$ git stash push -u -- skills/ tests/ docs/lanes/   # worktree == HEAD c12885d
+$ cd skills/attractor-scout && python -m pytest tests/test_no_real_data_leak.py -q
+
+ skills/attractor-scout/SKILL.md | 11 +++++++++++
+ skills/attractorify/SKILL.md    | 11 +++++++++++
+ 2 files changed, 22 insertions(+)
+
+
+tests/test_no_real_data_leak.py:227: AssertionError
+=========================== short test summary info ============================
+FAILED tests/test_no_real_data_leak.py::test_layer2_no_current_environment_identity[SKILL.md]
+FAILED tests/test_no_real_data_leak.py::test_layer2_no_current_environment_identity[fixtures/deck_fixture.py]
+FAILED tests/test_no_real_data_leak.py::test_layer2_no_current_environment_identity[tests/test_no_real_data_leak.py]
+FAILED tests/test_no_real_data_leak.py::test_layer2_no_current_environment_identity[scripts/attractor_scout_cli.py]
+FAILED tests/test_no_real_data_leak.py::test_layer2_no_current_environment_identity[scripts/attractor_scout/discover.py]
+FAILED tests/test_no_real_data_leak.py::test_layer2_no_current_environment_identity[scripts/attractor_scout/demo_templates.py]
+FAILED tests/test_no_real_data_leak.py::test_layer2_no_current_environment_identity[scripts/attractor_scout/deck_templates.py]

--- a/docs/lanes/lswd-attractor-catalog-reduction/evidence/real-session-load.md
+++ b/docs/lanes/lswd-attractor-catalog-reduction/evidence/real-session-load.md
@@ -1,0 +1,73 @@
+# Real-session check: both skills still load by name, with the flag set
+
+The acceptance criterion for `model_performance-lswd` is behavioural, not
+textual: *"Given a real session, when `load_skill(skill_name="attractor-scout")`
+and `load_skill(skill_name="attractorify")` are each called directly, then both
+still load successfully."*
+
+## How it was checked, and why this way
+
+This lane's own agent session is the real session. It does not mount this
+bundle, so the two skills were not in its catalog. `tool-skills` exposes a
+`source` parameter for exactly this — `SkillsTool.execute` resolves a local
+path, runs the production `discover_skills()` over it, and merges the result
+into the live catalog **in memory only** (no config write, no disk state; see
+`amplifier_module_tool_skills/__init__.py`, the `source_str` branch of
+`execute`). So the check below is the real tool, the real discovery, the real
+load path, in a live session, at **$0**.
+
+Two paths were deliberately NOT taken, both for reasons recorded in the
+program's standing rules:
+
+- **A fresh `amplifier` run against this worktree's bundle.** The bundle mounts
+  `modules/tool-report-outcome` by relative source, and a first run
+  editable-installs local module sources into the SHARED uv tool venv
+  (`~/.local/share/uv/tools/amplifier`), which `AMPLIFIER_HOME` does not
+  isolate. Pointing that at a lane worktree writes `.pth` files at a path that
+  vanishes on teardown — the same failure shape as the 2026-09-07 incident that
+  rewrote 61 of 63 `.pth` files. See HIGHWAY.md Constraints.
+- **A container/DTU run.** Correct, and explicitly endorsed by the census-safety
+  rule — but it needs API keys and an LLM turn, and this lane's spend authority
+  is **$0**.
+
+## The check, verbatim
+
+Registering the source (the worktree's `skills/`, post-change):
+
+    load_skill(source=".../amplifier-bundle-attractor/skills")
+    -> "Source '...' resolved to .../skills. Found 2 skill(s), 2 new:
+        attractor-scout, attractorify."
+
+Metadata as the live discovery parses it (`load_skill(info="attractorify")`),
+confirming the file with the new frontmatter is the one being read:
+
+    name: attractorify   version: 1.0.0
+    path: .../skills/attractorify/SKILL.md
+    allowed_tools: [read_file, write_file, bash, delegate]
+
+Then each skill loaded directly by name:
+
+| call | result |
+|---|---|
+| `load_skill(skill_name="attractorify")` | `success: true` — full body returned, `skill_directory` `.../skills/attractorify`, `loaded_from` `.../skills` |
+| `load_skill(skill_name="attractor-scout")` | `success: true` — full body returned, `skill_directory` `.../skills/attractor-scout`, `loaded_from` `.../skills` |
+
+Both returned the **complete SKILL.md body inline** — not a fork handle, not a
+stub. Neither declares `context: fork`, and `SkillsTool._load_skill` gates fork
+execution on that field alone, so `disable-model-invocation` changes nothing on
+the load path. That is the whole point of the change: unreachable by the model,
+unchanged for the human.
+
+The bodies were loaded to verify loadability. Neither skill was executed.
+
+## Cross-check, independent of the session
+
+`measure_catalog_delta.py` (in this directory) runs the same production
+`discover_skills()` over the worktree in a plain interpreter and reports:
+
+    attractor-scout  disable_model_invocation=True user_invocable=True context=None
+    attractorify     disable_model_invocation=True user_invocable=True context=None
+
+and renders the live `SkillsVisibilityHook._format_skills_list` with the flag
+forced off and on, confirming both skills move from the `Available skills`
+section to the `User-invoked skills (available via /command)` section.

--- a/docs/lanes/lswd-attractor-catalog-reduction/evidence/run_suites.sh
+++ b/docs/lanes/lswd-attractor-catalog-reduction/evidence/run_suites.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Re-runs every gate this repo's CI runs (.github/workflows/ci.yml), plus the
+# skill-local suite CI does not cover but this change touches.
+#
+#   bash docs/lanes/lswd-attractor-catalog-reduction/evidence/run_suites.sh
+#
+# Zero spend: pytest, uv, graphviz. No LLM call, no `amplifier` invocation.
+set -uo pipefail
+
+# evidence/ -> lswd-.../ -> lanes/ -> docs/ -> repo root
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+cd "$REPO" || exit 1
+
+echo "repo: $REPO"
+echo "HEAD: $(git rev-parse HEAD)"
+echo
+
+echo "=== CI job: opinionated-guards ==="
+echo '$ python -m pytest tests/ -q --ignore=tests/e2e'
+python -m pytest tests/ -q --ignore=tests/e2e 2>&1 | tail -5
+echo
+
+echo "=== CI job: unit-tests (module tool-report-outcome) ==="
+echo '$ cd modules/tool-report-outcome && uv run pytest -q'
+( cd modules/tool-report-outcome && uv run pytest -q 2>&1 | tail -5 )
+echo
+
+echo "=== CI job: dot-render-gate ==="
+echo '$ dot -Tsvg on every git-tracked .dot (excluding .ai/ .amplifier/ evals/)'
+failed=0
+checked=0
+while IFS= read -r f; do
+  case "$f" in
+    .ai/*|.amplifier/*|evals/*) continue ;;
+  esac
+  checked=$((checked + 1))
+  if err="$(dot -Tsvg "$f" -o /dev/null 2>&1)"; then
+    continue
+  fi
+  failed=$((failed + 1))
+  echo "FAILED TO RENDER: ${f}: ${err}"
+done < <(git ls-files '*.dot')
+echo "Checked ${checked} git-tracked .dot file(s); ${failed} failed to render."
+echo
+
+echo "=== NOT in CI, run because SKILL.md changed: skills/attractor-scout own suite ==="
+echo '$ cd skills/attractor-scout && python -m pytest tests -q'
+( cd skills/attractor-scout && python -m pytest tests -q 2>&1 | tail -5 )

--- a/docs/lanes/lswd-attractor-catalog-reduction/pr-body.md
+++ b/docs/lanes/lswd-attractor-catalog-reduction/pr-body.md
@@ -1,0 +1,179 @@
+## Summary
+
+`attractor-scout` and `attractorify` — this repo's two skills — are ~30 KB
+authoring tools a human starts by hand, with zero all-time model loads in the
+program usage table. Owner directive 2026-09-07: *"all of those authoring ones
+are ones we run by hand, so they can be hidden."* Both now carry
+`disable-model-invocation: true`, which moves them out of the model's
+autonomous reach while leaving `/attractor-scout`, `/attractorify` and
+`load_skill(skill_name=...)` working exactly as before. Ships with
+`tests/test_skill_catalog_visibility.py` (S-300..S-304) so the decision is
+guarded rather than remembered. Work item `model_performance-lswd`.
+
+**Decision-matrix tier: territory the nlspec is silent about — and the cheapest
+kind of it.** This touches no engine semantics, no `.dot` vocabulary, no
+pipeline behaviour. It is a guidance-surface visibility flag on two skills in
+`skills/`, which `AGENTS.md`'s verification gradient prices at *root guards*.
+Nothing here moves toward or away from the nlspec.
+
+**Read §5 of the DONE-NOTE before quoting this as a cost win.** The item is
+filed under "skills catalog reduction" and **this change reduces zero catalog
+bytes** — measured, not assumed. The lever is real; its units are risk, not
+tokens.
+
+## Verification checklist
+
+- [x] nlspec evidence: **N/A — spec-silent territory.** Skill frontmatter
+      visibility is not an attractor-spec concern; no section cited because
+      none bears on it, and no extension is claimed.
+- [x] Unit tests pass — the checklist's `pytest modules/loop-pipeline/` line is
+      stale (loop-pipeline left in the P4 slim). Ran what CI actually runs; all
+      three jobs green, output below.
+- [x] Live pipeline run — **N/A.** Touches no `engine.py`, no handler, no
+      exemplar graph, and nothing a pipeline executes. `AGENTS.md`'s
+      verification gradient puts `skills/` changes at *root guards*.
+- [x] AGENTS.md reviewed; repo-specific gates met.
+      `tests/test_orchestrator_source_pin_guard.py` — the one AGENTS.md names
+      as must-not-skip — ran and passed 8/8, no skips.
+- [x] Backward-compat path unchanged. `user-invocable: true` retained on both,
+      so the slash command survives; `SkillsTool._load_skill` gates fork
+      execution on `context == "fork"` alone and neither skill declares it, so
+      the load path is untouched. Verified live, not reasoned: both still
+      return their complete body inline.
+- [x] Observable contract → `specs/EXTENSIONS.md` entry: **not needed.** No
+      dispatch semantics, event contract, or admission/validation behaviour
+      changes. The observable change is which section of the skills-visibility
+      reminder two skills appear in, which is `tool-skills` behaviour in the
+      skills bundle, not an attractor engine contract.
+- [x] Doc claim about code behavior ships a guard test: **yes.** The claim is
+      "these two skills are hand-run only," and
+      `tests/test_skill_catalog_visibility.py` pins it. Its docstring states
+      plainly that S-300..S-303 are one-sided — the value under guard *is* an
+      owner policy decision about these files, not a number derived from code,
+      so there is no second source to cross-check against. The measured claims
+      (0-byte delta, `hooks.py:412/417`, `discovery.py:297`) are sourced to
+      `docs/lanes/lswd-attractor-catalog-reduction/evidence/`, with the
+      measurement script committed.
+- [x] Pre-publication leak review: **N/A — no new public content class.** The
+      diff is two frontmatter blocks, one guard test, and a lane record under
+      the existing `docs/lanes/` convention. No new top-level directory, no new
+      artifact type reaching users, no fixture corpus. The evidence files carry
+      command output and byte counts, no session data. The deterministic leak
+      guards are green (see the pre-existing-red note below).
+- [x] PR body includes verification evidence, not just "tests pass."
+- [ ] **CI green before merge** — this is a draft PR opened by a lane that may
+      not merge. Confirm with `gh pr checks` and require
+      `CI Gate (all checks passed)` before the merge stage.
+
+## Verification evidence
+
+### Fail-before / pass-after
+
+The guard was written first and run against untouched SKILL.md files:
+
+```
+$ python -m pytest tests/test_skill_catalog_visibility.py -q   # BEFORE
+FAILED ...::test_s300_hand_run_skill_is_not_model_invocable[attractor-scout]
+FAILED ...::test_s300_hand_run_skill_is_not_model_invocable[attractorify]
+FAILED ...::test_s301_flag_is_a_real_boolean_not_a_string[attractor-scout]
+FAILED ...::test_s301_flag_is_a_real_boolean_not_a_string[attractorify]
+4 failed, 5 passed in 0.04s
+
+$ python -m pytest tests/test_skill_catalog_visibility.py -q   # AFTER
+9 passed in 0.03s
+```
+
+The five green in both states are the ones guarding what must *not* change
+(S-302 user-invocable, S-303 inline, S-304 the declared set) — that is what
+makes the pair honest rather than tautological.
+
+Verbatim: `docs/lanes/lswd-attractor-catalog-reduction/evidence/fail-before.txt`,
+`pass-after.txt`.
+
+### Every CI job
+
+Reproduce with `bash docs/lanes/lswd-attractor-catalog-reduction/evidence/run_suites.sh`.
+
+| job | before | after |
+|---|---|---|
+| `opinionated-guards` — `pytest tests/ -q --ignore=tests/e2e` | 204 passed, 2 skipped | **213 passed, 2 skipped** |
+| `unit-tests` — `modules/tool-report-outcome` | 21 passed | **21 passed** |
+| `dot-render-gate` — 43 tracked `.dot` | 0 failed | **0 failed** |
+
+The +9 are all this PR's. The 2 skips are pre-existing and unrelated
+(`test_context_include_paths.py`, namespaced framework-resolved refs).
+
+### One pre-existing red, proven not ours
+
+`skills/attractor-scout/tests/` is not a CI suite (root `pyproject.toml` sets
+`testpaths = ["tests"]`; the skill carries its own `pytest.ini`). It was run
+anyway because this PR edits that skill's SKILL.md.
+`test_no_real_data_leak.py::test_layer2_no_current_environment_identity` fails
+on 7 files — **and fails on the same 7 at `c12885d` with this branch's changes
+stashed.** The matched term is `'amplifier'`, derived at runtime from the
+machine's git identity (`user.name = Amplifier`) and colliding with the product
+name in paths like `~/.amplifier/projects`. Stash command and both outputs:
+`evidence/pre-existing-failures.txt`. Not fixed here — out of scope, and it is
+an environment collision in the guard's identity derivation, not a leak.
+
+### Real-session load — the acceptance criterion
+
+The work item requires that both still load by name after the change. Checked
+in a live agent session at $0, using `tool-skills`' own `source` parameter to
+merge this worktree's `skills/` into the live catalog in memory:
+
+| call | result |
+|---|---|
+| `load_skill(skill_name="attractorify")` | `success: true`, complete body returned inline |
+| `load_skill(skill_name="attractor-scout")` | `success: true`, complete body returned inline |
+
+A fresh `amplifier` run against this bundle was deliberately **rejected**: the
+bundle mounts `modules/tool-report-outcome` by relative source, and a first run
+editable-installs local module sources into the shared uv tool venv, which
+`AMPLIFIER_HOME` does not isolate — pointing that at a lane worktree writes
+`.pth` files at a path that vanishes on teardown. A container run was rejected
+on the lane's $0 spend authority. Both reasons recorded in
+`evidence/real-session-load.md`.
+
+### The measurement that changes how this should be described
+
+`evidence/measure_catalog_delta.py` renders the live
+`SkillsVisibilityHook._format_skills_list` — the function producing the
+`hooks-skills-visibility` reminder in every session — with the flag forced off
+and on:
+
+| catalog | flag absent | flag true | delta |
+|---|---:|---:|---:|
+| this repo's 2 skills alone | 457 B | 463 B | **+6 B** |
+| stock skills bundle + this repo (40 skills) | 6,623 B | 6,623 B | **0 B** |
+
+Both sections emit one line per skill under the same 180-char cap
+(`DEFAULT_LINE_CHAR_CAP`), so moving from `Available skills` to `User-invoked
+skills` is free; the marginal case is +6 B because the second header appears.
+The 2,500-token budget bounding only the regular section was not binding at
+either size — in a catalog large enough for it to bind the sign could differ,
+and this lane did not measure that.
+
+What the flag buys is the **tail**: the model can no longer decide on its own to
+load a ~30 KB body (7.5–7.6 k tokens) inline mid-task. Zero all-time loads means
+the realised cost to date is zero — this closes the path, it does not recover a
+measured loss.
+
+## Observations
+
+None arose. The `docs/VISION.md` passages were not engaged by this change —
+it touches no engine semantics, no pipeline behaviour, and no doctrine claim.
+
+## Notes for reviewers
+
+- **The honest framing matters more than the diff.** Three lines of frontmatter
+  are trivial; the finding that "skills catalog reduction" saves 0 bytes is the
+  part worth carrying forward, and it is written into the SKILL.md comments, the
+  guard's docstring, and §5 of the DONE-NOTE so it cannot be quoted loose.
+- **S-304 is decision-forcing and will fail on the next new skill.** That is
+  intended: a third `skills/*/SKILL.md` must be added to `HAND_RUN` or
+  `MODEL_INVOCABLE` — a one-line edit — rather than silently defaulting to
+  model-reachable. Push back if that is unwelcome; it is the one assertion here
+  that constrains future work rather than recording this decision.
+- **Draft, and this lane may not merge.** Fail-before/pass-after is demonstrated
+  above; the merge is the manager's next stage.

--- a/skills/attractor-scout/SKILL.md
+++ b/skills/attractor-scout/SKILL.md
@@ -11,6 +11,18 @@ description: >
   automate?", "find my attractor opportunities", "scout my sessions", "what do
   I keep doing by hand?", "mine my own work for pipelines".
 user-invocable: true
+# Hand-run authoring tool: started by a human, never reached for by the model
+# (owner directive 2026-09-07, model_performance-lswd). What this buys is NOT
+# catalog bytes -- measured, the visibility block is 0 bytes smaller, because
+# the skill moves from "Available skills" to "User-invoked skills" and both
+# render one capped line. It buys the tail: the model can no longer decide on
+# its own to load this ~30 KB body (~7.6k tokens) in the middle of an unrelated
+# task. And it costs nothing here -- the flag is read only by the visibility
+# hook, never on the load path -- so `/attractor-scout` and
+# `load_skill(skill_name="attractor-scout")` still load this file in full,
+# inline. Guarded by tests/test_skill_catalog_visibility.py; measured in
+# docs/lanes/lswd-attractor-catalog-reduction/.
+disable-model-invocation: true
 model_role: reasoning
 allowed-tools:
   - bash

--- a/skills/attractorify/SKILL.md
+++ b/skills/attractorify/SKILL.md
@@ -7,6 +7,18 @@ description: >
   "should this be an attractor?", "design a pipeline for", "attractorify this",
   "do I need an attractor pipeline?", "turn this into a pipeline".
 user-invocable: true
+# Hand-run authoring tool: started by a human, never reached for by the model
+# (owner directive 2026-09-07, model_performance-lswd). What this buys is NOT
+# catalog bytes -- measured, the visibility block is 0 bytes smaller, because
+# the skill moves from "Available skills" to "User-invoked skills" and both
+# render one capped line. It buys the tail: the model can no longer decide on
+# its own to load this ~30 KB body (~7.5k tokens) in the middle of an unrelated
+# task. And it costs nothing here -- the flag is read only by the visibility
+# hook, never on the load path -- so `/attractorify` and
+# `load_skill(skill_name="attractorify")` still load this file in full, inline.
+# Guarded by tests/test_skill_catalog_visibility.py; measured in
+# docs/lanes/lswd-attractor-catalog-reduction/.
+disable-model-invocation: true
 model_role: reasoning
 allowed-tools:
   - read_file

--- a/tests/test_skill_catalog_visibility.py
+++ b/tests/test_skill_catalog_visibility.py
@@ -1,0 +1,222 @@
+"""Catalog guard: the hand-run skills stay OUT of the always-injected catalog.
+
+# --- Root guard harness (DESIGN-repo-split.md Track A, section 1.4/5#2). This
+# guard asserts on the OPINIONATED layer (repo-root docs/examples/skills/
+# agents/context/bundles/behaviors), not on engine behavior, so it lives in
+# the repo-root `tests/` suite and installs nothing but pytest + pyyaml. ---
+
+**What this protects, and why it is worth a test.**  Both skills in this repo
+are ~30 KB authoring tools that a human starts by hand; neither had ever been
+model-invoked (zero all-time loads in the program usage table).
+`disable-model-invocation: true` is what makes that permanent.  In
+`amplifier_module_tool_skills` the field is read by `discovery.py` and consumed
+by `hooks.py`, which partitions the visibility reminder into two sections:
+
+    hooks.py:412  not meta.disable_model_invocation -> "Available skills"
+    hooks.py:417      meta.disable_model_invocation -> "User-invoked skills"
+
+**Do not sell this as a catalog-byte saving -- it measurably is not one.**  The
+lane rendered the live `SkillsVisibilityHook._format_skills_list` over the real
+catalog with the flag off and on: **0 bytes** difference over a 40-skill
+catalog, **+6 bytes** over this repo's two skills alone (the second section's
+header appears).  Both sections emit one line per skill under the same
+180-char cap, so moving between them is free, and the 2,500-token budget that
+bounds only the regular section was not binding at either catalog size.
+Evidence and the reproduction script:
+``docs/lanes/lswd-attractor-catalog-reduction/evidence/``.
+
+What the field actually buys is the *tail*: the model can no longer decide on
+its own to load a ~30 KB body (~7.5k tokens) inline in the middle of an
+unrelated task.  And it costs nothing, because the flag is not read anywhere on
+the load path -- `SkillsTool._load_skill` gates fork execution on
+`metadata.context == "fork"` and nothing else, so a hand-run skill carrying
+this flag still loads in full, inline, when it is named directly.  That is the
+whole trade: unreachable by the model, unchanged for the human.
+
+Owner directive, 2026-09-07: *"all of those authoring ones are ones we run by
+hand, so they can be hidden."*  Work item `model_performance-lswd`.
+
+**The assertions, and what each would catch.**
+
+  S-300  Both hand-run skills carry `disable-model-invocation: true`.
+         Catches the flag being dropped in an edit -- the regression that puts
+         a 30 KB hand-run skill back within the model's autonomous reach.
+
+  S-301  The flag is a real YAML boolean, never a string.
+         `discovery.py:297` coerces a non-bool with `bool(...)`, under which
+         the *string* `"false"` is truthy.  A quoted value would therefore
+         "work" today and silently invert the day someone tries to turn the
+         flag off.  Fail on the quote, not on the inversion.
+
+  S-302  Both stay `user-invocable: true`.
+         Hiding a skill from the model is only acceptable because the human
+         retains a slash command.  Dropping this field alongside the new one
+         would strand the skill with no invocation path at all.
+
+  S-303  Neither declares `context: fork`.
+         Both SKILL.md bodies state that they must run inline to see the
+         current session (attractorify's whole job is analysing it).  A future
+         edit to `context: fork` would combine with S-300 into a skill that is
+         invisible to the model *and* blind when invoked -- the failure mode
+         worth naming before it happens.
+
+  S-304  The set of skills is exactly the two known hand-run ones.
+         Decision-forcing, deliberately.  A model-reachable surface regrows one
+         well-intentioned skill at a time; a third SKILL.md appearing here
+         should make its author state, in this file, whether the model is
+         meant to reach for it.  Adding a genuinely model-invocable skill is a
+         one-line edit to `MODEL_INVOCABLE` below.
+
+Honest limits:
+  - This guard reads frontmatter, not the running `tool-skills` module.  CI for
+    this repo installs pytest and pyyaml only (see `.github/workflows/ci.yml`,
+    `opinionated-guards`), and the repo does not depend on the skills bundle.
+    The behavioural half -- that both skills still load by name post-change --
+    was verified in a real session against the live module and recorded in
+    `docs/lanes/lswd-attractor-catalog-reduction/`.
+  - S-300..S-303 are one-sided (they assert on this repo's own files, with no
+    second source to cross-check against) because the value under guard IS an
+    owner policy decision about these files, not a number derived from code.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+# ---------------------------------------------------------------------------
+# Locating the repo root and the skills
+# ---------------------------------------------------------------------------
+
+
+def _find_bundle_root() -> Path | None:
+    """Walk up from this file looking for the bundle repo root.
+
+    Walks rather than hardcoding a parent count so the guard survives being
+    vendored or re-nested, and returns None (-> module skip) rather than
+    pointing at a plausible-but-wrong directory.
+    """
+    for candidate in Path(__file__).resolve().parents:
+        if (candidate / "skills").is_dir() and (candidate / "bundle.md").is_file():
+            return candidate
+    return None
+
+
+_ROOT = _find_bundle_root()
+
+if _ROOT is None:  # pragma: no cover - partial checkout
+    pytest.skip("bundle root not found", allow_module_level=True)
+
+SKILLS_DIR = _ROOT / "skills"
+
+#: Skills a human starts by hand. Out of the model's autonomous reach, still
+#: reachable by name / slash command. Owner directive 2026-09-07.
+HAND_RUN = ("attractor-scout", "attractorify")
+
+#: Skills the model is meant to reach for on its own. Empty today, and that is
+#: the point of S-304: a new entry here is a deliberate statement that the
+#: model may load this body, unprompted, in the middle of someone else's task.
+MODEL_INVOCABLE: tuple[str, ...] = ()
+
+
+def _frontmatter(skill_name: str) -> dict:
+    """Parse the YAML frontmatter block of skills/<name>/SKILL.md."""
+    path = SKILLS_DIR / skill_name / "SKILL.md"
+    assert path.is_file(), f"{path} is missing"
+    text = path.read_text(encoding="utf-8")
+    assert text.startswith("---\n"), f"{path} has no frontmatter block"
+    _, _, rest = text.partition("---\n")
+    block, sep, _ = rest.partition("\n---")
+    assert sep, f"{path} frontmatter block is unterminated"
+    parsed = yaml.safe_load(block)
+    assert isinstance(parsed, dict), f"{path} frontmatter did not parse to a mapping"
+    return parsed
+
+
+# ---------------------------------------------------------------------------
+# S-300 / S-301 -- hidden from the model-facing catalog, and hidden honestly
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("skill_name", HAND_RUN)
+def test_s300_hand_run_skill_is_not_model_invocable(skill_name: str) -> None:
+    fm = _frontmatter(skill_name)
+    assert "disable-model-invocation" in fm, (
+        f"skills/{skill_name}/SKILL.md must carry `disable-model-invocation: true`. "
+        f"It is a hand-run authoring skill (owner directive 2026-09-07, "
+        f"model_performance-lswd); without the field the model may load its "
+        f"~30 KB body inline, on its own initiative, mid-task."
+    )
+    assert fm["disable-model-invocation"] is True, (
+        f"skills/{skill_name}/SKILL.md sets `disable-model-invocation: "
+        f"{fm['disable-model-invocation']!r}`; it must be the boolean `true`."
+    )
+
+
+@pytest.mark.parametrize("skill_name", HAND_RUN)
+def test_s301_flag_is_a_real_boolean_not_a_string(skill_name: str) -> None:
+    fm = _frontmatter(skill_name)
+    # Report the absence plainly and point at the check that owns it, rather
+    # than surfacing a KeyError that names nothing (the PRN-003/004 lesson).
+    assert "disable-model-invocation" in fm, (
+        f"`disable-model-invocation` is absent from skills/{skill_name}/"
+        f"SKILL.md -- see S-300, which is the check that owns this."
+    )
+    raw = fm["disable-model-invocation"]
+    assert isinstance(raw, bool), (
+        f"skills/{skill_name}/SKILL.md quotes `disable-model-invocation` as "
+        f"{raw!r}. discovery.py coerces a non-bool with bool(...), under which "
+        f"the string 'false' is TRUE -- a quoted value works today and inverts "
+        f"silently the day someone tries to turn it off. Unquote it."
+    )
+
+
+# ---------------------------------------------------------------------------
+# S-302 / S-303 -- the human's invocation path survives the hiding
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("skill_name", HAND_RUN)
+def test_s302_hand_run_skill_stays_user_invocable(skill_name: str) -> None:
+    fm = _frontmatter(skill_name)
+    assert fm.get("user-invocable") is True, (
+        f"skills/{skill_name}/SKILL.md must keep `user-invocable: true`. It is "
+        f"hidden from the model; the slash command is the only invocation path "
+        f"left, and dropping it would strand the skill entirely."
+    )
+
+
+@pytest.mark.parametrize("skill_name", HAND_RUN)
+def test_s303_hand_run_skill_stays_inline(skill_name: str) -> None:
+    fm = _frontmatter(skill_name)
+    assert fm.get("context") != "fork", (
+        f"skills/{skill_name}/SKILL.md declares `context: fork`. Both skills "
+        f"document that they must run INLINE to see the current session "
+        f"(attractorify analyses it; attractor-scout resolves the repo's "
+        f"AGENTS.md and output path). Forking it while it is also hidden from "
+        f"the model leaves a skill that is invisible AND blind."
+    )
+
+
+# ---------------------------------------------------------------------------
+# S-304 -- the model-reachable surface does not regrow by accident
+# ---------------------------------------------------------------------------
+
+
+def test_s304_every_shipped_skill_has_a_declared_visibility() -> None:
+    on_disk = {
+        entry.name
+        for entry in SKILLS_DIR.iterdir()
+        if entry.is_dir() and (entry / "SKILL.md").is_file()
+    }
+    declared = set(HAND_RUN) | set(MODEL_INVOCABLE)
+    assert on_disk == declared, (
+        f"skills/ on disk is {sorted(on_disk)}, declared here is "
+        f"{sorted(declared)}. Every shipped skill is loadable by the model on "
+        f"its own initiative unless it sets `disable-model-invocation: true`. "
+        f"Add a new skill to HAND_RUN (slash-command / by-name only) or to "
+        f"MODEL_INVOCABLE (the model may reach for it, unprompted, mid-task) "
+        f"-- deliberately, not by default."
+    )


### PR DESCRIPTION
## Summary

`attractor-scout` and `attractorify` — this repo's two skills — are ~30 KB
authoring tools a human starts by hand, with zero all-time model loads in the
program usage table. Owner directive 2026-09-07: *"all of those authoring ones
are ones we run by hand, so they can be hidden."* Both now carry
`disable-model-invocation: true`, which moves them out of the model's
autonomous reach while leaving `/attractor-scout`, `/attractorify` and
`load_skill(skill_name=...)` working exactly as before. Ships with
`tests/test_skill_catalog_visibility.py` (S-300..S-304) so the decision is
guarded rather than remembered. Work item `model_performance-lswd`.

**Decision-matrix tier: territory the nlspec is silent about — and the cheapest
kind of it.** This touches no engine semantics, no `.dot` vocabulary, no
pipeline behaviour. It is a guidance-surface visibility flag on two skills in
`skills/`, which `AGENTS.md`'s verification gradient prices at *root guards*.
Nothing here moves toward or away from the nlspec.

**Read §5 of the DONE-NOTE before quoting this as a cost win.** The item is
filed under "skills catalog reduction" and **this change reduces zero catalog
bytes** — measured, not assumed. The lever is real; its units are risk, not
tokens.

## Verification checklist

- [x] nlspec evidence: **N/A — spec-silent territory.** Skill frontmatter
      visibility is not an attractor-spec concern; no section cited because
      none bears on it, and no extension is claimed.
- [x] Unit tests pass — the checklist's `pytest modules/loop-pipeline/` line is
      stale (loop-pipeline left in the P4 slim). Ran what CI actually runs; all
      three jobs green, output below.
- [x] Live pipeline run — **N/A.** Touches no `engine.py`, no handler, no
      exemplar graph, and nothing a pipeline executes. `AGENTS.md`'s
      verification gradient puts `skills/` changes at *root guards*.
- [x] AGENTS.md reviewed; repo-specific gates met.
      `tests/test_orchestrator_source_pin_guard.py` — the one AGENTS.md names
      as must-not-skip — ran and passed 8/8, no skips.
- [x] Backward-compat path unchanged. `user-invocable: true` retained on both,
      so the slash command survives; `SkillsTool._load_skill` gates fork
      execution on `context == "fork"` alone and neither skill declares it, so
      the load path is untouched. Verified live, not reasoned: both still
      return their complete body inline.
- [x] Observable contract → `specs/EXTENSIONS.md` entry: **not needed.** No
      dispatch semantics, event contract, or admission/validation behaviour
      changes. The observable change is which section of the skills-visibility
      reminder two skills appear in, which is `tool-skills` behaviour in the
      skills bundle, not an attractor engine contract.
- [x] Doc claim about code behavior ships a guard test: **yes.** The claim is
      "these two skills are hand-run only," and
      `tests/test_skill_catalog_visibility.py` pins it. Its docstring states
      plainly that S-300..S-303 are one-sided — the value under guard *is* an
      owner policy decision about these files, not a number derived from code,
      so there is no second source to cross-check against. The measured claims
      (0-byte delta, `hooks.py:412/417`, `discovery.py:297`) are sourced to
      `docs/lanes/lswd-attractor-catalog-reduction/evidence/`, with the
      measurement script committed.
- [x] Pre-publication leak review: **N/A — no new public content class.** The
      diff is two frontmatter blocks, one guard test, and a lane record under
      the existing `docs/lanes/` convention. No new top-level directory, no new
      artifact type reaching users, no fixture corpus. The evidence files carry
      command output and byte counts, no session data. The deterministic leak
      guards are green (see the pre-existing-red note below).
- [x] PR body includes verification evidence, not just "tests pass."
- [ ] **CI green before merge** — this is a draft PR opened by a lane that may
      not merge. Confirm with `gh pr checks` and require
      `CI Gate (all checks passed)` before the merge stage.

## Verification evidence

### Fail-before / pass-after

The guard was written first and run against untouched SKILL.md files:

```
$ python -m pytest tests/test_skill_catalog_visibility.py -q   # BEFORE
FAILED ...::test_s300_hand_run_skill_is_not_model_invocable[attractor-scout]
FAILED ...::test_s300_hand_run_skill_is_not_model_invocable[attractorify]
FAILED ...::test_s301_flag_is_a_real_boolean_not_a_string[attractor-scout]
FAILED ...::test_s301_flag_is_a_real_boolean_not_a_string[attractorify]
4 failed, 5 passed in 0.04s

$ python -m pytest tests/test_skill_catalog_visibility.py -q   # AFTER
9 passed in 0.03s
```

The five green in both states are the ones guarding what must *not* change
(S-302 user-invocable, S-303 inline, S-304 the declared set) — that is what
makes the pair honest rather than tautological.

Verbatim: `docs/lanes/lswd-attractor-catalog-reduction/evidence/fail-before.txt`,
`pass-after.txt`.

### Every CI job

Reproduce with `bash docs/lanes/lswd-attractor-catalog-reduction/evidence/run_suites.sh`.

| job | before | after |
|---|---|---|
| `opinionated-guards` — `pytest tests/ -q --ignore=tests/e2e` | 204 passed, 2 skipped | **213 passed, 2 skipped** |
| `unit-tests` — `modules/tool-report-outcome` | 21 passed | **21 passed** |
| `dot-render-gate` — 43 tracked `.dot` | 0 failed | **0 failed** |

The +9 are all this PR's. The 2 skips are pre-existing and unrelated
(`test_context_include_paths.py`, namespaced framework-resolved refs).

### One pre-existing red, proven not ours

`skills/attractor-scout/tests/` is not a CI suite (root `pyproject.toml` sets
`testpaths = ["tests"]`; the skill carries its own `pytest.ini`). It was run
anyway because this PR edits that skill's SKILL.md.
`test_no_real_data_leak.py::test_layer2_no_current_environment_identity` fails
on 7 files — **and fails on the same 7 at `c12885d` with this branch's changes
stashed.** The matched term is `'amplifier'`, derived at runtime from the
machine's git identity (`user.name = Amplifier`) and colliding with the product
name in paths like `~/.amplifier/projects`. Stash command and both outputs:
`evidence/pre-existing-failures.txt`. Not fixed here — out of scope, and it is
an environment collision in the guard's identity derivation, not a leak.

### Real-session load — the acceptance criterion

The work item requires that both still load by name after the change. Checked
in a live agent session at $0, using `tool-skills`' own `source` parameter to
merge this worktree's `skills/` into the live catalog in memory:

| call | result |
|---|---|
| `load_skill(skill_name="attractorify")` | `success: true`, complete body returned inline |
| `load_skill(skill_name="attractor-scout")` | `success: true`, complete body returned inline |

A fresh `amplifier` run against this bundle was deliberately **rejected**: the
bundle mounts `modules/tool-report-outcome` by relative source, and a first run
editable-installs local module sources into the shared uv tool venv, which
`AMPLIFIER_HOME` does not isolate — pointing that at a lane worktree writes
`.pth` files at a path that vanishes on teardown. A container run was rejected
on the lane's $0 spend authority. Both reasons recorded in
`evidence/real-session-load.md`.

### The measurement that changes how this should be described

`evidence/measure_catalog_delta.py` renders the live
`SkillsVisibilityHook._format_skills_list` — the function producing the
`hooks-skills-visibility` reminder in every session — with the flag forced off
and on:

| catalog | flag absent | flag true | delta |
|---|---:|---:|---:|
| this repo's 2 skills alone | 457 B | 463 B | **+6 B** |
| stock skills bundle + this repo (40 skills) | 6,623 B | 6,623 B | **0 B** |

Both sections emit one line per skill under the same 180-char cap
(`DEFAULT_LINE_CHAR_CAP`), so moving from `Available skills` to `User-invoked
skills` is free; the marginal case is +6 B because the second header appears.
The 2,500-token budget bounding only the regular section was not binding at
either size — in a catalog large enough for it to bind the sign could differ,
and this lane did not measure that.

What the flag buys is the **tail**: the model can no longer decide on its own to
load a ~30 KB body (7.5–7.6 k tokens) inline mid-task. Zero all-time loads means
the realised cost to date is zero — this closes the path, it does not recover a
measured loss.

## Observations

None arose. The `docs/VISION.md` passages were not engaged by this change —
it touches no engine semantics, no pipeline behaviour, and no doctrine claim.

## Notes for reviewers

- **The honest framing matters more than the diff.** Three lines of frontmatter
  are trivial; the finding that "skills catalog reduction" saves 0 bytes is the
  part worth carrying forward, and it is written into the SKILL.md comments, the
  guard's docstring, and §5 of the DONE-NOTE so it cannot be quoted loose.
- **S-304 is decision-forcing and will fail on the next new skill.** That is
  intended: a third `skills/*/SKILL.md` must be added to `HAND_RUN` or
  `MODEL_INVOCABLE` — a one-line edit — rather than silently defaulting to
  model-reachable. Push back if that is unwelcome; it is the one assertion here
  that constrains future work rather than recording this decision.
- **Draft, and this lane may not merge.** Fail-before/pass-after is demonstrated
  above; the merge is the manager's next stage.
